### PR TITLE
fix CurrentCommit in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MODULES:=
 
 CLEAN:=
 BINS:=
-GOFLAGS+=-ldflags="-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))"
+GOFLAGS+=-ldflags=-X="github.com/filecoin-project/lotus/build".CurrentCommit="+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))"
 
 ## FFI
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MODULES:=
 
 CLEAN:=
 BINS:=
-GOFLAGS+=-ldflags='-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))'
+GOFLAGS+=-ldflags="-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git$(subst -,.,$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null))"
 
 ## FFI
 


### PR DESCRIPTION
```
➜  lotus git:(fix/current_commit_flag) ✗
➜  lotus git:(fix/current_commit_flag) make
rm -f lotus
go build -ldflags='-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f' -o lotus ./cmd/lotus
go run github.com/GeertJohan/go.rice/rice append --exec lotus -i ./build
rm -f lotus-storage-miner
go build -ldflags='-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f' -o lotus-storage-miner ./cmd/lotus-storage-miner
go run github.com/GeertJohan/go.rice/rice append --exec lotus-storage-miner -i ./build
rm -f lotus-seal-worker
go build -ldflags='-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f' -o lotus-seal-worker ./cmd/lotus-seal-worker
go run github.com/GeertJohan/go.rice/rice append --exec lotus-seal-worker -i ./build
Caution: you have an existing lotus binary in your PATH. This may cause problems if you don't run 'sudo make install'
➜  lotus git:(fix/current_commit_flag) ./lotus --version
lotus version 0.2.5
➜  lotus git:(fix/current_commit_flag) vim .
➜  lotus git:(fix/current_commit_flag) ✗ make
rm -f lotus
go build -ldflags="-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f.dirty" -o lotus ./cmd/lotus
go run github.com/GeertJohan/go.rice/rice append --exec lotus -i ./build
rm -f lotus-storage-miner
go build -ldflags="-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f.dirty" -o lotus-storage-miner ./cmd/lotus-storage-miner
go run github.com/GeertJohan/go.rice/rice append --exec lotus-storage-miner -i ./build
rm -f lotus-seal-worker
go build -ldflags="-X="github.com/filecoin-project/lotus/build".CurrentCommit=+git4436148f.dirty" -o lotus-seal-worker ./cmd/lotus-seal-worker
go run github.com/GeertJohan/go.rice/rice append --exec lotus-seal-worker -i ./build
Caution: you have an existing lotus binary in your PATH. This may cause problems if you don't run 'sudo make install'
➜  lotus git:(fix/current_commit_flag) ✗ ./lotus --version
lotus version 0.2.5+git4436148f.dirty
➜  lotus git:(fix/current_commit_flag) ✗
➜  lotus git:(fix/current_commit_flag) ✗
```