### PR TITLE
Feat/symlink import preseal

### DIFF
--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -268,7 +268,7 @@ var aggregateSectorDirsCmd = &cli.Command{
 				return err
 			}
 
-			if err := agsb.ImportFrom(sb); err != nil {
+			if err := agsb.ImportFrom(sb, false); err != nil {
 				return xerrors.Errorf("importing sectors from %q failed: %w", dir, err)
 			}
 		}

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -76,11 +76,20 @@ var initCmd = &cli.Command{
 			Name:  "nosync",
 			Usage: "don't check full-node sync status",
 		},
+		&cli.BoolFlag{
+			Name:  "symlink-imported-sectors",
+			Usage: "attempt to symlink to presealed sectors instead of copying them into place",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		log.Info("Initializing lotus storage miner")
 
 		ssize := cctx.Uint64("sector-size")
+
+		symlink := cctx.Bool("symlink-imported-sectors")
+		if symlink {
+			log.Info("will attempt to symlink to imported sectors")
+		}
 
 		log.Info("Checking proof parameters")
 		if err := build.GetParams(ssize); err != nil {
@@ -184,7 +193,7 @@ var initCmd = &cli.Command{
 				return xerrors.Errorf("failed to open up sectorbuilder: %w", err)
 			}
 
-			if err := nsb.ImportFrom(oldsb); err != nil {
+			if err := nsb.ImportFrom(oldsb, symlink); err != nil {
 				return err
 			}
 			if err := lr.Close(); err != nil {

--- a/lib/sectorbuilder/sectorbuilder.go
+++ b/lib/sectorbuilder/sectorbuilder.go
@@ -684,15 +684,15 @@ func fallbackPostChallengeCount(sectors uint64) uint64 {
 }
 
 func (sb *SectorBuilder) ImportFrom(osb *SectorBuilder, symlink bool) error {
-	if err := dcopy.Copy(osb.cacheDir, sb.cacheDir); err != nil {
+	if err := migrate(osb.cacheDir, sb.cacheDir, true); err != nil {
 		return err
 	}
 
-	if err := dcopy.Copy(osb.sealedDir, sb.sealedDir); err != nil {
+	if err := migrate(osb.sealedDir, sb.sealedDir, true); err != nil {
 		return err
 	}
 
-	if err := dcopy.Copy(osb.stagedDir, sb.stagedDir); err != nil {
+	if err := migrate(osb.stagedDir, sb.stagedDir, true); err != nil {
 		return err
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -238,7 +238,7 @@ func builder(t *testing.T, nFull int, storage []int) ([]test.TestNode, []test.Te
 			t.Fatal(err)
 		}
 
-		if err := sma.SectorBuilder.ImportFrom(osb); err != nil {
+		if err := sma.SectorBuilder.ImportFrom(osb, false); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This allows us to avoid copying presealed sectors for initializing storage miners