### PR TITLE
Fix issues with payment channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.0.0-20200228192824-ee51014cc8c6
+	github.com/filecoin-project/go-fil-markets v0.0.0-20200229032800-36a9b170996a
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200228181617-f00e2c4cc050

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce 
 github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce/go.mod h1:b14UWxhxVCAjrQUYvVGrQRRsjAh79wXYejw9RbUcAww=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
+github.com/filecoin-project/go-fil-components v0.0.0-20200228192824-ee51014cc8c6 h1:GJTFEqi4HllM3MMSh4Q4oF1d7/sFkp05vd/f499BlJQ=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200228192824-ee51014cc8c6 h1:xYldVV9fZ+nsykQnEVMwcLU+6R5EshzmOWcyQDpludc=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200228192824-ee51014cc8c6/go.mod h1:rfRwhd3ujcCXnD4N9oEM2wjh8GRZGoeNXME+UPG/9ts=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -112,9 +112,8 @@ github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce 
 github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce/go.mod h1:b14UWxhxVCAjrQUYvVGrQRRsjAh79wXYejw9RbUcAww=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-fil-components v0.0.0-20200228192824-ee51014cc8c6 h1:GJTFEqi4HllM3MMSh4Q4oF1d7/sFkp05vd/f499BlJQ=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200228192824-ee51014cc8c6 h1:xYldVV9fZ+nsykQnEVMwcLU+6R5EshzmOWcyQDpludc=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200228192824-ee51014cc8c6/go.mod h1:rfRwhd3ujcCXnD4N9oEM2wjh8GRZGoeNXME+UPG/9ts=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200229032800-36a9b170996a h1:8Mgw8AxjfWF4dGxnRtGLss0wZYXI3mYnHUhIdvfQqOQ=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200229032800-36a9b170996a/go.mod h1:rfRwhd3ujcCXnD4N9oEM2wjh8GRZGoeNXME+UPG/9ts=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
@@ -129,7 +128,6 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
-github.com/filecoin-project/specs-actors v0.0.0-20200228215954-2c5be7cfad99/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/filecoin-project/specs-actors v0.0.0-20200229011003-1d726e3afd04 h1:O343OeQLkLWLj5ZqQ5nhevAGBTeB5LioiA53ddScqdY=
 github.com/filecoin-project/specs-actors v0.0.0-20200229011003-1d726e3afd04/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/markets/retrievaladapter/provider.go
+++ b/markets/retrievaladapter/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/storage"
 )
 
@@ -24,6 +25,11 @@ type retrievalProviderNode struct {
 // Lotus Node
 func NewRetrievalProviderNode(miner *storage.Miner, sb sectorbuilder.Interface, full api.FullNode) retrievalmarket.RetrievalProviderNode {
 	return &retrievalProviderNode{miner, sb, full}
+}
+
+func (rpn *retrievalProviderNode) GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error) {
+	addr, err := rpn.full.StateMinerWorker(ctx, miner, types.EmptyTSK)
+	return addr, err
 }
 
 func (rpn *retrievalProviderNode) UnsealSector(ctx context.Context, sectorID uint64, offset uint64, length uint64) (io.ReadCloser, error) {

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -187,7 +187,7 @@ func (a *API) ClientFindData(ctx context.Context, root cid.Cid) ([]api.QueryOffe
 				MinPrice:                queryResponse.PieceRetrievalPrice(),
 				PaymentInterval:         queryResponse.MaxPaymentInterval,
 				PaymentIntervalIncrease: queryResponse.MaxPaymentIntervalIncrease,
-				Miner:                   p.Address, // TODO: check
+				Miner:                   queryResponse.PaymentAddress, // TODO: check
 				MinerPeerID:             p.ID,
 			}
 		}

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -308,10 +308,10 @@ func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, path
 
 	unsubscribe := a.Retrieval.SubscribeToEvents(func(event retrievalmarket.ClientEvent, state retrievalmarket.ClientDealState) {
 		if state.PayloadCID.Equals(order.Root) {
-			switch event {
-			case retrievalmarket.ClientEventError:
+			switch state.Status {
+			case retrievalmarket.DealStatusFailed, retrievalmarket.DealStatusErrored:
 				retrievalResult <- xerrors.Errorf("Retrieval Error: %s", state.Message)
-			case retrievalmarket.ClientEventComplete:
+			case retrievalmarket.DealStatusCompleted:
 				retrievalResult <- nil
 			}
 		}

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -1,6 +1,7 @@
 package paychmgr
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -58,10 +59,12 @@ func (pm *Manager) createPaych(ctx context.Context, from, to address.Address, am
 		return address.Undef, cid.Undef, fmt.Errorf("payment channel creation failed (exit code %d)", mwait.Receipt.ExitCode)
 	}
 
-	paychaddr, err := address.NewFromBytes(mwait.Receipt.Return)
+	var decodedReturn init_.ExecReturn
+	err = decodedReturn.UnmarshalCBOR(bytes.NewReader(mwait.Receipt.Return))
 	if err != nil {
 		return address.Undef, cid.Undef, err
 	}
+	paychaddr := decodedReturn.RobustAddress
 
 	ci, err := pm.loadOutboundChannelInfo(ctx, paychaddr)
 	if err != nil {

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (pm *Manager) createPaych(ctx context.Context, from, to address.Address, amt types.BigInt) (address.Address, cid.Cid, error) {
-	params, aerr := actors.SerializeParams(&paych.ConstructorParams{To: to})
+	params, aerr := actors.SerializeParams(&paych.ConstructorParams{From: from, To: to})
 	if aerr != nil {
 		return address.Undef, cid.Undef, aerr
 	}


### PR DESCRIPTION
# Goals

Retrieval market is failing due to issues creating payment channels with specs-actors. This solves several of those issues -- it can now create the channel -- but it there is still a seperate issue creating vouchers.

# Implementation

1. First issue is serializing constructor params for PaymentChannel -- was missing the From field
2. Second issue is that the storage miner actor address was being passed in the call to create payment channel -- which then fails in the paych actor. The reason is cause right now we had not been translating from the storage miner actor address to the actual wallet address in retrieval in responding to queries. This is addressed in: https://github.com/filecoin-project/go-fil-markets/pull/130 and integrated here, so that the retrieval deal is initialized with the miner's actual wallet
3. Third issue is deserializing the return value for creating the payment channel address -- was not using init.ExecReturn. (Note: this probably also applies to code for multisigs but I did not attempt to address that.)

This gets us all the way through creating the payment channel, however...
Creating vouchers still fails - it appears that the payment channel has ID addresses in the From/To, which means that when you try to sign a voucher, the Wallen signing fails when you use just the ID address. I couldn't immediately figure out how to go from ID Address -> Full address with the statemanager. It's fairly clear how to do the other way but I could not immediately figure out how to go this way.
