### PR TITLE
documentation: updates library schema with fedora instructions

### DIFF
--- a/documentation/en/.library.json
+++ b/documentation/en/.library.json
@@ -33,6 +33,12 @@
           "value": null
         },
         {
+          "title": "Fedora Installation",
+          "slug": "en+install-lotus-fedora",
+          "github": "en/install-lotus-fedora.md",
+          "value": null
+        },
+        {
           "title": "MacOS Installation",
           "slug": "en+install-lotus-macos",
           "github": "en/install-lotus-macos.md",


### PR DESCRIPTION
# Whats in this PR?

This PR adds Fedora instructions to the library schema so that the docs website can render them.

### Notes

Merging because it is not a controversial change.