### PR TITLE
remove not found log, its okay

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -67,9 +67,6 @@ type mybs struct {
 func (m mybs) Get(c cid.Cid) (block.Block, error) {
 	b, err := m.Blockstore.Get(c)
 	if err != nil {
-		// change to error for stacktraces, don't commit with that pls
-		// TODO: debug why we get so many not founds in tests
-		log.Warnf("Get failed: %s %s", c, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
The reason we saw this log so many times was because we were using a buffered blockstore, and it would hit the memory based blockstore first, fail, print a log, then hit the backing blockstore. 

So this is super normal, and we don't need the log.