### PR TITLE
[wip] create miner test using the chain-validation package

### DIFF
--- a/chain/validation/lotus_test.go
+++ b/chain/validation/lotus_test.go
@@ -1,9 +1,12 @@
 package validation
 
 import (
+	"encoding/binary"
 	"math/big"
 	"testing"
 
+	"github.com/libp2p/go-libp2p-core/peer"
+	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -11,6 +14,9 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 	"github.com/filecoin-project/chain-validation/pkg/suites"
 )
+// Used to create the Network Address initial balance
+const FilecoinPrecision = 10000000000000000000
+const TotalFilecoin = 20000000000
 
 // A basic example validation test.
 // At present this code is verbose and demonstrates the opportunity for helper methods.
@@ -49,5 +55,63 @@ func TestLotusExample(t *testing.T) {
 	drv.AssertBalance(bob, 50)
 	// This should become non-zero after gas tracking and payments are integrated.
 	drv.AssertBalance(miner, uint64(expectedGasUsed))
+}
 
+func TestLotusMinerCreate(t *testing.T) {
+	factory := NewFactories()
+	drv := suites.NewStateDriver(t, factory.NewState())
+	gasPrice := big.NewInt(1)
+	gasLimit := state.GasUnit(2000) // needs to be over ~1100 for lotus operations
+	TotalNetworkBalance := big.NewInt(1).Mul(big.NewInt(TotalFilecoin), big.NewInt(0).SetUint64(FilecoinPrecision))
+
+	// create the init actor
+	_, _, err := drv.State().SetSingletonActor(state.InitAddress, big.NewInt(0))
+	require.NoError(t, err)
+	// then create network address
+	_, _, err = drv.State().SetSingletonActor(state.NetworkAddress, TotalNetworkBalance)
+	require.NoError(t, err)
+	// lastly, create storage market actor
+	_, _, err = drv.State().SetSingletonActor(state.StorageMarketAddress, big.NewInt(0))
+	require.NoError(t, err)
+
+
+	// miner that mines in this test
+	testMiner := drv.NewAccountActor(0)
+	// account that will own the miner
+	minerOwner := drv.NewAccountActor(20000000000)
+
+	producer := chain.NewMessageProducer(factory.NewMessageFactory(drv.State()), gasLimit, gasPrice)
+
+	sectorSize := big.NewInt(16 << 20)
+	publicKey := []byte{1} // lotus does not follow spec wrt miner publicKey
+
+	peerID := RequireIntPeerID(t, 1)
+	bpid, err := peerID.MarshalBinary()
+	require.NoError(t, err)
+
+	msg, err := producer.StoragePowerCreateStorageMiner(minerOwner, 0, minerOwner, publicKey, sectorSize, bpid, chain.Value(1000000))
+	require.NoError(t, err)
+
+	validator := chain.NewValidator(factory)
+	exeCtx := chain.NewExecutionContext(1, testMiner)
+
+	msgReceipt, err := validator.ApplyMessage(exeCtx, drv.State(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, msgReceipt)
+
+	expectedGasUsed := 1707 // NB: should be derived from the size of the message + some other lotus VM bits. Got this value by running the test and inspecting output
+	assert.Equal(t, uint8(0), msgReceipt.ExitCode)
+	assert.Equal(t, []byte{0, 102}, msgReceipt.ReturnValue)
+	assert.Equal(t, state.GasUnit(expectedGasUsed), msgReceipt.GasUsed)
+}
+
+// RequireIntPeerID takes in an integer and creates a unique peer id for it.
+func RequireIntPeerID(t *testing.T, i int64) peer.ID {
+	buf := make([]byte, 16)
+	n := binary.PutVarint(buf, i)
+	h, err := mh.Sum(buf[:n], mh.ID, -1)
+	require.NoError(t, err)
+	pid, err := peer.IDFromBytes(h)
+	require.NoError(t, err)
+	return pid
 }

--- a/chain/validation/types.go
+++ b/chain/validation/types.go
@@ -1,0 +1,123 @@
+package validation
+
+import(
+	"fmt"
+	"github.com/pkg/errors"
+
+	"github.com/filecoin-project/chain-validation/pkg/state"
+	"github.com/filecoin-project/go-lotus/chain/address"
+	"github.com/filecoin-project/go-lotus/chain/types"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+//
+// Most of the file is based on the abi/ package from go-filecoin.
+//
+var ErrInvalidType = fmt.Errorf("invalid type")
+
+type Type uint64
+
+const (
+	// Invalid is the default value for 'Type' and represents an erroneously set type.
+	Invalid = Type(iota)
+	Address
+	AttoFIL
+	PeerID
+)
+
+type Value struct {
+	Type Type
+	Val  interface{}
+}
+
+
+func ToEncodedValues(params ...interface{}) ([]byte, error) {
+	vals, err := ToValues(params)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert params to values")
+	}
+
+	bytes, err := EncodeValues(vals)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to encode values")
+	}
+
+	return bytes, nil
+}
+
+func ToValues(i []interface{}) ([]*Value, error) {
+	if len(i) == 0 {
+		return nil, nil
+	}
+	out := make([]*Value, 0, len(i))
+	for _, v := range i {
+		switch v := v.(type) {
+		case state.Address:
+			out = append(out, &Value{Type: Address, Val: v})
+		case state.AttoFIL:
+			out = append(out, &Value{Type: AttoFIL, Val: v})
+		case state.PeerID:
+			out = append(out, &Value{Type: PeerID, Val: v})
+		}
+	}
+	return out, nil
+}
+
+// EncodeValues encodes a set of values to raw bytes. Zero length arrays of
+// values are normalized to nil
+func EncodeValues(vals []*Value) ([]byte, error) {
+	if len(vals) == 0 {
+		return nil, nil
+	}
+
+	var arr [][]byte
+
+	for _, val := range vals {
+		data, err := val.Serialize()
+		if err != nil {
+			return nil, err
+		}
+
+		arr = append(arr, data)
+	}
+
+	return []byte{}, nil
+}
+
+type typeError struct {
+	exp interface{}
+	got interface{}
+}
+
+func (ate typeError) Error() string {
+	return fmt.Sprintf("expected type %T, got %T", ate.exp, ate.got)
+}
+
+
+func (av *Value) Serialize() ([]byte, error) {
+	switch av.Type {
+	case Invalid:
+		return nil, ErrInvalidType
+	case Address:
+		addr, ok := av.Val.(address.Address)
+		if !ok {
+			return nil, &typeError{address.Undef, av.Val}
+		}
+		return addr.Bytes(), nil
+	case AttoFIL:
+		ba, ok := av.Val.(types.BigInt)
+		if !ok {
+			return nil, &typeError{address.Undef, av.Val}
+		}
+		return ba.Bytes(), nil
+	case PeerID:
+		pid, ok := av.Val.(peer.ID)
+		if !ok {
+			return nil, &typeError{peer.ID(""), av.Val}
+		}
+		return []byte(pid), nil
+	default:
+		return nil, fmt.Errorf("unrecognized Type: %d", av.Type)
+	}
+}
+


### PR DESCRIPTION
### Motivation
Write a slightly more advanced test than #449 to surface implementation design and bugs

### Implementation
This PR depends on changes in filecoin-project/chain-validation#8 and https://github.com/filecoin-project/lotus/pull/449

Add a test creates a miner and asserts the message is applied successfully and take a first pass at reflection based serialization for message methods.

Looking for better options to:
- decoding parameters from chain-validation to message parameters in lotus messages: https://github.com/filecoin-project/lotus/pull/451/files#diff-01fd50106d58945045779fa80b1da646R64
- gas calculations after applying messages: https://github.com/filecoin-project/lotus/pull/451/files#diff-956a2f60b392c4fd4ca02d95b72b9578R113