### PR TITLE
feat(datatransfer): switch to graphsync implementation

### DIFF
--- a/chain/deals/cbor_gen.go
+++ b/chain/deals/cbor_gen.go
@@ -555,7 +555,7 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{135}); err != nil {
+	if _, err := w.Write([]byte{136}); err != nil {
 		return err
 	}
 
@@ -593,6 +593,12 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.t.PayloadCid (cid.Cid) (struct)
+
+	if err := cbg.WriteCid(w, t.PayloadCid); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PayloadCid: %w", err)
+	}
+
 	// t.t.PublishMessage (cid.Cid) (struct)
 
 	if t.PublishMessage == nil {
@@ -619,7 +625,7 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 7 {
+	if extra != 8 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -683,6 +689,18 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("wrong type for uint64 field")
 	}
 	t.DealID = uint64(extra)
+	// t.t.PayloadCid (cid.Cid) (struct)
+
+	{
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PayloadCid: %w", err)
+		}
+
+		t.PayloadCid = c
+
+	}
 	// t.t.PublishMessage (cid.Cid) (struct)
 
 	{

--- a/chain/deals/client.go
+++ b/chain/deals/client.go
@@ -36,6 +36,7 @@ type ClientDeal struct {
 	Miner       peer.ID
 	MinerWorker address.Address
 	DealID      uint64
+	PayloadCid  cid.Cid
 
 	PublishMessage *cid.Cid
 
@@ -246,8 +247,8 @@ func (c *Client) Start(ctx context.Context, p ClientDealProposal) (cid.Cid, erro
 		State:       api.DealUnknown,
 		Miner:       p.MinerID,
 		MinerWorker: p.MinerWorker,
-
-		s: s,
+		PayloadCid:  p.Data,
+		s:           s,
 	}
 
 	c.incoming <- deal

--- a/chain/deals/client_utils.go
+++ b/chain/deals/client_utils.go
@@ -1,7 +1,6 @@
 package deals
 
 import (
-	"bytes"
 	"context"
 	"runtime"
 
@@ -158,7 +157,7 @@ func (c *ClientRequestValidator) ValidatePull(
 	if deal.Miner != receiver {
 		return xerrors.Errorf("Deal Peer %s, Data Transfer Peer %s: %w", deal.Miner.String(), receiver.String(), ErrWrongPeer)
 	}
-	if !bytes.Equal(deal.Proposal.PieceRef, baseCid.Bytes()) {
+	if !deal.PayloadCid.Equals(baseCid) {
 		return xerrors.Errorf("Deal Payload CID %s, Data Transfer CID %s: %w", string(deal.Proposal.PieceRef), baseCid.String(), ErrWrongPiece)
 	}
 	for _, state := range DataTransferStates {

--- a/chain/deals/provider_utils.go
+++ b/chain/deals/provider_utils.go
@@ -1,7 +1,6 @@
 package deals
 
 import (
-	"bytes"
 	"context"
 	"runtime"
 
@@ -175,7 +174,7 @@ func (m *ProviderRequestValidator) ValidatePush(
 		return xerrors.Errorf("Deal Peer %s, Data Transfer Peer %s: %w", deal.Client.String(), sender.String(), ErrWrongPeer)
 	}
 
-	if !bytes.Equal(deal.Proposal.PieceRef, baseCid.Bytes()) {
+	if !deal.Ref.Equals(baseCid) {
 		return xerrors.Errorf("Deal Payload CID %s, Data Transfer CID %s: %w", string(deal.Proposal.PieceRef), baseCid.String(), ErrWrongPiece)
 	}
 	for _, state := range DataTransferStates {

--- a/chain/deals/request_validation_test.go
+++ b/chain/deals/request_validation_test.go
@@ -76,6 +76,7 @@ func newClientDeal(minerID peer.ID, state api.DealState) (deals.ClientDeal, erro
 	return deals.ClientDeal{
 		Proposal:    newProposal,
 		ProposalCid: proposalNd.Cid(),
+		PayloadCid:  blockGenerator.Next().Cid(),
 		Miner:       minerID,
 		MinerWorker: minerAddr,
 		State:       state,
@@ -91,10 +92,7 @@ func newMinerDeal(clientID peer.ID, state api.DealState) (deals.MinerDeal, error
 	if err != nil {
 		return deals.MinerDeal{}, err
 	}
-	ref, err := cid.Cast(newProposal.PieceRef)
-	if err != nil {
-		return deals.MinerDeal{}, err
-	}
+	ref := blockGenerator.Next().Cid()
 
 	return deals.MinerDeal{
 		Proposal:    newProposal,
@@ -143,11 +141,8 @@ func TestClientRequestValidation(t *testing.T) {
 		if err := state.Begin(clientDeal.ProposalCid, &clientDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(clientDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if !xerrors.Is(crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, pieceRef, nil), deals.ErrWrongPeer) {
+		payloadCid := clientDeal.PayloadCid
+		if !xerrors.Is(crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, payloadCid, nil), deals.ErrWrongPeer) {
 			t.Fatal("Pull should fail if miner address is incorrect")
 		}
 	})
@@ -171,11 +166,8 @@ func TestClientRequestValidation(t *testing.T) {
 		if err := state.Begin(clientDeal.ProposalCid, &clientDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(clientDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if !xerrors.Is(crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, pieceRef, nil), deals.ErrInacceptableDealState) {
+		payloadCid := clientDeal.PayloadCid
+		if !xerrors.Is(crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, payloadCid, nil), deals.ErrInacceptableDealState) {
 			t.Fatal("Pull should fail if deal is in a state that cannot be data transferred")
 		}
 	})
@@ -187,11 +179,8 @@ func TestClientRequestValidation(t *testing.T) {
 		if err := state.Begin(clientDeal.ProposalCid, &clientDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(clientDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, pieceRef, nil) != nil {
+		payloadCid := clientDeal.PayloadCid
+		if crv.ValidatePull(minerID, &deals.StorageDataTransferVoucher{clientDeal.ProposalCid, 1}, payloadCid, nil) != nil {
 			t.Fatal("Pull should should succeed when all parameters are correct")
 		}
 	})
@@ -236,11 +225,8 @@ func TestProviderRequestValidation(t *testing.T) {
 		if err := state.Begin(minerDeal.ProposalCid, &minerDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(minerDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if !xerrors.Is(mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, pieceRef, nil), deals.ErrWrongPeer) {
+		ref := minerDeal.Ref
+		if !xerrors.Is(mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, ref, nil), deals.ErrWrongPeer) {
 			t.Fatal("Push should fail if miner address is incorrect")
 		}
 	})
@@ -264,11 +250,8 @@ func TestProviderRequestValidation(t *testing.T) {
 		if err := state.Begin(minerDeal.ProposalCid, &minerDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(minerDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if !xerrors.Is(mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, pieceRef, nil), deals.ErrInacceptableDealState) {
+		ref := minerDeal.Ref
+		if !xerrors.Is(mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, ref, nil), deals.ErrInacceptableDealState) {
 			t.Fatal("Push should fail if deal is in a state that cannot be data transferred")
 		}
 	})
@@ -280,11 +263,8 @@ func TestProviderRequestValidation(t *testing.T) {
 		if err := state.Begin(minerDeal.ProposalCid, &minerDeal); err != nil {
 			t.Fatal("deal tracking failed")
 		}
-		pieceRef, err := cid.Cast(minerDeal.Proposal.PieceRef)
-		if err != nil {
-			t.Fatal("unable to construct piece cid")
-		}
-		if mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, pieceRef, nil) != nil {
+		ref := minerDeal.Ref
+		if mrv.ValidatePush(clientID, &deals.StorageDataTransferVoucher{minerDeal.ProposalCid, 1}, ref, nil) != nil {
 			t.Fatal("Push should should succeed when all parameters are correct")
 		}
 	})

--- a/datatransfer/impl/graphsync/graphsync_impl.go
+++ b/datatransfer/impl/graphsync/graphsync_impl.go
@@ -61,7 +61,7 @@ type graphsyncImpl struct {
 }
 
 // NewGraphSyncDataTransfer initializes a new graphsync based data transfer manager
-func NewGraphSyncDataTransfer(parent context.Context, host host.Host, gs graphsync.GraphExchange) datatransfer.Manager {
+func NewGraphSyncDataTransfer(host host.Host, gs graphsync.GraphExchange) datatransfer.Manager {
 	dataTransferNetwork := network.NewFromLibp2pHost(host)
 	impl := &graphsyncImpl{
 		dataTransferNetwork,
@@ -78,7 +78,7 @@ func NewGraphSyncDataTransfer(parent context.Context, host host.Host, gs graphsy
 		log.Error(err)
 		return nil
 	}
-	dtReceiver := &graphsyncReceiver{parent, impl}
+	dtReceiver := &graphsyncReceiver{impl}
 	dataTransferNetwork.SetDelegate(dtReceiver)
 	return impl
 }

--- a/datatransfer/impl/graphsync/graphsync_impl_test.go
+++ b/datatransfer/impl/graphsync/graphsync_impl_test.go
@@ -119,7 +119,7 @@ func TestDataTransferOneWay(t *testing.T) {
 	dtnet2.SetDelegate(r)
 
 	gs := gsData.setupGraphsyncHost1()
-	dt := NewGraphSyncDataTransfer(ctx, host1, gs)
+	dt := NewGraphSyncDataTransfer(host1, gs)
 
 	t.Run("OpenPushDataTransfer", func(t *testing.T) {
 		ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
@@ -277,7 +277,7 @@ func TestDataTransferValidation(t *testing.T) {
 	require.NoError(t, dagcbor.Encoder(gsData.allSelector, &buffer))
 
 	t.Run("ValidatePush", func(t *testing.T) {
-		dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt2 := NewGraphSyncDataTransfer(host2, gs2)
 		err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), fv)
 		require.NoError(t, err)
 		// create push request
@@ -428,7 +428,7 @@ func TestGraphsyncImpl_RegisterVoucherType(t *testing.T) {
 	gs1 := &fakeGraphSync{
 		requests: make(chan receivedGraphSyncRequest, 1),
 	}
-	dt := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dt := NewGraphSyncDataTransfer(host1, gs1)
 	fv := &fakeValidator{ctx, make(chan receivedValidation)}
 
 	// a voucher type can be registered
@@ -460,12 +460,12 @@ func TestDataTransferSubscribing(t *testing.T) {
 	sv := newSV()
 	sv.stubErrorPull()
 	sv.stubErrorPush()
-	dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+	dt2 := NewGraphSyncDataTransfer(host2, gs2)
 	require.NoError(t, dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 	voucher := fakeDTType{"applesauce"}
 	baseCid := testutil.GenerateCids(1)[0]
 
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
 
 	subscribe1Calls := make(chan struct{}, 1)
 	subscribe1 := func(event datatransfer.Event, channelState datatransfer.ChannelState) {
@@ -566,7 +566,7 @@ func TestDataTransferInitiatingPushGraphsyncRequests(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPush()
 
-		dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt2 := NewGraphSyncDataTransfer(host2, gs2)
 		require.NoError(t, dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 
 		require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
@@ -601,7 +601,7 @@ func TestDataTransferInitiatingPushGraphsyncRequests(t *testing.T) {
 		sv := newSV()
 		sv.expectErrorPush()
 
-		dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt2 := NewGraphSyncDataTransfer(host2, gs2)
 		require.NoError(t, dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 
 		require.NoError(t, dtnet1.SendMessage(ctx, host2.ID(), request))
@@ -639,12 +639,11 @@ func TestDataTransferInitiatingPullGraphsyncRequests(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPull()
 
-		bg := ctx
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
-		dtInit := NewGraphSyncDataTransfer(bg, host1, gs1Init)
-		dtSender := NewGraphSyncDataTransfer(bg, host2, gs2Sender)
+		dtInit := NewGraphSyncDataTransfer(host1, gs1Init)
+		dtSender := NewGraphSyncDataTransfer(host2, gs2Sender)
 		err := dtSender.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 
@@ -677,11 +676,11 @@ func TestDataTransferInitiatingPullGraphsyncRequests(t *testing.T) {
 			requests: make(chan receivedGraphSyncRequest, 1),
 		}
 
-		dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+		dt1 := NewGraphSyncDataTransfer(host1, gs1)
 		sv := newSV()
 		sv.expectErrorPull()
 
-		dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt2 := NewGraphSyncDataTransfer(host2, gs2)
 		err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 
@@ -719,12 +718,11 @@ func TestDataTransferInitiatingPullGraphsyncRequests(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPush()
 
-		bg := ctx
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
-		dt1 := NewGraphSyncDataTransfer(bg, host1, gs1)
-		dt2 := NewGraphSyncDataTransfer(bg, host2, gs2)
+		dt1 := NewGraphSyncDataTransfer(host1, gs1)
+		dt2 := NewGraphSyncDataTransfer(host2, gs2)
 		err := dt2.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 
@@ -813,7 +811,7 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	gsData.gsNet2.SetDelegate(gsr)
 
 	gs1 := gsData.setupGraphsyncHost1()
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
 
 	t.Run("when request is initiated", func(t *testing.T) {
 		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), &voucher, link.(cidlink.Link).Cid, gsData.allSelector)
@@ -898,7 +896,7 @@ func TestResponseHookWhenExtensionNotFound(t *testing.T) {
 	gsData.gsNet2.SetDelegate(gsr)
 
 	gs1 := gsData.setupGraphsyncHost1()
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
 
 	t.Run("when it's not our extension, does not error and does not validate", func(t *testing.T) {
 		//register a hook that validates the request so we don't fail in gs because the request
@@ -968,7 +966,7 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPull()
 
-		dt1 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt1 := NewGraphSyncDataTransfer(host2, gs2)
 		require.NoError(t, dt1.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 
 		_, _, request := createDTRequest(t, true, id, selectorBytes)
@@ -1008,7 +1006,7 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 	})
 
 	t.Run("When request is not initiated, graphsync response is error", func(t *testing.T) {
-		_ = NewGraphSyncDataTransfer(ctx, host2, gs2)
+		_ = NewGraphSyncDataTransfer(host2, gs2)
 		extStruct := &ExtensionDataTransferData{TransferID: rand.Uint64()}
 
 		var buf2 bytes.Buffer
@@ -1044,8 +1042,8 @@ func TestDataTransferPushRoundTrip(t *testing.T) {
 	gs1 := gsData.setupGraphsyncHost1()
 	gs2 := gsData.setupGraphsyncHost2()
 
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
-	dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
+	dt2 := NewGraphSyncDataTransfer(host2, gs2)
 
 	finished := make(chan struct{}, 1)
 	var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
@@ -1085,8 +1083,8 @@ func TestDataTransferPullRoundTrip(t *testing.T) {
 	gs1 := gsData.setupGraphsyncHost1()
 	gs2 := gsData.setupGraphsyncHost2()
 
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
-	dt2 := NewGraphSyncDataTransfer(ctx, host2, gs2)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
+	dt2 := NewGraphSyncDataTransfer(host2, gs2)
 
 	finished := make(chan struct{}, 1)
 	var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {

--- a/datatransfer/impl/graphsync/graphsync_receiver.go
+++ b/datatransfer/impl/graphsync/graphsync_receiver.go
@@ -16,7 +16,6 @@ import (
 )
 
 type graphsyncReceiver struct {
-	ctx  context.Context
 	impl *graphsyncImpl
 }
 

--- a/datatransfer/impl/graphsync/graphsync_receiver_test.go
+++ b/datatransfer/impl/graphsync/graphsync_receiver_test.go
@@ -51,7 +51,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPush()
 
-		dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt := NewGraphSyncDataTransfer(host2, gs2)
 		require.NoError(t, dt.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv))
 
 		isPull := false
@@ -86,7 +86,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		id := datatransfer.TransferID(rand.Int31())
 		sv := newSV()
 		sv.expectErrorPush()
-		dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt := NewGraphSyncDataTransfer(host2, gs2)
 		err = dt.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 
@@ -123,7 +123,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		sv := newSV()
 		sv.expectSuccessPull()
 
-		dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt := NewGraphSyncDataTransfer(host2, gs2)
 		err = dt.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 
@@ -160,7 +160,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		sv := newSV()
 		sv.expectErrorPull()
 
-		dt := NewGraphSyncDataTransfer(ctx, host2, gs2)
+		dt := NewGraphSyncDataTransfer(host2, gs2)
 		err = dt.RegisterVoucherType(reflect.TypeOf(&fakeDTType{}), sv)
 		require.NoError(t, err)
 

--- a/datatransfer/impl/graphsync/graphsync_whitebox_test.go
+++ b/datatransfer/impl/graphsync/graphsync_whitebox_test.go
@@ -42,7 +42,7 @@ func TestGraphsyncImpl_SubscribeToEvents(t *testing.T) {
 	gs1 := &fakeGraphSync{
 		receivedRequests: make(chan receivedGraphSyncRequest, 1),
 	}
-	dt1 := NewGraphSyncDataTransfer(ctx, host1, gs1)
+	dt1 := NewGraphSyncDataTransfer(host1, gs1)
 
 	subscribe1Calls := make(chan struct{}, 1)
 	subscriber := func(event datatransfer.Event, channelState datatransfer.ChannelState) {

--- a/node/builder.go
+++ b/node/builder.go
@@ -242,8 +242,9 @@ func Online() Option {
 			Override(new(storage.TicketFn), modules.SealTicketGen),
 			Override(new(*storage.Miner), modules.StorageMiner),
 
+			Override(new(dtypes.StagingBlockstore), modules.StagingBlockstore),
 			Override(new(dtypes.StagingDAG), modules.StagingDAG),
-
+			Override(new(dtypes.StagingGraphsync), modules.StagingGraphsync),
 			Override(new(*retrieval.Miner), retrieval.NewMiner),
 			Override(new(dtypes.ProviderDealStore), modules.NewProviderDealStore),
 			Override(new(dtypes.ProviderDataTransfer), modules.NewProviderDAGServiceDataTransfer),
@@ -361,6 +362,7 @@ func Repo(r repo.Repo) Option {
 			Override(new(dtypes.ClientFilestore), modules.ClientFstore),
 			Override(new(dtypes.ClientBlockstore), modules.ClientBlockstore),
 			Override(new(dtypes.ClientDAG), modules.ClientDAG),
+			Override(new(dtypes.ClientGraphsync), modules.ClientGraphsync),
 
 			Override(new(ci.PrivKey), lp2p.PrivKey),
 			Override(new(ci.PubKey), ci.PrivKey.GetPublic),

--- a/node/modules/client.go
+++ b/node/modules/client.go
@@ -9,6 +9,10 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"github.com/ipfs/go-bitswap"
 	"github.com/ipfs/go-bitswap/network"
+	graphsync "github.com/ipfs/go-graphsync/impl"
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/storeutil"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/routing"
 
@@ -21,7 +25,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/filecoin-project/lotus/chain/deals"
-	"github.com/filecoin-project/lotus/datatransfer/impl/dagservice"
+	"github.com/filecoin-project/lotus/datatransfer/impl/graphsync"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/repo"
 )
@@ -49,15 +53,15 @@ func ClientBlockstore(fstore dtypes.ClientFilestore) dtypes.ClientBlockstore {
 // request validator with the data transfer module as the validator for
 // StorageDataTransferVoucher types
 func RegisterClientValidator(crv *deals.ClientRequestValidator, dtm dtypes.ClientDataTransfer) {
-	if err := dtm.RegisterVoucherType(reflect.TypeOf(deals.StorageDataTransferVoucher{}), crv); err != nil {
+	if err := dtm.RegisterVoucherType(reflect.TypeOf(&deals.StorageDataTransferVoucher{}), crv); err != nil {
 		panic(err)
 	}
 }
 
 // NewClientDAGServiceDataTransfer returns a data transfer manager that just
 // uses the clients's Client DAG service for transfers
-func NewClientDAGServiceDataTransfer(dag dtypes.ClientDAG) dtypes.ClientDataTransfer {
-	return datatransfer.NewDAGServiceDataTransfer(dag)
+func NewClientDAGServiceDataTransfer(h host.Host, gs dtypes.ClientGraphsync) dtypes.ClientDataTransfer {
+	return graphsyncimpl.NewGraphSyncDataTransfer(h, gs)
 }
 
 // NewClientDealStore creates a statestore for the client to store its deals
@@ -65,6 +69,7 @@ func NewClientDealStore(ds dtypes.MetadataDS) dtypes.ClientDealStore {
 	return statestore.New(namespace.Wrap(ds, datastore.NewKey("/deals/client")))
 }
 
+// ClientDAG is a DAGService for the ClientBlockstore
 func ClientDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.ClientBlockstore, rt routing.Routing, h host.Host) dtypes.ClientDAG {
 	bitswapNetwork := network.NewFromIpfsHost(h, rt)
 	exch := bitswap.New(helpers.LifecycleCtx(mctx, lc), bitswapNetwork, ibs)
@@ -79,4 +84,16 @@ func ClientDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.ClientBlocks
 	})
 
 	return dag
+}
+
+// ClientGraphsync creates a graphsync instance which reads and writes blocks
+// to the ClientBlockstore
+func ClientGraphsync(mctx helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.ClientBlockstore, h host.Host) dtypes.ClientGraphsync {
+	graphsyncNetwork := gsnet.NewFromLibp2pHost(h)
+	ipldBridge := ipldbridge.NewIPLDBridge()
+	loader := storeutil.LoaderForBlockstore(ibs)
+	storer := storeutil.StorerForBlockstore(ibs)
+	gs := graphsync.New(helpers.LifecycleCtx(mctx, lc), graphsyncNetwork, ipldBridge, loader, storer)
+
+	return gs
 }

--- a/node/modules/dtypes/storage.go
+++ b/node/modules/dtypes/storage.go
@@ -4,6 +4,7 @@ import (
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-filestore"
+	"github.com/ipfs/go-graphsync"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -26,6 +27,7 @@ type ChainBlockService bserv.BlockService
 type ClientFilestore *filestore.Filestore
 type ClientBlockstore blockstore.Blockstore
 type ClientDAG ipld.DAGService
+type ClientGraphsync graphsync.GraphExchange
 type ClientDealStore *statestore.StateStore
 
 // ClientDataTransfer is a data transfer manager for the client
@@ -37,3 +39,5 @@ type ProviderDealStore *statestore.StateStore
 type ProviderDataTransfer datatransfer.Manager
 
 type StagingDAG ipld.DAGService
+type StagingBlockstore blockstore.Blockstore
+type StagingGraphsync graphsync.GraphExchange

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	graphsync "github.com/ipfs/go-graphsync/impl"
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/storeutil"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipfs/go-merkledag"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -24,7 +28,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/address"
 	"github.com/filecoin-project/lotus/chain/deals"
 	"github.com/filecoin-project/lotus/chain/gen"
-	"github.com/filecoin-project/lotus/datatransfer/impl/dagservice"
+	dtgraphsync "github.com/filecoin-project/lotus/datatransfer/impl/graphsync"
 	"github.com/filecoin-project/lotus/lib/sectorbuilder"
 	"github.com/filecoin-project/lotus/lib/statestore"
 	"github.com/filecoin-project/lotus/miner"
@@ -147,15 +151,15 @@ func HandleDeals(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host, h *de
 // request validator with the data transfer module as the validator for
 // StorageDataTransferVoucher types
 func RegisterProviderValidator(mrv *deals.ProviderRequestValidator, dtm dtypes.ProviderDataTransfer) {
-	if err := dtm.RegisterVoucherType(reflect.TypeOf(deals.StorageDataTransferVoucher{}), mrv); err != nil {
+	if err := dtm.RegisterVoucherType(reflect.TypeOf(&deals.StorageDataTransferVoucher{}), mrv); err != nil {
 		panic(err)
 	}
 }
 
 // NewProviderDAGServiceDataTransfer returns a data transfer manager that just
 // uses the provider's Staging DAG service for transfers
-func NewProviderDAGServiceDataTransfer(dag dtypes.StagingDAG) dtypes.ProviderDataTransfer {
-	return datatransfer.NewDAGServiceDataTransfer(dag)
+func NewProviderDAGServiceDataTransfer(h host.Host, gs dtypes.StagingGraphsync) dtypes.ProviderDataTransfer {
+	return dtgraphsync.NewGraphSyncDataTransfer(h, gs)
 }
 
 // NewProviderDealStore creates a statestore for the client to store its deals
@@ -163,7 +167,9 @@ func NewProviderDealStore(ds dtypes.MetadataDS) dtypes.ProviderDealStore {
 	return statestore.New(namespace.Wrap(ds, datastore.NewKey("/deals/client")))
 }
 
-func StagingDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, r repo.LockedRepo, rt routing.Routing, h host.Host) (dtypes.StagingDAG, error) {
+// StagingBlockstore creates a blockstore for staging blocks for a miner
+// in a storage deal, prior to sealing
+func StagingBlockstore(r repo.LockedRepo) (dtypes.StagingBlockstore, error) {
 	stagingds, err := r.Datastore("/staging")
 	if err != nil {
 		return nil, err
@@ -172,8 +178,14 @@ func StagingDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, r repo.LockedRepo, rt 
 	bs := blockstore.NewBlockstore(stagingds)
 	ibs := blockstore.NewIdStore(bs)
 
+	return ibs, nil
+}
+
+// StagingDAG is a DAGService for the StagingBlockstore
+func StagingDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.StagingBlockstore, rt routing.Routing, h host.Host) (dtypes.StagingDAG, error) {
+
 	bitswapNetwork := network.NewFromIpfsHost(h, rt)
-	exch := bitswap.New(helpers.LifecycleCtx(mctx, lc), bitswapNetwork, bs)
+	exch := bitswap.New(helpers.LifecycleCtx(mctx, lc), bitswapNetwork, ibs)
 
 	bsvc := blockservice.New(ibs, exch)
 	dag := merkledag.NewDAGService(bsvc)
@@ -185,6 +197,18 @@ func StagingDAG(mctx helpers.MetricsCtx, lc fx.Lifecycle, r repo.LockedRepo, rt 
 	})
 
 	return dag, nil
+}
+
+// StagingGraphsync creates a graphsync instance which reads and writes blocks
+// to the StagingBlockstore
+func StagingGraphsync(mctx helpers.MetricsCtx, lc fx.Lifecycle, ibs dtypes.StagingBlockstore, h host.Host) dtypes.StagingGraphsync {
+	graphsyncNetwork := gsnet.NewFromLibp2pHost(h)
+	ipldBridge := ipldbridge.NewIPLDBridge()
+	loader := storeutil.LoaderForBlockstore(ibs)
+	storer := storeutil.StorerForBlockstore(ibs)
+	gs := graphsync.New(helpers.LifecycleCtx(mctx, lc), graphsyncNetwork, ipldBridge, loader, storer)
+
+	return gs
 }
 
 func SetupBlockProducer(lc fx.Lifecycle, ds dtypes.MetadataDS, api api.FullNode, epp gen.ElectionPoStProver) (*miner.Miner, error) {


### PR DESCRIPTION
# Goals

Make the lotus codebase use the real DataTransfer implementation!

# Implementation

- switch data transfer instances over to using graphsync implementation
- provide code for constructing graphsync instances on the client and miner
- seperate blockstore construction from dag service on the miner side so it is available to construct graphsync
- remove context parameter from data transfer construction since it is unused