### PR TITLE
Use golog in stats tool, and better sync control

### DIFF
--- a/tools/stats/main.go
+++ b/tools/stats/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
 	"os"
 	"time"
+
+	logging "github.com/ipfs/go-log"
 )
+
+var log = logging.Logger("stats")
 
 const (
 	INFLUX_ADDR = "INFLUX_ADDR"
@@ -47,7 +50,7 @@ func main() {
 	if !reset && height == 0 {
 		h, err := GetLastRecordedHeight(influx, database)
 		if err != nil {
-			log.Print(err)
+			log.Info(err)
 		}
 
 		height = h
@@ -76,17 +79,17 @@ func main() {
 		height := tipset.Height()
 
 		if err := RecordTipsetPoints(ctx, api, pl, tipset); err != nil {
-			log.Printf("Failed to record tipset at height %d: %w", height, err)
+			log.Warnw("Failed to record tipset", "height", height, "error", err)
 			continue
 		}
 
 		if err := RecordTipsetMessagesPoints(ctx, api, pl, tipset); err != nil {
-			log.Printf("Failed to record messages at height %d: %w", height, err)
+			log.Warnw("Failed to record messages", "height", height, "error", err)
 			continue
 		}
 
 		if err := RecordTipsetStatePoints(ctx, api, pl, tipset); err != nil {
-			log.Printf("Failed to record state at height %d: %w", height, err)
+			log.Warnw("Failed to record state", "height", height, "error", err)
 			continue
 		}
 
@@ -108,7 +111,7 @@ func main() {
 
 		nb.SetDatabase(database)
 
-		log.Printf("Writing %d points for height %d", len(nb.Points()), tipset.Height())
+		log.Infow("Adding points", "count", len(nb.Points()), "height", tipset.Height())
 
 		wq.AddBatch(nb)
 	}

--- a/tools/stats/metrics.go
+++ b/tools/stats/metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/big"
 	"strings"
 	"time"
@@ -57,7 +56,7 @@ func NewInfluxWriteQueue(ctx context.Context, influx client.Client) *InfluxWrite
 			case batch := <-ch:
 				for i := 0; i < maxRetries; i++ {
 					if err := influx.Write(batch); err != nil {
-						log.Printf("Failed to write batch: %w", err)
+						log.Warnw("Failed to write batch", "error", err)
 						time.Sleep(time.Second * 15)
 						continue
 					}
@@ -65,7 +64,7 @@ func NewInfluxWriteQueue(ctx context.Context, influx client.Client) *InfluxWrite
 					continue main
 				}
 
-				log.Printf("Dropping batch due to failure to write")
+				log.Error("Dropping batch due to failure to write")
 			}
 		}
 	}()
@@ -259,14 +258,14 @@ func RecordTipsetMessagesPoints(ctx context.Context, api api.FullNode, pl *Point
 }
 
 func ResetDatabase(influx client.Client, database string) error {
-	log.Print("Resetting database")
+	log.Info("Resetting database")
 	q := client.NewQuery(fmt.Sprintf(`DROP DATABASE "%s"; CREATE DATABASE "%s";`, database, database), "", "")
 	_, err := influx.Query(q)
 	return err
 }
 
 func GetLastRecordedHeight(influx client.Client, database string) (int64, error) {
-	log.Print("Retrieving last record height")
+	log.Info("Retrieving last record height")
 	q := client.NewQuery(`SELECT "value" FROM "chain.height" ORDER BY time DESC LIMIT 1`, database, "")
 	res, err := influx.Query(q)
 	if err != nil {
@@ -286,7 +285,7 @@ func GetLastRecordedHeight(influx client.Client, database string) (int64, error)
 		return 0, err
 	}
 
-	log.Printf("Last record height %d", height)
+	log.Infow("Last record height", "height", height)
 
 	return height, nil
 }


### PR DESCRIPTION
Updating to golog so we can gather logs and monitor in a single place with the rest of our logs.

I've also updated the sync check. When there is a lot of volatility in block distribution we would never report stats because we were always seeing block much later than one block delay from when they were published. Also added back in the original sync code so we have better logging around the progress.