### PR TITLE
cmd: add log command

### DIFF
--- a/api/api_common.go
+++ b/api/api_common.go
@@ -29,6 +29,9 @@ type Common interface {
 
 	// Version provides information about API provider
 	Version(context.Context) (Version, error)
+
+	LogList(context.Context) ([]string, error)
+	LogSetLevel(context.Context, string, string) error
 }
 
 // Version provides various build-time information

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -32,6 +32,9 @@ type CommonStruct struct {
 
 		ID      func(context.Context) (peer.ID, error)     `perm:"read"`
 		Version func(context.Context) (api.Version, error) `perm:"read"`
+
+		LogList     func(context.Context) ([]string, error)     `perm:"write"`
+		LogSetLevel func(context.Context, string, string) error `perm:"write"`
 	}
 }
 
@@ -201,6 +204,14 @@ func (c *CommonStruct) ID(ctx context.Context) (peer.ID, error) {
 // Version implements API.Version
 func (c *CommonStruct) Version(ctx context.Context) (api.Version, error) {
 	return c.Internal.Version(ctx)
+}
+
+func (c *CommonStruct) LogList(ctx context.Context) ([]string, error) {
+	return c.Internal.LogList(ctx)
+}
+
+func (c *CommonStruct) LogSetLevel(ctx context.Context, group, level string) error {
+	return c.Internal.LogSetLevel(ctx, group, level)
 }
 
 func (c *FullNodeStruct) ClientListImports(ctx context.Context) ([]api.Import, error) {

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -210,4 +210,5 @@ var Commands = []*cli.Command{
 	syncCmd,
 	versionCmd,
 	walletCmd,
+	logCmd,
 }

--- a/cli/log.go
+++ b/cli/log.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+	"gopkg.in/urfave/cli.v2"
+)
+
+var logCmd = &cli.Command{
+	Name:  "log",
+	Usage: "Manage logging",
+	Subcommands: []*cli.Command{
+		logList,
+		logSetLevel,
+	},
+}
+
+var logList = &cli.Command{
+	Name:  "list",
+	Usage: "List log systems",
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := ReqContext(cctx)
+
+		systems, err := api.LogList(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, system := range systems {
+			fmt.Println(system)
+		}
+
+		return nil
+	},
+}
+
+var logSetLevel = &cli.Command{
+	Name:      "set-level",
+	Usage:     "Set log level",
+	ArgsUsage: "<level>",
+	Description: `Set the log level for logging systems:
+
+   The system flag can be specified multiple times.
+
+   eg) log set-level --system chain --system blocksync debug
+
+   Available Levels:
+   debug
+   info
+   warn
+   error
+
+   Environment Variables:
+   GOLOG_LOG_LEVEL - Default log level for all log systems
+   GOLOG_LOG_FMT   - Change output log format (json, nocolor)
+   GOLOG_FILE      - Write logs to file in addition to stderr
+`,
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:  "system",
+			Usage: "limit to log system",
+			Value: &cli.StringSlice{},
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := ReqContext(cctx)
+
+		if !cctx.Args().Present() {
+			return fmt.Errorf("level is required")
+		}
+
+		systems := cctx.StringSlice("system")
+		if len(systems) == 0 {
+			var err error
+			systems, err = api.LogList(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, system := range systems {
+			if err := api.LogSetLevel(ctx, system, cctx.Args().First()); err != nil {
+				return xerrors.Errorf("setting log level on %s: %w", system, err)
+			}
+		}
+
+		return nil
+	},
+}

--- a/node/impl/common.go
+++ b/node/impl/common.go
@@ -3,6 +3,8 @@ package impl
 import (
 	"context"
 
+	logging "github.com/ipfs/go-log/v2"
+
 	"github.com/gbrlsnchs/jwt/v3"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -90,6 +92,14 @@ func (a *CommonAPI) Version(context.Context) (api.Version, error) {
 
 		BlockDelay: build.BlockDelay,
 	}, nil
+}
+
+func (a *CommonAPI) LogList(context.Context) ([]string, error) {
+	return logging.GetSubsystems(), nil
+}
+
+func (a *CommonAPI) LogSetLevel(ctx context.Context, subsystem, level string) error {
+	return logging.SetLogLevel(subsystem, level)
 }
 
 var _ api.Common = &CommonAPI{}


### PR DESCRIPTION
Add a log command to the common api which allows for listing all initialized golog subsystems, and setting their log level during runtime.

Command description also adds golog environment variable documentation.