### PR TITLE
Dev

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -30,6 +30,7 @@ type FullNode interface {
 	ChainGetBlockMessages(context.Context, cid.Cid) (*BlockMessages, error)
 	ChainGetParentReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 	ChainGetParentMessages(context.Context, cid.Cid) ([]Message, error)
+	ChainGetReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt,error)
 	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 	ChainSetHead(context.Context, *types.TipSet) error

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -746,6 +746,21 @@ func (cs *ChainStore) MessagesForBlock(b *types.BlockHeader) ([]*types.Message, 
 	return blsmsgs, secpkmsgs, nil
 }
 
+func (cs *ChainStore) GetReceipt(b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
+	bs := amt.WrapBlockstore(cs.bs)
+	a, err := amt.LoadAMT(bs, b.MessageReceipts)
+	if err != nil {
+		return nil, xerrors.Errorf("amt load: %w", err)
+	}
+
+	var r types.MessageReceipt
+	if err := a.Get(uint64(i), &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
 func (cs *ChainStore) GetParentReceipt(b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
 	bs := amt.WrapBlockstore(cs.bs)
 	a, err := amt.LoadAMT(bs, b.ParentMessageReceipts)

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -50,6 +50,8 @@ type BlockHeader struct {
 
 	ParentStateRoot cid.Cid
 
+	MessageReceipts cid.Cid
+
 	ParentMessageReceipts cid.Cid
 
 	Messages cid.Cid

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -103,10 +103,15 @@ var chainGetBlock = &cli.Command{
 			return xerrors.Errorf("failed to get parent messages: %w", err)
 		}
 
-		recpts, err := api.ChainGetParentReceipts(ctx, bcid)
+		precpts, err := api.ChainGetParentReceipts(ctx, bcid)
 		if err != nil {
 			log.Warn(err)
 			//return xerrors.Errorf("failed to get receipts: %w", err)
+		}
+
+		recpts, err := api.ChainGetReceipts(ctx,bcid)
+		if err != nil {
+			log.Warn(err)
 		}
 
 		cblock := struct {
@@ -115,13 +120,17 @@ var chainGetBlock = &cli.Command{
 			SecpkMessages  []*types.SignedMessage
 			ParentReceipts []*types.MessageReceipt
 			ParentMessages []cid.Cid
+			Receipts       []*types.MessageReceipt
+			MessageCIDs    []cid.Cid
 		}{}
 
 		cblock.BlockHeader = *blk
 		cblock.BlsMessages = msgs.BlsMessages
 		cblock.SecpkMessages = msgs.SecpkMessages
-		cblock.ParentReceipts = recpts
+		cblock.ParentReceipts = precpts
 		cblock.ParentMessages = apiMsgCids(pmsgs)
+		cblock.MessageCIDs = msgs.Cids
+		cblock.Receipts = recpts
 
 		out, err := json.MarshalIndent(cblock, "", "  ")
 		if err != nil {

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -116,6 +116,39 @@ func (a *ChainAPI) ChainGetParentMessages(ctx context.Context, bcid cid.Cid) ([]
 	return out, nil
 }
 
+func (a *ChainAPI) ChainGetReceipts(ctx context.Context, bcid cid.Cid) ([]*types.MessageReceipt,error) {
+	b, err := a.Chain.GetBlock(bcid)
+	if err != nil {
+		return nil, err
+	}
+
+	if b.Height == 0 {
+		return nil,nil
+	}
+
+	pts,err := a.Chain.LoadTipSet(types.NewTipSetKey(b.MessageReceipts))
+	if err != nil {
+		return nil, err
+	}
+
+	cm, err := a.Chain.MessagesForTipset(pts)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*types.MessageReceipt
+	for i := 0 ; i < len(cm) ; i++ {
+		r,err := a.Chain.GetReceipt(b,i)
+		if err != nil {
+			return nil,err
+		}
+
+		out = append(out, r)
+	}
+
+	return out,nil
+}
+
 func (a *ChainAPI) ChainGetParentReceipts(ctx context.Context, bcid cid.Cid) ([]*types.MessageReceipt, error) {
 	b, err := a.Chain.GetBlock(bcid)
 	if err != nil {


### PR DESCRIPTION
Instead of getting only ParentReceipts and ParentMessages of a block, we also need to get a block's own receipts and messages.