### PR TITLE
cache bls signatures for later recovery during forks

### DIFF
--- a/build/params.go
+++ b/build/params.go
@@ -123,3 +123,7 @@ func init() {
 
 // Sync
 const BadBlockCacheSize = 8192
+
+// assuming 4000 blocks per round, this lets us not lose any messages across a
+// 10 block reorg. 
+const BlsSignatureCacheSize = 40000

--- a/chain/messagepool.go
+++ b/chain/messagepool.go
@@ -318,7 +318,6 @@ func (mp *MessagePool) HeadChange(revert []*types.TipSet, apply []*types.TipSet)
 }
 
 func (mp *MessagePool) RecoverSig(msg *types.Message) *types.SignedMessage {
-	// TODO: persist signatures for BLS messages for a little while in case of reorgs
 	val, ok := mp.blsSigCache.Get(msg.Cid())
 	if !ok {
 		return nil


### PR DESCRIPTION
currently when there is a fork/reorg, we lose bls messages because we don't have their signatures. This should help with that.