### PR TITLE
Add env var for API token and location

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -2,13 +2,16 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/mitchellh/go-homedir"
+	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"golang.org/x/xerrors"
 	"gopkg.in/urfave/cli.v2"
@@ -28,59 +31,121 @@ const (
 // ApiConnector returns API instance
 type ApiConnector func() api.FullNode
 
-func RepoInfo(ctx *cli.Context, repoFlag string) (string, string, error) {
+type APIInfo struct {
+	Addr  multiaddr.Multiaddr
+	Token []byte
+}
+
+func (a APIInfo) DialArgs() (string, error) {
+	_, addr, err := manet.DialArgs(a.Addr)
+
+	return "ws://" + addr + "/rpc/v0", err
+}
+
+func (a APIInfo) AuthHeader() http.Header {
+	if len(a.Token) != 0 {
+		headers := http.Header{}
+		headers.Add("Authorization", "Bearer "+string(a.Token))
+		return headers
+	}
+	log.Warn("API Token not set and requested, capabilities might be limited.")
+	return nil
+}
+
+func flagForRepo(t repo.RepoType) string {
+	switch t {
+	case repo.FullNode:
+		return "repo"
+	case repo.StorageMiner:
+		return "storagerepo"
+	default:
+		panic(fmt.Sprintf("Unknown repo type: %v", t))
+	}
+}
+
+func envForRepo(t repo.RepoType) string {
+	switch t {
+	case repo.FullNode:
+		return "FULLNODE_API_INFO"
+	case repo.StorageMiner:
+		return "STORAGE_API_INFO"
+	default:
+		panic(fmt.Sprintf("Unknown repo type: %v", t))
+	}
+}
+
+func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
+	if env, ok := os.LookupEnv(envForRepo(t)); ok {
+		sp := strings.SplitN(env, ":", 2)
+		if len(sp) != 2 {
+			log.Warnf("invalid env(%s) value, missing token or address", envForRepo(t))
+		} else {
+			ma, err := multiaddr.NewMultiaddr(sp[1])
+			if err != nil {
+				return APIInfo{}, xerrors.Errorf("could not parse multiaddr from env(%s): %w", envForRepo(t), err)
+			}
+			return APIInfo{
+				Addr:  ma,
+				Token: []byte(sp[0]),
+			}, nil
+		}
+	}
+
+	repoFlag := flagForRepo(t)
+
 	p, err := homedir.Expand(ctx.String(repoFlag))
 	if err != nil {
-		return "", "", err
+		return APIInfo{}, xerrors.Errorf("cound not exand home dir (%s): %w", repoFlag, err)
 	}
 
 	r, err := repo.NewFS(p)
 	if err != nil {
-		return "", "", err
+		return APIInfo{}, xerrors.Errorf("could not open repo at path: %s; %w", p, err)
 	}
 
 	ma, err := r.APIEndpoint()
 	if err != nil {
-		return "", "", xerrors.Errorf("failed to get api endpoint: (%s) %w", p, err)
-	}
-	_, addr, err := manet.DialArgs(ma)
-	if err != nil {
-		return "", "", err
+		return APIInfo{}, xerrors.Errorf("could not get api enpoint: %w", err)
 	}
 
-	return p, addr, nil
-}
-
-func GetRawAPI(ctx *cli.Context, repoFlag string) (string, http.Header, error) {
-	rdir, addr, err := RepoInfo(ctx, repoFlag)
-	if err != nil {
-		return "", nil, err
-	}
-
-	r, err := repo.NewFS(rdir)
-	if err != nil {
-		return "", nil, err
-	}
-
-	var headers http.Header
 	token, err := r.APIToken()
 	if err != nil {
-		log.Warnf("Couldn't load CLI token, capabilities may be limited: %w", err)
-	} else {
-		headers = http.Header{}
-		headers.Add("Authorization", "Bearer "+string(token))
+		log.Warnf("Couldn't load CLI token, capabilities may be limited: %v", err)
 	}
 
-	return "ws://" + addr + "/rpc/v0", headers, nil
+	return APIInfo{
+		Addr:  ma,
+		Token: token,
+	}, nil
+}
+
+func GetRawAPI(ctx *cli.Context, t repo.RepoType) (string, http.Header, error) {
+
+	ainfo, err := GetAPIInfo(ctx, t)
+	if err != nil {
+		return "", nil, xerrors.Errorf("could not get API info: %w", err)
+	}
+
+	addr, err := ainfo.DialArgs()
+	if err != nil {
+		return "", nil, xerrors.Errorf("could not get DialArgs: %w", err)
+	}
+
+	return addr, ainfo.AuthHeader(), nil
 }
 
 func GetAPI(ctx *cli.Context) (api.Common, jsonrpc.ClientCloser, error) {
-	f := "repo"
-	if ctx.String("storagerepo") != "" {
-		f = "storagerepo"
+	ti, ok := ctx.App.Metadata["repoType"]
+	if !ok {
+		log.Errorf("unknown repo type, are you sure you want to use GetAPI?")
+		ti = repo.FullNode
+	}
+	t, ok := ti.(repo.RepoType)
+	if !ok {
+		log.Errorf("repoType type does not match the type of repo.RepoType")
 	}
 
-	addr, headers, err := GetRawAPI(ctx, f)
+	addr, headers, err := GetRawAPI(ctx, t)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +154,7 @@ func GetAPI(ctx *cli.Context) (api.Common, jsonrpc.ClientCloser, error) {
 }
 
 func GetFullNodeAPI(ctx *cli.Context) (api.FullNode, jsonrpc.ClientCloser, error) {
-	addr, headers, err := GetRawAPI(ctx, "repo")
+	addr, headers, err := GetRawAPI(ctx, repo.FullNode)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +163,7 @@ func GetFullNodeAPI(ctx *cli.Context) (api.FullNode, jsonrpc.ClientCloser, error
 }
 
 func GetStorageMinerAPI(ctx *cli.Context) (api.StorageMiner, jsonrpc.ClientCloser, error) {
-	addr, headers, err := GetRawAPI(ctx, "storagerepo")
+	addr, headers, err := GetRawAPI(ctx, repo.StorageMiner)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/lotus/tracing"
 )
 
@@ -68,6 +69,8 @@ func main() {
 
 		Commands: append(local, lcli.Commands...),
 	}
+	app.Setup()
+	app.Metadata["repoType"] = repo.StorageMiner
 
 	if err := app.Run(os.Args); err != nil {
 		log.Warnf("%+v", err)

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/lotus/tracing"
 )
 
@@ -63,6 +64,7 @@ func main() {
 	}
 	app.Setup()
 	app.Metadata["traceContext"] = ctx
+	app.Metadata["repoType"] = repo.FullNode
 
 	if err := app.Run(os.Args); err != nil {
 		span.SetStatus(trace.Status{


### PR DESCRIPTION
Usage: FULLNODE_API_INFO or STORAGE_API_INFO
Content of env var: `<token>:<api multiaddr>`
Example: `FULLNODE_API_INFO="$(cat ~/.lotus/token)dsds:$(cat ~/.lotus/api)"`

