### PR TITLE
Make websocket connection upgrade header check case-insensitive

### DIFF
--- a/lib/jsonrpc/server.go
+++ b/lib/jsonrpc/server.go
@@ -65,7 +65,8 @@ func (s *RPCServer) handleWS(ctx context.Context, w http.ResponseWriter, r *http
 func (s *RPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	if strings.Contains(r.Header.Get("Connection"), "Upgrade") {
+	h := strings.ToLower(r.Header.Get("Connection"))
+	if strings.Contains(h, "upgrade") {
 		s.handleWS(ctx, w, r)
 		return
 	}


### PR DESCRIPTION
I was having troubles configuring an nginx reverse-proxy when
using Websockets.

It turns out my configuration was sending a "Connection: upgrade"
header, but Lotus expected "Connection: Upgrade".

This commit converts the check to be case-insensitive.

Some of the examples on the MDN page show lower-case "upgrade",
so I think it's not unusual for the usage to vary.