### PR TITLE
Set swarm log level to WARN

### DIFF
--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -18,6 +18,8 @@ const FlagStorageRepo = "storagerepo"
 
 func main() {
 	logging.SetLogLevel("*", "INFO")
+	logging.SetLogLevel("swarm", "WARN")
+
 	local := []*cli.Command{
 		runCmd,
 		initCmd,

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -16,6 +16,8 @@ import (
 func main() {
 	logging.SetLogLevel("*", "INFO")
 	logging.SetLogLevel("dht", "ERROR")
+	logging.SetLogLevel("swarm", "WARN")
+
 	local := []*cli.Command{
 		DaemonCmd,
 	}


### PR DESCRIPTION
It's producing lots of spam along the lines of:
```
2019-10-30T03:10:43.631+0800    INFO    swarm2  go-libp2p-swarm@v0.2.1/swarm_dial.go:420    got error on dial: dial tcp4 0.0.0.0:33055->172.16.0.139:45435: i/o timeout

2019-10-30T03:10:43.631+0800    INFO    swarm2  go-libp2p-swarm@v0.2.1/swarm_dial.go:420    got error on dial: dial tcp6 [::1]:46173: connect: network is unreachable

2019-10-30T03:10:43.631+0800    INFO    swarm2  go-libp2p-swarm@v0.2.1/swarm_dial.go:420    got error on dial: dial tcp4 127.0.0.1:43987: connect: connection refused

2019-10-30T03:10:44.367+0800    INFO    swarm2  go-libp2p-swarm@v0.2.1/swarm_dial.go:420    got error on dial: dial tcp4 0.0.0.0:33055->192.168.1.32:37003: i/o timeout

2019-10-30T03:10:44.367+0800    INFO    swarm2  go-libp2p-swarm@v0.2.1/swarm_dial.go:393    got error on dial: dial tcp4 0.0.0.0:33055->172.17.0.1:37003: i/o timeout
```