### PR TITLE
Include build/paramfetch.go in circle params checksum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,15 @@ commands:
       - restore_cache:
           name: Restore parameters cache
           keys: 
-            - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}'
+            - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
+            - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-'
             - 'v15-lotus-params-'
           paths:
             - /var/tmp/filecoin-proof-parameters/
       - run:  ./lotus fetch-params --include-test-params
       - save_cache:
           name: Save parameters cache
-          key: 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}'
+          key: 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
           paths:
             - /var/tmp/filecoin-proof-parameters/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ commands:
           keys: 
             - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
             - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-'
-            - 'v15-lotus-params-'
           paths:
             - /var/tmp/filecoin-proof-parameters/
       - run:  ./lotus fetch-params --include-test-params


### PR DESCRIPTION
and don't fallback to older parameters if parameters.json changes.