### PR TITLE
Re: #1239: Expose information about invoked messages

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -98,8 +98,8 @@ type FullNode interface {
 	//ClientListAsks() []Ask
 
 	// if tipset is nil, we'll use heaviest
-	StateCall(context.Context, *types.Message, types.TipSetKey) (*MethodCall, error)
-	StateReplay(context.Context, types.TipSetKey, cid.Cid) (*ReplayResults, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*InvocResult, error)
+	StateReplay(context.Context, types.TipSetKey, cid.Cid) (*InvocResult, error)
 	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
 	StateReadState(ctx context.Context, act *types.Actor, tsk types.TipSetKey) (*ActorState, error)
 	StateListMessages(ctx context.Context, match *types.Message, tsk types.TipSetKey, toht uint64) ([]cid.Cid, error)
@@ -271,15 +271,10 @@ type RetrievalOrder struct {
 	MinerPeerID peer.ID
 }
 
-type ReplayResults struct {
-	Msg     *types.Message
-	Receipt *types.MessageReceipt
+type InvocResult struct {
+	Msg *types.Message
+	MsgRct *types.MessageReceipt
 	Error   string
-}
-
-type MethodCall struct {
-	types.MessageReceipt
-	Error string
 }
 
 type ActiveSync struct {

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"github.com/filecoin-project/lotus/chain/vm"
 	"time"
 
 	"github.com/filecoin-project/go-address"
@@ -274,6 +275,7 @@ type RetrievalOrder struct {
 type InvocResult struct {
 	Msg *types.Message
 	MsgRct *types.MessageReceipt
+	InternalExecutions []*vm.ExecutionResult
 	Error   string
 }
 

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -99,26 +99,26 @@ type FullNodeStruct struct {
 		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, path string) error                                                                            `perm:"admin"`
 		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*types.SignedStorageAsk, error)                                                      `perm:"read"`
 
-		StateMinerSectors             func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)             `perm:"read"`
-		StateMinerProvingSet          func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)             `perm:"read"`
-		StateMinerPower               func(context.Context, address.Address, types.TipSetKey) (api.MinerPower, error)                     `perm:"read"`
-		StateMinerWorker              func(context.Context, address.Address, types.TipSetKey) (address.Address, error)                    `perm:"read"`
-		StateMinerPeerID              func(ctx context.Context, m address.Address, tsk types.TipSetKey) (peer.ID, error)                   `perm:"read"`
-		StateMinerElectionPeriodStart func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)                `perm:"read"`
-		StateMinerSectorSize          func(context.Context, address.Address, types.TipSetKey) (uint64, error)                             `perm:"read"`
-		StateMinerFaults              func(context.Context, address.Address, types.TipSetKey) ([]uint64, error)                           `perm:"read"`
-		StateCall                     func(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)                     `perm:"read"`
-		StateReplay                   func(context.Context, types.TipSetKey, cid.Cid) (*api.ReplayResults, error)                         `perm:"read"`
-		StateGetActor                 func(context.Context, address.Address, types.TipSetKey) (*types.Actor, error)                       `perm:"read"`
-		StateReadState                func(context.Context, *types.Actor, types.TipSetKey) (*api.ActorState, error)                       `perm:"read"`
-		StatePledgeCollateral         func(context.Context, types.TipSetKey) (types.BigInt, error)                                        `perm:"read"`
+		StateMinerSectors             func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)           `perm:"read"`
+		StateMinerProvingSet          func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)           `perm:"read"`
+		StateMinerPower               func(context.Context, address.Address, types.TipSetKey) (api.MinerPower, error)                   `perm:"read"`
+		StateMinerWorker              func(context.Context, address.Address, types.TipSetKey) (address.Address, error)                  `perm:"read"`
+		StateMinerPeerID              func(ctx context.Context, m address.Address, tsk types.TipSetKey) (peer.ID, error)                `perm:"read"`
+		StateMinerElectionPeriodStart func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)             `perm:"read"`
+		StateMinerSectorSize          func(context.Context, address.Address, types.TipSetKey) (uint64, error)                           `perm:"read"`
+		StateMinerFaults              func(context.Context, address.Address, types.TipSetKey) ([]uint64, error)                         `perm:"read"`
+		StateCall                     func(context.Context, *types.Message, types.TipSetKey) (*api.InvocResult, error)                  `perm:"read"`
+		StateReplay                   func(context.Context, types.TipSetKey, cid.Cid) (*api.InvocResult, error)                         `perm:"read"`
+		StateGetActor                 func(context.Context, address.Address, types.TipSetKey) (*types.Actor, error)                     `perm:"read"`
+		StateReadState                func(context.Context, *types.Actor, types.TipSetKey) (*api.ActorState, error)                     `perm:"read"`
+		StatePledgeCollateral         func(context.Context, types.TipSetKey) (types.BigInt, error)                                      `perm:"read"`
 		StateWaitMsg                  func(context.Context, cid.Cid) (*api.MsgWait, error)                                              `perm:"read"`
