### PR TITLE
Feat/dt gs pullrequests

### DIFF
--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -203,8 +203,6 @@ func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid
 	impl.channelsLk.Lock()
 	impl.channels[chid] = chst
 	impl.channelsLk.Unlock()
-	fmt.Printf("\nour peer id: %s, chid initiator: %s, saved Base CID: %s\n\n",
-				impl.peerID.String(), chid.Initiator.String(), chst.BaseCID().String())
 	return chid
 }
 

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -81,7 +81,7 @@ func (impl *graphsyncImpl) gsReqRecdHook(p peer.ID, request graphsync.RequestDat
 	var resp []graphsync.ExtensionData
 
 	// if this is a push request the sender is us.
-	tid, err := impl.transferIDFromExtension(request, impl.peerID)
+	tid, err := impl.transferIDFromExtension(request)
 	if err != nil {
 		return resp, err
 	}
@@ -96,7 +96,7 @@ func (impl *graphsyncImpl) gsReqRecdHook(p peer.ID, request graphsync.RequestDat
 	if impl.getChannelByIdAndSender(chid, impl.peerID) == datatransfer.EmptyChannelState {
 
 		// otherwise check if it's a pull request: the initiator is them
-		tid, err = impl.transferIDFromExtension(request, p)
+		tid, err = impl.transferIDFromExtension(request)
 
 		chid = datatransfer.ChannelID{Initiator: p, ID: tid}
 		// sender is still us
@@ -115,7 +115,7 @@ type gsExtended interface {
 
 // transferIDFromExtension extracts extension data and creates a channel id then returns
 // both. Returns any errors.
-func (impl *graphsyncImpl) transferIDFromExtension(extendedData gsExtended, initiator peer.ID) (datatransfer.TransferID, error) {
+func (impl *graphsyncImpl) transferIDFromExtension(extendedData gsExtended) (datatransfer.TransferID, error) {
 	data, ok := extendedData.Extension(ExtensionDataTransfer)
 	zero := datatransfer.TransferID(0)
 	if !ok {

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -108,12 +108,12 @@ func (impl *graphsyncImpl) gsReqRecdHook(p peer.ID, request graphsync.RequestDat
 	return resp, nil
 }
 
-// gsExtended is a small interface used by constructChannelIDFromExtensionData
+// gsExtended is a small interface used by transferIDFromExtension
 type gsExtended interface {
 	Extension(name graphsync.ExtensionName) ([]byte, bool)
 }
 
-// constructChannelIDFromExtensionData extracts extension data and creates a channel id then returns
+// transferIDFromExtension extracts extension data and creates a channel id then returns
 // both. Returns any errors.
 func (impl *graphsyncImpl) transferIDFromExtension(extendedData gsExtended, initiator peer.ID) (datatransfer.TransferID, error) {
 	data, ok := extendedData.Extension(ExtensionDataTransfer)

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -209,7 +209,6 @@ func (impl *graphsyncImpl) createNewChannel(tid datatransfer.TransferID, baseCid
 	impl.channelsLk.Lock()
 	defer impl.channelsLk.Unlock()
 	_, ok := impl.channels[chid]
-	fmt.Printf("Me: %s, tid: %d, initiator: %s", impl.peerID.String(), tid, initiator.String())
 	if ok {
 		return chid, errors.New("tried to create channel but it already exists")
 	}

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
@@ -273,6 +274,16 @@ func (impl *graphsyncImpl) hasPushChannel(chid datatransfer.ChannelID) bool {
 
 // hasPullChannel returns true if a channel with ID chid exists and is for a Pull request.
 func (impl *graphsyncImpl) hasPullChannel(chid datatransfer.ChannelID) bool {
+	return impl.getPullChannel(chid) != datatransfer.EmptyChannelState
+}
+
+// HasPushChannel returns true if a channel with ID chid exists and is for a Push request.
+func (impl *graphsyncImpl) HasPushChannel(chid datatransfer.ChannelID) bool {
+	return impl.getPushChannel(chid) != datatransfer.EmptyChannelState
+}
+
+// HasPullChannel returns true if a channel with ID chid exists and is for a Pull request.
+func (impl *graphsyncImpl) HasPullChannel(chid datatransfer.ChannelID) bool {
 	return impl.getPullChannel(chid) != datatransfer.EmptyChannelState
 }
 

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -834,6 +834,8 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 		}
 		requestReceived := messageReceived.message.(message.DataTransferRequest)
 
+		time.Sleep(150*time.Millisecond)
+
 		var buf bytes.Buffer
 		extStruct := &ExtensionDataTransferData{TransferID: uint64(requestReceived.TransferID())}
 		err = extStruct.MarshalCBOR(&buf)

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -673,89 +673,89 @@ func TestDataTransferInitiatingPullGraphsyncRequests(t *testing.T) {
 
 		require.Equal(t, gsData.allSelector, requestReceived.selector)
 	})
-	//
-	//t.Run("with error validation", func(t *testing.T) {
-	//	gs1 := &fakeGraphSync{
-	//		requests: make(chan receivedGraphSyncRequest, 1),
-	//	}
-	//	gs2 := &fakeGraphSync{
-	//		requests: make(chan receivedGraphSyncRequest, 1),
-	//	}
-	//
-	//	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
-	//	sv := newSV()
-	//	sv.expectErrorPull()
-	//
-	//	dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
-	//	err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
-	//	require.NoError(t, err)
-	//
-	//	subscribeCalls := make(chan struct{}, 1)
-	//	subscribe := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-	//		if event == datatransfer.Error {
-	//			subscribeCalls <- struct{}{}
-	//		}
-	//	}
-	//	unsub := dt1.SubscribeToEvents(subscribe)
-	//	_, err = dt1.OpenPullDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
-	//	require.NoError(t, err)
-	//
-	//	select {
-	//	case <-ctx.Done():
-	//		t.Fatal("subscribed events not received")
-	//	case <-subscribeCalls:
-	//	}
-	//
-	//	// give a little time for the validation to happen
-	//	//time.Sleep(15*time.Millisecond)
-	//	sv.verifyExpectations(t)
-	//
-	//	// no graphsync request should be scheduled
-	//	require.Empty(t, gs1.requests)
-	//	unsub()
-	//})
-	//
-	//t.Run("does not schedule graphsync request if is push request", func(t *testing.T) {
-	//	gs1 := &fakeGraphSync{
-	//		requests: make(chan receivedGraphSyncRequest, 1),
-	//	}
-	//	gs2 := &fakeGraphSync{
-	//		requests: make(chan receivedGraphSyncRequest, 1),
-	//	}
-	//
-	//	sv := newSV()
-	//	sv.expectSuccessPush()
-	//
-	//	bg := ctx
-	//	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	//	defer cancel()
-	//
-	//	dt1 := NewGraphSyncDataTransfer(bg, host1, gs1)
-	//	dt2 := NewGraphSyncDataTransfer(bg, host2, gs2)
-	//	err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
-	//	require.NoError(t, err)
-	//
-	//	subscribeCalls := make(chan struct{}, 1)
-	//	subscribe := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-	//		if event == datatransfer.Error {
-	//			subscribeCalls <- struct{}{}
-	//		}
-	//	}
-	//	unsub := dt1.SubscribeToEvents(subscribe)
-	//	_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
-	//	require.NoError(t, err)
-	//
-	//	select {
-	//	case <-ctx.Done():
-	//		t.Fatal("subscribed events not received")
-	//	case <-subscribeCalls:
-	//	}
-	//	sv.verifyExpectations(t)
-	//
-	//	// no graphsync request should be scheduled
-	//	require.Empty(t, gs1.requests)
-	//	unsub()
-	//})
+
+	t.Run("with error validation", func(t *testing.T) {
+		gs1 := &fakeGraphSync{
+			requests: make(chan receivedGraphSyncRequest, 1),
+		}
+		gs2 := &fakeGraphSync{
+			requests: make(chan receivedGraphSyncRequest, 1),
+		}
+
+		dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+		sv := newSV()
+		sv.expectErrorPull()
+
+		dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
+		require.NoError(t, err)
+
+		subscribeCalls := make(chan struct{}, 1)
+		subscribe := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+			if event == datatransfer.Error {
+				subscribeCalls <- struct{}{}
+			}
+		}
+		unsub := dt1.SubscribeToEvents(subscribe)
+		_, err = dt1.OpenPullDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		require.NoError(t, err)
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("subscribed events not received")
+		case <-subscribeCalls:
+		}
+
+		// give a little time for the validation to happen
+		//time.Sleep(15*time.Millisecond)
+		sv.verifyExpectations(t)
+
+		// no graphsync request should be scheduled
+		require.Empty(t, gs1.requests)
+		unsub()
+	})
+
+	t.Run("does not schedule graphsync request if is push request", func(t *testing.T) {
+		gs1 := &fakeGraphSync{
+			requests: make(chan receivedGraphSyncRequest, 1),
+		}
+		gs2 := &fakeGraphSync{
+			requests: make(chan receivedGraphSyncRequest, 1),
+		}
+
+		sv := newSV()
+		sv.expectSuccessPush()
+
+		bg := ctx
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		dt1 := NewGraphSyncDataTransfer(bg, host1, gs1)
+		dt2 := NewGraphSyncDataTransfer(bg, host2, gs2)
+		err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
+		require.NoError(t, err)
+
+		subscribeCalls := make(chan struct{}, 1)
+		subscribe := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+			if event == datatransfer.Error {
+				subscribeCalls <- struct{}{}
+			}
+		}
+		unsub := dt1.SubscribeToEvents(subscribe)
+		_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, baseCid, gsData.allSelector)
+		require.NoError(t, err)
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("subscribed events not received")
+		case <-subscribeCalls:
+		}
+		sv.verifyExpectations(t)
+
+		// no graphsync request should be scheduled
+		require.Empty(t, gs1.requests)
+		unsub()
+	})
 }
 
 type receivedGraphSyncMessage struct {
@@ -883,96 +883,101 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	})
 }
 
