### PR TITLE
Use power of 2 sizes when parsing byte counts

### DIFF
--- a/cli/params.go
+++ b/cli/params.go
@@ -17,7 +17,7 @@ var fetchParamCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		sectorSizeInt, err := units.FromHumanSize(cctx.String("proving-params"))
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("proving-params"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -129,7 +129,7 @@ func main() {
 				return err
 			}
 
-			sectorSizeInt, err := units.FromHumanSize(c.String("sector-size"))
+			sectorSizeInt, err := units.RAMInBytes(c.String("sector-size"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
```
// FromHumanSize returns an integer from a human-readable specification of a
// size using SI standard (eg. "44kB", "17MB").
func FromHumanSize(size string) (int64, error) {
	return parseSize(size, decimalMap)
}

// RAMInBytes parses a human-readable string representing an amount of RAM
// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
// returns the number of bytes, or -1 if the string is unparseable.
// Units are case-insensitive, and the 'b' suffix is optional.
func RAMInBytes(size string) (int64, error) {
	return parseSize(size, binaryMap)
}
```