### PR TITLE
yet another auto reconnect jsonrpc client implementation

### DIFF
--- a/lib/rpcli/client.go
+++ b/lib/rpcli/client.go
@@ -1,0 +1,567 @@
+package rpcli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+)
+
+var log = logging.Logger("rpc2")
+
+const (
+	reconnectMinInterval = time.Second
+	reconnectMaxInterval = 64 * time.Second
+)
+
+// NewMergeClient parses struct and set it's field with method
+func NewMergeClient(addr string, header http.Header, namespace string, outs []interface{}) (ClientCloser, error) {
+	connector := NewWebsocketConnector(addr, header)
+	client, closer, err := NewSimpleClient(connector, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	idgen := &simpleIDGen{}
+
+	for _, handler := range outs {
+		htyp := reflect.TypeOf(handler)
+		if htyp.Kind() != reflect.Ptr {
+			return nil, xerrors.New("expected handler to be a pointer")
+		}
+		typ := htyp.Elem()
+		if typ.Kind() != reflect.Struct {
+			return nil, xerrors.New("handler should be a struct")
+		}
+
+		val := reflect.ValueOf(handler)
+
+		for i := 0; i < typ.NumField(); i++ {
+			fn, err := newRPCMethod(typ.Field(i), client, idgen, namespace)
+			if err != nil {
+				return nil, err
+			}
+
+			val.Elem().Field(i).Set(fn)
+		}
+	}
+
+	return closer, nil
+}
+
+var _ Client = (*simpleClient)(nil)
+
+// Client represents a rpc Client, with all required policies inside
+type Client interface {
+	CallOption() CallOption
+
+	handleCall(*rpcContext)
+	cancel(*rpcContext)
+}
+
+type chanMapIdentifier struct {
+	connID uint64
+	chanID uint64
+}
+
+// ClientCloser controls
+type ClientCloser = func()
+
+// NewSimpleClient connects and returns a Client
+func NewSimpleClient(connector Connector, opt *ClientOption) (Client, ClientCloser, error) {
+	if opt == nil {
+		opt = &defaultClientOption
+	}
+
+	ctx := context.Background()
+
+	dialCtx := ctx
+	if opt.dialTimeout > 0 {
+		var dialCancel context.CancelFunc
+
+		dialCtx, dialCancel = context.WithTimeout(ctx, opt.dialTimeout)
+		defer dialCancel()
+
+	}
+
+	firstConn, err := connector.Dial(dialCtx)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("unable to connect: %w", err)
+	}
+
+	running, cancel := context.WithCancel(ctx)
+
+	cli := &simpleClient{
+		Connector: connector,
+
+		opt: *opt,
+
+		handling:   map[int64]*rpcContext{},
+		chanReqMap: map[chanMapIdentifier]int64{},
+		reqChanMap: map[int64]map[chanMapIdentifier]struct{}{},
+		firstConn:  firstConn,
+		reqIn:      make(chan *rpcContext),
+		cancelIn:   make(chan *rpcContext),
+
+		shouldReconnect: make(chan struct{}, 1),
+		reconnected:     make(chan RawConn),
+
+		running: running,
+	}
+
+	go cli.run()
+
+	return cli, cancel, nil
+}
+
+type simpleClient struct {
+	Connector
+
+	opt ClientOption
+
+	handling   map[int64]*rpcContext
+	chanReqMap map[chanMapIdentifier]int64
+	reqChanMap map[int64]map[chanMapIdentifier]struct{}
+
+	firstConn RawConn
+
+	reqIn    chan *rpcContext
+	cancelIn chan *rpcContext
+
+	shouldReconnect chan struct{}
+	reconnected     chan RawConn
+
+	running context.Context
+}
+
+func (sc *simpleClient) CallOption() CallOption {
+	return sc.opt.call
+}
+
+func (sc *simpleClient) handleCall(rctx *rpcContext) {
+	go func() {
+		select {
+		case <-sc.running.Done():
+			rctx.finish(nil, ErrClientClosed)
+			return
+
+		case <-rctx.ctx.Done():
+			rctx.finish(nil, rctx.ctx.Err())
+			return
+
+		case sc.reqIn <- rctx:
+
+		}
+	}()
+}
+
+func (sc *simpleClient) cancel(rctx *rpcContext) {
+	go func() {
+		select {
+		case <-sc.running.Done():
+			rctx.finish(nil, ErrClientClosed)
+			return
+
+		case <-rctx.ctx.Done():
+			rctx.finish(nil, rctx.ctx.Err())
+			return
+
+		case sc.cancelIn <- rctx:
+
+		}
+	}()
+}
+
+func (sc *simpleClient) run() {
+	go sc.startReconnectLoop()
+
+	conn := sc.firstConn
+	incomingCh, connCancel := sc.startRawConn(sc.running, conn)
+
+	defer func() {
+		sc.stop()
+		if connCancel != nil {
+			connCancel()
+		}
+	}()
+
+	var cleanupBadConn = func() {
+		if conn == nil {
+			return
+		}
+
+		connCancel()
+
+		connCancel = nil
+		conn = nil
+
+		// TODO: shall we consume remaining items in the incoming ch?
+		incomingCh = nil
+
+		sc.finishFailFastRequests(sc.running)
+		sc.triggerReconnect(sc.running)
+	}
+
+CLIENT_LOOP:
+	for {
+		select {
+		case <-sc.running.Done():
+			return
+
+		// incoming msg from underlying connection
+		case msgOrErr, ok := <-incomingCh:
+			if !ok {
+				cleanupBadConn()
+				continue CLIENT_LOOP
+			}
+
+			if msgOrErr.err != nil {
+				log.Warnf("get error from underlying incoming message loop: %s", msgOrErr.err)
+
+				// TODO: we may use this reader to debug
+				if msgOrErr.r != nil {
+
+				}
+
+				if isWsConnectionErr(msgOrErr.err) {
+					cleanupBadConn()
+				}
+
+				continue CLIENT_LOOP
+			}
+
+			var f frame
+			if err := json.NewDecoder(msgOrErr.r).Decode(&f); err != nil {
+				log.Warnf("unable to unmarshal incoming data into a frame: %s", err)
+				continue CLIENT_LOOP
+			}
+
+			sc.handleFrame(sc.running, msgOrErr.connID, f)
+
+		// new rpc request
+		case newReq := <-sc.reqIn:
+			select {
+			case <-newReq.ctx.Done():
+				newReq.finish(nil, nil)
+				continue CLIENT_LOOP
+
+			default:
+
+			}
+
+			err := conn.sendFrame(newReq.ctx, newReq.req)
+			if err != nil {
+				isConnErr := isWsConnectionErr(err)
+				if isConnErr {
+					cleanupBadConn()
+				}
+
+				// hold all non-failfast request here if we have no available ws conn
+				if !isConnErr || newReq.opt.failfast {
+					newReq.finish(nil, err)
+					continue CLIENT_LOOP
+				}
+			}
+
+			sc.registerRequest(newReq)
+
+		// cancel given rpc request
+		case canceled := <-sc.cancelIn:
+			rctx, ok := sc.handling[canceled.id]
+			if !ok {
+				continue CLIENT_LOOP
+			}
+
+			// send wsCancel for continuous requesst
+			if rctx.isChan {
+				if err := conn.sendFrame(sc.running, frame{
+					Jsonrpc: "2.0",
+					Method:  wsCancel,
+					Params:  []param{{v: reflect.ValueOf(rctx.id)}},
+				}); err != nil {
+					rctx.logger.Warnf("unable to send wsCancel: %s", err)
+				}
+			}
+
+			sc.onRequestErr(rctx.id, nil, ErrRequestFinished)
+
+		case newConn := <-sc.reconnected:
+			incomingCh, connCancel = sc.startRawConn(sc.running, newConn)
+			conn = newConn
+
+			// resend requests for non-failfast calls
+			for reqID := range sc.handling {
+				rctx := sc.handling[reqID]
+				if err := conn.sendFrame(rctx.ctx, rctx.req); err != nil {
+					if isWsConnectionErr(err) {
+						cleanupBadConn()
+						break
+					}
+
+					sc.onRequestErr(reqID, nil, err)
+				}
+			}
+		}
+	}
+}
+
+func (sc *simpleClient) startReconnectLoop() {
+	var reconnTimer <-chan time.Time
+	interval := reconnectMinInterval
+
+RE_LOOP:
+	for {
+		select {
+		case <-sc.running.Done():
+			return
+
+		case <-sc.shouldReconnect:
+			// only setup the timer if there is no previous reonnecting attemption
+			if reconnTimer == nil {
+				log.Debugf("websocket will auto-recoonect after %s", interval)
+				reconnTimer = time.After(interval)
+			}
+
+		case <-reconnTimer:
+			conn, err := sc.Dial(sc.running)
+			if err != nil {
+				interval *= 2
+				if interval > reconnectMaxInterval {
+					interval = reconnectMaxInterval
+				}
+
+				reconnTimer = time.After(interval)
+
+				log.Warnf("unable to establish a websocket connection: %s, will auto-recoonect after %s", err, interval)
+
+				continue RE_LOOP
+			}
+
+			select {
+			case <-sc.running.Done():
+				return
+
+			case sc.reconnected <- conn:
+				// reset timer and interval here
+				interval = reconnectMinInterval
+				reconnTimer = nil
+			}
+		}
+	}
+}
+
+func (sc *simpleClient) startRawConn(ctx context.Context, conn RawConn) (<-chan rawMsgOrErr, context.CancelFunc) {
+	connCtx, connCancel := context.WithCancel(ctx)
+
+	inCh := conn.startIncomingLoop(connCtx)
+
+	return inCh, connCancel
+}
+
+func (sc *simpleClient) registerRequest(rctx *rpcContext) {
+	sc.handling[rctx.id] = rctx
+}
+
+func (sc *simpleClient) unregisterRequest(reqID int64) {
+	if _, ok := sc.handling[reqID]; ok {
+		delete(sc.handling, reqID)
+	}
+
+	if m, ok := sc.reqChanMap[reqID]; ok {
+		delete(sc.reqChanMap, reqID)
+
+		for mapID := range m {
+			if _, ok := sc.chanReqMap[mapID]; ok {
+				delete(sc.chanReqMap, mapID)
+			}
+		}
+	}
+}
+
+func (sc *simpleClient) registerChanMap(connID, chanID uint64, reqID int64) {
+	mid := chanMapIdentifier{
+		connID: connID,
+		chanID: chanID,
+	}
+
+	sc.chanReqMap[mid] = reqID
+	if sc.reqChanMap[reqID] == nil {
+		sc.reqChanMap[reqID] = map[chanMapIdentifier]struct{}{}
+	}
+
+	sc.reqChanMap[reqID][mid] = struct{}{}
+}
+
+func (sc *simpleClient) findRPCContext(connID, chanID uint64) (*rpcContext, bool) {
+	mid := chanMapIdentifier{
+		connID: connID,
+		chanID: chanID,
+	}
+
+	reqID, ok := sc.chanReqMap[mid]
+	if !ok {
+		return nil, false
+	}
+
+	rctx, ok := sc.handling[reqID]
+	if !ok {
+		delete(sc.chanReqMap, mid)
+	}
+
+	return rctx, ok
+}
+
+func (sc *simpleClient) handleFrame(ctx context.Context, connID uint64, f frame) {
+	switch f.Method {
+	case "":
+		sc.handleResponseFrame(ctx, connID, f)
+
+	case chValue:
+		sc.handleChanMessageFrame(ctx, connID, f)
+
+	case chClose:
+		sc.handleChanCloseFrame(ctx, connID, f)
+
+	default:
+		log.Warnf("unexpected frame method for clien-side %s", f.Method)
+	}
+}
+
+func (sc *simpleClient) handleResponseFrame(ctx context.Context, connID uint64, f frame) {
+	if f.ID == nil {
+		log.Warn("got response frame without request id")
+		return
+	}
+
+	reqID := *f.ID
+
+	rctx, ok := sc.handling[reqID]
+	if !ok {
+		log.Warnf("got response frame with non-exist requesst id %d", *f.ID)
+		return
+	}
+
+	if f.Error != nil {
+		sc.onRequestErr(reqID, &connID, f.Error)
+		return
+	}
+
+	if !rctx.isChan {
+		rctx.send(dataOrErr{
+			connID: &connID,
+
+			// TODO: use pooled Buffer or Reader here
+			r: ioutil.NopCloser(bytes.NewReader(f.Result)),
+		})
+
+		sc.unregisterRequest(reqID)
+		return
+	}
+
+	handshaked := false
+	var chanID uint64
+	if len(f.Params) == 1 {
+		if err := json.Unmarshal(f.Params[0].data, &chanID); err != nil {
+			rctx.logger.Warnf("unable to parse chan id: %s", err)
+		} else {
+			handshaked = true
+		}
+	}
+
+	if !handshaked {
+		sc.onRequestErr(reqID, &connID, ErrBadHandshake)
+		return
+	}
+
+	sc.registerChanMap(connID, chanID, reqID)
+	rctx.send(dataOrErr{
+		connID: &connID,
+		err:    nil,
+		r:      nil,
+	})
+}
+
+func (sc *simpleClient) handleChanMessageFrame(ctx context.Context, connID uint64, f frame) {
+	if len(f.Params) != 2 {
+		log.Warnf("expected 2 params in %s frame, got %d", chValue, len(f.Params))
+		return
+	}
+
+	var chanID uint64
+	if err := json.Unmarshal(f.Params[0].data, &chanID); err != nil {
+		log.Errorf("unable to unmarshal channel id in %s: %s", chValue, err)
+		return
+	}
+
+	rctx, ok := sc.findRPCContext(connID, chanID)
+	if !ok {
+		log.Warnf("unable to find rpc context for conn %d chan %d", connID, chanID)
+		return
+	}
+
+	rctx.send(dataOrErr{
+		connID: &connID,
+		r:      ioutil.NopCloser(bytes.NewReader(f.Params[1].data)),
+	})
+}
+
+func (sc *simpleClient) handleChanCloseFrame(ctx context.Context, connID uint64, f frame) {
+	if len(f.Params) != 1 {
+		log.Warnf("expected 1 params in %s frame, got %d", chClose, len(f.Params))
+		return
+	}
+
+	var chanID uint64
+	if err := json.Unmarshal(f.Params[0].data, &chanID); err != nil {
+		log.Errorf("unable to unmarshal channel id in %s: %s", chClose, err)
+		return
+	}
+
+	rctx, ok := sc.findRPCContext(connID, chanID)
+	if !ok {
+		log.Warnf("unable to find rpc context for conn %d chan %d", connID, chanID)
+		return
+	}
+
+	rctx.finish(&connID, ErrRequestFinished)
+}
+
+func (sc *simpleClient) finishFailFastRequests(ctx context.Context) {
+	for reqID := range sc.handling {
+		rctx := sc.handling[reqID]
+		if rctx.opt.failfast {
+			sc.onRequestErr(reqID, nil, ErrNoAvailableConnection)
+		}
+	}
+}
+
+func (sc *simpleClient) triggerReconnect(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+
+	case sc.shouldReconnect <- struct{}{}:
+
+	}
+}
+
+func (sc *simpleClient) stop() {
+	for reqID := range sc.handling {
+		sc.onRequestErr(reqID, nil, ErrClientClosed)
+	}
+}
+
+func (sc *simpleClient) onRequestErr(reqID int64, connID *uint64, err error) {
+	rctx, ok := sc.handling[reqID]
+	if !ok {
+		return
+	}
+
+	rctx.finish(connID, err)
+	sc.unregisterRequest(reqID)
+}