-		StateListMiners               func(context.Context, types.TipSetKey) ([]address.Address, error)                                   `perm:"read"`
-		StateListActors               func(context.Context, types.TipSetKey) ([]address.Address, error)                                   `perm:"read"`
-		StateMarketBalance            func(context.Context, address.Address, types.TipSetKey) (actors.StorageParticipantBalance, error)   `perm:"read"`
-		StateMarketParticipants       func(context.Context, types.TipSetKey) (map[string]actors.StorageParticipantBalance, error)         `perm:"read"`
-		StateMarketDeals              func(context.Context, types.TipSetKey) (map[string]actors.OnChainDeal, error)                       `perm:"read"`
-		StateMarketStorageDeal        func(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)                         `perm:"read"`
+		StateListMiners               func(context.Context, types.TipSetKey) ([]address.Address, error)                                 `perm:"read"`
+		StateListActors               func(context.Context, types.TipSetKey) ([]address.Address, error)                                 `perm:"read"`
+		StateMarketBalance            func(context.Context, address.Address, types.TipSetKey) (actors.StorageParticipantBalance, error) `perm:"read"`
+		StateMarketParticipants       func(context.Context, types.TipSetKey) (map[string]actors.StorageParticipantBalance, error)       `perm:"read"`
+		StateMarketDeals              func(context.Context, types.TipSetKey) (map[string]actors.OnChainDeal, error)                     `perm:"read"`
+		StateMarketStorageDeal        func(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)                       `perm:"read"`
 		StateLookupID                 func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)        `perm:"read"`
 		StateChangedActors            func(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)                           `perm:"read"`
 		StateGetReceipt               func(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)                      `perm:"read"`
@@ -448,11 +448,11 @@ func (c *FullNodeStruct) StateMinerFaults(ctx context.Context, actor address.Add
 	return c.Internal.StateMinerFaults(ctx, actor, tsk)
 }
 
-func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.MethodCall, error) {
+func (c *FullNodeStruct) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.InvocResult, error) {
 	return c.Internal.StateCall(ctx, msg, tsk)
 }
 
-func (c *FullNodeStruct) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.ReplayResults, error) {
+func (c *FullNodeStruct) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.InvocResult, error) {
 	return c.Internal.StateReplay(ctx, tsk, mc)
 }
 

--- a/build/version.go
+++ b/build/version.go
@@ -31,7 +31,7 @@ func (ve Version) EqMajorMinor(v2 Version) bool {
 }
 
 // APIVersion is a semver version of the rpc api exposed
-var APIVersion Version = newVer(0, 1, 6)
+var APIVersion Version = newVer(0, 1, 7)
 
 const (
 	majorMask = 0xff0000

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -60,10 +60,12 @@ func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate 
 		errs = ret.ActorErr.Error()
 		log.Warnf("chain call failed: %s", ret.ActorErr)
 	}
