### PR TITLE
avoid deadlock for concurrent chan-kind RPC calls

### DIFF
--- a/lib/jsonrpc/websocket.go
+++ b/lib/jsonrpc/websocket.go
@@ -388,7 +388,8 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 	c.handling = map[int64]context.CancelFunc{}
 	c.chanHandlers = map[uint64]func(m []byte, ok bool){}
 
-	c.registerCh = make(chan outChanReg)
+	// multiple concurrent chan-kind-returned calls would cause a deadlock, set a buffer here
+	c.registerCh = make(chan outChanReg, 16)
 	defer close(c.registerCh)
 	defer close(c.exiting)
 

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -95,11 +95,12 @@ func (m *Miner) Run(ctx context.Context) error {
 		worker: m.worker,
 	}
 
-	go fps.run(ctx)
-
 	evts := events.NewEvents(ctx, m.api)
 	m.sealing = sealing.New(m.api, evts, m.maddr, m.worker, m.ds, m.sb, m.tktFn)
 
+	// if this happens before events.NewEvents, two concurrent ChianNotify calls are likely to block each other
+	// try to fix https://github.com/filecoin-project/lotus/issues/1126
+	go fps.run(ctx)
 	go m.sealing.Run(ctx)
 
 	return nil


### PR DESCRIPTION
#1126  is most likely caused by some underlying logic in lib/jsonrpc, when dispatching incoming messages to different chans

we just go around here

don't know if  #1123 will also fix this