### PR TITLE
Swap to opencensus for publishing data to prometheus

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -13,8 +13,9 @@ import (
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 	"gopkg.in/urfave/cli.v2"
 
@@ -33,6 +34,11 @@ import (
 const (
 	makeGenFlag          = "lotus-make-random-genesis"
 	preSealedSectorsFlag = "genesis-presealed-sectors"
+)
+
+var (
+	lotusInfo  = stats.Int64("info", "General info about lotus", stats.UnitDimensionless)
+	version, _ = tag.NewKey("version")
 )
 
 // DaemonCmd is the `go-lotus daemon` command
@@ -92,7 +98,7 @@ var DaemonCmd = &cli.Command{
 			defer pprof.StopCPUProfile()
 		}
 
-		ctx := context.Background()
+		ctx, _ := tag.New(context.Background(), tag.Insert(version, build.BuildVersion))
 		{
 			dir, err := homedir.Expand(cctx.String("repo"))
 			if err != nil {
@@ -173,16 +179,21 @@ var DaemonCmd = &cli.Command{
 			return xerrors.Errorf("initializing node: %w", err)
 		}
 
-		// Add lotus version info to prometheus metrics
-		var lotusInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "lotus_info",
-			Help: "Lotus version information.",
-		}, []string{"version"})
-
-		// Setting to 1 lets us multiply it with other stats to add the version labels
-		lotusInfoMetric.With(prometheus.Labels{
-			"version": build.UserVersion,
-		}).Set(1)
+		// We are using this metric to tag info about lotus even though
+		// it doesn't contain any actual metrics
+		if err = view.Register(
+			&view.View{
+				Name:        "info",
+				Description: "Lotus node information",
+				Measure:     lotusInfo,
+				Aggregation: view.LastValue(),
+				TagKeys:     []tag.Key{version},
+			},
+		); err != nil {
+			log.Fatalf("Cannot register the view: %v", err)
+		}
+		// Set the metric to one so it is published to the exporter
+		stats.Record(ctx, lotusInfo.M(1))
 
 		endpoint, err := r.APIEndpoint()
 		if err != nil {

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	lotusInfo  = stats.Int64("version", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	lotusInfo  = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
 	version, _ = tag.NewKey("version")
 	commit, _  = tag.NewKey("commit")
 )

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	lotusInfo  = stats.Int64("info", "General info about lotus", stats.UnitDimensionless)
+	lotusInfo  = stats.Int64("version", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
 	version, _ = tag.NewKey("version")
 )
 

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -39,6 +39,7 @@ const (
 var (
 	lotusInfo  = stats.Int64("version", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
 	version, _ = tag.NewKey("version")
+	commit, _  = tag.NewKey("commit")
 )
 
 // DaemonCmd is the `go-lotus daemon` command
@@ -98,7 +99,7 @@ var DaemonCmd = &cli.Command{
 			defer pprof.StopCPUProfile()
 		}
 
-		ctx, _ := tag.New(context.Background(), tag.Insert(version, build.BuildVersion))
+		ctx, _ := tag.New(context.Background(), tag.Insert(version, build.BuildVersion), tag.Insert(commit, build.CurrentCommit))
 		{
 			dir, err := homedir.Expand(cctx.String("repo"))
 			if err != nil {
@@ -187,7 +188,7 @@ var DaemonCmd = &cli.Command{
 				Description: "Lotus node information",
 				Measure:     lotusInfo,
 				Aggregation: view.LastValue(),
-				TagKeys:     []tag.Key{version},
+				TagKeys:     []tag.Key{version, commit},
 			},
 		); err != nil {
 			log.Fatalf("Cannot register the view: %v", err)

--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -53,7 +53,7 @@ func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr) erro
 		log.Fatalf("could not create the prometheus stats exporter: %v", err)
 	}
 
-	http.Handle("/metrics", exporter)
+	http.Handle("/debug/metrics", exporter)
 
 	lst, err := manet.Listen(addr)
 	if err != nil {

--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -23,7 +23,7 @@ import (
 	manet "github.com/multiformats/go-multiaddr-net"
 	"golang.org/x/xerrors"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"contrib.go.opencensus.io/exporter/prometheus"
 )
 
 var log = logging.Logger("main")
@@ -46,7 +46,14 @@ func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr) erro
 
 	http.Handle("/rest/v0/import", importAH)
 
-	http.Handle("/metrics", promhttp.Handler())
+	exporter, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "lotus",
+	})
+	if err != nil {
+		log.Fatalf("could not create the prometheus stats exporter: %v", err)
+	}
+
+	http.Handle("/metrics", exporter)
 
 	lst, err := manet.Listen(addr)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
+	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/BurntSushi/toml v0.3.1
 	github.com/GeertJohan/go.rice v1.0.0
 	github.com/Gurpartap/async v0.0.0-20180927173644-4f7f499dd9ee

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/jaeger v0.1.0 h1:WNc9HbA38xEQmsI40Tjd/MNU/g8byN2Of7lwIjv0Jdc=
 contrib.go.opencensus.io/exporter/jaeger v0.1.0/go.mod h1:VYianECmuFPwU37O699Vc1GOcy+y8kOsfaxHRImmjbA=
+contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE5H/ukPWBRo314xiDvg=
+contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -658,14 +660,17 @@ github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXx
 github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a h1:hjZfReYVLbqFkAtr2us7vdy04YWz3LVAirzP7reh8+M=
 github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f h1:BVwpUVJDADN2ufcGik7W992pyps0wZ888b/y9GXcLTU=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0 h1:kUZDBDTdBVBYBj5Tmh2NZLlF60mfjA27rM34b+cVwNU=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -818,6 +823,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Since we are already using opencensus elsewhere, it was suggested to switch to using the opencensus exporter for prometheus stats.

This has a similar end result to the prior diff, except I'm excluding the git commit hash (I can add it back easily if needed).

```
# HELP lotus_info Lotus node information
# TYPE lotus_info gauge
lotus_info{version="0.2.8"} 1
```