### PR TITLE
fix: duplicate unsub calls when client quits

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -155,6 +155,8 @@ func (cs *ChainStore) SubHeadChanges(ctx context.Context) chan []*HeadChange {
 
 	go func() {
 		defer close(out)
+		var unsubOnce sync.Once
+
 		for {
 			select {
 			case val, ok := <-subch:
@@ -170,7 +172,9 @@ func (cs *ChainStore) SubHeadChanges(ctx context.Context) chan []*HeadChange {
 				case <-ctx.Done():
 				}
 			case <-ctx.Done():
-				go cs.bestTips.Unsub(subch)
+				unsubOnce.Do(func() {
+					go cs.bestTips.Unsub(subch)
+				})
 			}
 		}
 	}()


### PR DESCRIPTION
this leads to increasing memory usage, as a reuslt of a huge number of unsub calls in the loop.
especially when we have many clients