### PR TITLE
Re: #1250: API methods should receive TipSetKeys, not TipSets, as input

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -30,16 +30,16 @@ type FullNode interface {
 	ChainGetBlockMessages(context.Context, cid.Cid) (*BlockMessages, error)
 	ChainGetParentReceipts(context.Context, cid.Cid) ([]*types.MessageReceipt, error)
 	ChainGetParentMessages(context.Context, cid.Cid) ([]Message, error)
-	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
+	ChainGetTipSetByHeight(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 	ChainHasObj(context.Context, cid.Cid) (bool, error)
-	ChainSetHead(context.Context, *types.TipSet) error
+	ChainSetHead(context.Context, types.TipSetKey) error
 	ChainGetGenesis(context.Context) (*types.TipSet, error)
-	ChainTipSetWeight(context.Context, *types.TipSet) (types.BigInt, error)
+	ChainTipSetWeight(context.Context, types.TipSetKey) (types.BigInt, error)
 	ChainGetNode(ctx context.Context, p string) (interface{}, error)
 	ChainGetMessage(context.Context, cid.Cid) (*types.Message, error)
 	ChainGetPath(ctx context.Context, from types.TipSetKey, to types.TipSetKey) ([]*store.HeadChange, error)
-	ChainExport(context.Context, *types.TipSet) (<-chan []byte, error)
+	ChainExport(context.Context, types.TipSetKey) (<-chan []byte, error)
 
 	// syncer
 	SyncState(context.Context) (*SyncState, error)
@@ -49,7 +49,7 @@ type FullNode interface {
 	SyncCheckBad(ctx context.Context, bcid cid.Cid) (string, error)
 
 	// messages
-	MpoolPending(context.Context, *types.TipSet) ([]*types.SignedMessage, error)
+	MpoolPending(context.Context, types.TipSetKey) ([]*types.SignedMessage, error)
 	MpoolPush(context.Context, *types.SignedMessage) (cid.Cid, error)
 	MpoolPushMessage(context.Context, *types.Message) (*types.SignedMessage, error) // get nonce, sign, push
 	MpoolGetNonce(context.Context, address.Address) (uint64, error)
@@ -59,7 +59,7 @@ type FullNode interface {
 
 	// miner
 
-	MinerCreateBlock(context.Context, address.Address, *types.TipSet, *types.Ticket, *types.EPostProof, []*types.SignedMessage, uint64, uint64) (*types.BlockMsg, error)
+	MinerCreateBlock(context.Context, address.Address, types.TipSetKey, *types.Ticket, *types.EPostProof, []*types.SignedMessage, uint64, uint64) (*types.BlockMsg, error)
 
 	// // UX ?
 
@@ -97,35 +97,35 @@ type FullNode interface {
 	//ClientListAsks() []Ask
 
 	// if tipset is nil, we'll use heaviest
-	StateCall(context.Context, *types.Message, *types.TipSet) (*MethodCall, error)
-	StateReplay(context.Context, *types.TipSet, cid.Cid) (*ReplayResults, error)
-	StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error)
-	StateReadState(ctx context.Context, act *types.Actor, ts *types.TipSet) (*ActorState, error)
-	StateListMessages(ctx context.Context, match *types.Message, ts *types.TipSet, toht uint64) ([]cid.Cid, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*MethodCall, error)
+	StateReplay(context.Context, types.TipSetKey, cid.Cid) (*ReplayResults, error)
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
+	StateReadState(ctx context.Context, act *types.Actor, tsk types.TipSetKey) (*ActorState, error)
+	StateListMessages(ctx context.Context, match *types.Message, tsk types.TipSetKey, toht uint64) ([]cid.Cid, error)
 
-	StateMinerSectors(context.Context, address.Address, *types.TipSet) ([]*ChainSectorInfo, error)
-	StateMinerProvingSet(context.Context, address.Address, *types.TipSet) ([]*ChainSectorInfo, error)
-	StateMinerPower(context.Context, address.Address, *types.TipSet) (MinerPower, error)
-	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
-	StateMinerPeerID(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error)
-	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)
-	StateMinerSectorSize(context.Context, address.Address, *types.TipSet) (uint64, error)
-	StateMinerFaults(context.Context, address.Address, *types.TipSet) ([]uint64, error)
-	StatePledgeCollateral(context.Context, *types.TipSet) (types.BigInt, error)
+	StateMinerSectors(context.Context, address.Address, types.TipSetKey) ([]*ChainSectorInfo, error)
+	StateMinerProvingSet(context.Context, address.Address, types.TipSetKey) ([]*ChainSectorInfo, error)
+	StateMinerPower(context.Context, address.Address, types.TipSetKey) (MinerPower, error)
+	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
+	StateMinerPeerID(ctx context.Context, m address.Address, tsk types.TipSetKey) (peer.ID, error)
+	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)
+	StateMinerSectorSize(context.Context, address.Address, types.TipSetKey) (uint64, error)
+	StateMinerFaults(context.Context, address.Address, types.TipSetKey) ([]uint64, error)
+	StatePledgeCollateral(context.Context, types.TipSetKey) (types.BigInt, error)
 	StateWaitMsg(context.Context, cid.Cid) (*MsgWait, error)
-	StateListMiners(context.Context, *types.TipSet) ([]address.Address, error)
-	StateListActors(context.Context, *types.TipSet) ([]address.Address, error)
-	StateMarketBalance(context.Context, address.Address, *types.TipSet) (actors.StorageParticipantBalance, error)
-	StateMarketParticipants(context.Context, *types.TipSet) (map[string]actors.StorageParticipantBalance, error)
-	StateMarketDeals(context.Context, *types.TipSet) (map[string]actors.OnChainDeal, error)
-	StateMarketStorageDeal(context.Context, uint64, *types.TipSet) (*actors.OnChainDeal, error)
-	StateLookupID(context.Context, address.Address, *types.TipSet) (address.Address, error)
+	StateListMiners(context.Context, types.TipSetKey) ([]address.Address, error)
+	StateListActors(context.Context, types.TipSetKey) ([]address.Address, error)
+	StateMarketBalance(context.Context, address.Address, types.TipSetKey) (actors.StorageParticipantBalance, error)
+	StateMarketParticipants(context.Context, types.TipSetKey) (map[string]actors.StorageParticipantBalance, error)
+	StateMarketDeals(context.Context, types.TipSetKey) (map[string]actors.OnChainDeal, error)
+	StateMarketStorageDeal(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)
+	StateLookupID(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 	StateChangedActors(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)
-	StateGetReceipt(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error)
-	StateMinerSectorCount(context.Context, address.Address, *types.TipSet) (MinerSectors, error)
-	StateCompute(context.Context, uint64, []*types.Message, *types.TipSet) (cid.Cid, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
+	StateMinerSectorCount(context.Context, address.Address, types.TipSetKey) (MinerSectors, error)
+	StateCompute(context.Context, uint64, []*types.Message, types.TipSetKey) (cid.Cid, error)
 
-	MsigGetAvailableBalance(context.Context, address.Address, *types.TipSet) (types.BigInt, error)
+	MsigGetAvailableBalance(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)
 
 	MarketEnsureAvailable(context.Context, address.Address, types.BigInt) error
 	// MarketFreeBalance

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -51,16 +51,16 @@ type FullNodeStruct struct {
 		ChainGetBlockMessages  func(context.Context, cid.Cid) (*api.BlockMessages, error)                           `perm:"read"`
 		ChainGetParentReceipts func(context.Context, cid.Cid) ([]*types.MessageReceipt, error)                      `perm:"read"`
 		ChainGetParentMessages func(context.Context, cid.Cid) ([]api.Message, error)                                `perm:"read"`
-		ChainGetTipSetByHeight func(context.Context, uint64, *types.TipSet) (*types.TipSet, error)                  `perm:"read"`
+		ChainGetTipSetByHeight func(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)                  `perm:"read"`
 		ChainReadObj           func(context.Context, cid.Cid) ([]byte, error)                                       `perm:"read"`
 		ChainHasObj            func(context.Context, cid.Cid) (bool, error)                                         `perm:"read"`
-		ChainSetHead           func(context.Context, *types.TipSet) error                                           `perm:"admin"`
+		ChainSetHead           func(context.Context, types.TipSetKey) error                                           `perm:"admin"`
 		ChainGetGenesis        func(context.Context) (*types.TipSet, error)                                         `perm:"read"`
-		ChainTipSetWeight      func(context.Context, *types.TipSet) (types.BigInt, error)                           `perm:"read"`
+		ChainTipSetWeight      func(context.Context, types.TipSetKey) (types.BigInt, error)                           `perm:"read"`
 		ChainGetNode           func(ctx context.Context, p string) (interface{}, error)                             `perm:"read"`
 		ChainGetMessage        func(context.Context, cid.Cid) (*types.Message, error)                               `perm:"read"`
 		ChainGetPath           func(context.Context, types.TipSetKey, types.TipSetKey) ([]*store.HeadChange, error) `perm:"read"`
-		ChainExport            func(context.Context, *types.TipSet) (<-chan []byte, error)                          `perm:"read"`
+		ChainExport            func(context.Context, types.TipSetKey) (<-chan []byte, error)                          `perm:"read"`
 
 		SyncState          func(context.Context) (*api.SyncState, error)                `perm:"read"`
 		SyncSubmitBlock    func(ctx context.Context, blk *types.BlockMsg) error         `perm:"write"`
@@ -68,13 +68,13 @@ type FullNodeStruct struct {
 		SyncMarkBad        func(ctx context.Context, bcid cid.Cid) error                `perm:"admin"`
 		SyncCheckBad       func(ctx context.Context, bcid cid.Cid) (string, error)      `perm:"read"`
 
-		MpoolPending     func(context.Context, *types.TipSet) ([]*types.SignedMessage, error) `perm:"read"`
+		MpoolPending     func(context.Context, types.TipSetKey) ([]*types.SignedMessage, error) `perm:"read"`
 		MpoolPush        func(context.Context, *types.SignedMessage) (cid.Cid, error)         `perm:"write"`
 		MpoolPushMessage func(context.Context, *types.Message) (*types.SignedMessage, error)  `perm:"sign"`
 		MpoolGetNonce    func(context.Context, address.Address) (uint64, error)               `perm:"read"`
 		MpoolSub         func(context.Context) (<-chan api.MpoolUpdate, error)                `perm:"read"`
 
-		MinerCreateBlock func(context.Context, address.Address, *types.TipSet, *types.Ticket, *types.EPostProof, []*types.SignedMessage, uint64, uint64) (*types.BlockMsg, error) `perm:"write"`
+		MinerCreateBlock func(context.Context, address.Address, types.TipSetKey, *types.Ticket, *types.EPostProof, []*types.SignedMessage, uint64, uint64) (*types.BlockMsg, error) `perm:"write"`
 
 		WalletNew            func(context.Context, string) (address.Address, error)                               `perm:"write"`
 		WalletHas            func(context.Context, address.Address) (bool, error)                                 `perm:"write"`
@@ -97,34 +97,34 @@ type FullNodeStruct struct {
 		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, path string) error                                                                            `perm:"admin"`
 		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*types.SignedStorageAsk, error)                                                      `perm:"read"`
 
-		StateMinerSectors             func(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)             `perm:"read"`
-		StateMinerProvingSet          func(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)             `perm:"read"`
-		StateMinerPower               func(context.Context, address.Address, *types.TipSet) (api.MinerPower, error)                     `perm:"read"`
-		StateMinerWorker              func(context.Context, address.Address, *types.TipSet) (address.Address, error)                    `perm:"read"`
-		StateMinerPeerID              func(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error)                   `perm:"read"`
-		StateMinerElectionPeriodStart func(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)                `perm:"read"`
-		StateMinerSectorSize          func(context.Context, address.Address, *types.TipSet) (uint64, error)                             `perm:"read"`
-		StateMinerFaults              func(context.Context, address.Address, *types.TipSet) ([]uint64, error)                           `perm:"read"`
-		StateCall                     func(context.Context, *types.Message, *types.TipSet) (*api.MethodCall, error)                     `perm:"read"`
-		StateReplay                   func(context.Context, *types.TipSet, cid.Cid) (*api.ReplayResults, error)                         `perm:"read"`
-		StateGetActor                 func(context.Context, address.Address, *types.TipSet) (*types.Actor, error)                       `perm:"read"`
-		StateReadState                func(context.Context, *types.Actor, *types.TipSet) (*api.ActorState, error)                       `perm:"read"`
-		StatePledgeCollateral         func(context.Context, *types.TipSet) (types.BigInt, error)                                        `perm:"read"`
+		StateMinerSectors             func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)             `perm:"read"`
+		StateMinerProvingSet          func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)             `perm:"read"`
+		StateMinerPower               func(context.Context, address.Address, types.TipSetKey) (api.MinerPower, error)                     `perm:"read"`
+		StateMinerWorker              func(context.Context, address.Address, types.TipSetKey) (address.Address, error)                    `perm:"read"`
+		StateMinerPeerID              func(ctx context.Context, m address.Address, tsk types.TipSetKey) (peer.ID, error)                   `perm:"read"`
+		StateMinerElectionPeriodStart func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)                `perm:"read"`
+		StateMinerSectorSize          func(context.Context, address.Address, types.TipSetKey) (uint64, error)                             `perm:"read"`
+		StateMinerFaults              func(context.Context, address.Address, types.TipSetKey) ([]uint64, error)                           `perm:"read"`
+		StateCall                     func(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)                     `perm:"read"`
+		StateReplay                   func(context.Context, types.TipSetKey, cid.Cid) (*api.ReplayResults, error)                         `perm:"read"`
+		StateGetActor                 func(context.Context, address.Address, types.TipSetKey) (*types.Actor, error)                       `perm:"read"`
+		StateReadState                func(context.Context, *types.Actor, types.TipSetKey) (*api.ActorState, error)                       `perm:"read"`
+		StatePledgeCollateral         func(context.Context, types.TipSetKey) (types.BigInt, error)                                        `perm:"read"`
 		StateWaitMsg                  func(context.Context, cid.Cid) (*api.MsgWait, error)                                              `perm:"read"`
-		StateListMiners               func(context.Context, *types.TipSet) ([]address.Address, error)                                   `perm:"read"`
-		StateListActors               func(context.Context, *types.TipSet) ([]address.Address, error)                                   `perm:"read"`
-		StateMarketBalance            func(context.Context, address.Address, *types.TipSet) (actors.StorageParticipantBalance, error)   `perm:"read"`
-		StateMarketParticipants       func(context.Context, *types.TipSet) (map[string]actors.StorageParticipantBalance, error)         `perm:"read"`
-		StateMarketDeals              func(context.Context, *types.TipSet) (map[string]actors.OnChainDeal, error)                       `perm:"read"`
-		StateMarketStorageDeal        func(context.Context, uint64, *types.TipSet) (*actors.OnChainDeal, error)                         `perm:"read"`
-		StateLookupID                 func(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error)        `perm:"read"`
+		StateListMiners               func(context.Context, types.TipSetKey) ([]address.Address, error)                                   `perm:"read"`
+		StateListActors               func(context.Context, types.TipSetKey) ([]address.Address, error)                                   `perm:"read"`
+		StateMarketBalance            func(context.Context, address.Address, types.TipSetKey) (actors.StorageParticipantBalance, error)   `perm:"read"`
+		StateMarketParticipants       func(context.Context, types.TipSetKey) (map[string]actors.StorageParticipantBalance, error)         `perm:"read"`
+		StateMarketDeals              func(context.Context, types.TipSetKey) (map[string]actors.OnChainDeal, error)                       `perm:"read"`
+		StateMarketStorageDeal        func(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)                         `perm:"read"`
+		StateLookupID                 func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)        `perm:"read"`
 		StateChangedActors            func(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)                           `perm:"read"`
-		StateGetReceipt               func(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error)                      `perm:"read"`
-		StateMinerSectorCount         func(context.Context, address.Address, *types.TipSet) (api.MinerSectors, error)                   `perm:"read"`
-		StateListMessages             func(ctx context.Context, match *types.Message, ts *types.TipSet, toht uint64) ([]cid.Cid, error) `perm:"read"`
-		StateCompute                  func(context.Context, uint64, []*types.Message, *types.TipSet) (cid.Cid, error)                   `perm:"read"`
+		StateGetReceipt               func(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)                      `perm:"read"`
+		StateMinerSectorCount         func(context.Context, address.Address, types.TipSetKey) (api.MinerSectors, error)                   `perm:"read"`
+		StateListMessages             func(ctx context.Context, match *types.Message, tsk types.TipSetKey, toht uint64) ([]cid.Cid, error) `perm:"read"`
+		StateCompute                  func(context.Context, uint64, []*types.Message, types.TipSetKey) (cid.Cid, error)                   `perm:"read"`
 
-		MsigGetAvailableBalance func(context.Context, address.Address, *types.TipSet) (types.BigInt, error) `perm:"read"`
+		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error) `perm:"read"`
 
 		MarketEnsureAvailable func(context.Context, address.Address, types.BigInt) error `perm:"sign"`
 