--- a/lib/rpcli/client.go
+++ b/lib/rpcli/client.go
@@ -468,12 +468,19 @@ func (sc *simpleClient) handleResponseFrame(ctx context.Context, connID uint64, 
 		return
 	}
 
+	rctx.logger.Debugf("assigned to conn %d chan %d", connID, chanID)
 	sc.registerChanMap(connID, chanID, reqID)
-	rctx.send(dataOrErr{
-		connID: &connID,
-		err:    nil,
-		r:      nil,
-	})
+
+	// we only send mapping frame on init
+	if !rctx.streaming {
+		rctx.send(dataOrErr{
+			connID: &connID,
+			err:    nil,
+			r:      nil,
+		})
+
+		rctx.streaming = true
+	}
 }
 
 func (sc *simpleClient) handleChanMessageFrame(ctx context.Context, connID uint64, f frame) {

--- a/lib/rpcli/client.go
+++ b/lib/rpcli/client.go
@@ -324,7 +324,7 @@ RE_LOOP:
 			}
 
 		case <-reconnTimer:
-			conn, err := sc.Dial(sc.running)
+			conn, err := sc.connect()
 			if err != nil {
 				interval *= 2
 				if interval > reconnectMaxInterval {
@@ -351,6 +351,17 @@ RE_LOOP:
 			}
 		}
 	}
