### PR TITLE
DTM sends data over graphsync for validated push requests

### DIFF
--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -1,6 +1,7 @@
 package graphsyncimpl
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -95,7 +96,7 @@ func (impl *graphsyncImpl) GsReqRecdHook(p peer.ID, request graphsync.RequestDat
 func (impl *graphsyncImpl) unmarshalExtensionData(data []byte) (*ExtensionDataTransferData, error) {
 	var extStruct ExtensionDataTransferData
 
-	reader := strings.NewReader(string(data[:]))
+	reader := bytes.NewReader(data)
 	if err := extStruct.UnmarshalCBOR(reader); err != nil {
 		return nil, err
 	}

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -66,7 +66,7 @@ func NewGraphSyncDataTransfer(parent context.Context, host host.Host, gs graphsy
 		host.ID(),
 		0,
 	}
-	if err := gs.RegisterRequestReceivedHook(true, impl.GsReqRecdHook); err != nil {
+	if err := gs.RegisterRequestReceivedHook(true, impl.gsReqRecdHook); err != nil {
 		log.Error(err)
 		return nil
 	}
@@ -75,9 +75,9 @@ func NewGraphSyncDataTransfer(parent context.Context, host host.Host, gs graphsy
 	return impl
 }
 
-// GsReqRecdHook is a graphsync.OnRequestReceivedHook hook
+// gsReqRecdHook is a graphsync.OnRequestReceivedHook hook
 // if an incoming request does not match a previous push request, it returns an error.
-func (impl *graphsyncImpl) GsReqRecdHook(p peer.ID, request graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+func (impl *graphsyncImpl) gsReqRecdHook(p peer.ID, request graphsync.RequestData) ([]graphsync.ExtensionData, error) {
 	var resp []graphsync.ExtensionData
 	chid, _, err := impl.getChannelIDAndData(request)
 
@@ -88,7 +88,7 @@ func (impl *graphsyncImpl) GsReqRecdHook(p peer.ID, request graphsync.RequestDat
 	if err != nil {
 		return resp, err
 	}
-	if !impl.HasPushChannel(chid) {
+	if !impl.hasPushChannel(chid) {
 		return resp, errors.New("could not find push channel")
 	}
 	resp = append(resp, extData)
@@ -266,13 +266,13 @@ func (impl *graphsyncImpl) InProgressChannels() map[datatransfer.ChannelID]datat
 	return channelsCopy
 }
 
-// HasPushChannel returns true if a channel with ID chid exists and is for a Push request.
-func (impl *graphsyncImpl) HasPushChannel(chid datatransfer.ChannelID) bool {
+// hasPushChannel returns true if a channel with ID chid exists and is for a Push request.
+func (impl *graphsyncImpl) hasPushChannel(chid datatransfer.ChannelID) bool {
 	return impl.getPushChannel(chid) != datatransfer.EmptyChannelState
 }
 
-// HasPullChannel returns true if a channel with ID chid exists and is for a Pull request.
-func (impl *graphsyncImpl) HasPullChannel(chid datatransfer.ChannelID) bool {
+// hasPullChannel returns true if a channel with ID chid exists and is for a Pull request.
+func (impl *graphsyncImpl) hasPullChannel(chid datatransfer.ChannelID) bool {
 	return impl.getPullChannel(chid) != datatransfer.EmptyChannelState
 }
 

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"reflect"
 
 	"github.com/filecoin-project/lotus/datatransfer"
 	"github.com/filecoin-project/lotus/datatransfer/message"

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -5,14 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
-	"strings"
-
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"reflect"
 
 	"github.com/filecoin-project/lotus/datatransfer"
 	"github.com/filecoin-project/lotus/datatransfer/message"

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -771,7 +771,6 @@ func (fgsr *fakeGraphSyncReceiver) Connected(p peer.ID) {
 func (fgsr *fakeGraphSyncReceiver) Disconnected(p peer.ID) {
 }
 
-// TODO: get passing to complete https://github.com/filecoin-project/go-data-transfer/issues/22
 func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	// create network
 	ctx := context.Background()

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -811,6 +811,8 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 		}
 		requestReceived := messageReceived.message.(message.DataTransferRequest)
 
+		time.Sleep(150*time.Millisecond)
+
 		var buf bytes.Buffer
 		extStruct := &ExtensionDataTransferData{TransferID: uint64(requestReceived.TransferID())}
 		err = extStruct.MarshalCBOR(&buf)

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -260,11 +260,11 @@ func TestDataTransferValidation(t *testing.T) {
 	gsData := newGraphsyncTestingData(t, ctx)
 	host1 := gsData.host1
 	host2 := gsData.host2
-
-	gs1 := &fakeGraphSync{
-		receivedRequests: make(chan receivedGraphSyncRequest, 1),
+	dtnet1 := network.NewFromLibp2pHost(host1)
+	r := &receiver{
+		messageReceived: make(chan receivedMessage),
 	}
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dtnet1.SetDelegate(r)
 
 	gs2 := &fakeGraphSync{
 		receivedRequests: make(chan receivedGraphSyncRequest, 1),
@@ -275,19 +275,20 @@ func TestDataTransferValidation(t *testing.T) {
 
 	err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), fv)
 	require.NoError(t, err)
+	id := datatransfer.TransferID(rand.Int31())
+	var buffer bytes.Buffer
+	err = dagcbor.Encoder(gsData.allSelector, &buffer)
+	require.NoError(t, err)
 
 	t.Run("ValidatePush", func(t *testing.T) {
 
 		voucher := fakeDTType{"applesauce"}
 		baseCid := testutil.GenerateCids(1)[0]
-		chid, err := dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		isPull := false
+		voucherBytes, err := voucher.ToBytes()
 		require.NoError(t, err)
-
-		assert.Equal(t, host1.ID(), chid.Initiator)
-		chs := dt1.InProgressChannels()
-		assert.Len(t, chs, 1)
-		assert.Equal(t, host2.ID(), chs[chid].Recipient())
-		assert.Equal(t, host1.ID(), chs[chid].Sender())
+		request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, baseCid, buffer.Bytes())
+		require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
 
 		var validation receivedValidation
 		select {
@@ -295,6 +296,12 @@ func TestDataTransferValidation(t *testing.T) {
 			t.Fatal("did not receive message sent")
 		case validation = <-fv.validationsReceived:
 			assert.False(t, validation.isPull)
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive message sent")
+		case _ = <-r.messageReceived:
 		}
 
 		assert.False(t, validation.isPull)
@@ -308,19 +315,22 @@ func TestDataTransferValidation(t *testing.T) {
 
 		voucher := fakeDTType{"applesauce"}
 		baseCid := testutil.GenerateCids(1)[0]
-		channelID, err := dt1.OpenPullDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		isPull := true
+		voucherBytes, err := voucher.ToBytes()
 		require.NoError(t, err)
-
-		assert.Equal(t, channelID.Initiator, host1.ID())
-		chs := dt1.InProgressChannels()
-		assert.Equal(t, host1.ID(), chs[channelID].Recipient())
-		assert.Equal(t, host2.ID(), chs[channelID].Sender())
+		request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, baseCid, buffer.Bytes())
+		require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
 
 		var validation receivedValidation
 		select {
 		case <-ctx.Done():
 			t.Fatal("did not receive message sent")
 		case validation = <-fv.validationsReceived:
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive message sent")
+		case _ = <-r.messageReceived:
 		}
 
 		assert.True(t, validation.isPull)
@@ -771,6 +781,21 @@ func (fgsr *fakeGraphSyncReceiver) Connected(p peer.ID) {
 func (fgsr *fakeGraphSyncReceiver) Disconnected(p peer.ID) {
 }
 
+func (fgsr *fakeGraphSyncReceiver) consumeResponses(ctx context.Context, t *testing.T) graphsync.ResponseStatusCode {
+	var gsMessageReceived receivedGraphSyncMessage
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive message sent")
+		case gsMessageReceived = <-fgsr.receivedMessages:
+			responses := gsMessageReceived.message.Responses()
+			if (len(responses) > 0) && gsmsg.IsTerminalResponseCode(responses[0].Status()) {
+				return responses[0].Status()
+			}
+		}
+	}
+}
+
 func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	// create network
 	ctx := context.Background()
@@ -780,9 +805,7 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	host1 := gsData.host1
 	host2 := gsData.host2
 	voucher := fakeDTType{"applesauce"}
-	baseBlock1 := blocks.NewBlock(testutil.RandomBytes(100))
-	err := gsData.bs1.Put(baseBlock1)
-	require.NoError(t, err)
+	link := gsData.loadUnixFSFile(t, false)
 
 	// setup receiving peer to just record message coming in
 	dtnet2 := network.NewFromLibp2pHost(host2)
@@ -800,7 +823,7 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
 
 	t.Run("when request is initiated", func(t *testing.T) {
-		_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseBlock1.Cid(), gsData.allSelector)
+		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, link.(cidlink.Link).Cid, gsData.allSelector)
 		require.NoError(t, err)
 
 		var messageReceived receivedMessage
@@ -811,8 +834,6 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 		}
 		requestReceived := messageReceived.message.(message.DataTransferRequest)
 
-		time.Sleep(150*time.Millisecond)
-
 		var buf bytes.Buffer
 		extStruct := &ExtensionDataTransferData{TransferID: uint64(requestReceived.TransferID())}
 		err = extStruct.MarshalCBOR(&buf)
@@ -820,11 +841,11 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 		extData := buf.Bytes()
 
 		var selBuf bytes.Buffer
-		err := dagcbor.Encoder(gsData.allSelector, &selBuf)
+		err = dagcbor.Encoder(gsData.allSelector, &selBuf)
 		require.NoError(t, err)
 		selectorBytes := selBuf.Bytes()
 
-		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), baseBlock1.Cid(), selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
 			Name: ExtensionDataTransfer,
 			Data: extData,
 		})
@@ -832,42 +853,31 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 		gsmessage.AddRequest(request)
 		require.NoError(t, gsData.gsNet2.SendMessage(ctx, host1.ID(), gsmessage))
 
-		var gsMessageReceived receivedGraphSyncMessage
-		select {
-		case <-ctx.Done():
-			t.Fatal("did not receive message sent")
-		case gsMessageReceived = <-gsr.receivedMessages:
-		}
-		response := gsMessageReceived.message.Responses()[0]
-		require.False(t, gsmsg.IsTerminalFailureCode(response.Status()))
+		status := gsr.consumeResponses(ctx, t)
+		require.False(t, gsmsg.IsTerminalFailureCode(status))
 	})
 
 	t.Run("when no request is initiated", func(t *testing.T) {
 		var buf bytes.Buffer
 		extStruct := &ExtensionDataTransferData{TransferID: rand.Uint64()}
-		err = extStruct.MarshalCBOR(&buf)
+		err := extStruct.MarshalCBOR(&buf)
 		require.NoError(t, err)
 		extData := buf.Bytes()
 
 		var selBuf bytes.Buffer
-		err := dagcbor.Encoder(gsData.allSelector, &selBuf)
+		err = dagcbor.Encoder(gsData.allSelector, &selBuf)
 		require.NoError(t, err)
 		selectorBytes := selBuf.Bytes()
-		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), baseBlock1.Cid(), selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
 			Name: ExtensionDataTransfer,
 			Data: extData,
 		})
 		gsmessage := gsmsg.New()
 		gsmessage.AddRequest(request)
 		require.NoError(t, gsData.gsNet2.SendMessage(ctx, host1.ID(), gsmessage))
-		var gsMessageReceived receivedGraphSyncMessage
-		select {
-		case <-ctx.Done():
-			t.Fatal("did not receive message sent")
-		case gsMessageReceived = <-gsr.receivedMessages:
-		}
-		response := gsMessageReceived.message.Responses()[0]
-		require.True(t, gsmsg.IsTerminalFailureCode(response.Status()))
+
+		status := gsr.consumeResponses(ctx, t)
+		require.True(t, gsmsg.IsTerminalFailureCode(status))
 	})
 }
 
@@ -897,12 +907,11 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 	// gs2 := gsData.setupGraphsyncHost2()
 
 	// voucher := fakeDTType{"applesauce"}
-	// baseBlock1 := blocks.NewBlock(testutil.RandomBytes(100))
-	// err := gsData.bs2.Put(baseBlock1)
-	// require.NoError(t, err)
+	// link := gsData.loadUnixFSFile(t, true)
+
 	// id := datatransfer.TransferID(rand.Int31())
 	// var buf bytes.Buffer
-	// err = dagcbor.Encoder(gsData.allSelector, &buf)
+	// err := dagcbor.Encoder(gsData.allSelector, &buf)
 	// require.NoError(t, err)
 	// selectorBytes := buf.Bytes()
 
@@ -916,7 +925,7 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 	// 	isPull := true
 	// 	voucherBytes, err := voucher.ToBytes()
 	// 	require.NoError(t, err)
-	// 	request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, baseBlock1.Cid(), selectorBytes)
+	// 	request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, link.(cidlink.Link).Cid, selectorBytes)
 	// 	require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
 	// 	var messageReceived receivedMessage
 	// 	select {
@@ -933,21 +942,15 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 	// 	err = extStruct.MarshalCBOR(&buf)
 	// 	require.NoError(t, err)
 	// 	extData := buf.Bytes()
-	// 	gsRequest := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), baseBlock1.Cid(), selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+	// 	gsRequest := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
 	// 		Name: ExtensionDataTransfer,
 	// 		Data: extData,
 	// 	})
 	// 	gsmessage := gsmsg.New()
 	// 	gsmessage.AddRequest(gsRequest)
 	// 	gsData.gsNet1.SendMessage(ctx, host1.ID(), gsmessage)
-	// 	var gsMessageReceived receivedGraphSyncMessage
-	// 	select {
-	// 	case <-ctx.Done():
-	// 		t.Fatal("did not receive message sent")
-	// 	case gsMessageReceived = <-gsr.receivedMessages:
-	// 	}
-	// 	response := gsMessageReceived.message.Responses()[0]
-	// 	require.False(t, gsmsg.IsTerminalFailureCode(response.Status()))
+	// 	status := gsr.consumeResponses(ctx, t)
+	// 	require.False(t, gsmsg.IsTerminalFailureCode(status))
 	// })
 
 	// // TODO: get passing to complete https://github.com/filecoin-project/go-data-transfer/issues/14
@@ -958,21 +961,15 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 	// 	err = extStruct.MarshalCBOR(&buf)
 	// 	require.NoError(t, err)
 	// 	extData := buf.Bytes()
-	// 	request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), baseBlock1.Cid(), selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+	// 	request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
 	// 		Name: ExtensionDataTransfer,
 	// 		Data: extData,
 	// 	})
 	// 	gsmessage := gsmsg.New()
 	// 	gsmessage.AddRequest(request)
 	// 	gsData.gsNet1.SendMessage(ctx, host1.ID(), gsmessage)
-	// 	var gsMessageReceived receivedGraphSyncMessage
-	// 	select {
-	// 	case <-ctx.Done():
-	// 		t.Fatal("did not receive message sent")
-	// 	case gsMessageReceived = <-gsr.receivedMessages:
-	// 	}
-	// 	response := gsMessageReceived.message.Responses()[0]
-	// 	require.True(t, gsmsg.IsTerminalFailureCode(response.Status()))
+	// 	status := gsr.consumeResponses(ctx, t)
+	// 	require.True(t, gsmsg.IsTerminalFailureCode(status))
 	// })
 }
 

