### PR TITLE
only trim zeros to the right of the decimal

### DIFF
--- a/chain/types/bigint_test.go
+++ b/chain/types/bigint_test.go
@@ -32,3 +32,20 @@ func TestBigIntSerializationRoundTrip(t *testing.T) {
 
 	}
 }
+
+func TestFilRoundTrip(t *testing.T) {
+	testValues := []string{
+		"0", "1", "1.001", "100.10001", "101100", "5000.01", "5000",
+	}
+
+	for _, v := range testValues {
+		fval, err := ParseFIL(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if fval.String() != v {
+			t.Fatal("mismatch in values!", v, fval.String())
+		}
+	}
+}

--- a/chain/types/fil.go
+++ b/chain/types/fil.go
@@ -12,7 +12,10 @@ type FIL BigInt
 
 func (f FIL) String() string {
 	r := new(big.Rat).SetFrac(f.Int, big.NewInt(build.FilecoinPrecision))
-	return strings.TrimRight(r.FloatString(18), "0.")
+	if r.Sign() == 0 {
+		return "0"
+	}
+	return strings.TrimRight(strings.TrimRight(r.FloatString(18), "0"), ".")
 }
 
 func (f FIL) Format(s fmt.State, ch rune) {


### PR DESCRIPTION
previously balances were printed incorrectly because all zeros on the right were trimmed, even to the left of the decimal point.