### PR TITLE
Feat/dt initiator cleanup

### DIFF
--- a/datatransfer/impl/graphsync/graphsync.go
+++ b/datatransfer/impl/graphsync/graphsync.go
@@ -112,9 +112,10 @@ func (impl *graphsyncImpl) OpenPushDataChannel(ctx context.Context, requestTo pe
 	if err != nil {
 		return datatransfer.ChannelID{}, err
 	}
-	// initiator = them, sender = me, receiver = them
+	// initiator = me, sender = me, receiver = them
 	chid := impl.createNewChannel(tid, baseCid, selector, voucher,
-		requestTo, impl.peerID, requestTo)
+		//requestTo, impl.peerID, requestTo)
+		impl.peerID, impl.peerID, requestTo)
 	return chid, nil
 }
 
@@ -126,9 +127,9 @@ func (impl *graphsyncImpl) OpenPullDataChannel(ctx context.Context, requestTo pe
 	if err != nil {
 		return datatransfer.ChannelID{}, err
 	}
-	// initiator = them, sender = them, receiver = me
+	// initiator = me, sender = them, receiver = me
 	chid := impl.createNewChannel(tid, baseCid, selector, voucher,
-		requestTo, requestTo, impl.peerID)
+		impl.peerID, requestTo, impl.peerID)
 	return chid, nil
 }
 
