### PR TITLE
params_debug.go: remove $TRUST_PARAMS override

### DIFF
--- a/build/params_debug.go
+++ b/build/params_debug.go
@@ -2,8 +2,6 @@
 
 package build
 
-import "os"
-
 var SectorSizes = []uint64{1024}
 
 // Seconds
@@ -31,7 +29,3 @@ const InteractivePoRepConfidence = 6
 
 // Bytes
 var MinimumMinerPower uint64 = 2 << 10 // 2KiB
-
-func init() {
-	os.Setenv("TRUST_PARAMS", "1")
-}


### PR DESCRIPTION
`TRUST_PARAMS` is hardcoded to 1 in the debug build configuration which causes the local devnet script (https://lotu.sh/en+setup-local-dev-net) to fail at the moment.

Credit to 0f5fa37a from Slack for finding the workaround.

Error log:
```
2020-01-07T20:46:28.852Z        ERROR   miner   miner/miner.go:178      mining block failed: computing election proof:
    github.com/filecoin-project/lotus/miner.(*Miner).mineOne
        /lotus/miner/miner.go:298
  - failed to compute snark for election proof:
    github.com/filecoin-project/lotus/chain/gen.ComputeProof
        /lotus/chain/gen/gen.go:552
  - No cached parameters found for proof-of-spacetime-election-a4e18190d4b4657ba1b4d08a341871b2a6f398e327cb9951b28ab141fbdbf49d
    github.com/filecoin-project/filecoin-ffi.GeneratePoSt
        /lotus/extern/filecoin-ffi/proofs.go:675
    github.com/filecoin-project/lotus/lib/sectorbuilder.(*SectorBuilder).ComputeElectionPoSt
        /lotus/lib/sectorbuilder/sectorbuilder.go:633
    github.com/filecoin-project/lotus/storage.(*SectorBuilderEpp).ComputeProof
        /lotus/storage/miner.go:176
    github.com/filecoin-project/lotus/chain/gen.ComputeProof
        /lotus/chain/gen/gen.go:550
    github.com/filecoin-project/lotus/miner.(*Miner).mineOne
        /lotus/miner/miner.go:296
    github.com/filecoin-project/lotus/miner.(*Miner).mine
        /lotus/miner/miner.go:176
    runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
github.com/filecoin-project/lotus/miner.(*Miner).mine
        /lotus/miner/miner.go:178
```