+}
+
+func (sc *simpleClient) connect() (RawConn, error) {
+	ctx := sc.running
+	if sc.opt.dialTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, sc.opt.dialTimeout)
+		defer cancel()
+	}
+
+	return sc.Connector.Dial(ctx)
 }
 
 func (sc *simpleClient) startRawConn(ctx context.Context, conn RawConn) (<-chan rawMsgOrErr, context.CancelFunc) {

--- a/lib/rpcli/options.go
+++ b/lib/rpcli/options.go
@@ -1,0 +1,61 @@
+package rpcli
+
+import (
+	"time"
+)
+
+var (
+	defaultDialTimeout = 10 * time.Second
+
+	defaultCallOption = CallOption{
+		failfast:          false,
+		keepBufferedItems: false,
+	}
+
+	defaultClientOption = ClientOption{
+		call:        defaultCallOption,
+		dialTimeout: defaultDialTimeout,
+	}
+)
+
+// CallOptionModifier modifies given call option
+type CallOptionModifier = func(*CallOption)
+
+// CallOption is the option for each rpc call
+type CallOption struct {
+	failfast bool
+
+	// TODO: keep sending buffered items util any error occurs
+	keepBufferedItems bool
+}
+
+// FailFast set failfast option to given value
+func FailFast(b bool) CallOptionModifier {
+	return func(opt *CallOption) {
+		opt.failfast = b
+	}
+}
+
+// ClientOptionModifier modifies given call option
+type ClientOptionModifier = func(*ClientOption)
+
+// ClientOption is the option for client
+type ClientOption struct {
+	call CallOption
+
+	dialTimeout time.Duration
+}
+
+// UpdateCallOption updates call option with given modifiers
+func (co *ClientOption) UpdateCallOption(opts ...CallOptionModifier) {
+	for _, mod := range opts {
+		mod(&co.call)
+	}
+}
+
+// DialTimeout set dial timeout to given duraiton
+func DialTimeout(d time.Duration) ClientOptionModifier {
+	return func(opt *ClientOption) {
+		opt.dialTimeout = d
+	}
+}

--- a/lib/rpcli/protocol.go
+++ b/lib/rpcli/protocol.go
@@ -1,0 +1,120 @@
+package rpcli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	errorType   = reflect.TypeOf(new(error)).Elem()
+	contextType = reflect.TypeOf(new(context.Context)).Elem()
+)
+
+const (
+	wsCancel = "xrpc.cancel"
+	chValue  = "xrpc.ch.val"
+	chClose  = "xrpc.ch.close"
+)
+
+// common errors
+var (
+	ErrContextDone = xerrors.New("context done")
+
+	ErrNoResponse       = xerrors.New("no response received")
+	ErrEmptyDataFrame   = xerrors.New("received an empty data frame")
+	ErrNilDataFrame     = xerrors.New("received a nil data frame")
+	ErrJSONUnmarshaling = xerrors.New("json unmarshaling failed")
+
+	ErrUnexpectedMessageType = xerrors.New("unexpected message type")
+	ErrMalformedFrame        = xerrors.New("malformed frame data")
+
+	ErrNoAvailableConnection = xerrors.New("no available websocket connection")
+
+	ErrClientClosed    = xerrors.New("rpc client closed")
+	ErrRequestFinished = xerrors.New("rpc request finished")
+
+	ErrBadHandshake = xerrors.New("bad handshake")
+)
+
+type param struct {
+	data []byte // from unmarshal
+
+	v reflect.Value // to marshal
+}
+
+func (p *param) UnmarshalJSON(raw []byte) error {
+	p.data = make([]byte, len(raw))
+	copy(p.data, raw)
+	return nil
+}
+
+func (p *param) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.v.Interface())
+}
+
+type respError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *respError) Error() string {
+	if e.Code >= -32768 && e.Code <= -32000 {
+		return fmt.Sprintf("RPC error (%d): %s", e.Code, e.Message)
+	}
+	return e.Message
+}
+
+type frame struct {
+	// common
+	Jsonrpc string            `json:"jsonrpc"`
+	ID      *int64            `json:"id,omitempty"`
+	Meta    map[string]string `json:"meta,omitempty"`
+
+	// request
+	Method string  `json:"method,omitempty"`
+	Params []param `json:"params,omitempty"`
+
+	// response
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *respError      `json:"error,omitempty"`
+}
+
+type dataOrErr struct {
+	connID *uint64
+	err    error
+
+	// call r.Close() to release pooled buffer
+	// maybe use a interface named ReadReleaser here?
+	r io.ReadCloser
+}
+
+func (de *dataOrErr) extractJSON(v interface{}, required bool) error {
+	if de == nil {
+		return ErrNilDataFrame
+	}
+
+	if de.err != nil {
+		return de.err
+	}
+
+	if de.r == nil {
+		if required {
+			return ErrEmptyDataFrame
+		}
+
+		return nil
+	}
+
+	defer de.r.Close()
+
+	if err := json.NewDecoder(de.r).Decode(v); err != nil {
+		return xerrors.Errorf("%w: %s", ErrJSONUnmarshaling, err)
+	}
+
+	return nil
+}

