### PR TITLE
Fuzz CBOR en/decoding of block messages

### DIFF
--- a/chain/types/message_fuzz.go
+++ b/chain/types/message_fuzz.go
@@ -2,9 +2,13 @@
 
 package types
 
-import "bytes"
+import (
+	"bytes"
+	"github.com/filecoin-project/go-address"
+)
 
-func FuzzMessage(data []byte) int {
+// FIXME: Separate this into `UnmarshalCBOR` calls of the underlying elements first.
+func FuzzMessageDecoder(data []byte) int {
 	var msg Message
 	err := msg.UnmarshalCBOR(bytes.NewReader(data))
 	if err != nil {
@@ -28,3 +32,42 @@ func FuzzMessage(data []byte) int {
 	}
 	return 1
 }
+
+func FuzzAddressEncoder(data []byte) int {
+	ads, err := address.NewFromBytes(data)
+	if err != nil {
+		return -1
+	}
+	// FIXME: The fuzzer should produce as many valid addresses as possible, `newAddress`
+	// should be partially expanded here. At the moment we signal invalid ones with `-1`.
+
+	if err := ads.MarshalCBOR(new(bytes.Buffer)); err != nil {
+		panic(err)
+	}
+
+	return 1
+}
+
+func FuzzBigIntEncoder(data []byte) int {
+	bi, err := fromCborBytes(data)
+	if err != nil {
+		return -1
+	}
+
+	buf := new(bytes.Buffer)
+	if err := bi.MarshalCBOR(buf); err != nil {
+		panic(err)
+	}
+
+	//if !bytes.Equal(data, buf.Bytes()) {
+	//	panic("reencoding not equal")
+	//}
+	// FIXME: We can't check this because we're not interpreting the input `data` as CBOR
+	// (to avoid using the same `UnmarshalCBOR` we're trying to fuzz), `fromCborBytes` is
+	// a bit misleading, here `data` is just the payload.
+
+	return 1
+}
+
+// FIXME: Encapsulate params encoding logic from `Message.MarshalCBOR` and fuzz it in a
+// separate function.

--- a/chain/types/message_fuzz.go
+++ b/chain/types/message_fuzz.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"bytes"
+
 	"github.com/filecoin-project/go-address"
 )
 
@@ -34,6 +35,9 @@ func FuzzMessageDecoder(data []byte) int {
 }
 
 func FuzzAddressEncoder(data []byte) int {
+	if len(data) == 0 {
+		return -2
+	}
 	ads, err := address.NewFromBytes(data)
 	if err != nil {
 		return -1


### PR DESCRIPTION
Fuzzing aggregated (repeated) structures makes the instrumentation tracking less reliable, for now we try to fuzz the smallest meaningful CBOR data items: addresses, big integers, method parameters, etc.