### PR TITLE
add chain export command

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -24,7 +24,7 @@ import (
 
 var log = logging.Logger("chainstore")
 
-var chainHeadKey = dstore.NewKey("head")
+var ChainHeadKey = dstore.NewKey("head")
 
 type ChainStore struct {
 	bs bstore.Blockstore
@@ -67,7 +67,7 @@ func NewChainStore(bs bstore.Blockstore, ds dstore.Batching) *ChainStore {
 }
 
 func (cs *ChainStore) Load() error {
-	head, err := cs.ds.Get(chainHeadKey)
+	head, err := cs.ds.Get(ChainHeadKey)
 	if err == dstore.ErrNotFound {
 		log.Warn("no previous chain state found")
 		return nil
@@ -97,7 +97,7 @@ func (cs *ChainStore) writeHead(ts *types.TipSet) error {
 		return errors.Wrap(err, "failed to marshal tipset")
 	}
 
-	if err := cs.ds.Put(chainHeadKey, data); err != nil {
+	if err := cs.ds.Put(ChainHeadKey, data); err != nil {
 		return errors.Wrap(err, "failed to write chain head to datastore")
 	}
 


### PR DESCRIPTION
Working on #135 

Next steps are obviously the 'import' and 'verify' commands. I'm not certain how those should work exactly.

For import, my main question is "Do we import only for initializing a new node? Or can we import at any time?"

For verify, do we pull all the blocks from the car into a temp datastore and run all the chain validation logic? Seems to be a decent way of doing it, but it also requires dumping the whole chain somewhere (taking 2x space).

Additionally, the way this is implemented, we dump the chain including all state. Having all the state in the backup isnt necessary as we will be regenerating that when we verify it all (also the entirety of historical state for any reasonably sized chain is going to be massive).