### PR TITLE
 miner: Don't fail on actor not found in selectMessages 

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -403,7 +403,8 @@ func selectMessages(ctx context.Context, al actorLookup, base *MiningBase, msgs 
 		if _, ok := inclNonces[from]; !ok {
 			act, err := al(ctx, from, base.ts)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to check message sender balance: %w", err)
+				log.Warnf("failed to check message sender balance, skipping message: %+v", err)
+				continue
 			}
 
 			inclNonces[from] = act.Nonce

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -393,7 +393,7 @@ func TestAPIRPC(t *testing.T) {
 }
 
 func TestAPIDealFlow(t *testing.T) {
-	test.TestDealFlow(t, mockSbBuilder, 10 * time.Millisecond)
+	test.TestDealFlow(t, mockSbBuilder, 10*time.Millisecond)
 }
 
 func TestAPIDealFlowReal(t *testing.T) {


### PR DESCRIPTION
Messages like these shouldn't be able to get into mpool, but someone hit that. 

Doesn't seem harmful enough to abort block production, so this makes this error a bit softer