### PR TITLE
range over right index to prevent bounds errors

### DIFF
--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -135,14 +135,14 @@ func checkWindow(ch chan CidWindow, t int) bool {
 		windowLen := len(window)
 		if windowLen >= t {
 		cidWindow:
-			for i, cids := range window {
+			for i := range window {
 				next := windowLen - 1 - i
 				// if array length is different, head is changing
 				if next >= 1 && len(window[next]) != len(window[next-1]) {
 					break cidWindow
 				}
 				// if cids are different, head is changing
-				for j := range cids {
+				for j := range window[next] {
 					if next >= 1 && window[next][j] != window[next-1][j] {
 						break cidWindow
 					}

--- a/cmd/lotus-health/main_test.go
+++ b/cmd/lotus-health/main_test.go
@@ -31,6 +31,7 @@ func TestCheckWindow(t *testing.T) {
 	ch := make(chan CidWindow, 1)
 	och := make(chan bool, 1)
 	threshold := 3
+
 	go func() {
 		och <- checkWindow(ch, threshold)
 	}()
@@ -51,6 +52,107 @@ func TestCheckWindow(t *testing.T) {
 	case ok := <-och:
 		assert.True(ok)
 	}
+
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var healthyHeadCheckWindow1 CidWindow
+	healthyHeadCheckWindow1 = appendCIDsToWindow(healthyHeadCheckWindow1, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+	}, threshold)
+	healthyHeadCheckWindow1 = appendCIDsToWindow(healthyHeadCheckWindow1, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+		makeCID("abcd"),
+	}, threshold)
+	healthyHeadCheckWindow1 = appendCIDsToWindow(healthyHeadCheckWindow1, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	ch <- healthyHeadCheckWindow1
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var healthyHeadCheckWindow2 CidWindow
+	healthyHeadCheckWindow2 = appendCIDsToWindow(healthyHeadCheckWindow2, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+	}, threshold)
+	healthyHeadCheckWindow2 = appendCIDsToWindow(healthyHeadCheckWindow2, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	ch <- healthyHeadCheckWindow2
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var healthyHeadCheckWindow3 CidWindow
+	healthyHeadCheckWindow3 = appendCIDsToWindow(healthyHeadCheckWindow3, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	healthyHeadCheckWindow3 = appendCIDsToWindow(healthyHeadCheckWindow3, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+	}, threshold)
+	ch <- healthyHeadCheckWindow3
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var healthyHeadCheckWindow4 CidWindow
+	healthyHeadCheckWindow4 = appendCIDsToWindow(healthyHeadCheckWindow4, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+	}, threshold)
+	ch <- healthyHeadCheckWindow4
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
+	go func() {
+		och <- checkWindow(ch, 5)
+	}()
+	var healthyHeadCheckWindow5 CidWindow
+	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+		makeCID("bbff"),
+	}, 5)
+	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
+		makeCID("bbcd"),
+		makeCID("bbfe"),
+	}, 5)
+	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
+		makeCID("abcd"),
+	}, 5)
+	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
+		makeCID("cbcd"),
+		makeCID("cbfe"),
+	}, 5)
+	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
+		makeCID("cbcd"),
+		makeCID("cbfe"),
+	}, 5)
+	ch <- healthyHeadCheckWindow5
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
 	go func() {
 		och <- checkWindow(ch, threshold)
 	}()
@@ -73,6 +175,42 @@ func TestCheckWindow(t *testing.T) {
 		assert.False(ok)
 	}
 
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var unhealthyHeadCheckWindow1 CidWindow
+	unhealthyHeadCheckWindow1 = appendCIDsToWindow(unhealthyHeadCheckWindow1, []cid.Cid{
+		makeCID("abcd"),
+		makeCID("fbcd"),
+	}, threshold)
+	unhealthyHeadCheckWindow1 = appendCIDsToWindow(unhealthyHeadCheckWindow1, []cid.Cid{
+		makeCID("abcd"),
+		makeCID("fbcd"),
+	}, threshold)
+	ch <- unhealthyHeadCheckWindow1
+	select {
+	case ok := <-och:
+		assert.True(ok)
+	}
+
+	go func() {
+		och <- checkWindow(ch, threshold)
+	}()
+	var unhealthyHeadCheckWindow2 CidWindow
+	unhealthyHeadCheckWindow2 = appendCIDsToWindow(unhealthyHeadCheckWindow2, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	unhealthyHeadCheckWindow2 = appendCIDsToWindow(unhealthyHeadCheckWindow2, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	unhealthyHeadCheckWindow2 = appendCIDsToWindow(unhealthyHeadCheckWindow2, []cid.Cid{
+		makeCID("abcd"),
+	}, threshold)
+	ch <- unhealthyHeadCheckWindow2
+	select {
+	case ok := <-och:
+		assert.False(ok)
+	}
 }
 
 func makeCID(s string) cid.Cid {


### PR DESCRIPTION
the test scenario 'healthyHeadCheckWindow5' was causing index out of bounds errors.
the second range function in checkWindow was iterating over the incorrect slice of cids.
should be comparing latest items in slices first.

adds more test scenarios to catch any potential index out of bounds errors.