### PR TITLE
chainwatch: reduce memory usage during large chain gaps

### DIFF
--- a/cmd/lotus-chainwatch/main.go
+++ b/cmd/lotus-chainwatch/main.go
@@ -60,6 +60,10 @@ var runCmd = &cli.Command{
 			Name:  "front",
 			Value: "127.0.0.1:8418",
 		},
+		&cli.IntFlag{
+			Name:  "max-batch",
+			Value: 1000,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := lcli.GetFullNodeAPI(cctx)
@@ -76,13 +80,15 @@ var runCmd = &cli.Command{
 
 		log.Info("Remote version: %s", v.Version)
 
+		maxBatch := cctx.Int("max-batch")
+
 		st, err := openStorage(cctx.String("db"))
 		if err != nil {
 			return err
 		}
 		defer st.close()
 
-		runSyncer(ctx, api, st)
+		runSyncer(ctx, api, st, maxBatch)
 
 		h, err := newHandler(api, st)
 		if err != nil {

--- a/cmd/lotus-chainwatch/main.go
+++ b/cmd/lotus-chainwatch/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -66,7 +66,6 @@ type actorInfo struct {
 }
 
 func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipSet) {
-	addresses := map[address.Address]address.Address{}
 	var alk sync.Mutex
 
 	log.Infof("Getting synced block list")
@@ -91,7 +90,6 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 		}
 
 		allToSync[bh.Cid()] = bh
-		addresses[bh.Miner] = address.Undef
 
 		if len(allToSync)%500 == 10 {
 			log.Infof("todo: (%d) %s @%d", len(allToSync), bh.Cid(), bh.Height)
@@ -114,6 +112,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 
 	for len(allToSync) > 0 {
 		actors := map[address.Address]map[types.Actor]actorInfo{}
+		addresses := map[address.Address]address.Address{}
 		minH := uint64(math.MaxUint64)
 
 		for _, header := range allToSync {
@@ -126,6 +125,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 		for c, header := range allToSync {
 			if header.Height < minH+maxBatch {
 				toSync[c] = header
+				addresses[header.Miner] = address.Undef
 			}
 		}
 		for c := range toSync {

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -67,7 +67,6 @@ type actorInfo struct {
 
 func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipSet) {
 	addresses := map[address.Address]address.Address{}
-	actors := map[address.Address]map[types.Actor]actorInfo{}
 	var alk sync.Mutex
 
 	log.Infof("Getting synced block list")
@@ -114,6 +113,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 	}
 
 	for len(allToSync) > 0 {
+		actors := map[address.Address]map[types.Actor]actorInfo{}
 		minH := uint64(math.MaxUint64)
 
 		for _, header := range allToSync {
@@ -200,7 +200,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, ts *types.TipS
 					log.Error(err)
 					return
 				}
-				ast, err := api.StateReadState(ctx, &act, ts.Key())
+				ast, err := api.StateReadState(ctx, &act, pts.Key())
 				if err != nil {
 					log.Error(err)
 					return


### PR DESCRIPTION
Running chainwatch on a new database OOM pretty quickly. I'm pretty sure the actor map can be cleared for each batch.