### PR TITLE
client: make wallet addr be a param in ClientStartDeal

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -73,7 +73,7 @@ type FullNode interface {
 
 	// ClientImport imports file under the specified path into filestore
 	ClientImport(ctx context.Context, path string) (cid.Cid, error)
-	ClientStartDeal(ctx context.Context, data cid.Cid, miner address.Address, epochPrice types.BigInt, blocksDuration uint64) (*cid.Cid, error)
+	ClientStartDeal(ctx context.Context, data cid.Cid, addr address.Address, miner address.Address, epochPrice types.BigInt, blocksDuration uint64) (*cid.Cid, error)
 	ClientGetDealInfo(context.Context, cid.Cid) (*DealInfo, error)
 	ClientListDeals(ctx context.Context) ([]DealInfo, error)
 	ClientHasLocal(ctx context.Context, root cid.Cid) (bool, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -77,15 +77,15 @@ type FullNodeStruct struct {
 		WalletExport         func(context.Context, address.Address) (*types.KeyInfo, error)                       `perm:"admin"`
 		WalletImport         func(context.Context, *types.KeyInfo) (address.Address, error)                       `perm:"admin"`
 
-		ClientImport      func(ctx context.Context, path string) (cid.Cid, error)                                                                     `perm:"admin"`
-		ClientListImports func(ctx context.Context) ([]api.Import, error)                                                                             `perm:"write"`
-		ClientHasLocal    func(ctx context.Context, root cid.Cid) (bool, error)                                                                       `perm:"write"`
-		ClientFindData    func(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error)                                                           `perm:"read"`
-		ClientStartDeal   func(ctx context.Context, data cid.Cid, miner address.Address, price types.BigInt, blocksDuration uint64) (*cid.Cid, error) `perm:"admin"`
-		ClientGetDealInfo func(context.Context, cid.Cid) (*api.DealInfo, error)                                                                       `perm:"read"`
-		ClientListDeals   func(ctx context.Context) ([]api.DealInfo, error)                                                                           `perm:"write"`
-		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, path string) error                                                      `perm:"admin"`
-		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*types.SignedStorageAsk, error)                                `perm:"read"`
+		ClientImport      func(ctx context.Context, path string) (cid.Cid, error)                                                                                           `perm:"admin"`
+		ClientListImports func(ctx context.Context) ([]api.Import, error)                                                                                                   `perm:"write"`
+		ClientHasLocal    func(ctx context.Context, root cid.Cid) (bool, error)                                                                                             `perm:"write"`
+		ClientFindData    func(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error)                                                                                 `perm:"read"`
+		ClientStartDeal   func(ctx context.Context, data cid.Cid, addr address.Address, miner address.Address, price types.BigInt, blocksDuration uint64) (*cid.Cid, error) `perm:"admin"`
+		ClientGetDealInfo func(context.Context, cid.Cid) (*api.DealInfo, error)                                                                                             `perm:"read"`
+		ClientListDeals   func(ctx context.Context) ([]api.DealInfo, error)                                                                                                 `perm:"write"`
+		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, path string) error                                                                            `perm:"admin"`
+		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*types.SignedStorageAsk, error)                                                      `perm:"read"`
 
 		StateMinerSectors             func(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)           `perm:"read"`
 		StateMinerProvingSet          func(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)           `perm:"read"`
@@ -208,8 +208,8 @@ func (c *FullNodeStruct) ClientFindData(ctx context.Context, root cid.Cid) ([]ap
 	return c.Internal.ClientFindData(ctx, root)
 }
 
-func (c *FullNodeStruct) ClientStartDeal(ctx context.Context, data cid.Cid, miner address.Address, price types.BigInt, blocksDuration uint64) (*cid.Cid, error) {
-	return c.Internal.ClientStartDeal(ctx, data, miner, price, blocksDuration)
+func (c *FullNodeStruct) ClientStartDeal(ctx context.Context, data cid.Cid, addr address.Address, miner address.Address, price types.BigInt, blocksDuration uint64) (*cid.Cid, error) {
+	return c.Internal.ClientStartDeal(ctx, data, addr, miner, price, blocksDuration)
 }
 func (c *FullNodeStruct) ClientGetDealInfo(ctx context.Context, deal cid.Cid) (*api.DealInfo, error) {
 	return c.Internal.ClientGetDealInfo(ctx, deal)

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -71,7 +71,11 @@ func TestDealFlow(t *testing.T, b APIBuilder) {
 			}
 		}
 	}()
-	deal, err := client.ClientStartDeal(ctx, fcid, maddr, types.NewInt(40000000), 100)
+	addr, err := client.WalletDefaultAddress(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, err := client.ClientStartDeal(ctx, fcid, addr, maddr, types.NewInt(40000000), 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -115,7 +115,11 @@ var clientDealCmd = &cli.Command{
 			return err
 		}
 
-		proposal, err := api.ClientStartDeal(ctx, data, miner, types.BigInt(price), uint64(dur))
+		a, err := api.WalletDefaultAddress(ctx)
+		if err != nil {
+			return err
+		}
+		proposal, err := api.ClientStartDeal(ctx, data, a, miner, types.BigInt(price), uint64(dur))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Avoid forcing using the default address of the wallet in `ClientStartDeal` API.
This was marked as a `//ToDo`.

~~I'll wait for CI to check the test before making PR reviewable.~~