### PR TITLE
Support multi storage directories in miner init

### DIFF
--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -34,6 +34,7 @@ import (
 	"github.com/filecoin-project/lotus/genesis"
 	"github.com/filecoin-project/lotus/markets/utils"
 	"github.com/filecoin-project/lotus/miner"
+	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -373,7 +374,22 @@ func storageMinerInit(ctx context.Context, cctx *cli.Context, api lapi.FullNode,
 				return err
 			}
 
-			sbcfg, err := modules.SectorBuilderConfig(sectorbuilder.SimplePath(lr.Path()), 2, false, false)(mds, api)
+			c, err := lr.Config()
+			if err != nil {
+				return err
+			}
+
+			cfg, ok := c.(*config.StorageMiner)
+			if !ok {
+				return xerrors.Errorf("invalid config from repo, got: %T", c)
+			}
+
+			scfg := sectorbuilder.SimplePath(lr.Path())
+			if len(cfg.SectorBuilder.Storage) > 0 {
+				scfg = cfg.SectorBuilder.Storage
+			}
+
+			sbcfg, err := modules.SectorBuilderConfig(scfg, 2, false, false)(mds, api)
 			if err != nil {
 				return xerrors.Errorf("getting genesis miner sector builder config: %w", err)
 			}

--- a/documentation/en/local-dev-net.md
+++ b/documentation/en/local-dev-net.md
@@ -26,7 +26,7 @@ Create the genesis block and start up the first node:
 Set up the genesis miner:
 
 ```sh
-./lotus-storage-miner init --genesis-miner --actor=t0101 --sector-size=1024 --pre-sealed-sectors=~/.genesis-sectors --nosync
+./lotus-storage-miner init --genesis-miner --actor=t0101 --sector-size=1024 --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t0101.json --nosync
 ```
 
 Now, finally, start up the miner:

--- a/lotuspond/spawn.go
+++ b/lotuspond/spawn.go
@@ -142,7 +142,8 @@ func (api *api) SpawnStorage(fullNodeRepo string) (nodeInfo, error) {
 
 	initArgs := []string{"init", "--nosync"}
 	if fullNodeRepo == api.running[1].meta.Repo {
-		initArgs = []string{"init", "--actor=t0101", "--genesis-miner", "--pre-sealed-sectors=" + filepath.Join(fullNodeRepo, "preseal")}
+		presealPrefix := filepath.Join(fullNodeRepo, "preseal")
+		initArgs = []string{"init", "--actor=t0101", "--genesis-miner", "--pre-sealed-sectors=" + presealPrefix, "--pre-sealed-metadata=" + filepath.Join(presealPrefix, "pre-seal-t0101.json")}
 	}
 
 	id := atomic.AddInt32(&api.cmds, 1)

--- a/scripts/dev/sminer-init
+++ b/scripts/dev/sminer-init
@@ -4,4 +4,4 @@ set -o xtrace
 
 export TRUST_PARAMS=1
 
-go run -tags=debug ./cmd/lotus-storage-miner init --actor=t0101 --genesis-miner --pre-sealed-sectors=~/.genesis-sectors
+go run -tags=debug ./cmd/lotus-storage-miner init --actor=t0101 --genesis-miner --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t0101.json

--- a/scripts/init-network.sh
+++ b/scripts/init-network.sh
@@ -86,12 +86,12 @@ mdt0111=$(mktemp -d)
 mdt0222=$(mktemp -d)
 mdt0333=$(mktemp -d)
 
-env LOTUS_PATH="${ldt0111}" LOTUS_STORAGE_PATH="${mdt0111}" ./lotus-storage-miner init --genesis-miner --actor=t0111 --pre-sealed-sectors="${sdt0111}" --nosync=true --sector-size="${SECTOR_SIZE}" || true
+env LOTUS_PATH="${ldt0111}" LOTUS_STORAGE_PATH="${mdt0111}" ./lotus-storage-miner init --genesis-miner --actor=t0111 --pre-sealed-sectors="${sdt0111}" --pre-sealed-metadata="${sdt0111}/pre-seal-t0111.json" --nosync=true --sector-size="${SECTOR_SIZE}" || true
 env LOTUS_PATH="${ldt0111}" LOTUS_STORAGE_PATH="${mdt0111}" ./lotus-storage-miner run --nosync &
 mpid=$!
 
-env LOTUS_PATH="${ldt0222}" LOTUS_STORAGE_PATH="${mdt0222}" ./lotus-storage-miner init                 --actor=t0222 --pre-sealed-sectors="${sdt0222}" --nosync=true --sector-size="${SECTOR_SIZE}" || true
-env LOTUS_PATH="${ldt0333}" LOTUS_STORAGE_PATH="${mdt0333}" ./lotus-storage-miner init                 --actor=t0333 --pre-sealed-sectors="${sdt0333}" --nosync=true --sector-size="${SECTOR_SIZE}" || true
+env LOTUS_PATH="${ldt0222}" LOTUS_STORAGE_PATH="${mdt0222}" ./lotus-storage-miner init                 --actor=t0222 --pre-sealed-sectors="${sdt0222}" --pre-sealed-metadata="${sdt0222}/pre-seal-t0222.json" --nosync=true --sector-size="${SECTOR_SIZE}" || true
+env LOTUS_PATH="${ldt0333}" LOTUS_STORAGE_PATH="${mdt0333}" ./lotus-storage-miner init                 --actor=t0333 --pre-sealed-sectors="${sdt0333}" --pre-sealed-metadata="${sdt0333}/pre-seal-t0333.json" --nosync=true --sector-size="${SECTOR_SIZE}" || true
 
 kill $mpid
 wait $mpid


### PR DESCRIPTION
- Added a new `pre-sealed-metadata` flag to specify the location of the metadata for the presealed sectors.
- Load storage directories from config
- Shifted the metadata loading to outside of the genesis miner condition