### PR TITLE
Don't reorg if parents don't change

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -370,6 +370,11 @@ func (cs *ChainStore) NearestCommonAncestor(a, b *types.TipSet) (*types.TipSet, 
 }
 
 func (cs *ChainStore) ReorgOps(a, b *types.TipSet) ([]*types.TipSet, []*types.TipSet, error) {
+	// Simple expansion of a tipset should not result in any reorg
+	if types.CidArrsEqual(a.Parents(), b.Parents()) && a.Height() == b.Height() {
+		return nil, nil, nil
+	}
+
 	left := a
 	right := b
 


### PR DESCRIPTION
We don't need to reorg if we're changing tipsets with the same parents and height, Since all the state anyone cares about is based on the parents, a change between any two tipsets sharing parents should be a noop