### PR TITLE
mark bad should be respected for every incoming tipset

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -118,6 +118,10 @@ func (syncer *Syncer) InformNewHead(from peer.ID, fts *store.FullTipSet) bool {
 	}
 
 	for _, b := range fts.Blocks {
+		if syncer.bad.Has(b.Cid()) {
+			log.Warnf("InformNewHead called on block marked as bad: %s", b.Cid())
+			return false
+		}
 		if err := syncer.ValidateMsgMeta(b); err != nil {
 			log.Warnf("invalid block received: %s", err)
 			return false


### PR DESCRIPTION
the bad tipset cache was originally used to prevent nodes from accepting chains based on blocks designated as 'bad', but it didnt prevent nodes from accepting blocks that themselves were marked bad (but who otherwise had a clean history). This should prevent any incoming bad blocks from being considered as potential sync candidates.