### PR TITLE
gitignore: add node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /lotus
 /lotus-storage-miner
 /pond
+/lotuspond/front/node_modules
 **/*.h
 **/*.a
 **/*.pc


### PR DESCRIPTION
It's already in `lotuspond/front/.gitignore`, but `ag` only reads the top-level one