### PR TITLE
Dockerfile: more binaries

### DIFF
--- a/tools/dockers/docker-examples/basic-miner-busybox/Dockerfile
+++ b/tools/dockers/docker-examples/basic-miner-busybox/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-buster
+FROM golang:1.13-buster
 MAINTAINER ldoublewood <ldoublewood@gmail.com>
 
 ENV SRC_DIR /lotus
@@ -44,10 +44,12 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
+ARG MAKE_TARGET=all
+
 # Build the thing.
 RUN cd $SRC_DIR \
   && . $HOME/.cargo/env \
-  && make
+  && make $MAKE_TARGET
 
 # Now comes the actual target image, which aims to be as small as possible.
 FROM busybox:1-glibc
@@ -56,7 +58,7 @@ MAINTAINER ldoublewood <ldoublewood@gmail.com>
 # Get the executable binary and TLS CAs from the build container.
 ENV SRC_DIR /lotus
 COPY --from=0 $SRC_DIR/lotus /usr/local/bin/lotus
-COPY --from=0 $SRC_DIR/lotus-storage-miner /usr/local/bin/lotus-storage-miner
+COPY --from=0 $SRC_DIR/lotus-* /usr/local/bin/
 COPY --from=0 /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=0 /tmp/tini /sbin/tini
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
Minor improvements:

* Use `1.13-buster` instead of `1.13.4-buster` base image (since patch versions are not expected to break compatibility)
* `MAKE_TARGET` build argument (enables `make debug`-builds which are required for smaller sectors/devnet)
* Copy all binaries beginning with `lotus-` into light stage. e.g. `lotus-seed` and `lotus-seal-worker`. Watching out not to copy source package `lotuspond` here.