### PR TITLE
fpost: Don't panic with nil new tipset

### DIFF
--- a/storage/fpost_sched.go
+++ b/storage/fpost_sched.go
@@ -70,6 +70,9 @@ func (s *fpostScheduler) run(ctx context.Context) {
 			var lowest, highest *types.TipSet = s.cur, nil
 
 			for _, change := range changes {
+				if change.Val == nil {
+					log.Errorf("change.Val was nil")
+				}
 				switch change.Type {
 				case store.HCRevert:
 					lowest = change.Val
@@ -111,6 +114,9 @@ func (s *fpostScheduler) revert(ctx context.Context, newLowest *types.TipSet) er
 }
 
 func (s *fpostScheduler) update(ctx context.Context, new *types.TipSet) error {
+	if new == nil {
+		return xerrors.Errorf("no new tipset in fpostScheduler.update")
+	}
 	newEPS, start, err := s.shouldFallbackPost(ctx, new)
 	if err != nil {
 		return err


### PR DESCRIPTION
User sent this panic.
```
2020-01-18T12:30:45.311Z	[33mWARN[0m	storageminer	storage/fpost_sched.go:148	Aborting Fallback PoSt (EPS: 2595)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xec6bcf]

goroutine 308 [running]:
github.com/filecoin-project/lotus/chain/types.(*TipSet).Height(...)
	/root/lotus/chain/types/tipset.go:136
github.com/filecoin-project/lotus/storage.(*fpostScheduler).shouldFallbackPost(0xc00029c070, 0x1f20b60, 0xc01de8c930, 0x0, 0x1f20b60, 0xc01de8c930, 0xc01e136800, 0xa23)
	/root/lotus/storage/fpost_sched.go:160 +0x11f
github.com/filecoin-project/lotus/storage.(*fpostScheduler).update(0xc00029c070, 0x1f20b60, 0xc01de8c930, 0x0, 0x0, 0x0)
	/root/lotus/storage/fpost_sched.go:114 +0x50
github.com/filecoin-project/lotus/storage.(*fpostScheduler).run(0xc00029c070, 0x1f20aa0, 0xc01dc26400)
	/root/lotus/storage/fpost_sched.go:84 +0x2f1
created by github.com/filecoin-project/lotus/storage.(*Miner).Run
	/root/lotus/storage/miner.go:106 +0x21f
```

Dunno how that happened, but it did, so..