### PR TITLE
More opencensus metrics

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -396,9 +396,6 @@ func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
 		)
 	}
 
-	// Record current network chain height when sync is called
-	stats.Record(ctx, metrics.ChainHeight.M(int64(maybeHead.Height())))
-
 	if syncer.store.GetHeaviestTipSet().ParentWeight().GreaterThan(maybeHead.ParentWeight()) {
 		return nil
 	}
@@ -1043,8 +1040,7 @@ func (syncer *Syncer) syncMessagesAndCheckState(ctx context.Context, headers []*
 			return xerrors.Errorf("message processing failed: %w", err)
 		}
 
-		// Set current node sync height
-		stats.Record(ctx, metrics.ChainNodeHeight.M(int64(fts.TipSet().Height())))
+		stats.Record(ctx, metrics.ChainNodeWorkerHeight.M(int64(fts.TipSet().Height())))
 		ss.SetHeight(fts.TipSet().Height())
 
 		return nil

--- a/lib/jsonrpc/handler.go
+++ b/lib/jsonrpc/handler.go
@@ -156,7 +156,7 @@ func (handlers) getSpan(ctx context.Context, req request) (context.Context, *tra
 func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer)), rpcError rpcErrFunc, done func(keepCtx bool), chOut chanOut) {
 	// Not sure if we need to sanitize the incoming req.Method or not.
 	ctx, span := h.getSpan(ctx, req)
-	ctx, _ = tag.New(context.Background(), tag.Insert(metrics.RPCMethod, req.Method))
+	ctx, _ = tag.New(ctx, tag.Insert(metrics.RPCMethod, req.Method))
 	defer span.End()
 
 	handler, ok := h[req.Method]
@@ -169,6 +169,7 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 
 	if len(req.Params) != handler.nParams {
 		rpcError(w, &req, rpcInvalidParams, fmt.Errorf("wrong param count"))
+		stats.Record(ctx, metrics.RPCRequestError.M(1))
 		done(false)
 		return
 	}
@@ -178,6 +179,7 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 
 	if chOut == nil && outCh {
 		rpcError(w, &req, rpcMethodNotFound, fmt.Errorf("method '%s' not supported in this mode (no out channel support)", req.Method))
+		stats.Record(ctx, metrics.RPCRequestError.M(1))
 		return
 	}
 
@@ -191,6 +193,7 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 		rp := reflect.New(handler.paramReceivers[i])
 		if err := json.NewDecoder(bytes.NewReader(req.Params[i].data)).Decode(rp.Interface()); err != nil {
 			rpcError(w, &req, rpcParseError, xerrors.Errorf("unmarshaling params for '%s': %w", handler.handlerFunc, err))
+			stats.Record(ctx, metrics.RPCRequestError.M(1))
 			return
 		}
 
@@ -202,12 +205,12 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 	callResult, err := doCall(req.Method, handler.handlerFunc, callParams)
 	if err != nil {
 		rpcError(w, &req, 0, xerrors.Errorf("fatal error calling '%s': %w", req.Method, err))
+		stats.Record(ctx, metrics.RPCRequestError.M(1))
 		return
 	}
 	if req.ID == nil {
 		return // notification
 	}
-	stats.Record(ctx, metrics.RPCRequestSuccess.M(1))
 
 	///////////////////
 
@@ -220,6 +223,7 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 		err := callResult[handler.errOut].Interface()
 		if err != nil {
 			log.Warnf("error in RPC call to '%s': %+v", req.Method, err)
+			stats.Record(ctx, metrics.RPCResponseError.M(1))
 			resp.Error = &respError{
 				Code:    1,
 				Message: err.(error).Error(),
@@ -241,6 +245,7 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 		}
 
 		log.Warnf("failed to setup channel in RPC call to '%s': %+v", req.Method, err)
+		stats.Record(ctx, metrics.RPCResponseError.M(1))
 		resp.Error = &respError{
 			Code:    1,
 			Message: err.(error).Error(),
@@ -250,8 +255,8 @@ func (h handlers) handle(ctx context.Context, req request, w func(func(io.Writer
 	w(func(w io.Writer) {
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			log.Error(err)
+			stats.Record(ctx, metrics.RPCResponseError.M(1))
 			return
 		}
-		stats.Record(ctx, metrics.RPCResponseSuccess.M(1))
 	})
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,20 +8,26 @@ import (
 
 // Global Tags
 var (
-	Version, _   = tag.NewKey("version")
-	Commit, _    = tag.NewKey("commit")
-	RPCMethod, _ = tag.NewKey("method")
+	Version, _      = tag.NewKey("version")
+	Commit, _       = tag.NewKey("commit")
+	RPCMethod, _    = tag.NewKey("method")
+	PeerID, _       = tag.NewKey("peer_id")
+	MessageFrom, _  = tag.NewKey("message_from")
+	MessageTo, _    = tag.NewKey("message_to")
+	MessageNonce, _ = tag.NewKey("message_nonce")
 )
 
 // Measures
 var (
-	LotusInfo        = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
-	ChainHeight      = stats.Int64("chain/height", "Current Height of the chain", stats.UnitDimensionless)
-	ChainNodeHeight  = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
-	PeerCount        = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
-	RPCInvalidMethod = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
-	RPCRequestError  = stats.Int64("rpc/request_error", "Total number of request errors handled", stats.UnitDimensionless)
-	RPCResponseError = stats.Int64("rpc/response_error", "Total number of responses errors handled", stats.UnitDimensionless)
+	LotusInfo             = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	ChainNodeHeight       = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	ChainNodeWorkerHeight = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
+	MessageAddFailure     = stats.Int64("message/add_faliure", "Counter for messages that failed to be added", stats.UnitDimensionless)
+	MessageDecodeFailure  = stats.Int64("message/decode_faliure", "Counter for messages that failed to be decoded", stats.UnitDimensionless)
+	PeerCount             = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
+	RPCInvalidMethod      = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
+	RPCRequestError       = stats.Int64("rpc/request_error", "Total number of request errors handled", stats.UnitDimensionless)
+	RPCResponseError      = stats.Int64("rpc/response_error", "Total number of responses errors handled", stats.UnitDimensionless)
 )
 
 // DefaultViews is an array of Consensus views for metric gathering purposes
@@ -34,11 +40,25 @@ var DefaultViews = []*view.View{
 		TagKeys:     []tag.Key{Version, Commit},
 	},
 	&view.View{
-		Measure:     ChainHeight,
+		Measure:     ChainNodeHeight,
 		Aggregation: view.LastValue(),
 	},
 	&view.View{
-		Measure:     ChainNodeHeight,
+		Measure:     ChainNodeWorkerHeight,
+		Aggregation: view.LastValue(),
+	},
+	&view.View{
+		Measure:     MessageAddFailure,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{MessageFrom, MessageTo, MessageNonce},
+	},
+	&view.View{
+		Measure:     MessageDecodeFailure,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{PeerID},
+	},
+	&view.View{
+		Measure:     PeerCount,
 		Aggregation: view.LastValue(),
 	},
 	// All RPC related metrics should at the very least tag the RPCMethod
@@ -56,9 +76,5 @@ var DefaultViews = []*view.View{
 		Measure:     RPCResponseError,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{RPCMethod},
-	},
-	&view.View{
-		Measure:     PeerCount,
-		Aggregation: view.LastValue(),
 	},
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,22 +12,28 @@ var (
 	Commit, _       = tag.NewKey("commit")
 	RPCMethod, _    = tag.NewKey("method")
 	PeerID, _       = tag.NewKey("peer_id")
+	FailureType, _  = tag.NewKey("failure_type")
 	MessageFrom, _  = tag.NewKey("message_from")
 	MessageTo, _    = tag.NewKey("message_to")
 	MessageNonce, _ = tag.NewKey("message_nonce")
+	ReceivedFrom, _ = tag.NewKey("received_from")
 )
 
 // Measures
 var (
-	LotusInfo             = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
-	ChainNodeHeight       = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
-	ChainNodeWorkerHeight = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
-	MessageAddFailure     = stats.Int64("message/add_faliure", "Counter for messages that failed to be added", stats.UnitDimensionless)
-	MessageDecodeFailure  = stats.Int64("message/decode_faliure", "Counter for messages that failed to be decoded", stats.UnitDimensionless)
-	PeerCount             = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
-	RPCInvalidMethod      = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
-	RPCRequestError       = stats.Int64("rpc/request_error", "Total number of request errors handled", stats.UnitDimensionless)
-	RPCResponseError      = stats.Int64("rpc/response_error", "Total number of responses errors handled", stats.UnitDimensionless)
+	LotusInfo                = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	ChainNodeHeight          = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	ChainNodeWorkerHeight    = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
+	MessageReceived          = stats.Int64("message/received", "Counter for total received messages", stats.UnitDimensionless)
+	MessageValidationFailure = stats.Int64("message/failure", "Counter for message validation failures", stats.UnitDimensionless)
+	MessageValidationSuccess = stats.Int64("message/success", "Counter for message validation successes", stats.UnitDimensionless)
+	BlockReceived            = stats.Int64("block/received", "Counter for total received blocks", stats.UnitDimensionless)
+	BlockValidationFailure   = stats.Int64("block/failure", "Counter for block validation failures", stats.UnitDimensionless)
+	BlockValidationSuccess   = stats.Int64("block/success", "Counter for block validation successes", stats.UnitDimensionless)
+	PeerCount                = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
+	RPCInvalidMethod         = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
+	RPCRequestError          = stats.Int64("rpc/request_error", "Total number of request errors handled", stats.UnitDimensionless)
+	RPCResponseError         = stats.Int64("rpc/response_error", "Total number of responses errors handled", stats.UnitDimensionless)
 )
 
 // DefaultViews is an array of Consensus views for metric gathering purposes
@@ -48,14 +54,30 @@ var DefaultViews = []*view.View{
 		Aggregation: view.LastValue(),
 	},
 	&view.View{
-		Measure:     MessageAddFailure,
+		Measure:     BlockReceived,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{MessageFrom, MessageTo, MessageNonce},
 	},
 	&view.View{
-		Measure:     MessageDecodeFailure,
+		Measure:     BlockValidationFailure,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{PeerID},
+		TagKeys:     []tag.Key{FailureType, PeerID},
+	},
+	&view.View{
+		Measure:     BlockValidationSuccess,
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     MessageReceived,
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     MessageValidationFailure,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{FailureType, MessageFrom, MessageTo, MessageNonce},
+	},
+	&view.View{
+		Measure:     MessageValidationSuccess,
+		Aggregation: view.Count(),
 	},
 	&view.View{
 		Measure:     PeerCount,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// Global Tags
+var (
+	Version, _   = tag.NewKey("version")
+	Commit, _    = tag.NewKey("commit")
+	RPCMethod, _ = tag.NewKey("method")
+)
+
+// Measures
+var (
+	LotusInfo          = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	ChainHeight        = stats.Int64("chain/height", "Current Height of the chain", stats.UnitDimensionless)
+	ChainNodeHeight    = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	PeerCount          = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
+	RPCInvalidMethod   = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
+	RPCRequestSuccess  = stats.Int64("rpc/request_success", "Total number of successful requests handled", stats.UnitDimensionless)
+	RPCResponseSuccess = stats.Int64("rpc/response_success", "Total number of succeessful responses handled", stats.UnitDimensionless)
+)
+
+// DefaultViews is an array of Consensus views for metric gathering purposes
+var DefaultViews = []*view.View{
+	&view.View{
+		Name:        "info",
+		Description: "Lotus node information",
+		Measure:     LotusInfo,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{Version, Commit},
+	},
+	&view.View{
+		Measure:     ChainHeight,
+		Aggregation: view.LastValue(),
+	},
+	&view.View{
+		Measure:     ChainNodeHeight,
+		Aggregation: view.LastValue(),
+	},
+	// All RPC related metrics should at the very least tag the RPCMethod
+	&view.View{
+		Measure:     RPCInvalidMethod,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{RPCMethod},
+	},
+	&view.View{
+		Measure:     RPCRequestSuccess,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{RPCMethod},
+	},
+	&view.View{
+		Measure:     RPCResponseSuccess,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{RPCMethod},
+	},
+	&view.View{
+		Measure:     PeerCount,
+		Aggregation: view.LastValue(),
+	},
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,13 +15,13 @@ var (
 
 // Measures
 var (
-	LotusInfo          = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
-	ChainHeight        = stats.Int64("chain/height", "Current Height of the chain", stats.UnitDimensionless)
-	ChainNodeHeight    = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
-	PeerCount          = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
-	RPCInvalidMethod   = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
-	RPCRequestSuccess  = stats.Int64("rpc/request_success", "Total number of successful requests handled", stats.UnitDimensionless)
-	RPCResponseSuccess = stats.Int64("rpc/response_success", "Total number of succeessful responses handled", stats.UnitDimensionless)
+	LotusInfo        = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	ChainHeight      = stats.Int64("chain/height", "Current Height of the chain", stats.UnitDimensionless)
+	ChainNodeHeight  = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	PeerCount        = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
+	RPCInvalidMethod = stats.Int64("rpc/invalid_method", "Total number of invalid RPC methods called", stats.UnitDimensionless)
+	RPCRequestError  = stats.Int64("rpc/request_error", "Total number of request errors handled", stats.UnitDimensionless)
+	RPCResponseError = stats.Int64("rpc/response_error", "Total number of responses errors handled", stats.UnitDimensionless)
 )
 
 // DefaultViews is an array of Consensus views for metric gathering purposes
@@ -48,12 +48,12 @@ var DefaultViews = []*view.View{
 		TagKeys:     []tag.Key{RPCMethod},
 	},
 	&view.View{
-		Measure:     RPCRequestSuccess,
+		Measure:     RPCRequestError,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{RPCMethod},
 	},
 	&view.View{
-		Measure:     RPCResponseSuccess,
+		Measure:     RPCResponseError,
 		Aggregation: view.Count(),
 		TagKeys:     []tag.Key{RPCMethod},
 	},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -60,7 +60,7 @@ var DefaultViews = []*view.View{
 	&view.View{
 		Measure:     BlockValidationFailure,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{FailureType, PeerID},
+		TagKeys:     []tag.Key{FailureType, PeerID, ReceivedFrom},
 	},
 	&view.View{
 		Measure:     BlockValidationSuccess,

--- a/peermgr/peermgr.go
+++ b/peermgr/peermgr.go
@@ -5,7 +5,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/filecoin-project/lotus/metrics"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"go.opencensus.io/stats"
 	"go.uber.org/fx"
 
 	host "github.com/libp2p/go-libp2p-core/host"
@@ -115,6 +117,7 @@ func (pmgr *PeerMgr) Run(ctx context.Context) {
 			} else if pcount > pmgr.maxFilPeers {
 				log.Debug("peer count about threshold: %d > %d", pcount, pmgr.maxFilPeers)
 			}
+			stats.Record(ctx, metrics.PeerCount.M(int64(pmgr.getPeerCount())))
 		}
 	}
 }


### PR DESCRIPTION
This diff adds some metrics that will be handy for establishing cluster health for the lotus nodes. Example prometheus output:

```
# HELP lotus_chain_height Current Height of the chain
# TYPE lotus_chain_height gauge
lotus_chain_height 84481
# HELP lotus_chain_node_height Current Height of the node
# TYPE lotus_chain_node_height gauge
lotus_chain_node_height 724
# HELP lotus_info Lotus node information
# TYPE lotus_info gauge
lotus_info{commit="+git08678e27",version="0.2.8"} 1
# HELP lotus_peer_count Current number of FIL peers
# TYPE lotus_peer_count gauge
lotus_peer_count 14
# HELP lotus_rpc_request_success Total number of successful requests handled
# TYPE lotus_rpc_request_success counter
lotus_rpc_request_success{method="Filecoin.ChainHead"} 6
lotus_rpc_request_success{method="Filecoin.MpoolPending"} 6
lotus_rpc_request_success{method="Filecoin.StateGetActor"} 6
lotus_rpc_request_success{method="Filecoin.SyncState"} 2
# HELP lotus_rpc_response_success Total number of succeessful responses handled
# TYPE lotus_rpc_response_success counter
lotus_rpc_response_success{method="Filecoin.ChainHead"} 6
lotus_rpc_response_success{method="Filecoin.MpoolPending"} 6
lotus_rpc_response_success{method="Filecoin.StateGetActor"} 6
lotus_rpc_response_success{method="Filecoin.SyncState"} 2

```

I'll do another pass, but this feels like a good bare-bones implementation for now (and will probably be expanded before long).