### PR TITLE
dont add too many messages to a block

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const MaxMessagesPerBlock = 4000
+
 var log = logging.Logger("miner")
 
 type waitFunc func(ctx context.Context, baseTime uint64) error
@@ -424,6 +426,9 @@ func selectMessages(ctx context.Context, al actorLookup, base *MiningBase, msgs 
 		inclCount[from]++
 
 		out = append(out, msg)
+		if len(out) >= MaxMessagesPerBlock {
+			break
+		}
 	}
 	return out, nil
 }


### PR DESCRIPTION
I'm not sure if we should reject blocks that go over this limit (but under the encoders limit).
But in any case, i've seen blocks coming over the network that failed to decode because they had over 8000 messages in them
