### PR TITLE
fix `IsTicketWinner` in ePoSt

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -526,9 +526,11 @@ func IsRoundWinner(ctx context.Context, ts *types.TipSet, round int64, miner add
 		return nil, xerrors.Errorf("failed to look up miners sector size: %w", err)
 	}
 
+	snum := types.BigDiv(pow.MinerPower, types.NewInt(ssize))
+
 	var winners []sectorbuilder.EPostCandidate
 	for _, c := range candidates {
-		if types.IsTicketWinner(c.PartialTicket[:], ssize, pow.TotalPower) {
+		if types.IsTicketWinner(c.PartialTicket[:], ssize, snum.Uint64(), pow.TotalPower) {
 			winners = append(winners, c)
 		}
 	}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -501,7 +501,7 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) err
 			return xerrors.Errorf("received block was from miner slashed at height %d", slashedAt)
 		}
 
-		_, tpow, err := stmgr.GetPower(ctx, syncer.sm, baseTs, h.Miner)
+		mpow, tpow, err := stmgr.GetPower(ctx, syncer.sm, baseTs, h.Miner)
 		if err != nil {
 			return xerrors.Errorf("failed getting power: %w", err)
 		}
@@ -511,8 +511,10 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) err
 			return xerrors.Errorf("failed to get sector size for block miner: %w", err)
 		}
 
+		snum := types.BigDiv(mpow, types.NewInt(ssize))
+
 		for _, t := range h.EPostProof.Candidates {
-			if !types.IsTicketWinner(t.Partial, ssize, tpow) {
+			if !types.IsTicketWinner(t.Partial, ssize, snum.Uint64(), tpow) {
 				return xerrors.Errorf("miner created a block but was not a winner")
 			}
 		}

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -214,8 +214,11 @@ func IsTicketWinner(partialTicket []byte, ssizeI uint64, snum uint64, totpow Big
 }
 
 func ElectionPostChallengeCount(sectors uint64) uint64 {
+	if sectors == 0 {
+		return 0
+	}
 	// ceil(sectors / build.SectorChallengeRatioDiv)
-	return (sectors + build.SectorChallengeRatioDiv - 1) / build.SectorChallengeRatioDiv
+	return (sectors-1)/build.SectorChallengeRatioDiv + 1
 }
 
 func (t *Ticket) Equals(ot *Ticket) bool {

--- a/lib/sectorbuilder/sectorbuilder.go
+++ b/lib/sectorbuilder/sectorbuilder.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/address"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
@@ -623,7 +624,7 @@ func (sb *SectorBuilder) GenerateEPostCandidates(sectorInfo SortedPublicSectorIn
 		return nil, err
 	}
 
-	challengeCount := ElectionPostChallengeCount(uint64(len(sectorInfo.Values())))
+	challengeCount := types.ElectionPostChallengeCount(uint64(len(sectorInfo.Values())))
 
 	proverID := addressToProverID(sb.Miner)
 	return sectorbuilder.GenerateCandidates(sb.ssize, proverID, challengeSeed, challengeCount, privsectors)
@@ -674,13 +675,8 @@ func (sb *SectorBuilder) Stop() {
 	close(sb.stopping)
 }
 
-func ElectionPostChallengeCount(sectors uint64) uint64 {
-	// ceil(sectors / build.SectorChallengeRatioDiv)
-	return (sectors + build.SectorChallengeRatioDiv - 1) / build.SectorChallengeRatioDiv
-}
-
 func fallbackPostChallengeCount(sectors uint64) uint64 {
-	challengeCount := ElectionPostChallengeCount(sectors)
+	challengeCount := types.ElectionPostChallengeCount(sectors)
 	if challengeCount > build.MaxFallbackPostChallengeCount {
 		return build.MaxFallbackPostChallengeCount
 	}

--- a/lib/sectorbuilder/simple.go
+++ b/lib/sectorbuilder/simple.go
@@ -8,6 +8,7 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/filecoin-project/lotus/chain/address"
+	"github.com/filecoin-project/lotus/chain/types"
 )
 
 func (sb *SectorBuilder) SectorSize() uint64 {
@@ -36,7 +37,7 @@ func NewSortedPublicSectorInfo(sectors []sectorbuilder.PublicSectorInfo) SortedP
 }
 
 func VerifyElectionPost(ctx context.Context, sectorSize uint64, sectorInfo SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []EPostCandidate, proverID address.Address) (bool, error) {
-	challengeCount := ElectionPostChallengeCount(uint64(len(sectorInfo.Values())))
+	challengeCount := types.ElectionPostChallengeCount(uint64(len(sectorInfo.Values())))
 	return verifyPost(ctx, sectorSize, sectorInfo, challengeCount, challengeSeed, proof, candidates, proverID)
 }
 


### PR DESCRIPTION
Fixing the `IsTicketWinner`'s target so it appropriately accounts for number of sectors in spite of sampling. 

Math is simply to replace the sampling logic in the target by `numSectors / sectorsSampled` so each ticket (ie `sectorsSampled`) is appropriately "powered"