### PR TITLE
add command for power users to manually update sector state

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -67,6 +67,8 @@ type StorageMiner interface {
 
 	SectorsRefs(context.Context) (map[string][]SealedRef, error)
 
+	SectorsUpdate(context.Context, uint64, SectorState) error
+
 	WorkerStats(context.Context) (sectorbuilder.WorkerStats, error)
 
 	// WorkerQueue registers a remote worker

--- a/api/struct.go
+++ b/api/struct.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"github.com/filecoin-project/lotus/lib/sectorbuilder"
 
 	"github.com/ipfs/go-cid"
@@ -138,6 +139,7 @@ type StorageMinerStruct struct {
 		SectorsStatus func(context.Context, uint64) (SectorInfo, error)     `perm:"read"`
 		SectorsList   func(context.Context) ([]uint64, error)               `perm:"read"`
 		SectorsRefs   func(context.Context) (map[string][]SealedRef, error) `perm:"read"`
+		SectorsUpdate func(context.Context, uint64, SectorState) error      `perm:"write"`
 
 		WorkerStats func(context.Context) (sectorbuilder.WorkerStats, error) `perm:"read"`
 
@@ -510,6 +512,10 @@ func (c *StorageMinerStruct) SectorsList(ctx context.Context) ([]uint64, error) 
 
 func (c *StorageMinerStruct) SectorsRefs(ctx context.Context) (map[string][]SealedRef, error) {
 	return c.Internal.SectorsRefs(ctx)
+}
+
+func (c *StorageMinerStruct) SectorsUpdate(ctx context.Context, id uint64, state SectorState) error {
+	return c.Internal.SectorsUpdate(ctx, id, state)
 }
 
 func (c *StorageMinerStruct) WorkerStats(ctx context.Context) (sectorbuilder.WorkerStats, error) {

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"golang.org/x/xerrors"
 	"gopkg.in/urfave/cli.v2"
 
 	"github.com/filecoin-project/lotus/api"
@@ -32,6 +33,7 @@ var sectorsCmd = &cli.Command{
 		sectorsStatusCmd,
 		sectorsListCmd,
 		sectorsRefsCmd,
+		sectorsUpdateCmd,
 	},
 }
 
@@ -170,6 +172,45 @@ var sectorsRefsCmd = &cli.Command{
 			}
 		}
 		return nil
+	},
+}
+
+var sectorsUpdateCmd = &cli.Command{
+	Name:  "update-state",
+	Usage: "ADVANCED: manually update the state of a sector, this may aid in error recovery",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "really-do-it",
+			Usage: "pass this flag if you know what you are doing",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if !cctx.Bool("really-do-it") {
+			return xerrors.Errorf("this is a command for advanced users, only us it if you are sure of what you are doing")
+		}
+		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+		if cctx.Args().Len() < 2 {
+			return xerrors.Errorf("must pass sector ID and new state")
+		}
+
+		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
+		if err != nil {
+			return xerrors.Errorf("could not parse sector ID: %w", err)
+		}
+
+		var st api.SectorState
+		for i, s := range api.SectorStates {
+			if cctx.Args().Get(1) == s {
+				st = api.SectorState(i)
+			}
+		}
+
+		return nodeApi.SectorsUpdate(ctx, id, st)
 	},
 }
 

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -186,7 +186,7 @@ var sectorsUpdateCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Bool("really-do-it") {
-			return xerrors.Errorf("this is a command for advanced users, only us it if you are sure of what you are doing")
+			return xerrors.Errorf("this is a command for advanced users, only use it if you are sure of what you are doing")
 		}
 		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -3,6 +3,12 @@ package impl
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/address"
 	"github.com/filecoin-project/lotus/lib/sectorbuilder"
@@ -12,11 +18,6 @@ import (
 	"github.com/filecoin-project/lotus/storage/sectorblocks"
 	"github.com/gorilla/mux"
 	files "github.com/ipfs/go-ipfs-files"
-	"io"
-	"mime"
-	"net/http"
-	"os"
-	"path/filepath"
 )
 
 type StorageMinerAPI struct {
@@ -199,6 +200,10 @@ func (sm *StorageMinerAPI) SectorsRefs(context.Context) (map[string][]api.Sealed
 	}
 
 	return out, nil
+}
+
+func (sm *StorageMinerAPI) SectorsUpdate(ctx context.Context, id uint64, state api.SectorState) error {
+	return sm.Miner.UpdateSectorState(ctx, id, state)
 }
 
 func (sm *StorageMinerAPI) WorkerQueue(ctx context.Context) (<-chan sectorbuilder.WorkerTask, error) {

--- a/storage/sectors.go
+++ b/storage/sectors.go
@@ -55,6 +55,18 @@ func (u *sectorUpdate) to(newState api.SectorState) *sectorUpdate {
 	}
 }
 
+func (m *Miner) UpdateSectorState(ctx context.Context, sector uint64, state api.SectorState) error {
+	select {
+	case m.sectorUpdated <- sectorUpdate{
+		newState: state,
+		id:       sector,
+	}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (m *Miner) sectorStateLoop(ctx context.Context) error {
 	trackedSectors, err := m.ListSectors()
 	if err != nil {


### PR DESCRIPTION
@magik6k I havent actually tested this out because my miner is still running on the devnet, but it seems like we want a way to manually trigger sector state changes. Automatic handling of sector failures is going to be non-trivial, and this at least lets the user make the call of what to do.