@@ -204,7 +205,7 @@ func (impl *graphsyncImpl) notifySubscribers(evt datatransfer.Event, cs datatran
 
 // get all in progress transfers
 func (impl *graphsyncImpl) InProgressChannels() map[datatransfer.ChannelID]datatransfer.ChannelState {
-	return nil
+	return impl.channels
 }
 
 // ReceiveRequest takes an incoming request, validates the voucher and processes the message.
@@ -294,7 +295,7 @@ func (receiver *graphsyncReceiver) ReceiveResponse(
 	chst := datatransfer.EmptyChannelState
 	if incoming.Accepted() {
 		chid := datatransfer.ChannelID{
-			Initiator: sender,
+			Initiator: receiver.impl.peerID,
 			ID:        incoming.TransferID(),
 		}
 		if chst = receiver.impl.getPullChannel(chid); chst != datatransfer.EmptyChannelState {

--- a/datatransfer/impl/graphsync/graphsync.go
+++ b/datatransfer/impl/graphsync/graphsync.go
@@ -134,8 +134,8 @@ func (impl *graphsyncImpl) OpenPullDataChannel(ctx context.Context, requestTo pe
 }
 
 // createNewChannel creates a new channel id and channel state and saves to channels
-func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid cid.Cid, selector ipld.Node, voucher datatransfer.Voucher, requestTo, dataSender, dataReceiver peer.ID) datatransfer.ChannelID {
-	chid := datatransfer.ChannelID{Initiator: requestTo, ID: tid}
+func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid cid.Cid, selector ipld.Node, voucher datatransfer.Voucher, initiator, dataSender, dataReceiver peer.ID) datatransfer.ChannelID {
+	chid := datatransfer.ChannelID{Initiator: initiator, ID: tid}
 	chst := datatransfer.ChannelState{Channel: datatransfer.NewChannel(0, baseCid, selector, voucher, dataSender, dataReceiver, 0)}
 	impl.channels[chid] = chst
 	return chid

--- a/datatransfer/impl/graphsync/graphsync.go
+++ b/datatransfer/impl/graphsync/graphsync.go
@@ -338,8 +338,8 @@ func nodeFromBytes(from []byte) (ipld.Node, error) {
 	return dagcbor.Decoder(ipldfree.NodeBuilder(), reader)
 }
 
-// TODO: implement a real transfer ID generator.
-// https://github.com/filecoin-project/go-data-transfer/issues/38
+// generateTransferID() generates a unique-to-runtime TransferID for use in creating
+// ChannelIDs
 func (impl *graphsyncImpl) generateTransferID() datatransfer.TransferID {
 	impl.lastTID++
 	return datatransfer.TransferID(impl.lastTID)

--- a/datatransfer/impl/graphsync/graphsync.go
+++ b/datatransfer/impl/graphsync/graphsync.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"reflect"
 
 	"github.com/ipfs/go-cid"
@@ -53,6 +52,8 @@ type graphsyncImpl struct {
 	validatedTypes      map[string]validateType
 	channels            map[datatransfer.ChannelID]datatransfer.ChannelState
 	gs                  graphsync.GraphExchange
+	peerID              peer.ID
+	lastTID             int64
 }
 
 type graphsyncReceiver struct {
@@ -69,6 +70,8 @@ func NewGraphSyncDataTransfer(parent context.Context, host host.Host, gs graphsy
 		make(map[string]validateType),
 		make(map[datatransfer.ChannelID]datatransfer.ChannelState),
 		gs,
+		host.ID(),
+		0,
 	}
 	receiver := &graphsyncReceiver{parent, impl}
 	dataTransferNetwork.SetDelegate(receiver)
@@ -104,31 +107,35 @@ func (impl *graphsyncImpl) RegisterVoucherType(voucherType reflect.Type, validat
 
 // OpenPushDataChannel opens a data transfer that will send data to the recipient peer and
 // transfer parts of the piece that match the selector
-func (impl *graphsyncImpl) OpenPushDataChannel(ctx context.Context, to peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) (datatransfer.ChannelID, error) {
-	tid, err := impl.sendRequest(ctx, selector, false, voucher, baseCid, to)
+func (impl *graphsyncImpl) OpenPushDataChannel(ctx context.Context, requestTo peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) (datatransfer.ChannelID, error) {
+	tid, err := impl.sendRequest(ctx, selector, false, voucher, baseCid, requestTo)
 	if err != nil {
 		return datatransfer.ChannelID{}, err
 	}
-	chid := impl.createNewChannel(tid, baseCid, selector, voucher, to, "", to)
+	// initiator = them, sender = me, receiver = them
+	chid := impl.createNewChannel(tid, baseCid, selector, voucher,
+		requestTo, impl.peerID, requestTo)
 	return chid, nil
 }
 
 // OpenPullDataChannel opens a data transfer that will request data from the sending peer and
 // transfer parts of the piece that match the selector
-func (impl *graphsyncImpl) OpenPullDataChannel(ctx context.Context, to peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) (datatransfer.ChannelID, error) {
+func (impl *graphsyncImpl) OpenPullDataChannel(ctx context.Context, requestTo peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) (datatransfer.ChannelID, error) {
 
-	tid, err := impl.sendRequest(ctx, selector, true, voucher, baseCid, to)
+	tid, err := impl.sendRequest(ctx, selector, true, voucher, baseCid, requestTo)
 	if err != nil {
 		return datatransfer.ChannelID{}, err
 	}
-	chid := impl.createNewChannel(tid, baseCid, selector, voucher, to, to, "")
+	// initiator = them, sender = them, receiver = me
+	chid := impl.createNewChannel(tid, baseCid, selector, voucher,
+		requestTo, requestTo, impl.peerID)
 	return chid, nil
 }
 
 // createNewChannel creates a new channel id and channel state and saves to channels
-func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid cid.Cid, selector ipld.Node, voucher datatransfer.Voucher, to, sender, receiver peer.ID) datatransfer.ChannelID {
-	chid := datatransfer.ChannelID{To: to, ID: tid}
-	chst := datatransfer.ChannelState{Channel: datatransfer.NewChannel(0, baseCid, selector, voucher, sender, receiver, 0)}
+func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid cid.Cid, selector ipld.Node, voucher datatransfer.Voucher, requestTo, dataSender, dataReceiver peer.ID) datatransfer.ChannelID {
+	chid := datatransfer.ChannelID{Initiator: requestTo, ID: tid}
+	chst := datatransfer.ChannelState{Channel: datatransfer.NewChannel(0, baseCid, selector, voucher, dataSender, dataReceiver, 0)}
 	impl.channels[chid] = chst
 	return chid
 }
@@ -287,8 +294,8 @@ func (receiver *graphsyncReceiver) ReceiveResponse(
 	chst := datatransfer.EmptyChannelState
 	if incoming.Accepted() {
 		chid := datatransfer.ChannelID{
-			To: sender,
-			ID: incoming.TransferID(),
+			Initiator: sender,
+			ID:        incoming.TransferID(),
 		}
 		if chst = receiver.impl.getPullChannel(chid); chst != datatransfer.EmptyChannelState {
 			baseCid := chst.BaseCID()
@@ -306,7 +313,7 @@ func (receiver *graphsyncReceiver) ReceiveResponse(
 //   * it is not related to a pull request
 func (impl *graphsyncImpl) getPullChannel(chid datatransfer.ChannelID) datatransfer.ChannelState {
 	channelState, ok := impl.channels[chid]
-	if !ok || channelState.Sender() == "" {
+	if !ok || channelState.Sender() == impl.peerID {
 		return datatransfer.EmptyChannelState
 	}
 	return channelState
@@ -333,5 +340,6 @@ func nodeFromBytes(from []byte) (ipld.Node, error) {
 // TODO: implement a real transfer ID generator.
 // https://github.com/filecoin-project/go-data-transfer/issues/38
 func (impl *graphsyncImpl) generateTransferID() datatransfer.TransferID {
-	return datatransfer.TransferID(rand.Int31())
+	impl.lastTID++
+	return datatransfer.TransferID(impl.lastTID)
 }

--- a/datatransfer/impl/graphsync/graphsync_test.go
+++ b/datatransfer/impl/graphsync/graphsync_test.go
@@ -1422,7 +1422,7 @@ func (fgs *fakeGraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link
 	close(errors)
 	return responses, errors
 }
-
+// RegisterResponseReceivedHook adds a hook that runs when a request is received
 func (fgs *fakeGraphSync)RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
 	return nil
 }

--- a/datatransfer/impl/graphsync/graphsync_test.go
+++ b/datatransfer/impl/graphsync/graphsync_test.go
@@ -134,7 +134,7 @@ func TestDataTransferOneWay(t *testing.T) {
 		channelID, err := dt.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, stor)
 		require.NoError(t, err)
 		require.NotNil(t, channelID)
-		require.Equal(t, channelID.To, host2.ID())
+		require.Equal(t, channelID.Initiator, host2.ID())
 		require.NoError(t, err)
 
 		var messageReceived receivedMessage
@@ -179,7 +179,7 @@ func TestDataTransferOneWay(t *testing.T) {
 		channelID, err := dt.OpenPullDataChannel(ctx, host2.ID(), &voucher, baseCid, stor)
 		require.NoError(t, err)
 		require.NotNil(t, channelID)
-		require.Equal(t, channelID.To, host2.ID())
+		require.Equal(t, channelID.Initiator, host2.ID())
 		require.NoError(t, err)
 
 		var messageReceived receivedMessage
@@ -280,7 +280,9 @@ func TestDataTransferValidation(t *testing.T) {
 
 		voucher := fakeDTType{"applesauce"}
 		baseCid := testutil.GenerateCids(1)[0]
-		dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		require.NoError(t, err)
+
 		var validation receivedValidation
 		select {
 		case <-ctx.Done():
@@ -303,7 +305,7 @@ func TestDataTransferValidation(t *testing.T) {
 		channelID, err := dt1.OpenPullDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
 		require.NoError(t, err)
 
-		assert.Equal(t, channelID.To, host2.ID())
+		assert.Equal(t, channelID.Initiator, host2.ID())
 
 		var validation receivedValidation
 		select {
@@ -1412,7 +1414,11 @@ func (fgs *fakeGraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link
 	return responses, errors
 }
 
-// RegisterExtension adds a user supplied extension with the given extension config
-func (fgs *fakeGraphSync) RegisterExtension(config graphsync.ExtensionConfig) error {
+func (fgs *fakeGraphSync)RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	return nil
+}
+
+// RegisterResponseReceivedHook adds a hook that runs when a response is received
+func (fgs *fakeGraphSync)RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
 	return nil
 }

--- a/datatransfer/impl/graphsync/graphsync_whitebox_test.go
+++ b/datatransfer/impl/graphsync/graphsync_whitebox_test.go
@@ -176,8 +176,13 @@ func (fgs *fakeGraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link
 	return responses, errors
 }
 
-// RegisterExtension adds a user supplied extension with the given extension config
-func (fgs *fakeGraphSync) RegisterExtension(config graphsync.ExtensionConfig) error {
+// RegisterResponseReceivedHook adds a hook that runs when a request is received
+func (fgs *fakeGraphSync)RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	return nil
+}
+
+// RegisterResponseReceivedHook adds a hook that runs when a response is received
+func (fgs *fakeGraphSync)RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
 	return nil
 }
 

--- a/datatransfer/types.go
+++ b/datatransfer/types.go
@@ -46,8 +46,8 @@ type TransferID uint64
 // ChannelID is a unique identifier for a channel, distinct by both the other
 // party's peer ID + the transfer ID
 type ChannelID struct {
-	To peer.ID
-	ID TransferID
+	Initiator peer.ID
+	ID        TransferID
 }
 
 // Channel represents all the parameters for a single data transfer

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ipfs/go-ds-badger v0.0.5
 	github.com/ipfs/go-filestore v0.0.2
 	github.com/ipfs/go-fs-lock v0.0.1
-	github.com/ipfs/go-graphsync v0.0.4-0.20191113083505-1031418ebc59
+	github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e
 	github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456
 	github.com/ipfs/go-ipfs-blockstore v0.1.0
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/ipfs/go-filestore v0.0.2 h1:pcYwpjtXXwirtbjBXKVJM9CTa9F7/8v1EkfnDaHTO
 github.com/ipfs/go-filestore v0.0.2/go.mod h1:KnZ41qJsCt2OX2mxZS0xsK3Psr0/oB93HMMssLujjVc=
 github.com/ipfs/go-fs-lock v0.0.1 h1:XHX8uW4jQBYWHj59XXcjg7BHlHxV9ZOYs6Y43yb7/l0=
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
-github.com/ipfs/go-graphsync v0.0.4-0.20191113083505-1031418ebc59 h1:YdU3KjDhLhP5QpJVG2qXbkhKrO4wfN7Tf9H4abutL8c=
-github.com/ipfs/go-graphsync v0.0.4-0.20191113083505-1031418ebc59/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
+github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e h1:8rfC0Hz6+fsPnOuZIunD/1h09LucIs5HPw8VQ/wXVy0=
+github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e/go.mod h1:qgStQzFVR9yhotzhTdDQkReleXPxzPXqz4tUIMUQa5A=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456 h1:I0DHyyygfm9fxWK3dZ6XAXBHVY2u93ske4kprAmm4og=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456/go.mod h1:oVAOWGetjaaAPloFDCudyhxofsSG/WijXMJLTA0kRhM=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
@@ -233,6 +233,7 @@ github.com/ipfs/go-merkledag v0.2.4 h1:ZSHQSe9BENfixUjT+MaLeHEeZGxrZQfgo3KT3SLos
 github.com/ipfs/go-merkledag v0.2.4/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
+github.com/ipfs/go-peertaskqueue v0.0.4/go.mod h1:03H8fhyeMfKNFWqzYEVyMbcPUeYrqP1MX6Kd+aN+rMQ=
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
 github.com/ipfs/go-peertaskqueue v0.1.1 h1:+gPjbI+V3NktXZOqJA1kzbms2pYmhjgQQal0MzZrOAY=
 github.com/ipfs/go-peertaskqueue v0.1.1/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
@@ -242,10 +243,9 @@ github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb h1:tmWYgjltxwM7PD
 github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb/go.mod h1:IwAAgul1UQIcNZzKPYZWOCijryFBeCV79cNubPzol+k=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
+github.com/ipld/go-ipld-prime v0.0.2-0.20191025153308-092ea9a7696d/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785 h1:fASnkvtR+SmB2y453RxmDD3Uvd4LonVUgFGk9JoDaZs=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
-github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5 h1:lSip43rAdyGA+yRQuy6ju0ucZkWpYc1F2CTQtZTVW/4=
-github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.4/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
@@ -324,6 +324,7 @@ github.com/libp2p/go-libp2p-core v0.2.0/go.mod h1:X0eyB0Gy93v0DZtSYbEM7RnMChm9Uv
 github.com/libp2p/go-libp2p-core v0.2.2 h1:Sv1ggdoMx9c7v7FOFkR7agraHCnAgqYsXrU1ARSRUMs=
 github.com/libp2p/go-libp2p-core v0.2.2/go.mod h1:8fcwTbsG2B+lTgRJ1ICZtiM5GWCWZVoVrLaDRvIRng0=
 github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
+github.com/libp2p/go-libp2p-crypto v0.0.2/go.mod h1:eETI5OUfBnvARGOHrJz2eWNyTUxEGZnBxMcbUjfIj4I=
 github.com/libp2p/go-libp2p-crypto v0.1.0 h1:k9MFy+o2zGDNGsaoZl0MA3iZ75qXxr9OOoAZF+sD5OQ=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0 h1:j+R6cokKcGbnZLf4kcNwpx6mDEUPF3N6SrqMymQhmvs=
@@ -349,6 +350,7 @@ github.com/libp2p/go-libp2p-net v0.0.1/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8
 github.com/libp2p/go-libp2p-netutil v0.1.0 h1:zscYDNVEcGxyUpMd0JReUZTrpMfia8PmLKcKF72EAMQ=
 github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCThNdbQD54k3TqjpbFU=
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
+github.com/libp2p/go-libp2p-peer v0.1.1/go.mod h1:jkF12jGB4Gk/IOo+yomm+7oLWxF278F7UnrYUQ1Q8es=
 github.com/libp2p/go-libp2p-peer v0.2.0 h1:EQ8kMjaCUwt/Y5uLgjT8iY2qg0mGUT0N1zUjer50DsY=
 github.com/libp2p/go-libp2p-peer v0.2.0/go.mod h1:RCffaCvUyW2CJmG2gAWVqwePwW7JMgxjsHm7+J5kjWY=
 github.com/libp2p/go-libp2p-peerstore v0.0.1/go.mod h1:RabLyPVJLuNQ+GFyoEkfi8H4Ti6k/HtZJ7YKgtSq+20=


### PR DESCRIPTION
* ChannelID.To --> ChannelID.Initiator
* We now store our peer ID (from host.ID()) so it can be used when creating ChannelIDs.
* InProgressChannels returns all of impl.channels, currently just for testing
* Implements [go-data-transfer issue]( https://github.com/filecoin-project/go-data-transfer/issues/38)
* Some assertions were changed based on the above.
* Renamed some variables and added some assertions based on the new understanding
* Updated SHA for graphsync module
* Updated fakeGraphSync test structs to use new interfaces from new SHA above 