### PR TITLE
storageminer: Setup actor on init

### DIFF
--- a/chain/address/constants.go
+++ b/chain/address/constants.go
@@ -20,21 +20,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-
-	NetworkAddress, err = NewActorAddress([]byte("filecoin"))
-	if err != nil {
-		panic(err)
-	}
-
-	StorageMarketAddress, err = NewActorAddress([]byte("storage"))
-	if err != nil {
-		panic(err)
-	}
-
-	PaymentBrokerAddress, err = NewActorAddress([]byte("payments"))
-	if err != nil {
-		panic(err)
-	}
 }
 
 var (
@@ -42,13 +27,6 @@ var (
 	TestAddress Address
 	// TestAddress2 is an account with some initial funds in it.
 	TestAddress2 Address
-
-	// NetworkAddress is the filecoin network.
-	NetworkAddress Address
-	// StorageMarketAddress is the hard-coded address of the filecoin storage market.
-	StorageMarketAddress Address
-	// PaymentBrokerAddress is the hard-coded address of the filecoin storage market.
-	PaymentBrokerAddress Address
 )
 
 var (

--- a/chain/vm/mkactor.go
+++ b/chain/vm/mkactor.go
@@ -34,7 +34,7 @@ func makeActor(st *state.StateTree, addr address.Address) (*types.Actor, error) 
 	case address.ID:
 		return nil, fmt.Errorf("no actor with given ID")
 	case address.Actor:
-		return nil, fmt.Errorf("no such actor")
+		return nil, fmt.Errorf("no such actor: %s", addr)
 	default:
 		return nil, fmt.Errorf("address has unsupported protocol: %d", addr.Protocol())
 	}

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -252,7 +252,7 @@ func (vm *VM) ApplyMessage(msg *types.Message) (*types.MessageReceipt, error) {
 	// reward miner gas fees
 	miner, err := st.GetActor(vm.blockMiner)
 	if err != nil {
-		return nil, xerrors.Errorf("getting block miner actor failed: %w", err)
+		return nil, xerrors.Errorf("getting block miner actor (%s) failed: %w", vm.blockMiner, err)
 	}
 
 	gasReward := types.BigMul(msg.GasPrice, vmctx.GasUsed())

--- a/cli/miner.go
+++ b/cli/miner.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"gopkg.in/urfave/cli.v2"
-
-	"github.com/filecoin-project/go-lotus/chain/address"
 )
 
 var minerCmd = &cli.Command{
@@ -29,7 +27,7 @@ var minerStart = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		// TODO: this address needs to be the address of an actual miner
-		maddr, err := address.NewIDAddress(523423423)
+		maddr, err := api.WalletDefaultAddress(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to create miner address")
 		}

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -8,7 +8,6 @@ import (
 	"github.com/filecoin-project/go-lotus/build"
 	"github.com/filecoin-project/go-lotus/chain"
 	"github.com/filecoin-project/go-lotus/chain/actors"
-	"github.com/filecoin-project/go-lotus/chain/address"
 	"github.com/filecoin-project/go-lotus/chain/types"
 	lcli "github.com/filecoin-project/go-lotus/cli"
 	"github.com/filecoin-project/go-lotus/node/repo"
@@ -119,7 +118,7 @@ var initCmd = &cli.Command{
 		}
 
 		createStorageMinerMsg := types.Message{
-			To:   address.StorageMarketAddress,
+			To:   actors.StorageMarketAddress,
 			From: defOwner,
 
 			Nonce: nonce,


### PR DESCRIPTION
Not sure how correct this is, but it's an attempt to move something on this front

Also, miming now fails with:
```
adding 1 messages to block...2019-07-25T14:51:20.040+0200	ERROR	miner	miner/miner.go:68	mining block failed: failed to create block: apply message failure: no such actor
github.com/filecoin-project/go-lotus/miner.(*Miner).Mine
	/home/magik6k/github.com/filecoin-project/go-lotus/miner/miner.go:68
2019-07-25T14:51:20.040+0200	INFO	miner	miner/miner.go:107	attempting to mine a block on:[baep2bzacecfbcxh623n7ixbwhaoctueqvi4pffqqt7lca4ly6ks4q5f4cclt4]

```