### PR TITLE
uint64 to replace int in GetRandomness

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -52,7 +52,7 @@ type FullNode interface {
 	// First message is guaranteed to be of len == 1, and type == 'current'
 	ChainNotify(context.Context) (<-chan []*store.HeadChange, error)
 	ChainHead(context.Context) (*types.TipSet, error)
-	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, int) ([]byte, error)
+	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, uint64) ([]byte, error)
 	ChainGetBlock(context.Context, cid.Cid) (*types.BlockHeader, error)
 	ChainGetTipSet(context.Context, []cid.Cid) (*types.TipSet, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*BlockMessages, error)

--- a/api/struct.go
+++ b/api/struct.go
@@ -40,7 +40,7 @@ type FullNodeStruct struct {
 	Internal struct {
 		ChainNotify            func(context.Context) (<-chan []*store.HeadChange, error)                  `perm:"read"`
 		ChainHead              func(context.Context) (*types.TipSet, error)                               `perm:"read"`
-		ChainGetRandomness     func(context.Context, *types.TipSet, []*types.Ticket, int) ([]byte, error) `perm:"read"`
+		ChainGetRandomness     func(context.Context, *types.TipSet, []*types.Ticket, uint64) ([]byte, error) `perm:"read"`
 		ChainGetBlock          func(context.Context, cid.Cid) (*types.BlockHeader, error)                 `perm:"read"`
 		ChainGetTipSet         func(context.Context, []cid.Cid) (*types.TipSet, error)                    `perm:"read"`
 		ChainGetBlockMessages  func(context.Context, cid.Cid) (*BlockMessages, error)                     `perm:"read"`
@@ -240,7 +240,7 @@ func (c *FullNodeStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	return c.Internal.ChainHead(ctx)
 }
 
-func (c *FullNodeStruct) ChainGetRandomness(ctx context.Context, pts *types.TipSet, ticks []*types.Ticket, lb int) ([]byte, error) {
+func (c *FullNodeStruct) ChainGetRandomness(ctx context.Context, pts *types.TipSet, ticks []*types.Ticket, lb uint64) ([]byte, error) {
 	return c.Internal.ChainGetRandomness(ctx, pts, ticks, lb)
 }
 

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -360,7 +360,7 @@ func (cg *ChainGen) YieldRepo() (repo.Repo, error) {
 }
 
 type MiningCheckAPI interface {
-	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, int) ([]byte, error)
+	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, uint64) ([]byte, error)
 
 	StateMinerPower(context.Context, address.Address, *types.TipSet) (api.MinerPower, error)
 
@@ -374,8 +374,8 @@ type mca struct {
 	sm *stmgr.StateManager
 }
 
-func (mca mca) ChainGetRandomness(ctx context.Context, pts *types.TipSet, ticks []*types.Ticket, lb int) ([]byte, error) {
-	return mca.sm.ChainStore().GetRandomness(ctx, pts.Cids(), ticks, int64(lb))
+func (mca mca) ChainGetRandomness(ctx context.Context, pts *types.TipSet, ticks []*types.Ticket, lb uint64) ([]byte, error) {
+	return mca.sm.ChainStore().GetRandomness(ctx, pts.Cids(), ticks, lb)
 }
 
 func (mca mca) StateMinerPower(ctx context.Context, maddr address.Address, ts *types.TipSet) (api.MinerPower, error) {

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -70,7 +70,7 @@ func (vmc *VMContext) Message() *types.Message {
 
 func (vmc *VMContext) GetRandomness(height uint64) ([]byte, aerrors.ActorError) {
 
-	res, err := vmc.vm.rand.GetRandomness(vmc.ctx, int64(height))
+	res, err := vmc.vm.rand.GetRandomness(vmc.ctx, height)
 	if err != nil {
 		return nil, aerrors.Escalate(err, "could not get randomness")
 	}
@@ -329,7 +329,7 @@ func NewVM(base cid.Cid, height uint64, r Rand, maddr address.Address, cbs block
 }
 
 type Rand interface {
-	GetRandomness(ctx context.Context, h int64) ([]byte, error)
+	GetRandomness(ctx context.Context, h uint64) ([]byte, error)
 }
 
 type ApplyRet struct {

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -28,8 +28,8 @@ func (a *ChainAPI) ChainHead(context.Context) (*types.TipSet, error) {
 	return a.Chain.GetHeaviestTipSet(), nil
 }
 
-func (a *ChainAPI) ChainGetRandomness(ctx context.Context, pts *types.TipSet, tickets []*types.Ticket, lb int) ([]byte, error) {
-	return a.Chain.GetRandomness(ctx, pts.Cids(), tickets, int64(lb))
+func (a *ChainAPI) ChainGetRandomness(ctx context.Context, pts *types.TipSet, tickets []*types.Ticket, lb uint64) ([]byte, error) {
+	return a.Chain.GetRandomness(ctx, pts.Cids(), tickets, lb)
 }
 
 func (a *ChainAPI) ChainGetBlock(ctx context.Context, msg cid.Cid) (*types.BlockHeader, error) {

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -62,7 +62,7 @@ type storageMinerApi interface {
 
 	ChainHead(context.Context) (*types.TipSet, error)
 	ChainNotify(context.Context) (<-chan []*store.HeadChange, error)
-	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, int) ([]byte, error)
+	ChainGetRandomness(context.Context, *types.TipSet, []*types.Ticket, uint64) ([]byte, error)
 	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
 


### PR DESCRIPTION
`ChainGetRandomness` and `GetRandomness` functions are using int type for lookback parameters. Change it to uint64. It is for interoperability and also make it more reasonable, since it is for lookback, negative lookback is not allowed. 