### PR TITLE
Reduce default storage miner worker count

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -96,7 +96,7 @@ func DefaultStorageMiner() *StorageMiner {
 		Common: defCommon(),
 
 		SectorBuilder: SectorBuilder{
-			WorkerCount: 5,
+			WorkerCount: 2,
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"


### PR DESCRIPTION
The current default worker count of 5 can result in high memory usage of the lotus-storage-miner process when a user starts multiple sector pledges within a short time of each other and can result in the process being killed for OOM.

Reducing the worker count to 2 will provide a safer default.