### PR TITLE
Re: #1290: Add sign and verify CLI commands

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -71,6 +71,7 @@ type FullNode interface {
 	WalletBalance(context.Context, address.Address) (types.BigInt, error)
 	WalletSign(context.Context, address.Address, []byte) (*types.Signature, error)
 	WalletSignMessage(context.Context, address.Address, *types.Message) (*types.SignedMessage, error)
+	WalletVerify(context.Context, address.Address, []byte, *types.Signature) bool
 	WalletDefaultAddress(context.Context) (address.Address, error)
 	WalletSetDefault(context.Context, address.Address) error
 	WalletExport(context.Context, address.Address) (*types.KeyInfo, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -83,6 +83,7 @@ type FullNodeStruct struct {
 		WalletBalance        func(context.Context, address.Address) (types.BigInt, error)                         `perm:"read"`
 		WalletSign           func(context.Context, address.Address, []byte) (*types.Signature, error)             `perm:"sign"`
 		WalletSignMessage    func(context.Context, address.Address, *types.Message) (*types.SignedMessage, error) `perm:"sign"`
+		WalletVerify         func(context.Context, address.Address, []byte, *types.Signature) bool                `perm:"read"`
 		WalletDefaultAddress func(context.Context) (address.Address, error)                                       `perm:"write"`
 		WalletSetDefault     func(context.Context, address.Address) error                                         `perm:"admin"`
 		WalletExport         func(context.Context, address.Address) (*types.KeyInfo, error)                       `perm:"admin"`
@@ -309,6 +310,10 @@ func (c *FullNodeStruct) WalletSign(ctx context.Context, k address.Address, msg 
 
 func (c *FullNodeStruct) WalletSignMessage(ctx context.Context, k address.Address, msg *types.Message) (*types.SignedMessage, error) {
 	return c.Internal.WalletSignMessage(ctx, k, msg)
+}
+
+func (c *FullNodeStruct) WalletVerify(ctx context.Context, k address.Address, msg []byte, sig *types.Signature) bool {
+	return c.Internal.WalletVerify(ctx, k, msg, sig)
 }
 
 func (c *FullNodeStruct) WalletDefaultAddress(ctx context.Context) (address.Address, error) {

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -28,6 +28,20 @@ const (
 	metadataTraceConetxt = "traceContext"
 )
 
+// custom CLI error
+
+type ErrCmdFailed struct {
+	msg string
+}
+
+func (e *ErrCmdFailed) Error() string {
+	return e.msg
+}
+
+func NewCliError(s string) error {
+	return &ErrCmdFailed{s}
+}
+
 // ApiConnector returns API instance
 type ApiConnector func() api.FullNode
 

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -25,6 +25,7 @@ var walletCmd = &cli.Command{
 		walletGetDefault,
 		walletSetDefault,
 		walletSign,
+		walletVerify,
 	},
 }
 
@@ -275,5 +276,55 @@ var walletSign = &cli.Command{
 
 		fmt.Println(hex.EncodeToString(sigBytes))
 		return nil
+	},
+}
+
+var walletVerify = &cli.Command{
+	Name:      "verify",
+	Usage:     "verify the signature of a message",
+	ArgsUsage: "<signing address> <hexMessage> <signature>",
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := ReqContext(cctx)
+
+		if !cctx.Args().Present() || cctx.NArg() != 3 {
+			return fmt.Errorf("must specify signing address, message, and signature to verify")
+		}
+
+		addr, err := address.NewFromString(cctx.Args().First())
+
+		if err != nil {
+			return err
+		}
+
+		msg, err := hex.DecodeString(cctx.Args().Get(1))
+
+		if err != nil {
+			return err
+		}
+
+		sigBytes, err := hex.DecodeString(cctx.Args().Get(2))
+
+		if err != nil {
+			return err
+		}
+
+		sig, err := types.SignatureFromBytes(sigBytes)
+
+		if err != nil {
+			return err
+		}
+
+		if api.WalletVerify(ctx, addr, msg, &sig) {
+			fmt.Println("valid")
+			return nil
+		} else {
+			fmt.Println("invalid")
+			return NewCliError("CLI Verify called with invalid signature")
+		}
 	},
 }

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -73,7 +73,12 @@ func main() {
 			Code:    trace.StatusCodeFailedPrecondition,
 			Message: err.Error(),
 		})
-		log.Warnf("%+v", err)
+		_, ok := err.(*lcli.ErrCmdFailed)
+		if ok {
+			log.Debugf("%+v", err)
+		} else {
+			log.Warnf("%+v", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/node/impl/full/wallet.go
+++ b/node/impl/full/wallet.go
@@ -2,6 +2,7 @@ package full
 
 import (
 	"context"
+	"github.com/filecoin-project/lotus/lib/sigs"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -51,6 +52,10 @@ func (a *WalletAPI) WalletSignMessage(ctx context.Context, k address.Address, ms
 		Message:   *msg,
 		Signature: *sig,
 	}, nil
+}
+
+func (a *WalletAPI) WalletVerify(ctx context.Context, k address.Address, msg []byte, sig *types.Signature) bool {
+	return sigs.Verify(sig, k, msg) == nil
 }
 
 func (a *WalletAPI) WalletDefaultAddress(ctx context.Context) (address.Address, error) {


### PR DESCRIPTION
Basically as in #1290. Usage is as follows:

- `lotus wallet sign <msg>` signs `<msg>` with the wallet's default account
- `lotus wallet sign --from <addr> <msg>` signs <msg> with <addr>
- `lotus waller verify <addr> <msg> <sigBytes>` prints "Valid" if <sigBytes> is a valid signature of <msg> by <addr>, else prints "Invalid"