### PR TITLE
Remove height tag from stats tool

### DIFF
--- a/tools/stats/main.go
+++ b/tools/stats/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -94,7 +93,6 @@ func main() {
 		// Instead of having to pass around a bunch of generic stuff we want for each point
 		// we will just add them at the end.
 
-		tsHeight := fmt.Sprintf("%d", tipset.Height())
 		tsTimestamp := time.Unix(int64(tipset.MinTimestamp()), int64(0))
 
 		nb, err := InfluxNewBatch()
@@ -103,7 +101,6 @@ func main() {
 		}
 
 		for _, pt := range pl.Points() {
-			pt.AddTag("height", tsHeight)
 			pt.SetTime(tsTimestamp)
 
 			nb.AddPoint(NewPointFrom(pt))


### PR DESCRIPTION
Having a height tags resulted in performance issues due to an increase in series cardinality.