### PR TITLE
planCommitting must handle SectorCommitFailed

### DIFF
--- a/storage/sealing/fsm.go
+++ b/storage/sealing/fsm.go
@@ -205,6 +205,8 @@ func planCommitting(events []statemachine.Event, state *SectorInfo) error {
 			state.State = api.SealCommitFailed
 		case SectorSealFailed:
 			state.State = api.CommitFailed
+		case SectorCommitFailed:
+			state.State = api.CommitFailed
 		default:
 			return xerrors.Errorf("planCommitting got event of unknown type %T, events: %+v", event.User, events)
 		}

--- a/storage/sealing/fsm_test.go
+++ b/storage/sealing/fsm_test.go
@@ -83,3 +83,17 @@ func TestSeedRevert(t *testing.T) {
 	m.planSingle(SectorProving{})
 	require.Equal(m.t, m.state.State, api.Proving)
 }
+
+func TestPlanCommittingHandlesSectorCommitFailed(t *testing.T) {
+	m := test{
+		s:     &Sealing{},
+		t:     t,
+		state: &SectorInfo{State: api.Committing},
+	}
+
+	events := []statemachine.Event{{SectorCommitFailed{}}}
+
+	require.NoError(t, planCommitting(events, m.state))
+
+	require.Equal(t, api.SectorStates[api.CommitFailed], api.SectorStates[m.state.State])
+}


### PR DESCRIPTION
The `SectorCommitFailed` struct can be created [from within `Sealing#handleCommitting`](https://github.com/filecoin-project/lotus/blob/9fc5f0cd9d43c1d31bbf9a0d80dfa57ac4f84862/storage/sealing/states.go#L191), and is created if `actors.SerializeParams(params)` produces an error or if `m.api.MpoolPushMessage(ctx.Context(), msg)` produces an error. 

The `planCommitting` function [needs to handle this struct (it currently produces an error)](https://github.com/filecoin-project/lotus/blob/9fc5f0cd9d43c1d31bbf9a0d80dfa57ac4f84862/storage/sealing/fsm.go#L209).