### PR TITLE
Add DealID to DealInfo

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"context"
-	"github.com/filecoin-project/lotus/chain/vm"
 	"time"
+
+	"github.com/filecoin-project/lotus/chain/vm"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
@@ -168,6 +169,8 @@ type DealInfo struct {
 
 	PricePerEpoch types.BigInt
 	Duration      uint64
+
+	DealID uint64
 }
 
 type MsgWait struct {
@@ -273,10 +276,10 @@ type RetrievalOrder struct {
 }
 
 type InvocResult struct {
-	Msg *types.Message
-	MsgRct *types.MessageReceipt
+	Msg                *types.Message
+	MsgRct             *types.MessageReceipt
 	InternalExecutions []*vm.ExecutionResult
-	Error   string
+	Error              string
 }
 
 type ActiveSync struct {

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -110,6 +110,8 @@ func (a *API) ClientListDeals(ctx context.Context) ([]api.DealInfo, error) {
 
 			PricePerEpoch: utils.FromSharedTokenAmount(v.Proposal.StoragePricePerEpoch),
 			Duration:      v.Proposal.Duration,
+
+			DealID: v.DealID,
 		}
 	}
 
@@ -121,7 +123,6 @@ func (a *API) ClientGetDealInfo(ctx context.Context, d cid.Cid) (*api.DealInfo, 
 	if err != nil {
 		return nil, err
 	}
-
 	return &api.DealInfo{
 		ProposalCid:   v.ProposalCid,
 		State:         v.State,
@@ -130,6 +131,7 @@ func (a *API) ClientGetDealInfo(ctx context.Context, d cid.Cid) (*api.DealInfo, 
 		Size:          v.Proposal.PieceSize,
 		PricePerEpoch: utils.FromSharedTokenAmount(v.Proposal.StoragePricePerEpoch),
 		Duration:      v.Proposal.Duration,
+		DealID:        v.DealID,
 	}, nil
 }
 


### PR DESCRIPTION
This enables, from a _proposalCid_ having the _dealID_, which is useful for calling:
`StateMarketStorageDeal(context.Context, uint64, types.TipSetKey) (*actors.OnChainDeal, error)`