### PR TITLE
refactor to use 'randomness' as input to new vm creation

### DIFF
--- a/chain/actors/actors_test.go
+++ b/chain/actors/actors_test.go
@@ -51,7 +51,8 @@ func setupVMTestEnv(t *testing.T) (*vm.VM, []address.Address) {
 
 	cs := store.NewChainStore(bs, nil)
 
-	vm, err := vm.NewVM(stateroot, 1, maddr, cs)
+	// TODO: should probabaly mock out the randomness bit, nil works for now
+	vm, err := vm.NewVM(stateroot, 1, nil, maddr, cs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/actors/harness2_test.go
+++ b/chain/actors/harness2_test.go
@@ -158,7 +158,7 @@ func NewHarness(t *testing.T, options ...HarnessOpt) *Harness {
 		t.Fatal(err)
 	}
 	h.cs = store.NewChainStore(h.bs, nil)
-	h.vm, err = vm.NewVM(stateroot, 1, h.HI.Miner, h.cs)
+	h.vm, err = vm.NewVM(stateroot, 1, nil, h.HI.Miner, h.cs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -360,7 +360,7 @@ type mca struct {
 }
 
 func (mca mca) ChainGetRandomness(ctx context.Context, pts *types.TipSet, ticks []*types.Ticket, lb int) ([]byte, error) {
-	return mca.sm.ChainStore().GetRandomness(ctx, pts, ticks, lb)
+	return mca.sm.ChainStore().GetRandomness(ctx, pts, ticks, int64(lb))
 }
 
 func (mca mca) StateMinerPower(ctx context.Context, maddr address.Address, ts *types.TipSet) (api.MinerPower, error) {

--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -27,7 +27,8 @@ func MinerCreateBlock(ctx context.Context, sm *stmgr.StateManager, w *wallet.Wal
 
 	height := parents.Height() + uint64(len(tickets))
 
-	vmi, err := vm.NewVM(st, height, miner, sm.ChainStore())
+	r := vm.NewChainRand(sm.ChainStore(), parents, tickets)
+	vmi, err := vm.NewVM(st, height, r, miner, sm.ChainStore())
 	if err != nil {
 		return nil, err
 	}

--- a/chain/gen/utils.go
+++ b/chain/gen/utils.go
@@ -169,7 +169,7 @@ func mustEnc(i cbg.CBORMarshaler) []byte {
 }
 
 func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sroot cid.Cid, gmcfg *GenMinerCfg) (cid.Cid, error) {
-	vm, err := vm.NewVM(sroot, 0, actors.NetworkAddress, cs)
+	vm, err := vm.NewVM(sroot, 0, nil, actors.NetworkAddress, cs)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to create NewVM: %w", err)
 	}

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -11,8 +11,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate cid.Cid, bheight uint64) (*types.MessageReceipt, error) {
-	vmi, err := vm.NewVM(bstate, bheight, actors.NetworkAddress, sm.cs)
+func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate cid.Cid, r vm.Rand, bheight uint64) (*types.MessageReceipt, error) {
+	vmi, err := vm.NewVM(bstate, bheight, r, actors.NetworkAddress, sm.cs)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to set up vm: %w", err)
 	}
@@ -57,5 +57,7 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		return nil, err
 	}
 
-	return sm.CallRaw(ctx, msg, state, ts.Height())
+	r := vm.NewChainRand(sm.cs, ts, nil)
+
+	return sm.CallRaw(ctx, msg, state, r, ts.Height())
 }

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -78,7 +78,9 @@ func (sm *StateManager) computeTipSetState(cids []cid.Cid) (cid.Cid, error) {
 		return cid.Undef, xerrors.Errorf("recursive TipSetState failed: %w", err)
 	}
 
-	vmi, err := vm.NewVM(pstate, ts.Height(), address.Undef, sm.cs)
+	r := vm.NewChainRand(sm.cs, ts, nil)
+
+	vmi, err := vm.NewVM(pstate, ts.Height(), r, address.Undef, sm.cs)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("instantiating VM failed: %w", err)
 	}

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -22,7 +22,7 @@ func GetMinerWorker(ctx context.Context, sm *StateManager, st cid.Cid, maddr add
 		To:     maddr,
 		From:   maddr,
 		Method: actors.MAMethods.GetWorkerAddr,
-	}, st, 0)
+	}, st, nil, 0)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("callRaw failed: %w", err)
 	}
@@ -48,7 +48,7 @@ func GetMinerOwner(ctx context.Context, sm *StateManager, st cid.Cid, maddr addr
 		To:     maddr,
 		From:   maddr,
 		Method: actors.MAMethods.GetOwner,
-	}, st, 0)
+	}, st, nil, 0)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("callRaw failed: %w", err)
 	}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -313,7 +313,7 @@ func (syncer *Syncer) ValidateTipSet(ctx context.Context, fts *store.FullTipSet)
 
 	for _, b := range fts.Blocks {
 		if err := syncer.ValidateBlock(ctx, b); err != nil {
-			return err
+			return xerrors.Errorf("validating block %s: %w", b.Cid(), err)
 		}
 	}
 	return nil
@@ -440,7 +440,8 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) err
 		return xerrors.Errorf("miner created a block but was not a winner")
 	}
 
-	vmi, err := vm.NewVM(stateroot, h.Height, h.Miner, syncer.store)
+	r := vm.NewChainRand(syncer.store, baseTs, h.Tickets)
+	vmi, err := vm.NewVM(stateroot, h.Height, r, h.Miner, syncer.store)
 	if err != nil {
 		return xerrors.Errorf("failed to instantiate VM: %w", err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,6 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/filecoin-project/go-amt-ipld v0.0.0-20190917221444-2ed85149c65d/go.mod h1:lKjJYPg2kwbav5f78i5YA8kGccnZn18IySbpneXvaQs=
 github.com/filecoin-project/go-amt-ipld v0.0.0-20190919045431-3650716fff16 h1:NzojcJU1VbS6zdLG13JMYis/cQy/MrN3rxmZRq56jKA=
 github.com/filecoin-project/go-amt-ipld v0.0.0-20190919045431-3650716fff16/go.mod h1:lKjJYPg2kwbav5f78i5YA8kGccnZn18IySbpneXvaQs=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -45,7 +45,7 @@ func (a *ChainAPI) ChainHead(context.Context) (*types.TipSet, error) {
 }
 
 func (a *ChainAPI) ChainGetRandomness(ctx context.Context, pts *types.TipSet, tickets []*types.Ticket, lb int) ([]byte, error) {
-	return a.Chain.GetRandomness(ctx, pts, tickets, lb)
+	return a.Chain.GetRandomness(ctx, pts, tickets, int64(lb))
 }
 
 func (a *ChainAPI) ChainWaitMsg(ctx context.Context, msg cid.Cid) (*api.MsgWait, error) {


### PR DESCRIPTION
This fixes the bug that was caused by syncing chains with messages that use randomness