### PR TITLE
events: always call revert in CahinAt

### DIFF
--- a/chain/events/events_height.go
+++ b/chain/events/events_height.go
@@ -20,20 +20,12 @@ type heightEvents struct {
 }
 
 func (e *heightEvents) headChangeAt(rev, app []*types.TipSet) error {
-	// highest tipset is always the first (see api.ReorgOps)
-	newH := app[0].Height()
-
 	for _, ts := range rev {
 		// TODO: log error if h below gcconfidence
 		// revert height-based triggers
 
 		revert := func(h uint64, ts *types.TipSet) {
 			for _, tid := range e.htHeights[h] {
-				// don't revert if newH is above this ts
-				if newH >= h {
-					continue
-				}
-
 				err := e.heightTriggers[tid].revert(ts)
 				if err != nil {
 					log.Errorf("reverting chain trigger (@H %d): %s", h, err)

--- a/chain/events/events_test.go
+++ b/chain/events/events_test.go
@@ -211,6 +211,12 @@ func TestAt(t *testing.T) {
 	require.Equal(t, false, applied)
 	require.Equal(t, false, reverted)
 
+	fcs.advance(10, 10, nil)
+	require.Equal(t, true, applied)
+	require.Equal(t, true, reverted)
+	applied = false
+	reverted = false
+
 	fcs.advance(10, 1, nil)
 	require.Equal(t, false, applied)
 	require.Equal(t, true, reverted)


### PR DESCRIPTION
This is part of the fix for running duplicate PoSts, the other part is cancelling post computation on revert