### PR TITLE
Faucet: Provide more info when a user tries to create a miner with a non-BLS address

### DIFF
--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -207,7 +207,8 @@ func (h *handler) mkminer(w http.ResponseWriter, r *http.Request) {
 
 	if owner.Protocol() != address.BLS {
 		w.WriteHeader(400)
-		w.Write([]byte("Miner address must use BLS"))
+		w.Write([]byte("Miner address must use BLS. A BLS address starts with the prefix 't3'."))
+		w.Write([]byte("Please create a BLS address by running \"lotus wallet new bls\" while connected to a Lotus node."))
 		return
 	}
 


### PR DESCRIPTION
The current error message doesn't really tell miners what to do to fix the problem. C.f.: https://github.com/filecoin-project/lotus/pull/1260