--- a/datatransfer/message/message_test.go
+++ b/datatransfer/message/message_test.go
@@ -52,7 +52,7 @@ func TestTransferRequest_UnmarshalCBOR(t *testing.T) {
 	// use ToNet / FromNet
 	require.NoError(t, req.ToNet(wbuf))
 
-	desMsg, err := FromNet(strings.NewReader(wbuf.String()))
+	desMsg, err := FromNet(wbuf)
 	require.NoError(t, err)
 
 	// Verify round-trip
@@ -101,7 +101,7 @@ func TestTransferResponse_UnmarshalCBOR(t *testing.T) {
 	require.NoError(t, response.ToNet(wbuf))
 
 	// verify round trip
-	desMsg, err := FromNet(strings.NewReader(wbuf.String()))
+	desMsg, err := FromNet(wbuf)
 	require.NoError(t, err)
 	assert.False(t, desMsg.IsRequest())
 	assert.Equal(t, id, desMsg.TransferID())
@@ -121,7 +121,7 @@ func TestRequestCancel(t *testing.T) {
 	wbuf := new(bytes.Buffer)
 	require.NoError(t, req.ToNet(wbuf))
 
-	deserialized, err := FromNet(strings.NewReader(wbuf.String()))
+	deserialized, err := FromNet(wbuf)
 	require.NoError(t, err)
 
 	deserializedRequest, ok := deserialized.(DataTransferRequest)

--- a/datatransfer/message/message_test.go
+++ b/datatransfer/message/message_test.go
@@ -3,7 +3,6 @@ package message_test
 import (
 	"bytes"
 	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ipfs/go-ds-badger v0.0.5
 	github.com/ipfs/go-filestore v0.0.2
 	github.com/ipfs/go-fs-lock v0.0.1
-	github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e
+	github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d
 	github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456
 	github.com/ipfs/go-ipfs-blockstore v0.1.0
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/ipfs/go-filestore v0.0.2 h1:pcYwpjtXXwirtbjBXKVJM9CTa9F7/8v1EkfnDaHTO
 github.com/ipfs/go-filestore v0.0.2/go.mod h1:KnZ41qJsCt2OX2mxZS0xsK3Psr0/oB93HMMssLujjVc=
 github.com/ipfs/go-fs-lock v0.0.1 h1:XHX8uW4jQBYWHj59XXcjg7BHlHxV9ZOYs6Y43yb7/l0=
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
-github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e h1:8rfC0Hz6+fsPnOuZIunD/1h09LucIs5HPw8VQ/wXVy0=
-github.com/ipfs/go-graphsync v0.0.4-0.20191119222851-ebbe6562136e/go.mod h1:qgStQzFVR9yhotzhTdDQkReleXPxzPXqz4tUIMUQa5A=
+github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d h1:Ub6swp/fxj8G+E9Xy65UY6iN2HCregPQj2Rr9GdLwto=
+github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456 h1:I0DHyyygfm9fxWK3dZ6XAXBHVY2u93ske4kprAmm4og=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456/go.mod h1:oVAOWGetjaaAPloFDCudyhxofsSG/WijXMJLTA0kRhM=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
@@ -233,7 +233,6 @@ github.com/ipfs/go-merkledag v0.2.4 h1:ZSHQSe9BENfixUjT+MaLeHEeZGxrZQfgo3KT3SLos
 github.com/ipfs/go-merkledag v0.2.4/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
-github.com/ipfs/go-peertaskqueue v0.0.4/go.mod h1:03H8fhyeMfKNFWqzYEVyMbcPUeYrqP1MX6Kd+aN+rMQ=
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
 github.com/ipfs/go-peertaskqueue v0.1.1 h1:+gPjbI+V3NktXZOqJA1kzbms2pYmhjgQQal0MzZrOAY=
 github.com/ipfs/go-peertaskqueue v0.1.1/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
@@ -243,9 +242,10 @@ github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb h1:tmWYgjltxwM7PD
 github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb/go.mod h1:IwAAgul1UQIcNZzKPYZWOCijryFBeCV79cNubPzol+k=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
-github.com/ipld/go-ipld-prime v0.0.2-0.20191025153308-092ea9a7696d/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785 h1:fASnkvtR+SmB2y453RxmDD3Uvd4LonVUgFGk9JoDaZs=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
+github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5 h1:lSip43rAdyGA+yRQuy6ju0ucZkWpYc1F2CTQtZTVW/4=
+github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/jackpal/gateway v1.0.4/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
@@ -324,7 +324,6 @@ github.com/libp2p/go-libp2p-core v0.2.0/go.mod h1:X0eyB0Gy93v0DZtSYbEM7RnMChm9Uv
 github.com/libp2p/go-libp2p-core v0.2.2 h1:Sv1ggdoMx9c7v7FOFkR7agraHCnAgqYsXrU1ARSRUMs=
 github.com/libp2p/go-libp2p-core v0.2.2/go.mod h1:8fcwTbsG2B+lTgRJ1ICZtiM5GWCWZVoVrLaDRvIRng0=
 github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
-github.com/libp2p/go-libp2p-crypto v0.0.2/go.mod h1:eETI5OUfBnvARGOHrJz2eWNyTUxEGZnBxMcbUjfIj4I=
 github.com/libp2p/go-libp2p-crypto v0.1.0 h1:k9MFy+o2zGDNGsaoZl0MA3iZ75qXxr9OOoAZF+sD5OQ=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0 h1:j+R6cokKcGbnZLf4kcNwpx6mDEUPF3N6SrqMymQhmvs=
@@ -350,7 +349,6 @@ github.com/libp2p/go-libp2p-net v0.0.1/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8
 github.com/libp2p/go-libp2p-netutil v0.1.0 h1:zscYDNVEcGxyUpMd0JReUZTrpMfia8PmLKcKF72EAMQ=
 github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCThNdbQD54k3TqjpbFU=
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
-github.com/libp2p/go-libp2p-peer v0.1.1/go.mod h1:jkF12jGB4Gk/IOo+yomm+7oLWxF278F7UnrYUQ1Q8es=
 github.com/libp2p/go-libp2p-peer v0.2.0 h1:EQ8kMjaCUwt/Y5uLgjT8iY2qg0mGUT0N1zUjer50DsY=
 github.com/libp2p/go-libp2p-peer v0.2.0/go.mod h1:RCffaCvUyW2CJmG2gAWVqwePwW7JMgxjsHm7+J5kjWY=
 github.com/libp2p/go-libp2p-peerstore v0.0.1/go.mod h1:RabLyPVJLuNQ+GFyoEkfi8H4Ti6k/HtZJ7YKgtSq+20=
@@ -710,6 +708,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c h1:97SnQk1GYRXJgvwZ8fadnxDOWfKvkNQHH3CtZntPSrM=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/go.sum
+++ b/go.sum
@@ -105,7 +105,6 @@ github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
-github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Implements [go-data-transfer issue #22](https://github.com/filecoin-project/go-data-transfer/issues/22)

1. register push request hook with graphsync. 
1. create channels when a request is received. 
1. fix tests.
1. better NewReader instantiation