### PR TITLE
add error status to trace

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -446,11 +446,19 @@ func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
 
 	if err := syncer.collectChain(ctx, maybeHead); err != nil {
 		span.AddAttributes(trace.StringAttribute("col_error", err.Error()))
+		span.SetStatus(trace.Status{
+			Code:    13,
+			Message: err.Error(),
+		})
 		return xerrors.Errorf("collectChain failed: %w", err)
 	}
 
 	if err := syncer.store.PutTipSet(ctx, maybeHead); err != nil {
 		span.AddAttributes(trace.StringAttribute("put_error", err.Error()))
+		span.SetStatus(trace.Status{
+			Code:    13,
+			Message: err.Error(),
+		})
 		return xerrors.Errorf("failed to put synced tipset to chainstore: %w", err)
 	}
 


### PR DESCRIPTION
![Screenshot from 2019-12-04 18-01-58](https://user-images.githubusercontent.com/5924712/70189990-7cf50680-1740-11ea-83d0-07a4ebd60ae2.png)
The screenshot shows the benefit of this change in the Jaeger UI, as it makes it clear which traces have errors occurring in them from the top-level. 