-// TODO: get passing to complete https://github.com/filecoin-project/go-data-transfer/issues/23
 func TestRespondingToPullGraphsyncRequests(t *testing.T) {
-	// create network
-	// ctx := context.Background()
-	// ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	// defer cancel()
+	//create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 
-	// gsData := newGraphsyncTestingData(t, ctx)
-	// host1 := gsData.host1
-	// host2 := gsData.host2
+	gsData := newGraphsyncTestingData(t, ctx)
+	host1 := gsData.host1 // initiator
+	host2 := gsData.host2 // data sender
 
-	// // setup receiving peer to just record message coming in
-	// dtnet1 := network.NewFromLibp2pHost(host1)
-	// r := &receiver{
-	// 	messageReceived: make(chan receivedMessage),
-	// }
-	// dtnet1.SetDelegate(r)
+	// setup receiving peer to just record message coming in
+	dtnet1 := network.NewFromLibp2pHost(host1)
+	r := &receiver{
+		messageReceived: make(chan receivedMessage),
+	}
+	dtnet1.SetDelegate(r)
 
-	// gsr := &fakeGraphSyncReceiver{
-	// 	receivedMessages: make(chan receivedGraphSyncMessage),
-	// }
-	// gsData.gsNet1.SetDelegate(gsr)
+	gsr := &fakeGraphSyncReceiver{
+		receivedMessages: make(chan receivedGraphSyncMessage),
+	}
+	gsData.gsNet1.SetDelegate(gsr)
 
-	// gs2 := gsData.setupGraphsyncHost2()
+	gs2 := gsData.setupGraphsyncHost2()
 
-	// voucher := fakeDTType{"applesauce"}
-	// link := gsData.loadUnixFSFile(t, true)
+	voucher := fakeDTType{"applesauce"}
+	link := gsData.loadUnixFSFile(t, true)
 
-	// id := datatransfer.TransferID(rand.Int31())
-	// var buf bytes.Buffer
-	// err := dagcbor.Encoder(gsData.allSelector, &buf)
-	// require.NoError(t, err)
-	// selectorBytes := buf.Bytes()
+	id := datatransfer.TransferID(rand.Int31())
+	var buf bytes.Buffer
+	err := dagcbor.Encoder(gsData.allSelector, &buf)
+	require.NoError(t, err)
+	selectorBytes := buf.Bytes()
 
-	// t.Run("When request is initated and validated", func(t *testing.T) {
-	// 	sv := newSV()
-	// 	sv.expectSuccessPull()
+	t.Run("When a pull request is initiated and validated", func(t *testing.T) {
+		sv := newSV()
+		sv.expectSuccessPull()
 
-	// 	dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
-	// 	require.NoError(t, dt.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
+		dt1 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		require.NoError(t, dt1.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 
-	// 	isPull := true
-	// 	voucherBytes, err := voucher.ToBytes()
-	// 	require.NoError(t, err)
-	// 	request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, link.(cidlink.Link).Cid, selectorBytes)
-	// 	require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
-	// 	var messageReceived receivedMessage
-	// 	select {
-	// 	case <-ctx.Done():
-	// 		t.Fatal("did not receive message sent")
-	// 	case messageReceived = <-r.messageReceived:
-	// 	}
-	// 	sv.verifyExpectations(t)
-	// 	receivedResponse, ok := messageReceived.message.(message.DataTransferResponse)
-	// 	require.True(t, ok)
-	// 	require.True(t, receivedResponse.Accepted())
-	// 	extStruct := &ExtensionDataTransferData{TransferID: uint64(receivedResponse.TransferID())}
-	// 	buf.Truncate(0)
-	// 	err = extStruct.MarshalCBOR(&buf)
-	// 	require.NoError(t, err)
-	// 	extData := buf.Bytes()
-	// 	gsRequest := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
-	// 		Name: ExtensionDataTransfer,
-	// 		Data: extData,
-	// 	})
-	// 	gsmessage := gsmsg.New()
-	// 	gsmessage.AddRequest(gsRequest)
-	// 	gsData.gsNet1.SendMessage(ctx, host1.ID(), gsmessage)
-	// 	status := gsr.consumeResponses(ctx, t)
-	// 	require.False(t, gsmsg.IsTerminalFailureCode(status))
-	// })
+		isPull := true
+		voucherBytes, err := voucher.ToBytes()
+		require.NoError(t, err)
+		request := message.NewRequest(id, isPull, voucher.Type(), voucherBytes, link.(cidlink.Link).Cid, selectorBytes)
+		require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
+		var messageReceived receivedMessage
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive message sent")
+		case messageReceived = <-r.messageReceived:
+		}
+		sv.verifyExpectations(t)
+		receivedResponse, ok := messageReceived.message.(message.DataTransferResponse)
+		require.True(t, ok)
+		require.True(t, receivedResponse.Accepted())
+		extStruct := &ExtensionDataTransferData{TransferID: uint64(receivedResponse.TransferID())}
 
-	// // TODO: get passing to complete https://github.com/filecoin-project/go-data-transfer/issues/14
-	// t.Run("When request is not initiated", func(t *testing.T) {
-	// 	_ = NewGraphSyncDataTransfer(ctx, host2, gs2)
-	// 	extStruct := &ExtensionDataTransferData{TransferID: rand.Uint64()}
-	// 	buf.Truncate(0)
-	// 	err = extStruct.MarshalCBOR(&buf)
-	// 	require.NoError(t, err)
-	// 	extData := buf.Bytes()
-	// 	request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
-	// 		Name: ExtensionDataTransfer,
-	// 		Data: extData,
-	// 	})
-	// 	gsmessage := gsmsg.New()
-	// 	gsmessage.AddRequest(request)
-	// 	gsData.gsNet1.SendMessage(ctx, host1.ID(), gsmessage)
-	// 	status := gsr.consumeResponses(ctx, t)
-	// 	require.True(t, gsmsg.IsTerminalFailureCode(status))
-	// })
+		var buf2 = bytes.Buffer{}
+		err = extStruct.MarshalCBOR(&buf2)
+		require.NoError(t, err)
+		extData := buf2.Bytes()
+
+		gsRequest := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+			Name: ExtensionDataTransfer,
+			Data: extData,
+		})
+
+		// initiator requests data over graphsync network
+		gsmessage := gsmsg.New()
+		gsmessage.AddRequest(gsRequest)
+		require.NoError(t, gsData.gsNet1.SendMessage(ctx, host2.ID(), gsmessage))
+		status := gsr.consumeResponses(ctx, t)
+		require.False(t, gsmsg.IsTerminalFailureCode(status))
+	})
+
+	t.Run("When request is not initiated, graphsync response is error", func(t *testing.T) {
+		_ = NewGraphSyncDataTransfer(ctx, host2, gs2)
+		extStruct := &ExtensionDataTransferData{TransferID: rand.Uint64()}
+		buf.Truncate(0)
+		err = extStruct.MarshalCBOR(&buf)
+		require.NoError(t, err)
+		extData := buf.Bytes()
+		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, selectorBytes, graphsync.Priority(rand.Int31()), graphsync.ExtensionData{
+			Name: ExtensionDataTransfer,
+			Data: extData,
+		})
+		gsmessage := gsmsg.New()
+		gsmessage.AddRequest(request)
+
+		// non-initiator requests data over graphsync network, but should not get it
+		// because there was no previous request
+		require.NoError(t, gsData.gsNet1.SendMessage(ctx, host2.ID(), gsmessage))
+		status := gsr.consumeResponses(ctx, t)
+		require.True(t, gsmsg.IsTerminalFailureCode(status))
+	})
 }
 
 // TODO: get passing to complete https://github.com/filecoin-project/go-data-transfer/issues/24

