### PR TITLE
new api to calculate arbitrary forks revert and applys

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -37,6 +37,7 @@ type FullNode interface {
 	ChainTipSetWeight(context.Context, *types.TipSet) (types.BigInt, error)
 	ChainGetNode(ctx context.Context, p string) (interface{}, error)
 	ChainGetMessage(context.Context, cid.Cid) (*types.Message, error)
+	ChainGetPath(ctx context.Context, from types.TipSetKey, to types.TipSetKey) ([]*store.HeadChange, error)
 
 	// syncer
 	SyncState(context.Context) (*SyncState, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -40,21 +40,22 @@ type FullNodeStruct struct {
 	CommonStruct
 
 	Internal struct {
-		ChainNotify            func(context.Context) (<-chan []*store.HeadChange, error)           `perm:"read"`
-		ChainHead              func(context.Context) (*types.TipSet, error)                        `perm:"read"`
-		ChainGetRandomness     func(context.Context, types.TipSetKey, int64) ([]byte, error)       `perm:"read"`
-		ChainGetBlock          func(context.Context, cid.Cid) (*types.BlockHeader, error)          `perm:"read"`
-		ChainGetTipSet         func(context.Context, types.TipSetKey) (*types.TipSet, error)       `perm:"read"`
-		ChainGetBlockMessages  func(context.Context, cid.Cid) (*api.BlockMessages, error)          `perm:"read"`
-		ChainGetParentReceipts func(context.Context, cid.Cid) ([]*types.MessageReceipt, error)     `perm:"read"`
-		ChainGetParentMessages func(context.Context, cid.Cid) ([]api.Message, error)               `perm:"read"`
-		ChainGetTipSetByHeight func(context.Context, uint64, *types.TipSet) (*types.TipSet, error) `perm:"read"`
-		ChainReadObj           func(context.Context, cid.Cid) ([]byte, error)                      `perm:"read"`
-		ChainSetHead           func(context.Context, *types.TipSet) error                          `perm:"admin"`
-		ChainGetGenesis        func(context.Context) (*types.TipSet, error)                        `perm:"read"`
-		ChainTipSetWeight      func(context.Context, *types.TipSet) (types.BigInt, error)          `perm:"read"`
-		ChainGetNode           func(ctx context.Context, p string) (interface{}, error)            `perm:"read"`
-		ChainGetMessage        func(context.Context, cid.Cid) (*types.Message, error)              `perm:"read"`
+		ChainNotify            func(context.Context) (<-chan []*store.HeadChange, error)                            `perm:"read"`
+		ChainHead              func(context.Context) (*types.TipSet, error)                                         `perm:"read"`
+		ChainGetRandomness     func(context.Context, types.TipSetKey, int64) ([]byte, error)                        `perm:"read"`
+		ChainGetBlock          func(context.Context, cid.Cid) (*types.BlockHeader, error)                           `perm:"read"`
+		ChainGetTipSet         func(context.Context, types.TipSetKey) (*types.TipSet, error)                        `perm:"read"`
+		ChainGetBlockMessages  func(context.Context, cid.Cid) (*api.BlockMessages, error)                           `perm:"read"`
+		ChainGetParentReceipts func(context.Context, cid.Cid) ([]*types.MessageReceipt, error)                      `perm:"read"`
+		ChainGetParentMessages func(context.Context, cid.Cid) ([]api.Message, error)                                `perm:"read"`
+		ChainGetTipSetByHeight func(context.Context, uint64, *types.TipSet) (*types.TipSet, error)                  `perm:"read"`
+		ChainReadObj           func(context.Context, cid.Cid) ([]byte, error)                                       `perm:"read"`
+		ChainSetHead           func(context.Context, *types.TipSet) error                                           `perm:"admin"`
+		ChainGetGenesis        func(context.Context) (*types.TipSet, error)                                         `perm:"read"`
+		ChainTipSetWeight      func(context.Context, *types.TipSet) (types.BigInt, error)                           `perm:"read"`
+		ChainGetNode           func(ctx context.Context, p string) (interface{}, error)                             `perm:"read"`
+		ChainGetMessage        func(context.Context, cid.Cid) (*types.Message, error)                               `perm:"read"`
+		ChainGetPath           func(context.Context, types.TipSetKey, types.TipSetKey) ([]*store.HeadChange, error) `perm:"read"`
 
 		SyncState          func(context.Context) (*api.SyncState, error)                `perm:"read"`
 		SyncSubmitBlock    func(ctx context.Context, blk *types.BlockMsg) error         `perm:"write"`
@@ -353,6 +354,10 @@ func (c *FullNodeStruct) ChainGetNode(ctx context.Context, p string) (interface{
 
 func (c *FullNodeStruct) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
 	return c.Internal.ChainGetMessage(ctx, mc)
+}
+
+func (c *FullNodeStruct) ChainGetPath(ctx context.Context, from types.TipSetKey, to types.TipSetKey) ([]*store.HeadChange, error) {
+	return c.Internal.ChainGetPath(ctx, from, to)
 }
 
 func (c *FullNodeStruct) SyncState(ctx context.Context) (*api.SyncState, error) {

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -83,6 +83,10 @@ func (a *ChainAPI) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api
 	}, nil
 }
 
+func (a *ChainAPI) ChainGetPath(ctx context.Context, from types.TipSetKey, to types.TipSetKey) ([]*store.HeadChange, error) {
+	return a.Chain.GetPath(ctx, from, to)
+}
+
 func (a *ChainAPI) ChainGetParentMessages(ctx context.Context, bcid cid.Cid) ([]api.Message, error) {
 	b, err := a.Chain.GetBlock(bcid)
 	if err != nil {


### PR DESCRIPTION
This PR adds a new API endpoint and implementation to get a similar output of `ChainNotify` but for arbitrary `from` and `to`. 

The motivation for this is the following:
-  A client is following the chain to build up some index or view about it. 
- The client stops their service. 
- In the meantime, the chain can fork from the last known tipset for the client. 
- When the client resumes, it can't use `ChainNotify` directly since it inspects changes from the current head of the lotus node.
- The client should check if the current head is in the same chain from his last known tipset, because if that isn't the case, it will apply new blocks using (what could be described) the wrong state. 

The whole point of this API is to allow a client to provide his last known tipset, and some other new one (most probably, `ChainHead`), and do whatever is necessary to move on. 

This API it's a bit more generic than this use case and can compare any two tipsets. Preferred doing it this way, than assuming will always compare to tipset of the heaviest chain.

TBH, I'm not quite sure that names or package where I made the changes are the correct ones, so there's a high chance that might be better to rename and/or move. If that's the case, I'm happy to fix it.

--- 

I thought about modifying `ChainNotify` to receive a `from` value, but realized that this way may be more orthogonal and allows resolving other cases other from current `head`.

I'd imagine being common a combination like the following:
Call `ChainNotify`, get the first `Current` type value, and call `ChainGetPath` to resolve using his `from` with the current head as `to`. The last call will give enough information to fix a possible unknown fork, and then it would continue listening to `ChainNotify` results as usual.

---

I chose some arbitrary maximum chain height for the fork to put a cap on the worst-case scenario. Maybe there's other more reasonable value.