### PR TITLE
dont hang requests if websockets server shuts down

### DIFF
--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -33,11 +33,11 @@ func serveRPC(a api.FullNode, stop node.StopFunc, addr string) error {
 	sigChan := make(chan os.Signal, 2)
 	go func() {
 		<-sigChan
-		if err := stop(context.TODO()); err != nil {
-			log.Errorf("graceful shutting down failed: %s", err)
-		}
 		if err := srv.Shutdown(context.TODO()); err != nil {
 			log.Errorf("shutting down RPC server failed: %s", err)
+		}
+		if err := stop(context.TODO()); err != nil {
+			log.Errorf("graceful shutting down failed: %s", err)
 		}
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)


### PR DESCRIPTION
If the websocket connection closes, expose that to the client so that new requests don't hang indefinitely