--- a/datatransfer/impl/graphsync/graphsync_receiver_test.go
+++ b/datatransfer/impl/graphsync/graphsync_receiver_test.go
@@ -37,7 +37,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	dtnet1.SetDelegate(r)
 
 	gs2 := &fakeGraphSync{
-		receivedRequests: make(chan receivedGraphSyncRequest, 1),
+		requests: make(chan receivedGraphSyncRequest, 1),
 	}
 
 	voucher := fakeDTType{"applesauce"}

--- a/datatransfer/impl/graphsync/graphsync_receiver_test.go
+++ b/datatransfer/impl/graphsync/graphsync_receiver_test.go
@@ -42,12 +42,12 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 
 	voucher := fakeDTType{"applesauce"}
 	baseCid := testutil.GenerateCids(1)[0]
-	id := datatransfer.TransferID(rand.Int31())
 	var buffer bytes.Buffer
 	err := dagcbor.Encoder(gsData.allSelector, &buffer)
 	require.NoError(t, err)
 
 	t.Run("Response to push with successful validation", func(t *testing.T) {
+		id := datatransfer.TransferID(rand.Int31())
 		sv := newSV()
 		sv.expectSuccessPush()
 
@@ -83,6 +83,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	})
 
 	t.Run("Response to push with error validation", func(t *testing.T) {
+		id := datatransfer.TransferID(rand.Int31())
 		sv := newSV()
 		sv.expectErrorPush()
 		dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
@@ -118,6 +119,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	})
 
 	t.Run("Response to pull with successful validation", func(t *testing.T) {
+		id := datatransfer.TransferID(rand.Int31())
 		sv := newSV()
 		sv.expectSuccessPull()
 
@@ -154,6 +156,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	})
 
 	t.Run("Response to push with error validation", func(t *testing.T) {
+		id := datatransfer.TransferID(rand.Int31())
 		sv := newSV()
 		sv.expectErrorPull()
 


### PR DESCRIPTION
Implements [DTM Sends Data Over Graphsync For Validated Pull Requests](https://github.com/filecoin-project/go-data-transfer/issues/23)

Ensures that when an initiator receives an "accepted" response to their pull request, and that this response matches a pull request in the list of channels, that the initiator sends a graphsync request for data.

Other changes:
* rename a field in a test struct because it was confusing me in the tests.
* refactor a couple of private functions (one was refactored out of existence), and take an initiator peer ID or a sender peer id as a parameter so we can control getting a channel for a push or pull request.