### PR TITLE
fix sync tests by sorting tipsets

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -507,7 +507,7 @@ func (syncer *Syncer) collectHeaders(from *types.TipSet, to *types.TipSet) ([]*t
 		log.Warn("syncing local: ", at)
 		ts, err := syncer.store.LoadTipSet(at)
 		if err != nil {
-			if err == bstore.ErrNotFound {
+			if xerrors.Is(err, bstore.ErrNotFound) {
 				log.Info("tipset not found locally, starting sync: ", at)
 				break
 			}

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -283,10 +283,7 @@ func TestSyncMining(t *testing.T) {
 
 	require.NoError(t, tu.mn.LinkAll())
 	tu.connect(client, 0)
-	fmt.Println("waiting for sync...")
 	tu.waitUntilSync(0, client)
-
-	fmt.Println("after wait until sync")
 
 	//tu.checkHeight("client", client, H)
 

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -174,3 +174,7 @@ func PowerCmp(eproof ElectionProof, mpow, totpow BigInt) bool {
 	hp := BigFromBytes(h[:])
 	return hp.LessThan(out)
 }
+
+func (t *Ticket) Equals(ot *Ticket) bool {
+	return bytes.Equal(t.VDFResult, ot.VDFResult)
+}


### PR DESCRIPTION
Tipsets were getting out of order, so two tipsets with the same blocks in a different order were causing issues.