+
 	return &api.InvocResult{
-		Msg: 		msg,
+		Msg: 			msg,
 		MsgRct: 	&ret.MessageReceipt,
-		Error:  	errs,
+		InternalExecutions: ret.InternalExecutions,
+		Error:          	errs,
 	}, nil
 
 }

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -15,7 +15,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/vm"
 )
 
-func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate cid.Cid, r vm.Rand, bheight uint64) (*api.MethodCall, error) {
+func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate cid.Cid, r vm.Rand, bheight uint64) (*api.InvocResult, error) {
 	ctx, span := trace.StartSpan(ctx, "statemanager.CallRaw")
 	defer span.End()
 
@@ -60,14 +60,15 @@ func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate 
 		errs = ret.ActorErr.Error()
 		log.Warnf("chain call failed: %s", ret.ActorErr)
 	}
-	return &api.MethodCall{
-		MessageReceipt: ret.MessageReceipt,
-		Error:          errs,
+	return &api.InvocResult{
+		Msg: 		msg,
+		MsgRct: 	&ret.MessageReceipt,
+		Error:  	errs,
 	}, nil
 
 }
 
-func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.MethodCall, error) {
+func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error) {
 	if ts == nil {
 		ts = sm.cs.GetHeaviestTipSet()
 	}

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -36,11 +36,11 @@ func GetMinerWorkerRaw(ctx context.Context, sm *StateManager, st cid.Cid, maddr 
 		return address.Undef, xerrors.Errorf("callRaw failed: %w", err)
 	}
 
-	if recp.ExitCode != 0 {
-		return address.Undef, xerrors.Errorf("getting miner worker addr failed (exit code %d)", recp.ExitCode)
+	if recp.MsgRct.ExitCode != 0 {
+		return address.Undef, xerrors.Errorf("getting miner worker addr failed (exit code %d)", recp.MsgRct.ExitCode)
 	}
 
-	worker, err := address.NewFromBytes(recp.Return)
+	worker, err := address.NewFromBytes(recp.MsgRct.Return)
 	if err != nil {
 		return address.Undef, err
 	}
@@ -62,11 +62,11 @@ func GetMinerOwner(ctx context.Context, sm *StateManager, st cid.Cid, maddr addr
 		return address.Undef, xerrors.Errorf("callRaw failed: %w", err)
 	}
 
-	if recp.ExitCode != 0 {
-		return address.Undef, xerrors.Errorf("getting miner owner addr failed (exit code %d)", recp.ExitCode)
+	if recp.MsgRct.ExitCode != 0 {
+		return address.Undef, xerrors.Errorf("getting miner owner addr failed (exit code %d)", recp.MsgRct.ExitCode)
 	}
 
-	owner, err := address.NewFromBytes(recp.Return)
+	owner, err := address.NewFromBytes(recp.MsgRct.Return)
 	if err != nil {
 		return address.Undef, err
 	}
@@ -97,11 +97,11 @@ func GetPower(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr add
 		if err != nil {
 			return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get miner power from chain: %w", err)
 		}
-		if ret.ExitCode != 0 {
-			return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get miner power from chain (exit code %d)", ret.ExitCode)
+		if ret.MsgRct.ExitCode != 0 {
+			return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get miner power from chain (exit code %d)", ret.MsgRct.ExitCode)
 		}
 
-		mpow = types.BigFromBytes(ret.Return)
+		mpow = types.BigFromBytes(ret.MsgRct.Return)
 	}
 
 	ret, err := sm.Call(ctx, &types.Message{
@@ -112,11 +112,11 @@ func GetPower(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr add
 	if err != nil {
 		return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get total power from chain: %w", err)
 	}
-	if ret.ExitCode != 0 {
-		return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get total power from chain (exit code %d)", ret.ExitCode)
+	if ret.MsgRct.ExitCode != 0 {
+		return types.EmptyInt, types.EmptyInt, xerrors.Errorf("failed to get total power from chain (exit code %d)", ret.MsgRct.ExitCode)
 	}
 
-	tpow := types.BigFromBytes(ret.Return)
+	tpow := types.BigFromBytes(ret.MsgRct.Return)
 
 	return mpow, tpow, nil
 }
@@ -131,11 +131,11 @@ func GetMinerPeerID(ctx context.Context, sm *StateManager, ts *types.TipSet, mad
 		return "", xerrors.Errorf("call failed: %w", err)
 	}
 
-	if recp.ExitCode != 0 {
-		return "", xerrors.Errorf("getting miner peer ID failed (exit code %d)", recp.ExitCode)
+	if recp.MsgRct.ExitCode != 0 {
+		return "", xerrors.Errorf("getting miner peer ID failed (exit code %d)", recp.MsgRct.ExitCode)
 	}
 
-	return peer.IDFromBytes(recp.Return)
+	return peer.IDFromBytes(recp.MsgRct.Return)
 }
 
 func GetMinerWorker(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr address.Address) (address.Address, error) {
@@ -148,11 +148,11 @@ func GetMinerWorker(ctx context.Context, sm *StateManager, ts *types.TipSet, mad
 		return address.Undef, xerrors.Errorf("call failed: %w", err)
 	}
 
-	if recp.ExitCode != 0 {
-		return address.Undef, xerrors.Errorf("getting miner peer ID failed (exit code %d)", recp.ExitCode)
+	if recp.MsgRct.ExitCode != 0 {
+		return address.Undef, xerrors.Errorf("getting miner peer ID failed (exit code %d)", recp.MsgRct.ExitCode)
 	}
 
-	return address.NewFromBytes(recp.Return)
+	return address.NewFromBytes(recp.MsgRct.Return)
 }
 
 func GetMinerElectionPeriodStart(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr address.Address) (uint64, error) {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -481,11 +481,11 @@ func (syncer *Syncer) minerIsValid(ctx context.Context, maddr address.Address, b
 		return xerrors.Errorf("checking if block miner is valid failed: %w", err)
 	}
 
-	if ret.ExitCode != 0 {
-		return xerrors.Errorf("StorageMarket.IsValidMiner check failed (exit code %d)", ret.ExitCode)
+	if ret.MsgRct.ExitCode != 0 {
+		return xerrors.Errorf("StorageMarket.IsValidMiner check failed (exit code %d)", ret.MsgRct.ExitCode)
 	}
 
-	if !bytes.Equal(ret.Return, cbg.CborBoolTrue) {
+	if !bytes.Equal(ret.MsgRct.Return, cbg.CborBoolTrue) {
 		return xerrors.New("miner isn't valid")
 	}
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -300,14 +300,14 @@ var clientQueryAskCmd = &cli.Command{
 				return xerrors.Errorf("failed to get peerID for miner: %w", err)
 			}
 
-			if ret.ExitCode != 0 {
-				return fmt.Errorf("call to GetPeerID was unsuccesful (exit code %d)", ret.ExitCode)
+			if ret.MsgRct.ExitCode != 0 {
+				return fmt.Errorf("call to GetPeerID was unsuccesful (exit code %d)", ret.MsgRct.ExitCode)
 			}
-			if peer.ID(ret.Return) == peer.ID("SETME") {
+			if peer.ID(ret.MsgRct.Return) == peer.ID("SETME") {
 				return fmt.Errorf("the miner hasn't initialized yet")
 			}
 
-			p, err := peer.IDFromBytes(ret.Return)
+			p, err := peer.IDFromBytes(ret.MsgRct.Return)
 			if err != nil {
 				return err
 			}

--- a/cli/state.go
+++ b/cli/state.go
@@ -328,10 +328,10 @@ var stateReplaySetCmd = &cli.Command{
 		}
 
 		fmt.Println("Replay receipt:")
-		fmt.Printf("Exit code: %d\n", res.Receipt.ExitCode)
-		fmt.Printf("Return: %x\n", res.Receipt.Return)
-		fmt.Printf("Gas Used: %s\n", res.Receipt.GasUsed)
-		if res.Receipt.ExitCode != 0 {
+		fmt.Printf("Exit code: %d\n", res.MsgRct.ExitCode)
+		fmt.Printf("Return: %x\n", res.MsgRct.Return)
+		fmt.Printf("Gas Used: %s\n", res.MsgRct.GasUsed)
+		if res.MsgRct.ExitCode != 0 {
 			fmt.Printf("Error message: %q\n", res.Error)
 		}
 
@@ -894,11 +894,11 @@ var stateCallCmd = &cli.Command{
 			return fmt.Errorf("state call failed: %s", err)
 		}
 
-		if ret.ExitCode != 0 {
-			return fmt.Errorf("invocation failed (exit: %d): %s", ret.ExitCode, ret.Error)
+		if ret.MsgRct.ExitCode != 0 {
+			return fmt.Errorf("invocation failed (exit: %d): %s", ret.MsgRct.ExitCode, ret.Error)
 		}
 
-		s, err := formatOutput(cctx.String("ret"), ret.Return)
+		s, err := formatOutput(cctx.String("ret"), ret.MsgRct.Return)
 		if err != nil {
 			return fmt.Errorf("failed to format output: %s", err)
 		}

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -491,11 +491,11 @@ func configureStorageMiner(ctx context.Context, api lapi.FullNode, addr address.
 		return xerrors.Errorf("failed to get worker address: %w", err)
 	}
 
-	if recp.ExitCode != 0 {
-		return xerrors.Errorf("getWorkerAddr returned exit code %d", recp.ExitCode)
+	if recp.MsgRct.ExitCode != 0 {
+		return xerrors.Errorf("getWorkerAddr returned exit code %d", recp.MsgRct.ExitCode)
 	}
 
-	waddr, err := address.NewFromBytes(recp.Return)
+	waddr, err := address.NewFromBytes(recp.MsgRct.Return)
 	if err != nil {
 		return xerrors.Errorf("getWorkerAddr returned bad address: %w", err)
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -359,11 +359,11 @@ func (m *Miner) getMinerWorker(ctx context.Context, addr address.Address, tsk ty
 		return address.Undef, xerrors.Errorf("failed to get miner worker addr: %w", err)
 	}
 
-	if ret.ExitCode != 0 {
-		return address.Undef, xerrors.Errorf("failed to get miner worker addr (exit code %d)", ret.ExitCode)
+	if ret.MsgRct.ExitCode != 0 {
+		return address.Undef, xerrors.Errorf("failed to get miner worker addr (exit code %d)", ret.MsgRct.ExitCode)
 	}
 
-	w, err := address.NewFromBytes(ret.Return)
+	w, err := address.NewFromBytes(ret.MsgRct.Return)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("GetWorkerAddr returned malformed address: %w", err)
 	}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -143,14 +143,14 @@ func (a *StateAPI) StatePledgeCollateral(ctx context.Context, tsk types.TipSetKe
 		return types.NewInt(0), xerrors.Errorf("failed to get miner worker addr: %w", err)
 	}
 
-	if ret.ExitCode != 0 {
-		return types.NewInt(0), xerrors.Errorf("failed to get miner worker addr (exit code %d)", ret.ExitCode)
+	if ret.MsgRct.ExitCode != 0 {
+		return types.NewInt(0), xerrors.Errorf("failed to get miner worker addr (exit code %d)", ret.MsgRct.ExitCode)
 	}
 
-	return types.BigFromBytes(ret.Return), nil
+	return types.BigFromBytes(ret.MsgRct.Return), nil
 }
 
-func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.MethodCall, error) {
+func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.InvocResult, error) {
 	ts, err := a.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
@@ -158,7 +158,7 @@ func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.
 	return a.StateManager.Call(ctx, msg, ts)
 }
 
-func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.ReplayResults, error) {
+func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.InvocResult, error) {
 	ts, err := a.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
@@ -173,10 +173,10 @@ func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.
 		errstr = r.ActorErr.Error()
 	}
 
-	return &api.ReplayResults{
-		Msg:     m,
-		Receipt: &r.MessageReceipt,
-		Error:   errstr,
+	return &api.InvocResult{
+		Msg:    m,
+		MsgRct: &r.MessageReceipt,
+		Error:	errstr,
 	}, nil
 }
 

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -174,9 +174,10 @@ func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.
 	}
 
 	return &api.InvocResult{
-		Msg:    m,
-		MsgRct: &r.MessageReceipt,
-		Error:	errstr,
+		Msg:     		m,
+		MsgRct: 	&r.MessageReceipt,
+		InternalExecutions: r.InternalExecutions,
+		Error:   			errstr,
 	}, nil
 }
 

--- a/paych/paych.go
+++ b/paych/paych.go
@@ -218,7 +218,7 @@ func (pm *Manager) CheckVoucherSpendable(ctx context.Context, ch address.Address
 		return false, err
 	}
 
-	if ret.ExitCode != 0 {
+	if ret.MsgRct.ExitCode != 0 {
 		return false, nil
 	}
 
@@ -235,11 +235,11 @@ func (pm *Manager) getPaychOwner(ctx context.Context, ch address.Address) (addre
 		return address.Undef, err
 	}
 
-	if ret.ExitCode != 0 {
-		return address.Undef, fmt.Errorf("failed to get payment channel owner (exit code %d)", ret.ExitCode)
+	if ret.MsgRct.ExitCode != 0 {
+		return address.Undef, fmt.Errorf("failed to get payment channel owner (exit code %d)", ret.MsgRct.ExitCode)
 	}
 
-	return address.NewFromBytes(ret.Return)
+	return address.NewFromBytes(ret.MsgRct.Return)
 }
 
 func (pm *Manager) AddVoucher(ctx context.Context, ch address.Address, sv *types.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error) {

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -40,7 +40,7 @@ type Miner struct {
 
 type storageMinerApi interface {
 	// Call a read only method on actors (no interaction with the chain required)
-	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.InvocResult, error)
 	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)
 	StateMinerSectors(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)

--- a/storage/sealing/checks.go
+++ b/storage/sealing/checks.go
@@ -89,11 +89,11 @@ func checkSeal(ctx context.Context, maddr address.Address, si SectorInfo, api se
 	if err != nil {
 		return &ErrApi{xerrors.Errorf("calling ComputeDataCommitment: %w", err)}
 	}
-	if r.ExitCode != 0 {
-		return &ErrBadCommD{xerrors.Errorf("receipt for ComputeDataCommitment had exit code %d", r.ExitCode)}
+	if r.MsgRct.ExitCode != 0 {
+		return &ErrBadCommD{xerrors.Errorf("receipt for ComputeDataCommitment had exit code %d", r.MsgRct.ExitCode)}
 	}
-	if string(r.Return) != string(si.CommD) {
-		return &ErrBadCommD{xerrors.Errorf("on chain CommD differs from sector: %x != %x", r.Return, si.CommD)}
+	if string(r.MsgRct.Return) != string(si.CommD) {
+		return &ErrBadCommD{xerrors.Errorf("on chain CommD differs from sector: %x != %x", r.MsgRct.Return, si.CommD)}
 	}
 
 	if int64(head.Height())-int64(si.Ticket.BlockHeight+build.SealRandomnessLookback) > build.SealRandomnessLookbackLimit {

--- a/storage/sealing/sealing.go
+++ b/storage/sealing/sealing.go
@@ -29,7 +29,7 @@ type TicketFn func(context.Context) (*sectorbuilder.SealTicket, error)
 
 type sealingApi interface { // TODO: trim down
 	// Call a read only method on actors (no interaction with the chain required)
-	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.MethodCall, error)
+	StateCall(context.Context, *types.Message, types.TipSetKey) (*api.InvocResult, error)
 	StateMinerWorker(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 	StateMinerElectionPeriodStart(ctx context.Context, actor address.Address, tsk types.TipSetKey) (uint64, error)
 	StateMinerSectors(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)


### PR DESCRIPTION
- Invoking the RPC method StateReplay now provides the total call chain, inlcuding invoked messages (internal txs)
- Returns null if chain had no invoked messages