### PR TITLE
macos build and linux and darwin bin artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   golang:
     docker:
       - image: circleci/golang:1.13
-    resource_class: 2xlarge      
+    resource_class: 2xlarge
 
 commands:
   install-deps:
@@ -14,25 +14,37 @@ commands:
       - go/install-ssh
       - go/install: {package: git}
   prepare:
+    parameters:
+      linux:
+        default: true
+        description: is a linux build environment?
+        type: boolean
+      darwin:
+        default: false
+        description: is a darwin build environment?
+        type: boolean
     steps:
       - checkout
-      - run: sudo apt-get update
-      - run: sudo apt-get install ocl-icd-opencl-dev
+      - when:
+          condition: << parameters.linux >>
+          steps:
+            - run: sudo apt-get update
+            - run: sudo apt-get install ocl-icd-opencl-dev
       - run: git submodule sync
       - run: git submodule update --init
   download-params:
     steps:
       - restore_cache:
           name: Restore parameters cache
-          keys: 
-            - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
-            - 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-'
+          keys:
+            - 'v19-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
+            - 'v19-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-'
           paths:
             - /var/tmp/filecoin-proof-parameters/
       - run:  ./lotus fetch-params --include-test-params
       - save_cache:
           name: Save parameters cache
-          key: 'v15-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
+          key: 'v19-lotus-params-{{ checksum "build/proof-params/parameters.json" }}-{{ checksum "build/paramfetch.go" }}'
           paths:
             - /var/tmp/filecoin-proof-parameters/
 
@@ -54,8 +66,15 @@ jobs:
       - go/mod-download
       - run: sudo apt-get update
       - run: sudo apt-get install npm
+      - restore_cache:
+          name: restore go mod cache
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.mod" }}
       - run:
           command: make buildall
+      - store_artifacts:
+          path: lotus
+      - store_artifacts:
+          path: lotus-storage-miner
 
   test:
     description: |
@@ -95,6 +114,9 @@ jobs:
       - install-deps
       - prepare
       - go/mod-download
+      - restore_cache:
+          name: restore go mod cache
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.mod" }}
       - run:
           command: make deps lotus
           no_output_timeout: 30m
@@ -123,6 +145,63 @@ jobs:
                 shell: /bin/bash -eo pipefail
                 command: |
                   bash <(curl -s https://codecov.io/bash)
+      - save_cache:
+          name: save go mod cache
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.mod" }}
+          paths:
+            - "~/go/pkg"
+            - "~/go/src/github.com"
+            - "~/go/src/golang.org"
+
+  build_macos:
+    description: build darwin lotus binary
+    macos:
+      xcode: "10.0.0"
+    working_directory: ~/go/src/github.com/filecoin-project/lotus
+    steps:
+      - prepare:
+          linux: false
+          darwin: true
+      - run:
+          name: Install go
+          command: |
+            curl -O https://dl.google.com/go/go1.13.4.darwin-amd64.pkg && \
+            sudo installer -pkg go1.13.4.darwin-amd64.pkg -target /
+      - run:
+          name: Install pkg-config
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config
+      - run: go version
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - run:
+          name: Install jq
+          command: |
+            mkdir $HOME/.bin
+            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output $HOME/.bin/jq
+            chmod +x $HOME/.bin/jq
+      - restore_cache:
+          name: restore go mod and cargo cache
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.mod" }}
+      - install-deps
+      - go/mod-download
+      - run:
+          command: make build
+          no_output_timeout: 30m
+      - store_artifacts:
+          path: lotus
+      - store_artifacts:
+          path: lotus-storage-miner
+      - save_cache:
+          name: save go mod and cargo cache
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.mod" }}
+          paths:
+            - "~/go/pkg"
+            - "~/go/src/github.com"
+            - "~/go/src/golang.org"
+            - "~/.rustup"
+            - "~/.cargo"
 
   lint: &lint
     description: |
@@ -178,3 +257,7 @@ workflows:
           codecov-upload: true
       - mod-tidy-check
       - build-all
+      - build_macos:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
- adds a new job to run build in macos and produce lotus and
lotus-storage-miner binaries
- persist linux ad darwin lotus and lotus-storage-miner binaries as
CircleCI artifacts
- create CircleCI cache for go mod and cargo