### PR TITLE
Makefile: fix $GOFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MODULES:=
 
 CLEAN:=
 BINS:=
-GOFLAGS+=-ldflags="-X "github.com/filecoin-project/lotus/build".CurrentCommit=+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))"
+GOFLAGS+=-ldflags='-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))'
 
 ## FFI
 


### PR DESCRIPTION
When building (`make debug`), I get this log on my system (Ubuntu 20.04, go1.14beta1, Make 4.2.1):
```
rm -f lotus
go build  -mod= -ldflags="-X "github.com/filecoin-project/lotus/build".CurrentCommit=+gitbe6badc6.dirty" -tags=debug -o lotus ./cmd/lotus
go: parsing $GOFLAGS: non-flag "\"github.com/filecoin-project/lotus/build\".CurrentCommit=+gitbe6badc6.dirty\""
make: *** [Makefile:56: lotus] Error 1
```

It seems like it's having trouble parsing the shell quotes and https://github.com/filecoin-project/lotus/pull/932 didn't fix it.
My suspicion is that the go command receives these arguments
```
-mod=
-ldflags=-X
"github.com/filecoin-project/lotus/build".CurrentCommit"=+gitbe6badc6.dirty
-tags=debug
...
```
which would explain the error.

This PR uses a `'-K="V"'` style argument to fix the error.