### PR TITLE
Re: #1232: Add a FindPeer RPC method

### DIFF
--- a/api/api_common.go
+++ b/api/api_common.go
@@ -23,6 +23,7 @@ type Common interface {
 	NetConnect(context.Context, peer.AddrInfo) error
 	NetAddrsListen(context.Context) (peer.AddrInfo, error)
 	NetDisconnect(context.Context, peer.ID) error
+	NetFindPeer(context.Context, peer.ID) (peer.AddrInfo, error)
 
 	// ID returns peerID of libp2p node backing this API
 	ID(context.Context) (peer.ID, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -29,6 +29,7 @@ type CommonStruct struct {
 		NetConnect       func(context.Context, peer.AddrInfo) error                    `perm:"write"`
 		NetAddrsListen   func(context.Context) (peer.AddrInfo, error)                  `perm:"read"`
 		NetDisconnect    func(context.Context, peer.ID) error                          `perm:"write"`
+		NetFindPeer      func(context.Context, peer.ID) (peer.AddrInfo, error)         `perm:"read"`
 
 		ID      func(context.Context) (peer.ID, error)     `perm:"read"`
 		Version func(context.Context) (api.Version, error) `perm:"read"`
@@ -195,6 +196,10 @@ func (c *CommonStruct) NetAddrsListen(ctx context.Context) (peer.AddrInfo, error
 
 func (c *CommonStruct) NetDisconnect(ctx context.Context, p peer.ID) error {
 	return c.Internal.NetDisconnect(ctx, p)
+}
+
+func (c *CommonStruct) NetFindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, error) {
+	return c.Internal.NetFindPeer(ctx, p)
 }
 
 // ID implements API.ID

--- a/cli/net.go
+++ b/cli/net.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"sort"
 	"strings"
 
@@ -18,6 +19,7 @@ var netCmd = &cli.Command{
 		netConnect,
 		netListen,
 		netId,
+		netFindPeer,
 	},
 }
 
@@ -120,6 +122,40 @@ var netId = &cli.Command{
 		}
 
 		fmt.Println(pid)
+		return nil
+	},
+}
+
+var netFindPeer = &cli.Command{
+	Name:      "findpeer",
+	Usage:     "Find the addresses of a given peerID",
+	ArgsUsage: "<peer ID>",
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 1 {
+			fmt.Println("Usage: findpeer [peer ID]")
+			return nil
+		}
+
+		pid, err := peer.IDB58Decode(cctx.Args().First())
+		if err != nil {
+			return err
+		}
+
+		api, closer, err := GetAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := ReqContext(cctx)
+
+		addrs, err := api.NetFindPeer(ctx, pid)
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(addrs)
 		return nil
 	},
 }

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,6 @@ github.com/libp2p/go-eventbus v0.1.0 h1:mlawomSAjjkk97QnYiEmHsLu7E136+2oCWSHRUvM
 github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=
 github.com/libp2p/go-flow-metrics v0.0.1 h1:0gxuFd2GuK7IIP5pKljLwps6TvcuYgvG7Atqi3INF5s=
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
-github.com/libp2p/go-flow-metrics v0.0.2 h1:U5TvqfoyR6GVRM+bC15Ux1ltar1kbj6Zw6xOVR02CZs=
-github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-libp2p v0.0.30/go.mod h1:XWT8FGHlhptAv1+3V/+J5mEpzyui/5bvFsNuWYs611A=
@@ -409,8 +407,6 @@ github.com/libp2p/go-libp2p-core v0.2.0/go.mod h1:X0eyB0Gy93v0DZtSYbEM7RnMChm9Uv
 github.com/libp2p/go-libp2p-core v0.2.2/go.mod h1:8fcwTbsG2B+lTgRJ1ICZtiM5GWCWZVoVrLaDRvIRng0=
 github.com/libp2p/go-libp2p-core v0.2.4 h1:Et6ykkTwI6PU44tr8qUF9k43vP0aduMNniShAbUJJw8=
 github.com/libp2p/go-libp2p-core v0.2.4/go.mod h1:STh4fdfa5vDYr0/SzYYeqnt+E6KfEV5VxfIrm0bcI0g=
