### PR TITLE
refactor lotus-health agent for robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lotus-storage-miner
 /lotus-seal-worker
 /lotus-seed
+/lotus-health
 /pond
 /townhall
 /fountain

--- a/cmd/lotus-health/main_test.go
+++ b/cmd/lotus-health/main_test.go
@@ -28,13 +28,8 @@ func TestAppendCIDsToWindow(t *testing.T) {
 
 func TestCheckWindow(t *testing.T) {
 	assert := assert.New(t)
-	ch := make(chan CidWindow, 1)
-	och := make(chan bool, 1)
 	threshold := 3
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var healthyHeadCheckWindow CidWindow
 	healthyHeadCheckWindow = appendCIDsToWindow(healthyHeadCheckWindow, []cid.Cid{
 		makeCID("abcd"),
@@ -47,15 +42,9 @@ func TestCheckWindow(t *testing.T) {
 		makeCID("bbcd"),
 		makeCID("bbfe"),
 	}, threshold)
-	ch <- healthyHeadCheckWindow
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok := checkWindow(healthyHeadCheckWindow, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var healthyHeadCheckWindow1 CidWindow
 	healthyHeadCheckWindow1 = appendCIDsToWindow(healthyHeadCheckWindow1, []cid.Cid{
 		makeCID("bbcd"),
@@ -69,15 +58,9 @@ func TestCheckWindow(t *testing.T) {
 	healthyHeadCheckWindow1 = appendCIDsToWindow(healthyHeadCheckWindow1, []cid.Cid{
 		makeCID("abcd"),
 	}, threshold)
-	ch <- healthyHeadCheckWindow1
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(healthyHeadCheckWindow1, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var healthyHeadCheckWindow2 CidWindow
 	healthyHeadCheckWindow2 = appendCIDsToWindow(healthyHeadCheckWindow2, []cid.Cid{
 		makeCID("bbcd"),
@@ -86,15 +69,9 @@ func TestCheckWindow(t *testing.T) {
 	healthyHeadCheckWindow2 = appendCIDsToWindow(healthyHeadCheckWindow2, []cid.Cid{
 		makeCID("abcd"),
 	}, threshold)
-	ch <- healthyHeadCheckWindow2
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(healthyHeadCheckWindow2, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var healthyHeadCheckWindow3 CidWindow
 	healthyHeadCheckWindow3 = appendCIDsToWindow(healthyHeadCheckWindow3, []cid.Cid{
 		makeCID("abcd"),
@@ -103,29 +80,17 @@ func TestCheckWindow(t *testing.T) {
 		makeCID("bbcd"),
 		makeCID("bbfe"),
 	}, threshold)
-	ch <- healthyHeadCheckWindow3
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(healthyHeadCheckWindow3, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var healthyHeadCheckWindow4 CidWindow
 	healthyHeadCheckWindow4 = appendCIDsToWindow(healthyHeadCheckWindow4, []cid.Cid{
 		makeCID("bbcd"),
 		makeCID("bbfe"),
 	}, threshold)
-	ch <- healthyHeadCheckWindow4
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(healthyHeadCheckWindow4, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, 5)
-	}()
 	var healthyHeadCheckWindow5 CidWindow
 	healthyHeadCheckWindow5 = appendCIDsToWindow(healthyHeadCheckWindow5, []cid.Cid{
 		makeCID("bbcd"),
@@ -147,15 +112,9 @@ func TestCheckWindow(t *testing.T) {
 		makeCID("cbcd"),
 		makeCID("cbfe"),
 	}, 5)
-	ch <- healthyHeadCheckWindow5
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(healthyHeadCheckWindow5, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var unhealthyHeadCheckWindow CidWindow
 	unhealthyHeadCheckWindow = appendCIDsToWindow(unhealthyHeadCheckWindow, []cid.Cid{
 		makeCID("abcd"),
@@ -169,15 +128,9 @@ func TestCheckWindow(t *testing.T) {
 		makeCID("abcd"),
 		makeCID("fbcd"),
 	}, threshold)
-	ch <- unhealthyHeadCheckWindow
-	select {
-	case ok := <-och:
-		assert.False(ok)
-	}
+	ok = checkWindow(unhealthyHeadCheckWindow, threshold)
+	assert.False(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var unhealthyHeadCheckWindow1 CidWindow
 	unhealthyHeadCheckWindow1 = appendCIDsToWindow(unhealthyHeadCheckWindow1, []cid.Cid{
 		makeCID("abcd"),
@@ -187,15 +140,9 @@ func TestCheckWindow(t *testing.T) {
 		makeCID("abcd"),
 		makeCID("fbcd"),
 	}, threshold)
-	ch <- unhealthyHeadCheckWindow1
-	select {
-	case ok := <-och:
-		assert.True(ok)
-	}
+	ok = checkWindow(unhealthyHeadCheckWindow1, threshold)
+	assert.True(ok)
 
-	go func() {
-		och <- checkWindow(ch, threshold)
-	}()
 	var unhealthyHeadCheckWindow2 CidWindow
 	unhealthyHeadCheckWindow2 = appendCIDsToWindow(unhealthyHeadCheckWindow2, []cid.Cid{
 		makeCID("abcd"),
@@ -206,11 +153,8 @@ func TestCheckWindow(t *testing.T) {
 	unhealthyHeadCheckWindow2 = appendCIDsToWindow(unhealthyHeadCheckWindow2, []cid.Cid{
 		makeCID("abcd"),
 	}, threshold)
-	ch <- unhealthyHeadCheckWindow2
-	select {
-	case ok := <-och:
-		assert.False(ok)
-	}
+	ok = checkWindow(unhealthyHeadCheckWindow2, threshold)
+	assert.False(ok)
 }
 
 func makeCID(s string) cid.Cid {

--- a/cmd/lotus-health/notify.go
+++ b/cmd/lotus-health/notify.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/coreos/go-systemd/dbus"
 )
 
-func alertHandler(n string, ch chan interface{}) (string, error) {
+func notifyHandler(n string, ch chan interface{}, sCh chan os.Signal) (string, error) {
 	select {
+	// alerts to restart systemd unit
 	case <-ch:
 		statusCh := make(chan string, 1)
 		c, err := dbus.New()
@@ -20,5 +23,9 @@ func alertHandler(n string, ch chan interface{}) (string, error) {
 		case result := <-statusCh:
 			return result, nil
 		}
+	// SIGTERM
+	case <-sCh:
+		os.Exit(1)
+		return "", nil
 	}
 }


### PR DESCRIPTION
add retry logic when calls to API fail.
if API reconnects fail, restart lotus-daemon as it means lotus-daemon is likely unhealthy.

wait for lotus node's chain to sync during each check cycle, to avoid restarting lotus-daemon if needing to sync.

handle SIGTERM properly.

general cleanup and refactor of code, getting ready of unnecessary channels