### PR TITLE
Fix mining after typecode changes to signatures

### DIFF
--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -47,7 +47,7 @@ func MinerCreateBlock(ctx context.Context, cs *store.ChainStore, miner address.A
 	var blsMsgCids, secpkMsgCids []cid.Cid
 	var blsSigs []types.Signature
 	for _, msg := range msgs {
-		if msg.Signature.TypeCode() == 2 {
+		if msg.Signature.TypeCode() == types.IKTBLS {
 			blsSigs = append(blsSigs, msg.Signature)
 			blsMessages = append(blsMessages, &msg.Message)
 

--- a/chain/types/signature.go
+++ b/chain/types/signature.go
@@ -22,6 +22,11 @@ const (
 	KTBLS       = "bls"
 )
 
+const (
+	IKTSecp256k1 = iota
+	IKTBLS
+)
+
 func init() {
 	cbor.RegisterCborType(atlas.BuildEntry(Signature{}).Transform().
 		TransformMarshal(atlas.MakeMarshalTransformFunc(
@@ -49,9 +54,9 @@ func SignatureFromBytes(x []byte) (Signature, error) {
 	}
 	var ts string
 	switch val {
-	case 0:
+	case IKTSecp256k1:
 		ts = KTSecp256k1
-	case 1:
+	case IKTBLS:
 		ts = KTBLS
 	default:
 		return Signature{}, fmt.Errorf("unsupported signature type: %d", val)
@@ -109,9 +114,9 @@ func (s *Signature) Verify(addr address.Address, msg []byte) error {
 func (s *Signature) TypeCode() int {
 	switch s.Type {
 	case KTSecp256k1:
-		return 0
+		return IKTSecp256k1
 	case KTBLS:
-		return 1
+		return IKTBLS
 	default:
 		panic("unsupported signature type")
 	}
@@ -157,9 +162,9 @@ func (s *Signature) UnmarshalCBOR(br cbg.ByteReader) error {
 	switch buf[0] {
 	default:
 		return fmt.Errorf("invalid signature type in cbor input: %d", buf[0])
-	case 0:
+	case IKTSecp256k1:
 		s.Type = KTSecp256k1
-	case 1:
+	case IKTBLS:
 		s.Type = KTBLS
 	}
 	s.Data = buf[1:]


### PR DESCRIPTION
This change happened in https://github.com/filecoin-project/go-lotus/commit/357c49eed8ec4bcd17d1c50098bc4a24bcb0b08e#diff-9d58fa67e0e17e3626424a1c8fadd07dL47-R114

(also added consts for that so it's harder to miss next time)