### PR TITLE
use http because i don't have a cert

### DIFF
--- a/build/proof-params/paramfetch.sh
+++ b/build/proof-params/paramfetch.sh
@@ -67,7 +67,7 @@ fetch_gateway() {
   local dest="$1"
   local cid="$2"
 
-  local url="https://198.211.99.118/ipfs/$cid"
+  local url="http://198.211.99.118/ipfs/$cid"
 
   download "$url" "$dest"
 }


### PR DESCRIPTION
not sure why this worked before, but it doesn't work for me locally without this (i don't have https configured on that machine)