-github.com/libp2p/go-libp2p-core v0.2.5 h1:iP1PIiIrlRrGbE1fYq2918yBc5NlCH3pFuIPSWU9hds=
-github.com/libp2p/go-libp2p-core v0.2.5/go.mod h1:6+5zJmKhsf7yHn1RbmYDu08qDUpIUxGdqHuEZckmZOA=
 github.com/libp2p/go-libp2p-core v0.3.0 h1:F7PqduvrztDtFsAa/bcheQ3azmNo+Nq7m8hQY5GiUW8=
 github.com/libp2p/go-libp2p-core v0.3.0/go.mod h1:ACp3DmS3/N64c2jDzcV429ukDpicbL6+TrrxANBjPGw=
 github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
@@ -460,10 +456,6 @@ github.com/libp2p/go-libp2p-peerstore v0.1.4 h1:d23fvq5oYMJ/lkkbO4oTwBp/JP+I/1m5
 github.com/libp2p/go-libp2p-peerstore v0.1.4/go.mod h1:+4BDbDiiKf4PzpANZDAT+knVdLxvqh7hXOujessqdzs=
 github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1VZNHYcK8cLgFJLZ4s=
 github.com/libp2p/go-libp2p-protocol v0.1.0/go.mod h1:KQPHpAabB57XQxGrXCNvbL6UEXfQqUgC/1adR2Xtflk=
-github.com/libp2p/go-libp2p-pubsub v0.2.3 h1:qJRnRnM7Z4xnHb4i6EBb3DKQXRPgtFWlKP4AmfJudLQ=
-github.com/libp2p/go-libp2p-pubsub v0.2.3/go.mod h1:Jscj3fk23R5mCrOwb625xjVs5ZEyTZcx/OlTwMDqU+g=
-github.com/libp2p/go-libp2p-pubsub v0.2.5 h1:tPKbkjAUI0xLGN3KKTKKy9TQEviVfrP++zJgH5Muke4=
-github.com/libp2p/go-libp2p-pubsub v0.2.5/go.mod h1:9Q2RRq8ofXkoewORcyVlgUFDKLKw7BuYSlJVWRcVk3Y=
 github.com/libp2p/go-libp2p-pubsub v0.2.6 h1:ypZaukCFrtD8cNeeb9nnWG4MD2Y1T0p22aQ+f7FKJig=
 github.com/libp2p/go-libp2p-pubsub v0.2.6/go.mod h1:5jEp7R3ItQ0pgcEMrPZYE9DQTg/H3CTc7Mu1j2G4Y5o=
 github.com/libp2p/go-libp2p-quic-transport v0.1.1 h1:MFMJzvsxIEDEVKzO89BnB/FgvMj9WI4GDGUW2ArDPUA=

--- a/node/impl/common.go
+++ b/node/impl/common.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"context"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
 
 	logging "github.com/ipfs/go-log/v2"
 
@@ -23,6 +24,7 @@ type CommonAPI struct {
 
 	APISecret *dtypes.APIAlg
 	Host      host.Host
+	Router    lp2p.BaseIpfsRouting
 }
 
 type jwtPayload struct {
@@ -79,6 +81,10 @@ func (a *CommonAPI) NetAddrsListen(context.Context) (peer.AddrInfo, error) {
 
 func (a *CommonAPI) NetDisconnect(ctx context.Context, p peer.ID) error {
 	return a.Host.Network().ClosePeer(p)
+}
+
+func (a *CommonAPI) NetFindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, error) {
+	return a.Router.FindPeer(ctx, p)
 }
 
 func (a *CommonAPI) ID(context.Context) (peer.ID, error) {


### PR DESCRIPTION
As in commit message. Some points of discussion:

- The `CommonAPI` now has access to a `BaseIpfsRouting` router
- Tested it manually by running a node and issuing requests from the CLI and cURL