### PR TITLE
fix incoming tipset bucketing

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -33,6 +33,9 @@ func HandleIncomingBlocks(ctx context.Context, bsub *pubsub.Subscription, s *cha
 		}
 
 		go func() {
+			log.Infof("New block over pubsub: %s", blk.Cid())
+
+			start := time.Now()
 			log.Debug("about to fetch messages for block from pubsub")
 			bmsgs, err := s.Bsync.FetchMessagesByCids(context.TODO(), blk.BlsMessages)
 			if err != nil {
@@ -46,7 +49,8 @@ func HandleIncomingBlocks(ctx context.Context, bsub *pubsub.Subscription, s *cha
 				return
 			}
 
-			log.Debugw("new block over pubsub", "cid", blk.Header.Cid(), "source", msg.GetFrom())
+			took := time.Since(start)
+			log.Infow("new block over pubsub", "cid", blk.Header.Cid(), "source", msg.GetFrom(), "msgfetch", took)
 			if delay := time.Now().Unix() - int64(blk.Header.Timestamp); delay > 5 {
 				log.Warnf("Received block with large delay %d from miner %s", delay, blk.Header.Miner)
 			}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -362,6 +362,7 @@ func (syncer *Syncer) tryLoadFullTipSet(cids []cid.Cid) (*store.FullTipSet, erro
 }
 
 func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
+	log.Info("SYNC TIME: ", maybeHead.Cids())
 	ctx, span := trace.StartSpan(ctx, "chain.Sync")
 	defer span.End()
 

--- a/chain/sync_manager.go
+++ b/chain/sync_manager.go
@@ -203,9 +203,6 @@ func (stb *syncTargetBucket) sameChainAs(ts *types.TipSet) bool {
 		if types.CidArrsEqual(ts.Parents(), t.Cids()) {
 			return true
 		}
-		if types.CidArrsEqual(ts.Parents(), t.Parents()) {
-			return true
-		}
 	}
 	return false
 }
@@ -283,6 +280,7 @@ func (sm *SyncManager) syncScheduler() {
 }
 
 func (sm *SyncManager) scheduleIncoming(ts *types.TipSet) {
+	log.Info("scheduling incoming tipset sync: ", ts.Cids())
 	if sm.getBootstrapState() == BSStateSelected {
 		sm.setBootstrapState(BSStateScheduled)
 		sm.syncTargets <- ts
@@ -295,7 +293,7 @@ func (sm *SyncManager) scheduleIncoming(ts *types.TipSet) {
 			break
 		}
 
-		if types.CidArrsEqual(ts.Parents(), acts.Cids()) || types.CidArrsEqual(ts.Parents(), acts.Parents()) {
+		if types.CidArrsEqual(ts.Parents(), acts.Cids()) {
 			// sync this next, after that sync process finishes
 			relatedToActiveSync = true
 		}


### PR DESCRIPTION
There is a bug in master right now where if you receive three or more blocks that could form a tipset at roughly the same time, you will sync to the first one, and bucket the others. Then when the first one finishes syncing, we pull the heaviest tipset out of that bucket (and ignore the rest). This means we only end up syncing at most two of the blocks in that tipset.

This should fix the issue, we avoid bucketing blocks if they have the same parent tipsets as active syncs (aka, could form a tipset with an active sync target).