--- a/lib/rpcli/rpc.go
+++ b/lib/rpcli/rpc.go
@@ -1,0 +1,355 @@
+package rpcli
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"sync"
+
+	logging "github.com/ipfs/go-log/v2"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+	"golang.org/x/xerrors"
+)
+
+var nullValue = reflect.ValueOf(struct{}{})
+
+type rpcContext struct {
+	id     int64
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	req    frame
+	isChan bool
+
+	opt CallOption
+
+	// we take the advantage of mutex fairness since go1.12 here
+	// to keep incoming dataOrErrs ordered
+	// and since there can be only 1 receiver, no need to acquire mutex before consuming
+	resChMu sync.Mutex
+	resCh   chan dataOrErr
+	logger  logging.StandardLogger
+}
+
+func (rc *rpcContext) send(de dataOrErr) {
+	if contextDone(rc.ctx) {
+		return
+	}
+
+	started := make(chan struct{}, 0)
+
+	go func() {
+		close(started)
+
+		rc.resChMu.Lock()
+		defer rc.resChMu.Unlock()
+
+		select {
+		case <-rc.ctx.Done():
+			return
+
+		case rc.resCh <- de:
+			return
+		}
+	}()
+
+	<-started
+}
+
+func (rc *rpcContext) finish(connID *uint64, err error) {
+	if contextDone(rc.ctx) {
+		return
+	}
+
+	started := make(chan struct{}, 0)
+
+	go func() {
+		close(started)
+
+		rc.resChMu.Lock()
+		defer func() {
+			rc.cancel()
+			rc.resChMu.Unlock()
+		}()
+
+		if err != nil {
+			select {
+			case <-rc.ctx.Done():
+				return
+
+			case rc.resCh <- dataOrErr{
+				connID: connID,
+				err:    err,
+			}:
+				return
+			}
+		}
+
+	}()
+
+	<-started
+}
+
+func newRPCMethod(field reflect.StructField, cli Client, idgen idGenerator, namespace string) (reflect.Value, error) {
+	ftyp := field.Type
+	if ftyp.Kind() != reflect.Func {
+		return reflect.Value{}, xerrors.New("handler field not a func")
+	}
+
+	rm := &rpcMethod{
+		method:  fmt.Sprintf("%s.%s", namespace, field.Name),
+		idgen:   idgen,
+		cli:     cli,
+		refFunc: ftyp,
+	}
+
+	rm.outValIdx, rm.outErrIdx, rm.outNum = processFuncOut(ftyp)
+
+	rm.inHasCtx = ftyp.NumIn() > 0 && ftyp.In(0) == contextType
+	rm.returnChan = rm.outValIdx != -1 && ftyp.Out(rm.outValIdx).Kind() == reflect.Chan
+
+	var mods []CallOptionModifier
+	_, failfast := field.Tag.Lookup("failfast")
+	mods = append(mods, FailFast(failfast))
+
+	rm.callOptMods = mods
+
+	log.Debugf("rpc method constructed %#v", rm)
+	return reflect.MakeFunc(ftyp, rm.call), nil
+}
+
+// parsed func
+type rpcMethod struct {
+	method string
+	idgen  idGenerator
+	cli    Client
+
+	refFunc reflect.Type
+
+	inHasCtx bool
+
+	outNum    int
+	outValIdx int
+	outErrIdx int
+
+	returnChan  bool
+	callOptMods []CallOptionModifier
+}
+
+func (rm *rpcMethod) call(args []reflect.Value) []reflect.Value {
+	id := int64(rm.idgen.next())
+	meta := map[string]string{}
+
+	var rawCtx context.Context
+	var span *trace.Span
+
+	if rm.inHasCtx {
+		rawCtx = args[0].Interface().(context.Context)
+		rawCtx, span = trace.StartSpan(rawCtx, "api.call")
+		defer span.End()
+
+		span.AddAttributes(trace.StringAttribute("method", rm.method))
+
+		meta["SpanContext"] = base64.StdEncoding.EncodeToString(
+			propagation.Binary(span.SpanContext()))
+
+		args = args[1:]
+
+	} else {
+		rawCtx = context.Background()
+	}
+
+	params := make([]param, len(args))
+	for i := range args {
+		params[i] = param{
+			v: args[i],
+		}
+	}
+
+	ctx, cancel := context.WithCancel(rawCtx)
+
+	callOpt := rm.cli.CallOption()
+
+	for _, opt := range rm.callOptMods {
+		opt(&callOpt)
+	}
+
+	rpcCtx := &rpcContext{
+		id:     id,
+		ctx:    ctx,
+		cancel: cancel,
+		req: frame{
+			Jsonrpc: "2.0",
+			ID:      &id,
+			Method:  rm.method,
+			Params:  params,
+		},
+		isChan: rm.returnChan,
+		opt:    callOpt,
+		resCh:  make(chan dataOrErr, 1),
+		logger: log.With("method", rm.method, "reqid", id),
+	}
+
+	rm.cli.handleCall(rpcCtx)
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return rm.processError(xerrors.Errorf("%w: %s", ErrContextDone, ctx.Err()))
+
+	case de, ok := <-rpcCtx.resCh:
+		if !ok {
+			cancel()
+			return rm.processError(ErrNoResponse)
+		}
+
+		if de.err != nil {
+			cancel()
+			return rm.processError(de.err)
+		}
+
+		if !rpcCtx.isChan {
+			return rm.processSingleCall(rpcCtx, de)
+		}
+
+		return rm.processOutChan(rm.cli, rpcCtx)
+	}
+}
+
+func (rm *rpcMethod) processError(err error) []reflect.Value {
+	out := make([]reflect.Value, rm.outNum)
+
+	if rm.outValIdx != -1 {
+		out[rm.outValIdx] = reflect.New(rm.refFunc.Out(rm.outValIdx)).Elem()
+	}
+
+	if rm.outErrIdx != -1 {
+		out[rm.outErrIdx] = reflect.New(errorType).Elem()
+		out[rm.outErrIdx].Set(reflect.ValueOf(err))
+	}
+
+	return out
+}
+
+func (rm *rpcMethod) processResponse(val reflect.Value) []reflect.Value {
+	out := make([]reflect.Value, rm.outNum)
+
+	if rm.outValIdx != -1 {
+		out[rm.outValIdx] = val
+	}
+
+	if rm.outErrIdx != -1 {
+		out[rm.outErrIdx] = reflect.New(errorType).Elem()
+	}
+
+	return out
+}
+
+func (rm *rpcMethod) processSingleCall(rctx *rpcContext, de dataOrErr) []reflect.Value {
+	defer rctx.cancel()
+
+	if rm.outValIdx == -1 {
+		return rm.processResponse(nullValue)
+	}
+
+	val := reflect.New(rm.refFunc.Out(rm.outValIdx))
+
+	rctx.logger.Debugf("rpc result type=%v", rm.refFunc.Out(rm.outValIdx))
+	if err := de.extractJSON(val.Interface(), false); err != nil {
+		return rm.processError(err)
+	}
+
+	return rm.processResponse(val)
+}
+
+func (rm *rpcMethod) processOutChan(cli Client, rctx *rpcContext) []reflect.Value {
+	rctx.logger.Debug("chan handshake made")
+
+	elemType := rm.refFunc.Out(rm.outValIdx).Elem()
+	stream, err := newRPCStream(cli, rctx, elemType)
+	if err != nil {
+		rctx.cancel()
+		return rm.processError(err)
+	}
+
+	go stream.start()
+
+	return rm.processResponse(stream.outCh.Convert(rm.refFunc.Out(rm.outValIdx)))
+}
+
+func newRPCStream(cli Client, rctx *rpcContext, elemType reflect.Type) (*rpcStream, error) {
+	chType := reflect.ChanOf(reflect.BothDir, elemType)
+	outCh := reflect.MakeChan(chType, 1)
+
+	return &rpcStream{
+		cli:      cli,
+		rctx:     rctx,
+		elemType: elemType,
+		outCh:    outCh,
+	}, nil
+}
+
+type rpcStream struct {
+	cli      Client
+	rctx     *rpcContext
+	elemType reflect.Type
+	outCh    reflect.Value
+}
+
+func (rs *rpcStream) start() {
+	rs.rctx.logger.Debug("rpc stream loop start")
+
+	defer func() {
+		rs.outCh.Close()
+		rs.rctx.cancel()
+		rs.cli.cancel(rs.rctx)
+		rs.rctx.logger.Debug("rpc stream loop stop")
+	}()
+
+	selCases := [2]reflect.SelectCase{}
+	selCases[0] = reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(rs.rctx.ctx.Done()),
+	}
+
+	for {
+		select {
+		case <-rs.rctx.ctx.Done():
+			return
+
+		case de, ok := <-rs.rctx.resCh:
+			if !ok {
+				return
+			}
+
+			if de.err != nil {
+				if de.err == ErrRequestFinished {
+					rs.rctx.logger.Debugf("received terminate err")
+				} else {
+					rs.rctx.logger.Warnf("received err: %s", de.err)
+				}
+
+				return
+			}
+
+			val := reflect.New(rs.elemType)
+			if err := de.extractJSON(val.Interface(), true); err != nil {
+				rs.rctx.logger.Warnf("unable to extract json data from incoming: %s", err)
+				return
+			}
+
+			selCases[1] = reflect.SelectCase{
+				Dir:  reflect.SelectSend,
+				Chan: rs.outCh,
+				Send: val,
+			}
+
+			choose, _, _ := reflect.Select(selCases[:])
+			if choose == 0 {
+				return
+			}
+		}
+	}
+}

