### PR TITLE
Fix copying partial ticket arrays into slices

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -557,8 +557,10 @@ func ComputeProof(ctx context.Context, epp ElectionPoStProver, pi *ProofInput) (
 		PostRand: pi.vrfout,
 	}
 	for _, win := range pi.winners {
+		part := make([]byte, 32)
+		copy(part, win.PartialTicket[:])
 		ept.Candidates = append(ept.Candidates, types.EPostTicket{
-			Partial:        win.PartialTicket[:],
+			Partial:        part,
 			SectorID:       win.SectorID,
 			ChallengeIndex: win.SectorChallengeIndex,
 		})

--- a/storage/fpost_run.go
+++ b/storage/fpost_run.go
@@ -73,8 +73,10 @@ func (s *fpostScheduler) runPost(ctx context.Context, eps uint64, ts *types.TipS
 
 	candidates := make([]types.EPostTicket, len(scandidates))
 	for i, sc := range scandidates {
+		part := make([]byte, 32)
+		copy(part, sc.PartialTicket[:])
 		candidates[i] = types.EPostTicket{
-			Partial:        sc.PartialTicket[:],
+			Partial:        part,
 			SectorID:       sc.SectorID,
 			ChallengeIndex: sc.SectorChallengeIndex,
 		}


### PR DESCRIPTION
Should address the immediate concern in #757

However, we need to scan the codebase for other places where we might be using this same pattern incorrectly.