@@ -144,8 +144,8 @@ type FullNodeStruct struct {
 	}
 }
 
-func (c *FullNodeStruct) StateMinerSectorCount(ctx context.Context, addr address.Address, ts *types.TipSet) (api.MinerSectors, error) {
-	return c.Internal.StateMinerSectorCount(ctx, addr, ts)
+func (c *FullNodeStruct) StateMinerSectorCount(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MinerSectors, error) {
+	return c.Internal.StateMinerSectorCount(ctx, addr, tsk)
 }
 
 type StorageMinerStruct struct {
@@ -250,8 +250,8 @@ func (c *FullNodeStruct) ClientQueryAsk(ctx context.Context, p peer.ID, miner ad
 	return c.Internal.ClientQueryAsk(ctx, p, miner)
 }
 
-func (c *FullNodeStruct) MpoolPending(ctx context.Context, ts *types.TipSet) ([]*types.SignedMessage, error) {
-	return c.Internal.MpoolPending(ctx, ts)
+func (c *FullNodeStruct) MpoolPending(ctx context.Context, tsk types.TipSetKey) ([]*types.SignedMessage, error) {
+	return c.Internal.MpoolPending(ctx, tsk)
 }
 
 func (c *FullNodeStruct) MpoolPush(ctx context.Context, smsg *types.SignedMessage) (cid.Cid, error) {
@@ -266,7 +266,7 @@ func (c *FullNodeStruct) MpoolSub(ctx context.Context) (<-chan api.MpoolUpdate, 
 	return c.Internal.MpoolSub(ctx)
 }
 
-func (c *FullNodeStruct) MinerCreateBlock(ctx context.Context, addr address.Address, base *types.TipSet, ticket *types.Ticket, eproof *types.EPostProof, msgs []*types.SignedMessage, height, ts uint64) (*types.BlockMsg, error) {
+func (c *FullNodeStruct) MinerCreateBlock(ctx context.Context, addr address.Address, base types.TipSetKey, ticket *types.Ticket, eproof *types.EPostProof, msgs []*types.SignedMessage, height, ts uint64) (*types.BlockMsg, error) {
 	return c.Internal.MinerCreateBlock(ctx, addr, base, ticket, eproof, msgs, height, ts)
 }
 
@@ -278,8 +278,8 @@ func (c *FullNodeStruct) ChainGetRandomness(ctx context.Context, pts types.TipSe
 	return c.Internal.ChainGetRandomness(ctx, pts, round)
 }
 
-func (c *FullNodeStruct) ChainGetTipSetByHeight(ctx context.Context, h uint64, ts *types.TipSet) (*types.TipSet, error) {
-	return c.Internal.ChainGetTipSetByHeight(ctx, h, ts)
+func (c *FullNodeStruct) ChainGetTipSetByHeight(ctx context.Context, h uint64, tsk types.TipSetKey) (*types.TipSet, error) {
+	return c.Internal.ChainGetTipSetByHeight(ctx, h, tsk)
 }
 
 func (c *FullNodeStruct) WalletNew(ctx context.Context, typ string) (address.Address, error) {
@@ -358,16 +358,16 @@ func (c *FullNodeStruct) ChainHasObj(ctx context.Context, o cid.Cid) (bool, erro
 	return c.Internal.ChainHasObj(ctx, o)
 }
 
-func (c *FullNodeStruct) ChainSetHead(ctx context.Context, ts *types.TipSet) error {
-	return c.Internal.ChainSetHead(ctx, ts)
+func (c *FullNodeStruct) ChainSetHead(ctx context.Context, tsk types.TipSetKey) error {
+	return c.Internal.ChainSetHead(ctx, tsk)
 }
 
 func (c *FullNodeStruct) ChainGetGenesis(ctx context.Context) (*types.TipSet, error) {
 	return c.Internal.ChainGetGenesis(ctx)
 }
 
-func (c *FullNodeStruct) ChainTipSetWeight(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
-	return c.Internal.ChainTipSetWeight(ctx, ts)
+func (c *FullNodeStruct) ChainTipSetWeight(ctx context.Context, tsk types.TipSetKey) (types.BigInt, error) {
+	return c.Internal.ChainTipSetWeight(ctx, tsk)
 }
 
 func (c *FullNodeStruct) ChainGetNode(ctx context.Context, p string) (interface{}, error) {
@@ -382,8 +382,8 @@ func (c *FullNodeStruct) ChainGetPath(ctx context.Context, from types.TipSetKey,
 	return c.Internal.ChainGetPath(ctx, from, to)
 }
 
-func (c *FullNodeStruct) ChainExport(ctx context.Context, ts *types.TipSet) (<-chan []byte, error) {
-	return c.Internal.ChainExport(ctx, ts)
+func (c *FullNodeStruct) ChainExport(ctx context.Context, tsk types.TipSetKey) (<-chan []byte, error) {
+	return c.Internal.ChainExport(ctx, tsk)
 }
 
 func (c *FullNodeStruct) SyncState(ctx context.Context) (*api.SyncState, error) {
@@ -406,107 +406,107 @@ func (c *FullNodeStruct) SyncCheckBad(ctx context.Context, bcid cid.Cid) (string
 	return c.Internal.SyncCheckBad(ctx, bcid)
 }
 
-func (c *FullNodeStruct) StateMinerSectors(ctx context.Context, addr address.Address, ts *types.TipSet) ([]*api.ChainSectorInfo, error) {
-	return c.Internal.StateMinerSectors(ctx, addr, ts)
+func (c *FullNodeStruct) StateMinerSectors(ctx context.Context, addr address.Address, tsk types.TipSetKey) ([]*api.ChainSectorInfo, error) {
+	return c.Internal.StateMinerSectors(ctx, addr, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerProvingSet(ctx context.Context, addr address.Address, ts *types.TipSet) ([]*api.ChainSectorInfo, error) {
-	return c.Internal.StateMinerProvingSet(ctx, addr, ts)
+func (c *FullNodeStruct) StateMinerProvingSet(ctx context.Context, addr address.Address, tsk types.TipSetKey) ([]*api.ChainSectorInfo, error) {
+	return c.Internal.StateMinerProvingSet(ctx, addr, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerPower(ctx context.Context, a address.Address, ts *types.TipSet) (api.MinerPower, error) {
-	return c.Internal.StateMinerPower(ctx, a, ts)
+func (c *FullNodeStruct) StateMinerPower(ctx context.Context, a address.Address, tsk types.TipSetKey) (api.MinerPower, error) {
+	return c.Internal.StateMinerPower(ctx, a, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerWorker(ctx context.Context, m address.Address, ts *types.TipSet) (address.Address, error) {
-	return c.Internal.StateMinerWorker(ctx, m, ts)
+func (c *FullNodeStruct) StateMinerWorker(ctx context.Context, m address.Address, tsk types.TipSetKey) (address.Address, error) {
+	return c.Internal.StateMinerWorker(ctx, m, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerPeerID(ctx context.Context, m address.Address, ts *types.TipSet) (peer.ID, error) {
-	return c.Internal.StateMinerPeerID(ctx, m, ts)
+func (c *FullNodeStruct) StateMinerPeerID(ctx context.Context, m address.Address, tsk types.TipSetKey) (peer.ID, error) {
+	return c.Internal.StateMinerPeerID(ctx, m, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error) {
-	return c.Internal.StateMinerElectionPeriodStart(ctx, actor, ts)
+func (c *FullNodeStruct) StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error) {
+	return c.Internal.StateMinerElectionPeriodStart(ctx, actor, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerSectorSize(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error) {
-	return c.Internal.StateMinerSectorSize(ctx, actor, ts)
+func (c *FullNodeStruct) StateMinerSectorSize(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error) {
+	return c.Internal.StateMinerSectorSize(ctx, actor, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerFaults(ctx context.Context, actor address.Address, ts *types.TipSet) ([]uint64, error) {
-	return c.Internal.StateMinerFaults(ctx, actor, ts)
+func (c *FullNodeStruct) StateMinerFaults(ctx context.Context, actor address.Address, tsk types.TipSetKey) ([]uint64, error) {
+	return c.Internal.StateMinerFaults(ctx, actor, tsk)
 }
 
-func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.MethodCall, error) {
-	return c.Internal.StateCall(ctx, msg, ts)
+func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.MethodCall, error) {
+	return c.Internal.StateCall(ctx, msg, tsk)
 }
 
-func (c *FullNodeStruct) StateReplay(ctx context.Context, ts *types.TipSet, mc cid.Cid) (*api.ReplayResults, error) {
-	return c.Internal.StateReplay(ctx, ts, mc)
+func (c *FullNodeStruct) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.ReplayResults, error) {
+	return c.Internal.StateReplay(ctx, tsk, mc)
 }
 
-func (c *FullNodeStruct) StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error) {
-	return c.Internal.StateGetActor(ctx, actor, ts)
+func (c *FullNodeStruct) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
+	return c.Internal.StateGetActor(ctx, actor, tsk)
 }
 
-func (c *FullNodeStruct) StateReadState(ctx context.Context, act *types.Actor, ts *types.TipSet) (*api.ActorState, error) {
-	return c.Internal.StateReadState(ctx, act, ts)
+func (c *FullNodeStruct) StateReadState(ctx context.Context, act *types.Actor, tsk types.TipSetKey) (*api.ActorState, error) {
+	return c.Internal.StateReadState(ctx, act, tsk)
 }
 
-func (c *FullNodeStruct) StatePledgeCollateral(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
-	return c.Internal.StatePledgeCollateral(ctx, ts)
+func (c *FullNodeStruct) StatePledgeCollateral(ctx context.Context, tsk types.TipSetKey) (types.BigInt, error) {
+	return c.Internal.StatePledgeCollateral(ctx, tsk)
 }
 
 func (c *FullNodeStruct) StateWaitMsg(ctx context.Context, msgc cid.Cid) (*api.MsgWait, error) {
 	return c.Internal.StateWaitMsg(ctx, msgc)
 }
-func (c *FullNodeStruct) StateListMiners(ctx context.Context, ts *types.TipSet) ([]address.Address, error) {
-	return c.Internal.StateListMiners(ctx, ts)
+func (c *FullNodeStruct) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	return c.Internal.StateListMiners(ctx, tsk)
 }
 
-func (c *FullNodeStruct) StateListActors(ctx context.Context, ts *types.TipSet) ([]address.Address, error) {
-	return c.Internal.StateListActors(ctx, ts)
+func (c *FullNodeStruct) StateListActors(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	return c.Internal.StateListActors(ctx, tsk)
 }
 
-func (c *FullNodeStruct) StateMarketBalance(ctx context.Context, addr address.Address, ts *types.TipSet) (actors.StorageParticipantBalance, error) {
-	return c.Internal.StateMarketBalance(ctx, addr, ts)
+func (c *FullNodeStruct) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (actors.StorageParticipantBalance, error) {
+	return c.Internal.StateMarketBalance(ctx, addr, tsk)
 }
 
-func (c *FullNodeStruct) StateMarketParticipants(ctx context.Context, ts *types.TipSet) (map[string]actors.StorageParticipantBalance, error) {
-	return c.Internal.StateMarketParticipants(ctx, ts)
+func (c *FullNodeStruct) StateMarketParticipants(ctx context.Context, tsk types.TipSetKey) (map[string]actors.StorageParticipantBalance, error) {
+	return c.Internal.StateMarketParticipants(ctx, tsk)
 }
 
-func (c *FullNodeStruct) StateMarketDeals(ctx context.Context, ts *types.TipSet) (map[string]actors.OnChainDeal, error) {
-	return c.Internal.StateMarketDeals(ctx, ts)
+func (c *FullNodeStruct) StateMarketDeals(ctx context.Context, tsk types.TipSetKey) (map[string]actors.OnChainDeal, error) {
+	return c.Internal.StateMarketDeals(ctx, tsk)
 }
 
-func (c *FullNodeStruct) StateMarketStorageDeal(ctx context.Context, dealid uint64, ts *types.TipSet) (*actors.OnChainDeal, error) {
-	return c.Internal.StateMarketStorageDeal(ctx, dealid, ts)
+func (c *FullNodeStruct) StateMarketStorageDeal(ctx context.Context, dealid uint64, tsk types.TipSetKey) (*actors.OnChainDeal, error) {
+	return c.Internal.StateMarketStorageDeal(ctx, dealid, tsk)
 }
 
-func (c *FullNodeStruct) StateLookupID(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
-	return c.Internal.StateLookupID(ctx, addr, ts)
+func (c *FullNodeStruct) StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
+	return c.Internal.StateLookupID(ctx, addr, tsk)
 }
 
 func (c *FullNodeStruct) StateChangedActors(ctx context.Context, olnstate cid.Cid, newstate cid.Cid) (map[string]types.Actor, error) {
 	return c.Internal.StateChangedActors(ctx, olnstate, newstate)
 }
 
-func (c *FullNodeStruct) StateGetReceipt(ctx context.Context, msg cid.Cid, ts *types.TipSet) (*types.MessageReceipt, error) {
-	return c.Internal.StateGetReceipt(ctx, msg, ts)
+func (c *FullNodeStruct) StateGetReceipt(ctx context.Context, msg cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
+	return c.Internal.StateGetReceipt(ctx, msg, tsk)
 }
 
-func (c *FullNodeStruct) StateListMessages(ctx context.Context, match *types.Message, ts *types.TipSet, toht uint64) ([]cid.Cid, error) {
-	return c.Internal.StateListMessages(ctx, match, ts, toht)
+func (c *FullNodeStruct) StateListMessages(ctx context.Context, match *types.Message, tsk types.TipSetKey, toht uint64) ([]cid.Cid, error) {
+	return c.Internal.StateListMessages(ctx, match, tsk, toht)
 }
 
-func (c *FullNodeStruct) StateCompute(ctx context.Context, height uint64, msgs []*types.Message, ts *types.TipSet) (cid.Cid, error) {
-	return c.Internal.StateCompute(ctx, height, msgs, ts)
+func (c *FullNodeStruct) StateCompute(ctx context.Context, height uint64, msgs []*types.Message, tsk types.TipSetKey) (cid.Cid, error) {
+	return c.Internal.StateCompute(ctx, height, msgs, tsk)
 }
 
-func (c *FullNodeStruct) MsigGetAvailableBalance(ctx context.Context, a address.Address, ts *types.TipSet) (types.BigInt, error) {
-	return c.Internal.MsigGetAvailableBalance(ctx, a, ts)
+func (c *FullNodeStruct) MsigGetAvailableBalance(ctx context.Context, a address.Address, tsk types.TipSetKey) (types.BigInt, error) {
+	return c.Internal.MsigGetAvailableBalance(ctx, a, tsk)
 }
 
 func (c *FullNodeStruct) MarketEnsureAvailable(ctx context.Context, addr address.Address, amt types.BigInt) error {

--- a/chain/events/events.go
+++ b/chain/events/events.go
@@ -33,10 +33,10 @@ type heightHandler struct {
 type eventApi interface {
 	ChainNotify(context.Context) (<-chan []*store.HeadChange, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
-	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
-	StateGetReceipt(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error)
+	ChainGetTipSetByHeight(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
 
-	StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error) // optional / for CalledMsg
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) // optional / for CalledMsg
 }
 
 type Events struct {

--- a/chain/events/events_called.go
+++ b/chain/events/events_called.go
@@ -192,7 +192,7 @@ func (e *calledEvents) applyWithConfidence(ts *types.TipSet) {
 				continue
 			}
 
-			rec, err := e.cs.StateGetReceipt(e.ctx, event.msg.Cid(), ts)
+			rec, err := e.cs.StateGetReceipt(e.ctx, event.msg.Cid(), ts.Key())
 			if err != nil {
 				log.Error(err)
 				return

--- a/chain/events/events_test.go
+++ b/chain/events/events_test.go
@@ -40,15 +40,15 @@ type fakeCS struct {
 	sub func(rev, app []*types.TipSet)
 }
 
-func (fcs *fakeCS) StateGetReceipt(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error) {
+func (fcs *fakeCS) StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error) {
 	return nil, nil
 }
 
-func (fcs *fakeCS) StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error) {
+func (fcs *fakeCS) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
 	panic("Not Implemented")
 }
 
-func (fcs *fakeCS) ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error) {
+func (fcs *fakeCS) ChainGetTipSetByHeight(context.Context, uint64, types.TipSetKey) (*types.TipSet, error) {
 	panic("Not Implemented")
 }
 

--- a/chain/events/tscache.go
+++ b/chain/events/tscache.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-type tsByHFunc func(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
+type tsByHFunc func(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)
 
 // tipSetCache implements a simple ring-buffer cache to keep track of recent
 // tipsets
@@ -93,7 +93,7 @@ func (tsc *tipSetCache) getNonNull(height uint64) (*types.TipSet, error) {
 func (tsc *tipSetCache) get(height uint64) (*types.TipSet, error) {
 	if tsc.len == 0 {
 		log.Warnf("tipSetCache.get: cache is empty, requesting from storage (h=%d)", height)
-		return tsc.storage(context.TODO(), height, nil)
+		return tsc.storage(context.TODO(), height, types.EmptyTSK)
 	}
 
 	headH := tsc.cache[tsc.start].Height()
@@ -113,7 +113,7 @@ func (tsc *tipSetCache) get(height uint64) (*types.TipSet, error) {
 
 	if height < tail.Height() {
 		log.Warnf("tipSetCache.get: requested tipset not in cache, requesting from storage (h=%d; tail=%d)", height, tail.Height())
-		return tsc.storage(context.TODO(), height, tail)
+		return tsc.storage(context.TODO(), height, tail.Key())
 	}
 
 	return tsc.cache[normalModulo(tsc.start-int(headH-height), clen)], nil

--- a/chain/events/tscache_test.go
+++ b/chain/events/tscache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTsCache(t *testing.T) {
-	tsc := newTSCache(50, func(context.Context, uint64, *types.TipSet) (*types.TipSet, error) {
+	tsc := newTSCache(50, func(context.Context, uint64, types.TipSetKey) (*types.TipSet, error) {
 		t.Fatal("storage call")
 		return &types.TipSet{}, nil
 	})
@@ -54,7 +54,7 @@ func TestTsCache(t *testing.T) {
 }
 
 func TestTsCacheNulls(t *testing.T) {
-	tsc := newTSCache(50, func(context.Context, uint64, *types.TipSet) (*types.TipSet, error) {
+	tsc := newTSCache(50, func(context.Context, uint64, types.TipSetKey) (*types.TipSet, error) {
 		t.Fatal("storage call")
 		return &types.TipSet{}, nil
 	})

--- a/chain/events/utils.go
+++ b/chain/events/utils.go
@@ -13,7 +13,7 @@ func (e *calledEvents) CheckMsg(ctx context.Context, smsg store.ChainMsg, hnd Ca
 	msg := smsg.VMMessage()
 
 	return func(ts *types.TipSet) (done bool, more bool, err error) {
-		fa, err := e.cs.StateGetActor(ctx, msg.From, ts)
+		fa, err := e.cs.StateGetActor(ctx, msg.From, ts.Key())
 		if err != nil {
 			return false, true, err
 		}
@@ -23,7 +23,7 @@ func (e *calledEvents) CheckMsg(ctx context.Context, smsg store.ChainMsg, hnd Ca
 			return false, true, nil
 		}
 
-		rec, err := e.cs.StateGetReceipt(ctx, smsg.VMMessage().Cid(), ts)
+		rec, err := e.cs.StateGetReceipt(ctx, smsg.VMMessage().Cid(), ts.Key())
 		if err != nil {
 			return false, true, xerrors.Errorf("getting receipt in CheckMsg: %w", err)
 		}

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -419,13 +419,13 @@ func (cg *ChainGen) YieldRepo() (repo.Repo, error) {
 type MiningCheckAPI interface {
 	ChainGetRandomness(context.Context, types.TipSetKey, int64) ([]byte, error)
 
-	StateMinerPower(context.Context, address.Address, *types.TipSet) (api.MinerPower, error)
+	StateMinerPower(context.Context, address.Address, types.TipSetKey) (api.MinerPower, error)
 
-	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
+	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 
-	StateMinerSectorSize(context.Context, address.Address, *types.TipSet) (uint64, error)
+	StateMinerSectorSize(context.Context, address.Address, types.TipSetKey) (uint64, error)
 
-	StateMinerProvingSet(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)
+	StateMinerProvingSet(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)
 
 	WalletSign(context.Context, address.Address, []byte) (*types.Signature, error)
 }
@@ -439,7 +439,11 @@ func (mca mca) ChainGetRandomness(ctx context.Context, pts types.TipSetKey, lb i
 	return mca.sm.ChainStore().GetRandomness(ctx, pts.Cids(), int64(lb))
 }
 
-func (mca mca) StateMinerPower(ctx context.Context, maddr address.Address, ts *types.TipSet) (api.MinerPower, error) {
+func (mca mca) StateMinerPower(ctx context.Context, maddr address.Address, tsk types.TipSetKey) (api.MinerPower, error) {
+	ts, err := mca.sm.ChainStore().LoadTipSet(tsk)
+	if err != nil {
+		return api.MinerPower{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	mpow, tpow, err := stmgr.GetPower(ctx, mca.sm, ts, maddr)
 	if err != nil {
 		return api.MinerPower{}, err
@@ -451,15 +455,27 @@ func (mca mca) StateMinerPower(ctx context.Context, maddr address.Address, ts *t
 	}, err
 }
 
-func (mca mca) StateMinerWorker(ctx context.Context, maddr address.Address, ts *types.TipSet) (address.Address, error) {
+func (mca mca) StateMinerWorker(ctx context.Context, maddr address.Address, tsk types.TipSetKey) (address.Address, error) {
+	ts, err := mca.sm.ChainStore().LoadTipSet(tsk)
+	if err != nil {
+		return address.Undef, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return stmgr.GetMinerWorkerRaw(ctx, mca.sm, ts.ParentState(), maddr)
 }
 
-func (mca mca) StateMinerSectorSize(ctx context.Context, maddr address.Address, ts *types.TipSet) (uint64, error) {
+func (mca mca) StateMinerSectorSize(ctx context.Context, maddr address.Address, tsk types.TipSetKey) (uint64, error) {
+	ts, err := mca.sm.ChainStore().LoadTipSet(tsk)
+	if err != nil {
+		return 0, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return stmgr.GetMinerSectorSize(ctx, mca.sm, ts, maddr)
 }
 
-func (mca mca) StateMinerProvingSet(ctx context.Context, maddr address.Address, ts *types.TipSet) ([]*api.ChainSectorInfo, error) {
+func (mca mca) StateMinerProvingSet(ctx context.Context, maddr address.Address, tsk types.TipSetKey) ([]*api.ChainSectorInfo, error) {
+	ts, err := mca.sm.ChainStore().LoadTipSet(tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return stmgr.GetMinerProvingSet(ctx, mca.sm, ts, maddr)
 }
 
@@ -503,7 +519,7 @@ func IsRoundWinner(ctx context.Context, ts *types.TipSet, round int64, miner add
 		return nil, xerrors.Errorf("chain get randomness: %w", err)
 	}
 
-	mworker, err := a.StateMinerWorker(ctx, miner, ts)
+	mworker, err := a.StateMinerWorker(ctx, miner, ts.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get miner worker: %w", err)
 	}
@@ -513,7 +529,7 @@ func IsRoundWinner(ctx context.Context, ts *types.TipSet, round int64, miner add
 		return nil, xerrors.Errorf("failed to compute VRF: %w", err)
 	}
 
-	pset, err := a.StateMinerProvingSet(ctx, miner, ts)
+	pset, err := a.StateMinerProvingSet(ctx, miner, ts.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load proving set for miner: %w", err)
 	}
@@ -538,12 +554,12 @@ func IsRoundWinner(ctx context.Context, ts *types.TipSet, round int64, miner add
 		return nil, xerrors.Errorf("failed to generate electionPoSt candidates: %w", err)
 	}
 
-	pow, err := a.StateMinerPower(ctx, miner, ts)
+	pow, err := a.StateMinerPower(ctx, miner, ts.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to check power: %w", err)
 	}
 
-	ssize, err := a.StateMinerSectorSize(ctx, miner, ts)
+	ssize, err := a.StateMinerSectorSize(ctx, miner, ts.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to look up miners sector size: %w", err)
 	}

--- a/chain/metrics/consensus.go
+++ b/chain/metrics/consensus.go
@@ -95,7 +95,7 @@ func sendHeadNotifs(ctx context.Context, ps *pubsub.PubSub, topic string, chain 
 		case notif := <-notifs:
 			n := notif[len(notif)-1]
 
-			w, err := chain.ChainTipSetWeight(ctx, n.Val)
+			w, err := chain.ChainTipSetWeight(ctx, n.Val.Key())
 			if err != nil {
 				return err
 			}

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1019,3 +1019,11 @@ func NewChainRand(cs *ChainStore, blks []cid.Cid, bheight uint64) vm.Rand {
 func (cr *chainRand) GetRandomness(ctx context.Context, round int64) ([]byte, error) {
 	return cr.cs.GetRandomness(ctx, cr.blks, round)
 }
+
+func (cs *ChainStore) GetTipSetFromKey(tsk types.TipSetKey) (*types.TipSet, error) {
+	if tsk.IsEmpty() {
+		return cs.GetHeaviestTipSet(), nil
+	} else {
+		return cs.LoadTipSet(tsk)
+	}
+}

--- a/chain/types/tipset.go
+++ b/chain/types/tipset.go
@@ -129,6 +129,9 @@ func (ts *TipSet) Cids() []cid.Cid {
 }
 
 func (ts *TipSet) Key() TipSetKey {
+	if ts == nil {
+		return EmptyTSK
+	}
 	return NewTipSetKey(ts.cids...)
 }
 

--- a/chain/types/tipset_key.go
+++ b/chain/types/tipset_key.go
@@ -9,6 +9,8 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+var EmptyTSK = TipSetKey{}
+
 // The length of a block header CID in bytes.
 var blockHeaderCIDLen int
 
@@ -88,6 +90,10 @@ func (k *TipSetKey) UnmarshalJSON(b []byte) error {
 	}
 	k.value = string(encodeKey(cids))
 	return nil
+}
+
+func (k TipSetKey) IsEmpty() bool {
+	return len(k.value) == 0
 }
 
 func encodeKey(cids []cid.Cid) []byte {

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -250,7 +250,7 @@ var chainSetHeadCmd = &cli.Command{
 			ts, err = api.ChainGetGenesis(ctx)
 		}
 		if ts == nil && cctx.IsSet("epoch") {
-			ts, err = api.ChainGetTipSetByHeight(ctx, cctx.Uint64("epoch"), nil)
+			ts, err = api.ChainGetTipSetByHeight(ctx, cctx.Uint64("epoch"), types.EmptyTSK)
 		}
 		if ts == nil {
 			ts, err = parseTipSet(api, ctx, cctx.Args().Slice())
@@ -263,7 +263,7 @@ var chainSetHeadCmd = &cli.Command{
 			return fmt.Errorf("must pass cids for tipset to set as head")
 		}
 
-		if err := api.ChainSetHead(ctx, ts); err != nil {
+		if err := api.ChainSetHead(ctx, ts.Key()); err != nil {
 			return err
 		}
 
@@ -313,7 +313,7 @@ var chainListCmd = &cli.Command{
 		var head *types.TipSet
 
 		if cctx.IsSet("height") {
-			head, err = api.ChainGetTipSetByHeight(ctx, cctx.Uint64("height"), nil)
+			head, err = api.ChainGetTipSetByHeight(ctx, cctx.Uint64("height"), types.EmptyTSK)
 		} else {
 			head, err = api.ChainHead(ctx)
 		}
@@ -446,7 +446,7 @@ var chainBisectCmd = &cli.Command{
 
 		subPath := cctx.Args().Get(2)
 
-		highest, err := api.ChainGetTipSetByHeight(ctx, end, nil)
+		highest, err := api.ChainGetTipSetByHeight(ctx, end, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -460,7 +460,7 @@ var chainBisectCmd = &cli.Command{
 				start = end
 			}
 
-			midTs, err := api.ChainGetTipSetByHeight(ctx, mid, highest)
+			midTs, err := api.ChainGetTipSetByHeight(ctx, mid, highest.Key())
 			if err != nil {
 				return err
 			}
@@ -542,7 +542,7 @@ var chainExportCmd = &cli.Command{
 			return err
 		}
 
-		stream, err := api.ChainExport(ctx, ts)
+		stream, err := api.ChainExport(ctx, ts.Key())
 		if err != nil {
 			return err
 		}

--- a/cli/client.go
+++ b/cli/client.go
@@ -295,7 +295,7 @@ var clientQueryAskCmd = &cli.Command{
 				To:     maddr,
 				From:   maddr,
 				Method: actors.MAMethods.GetPeerID,
-			}, nil)
+			}, types.EmptyTSK)
 			if err != nil {
 				return xerrors.Errorf("failed to get peerID for miner: %w", err)
 			}

--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -33,7 +33,7 @@ var mpoolPending = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		msgs, err := api.MpoolPending(ctx, nil)
+		msgs, err := api.MpoolPending(ctx, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ var mpoolStat = &cli.Command{
 			return xerrors.Errorf("getting chain head: %w", err)
 		}
 
-		msgs, err := api.MpoolPending(ctx, nil)
+		msgs, err := api.MpoolPending(ctx, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ var mpoolStat = &cli.Command{
 			bkt.msgs[v.Message.Nonce] = v
 		}
 		for a, bkt := range buckets {
-			act, err := api.StateGetActor(ctx, a, ts)
+			act, err := api.StateGetActor(ctx, a, ts.Key())
 			if err != nil {
 				fmt.Printf("%s, err: %s\n", a, err)
 				continue

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -163,7 +163,7 @@ var msigInspectCmd = &cli.Command{
 			return err
 		}
 
-		act, err := api.StateGetActor(ctx, maddr, nil)
+		act, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}

--- a/cli/state.go
+++ b/cli/state.go
@@ -115,7 +115,7 @@ var statePowerCmd = &cli.Command{
 			return err
 		}
 
-		power, err := api.StateMinerPower(ctx, maddr, ts)
+		power, err := api.StateMinerPower(ctx, maddr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ var stateSectorsCmd = &cli.Command{
 			return err
 		}
 
-		sectors, err := api.StateMinerSectors(ctx, maddr, ts)
+		sectors, err := api.StateMinerSectors(ctx, maddr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -198,7 +198,7 @@ var stateProvingSetCmd = &cli.Command{
 			return err
 		}
 
-		sectors, err := api.StateMinerProvingSet(ctx, maddr, ts)
+		sectors, err := api.StateMinerProvingSet(ctx, maddr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ var stateReplaySetCmd = &cli.Command{
 			return err
 		}
 
-		res, err := api.StateReplay(ctx, ts, mcid)
+		res, err := api.StateReplay(ctx, ts.Key(), mcid)
 		if err != nil {
 			return xerrors.Errorf("replay call failed: %w", err)
 		}
@@ -294,7 +294,7 @@ var statePledgeCollateralCmd = &cli.Command{
 			return err
 		}
 
-		coll, err := api.StatePledgeCollateral(ctx, ts)
+		coll, err := api.StatePledgeCollateral(ctx, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -330,7 +330,7 @@ var stateGetDealSetCmd = &cli.Command{
 			return err
 		}
 
-		deal, err := api.StateMarketStorageDeal(ctx, dealid, ts)
+		deal, err := api.StateMarketStorageDeal(ctx, dealid, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -362,7 +362,7 @@ var stateListMinersCmd = &cli.Command{
 			return err
 		}
 
-		miners, err := api.StateListMiners(ctx, ts)
+		miners, err := api.StateListMiners(ctx, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -392,7 +392,7 @@ var stateListActorsCmd = &cli.Command{
 			return err
 		}
 
-		actors, err := api.StateListActors(ctx, ts)
+		actors, err := api.StateListActors(ctx, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -431,7 +431,7 @@ var stateGetActorCmd = &cli.Command{
 			return err
 		}
 
-		a, err := api.StateGetActor(ctx, addr, ts)
+		a, err := api.StateGetActor(ctx, addr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -472,7 +472,7 @@ var stateLookupIDCmd = &cli.Command{
 			return err
 		}
 
-		a, err := api.StateLookupID(ctx, addr, ts)
+		a, err := api.StateLookupID(ctx, addr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -509,7 +509,7 @@ var stateSectorSizeCmd = &cli.Command{
 			return err
 		}
 
-		ssize, err := api.StateMinerSectorSize(ctx, addr, ts)
+		ssize, err := api.StateMinerSectorSize(ctx, addr, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -545,12 +545,12 @@ var stateReadStateCmd = &cli.Command{
 			return err
 		}
 
-		act, err := api.StateGetActor(ctx, addr, ts)
+		act, err := api.StateGetActor(ctx, addr, ts.Key())
 		if err != nil {
 			return err
 		}
 
-		as, err := api.StateReadState(ctx, act, ts)
+		as, err := api.StateReadState(ctx, act, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -619,7 +619,7 @@ var stateListMessagesCmd = &cli.Command{
 			return err
 		}
 
-		msgs, err := api.StateListMessages(ctx, &types.Message{To: toa, From: froma}, ts, toh)
+		msgs, err := api.StateListMessages(ctx, &types.Message{To: toa, From: froma}, ts.Key(), toh)
 		if err != nil {
 			return err
 		}
@@ -686,7 +686,7 @@ var stateComputeStateCmd = &cli.Command{
 
 		var msgs []*types.Message
 		if cctx.Bool("apply-mpool-messages") {
-			pmsgs, err := api.MpoolPending(ctx, ts)
+			pmsgs, err := api.MpoolPending(ctx, ts.Key())
 			if err != nil {
 				return err
 			}
@@ -701,7 +701,7 @@ var stateComputeStateCmd = &cli.Command{
 			}
 		}
 
-		nstate, err := api.StateCompute(ctx, h, msgs, ts)
+		nstate, err := api.StateCompute(ctx, h, msgs, ts.Key())
 		if err != nil {
 			return err
 		}
@@ -809,7 +809,7 @@ var stateCallCmd = &cli.Command{
 			return fmt.Errorf("failed to parse 'value': %s", err)
 		}
 
-		act, err := api.StateGetActor(ctx, toa, ts)
+		act, err := api.StateGetActor(ctx, toa, ts.Key())
 		if err != nil {
 			return fmt.Errorf("failed to lookup target actor: %s", err)
 		}
@@ -827,7 +827,7 @@ var stateCallCmd = &cli.Command{
 			GasPrice: types.NewInt(0),
 			Method:   method,
 			Params:   params,
-		}, ts)
+		}, ts.Key())
 		if err != nil {
 			return fmt.Errorf("state call failed: %s", err)
 		}

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -143,19 +143,19 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 
 			if len(bh.Parents) == 0 { // genesis case
 				ts, err := types.NewTipSet([]*types.BlockHeader{bh})
-				aadrs, err := api.StateListActors(ctx, ts)
+				aadrs, err := api.StateListActors(ctx, ts.Key())
 				if err != nil {
 					log.Error(err)
 					return
 				}
 
 				par(50, aadrs, func(addr address.Address) {
-					act, err := api.StateGetActor(ctx, addr, ts)
+					act, err := api.StateGetActor(ctx, addr, ts.Key())
 					if err != nil {
 						log.Error(err)
 						return
 					}
-					ast, err := api.StateReadState(ctx, act, ts)
+					ast, err := api.StateReadState(ctx, act, ts.Key())
 					if err != nil {
 						log.Error(err)
 						return
@@ -200,7 +200,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 					log.Error(err)
 					return
 				}
-				ast, err := api.StateReadState(ctx, &act, ts)
+				ast, err := api.StateReadState(ctx, &act, ts.Key())
 				if err != nil {
 					log.Error(err)
 					return
@@ -237,7 +237,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 		}
 
 		par(50, kmaparr(addresses), func(addr address.Address) {
-			raddr, err := api.StateLookupID(ctx, addr, nil)
+			raddr, err := api.StateLookupID(ctx, addr, types.EmptyTSK)
 			if err != nil {
 				log.Warn(err)
 				return
@@ -268,7 +268,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 		par(50, kvmaparr(miners), func(it func() (minerKey, *minerInfo)) {
 			k, info := it()
 
-			sszs, err := api.StateMinerSectorCount(ctx, k.addr, nil)
+			sszs, err := api.StateMinerSectorCount(ctx, k.addr, types.EmptyTSK)
 			if err != nil {
 				log.Error(err)
 				return
@@ -357,7 +357,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 	log.Infof("Get deals")
 
 	// TODO: incremental, gather expired
-	deals, err := api.StateMarketDeals(ctx, ts)
+	deals, err := api.StateMarketDeals(ctx, ts.Key())
 	if err != nil {
 		log.Error(err)
 		return

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -239,7 +239,7 @@ func (h *handler) mkminer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	collateral, err := h.api.StatePledgeCollateral(r.Context(), nil)
+	collateral, err := h.api.StatePledgeCollateral(r.Context(), types.EmptyTSK)
 	if err != nil {
 		w.WriteHeader(400)
 		w.Write([]byte(err.Error()))

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -38,14 +38,14 @@ var infoCmd = &cli.Command{
 		fmt.Printf("Miner: %s\n", maddr)
 
 		// Sector size
-		sizeByte, err := api.StateMinerSectorSize(ctx, maddr, nil)
+		sizeByte, err := api.StateMinerSectorSize(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
 
 		fmt.Printf("Sector Size: %s\n", types.NewInt(sizeByte).SizeStr())
 
-		pow, err := api.StateMinerPower(ctx, maddr, nil)
+		pow, err := api.StateMinerPower(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -53,11 +53,11 @@ var infoCmd = &cli.Command{
 		percI := types.BigDiv(types.BigMul(pow.MinerPower, types.NewInt(1000000)), pow.TotalPower)
 		fmt.Printf("Power: %s / %s (%0.4f%%)\n", pow.MinerPower.SizeStr(), pow.TotalPower.SizeStr(), float64(percI.Int64())/10000)
 
-		secCounts, err := api.StateMinerSectorCount(ctx, maddr, nil)
+		secCounts, err := api.StateMinerSectorCount(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
-		faults, err := api.StateMinerFaults(ctx, maddr, nil)
+		faults, err := api.StateMinerFaults(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -88,7 +88,7 @@ var infoCmd = &cli.Command{
 		fmt.Printf("\tCommit: %d\n", wstat.CommitWait)
 		fmt.Printf("\tUnseal: %d\n", wstat.UnsealWait)
 
-		eps, err := api.StateMinerElectionPeriodStart(ctx, maddr, nil)
+		eps, err := api.StateMinerElectionPeriodStart(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -324,7 +324,7 @@ func findMarketDealID(ctx context.Context, api lapi.FullNode, deal actors.Storag
 	// TODO: find a better way
 	//  (this is only used by genesis miners)
 
-	deals, err := api.StateMarketDeals(ctx, nil)
+	deals, err := api.StateMarketDeals(ctx, types.EmptyTSK)
 	if err != nil {
 		return 0, xerrors.Errorf("getting market deals: %w", err)
 	}
@@ -486,7 +486,7 @@ func configureStorageMiner(ctx context.Context, api lapi.FullNode, addr address.
 		To:     addr,
 		From:   addr,
 		Method: actors.MAMethods.GetWorkerAddr,
-	}, nil)
+	}, types.EmptyTSK)
 	if err != nil {
 		return xerrors.Errorf("failed to get worker address: %w", err)
 	}
@@ -559,7 +559,7 @@ func createStorageMiner(ctx context.Context, api lapi.FullNode, peerid peer.ID, 
 		return address.Undef, err
 	}
 
-	collateral, err := api.StatePledgeCollateral(ctx, nil)
+	collateral, err := api.StatePledgeCollateral(ctx, types.EmptyTSK)
 	if err != nil {
 		return address.Undef, err
 	}

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/filecoin-project/lotus/chain/types"
 	"os"
 	"sort"
 	"strconv"
@@ -129,7 +130,7 @@ var sectorsListCmd = &cli.Command{
 			return err
 		}
 
-		pset, err := fullApi.StateMinerProvingSet(ctx, maddr, nil)
+		pset, err := fullApi.StateMinerProvingSet(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}
@@ -138,7 +139,7 @@ var sectorsListCmd = &cli.Command{
 			provingIDs[info.SectorID] = struct{}{}
 		}
 
-		sset, err := fullApi.StateMinerSectors(ctx, maddr, nil)
+		sset, err := fullApi.StateMinerSectors(ctx, maddr, types.EmptyTSK)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus/debug_advance.go
+++ b/cmd/lotus/debug_advance.go
@@ -30,7 +30,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			pending, err := api.MpoolPending(ctx, head)
+			pending, err := api.MpoolPending(ctx, head.Key())
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func init() {
 				if err != nil {
 					return xerrors.Errorf("chain get randomness: %w", err)
 				}
-				mworker, err := api.StateMinerWorker(ctx, addr, head)
+				mworker, err := api.StateMinerWorker(ctx, addr, head.Key())
 				if err != nil {
 					return xerrors.Errorf("failed to get miner worker: %w", err)
 				}

--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -60,7 +60,7 @@ func (n *ClientNodeAdapter) ListStorageProviders(ctx context.Context) ([]*storag
 		return nil, err
 	}
 
-	addresses, err := n.StateListMiners(ctx, ts)
+	addresses, err := n.StateListMiners(ctx, ts.Key())
 	if err != nil {
 		return nil, err
 	}
@@ -68,17 +68,17 @@ func (n *ClientNodeAdapter) ListStorageProviders(ctx context.Context) ([]*storag
 	var out []*storagemarket.StorageProviderInfo
 
 	for _, addr := range addresses {
-		workerAddr, err := n.StateMinerWorker(ctx, addr, ts)
+		workerAddr, err := n.StateMinerWorker(ctx, addr, ts.Key())
 		if err != nil {
 			return nil, err
 		}
 
-		sectorSize, err := n.StateMinerSectorSize(ctx, addr, ts)
+		sectorSize, err := n.StateMinerSectorSize(ctx, addr, ts.Key())
 		if err != nil {
 			return nil, err
 		}
 
-		peerId, err := n.StateMinerPeerID(ctx, addr, ts)
+		peerId, err := n.StateMinerPeerID(ctx, addr, ts.Key())
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (n *ClientNodeAdapter) ListStorageProviders(ctx context.Context) ([]*storag
 }
 
 func (n *ClientNodeAdapter) ListClientDeals(ctx context.Context, addr address.Address) ([]storagemarket.StorageDeal, error) {
-	allDeals, err := n.StateMarketDeals(ctx, nil)
+	allDeals, err := n.StateMarketDeals(ctx, types.EmptyTSK)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (n *ClientNodeAdapter) EnsureFunds(ctx context.Context, addr address.Addres
 }
 
 func (n *ClientNodeAdapter) GetBalance(ctx context.Context, addr address.Address) (storagemarket.Balance, error) {
-	bal, err := n.StateMarketBalance(ctx, addr, nil)
+	bal, err := n.StateMarketBalance(ctx, addr, types.EmptyTSK)
 	if err != nil {
 		return storagemarket.Balance{}, err
 	}

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -46,7 +46,7 @@ func NewProviderNodeAdapter(dag dtypes.StagingDAG, secb *sectorblocks.SectorBloc
 func (n *ProviderNodeAdapter) PublishDeals(ctx context.Context, deal storagemarket.MinerDeal) (storagemarket.DealID, cid.Cid, error) {
 	log.Info("publishing deal")
 
-	worker, err := n.StateMinerWorker(ctx, deal.Proposal.Provider, nil)
+	worker, err := n.StateMinerWorker(ctx, deal.Proposal.Provider, types.EmptyTSK)
 	if err != nil {
 		return 0, cid.Undef, err
 	}
@@ -132,7 +132,7 @@ func (n *ProviderNodeAdapter) OnDealComplete(ctx context.Context, deal storagema
 }
 
 func (n *ProviderNodeAdapter) ListProviderDeals(ctx context.Context, addr address.Address) ([]storagemarket.StorageDeal, error) {
-	allDeals, err := n.StateMarketDeals(ctx, nil)
+	allDeals, err := n.StateMarketDeals(ctx, types.EmptyTSK)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (n *ProviderNodeAdapter) ListProviderDeals(ctx context.Context, addr addres
 }
 
 func (n *ProviderNodeAdapter) GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error) {
-	addr, err := n.StateMinerWorker(ctx, miner, nil)
+	addr, err := n.StateMinerWorker(ctx, miner, types.EmptyTSK)
 	return addr, err
 }
 
@@ -198,7 +198,7 @@ func (n *ProviderNodeAdapter) AddFunds(ctx context.Context, addr address.Address
 }
 
 func (n *ProviderNodeAdapter) GetBalance(ctx context.Context, addr address.Address) (storagemarket.Balance, error) {
-	bal, err := n.StateMarketBalance(ctx, addr, nil)
+	bal, err := n.StateMarketBalance(ctx, addr, types.EmptyTSK)
 	if err != nil {
 		return storagemarket.Balance{}, err
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -257,11 +257,11 @@ func (m *Miner) GetBestMiningCandidate(ctx context.Context) (*MiningBase, error)
 			return m.lastWork, nil
 		}
 
-		btsw, err := m.api.ChainTipSetWeight(ctx, bts)
+		btsw, err := m.api.ChainTipSetWeight(ctx, bts.Key())
 		if err != nil {
 			return nil, err
 		}
-		ltsw, err := m.api.ChainTipSetWeight(ctx, m.lastWork.ts)
+		ltsw, err := m.api.ChainTipSetWeight(ctx, m.lastWork.ts.Key())
 		if err != nil {
 			return nil, err
 		}
@@ -276,7 +276,7 @@ func (m *Miner) GetBestMiningCandidate(ctx context.Context) (*MiningBase, error)
 }
 
 func (m *Miner) hasPower(ctx context.Context, addr address.Address, ts *types.TipSet) (bool, error) {
-	power, err := m.api.StateMinerPower(ctx, addr, ts)
+	power, err := m.api.StateMinerPower(ctx, addr, ts.Key())
 	if err != nil {
 		return false, err
 	}
@@ -316,7 +316,7 @@ func (m *Miner) mineOne(ctx context.Context, addr address.Address, base *MiningB
 	}
 
 	// get pending messages early,
-	pending, err := m.api.MpoolPending(context.TODO(), base.ts)
+	pending, err := m.api.MpoolPending(context.TODO(), base.ts.Key())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get pending messages: %w", err)
 	}
@@ -341,7 +341,7 @@ func (m *Miner) mineOne(ctx context.Context, addr address.Address, base *MiningB
 }
 
 func (m *Miner) computeVRF(ctx context.Context, addr address.Address, input []byte) ([]byte, error) {
-	w, err := m.getMinerWorker(ctx, addr, nil)
+	w, err := m.getMinerWorker(ctx, addr, types.EmptyTSK)
 	if err != nil {
 		return nil, err
 	}
@@ -349,12 +349,12 @@ func (m *Miner) computeVRF(ctx context.Context, addr address.Address, input []by
 	return gen.ComputeVRF(ctx, m.api.WalletSign, w, addr, gen.DSepTicket, input)
 }
 
-func (m *Miner) getMinerWorker(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
+func (m *Miner) getMinerWorker(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
 	ret, err := m.api.StateCall(ctx, &types.Message{
 		From:   addr,
 		To:     addr,
 		Method: actors.MAMethods.GetWorkerAddr,
-	}, ts)
+	}, tsk)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("failed to get miner worker addr: %w", err)
 	}
@@ -401,10 +401,10 @@ func (m *Miner) createBlock(base *MiningBase, addr address.Address, ticket *type
 	nheight := base.ts.Height() + base.nullRounds + 1
 
 	// why even return this? that api call could just submit it for us
-	return m.api.MinerCreateBlock(context.TODO(), addr, base.ts, ticket, proof, msgs, nheight, uint64(uts))
+	return m.api.MinerCreateBlock(context.TODO(), addr, base.ts.Key(), ticket, proof, msgs, nheight, uint64(uts))
 }
 
-type ActorLookup func(context.Context, address.Address, *types.TipSet) (*types.Actor, error)
+type ActorLookup func(context.Context, address.Address, types.TipSetKey) (*types.Actor, error)
 
 func countFrom(msgs []*types.SignedMessage, from address.Address) (out int) {
 	for _, msg := range msgs {
@@ -431,7 +431,7 @@ func SelectMessages(ctx context.Context, al ActorLookup, ts *types.TipSet, msgs 
 		from := msg.Message.From
 
 		if _, ok := inclNonces[from]; !ok {
-			act, err := al(ctx, from, ts)
+			act, err := al(ctx, from, ts.Key())
 			if err != nil {
 				log.Warnf("failed to check message sender balance, skipping message: %+v", err)
 				continue

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -33,7 +33,7 @@ func TestMessageFiltering(t *testing.T) {
 		},
 	}
 
-	af := func(ctx context.Context, addr address.Address, ts *types.TipSet) (*types.Actor, error) {
+	af := func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error) {
 		return actors[addr], nil
 	}
 

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -65,12 +65,12 @@ func (a *API) ClientStartDeal(ctx context.Context, data cid.Cid, addr address.Ad
 		return nil, xerrors.Errorf("provided address doesn't exist in wallet")
 	}
 
-	pid, err := a.StateMinerPeerID(ctx, miner, nil)
+	pid, err := a.StateMinerPeerID(ctx, miner, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("failed getting peer ID: %w", err)
 	}
 
-	mw, err := a.StateMinerWorker(ctx, miner, nil)
+	mw, err := a.StateMinerWorker(ctx, miner, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("failed getting miner worker: %w", err)
 	}
@@ -268,7 +268,7 @@ func (a *API) ClientListImports(ctx context.Context) ([]api.Import, error) {
 
 func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, path string) error {
 	if order.MinerPeerID == "" {
-		pid, err := a.StateMinerPeerID(ctx, order.Miner, nil)
+		pid, err := a.StateMinerPeerID(ctx, order.Miner, types.EmptyTSK)
 		if err != nil {
 			return err
 		}

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -157,7 +157,11 @@ func (a *ChainAPI) ChainGetParentReceipts(ctx context.Context, bcid cid.Cid) ([]
 	return out, nil
 }
 
-func (a *ChainAPI) ChainGetTipSetByHeight(ctx context.Context, h uint64, ts *types.TipSet) (*types.TipSet, error) {
+func (a *ChainAPI) ChainGetTipSetByHeight(ctx context.Context, h uint64, tsk types.TipSetKey) (*types.TipSet, error) {
+	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return a.Chain.GetTipsetByHeight(ctx, h, ts)
 }
 
@@ -174,7 +178,11 @@ func (a *ChainAPI) ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error) {
 	return a.Chain.Blockstore().Has(obj)
 }
 
-func (a *ChainAPI) ChainSetHead(ctx context.Context, ts *types.TipSet) error {
+func (a *ChainAPI) ChainSetHead(ctx context.Context, tsk types.TipSetKey) error {
+	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	if err != nil {
+		return xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return a.Chain.SetHead(ts)
 }
 
@@ -187,7 +195,11 @@ func (a *ChainAPI) ChainGetGenesis(ctx context.Context) (*types.TipSet, error) {
 	return types.NewTipSet([]*types.BlockHeader{genb})
 }
 
-func (a *ChainAPI) ChainTipSetWeight(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
+func (a *ChainAPI) ChainTipSetWeight(ctx context.Context, tsk types.TipSetKey) (types.BigInt, error) {
+	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	if err != nil {
+		return types.EmptyInt, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	return a.Chain.Weight(ctx, ts)
 }
 
@@ -320,7 +332,11 @@ func (a *ChainAPI) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Mess
 	return cm.VMMessage(), nil
 }
 
-func (a *ChainAPI) ChainExport(ctx context.Context, ts *types.TipSet) (<-chan []byte, error) {
+func (a *ChainAPI) ChainExport(ctx context.Context, tsk types.TipSetKey) (<-chan []byte, error) {
+	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	r, w := io.Pipe()
 	out := make(chan []byte)
 	go func() {

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -24,7 +24,11 @@ type MpoolAPI struct {
 	Mpool *messagepool.MessagePool
 }
 
-func (a *MpoolAPI) MpoolPending(ctx context.Context, ts *types.TipSet) ([]*types.SignedMessage, error) {
+func (a *MpoolAPI) MpoolPending(ctx context.Context, tsk types.TipSetKey) ([]*types.SignedMessage, error) {
+	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+	}
 	pending, mpts := a.Mpool.Pending()
 
 	haveCids := map[cid.Cid]struct{}{}

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"encoding/json"
+	"github.com/filecoin-project/lotus/chain/types"
 	"io"
 	"mime"
 	"net/http"
@@ -168,7 +169,7 @@ func (sm *StorageMinerAPI) ActorAddress(context.Context) (address.Address, error
 }
 
 func (sm *StorageMinerAPI) ActorSectorSize(ctx context.Context, addr address.Address) (uint64, error) {
-	return sm.Full.StateMinerSectorSize(ctx, addr, nil)
+	return sm.Full.StateMinerSectorSize(ctx, addr, types.EmptyTSK)
 }
 
 func (sm *StorageMinerAPI) PledgeSector(ctx context.Context) error {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"github.com/filecoin-project/lotus/chain/types"
 	"math"
 	"reflect"
 
@@ -70,7 +71,7 @@ func SectorBuilderConfig(storage []fs.PathConfig, threads uint, noprecommit, noc
 			return nil, err
 		}
 
-		ssize, err := api.StateMinerSectorSize(context.TODO(), minerAddr, nil)
+		ssize, err := api.StateMinerSectorSize(context.TODO(), minerAddr, types.EmptyTSK)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +110,7 @@ func StorageMiner(mctx helpers.MetricsCtx, lc fx.Lifecycle, api api.FullNode, h 
 
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
-	worker, err := api.StateMinerWorker(ctx, maddr, nil)
+	worker, err := api.StateMinerWorker(ctx, maddr, types.EmptyTSK)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/fpost_run.go
+++ b/storage/fpost_run.go
@@ -92,7 +92,7 @@ func (s *FPoStScheduler) checkFaults(ctx context.Context, ssi sectorbuilder.Sort
 	declaredFaults := map[uint64]struct{}{}
 
 	{
-		chainFaults, err := s.api.StateMinerFaults(ctx, s.actor, nil)
+		chainFaults, err := s.api.StateMinerFaults(ctx, s.actor, types.EmptyTSK)
 		if err != nil {
 			return nil, xerrors.Errorf("checking on-chain faults: %w", err)
 		}
@@ -195,7 +195,7 @@ func (s *FPoStScheduler) runPost(ctx context.Context, eps uint64, ts *types.TipS
 }
 
 func (s *FPoStScheduler) sortedSectorInfo(ctx context.Context, ts *types.TipSet) (sectorbuilder.SortedPublicSectorInfo, error) {
-	sset, err := s.api.StateMinerProvingSet(ctx, s.actor, ts)
+	sset, err := s.api.StateMinerProvingSet(ctx, s.actor, ts.Key())
 	if err != nil {
 		return sectorbuilder.SortedPublicSectorInfo{}, xerrors.Errorf("failed to get proving set for miner (tsH: %d): %w", ts.Height(), err)
 	}

--- a/storage/fpost_sched.go
+++ b/storage/fpost_sched.go
@@ -162,7 +162,7 @@ func (s *FPoStScheduler) abortActivePoSt() {
 }
 
 func (s *FPoStScheduler) shouldFallbackPost(ctx context.Context, ts *types.TipSet) (uint64, bool, error) {
-	eps, err := s.api.StateMinerElectionPeriodStart(ctx, s.actor, ts)
+	eps, err := s.api.StateMinerElectionPeriodStart(ctx, s.actor, ts.Key())
 	if err != nil {
 		return 0, false, xerrors.Errorf("getting ElectionPeriodStart: %w", err)
 	}

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -40,24 +40,24 @@ type Miner struct {
 
 type storageMinerApi interface {
 	// Call a read only method on actors (no interaction with the chain required)
-	StateCall(context.Context, *types.Message, *types.TipSet) (*api.MethodCall, error)
-	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
-	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)
-	StateMinerSectors(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)
-	StateMinerProvingSet(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)
-	StateMinerSectorSize(context.Context, address.Address, *types.TipSet) (uint64, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)
+	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
+	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)
+	StateMinerSectors(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)
+	StateMinerProvingSet(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)
+	StateMinerSectorSize(context.Context, address.Address, types.TipSetKey) (uint64, error)
 	StateWaitMsg(context.Context, cid.Cid) (*api.MsgWait, error) // TODO: removeme eventually
-	StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error)
-	StateGetReceipt(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error)
-	StateMarketStorageDeal(context.Context, uint64, *types.TipSet) (*actors.OnChainDeal, error)
-	StateMinerFaults(context.Context, address.Address, *types.TipSet) ([]uint64, error)
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
+	StateMarketStorageDeal(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)
+	StateMinerFaults(context.Context, address.Address, types.TipSetKey) ([]uint64, error)
 
 	MpoolPushMessage(context.Context, *types.Message) (*types.SignedMessage, error)
 
 	ChainHead(context.Context) (*types.TipSet, error)
 	ChainNotify(context.Context) (<-chan []*store.HeadChange, error)
 	ChainGetRandomness(context.Context, types.TipSetKey, int64) ([]byte, error)
-	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
+	ChainGetTipSetByHeight(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 

--- a/storage/sealing/checks.go
+++ b/storage/sealing/checks.go
@@ -34,7 +34,7 @@ func checkPieces(ctx context.Context, si SectorInfo, api sealingApi) error {
 	}
 
 	for i, piece := range si.Pieces {
-		deal, err := api.StateMarketStorageDeal(ctx, piece.DealID, nil)
+		deal, err := api.StateMarketStorageDeal(ctx, piece.DealID, types.EmptyTSK)
 		if err != nil {
 			return &ErrApi{xerrors.Errorf("getting deal %d for piece %d: %w", piece.DealID, i, err)}
 		}
@@ -63,7 +63,7 @@ func checkSeal(ctx context.Context, maddr address.Address, si SectorInfo, api se
 		return &ErrApi{xerrors.Errorf("getting chain head: %w", err)}
 	}
 
-	ssize, err := api.StateMinerSectorSize(ctx, maddr, head)
+	ssize, err := api.StateMinerSectorSize(ctx, maddr, head.Key())
 	if err != nil {
 		return &ErrApi{err}
 	}
@@ -85,7 +85,7 @@ func checkSeal(ctx context.Context, maddr address.Address, si SectorInfo, api se
 		Method:   actors.SMAMethods.ComputeDataCommitment,
 		Params:   ccparams,
 	}
-	r, err := api.StateCall(ctx, ccmt, nil)
+	r, err := api.StateCall(ctx, ccmt, types.EmptyTSK)
 	if err != nil {
 		return &ErrApi{xerrors.Errorf("calling ComputeDataCommitment: %w", err)}
 	}

--- a/storage/sealing/sealing.go
+++ b/storage/sealing/sealing.go
@@ -29,23 +29,23 @@ type TicketFn func(context.Context) (*sectorbuilder.SealTicket, error)
 
 type sealingApi interface { // TODO: trim down
 	// Call a read only method on actors (no interaction with the chain required)
-	StateCall(context.Context, *types.Message, *types.TipSet) (*api.MethodCall, error)
-	StateMinerWorker(context.Context, address.Address, *types.TipSet) (address.Address, error)
-	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, ts *types.TipSet) (uint64, error)
-	StateMinerSectors(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)
-	StateMinerProvingSet(context.Context, address.Address, *types.TipSet) ([]*api.ChainSectorInfo, error)
-	StateMinerSectorSize(context.Context, address.Address, *types.TipSet) (uint64, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)
+	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
+	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)
+	StateMinerSectors(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)
+	StateMinerProvingSet(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)
+	StateMinerSectorSize(context.Context, address.Address, types.TipSetKey) (uint64, error)
 	StateWaitMsg(context.Context, cid.Cid) (*api.MsgWait, error) // TODO: removeme eventually
-	StateGetActor(ctx context.Context, actor address.Address, ts *types.TipSet) (*types.Actor, error)
-	StateGetReceipt(context.Context, cid.Cid, *types.TipSet) (*types.MessageReceipt, error)
-	StateMarketStorageDeal(context.Context, uint64, *types.TipSet) (*actors.OnChainDeal, error)
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
+	StateMarketStorageDeal(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)
 
 	MpoolPushMessage(context.Context, *types.Message) (*types.SignedMessage, error)
 
 	ChainHead(context.Context) (*types.TipSet, error)
 	ChainNotify(context.Context) (<-chan []*store.HeadChange, error)
 	ChainGetRandomness(context.Context, types.TipSetKey, int64) ([]byte, error)
-	ChainGetTipSetByHeight(context.Context, uint64, *types.TipSet) (*types.TipSet, error)
+	ChainGetTipSetByHeight(context.Context, uint64, types.TipSetKey) (*types.TipSet, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 

--- a/storage/sealing/states_failed.go
+++ b/storage/sealing/states_failed.go
@@ -3,6 +3,7 @@ package sealing
 import (
 	"bytes"
 	"fmt"
+	"github.com/filecoin-project/lotus/chain/types"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -29,7 +30,7 @@ func failedCooldown(ctx statemachine.Context, sector SectorInfo) error {
 }
 
 func (m *Sealing) checkPreCommitted(ctx statemachine.Context, sector SectorInfo) (*actors.PreCommittedSector, bool) {
-	act, err := m.api.StateGetActor(ctx.Context(), m.maddr, nil)
+	act, err := m.api.StateGetActor(ctx.Context(), m.maddr, types.EmptyTSK)
 	if err != nil {
 		log.Errorf("handleSealFailed(%d): temp error: %+v", sector.SectorID, err)
 		return nil, true

--- a/tools/stats/metrics.go
+++ b/tools/stats/metrics.go
@@ -137,7 +137,7 @@ func RecordTipsetPoints(ctx context.Context, api api.FullNode, pl *PointList, ti
 }
 
 func RecordTipsetStatePoints(ctx context.Context, api api.FullNode, pl *PointList, tipset *types.TipSet) error {
-	pc, err := api.StatePledgeCollateral(ctx, tipset)
+	pc, err := api.StatePledgeCollateral(ctx, tipset.Key())
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func RecordTipsetStatePoints(ctx context.Context, api api.FullNode, pl *PointLis
 	p = NewPoint("network.balance", netBalFilFloat)
 	pl.AddPoint(p)
 
-	power, err := api.StateMinerPower(ctx, address.Address{}, tipset)
+	power, err := api.StateMinerPower(ctx, address.Address{}, tipset.Key())
 	if err != nil {
 		return err
 	}
@@ -167,9 +167,9 @@ func RecordTipsetStatePoints(ctx context.Context, api api.FullNode, pl *PointLis
 	p = NewPoint("chain.power", power.TotalPower.Int64())
 	pl.AddPoint(p)
 
-	miners, err := api.StateListMiners(ctx, tipset)
+	miners, err := api.StateListMiners(ctx, tipset.Key())
 	for _, miner := range miners {
-		power, err := api.StateMinerPower(ctx, miner, tipset)
+		power, err := api.StateMinerPower(ctx, miner, tipset.Key())
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func RecordTipsetMessagesPoints(ctx context.Context, api api.FullNode, pl *Point
 		p = NewPoint("chain.message_size", len(bs))
 		pl.AddPoint(p)
 
-		actor, err := api.StateGetActor(ctx, msg.Message.To, tipset)
+		actor, err := api.StateGetActor(ctx, msg.Message.To, tipset.Key())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR reconfigures the API methods to receive TipSetKeys.

- A new `EmptyTSK` type is created
- Attempting to retrieve the key of a null tipset returns the `EmptyTSK`
- Methods that formerly called API methods with a tipset pointer now use `tipset.Key()`
- Methods that formerly called API methods with nil now use `EmptyTSK`

---
EDIT(Kubuxu)
Resolves #1250 