### PR TITLE
docs(jq): add jq to deps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ board](https://github.com/filecoin-project/go-lotus/projects/1).
 - git
 - bzr (some go dependency needs this)
 - b2sum
+- jq
 
 *Building:*
 ```


### PR DESCRIPTION
## Why is this PR required?

The dependencies list is missing `jq`, which is required when parsing GitHub Release JSON in order to obtain the URL of the release tarball associated with a rust-fil-sector-builder Git SHA (go-sectorbuilder).

## What's in this PR?

This changeset adds `jq` to the build dependencies list.