### PR TITLE
Pass correct datastore into sectorbuilder

### DIFF
--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 
 	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	badger "github.com/ipfs/go-ds-badger"
 	logging "github.com/ipfs/go-log"
 	"github.com/mitchellh/go-homedir"
@@ -196,7 +198,7 @@ var aggregateSectorDirsCmd = &cli.Command{
 			SectorSize:    ssize,
 			Dir:           destdir,
 			WorkerThreads: 2,
-		}, agmds)
+		}, namespace.Wrap(agmds, datastore.NewKey("/sectorbuilder")))
 		if err != nil {
 			return err
 		}
@@ -257,7 +259,7 @@ var aggregateSectorDirsCmd = &cli.Command{
 				SectorSize:    genm.SectorSize,
 				Dir:           dir,
 				WorkerThreads: 2,
-			}, mds)
+			}, namespace.Wrap(mds, datastore.NewKey("/sectorbuilder")))
 			if err != nil {
 				return err
 			}

--- a/cmd/lotus-seed/seed/seed.go
+++ b/cmd/lotus-seed/seed/seed.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 
 	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	badger "github.com/ipfs/go-ds-badger"
 	logging "github.com/ipfs/go-log"
 	"golang.org/x/xerrors"
@@ -43,7 +45,7 @@ func PreSeal(maddr address.Address, ssize uint64, offset uint64, sectors int, sb
 		return nil, err
 	}
 
-	sb, err := sectorbuilder.New(cfg, mds)
+	sb, err := sectorbuilder.New(cfg, namespace.Wrap(mds, datastore.NewKey("/sectorbuilder")))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -13,6 +13,7 @@ import (
 
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	badger "github.com/ipfs/go-ds-badger"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -174,7 +175,7 @@ var initCmd = &cli.Command{
 				SectorSize:    ssize,
 				WorkerThreads: 2,
 				Dir:           pssb,
-			}, oldmds)
+			}, namespace.Wrap(oldmds, datastore.NewKey("/sectorbuilder")))
 			if err != nil {
 				return xerrors.Errorf("failed to open up preseal sectorbuilder: %w", err)
 			}
@@ -183,7 +184,7 @@ var initCmd = &cli.Command{
 				SectorSize:    ssize,
 				WorkerThreads: 2,
 				Dir:           lr.Path(),
-			}, mds)
+			}, namespace.Wrap(mds, datastore.NewKey("/sectorbuilder")))
 			if err != nil {
 				return xerrors.Errorf("failed to open up sectorbuilder: %w", err)
 			}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -206,7 +206,7 @@ func SetupBlockProducer(lc fx.Lifecycle, ds dtypes.MetadataDS, api api.FullNode,
 }
 
 func SectorBuilder(cfg *sectorbuilder.Config, ds dtypes.MetadataDS) (*sectorbuilder.SectorBuilder, error) {
-	sb, err := sectorbuilder.New(cfg, ds)
+	sb, err := sectorbuilder.New(cfg, namespace.Wrap(ds, datastore.NewKey("/sectorbuilder")))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -9,19 +9,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/filecoin-project/lotus/build"
-
-	"github.com/libp2p/go-libp2p-core/crypto"
-
+	"github.com/filecoin-project/go-address"
 	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	badger "github.com/ipfs/go-ds-badger"
 	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/filecoin-project/go-address"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/client"
@@ -231,7 +229,7 @@ func builder(t *testing.T, nFull int, storage []int) ([]test.TestNode, []test.Te
 			WorkerThreads: 2,
 			Miner:         genMiner,
 			Dir:           psd,
-		}, mds)
+		}, namespace.Wrap(mds, datastore.NewKey("/sectorbuilder")))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Before extraction is did the prefixing internally, it now doesn't