--- a/lib/rpcli/rpc.go
+++ b/lib/rpcli/rpc.go
@@ -28,9 +28,10 @@ type rpcContext struct {
 	// we take the advantage of mutex fairness since go1.12 here
 	// to keep incoming dataOrErrs ordered
 	// and since there can be only 1 receiver, no need to acquire mutex before consuming
-	resChMu sync.Mutex
-	resCh   chan dataOrErr
-	logger  logging.StandardLogger
+	resChMu   sync.Mutex
+	resCh     chan dataOrErr
+	logger    logging.StandardLogger
+	streaming bool
 }
 
 func (rc *rpcContext) send(de dataOrErr) {
@@ -343,7 +344,7 @@ func (rs *rpcStream) start() {
 			selCases[1] = reflect.SelectCase{
 				Dir:  reflect.SelectSend,
 				Chan: rs.outCh,
-				Send: val,
+				Send: val.Elem(),
 			}
 
 			choose, _, _ := reflect.Select(selCases[:])

--- a/lib/rpcli/rpc.go
+++ b/lib/rpcli/rpc.go
@@ -262,7 +262,7 @@ func (rm *rpcMethod) processSingleCall(rctx *rpcContext, de dataOrErr) []reflect
 		return rm.processError(err)
 	}
 
-	return rm.processResponse(val)
+	return rm.processResponse(val.Elem())
 }
 
 func (rm *rpcMethod) processOutChan(cli Client, rctx *rpcContext) []reflect.Value {

--- a/lib/rpcli/util.go
+++ b/lib/rpcli/util.go
@@ -1,0 +1,58 @@
+package rpcli
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+)
+
+func contextDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+
+	default:
+		return false
+	}
+}
+
+type idGenerator interface {
+	next() uint64
+}
+
+type simpleIDGen struct {
+	id uint64
+}
+
+func (g *simpleIDGen) next() uint64 {
+	return atomic.AddUint64(&g.id, 1)
+}
+
+// processFuncOut finds value and error Outs in function
+func processFuncOut(funcType reflect.Type) (valOut int, errOut int, n int) {
+	errOut = -1 // -1 if not found
+	valOut = -1
+	n = funcType.NumOut()
+
+	switch n {
+	case 0:
+	case 1:
+		if funcType.Out(0) == errorType {
+			errOut = 0
+		} else {
+			valOut = 0
+		}
+	case 2:
+		valOut = 0
+		errOut = 1
+		if funcType.Out(1) != errorType {
+			panic("expected error as second return value")
+		}
+	default:
+		errstr := fmt.Sprintf("too many return values: %s", funcType)
+		panic(errstr)
+	}
+
+	return
+}

