### PR TITLE
implement state call command for easy method calling

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -94,7 +94,7 @@ type FullNode interface {
 	//ClientListAsks() []Ask
 
 	// if tipset is nil, we'll use heaviest
-	StateCall(context.Context, *types.Message, *types.TipSet) (*types.MessageReceipt, error)
+	StateCall(context.Context, *types.Message, *types.TipSet) (*MethodCall, error)
 	StateReplay(context.Context, *types.TipSet, cid.Cid) (*ReplayResults, error)
 	StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error)
 	StateReadState(ctx context.Context, act *types.Actor, ts *types.TipSet) (*ActorState, error)
@@ -268,6 +268,11 @@ type ReplayResults struct {
 	Msg     *types.Message
 	Receipt *types.MessageReceipt
 	Error   string
+}
+
+type MethodCall struct {
+	types.MessageReceipt
+	Error string
 }
 
 type ActiveSync struct {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -98,7 +98,7 @@ type FullNodeStruct struct {
 		StateMinerPeerID              func(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error)                   `perm:"read"`
 		StateMinerElectionPeriodStart func(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)                `perm:"read"`
 		StateMinerSectorSize          func(context.Context, address.Address, *types.TipSet) (uint64, error)                             `perm:"read"`
-		StateCall                     func(context.Context, *types.Message, *types.TipSet) (*types.MessageReceipt, error)               `perm:"read"`
+		StateCall                     func(context.Context, *types.Message, *types.TipSet) (*api.MethodCall, error)                     `perm:"read"`
 		StateReplay                   func(context.Context, *types.TipSet, cid.Cid) (*api.ReplayResults, error)                         `perm:"read"`
 		StateGetActor                 func(context.Context, address.Address, *types.TipSet) (*types.Actor, error)                       `perm:"read"`
 		StateReadState                func(context.Context, *types.Actor, *types.TipSet) (*api.ActorState, error)                       `perm:"read"`
@@ -405,7 +405,7 @@ func (c *FullNodeStruct) StateMinerSectorSize(ctx context.Context, actor address
 	return c.Internal.StateMinerSectorSize(ctx, actor, ts)
 }
 
-func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*types.MessageReceipt, error) {
+func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.MethodCall, error) {
 	return c.Internal.StateCall(ctx, msg, ts)
 }
 

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -172,6 +172,10 @@ var chainGetMsgCmd = &cli.Command{
 	Name:  "getmessage",
 	Usage: "Get and print a message by its cid",
 	Action: func(cctx *cli.Context) error {
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass a cid of a message to get")
+		}
+
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
 			return err

--- a/cli/state.go
+++ b/cli/state.go
@@ -834,9 +834,21 @@ func parseParamsForMethod(act cid.Cid, method uint64, args []string) ([]byte, er
 		case reflect.TypeOf(address.Address{}):
 			a, err := address.NewFromString(args[i])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse address: %s", err)
 			}
 			p.Elem().Field(i).Set(reflect.ValueOf(a))
+		case reflect.TypeOf(uint64(0)):
+			val, err := strconv.ParseUint(args[i], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			p.Elem().Field(i).Set(reflect.ValueOf(val))
+		case reflect.TypeOf(peer.ID("")):
+			pid, err := peer.IDB58Decode(args[i])
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse peer ID: %s", err)
+			}
+			p.Elem().Field(i).Set(reflect.ValueOf(pid))
 		default:
 			return nil, fmt.Errorf("unsupported type for call (TODO): %s", paramObj.Field(i).Type)
 		}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -108,7 +108,7 @@ func (a *StateAPI) StatePledgeCollateral(ctx context.Context, ts *types.TipSet) 
 	return types.BigFromBytes(ret.Return), nil
 }
 
-func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*types.MessageReceipt, error) {
+func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.MethodCall, error) {
 	return a.StateManager.Call(ctx, msg, ts)
 }
 

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -48,7 +48,7 @@ type Miner struct {
 
 type storageMinerApi interface {
 	// Call a read only method on actors (no interaction with the chain required)
-	StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*types.MessageReceipt, error)
+	StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.MethodCall, error)
 	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
 	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)
 	StateMinerSectors(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)


### PR DESCRIPTION
Input types are a bit limited right now, but this is already pretty useful. 

Example:
```
why@sirius ~/c/lotus> ./lotus state call t0222 12
return: peerID: 12D3KooWNFmyeVbLf6wvPrHNdiaJg5gawTuNmXyP8cKuZDEhPzXb
why@sirius ~/c/lotus> ./lotus state call t02 6 t0333
return: bigint: 1374389534720
```

It also lets you run methods at any given tipset by passing the global 'tipset' flag before the 'call' command.