### PR TITLE
may loop faster

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1091,7 +1091,7 @@ func (syncer *Syncer) iterFullTipsets(ctx context.Context, headers []*types.TipS
 				return xerrors.Errorf("message processing failed: %w", err)
 			}
 		}
-		i -= windowSize
+		i -= （windowSize+1）
 	}
 
 	return nil


### PR DESCRIPTION
len(bstips)=batchSize+ 1 , so when loop `i -= (windowSize+1)`may faster