--- a/lib/rpcli/websocket.go
+++ b/lib/rpcli/websocket.go
@@ -167,3 +167,11 @@ type rawMsgOrErr struct {
 	frame
 	err error
 }
+
+func safeSendFrame(ctx context.Context, conn RawConn, f frame) error {
+	if conn == nil {
+		return ErrNoAvailableConnection
+	}
+
+	return conn.sendFrame(ctx, f)
+}

--- a/lib/rpcli/websocket.go
+++ b/lib/rpcli/websocket.go
@@ -1,0 +1,162 @@
+package rpcli
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+// Connector dials with inside context and returns established connection or any failure
+type Connector interface {
+	Dial(context.Context) (RawConn, error)
+}
+
+// NewWebsocketConnector returns a connector with given infomation
+func NewWebsocketConnector(endpoint string, header http.Header) Connector {
+	return &wsConnector{
+		endpoint: endpoint,
+		header:   header,
+		idgen:    &simpleIDGen{},
+	}
+}
+
+type wsConnector struct {
+	endpoint string
+	header   http.Header
+	idgen    idGenerator
+}
+
+func (wsc *wsConnector) Dial(ctx context.Context) (RawConn, error) {
+	wsconn, _, err := websocket.DefaultDialer.DialContext(ctx, wsc.endpoint, wsc.header)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wsConn{
+		id: wsc.idgen.next(),
+		ws: wsconn,
+	}, nil
+}
+
+// RawConn defines a bio-direction connection, and can be mocked for testing
+type RawConn interface {
+	startIncomingLoop(ctx context.Context) <-chan rawMsgOrErr
+	sendFrame(ctx context.Context, f frame) error
+}
+
+var _ RawConn = (*wsConn)(nil)
+
+// wsConn is a simple wrapper around websocket.wsConn
+type wsConn struct {
+	id uint64
+	ws *websocket.Conn
+}
+
+func (c *wsConn) startIncomingLoop(ctx context.Context) <-chan rawMsgOrErr {
+	out := make(chan rawMsgOrErr, 1)
+	go func() {
+
+		defer func() {
+			close(out)
+			c.ws.Close()
+		}()
+
+		onNext := func(r io.Reader) {
+			select {
+			case <-ctx.Done():
+
+			case out <- rawMsgOrErr{
+				connID: c.id,
+				r:      r,
+			}:
+
+			}
+		}
+
+		onErr := func(err error) {
+			select {
+			case <-ctx.Done():
+
+			case out <- rawMsgOrErr{
+				connID: c.id,
+				err:    err,
+			}:
+
+			}
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			default:
+
+			}
+
+			mtype, reader, err := c.ws.NextReader()
+			if err != nil {
+				onErr(err)
+				return
+			}
+
+			if mtype != websocket.BinaryMessage && mtype != websocket.TextMessage {
+				onErr(ErrUnexpectedMessageType)
+				return
+			}
+
+			onNext(reader)
+		}
+	}()
+
+	return out
+}
+
+func (c *wsConn) sendFrame(ctx context.Context, f frame) error {
+	if c == nil {
+		return ErrNoAvailableConnection
+	}
+
+	err := c.ws.WriteJSON(f)
+	if err == nil {
+		return nil
+	}
+
+	if isWsConnectionErr(err) {
+		return ErrNoAvailableConnection
+	}
+
+	return err
+}
+
+func isWsConnectionErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if err == ErrNoAvailableConnection {
+		return true
+	}
+
+	// see RFC 6455
+	// https://tools.ietf.org/html/rfc6455#section-7.4.1
+	return websocket.IsCloseError(
+		err,
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseProtocolError,
+		websocket.CloseUnsupportedData,
+		websocket.CloseInvalidFramePayloadData,
+		websocket.ClosePolicyViolation,
+		// shall we handle `message too big` in a special way?
+		websocket.CloseMessageTooBig,
+	)
+}
+
+type rawMsgOrErr struct {
+	connID uint64
+	r      io.Reader
+	err    error
+}


### PR DESCRIPTION
- a jsonrpc client implementation aimed to be compatible with client-side codes in `lib/jsonrpc`
- support auto-reconnection, trying to fix #127 
- provide some configurable call policy on each method, including auto-retry(failfast)
- channels will be maintained even if conn is unavailable, unless the request is `failfast`ed


tested  both `failfast` and `non-failfast` scenario in `ChainNotify`
may need more tests, including both units & integrations