### PR TITLE
cli: print nicer message when miner hasn't initialized

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -299,6 +299,9 @@ var clientQueryAskCmd = &cli.Command{
 			if ret.ExitCode != 0 {
 				return fmt.Errorf("call to GetPeerID was unsuccesful (exit code %d)", ret.ExitCode)
 			}
+			if peer.ID(ret.Return) == peer.ID("SETME") {
+				return fmt.Errorf("the miner hasn't initialized yet")
+			}
 
 			p, err := peer.IDFromBytes(ret.Return)
 			if err != nil {


### PR DESCRIPTION
Fixes #810 
The GH issue has a little history of this error that has popped in Slack channel a few times.

Feels like this `peer.ID("SETME")` should be a constant somewhere. The other place that is used is in `lotus-fountain`. If there's a clear place to put it, I can change it.

