### PR TITLE
fix linker failure for OpenCL lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ commands:
   prepare:
     steps:
       - checkout
+      - run: sudo apt-get update
+      - run: sudo apt-get install ocl-icd-opencl-dev
       - run: git submodule sync
       - run: git submodule update --init
   download-params:


### PR DESCRIPTION
This change fixes the CircleCI linker failure by installing the opencl lib via apt-get