### PR TITLE
fix issue #127

### DIFF
--- a/lib/jsonrpc/client.go
+++ b/lib/jsonrpc/client.go
@@ -19,11 +19,15 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var log = logging.Logger("rpc")
+const (
+	methodRetryFrequency = time.Second * 3
+)
 
 var (
 	errorType   = reflect.TypeOf(new(error)).Elem()
 	contextType = reflect.TypeOf(new(context.Context)).Elem()
+
+	log = logging.Logger("rpc")
 )
 
 // ErrClient is an error which occurred on the client side the library
@@ -389,7 +393,7 @@ func (fn *rpcFunc) handleRpcCall(args []reflect.Value) (results []reflect.Value)
 		if !retry {
 			break
 		}
-		time.Sleep(time.Second * 3)
+		time.Sleep(methodRetryFrequency)
 	}
 
 	return fn.processResponse(resp, retVal())

--- a/lib/jsonrpc/client.go
+++ b/lib/jsonrpc/client.go
@@ -385,7 +385,7 @@ func (fn *rpcFunc) handleRpcCall(args []reflect.Value) (results []reflect.Value)
 
 			retVal = func() reflect.Value { return val.Elem() }
 		}
-		retry := resp.Error != nil && resp.Error.Code == 0 && fn.retry
+		retry := resp.Error != nil && resp.Error.Code == 2 && fn.retry
 		if !retry {
 			break
 		}

--- a/lib/jsonrpc/options.go
+++ b/lib/jsonrpc/options.go
@@ -1,0 +1,19 @@
+package jsonrpc
+
+import "time"
+
+type Config struct {
+	ReconnectInterval time.Duration
+}
+
+var defaultConfig = Config{
+	ReconnectInterval: time.Second * 5,
+}
+
+type Option func(c *Config)
+
+func WithReconnectInterval(d time.Duration) func(c *Config) {
+	return func(c *Config) {
+		c.ReconnectInterval = d
+	}
+}

