### PR TITLE
ci: disable lint-changes check for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,8 +134,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - lint-changes:
-          args: "--new-from-rev origin/master"
       - test:
           codecov-upload: true
       - mod-tidy-check


### PR DESCRIPTION
It's currently broken (fails with `/bin/bash: golangci-lint: command not found`), and never green because of the docs check.

We should eventually fix it and probably disable the docs check (or extract as separate check), to make actual issues with code more visible.