### PR TITLE
Use HTTPS for links to the dashboard

### DIFF
--- a/documentation/en/join-testnet.md
+++ b/documentation/en/join-testnet.md
@@ -36,7 +36,7 @@ In order to connect to the network, you need to be connected to at least 1 peer.
 
 ## Chain sync
 
-While the daemon is running, the next requirement is to sync the chain. Run the command below to start the chain sync progress. To see current chain height, visit the [network stats page](http://stats.testnet.filecoin.io/).
+While the daemon is running, the next requirement is to sync the chain. Run the command below to start the chain sync progress. To see current chain height, visit the [network stats page](https://stats.testnet.filecoin.io/).
 
 ```sh
 lotus sync wait


### PR DESCRIPTION
Without HTTPS specified, the link fails to load in a fresh setting (try a new browser or Incognito mode to confirm).