--- a/lib/jsonrpc/websocket.go
+++ b/lib/jsonrpc/websocket.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"golang.org/x/xerrors"
@@ -42,11 +43,13 @@ type outChanReg struct {
 
 type wsConn struct {
 	// outside params
-	conn     *websocket.Conn
-	handler  handlers
-	requests <-chan clientRequest
-	stop     <-chan struct{}
-	exiting  chan struct{}
+	conn              *websocket.Conn
+	connFactory       func() (*websocket.Conn, error)
+	reconnectInterval time.Duration
+	handler           handlers
+	requests          <-chan clientRequest
+	stop              <-chan struct{}
+	exiting           chan struct{}
 
 	// incoming messages
 	incoming    chan io.Reader
@@ -419,6 +422,32 @@ func (c *wsConn) handleFrame(ctx context.Context, frame frame) {
 	}
 }
 
+func (c *wsConn) closeInFlight() {
+	for id, req := range c.inflight {
+		req.ready <- clientResponse{
+			Jsonrpc: "2.0",
+			ID:      id,
+			Error: &respError{
+				Message: "handler: websocket connection closed",
+			},
+		}
+
+		c.handlingLk.Lock()
+		for _, cancel := range c.handling {
+			cancel()
+		}
+		c.handlingLk.Unlock()
+	}
+}
+
+func (c *wsConn) closeChans() {
+	for chid := range c.chanHandlers {
+		hnd := c.chanHandlers[chid]
+		delete(c.chanHandlers, chid)
+		hnd(nil, false)
+	}
+}
+
 func (c *wsConn) handleWsConn(ctx context.Context) {
 	c.incoming = make(chan io.Reader)
 	c.inflight = map[int64]clientRequest{}
@@ -432,27 +461,10 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 
 	// on close, make sure to return from all pending calls, and cancel context
 	//  on all calls we handle
-	defer func() {
-		for id, req := range c.inflight {
-			req.ready <- clientResponse{
-				Jsonrpc: "2.0",
-				ID:      id,
-				Error: &respError{
-					Message: "handler: websocket connection closed",
-				},
-			}
-
-			c.handlingLk.Lock()
-			for _, cancel := range c.handling {
-				cancel()
-			}
-			c.handlingLk.Unlock()
-		}
-	}()
+	defer c.closeInFlight()
 
 	// wait for the first message
 	go c.nextMessage()
-
 	for {
 		select {
 		case r, ok := <-c.incoming:
@@ -460,6 +472,28 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 				if c.incomingErr != nil {
 					if !websocket.IsCloseError(c.incomingErr, websocket.CloseNormalClosure) {
 						log.Debugw("websocket error", "error", c.incomingErr)
+						// connection dropped unexpectedly, do our best to recover it
+						c.closeInFlight()
+						c.closeChans()
+						c.incoming = make(chan io.Reader) // listen again for responses
+						go func() {
+							var conn *websocket.Conn
+							for conn == nil {
+								time.Sleep(c.reconnectInterval)
+								var err error
+								if conn, err = c.connFactory(); err != nil {
+									log.Debugw("websocket connection retried failed", "error", err)
+								}
+							}
+
+							c.writeLk.Lock()
+							c.conn = conn
+							c.incomingErr = nil
+							c.writeLk.Unlock()
+
+							go c.nextMessage()
+						}()
+						continue
 					}
 				}
 				return // remote closed
@@ -477,9 +511,22 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 			c.handleFrame(ctx, frame)
 			go c.nextMessage()
 		case req := <-c.requests:
+			c.writeLk.Lock()
 			if req.req.ID != nil {
+				if c.incomingErr != nil { // No conn?, immediate fail
+					req.ready <- clientResponse{
+						Jsonrpc: "2.0",
+						ID:      *req.req.ID,
+						Error: &respError{
+							Message: "handler: websocket connection closed",
+						},
+					}
+					c.writeLk.Unlock()
+					break
+				}
 				c.inflight[*req.req.ID] = req
 			}
+			c.writeLk.Unlock()
 			c.sendRequest(req.req)
 		case <-c.stop:
 			c.writeLk.Lock()

--- a/lib/jsonrpc/websocket.go
+++ b/lib/jsonrpc/websocket.go
@@ -429,6 +429,7 @@ func (c *wsConn) closeInFlight() {
 			ID:      id,
 			Error: &respError{
 				Message: "handler: websocket connection closed",
+				Code:    2,
 			},
 		}
 
@@ -438,6 +439,8 @@ func (c *wsConn) closeInFlight() {
 		}
 		c.handlingLk.Unlock()
 	}
+	c.inflight = map[int64]clientRequest{}
+	c.handling = map[int64]context.CancelFunc{}
 }
 
 func (c *wsConn) closeChans() {
@@ -519,6 +522,7 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 						ID:      *req.req.ID,
 						Error: &respError{
 							Message: "handler: websocket connection closed",
+							Code:    2,
 						},
 					}
 					c.writeLk.Unlock()


### PR DESCRIPTION
Closes #127
This is a continuation of https://github.com/filecoin-project/lotus/pull/1146, since the main idea of the other PR changed.

---

There's a new tag available `retry:"true"`.
e.g" 
```
ChainHead              func(context.Context) (*types.TipSet, error)                `perm:"read" retry:"true"`
```
It works the same if the return value is a chan or not.
The meaning is: the function call will not return with failure on a closed websocket channel. It will keep retrying while the connection is trying to be reestablished.

If the connection is closed before `sendRequest`; saying it differently, the method is called with a closed connection:
- if retry is true, will keep trying until the connection is resumed
- if retry is false, will fail immediately with an `err` of closed connection

If the connection is closed after the request was sent, but before received reply (in-flight):
- if retry is true, will retry until connection is resumed
- if retry is false, will fail immediately with an `err`

---

When a connection is lost:
- all in-flight connections are failed (in case of `retry:"true"` cases, they will continue retrying
- all open chans will be closed, so rpc calls that returns chan will close. (doesn't matter if retry is true or not for them)

---
Tested with `ChainHead` and `ChainNotify` and seems to work correctly.
