### PR TITLE
[wip] first pass at integrating the chain-validator. 

### DIFF
--- a/chain/state/statetree.go
+++ b/chain/state/statetree.go
@@ -127,7 +127,6 @@ func (st *StateTree) Flush() (cid.Cid, error) {
 	if err := st.root.Flush(context.TODO()); err != nil {
 		return cid.Undef, err
 	}
-
 	return st.Store.Put(context.TODO(), st.root)
 }
 

--- a/chain/types/signature_cgo.go
+++ b/chain/types/signature_cgo.go
@@ -44,7 +44,7 @@ func (s *Signature) Verify(addr address.Address, msg []byte) error {
 		var sig bls.Signature
 		copy(sig[:], s.Data)
 
-		if !bls.Verify(sig, digests, pubkeys) {
+		if !bls.Verify(&sig, digests, pubkeys) {
 			return fmt.Errorf("bls signature failed to verify")
 		}
 

--- a/chain/types/signature_cgo.go
+++ b/chain/types/signature_cgo.go
@@ -44,7 +44,7 @@ func (s *Signature) Verify(addr address.Address, msg []byte) error {
 		var sig bls.Signature
 		copy(sig[:], s.Data)
 
-		if !bls.Verify(&sig, digests, pubkeys) {
+		if !bls.Verify(sig, digests, pubkeys) {
 			return fmt.Errorf("bls signature failed to verify")
 		}
 

--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -5,8 +5,6 @@ import (
 
 	vchain "github.com/filecoin-project/chain-validation/pkg/chain"
 	vstate "github.com/filecoin-project/chain-validation/pkg/state"
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/go-lotus/chain/address"
 	"github.com/filecoin-project/go-lotus/chain/types"
 	"github.com/filecoin-project/go-lotus/chain/vm"
@@ -26,7 +24,7 @@ func (a *Applier) ApplyMessage(eCtx *vchain.ExecutionContext, state vstate.Wrapp
 	ctx := context.TODO()
 	st := state.(*StateWrapper)
 
-	base := cid.Undef // unused
+	base := state.Cid()
 	randSrc := &vmRand{eCtx}
 	minerAddr, err := address.NewFromBytes([]byte(eCtx.MinerOwner))
 	if err != nil {

--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -2,10 +2,11 @@ package validation
 
 import (
 	"context"
-
 	vchain "github.com/filecoin-project/chain-validation/pkg/chain"
 	vstate "github.com/filecoin-project/chain-validation/pkg/state"
+
 	"github.com/filecoin-project/go-lotus/chain/address"
+	lstate "github.com/filecoin-project/go-lotus/chain/state"
 	"github.com/filecoin-project/go-lotus/chain/types"
 	"github.com/filecoin-project/go-lotus/chain/vm"
 )
@@ -24,7 +25,7 @@ func (a *Applier) ApplyMessage(eCtx *vchain.ExecutionContext, state vstate.Wrapp
 	ctx := context.TODO()
 	st := state.(*StateWrapper)
 
-	base := state.Cid()
+	base := st.Cid()
 	randSrc := &vmRand{eCtx}
 	minerAddr, err := address.NewFromBytes([]byte(eCtx.MinerOwner))
 	if err != nil {
@@ -39,6 +40,10 @@ func (a *Applier) ApplyMessage(eCtx *vchain.ExecutionContext, state vstate.Wrapp
 	if err != nil {
 		return vchain.MessageReceipt{}, err
 	}
+
+	// FIXME this is pretty hacky (it works), flushing the lotusVM fails becasue the root of lotusVM.StateTree is not
+	// its buffered blockstore.
+	st.StateTree = lotusVM.StateTree().(*lstate.StateTree)
 
 	mr := vchain.MessageReceipt{
 		ExitCode:    ret.ExitCode,

--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -2,11 +2,11 @@ package validation
 
 import (
 	"context"
+
 	vchain "github.com/filecoin-project/chain-validation/pkg/chain"
 	vstate "github.com/filecoin-project/chain-validation/pkg/state"
 
 	"github.com/filecoin-project/go-lotus/chain/address"
-	lstate "github.com/filecoin-project/go-lotus/chain/state"
 	"github.com/filecoin-project/go-lotus/chain/types"
 	"github.com/filecoin-project/go-lotus/chain/vm"
 )
@@ -41,9 +41,10 @@ func (a *Applier) ApplyMessage(eCtx *vchain.ExecutionContext, state vstate.Wrapp
 		return vchain.MessageReceipt{}, err
 	}
 
-	// FIXME this is pretty hacky (it works), flushing the lotusVM fails becasue the root of lotusVM.StateTree is not
-	// its buffered blockstore.
-	st.StateTree = lotusVM.StateTree().(*lstate.StateTree)
+	st.stateRoot, err = lotusVM.Flush(ctx)
+	if err != nil {
+		return vchain.MessageReceipt{}, err
+	}
 
 	mr := vchain.MessageReceipt{
 		ExitCode:    ret.ExitCode,

--- a/chain/validation/lotus_test.go
+++ b/chain/validation/lotus_test.go
@@ -1,19 +1,56 @@
 package validation
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/chain-validation/pkg/chain"
+	"github.com/filecoin-project/chain-validation/pkg/state"
+	"github.com/filecoin-project/chain-validation/pkg/suites"
 )
 
 // A basic example validation test.
 // At present this code is verbose and demonstrates the opportunity for helper methods.
 func TestLotusExample(t *testing.T) {
-	//factories := NewFactories()
-	//drv := suites.NewStateDriver(t, factories.NewState())
+	factory := NewFactories()
+	drv := suites.NewStateDriver(t, factory.NewState())
 
-	//alice := drv.NewAccountActor(2000)
-	//bob := drv.NewAccountActor(0)
-	//miner := drv.NewAccountActor(0) // Miner owner
+	// create the init actor
+	initActorAddress, err := state.NewIDAddress(0)
+	require.NoError(t, err)
+	_, _, err = drv.State().SetActor(initActorAddress, state.InitActorCodeCid, state.AttoFIL(big.NewInt(0)))
+	require.NoError(t, err)
 
-	// TODO: write lotus-specific tests here.
+	alice := drv.NewAccountActor(2000)
+	bob := drv.NewAccountActor(0)
+	miner := drv.NewAccountActor(0) // Miner owner
+
+
+	gasPrice := big.NewInt(1)
+	gasLimit := state.GasUnit(1000)
+
+	producer := chain.NewMessageProducer(factory.NewMessageFactory(drv.State()), gasLimit, gasPrice)
+	msg, err := producer.Transfer(alice, bob, 0, 50)
+	require.NoError(t, err)
+
+	validator := chain.NewValidator(factory)
+	exeCtx := chain.NewExecutionContext(1, miner)
+
+	msgReceipt, err := validator.ApplyMessage(exeCtx, drv.State(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, msgReceipt)
+
+	expectedGasUsed := 126 // NB: should be derived from the size of the message + some other lotus VM bits
+	assert.Equal(t, uint8(0), msgReceipt.ExitCode)
+	assert.Empty(t, msgReceipt.ReturnValue)
+	assert.Equal(t, state.GasUnit(expectedGasUsed), msgReceipt.GasUsed)
+
+	drv.AssertBalance(alice, uint64(1950 - expectedGasUsed))
+	drv.AssertBalance(bob, 50)
+	// This should become non-zero after gas tracking and payments are integrated.
+	drv.AssertBalance(miner, uint64(expectedGasUsed))
 
 }

--- a/chain/validation/lotus_test.go
+++ b/chain/validation/lotus_test.go
@@ -18,10 +18,7 @@ func TestLotusExample(t *testing.T) {
 	factory := NewFactories()
 	drv := suites.NewStateDriver(t, factory.NewState())
 
-	// create the init actor
-	initActorAddress, err := state.NewIDAddress(0)
-	require.NoError(t, err)
-	_, _, err = drv.State().SetActor(initActorAddress, state.InitActorCodeCid, state.AttoFIL(big.NewInt(0)))
+	_, _, err := drv.State().SetSingletonActor(state.InitAddress, big.NewInt(0))
 	require.NoError(t, err)
 
 	alice := drv.NewAccountActor(2000)

--- a/chain/validation/message.go
+++ b/chain/validation/message.go
@@ -57,6 +57,10 @@ func (mf *MessageFactory) MakeMessage(from, to state.Address, method chain.Metho
 	return msg, nil
 }
 
+func (mf *MessageFactory) FromSingletonAddress(addr state.SingletonActorAddress) (state.Address, error) {
+	return fromSingletonAddress(addr)
+}
+
 // Maps method enumeration values to method names.
 // This will change to a mapping to method ids when method dispatch is updated to use integers.
 var methods = []uint64{

--- a/chain/validation/message.go
+++ b/chain/validation/message.go
@@ -57,7 +57,7 @@ func (mf *MessageFactory) MakeMessage(from, to state.Address, method chain.Metho
 	return msg, nil
 }
 
-func (mf *MessageFactory) FromSingletonAddress(addr state.SingletonActorAddress) (state.Address, error) {
+func (mf *MessageFactory) FromSingletonAddress(addr state.SingletonActorAddress) (state.Address) {
 	return fromSingletonAddress(addr)
 }
 

--- a/chain/validation/message.go
+++ b/chain/validation/message.go
@@ -57,7 +57,7 @@ func (mf *MessageFactory) MakeMessage(from, to state.Address, method chain.Metho
 	return msg, nil
 }
 
-func (mf *MessageFactory) FromSingletonAddress(addr state.SingletonActorAddress) (state.Address) {
+func (mf *MessageFactory) FromSingletonAddress(addr state.SingletonActorID) (state.Address) {
 	return fromSingletonAddress(addr)
 }
 

--- a/chain/validation/message_test.go
+++ b/chain/validation/message_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-lotus/chain/actors"
 	"github.com/filecoin-project/go-lotus/chain/types"
 	"github.com/filecoin-project/go-lotus/chain/wallet"
 )
@@ -34,6 +35,6 @@ func TestMessageFactory(t *testing.T) {
 	msg := m.(*types.Message)
 	assert.Equal(t, m, msg)
 	assert.Equal(t, sender, msg.From)
-	assert.Equal(t, state.BurntFundsAddress, state.Address(msg.To.Bytes()))
+	assert.Equal(t, actors.BurntFundsAddress, msg.To)
 	assert.Equal(t, types.NewInt(1), msg.Value)
 }

--- a/chain/validation/message_test.go
+++ b/chain/validation/message_test.go
@@ -27,9 +27,7 @@ func TestMessageFactory(t *testing.T) {
 	sender, err := wallet.GenerateKey(types.KTSecp256k1)
 	require.NoError(t, err)
 
-	bfAddr, err := factory.FromSingletonAddress(state.BurntFundsAddress)
-	require.NoError(t, err)
-
+	bfAddr := factory.FromSingletonAddress(state.BurntFundsAddress)
 	m, err := p.Transfer(state.Address(sender.Bytes()), bfAddr,0, 1)
 	require.NoError(t, err)
 

--- a/chain/validation/message_test.go
+++ b/chain/validation/message_test.go
@@ -18,15 +18,15 @@ func TestMessageFactory(t *testing.T) {
 	wallet, err := wallet.NewWallet(ks)
 	require.NoError(t, err)
 	factory := NewMessageFactory(wallet)
-	p := chain.NewMessageProducer(factory)
 
 	gasPrice := big.NewInt(1)
 	gasLimit := state.GasUnit(1000)
+	p := chain.NewMessageProducer(factory, gasLimit, gasPrice)
 
 	sender, err := wallet.GenerateKey(types.KTSecp256k1)
 
 	require.NoError(t, err)
-	m, err := p.Transfer(state.Address(sender.Bytes()), state.BurntFundsAddress, big.NewInt(1), gasPrice, gasLimit)
+	m, err := p.Transfer(state.Address(sender.Bytes()), state.BurntFundsAddress,0, 1)
 	require.NoError(t, err)
 
 	messages := p.Messages()
@@ -34,6 +34,6 @@ func TestMessageFactory(t *testing.T) {
 	msg := m.(*types.Message)
 	assert.Equal(t, m, msg)
 	assert.Equal(t, sender, msg.From)
-	assert.Equal(t, state.BurntFundsAddress, msg.To)
+	assert.Equal(t, state.BurntFundsAddress, state.Address(msg.To.Bytes()))
 	assert.Equal(t, types.NewInt(1), msg.Value)
 }

--- a/chain/validation/message_test.go
+++ b/chain/validation/message_test.go
@@ -25,9 +25,12 @@ func TestMessageFactory(t *testing.T) {
 	p := chain.NewMessageProducer(factory, gasLimit, gasPrice)
 
 	sender, err := wallet.GenerateKey(types.KTSecp256k1)
-
 	require.NoError(t, err)
-	m, err := p.Transfer(state.Address(sender.Bytes()), state.BurntFundsAddress,0, 1)
+
+	bfAddr, err := factory.FromSingletonAddress(state.BurntFundsAddress)
+	require.NoError(t, err)
+
+	m, err := p.Transfer(state.Address(sender.Bytes()), bfAddr,0, 1)
 	require.NoError(t, err)
 
 	messages := p.Messages()

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -47,8 +47,6 @@ func NewState() *StateWrapper {
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	cst := hamt.CSTFromBstore(bs)
 	// Put EmptyObjectCid value in the store. When an actor is initially created its Head is set to this value.
-	// Normally this happens in chain/vm/mkactor.go's init function. Without this flushing the state tree fails as this
-	// CID is not found in the store.
 	_, err := cst.Put(context.TODO(), map[string]string{})
 	if err != nil {
 		panic(err)
@@ -118,9 +116,6 @@ func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeID, ba
 
 func (s *StateWrapper) SetSingletonActor(addr vstate.SingletonActorID, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error){
 	vaddr := fromSingletonAddress(addr)
-	if err != nil {
-		return nil, nil, err
-	}
 	tree, err := state.LoadStateTree(s.cst, s.stateRoot)
 	if err != nil {
 		return nil, nil, err

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -94,7 +94,7 @@ func (s *StateWrapper) NewAccountAddress() (vstate.Address, error) {
 	return s.keys.NewAddress()
 }
 
-func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeCid, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error) {
+func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeID, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error) {
 	addrInt, err := address.NewFromBytes([]byte(addr))
 	if err != nil {
 		return nil, nil, err
@@ -120,7 +120,7 @@ func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeCid, b
 	return actr, s.storage, s.flush(tree)
 }
 
-func (s *StateWrapper) SetSingletonActor(addr vstate.SingletonActorAddress, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error){
+func (s *StateWrapper) SetSingletonActor(addr vstate.SingletonActorID, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error){
 	vaddr, err := fromSingletonAddress(addr)
 	if err != nil {
 		return nil, nil, err
@@ -277,7 +277,7 @@ func (d *directStorage) Get(cid cid.Cid) ([]byte, error) {
 	panic("implement me")
 }
 
-func fromActorCode(code vstate.ActorCodeCid) (cid.Cid, error) {
+func fromActorCode(code vstate.ActorCodeID) (cid.Cid, error) {
 	switch code {
 	case vstate.AccountActorCodeCid:
 		return actors.AccountActorCodeCid, nil
@@ -292,7 +292,7 @@ func fromActorCode(code vstate.ActorCodeCid) (cid.Cid, error) {
 	}
 }
 
-func fromSingletonAddress(addr vstate.SingletonActorAddress) (vstate.Address, error) {
+func fromSingletonAddress(addr vstate.SingletonActorID) (vstate.Address, error) {
 	switch addr {
 	case vstate.InitAddress:
 		return vstate.Address(actors.InitActorAddress.Bytes()), nil

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -154,8 +154,8 @@ func (s *keyStore) NewAddress() (vstate.Address, error) {
 	return vstate.Address(key.Address.Bytes()), nil
 }
 
-func (as *keyStore) Sign(ctx context.Context, addr address.Address, data []byte) (*types.Signature, error) {
-	ki, ok := as.keys[addr]
+func (s *keyStore) Sign(ctx context.Context, addr address.Address, data []byte) (*types.Signature, error) {
+	ki, ok := s.keys[addr]
 	if !ok {
 		return &types.Signature{}, fmt.Errorf("unknown address %v", addr)
 	}

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -46,6 +46,14 @@ var _ vstate.Wrapper = &StateWrapper{}
 func NewState() *StateWrapper {
 	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
 	cst := hamt.CSTFromBstore(bs)
+	// Put EmptyObjectCid value in the store. When an actor is initially created its Head is set to this value.
+	// Normally this happens in chain/vm/mkactor.go's init function. Without this flushing the state tree fails as this
+	// CID is not found in the store.
+	_, err := cst.Put(context.TODO(), map[string]string{})
+	if err != nil {
+		panic(err)
+	}
+
 	treeImpl, err := state.NewStateTree(cst)
 	if err != nil {
 		panic(err) // Never returns error, the error return should be removed.

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -99,16 +99,12 @@ func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeID, ba
 	if err != nil {
 		return nil, nil, err
 	}
-	lotusCode, err := fromActorCode(code)
-	if err != nil {
-		return nil, nil, err
-	}
 	tree, err := state.LoadStateTree(s.cst, s.stateRoot)
 	if err != nil {
 		return nil, nil, err
 	}
 	actr := &actorWrapper{types.Actor{
-		Code:    lotusCode,
+		Code:    fromActorCode(code),
 		Balance: types.BigInt{balance},
 		Head:    vm.EmptyObjectCid,
 	}}
@@ -121,7 +117,7 @@ func (s *StateWrapper) SetActor(addr vstate.Address, code vstate.ActorCodeID, ba
 }
 
 func (s *StateWrapper) SetSingletonActor(addr vstate.SingletonActorID, balance vstate.AttoFIL) (vstate.Actor, vstate.Storage, error){
-	vaddr, err := fromSingletonAddress(addr)
+	vaddr := fromSingletonAddress(addr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -277,32 +273,32 @@ func (d *directStorage) Get(cid cid.Cid) ([]byte, error) {
 	panic("implement me")
 }
 
-func fromActorCode(code vstate.ActorCodeID) (cid.Cid, error) {
+func fromActorCode(code vstate.ActorCodeID) cid.Cid {
 	switch code {
 	case vstate.AccountActorCodeCid:
-		return actors.AccountActorCodeCid, nil
+		return actors.AccountActorCodeCid
 	case vstate.StorageMinerCodeCid:
-		return actors.StorageMinerCodeCid, nil
+		return actors.StorageMinerCodeCid
 	case vstate.MultisigActorCodeCid:
-		return actors.MultisigActorCodeCid, nil
+		return actors.MultisigActorCodeCid
 	case vstate.PaymentChannelActorCodeCid:
-		return actors.PaymentChannelActorCodeCid, nil
+		return actors.PaymentChannelActorCodeCid
 	default:
-		return cid.Undef, errors.Errorf("Unknown actor code: %v", code)
+		panic(fmt.Errorf("unknown actor code: %v", code))
 	}
 }
 
-func fromSingletonAddress(addr vstate.SingletonActorID) (vstate.Address, error) {
+func fromSingletonAddress(addr vstate.SingletonActorID) vstate.Address {
 	switch addr {
 	case vstate.InitAddress:
-		return vstate.Address(actors.InitActorAddress.Bytes()), nil
+		return vstate.Address(actors.InitActorAddress.Bytes())
 	case vstate.NetworkAddress:
-		return vstate.Address(actors.NetworkAddress.Bytes()), nil
+		return vstate.Address(actors.NetworkAddress.Bytes())
 	case vstate.StorageMarketAddress:
-		return vstate.Address(actors.StorageMarketAddress.Bytes()), nil
+		return vstate.Address(actors.StorageMarketAddress.Bytes())
 	case vstate.BurntFundsAddress:
-		return vstate.Address(actors.BurntFundsAddress.Bytes()), nil
+		return vstate.Address(actors.BurntFundsAddress.Bytes())
 	default:
-		return "", errors.Errorf("Unknown singleton actor address: %v", addr)
+		panic(fmt.Errorf("unknown singleton actor address: %v", addr))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/ipfs/go-bitswap v0.1.8
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c
-	github.com/ipfs/go-car v0.0.1
+	github.com/ipfs/go-car v0.0.2
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-datastore v0.1.0
 	github.com/ipfs/go-ds-badger v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba
 	github.com/whyrusleeping/cbor-gen v0.0.0-20191001154818-b4b5288fcb86
+	github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	github.com/whyrusleeping/pubsub v0.0.0-20131020042734-02de8aa2db3d
 	go.opencensus.io v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -221,7 +221,10 @@ github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c h1:lN5IQA07
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c/go.mod h1:t+411r7psEUhLueM8C7aPA7cxCclv4O3VsUVxt9kz2I=
 github.com/ipfs/go-car v0.0.0-20190823083746-79984a8632b4 h1:qYLz/x/d1SOiiFGS8dwCBCFJ5Oh64Y8HMBrS+MbaU8c=
 github.com/ipfs/go-car v0.0.0-20190823083746-79984a8632b4/go.mod h1:NSSM0pxlhej9rSFXQmB/lDru7TYNoDjKgmvqzlsd06Y=
+github.com/ipfs/go-car v0.0.1 h1:Nn3RjJbysnDud4wILAybzOAvzsaycrCoKM4BMIK0Y04=
 github.com/ipfs/go-car v0.0.1/go.mod h1:pUz3tUIpudsTch0ZQrEPOvNUBT1LufCXg8aZ4KOrEMM=
+github.com/ipfs/go-car v0.0.2 h1:j02lzgeijorstzoMl3nQmvvb8wjJUVCiOAl8XEwYMCQ=
+github.com/ipfs/go-car v0.0.2/go.mod h1:60pzeu308k5kVFHzq0HIi2kPtITgor+1ll1xuGk5JwQ=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3 h1:UIAh32wymBpStoe83YCzwVQQ5Oy/H0FdxvUS6DJDzms=


### PR DESCRIPTION
### Motivation
Sketch a simple integration with the `github.com/filecoin-project/chain-validation package`, to help surface any issues with its current design.

### Implementation & Notes
This PR despends on changes in https://github.com/filecoin-project/chain-validation/pull/8
A test, `TestLotusExample`, was added to creates some actors, transfers balance between them, and asserts success. This requires interaction with the Init actor and the setup required for it.

Looking for better options to:
- state tree updates: https://github.com/filecoin-project/lotus/pull/449/files#diff-173eebafb6fcc6d6702e21f1d357a334R59
- keeping state for message application: https://github.com/filecoin-project/lotus/pull/449/files#diff-117f4a49b352d3df7f1ac26284ec2f06R46