### PR TITLE
lotus-shed: add back support for bls and secp after sig changes

### DIFF
--- a/cmd/lotus-shed/keyinfo.go
+++ b/cmd/lotus-shed/keyinfo.go
@@ -11,6 +11,9 @@ import (
 
 	"gopkg.in/urfave/cli.v2"
 
+	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
+	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
+
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
 )


### PR DESCRIPTION
Fix similar to #1220 