### PR TITLE
Allow miners to create differently sized sectors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -129,6 +129,7 @@ type FullNode interface {
 	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
 	StateMinerPeerID(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error)
 	StateMinerProvingPeriodEnd(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)
+	StateMinerSectorSize(context.Context, address.Address, *types.TipSet) (uint64, error)
 	StatePledgeCollateral(context.Context, *types.TipSet) (types.BigInt, error)
 	StateWaitMsg(context.Context, cid.Cid) (*MsgWait, error)
 	StateListMiners(context.Context, *types.TipSet) ([]address.Address, error)

--- a/api/struct.go
+++ b/api/struct.go
@@ -92,6 +92,7 @@ type FullNodeStruct struct {
 		StateMinerWorker           func(context.Context, address.Address, *types.TipSet) (address.Address, error)                  `perm:"read"`
 		StateMinerPeerID           func(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error)                 `perm:"read"`
 		StateMinerProvingPeriodEnd func(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)              `perm:"read"`
+		StateMinerSectorSize       func(context.Context, address.Address, *types.TipSet) (uint64, error)                           `perm:"read"`
 		StateCall                  func(context.Context, *types.Message, *types.TipSet) (*types.MessageReceipt, error)             `perm:"read"`
 		StateReplay                func(context.Context, *types.TipSet, cid.Cid) (*ReplayResults, error)                           `perm:"read"`
 		StateGetActor              func(context.Context, address.Address, *types.TipSet) (*types.Actor, error)                     `perm:"read"`
@@ -357,8 +358,13 @@ func (c *FullNodeStruct) StateMinerWorker(ctx context.Context, m address.Address
 func (c *FullNodeStruct) StateMinerPeerID(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error) {
 	return c.Internal.StateMinerPeerID(ctx, m, ts)
 }
+
 func (c *FullNodeStruct) StateMinerProvingPeriodEnd(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error) {
 	return c.Internal.StateMinerProvingPeriodEnd(ctx, actor, ts)
+}
+
+func (c *FullNodeStruct) StateMinerSectorSize(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error) {
+	return c.Internal.StateMinerSectorSize(ctx, actor, ts)
 }
 
 func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*types.MessageReceipt, error) {

--- a/build/paramfetch.go
+++ b/build/paramfetch.go
@@ -39,7 +39,7 @@ func GetParams(storage bool) error {
 	}
 
 	for name, info := range params {
-		if info.SectorSize != SectorSize {
+		if !SupportedSectorSize(info.SectorSize) {
 			continue
 		}
 		if !storage && strings.HasSuffix(name, ".params") {

--- a/build/params.go
+++ b/build/params.go
@@ -1,6 +1,8 @@
 package build
 
-import "math/big"
+import (
+	"math/big"
+)
 
 // Core network constants
 
@@ -10,7 +12,19 @@ import "math/big"
 const UnixfsChunkSize uint64 = 1 << 20
 const UnixfsLinksPerLevel = 1024
 
-const SectorSize = 16 << 20
+var SectorSizes = []uint64{
+	16 << 20,
+	1 << 30,
+}
+
+func SupportedSectorSize(ssize uint64) bool {
+	for _, ss := range SectorSizes {
+		if ssize == ss {
+			return true
+		}
+	}
+	return false
+}
 
 // /////
 // Payments

--- a/build/params.go
+++ b/build/params.go
@@ -14,6 +14,7 @@ const UnixfsLinksPerLevel = 1024
 
 var SectorSizes = []uint64{
 	16 << 20,
+	256 << 20,
 	1 << 30,
 }
 

--- a/chain/actors/actor_storagepower.go
+++ b/chain/actors/actor_storagepower.go
@@ -53,12 +53,12 @@ type StoragePowerState struct {
 type CreateStorageMinerParams struct {
 	Owner      address.Address
 	Worker     address.Address
-	SectorSize types.BigInt
+	SectorSize uint64
 	PeerID     peer.ID
 }
 
 func (spa StoragePowerActor) CreateStorageMiner(act *types.Actor, vmctx types.VMContext, params *CreateStorageMinerParams) ([]byte, ActorError) {
-	if !SupportedSectorSize(params.SectorSize) {
+	if !build.SupportedSectorSize(params.SectorSize) {
 		return nil, aerrors.New(1, "Unsupported sector size")
 	}
 
@@ -114,13 +114,6 @@ func (spa StoragePowerActor) CreateStorageMiner(act *types.Actor, vmctx types.VM
 	}
 
 	return naddr.Bytes(), nil
-}
-
-func SupportedSectorSize(ssize types.BigInt) bool {
-	if ssize.Uint64() == build.SectorSize {
-		return true
-	}
-	return false
 }
 
 type ArbitrateConsensusFaultParams struct {

--- a/chain/actors/actor_storagepower_test.go
+++ b/chain/actors/actor_storagepower_test.go
@@ -42,7 +42,7 @@ func TestStorageMarketCreateAndSlashMiner(t *testing.T) {
 			&CreateStorageMinerParams{
 				Owner:      ownerAddr,
 				Worker:     workerAddr,
-				SectorSize: types.NewInt(build.SectorSize),
+				SectorSize: build.SectorSizes[0],
 				PeerID:     "fakepeerid",
 			})
 		ApplyOK(t, ret)

--- a/chain/actors/actors_test.go
+++ b/chain/actors/actors_test.go
@@ -118,7 +118,7 @@ func TestStorageMarketActorCreateMiner(t *testing.T) {
 	params := &StorageMinerConstructorParams{
 		Owner:      maddr,
 		Worker:     maddr,
-		SectorSize: types.NewInt(build.SectorSize),
+		SectorSize: build.SectorSizes[0],
 		PeerID:     "fakepeerid",
 	}
 	var err error

--- a/chain/actors/cbor_gen.go
+++ b/chain/actors/cbor_gen.go
@@ -421,8 +421,8 @@ func (t *StorageMinerConstructorParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.t.SectorSize (types.BigInt)
-	if err := t.SectorSize.MarshalCBOR(w); err != nil {
+	// t.t.SectorSize (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, t.SectorSize)); err != nil {
 		return err
 	}
 
@@ -469,15 +469,16 @@ func (t *StorageMinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.t.SectorSize (types.BigInt)
+	// t.t.SectorSize (uint64)
 
-	{
-
-		if err := t.SectorSize.UnmarshalCBOR(br); err != nil {
-			return err
-		}
-
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.SectorSize = extra
 	// t.t.PeerID (peer.ID)
 
 	{
@@ -702,8 +703,8 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.t.SectorSize (types.BigInt)
-	if err := t.SectorSize.MarshalCBOR(w); err != nil {
+	// t.t.SectorSize (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, t.SectorSize)); err != nil {
 		return err
 	}
 	return nil
@@ -752,15 +753,16 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 
 		t.PeerID = peer.ID(sval)
 	}
-	// t.t.SectorSize (types.BigInt)
+	// t.t.SectorSize (uint64)
 
-	{
-
-		if err := t.SectorSize.UnmarshalCBOR(br); err != nil {
-			return err
-		}
-
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.SectorSize = extra
 	return nil
 }
 
@@ -2377,8 +2379,8 @@ func (t *CreateStorageMinerParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.t.SectorSize (types.BigInt)
-	if err := t.SectorSize.MarshalCBOR(w); err != nil {
+	// t.t.SectorSize (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, t.SectorSize)); err != nil {
 		return err
 	}
 
@@ -2425,15 +2427,16 @@ func (t *CreateStorageMinerParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.t.SectorSize (types.BigInt)
+	// t.t.SectorSize (uint64)
 
-	{
-
-		if err := t.SectorSize.UnmarshalCBOR(br); err != nil {
-			return err
-		}
-
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.SectorSize = extra
 	// t.t.PeerID (peer.ID)
 
 	{

--- a/chain/deals/client_states.go
+++ b/chain/deals/client_states.go
@@ -2,11 +2,12 @@ package deals
 
 import (
 	"context"
+
+	"golang.org/x/xerrors"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/stmgr"
-
-	"golang.org/x/xerrors"
 )
 
 type clientHandlerFunc func(ctx context.Context, deal ClientDeal) error
@@ -108,7 +109,12 @@ func (c *Client) staged(ctx context.Context, deal ClientDeal) error {
 	log.Info("DEAL SEALED!")
 
 	// TODO: want?
-	/*ok, err := sectorbuilder.VerifyPieceInclusionProof(build.SectorSize, deal.Proposal.PieceSize, deal.Proposal.CommP, resp.CommD, resp.PieceInclusionProof.ProofElements)
+	/*ssize, err := stmgr.GetMinerSectorSize(ctx, c.sm, nil, deal.Proposal.MinerAddress)
+	if err != nil {
+		return xerrors.Errorf("failed to get miner sector size: %w", err)
+	}
+
+	ok, err := sectorbuilder.VerifyPieceInclusionProof(ssize, deal.Proposal.Size, deal.Proposal.CommP, resp.CommD, resp.PieceInclusionProof.ProofElements)
 	if err != nil {
 		return xerrors.Errorf("verifying piece inclusion proof in staged deal %s: %w", deal.ProposalCid, err)
 	}

--- a/chain/gen/utils.go
+++ b/chain/gen/utils.go
@@ -239,7 +239,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sroot cid.Cid
 		params := mustEnc(&actors.CreateStorageMinerParams{
 			Owner:      owner,
 			Worker:     worker,
-			SectorSize: types.NewInt(build.SectorSize),
+			SectorSize: build.SectorSizes[0],
 			PeerID:     pid,
 		})
 

--- a/cli/createminer.go
+++ b/cli/createminer.go
@@ -53,7 +53,7 @@ var createMinerCmd = &cli.Command{
 		createMinerArgs := actors.CreateStorageMinerParams{
 			Worker:     worker,
 			Owner:      owner,
-			SectorSize: types.NewInt(ssize),
+			SectorSize: ssize,
 			PeerID:     pid,
 		}
 

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -49,6 +49,11 @@ var initCmd = &cli.Command{
 			Aliases: []string{"o"},
 			Usage:   "owner key to use",
 		},
+		&cli.Uint64Flag{
+			Name:  "sector-size",
+			Usage: "specify sector size to use",
+			Value: build.SectorSizes[0],
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		log.Info("Initializing lotus storage miner")
@@ -276,6 +281,8 @@ func createStorageMiner(ctx context.Context, api api.FullNode, peerid peer.ID, c
 		return address.Undef, err
 	}
 
+	ssize := cctx.Uint64("sector-size")
+
 	worker := owner
 	if cctx.String("worker") != "" {
 		worker, err = address.NewFromString(cctx.String("worker"))
@@ -295,7 +302,7 @@ func createStorageMiner(ctx context.Context, api api.FullNode, peerid peer.ID, c
 	params, err := actors.SerializeParams(&actors.CreateStorageMinerParams{
 		Owner:      owner,
 		Worker:     worker,
-		SectorSize: types.NewInt(build.SectorSize),
+		SectorSize: ssize,
 		PeerID:     peerid,
 	})
 	if err != nil {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -69,6 +69,10 @@ func (a *StateAPI) StateMinerProvingPeriodEnd(ctx context.Context, actor address
 	return stmgr.GetMinerProvingPeriodEnd(ctx, a.StateManager, ts, actor)
 }
 
+func (a *StateAPI) StateMinerSectorSize(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error) {
+	return stmgr.GetMinerSectorSize(ctx, a.StateManager, ts, actor)
+}
+
 func (a *StateAPI) StatePledgeCollateral(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
 	param, err := actors.SerializeParams(&actors.PledgeCollateralParams{Size: types.NewInt(0)})
 	if err != nil {

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -7,12 +7,13 @@ import (
 	"math/rand"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/address"
 	"github.com/filecoin-project/lotus/lib/sectorbuilder"
 	"github.com/filecoin-project/lotus/storage"
 	"github.com/filecoin-project/lotus/storage/sector"
 	"github.com/filecoin-project/lotus/storage/sectorblocks"
+
+	"golang.org/x/xerrors"
 )
 
 type StorageMinerAPI struct {
@@ -31,7 +32,11 @@ func (sm *StorageMinerAPI) ActorAddress(context.Context) (address.Address, error
 }
 
 func (sm *StorageMinerAPI) StoreGarbageData(ctx context.Context) (uint64, error) {
-	size := sectorbuilder.UserBytesForSectorSize(build.SectorSize)
+	ssize, err := sm.Miner.SectorSize(ctx)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to get miner sector size: %w", err)
+	}
+	size := sectorbuilder.UserBytesForSectorSize(ssize)
 
 	// TODO: create a deal
 	name := fmt.Sprintf("fake-file-%d", rand.Intn(100000000))


### PR DESCRIPTION
Now miners can specify which sector size they want to use when initializing their miner

cc @dignifiedquire 