### PR TITLE
Git ignore default location for GoLand IDE project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/paramfetch.sh
 /chain/types/work_msg/
 bin/ipget
 bin/tmp/*
+.idea


### PR DESCRIPTION
This directory is created automatically by GoLand when someone does the most straightforward thing of opening the project directory in GoLand. It's possible to configure the project files to be placed elsewhere, but that's not the default.