### PR TITLE
Don't respond with error in gsReqRcdHook when we can't find the datatransfer extension.

### DIFF
--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -97,9 +97,8 @@ func (impl *graphsyncImpl) gsReqRecdHook(p peer.ID, request graphsync.RequestDat
 	raw, _ := request.Extension(ExtensionDataTransfer)
 	respData := graphsync.ExtensionData{Name: ExtensionDataTransfer, Data: raw}
 
+	// extension not found; probably not our request.
 	if transferData == EmptyExtensionDataTransferData {
-		// extension not found; probably not our request. Return without validating.
-		//hookActions.SendExtensionData(respData)
 		return
 	}
 

--- a/datatransfer/impl/graphsync/graphsync_whitebox_test.go
+++ b/datatransfer/impl/graphsync/graphsync_whitebox_test.go
@@ -177,7 +177,7 @@ func (fgs *fakeGraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link
 }
 
 // RegisterResponseReceivedHook adds a hook that runs when a request is received
-func (fgs *fakeGraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+func (fgs *fakeGraphSync) RegisterRequestReceivedHook(graphsync.OnRequestReceivedHook) error {
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ipfs/go-ds-badger v0.0.5
 	github.com/ipfs/go-filestore v0.0.2
 	github.com/ipfs/go-fs-lock v0.0.1
-	github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d
+	github.com/ipfs/go-graphsync v0.0.4
 	github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456
 	github.com/ipfs/go-ipfs-blockstore v0.1.0
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/ipfs/go-filestore v0.0.2 h1:pcYwpjtXXwirtbjBXKVJM9CTa9F7/8v1EkfnDaHTO
 github.com/ipfs/go-filestore v0.0.2/go.mod h1:KnZ41qJsCt2OX2mxZS0xsK3Psr0/oB93HMMssLujjVc=
 github.com/ipfs/go-fs-lock v0.0.1 h1:XHX8uW4jQBYWHj59XXcjg7BHlHxV9ZOYs6Y43yb7/l0=
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
-github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d h1:Ub6swp/fxj8G+E9Xy65UY6iN2HCregPQj2Rr9GdLwto=
-github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
 github.com/ipfs/go-graphsync v0.0.4 h1:iF98+J8pcqvEb48IM0TemqeGARsCDtwQ73P9ejMZIuU=
 github.com/ipfs/go-graphsync v0.0.4/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456 h1:I0DHyyygfm9fxWK3dZ6XAXBHVY2u93ske4kprAmm4og=

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/ipfs/go-fs-lock v0.0.1 h1:XHX8uW4jQBYWHj59XXcjg7BHlHxV9ZOYs6Y43yb7/l0
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
 github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d h1:Ub6swp/fxj8G+E9Xy65UY6iN2HCregPQj2Rr9GdLwto=
 github.com/ipfs/go-graphsync v0.0.4-0.20191119222929-854c867d838d/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
+github.com/ipfs/go-graphsync v0.0.4 h1:iF98+J8pcqvEb48IM0TemqeGARsCDtwQ73P9ejMZIuU=
+github.com/ipfs/go-graphsync v0.0.4/go.mod h1:6UACBjfOXEa8rQL3Q/JpZpWS0nZDCLx134WUkjrmFpQ=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456 h1:I0DHyyygfm9fxWK3dZ6XAXBHVY2u93ske4kprAmm4og=
 github.com/ipfs/go-hamt-ipld v0.0.12-0.20190910032255-ee6e898f0456/go.mod h1:oVAOWGetjaaAPloFDCudyhxofsSG/WijXMJLTA0kRhM=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=


### PR DESCRIPTION
Implements [Refactor to v0.0.4 of Graphsync, don't error when extension is not present](https://github.com/filecoin-project/go-data-transfer/issues/41)

* feat/dt-implementation now using real graphsync v0.0.4 
* getExtensionData calls new graphsync action hooks
* Test for same