### PR TITLE
dont allow submitting blocks more than a second in the future

### DIFF
--- a/build/params_shared.go
+++ b/build/params_shared.go
@@ -31,7 +31,7 @@ const PaymentChannelClosingDelay = 6 * 60 * 60 / BlockDelay // six hours
 // Consensus / Network
 
 // Seconds
-const AllowableClockDrift = BlockDelay * 2
+const AllowableClockDrift = 1
 
 // Epochs
 const ForkLengthThreshold = Finality

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -480,7 +480,7 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) err
 	}
 
 	if h.Timestamp > uint64(time.Now().Unix()+build.AllowableClockDrift) {
-		return xerrors.Errorf("block was from the future")
+		return xerrors.Errorf("block was from the future: %w", ErrTemporal)
 	}
 	if h.Timestamp > uint64(time.Now().Unix()) {
 		log.Warn("Got block from the future, but within threshold", h.Timestamp, time.Now().Unix())


### PR DESCRIPTION
Miner t01475 was exploiting this, its a pretty good demonstration of why our allowable clock drift was wayyy too high.