### PR TITLE
Fixes to make graphsync work for chain fetching

### DIFF
--- a/node/modules/graphsync.go
+++ b/node/modules/graphsync.go
@@ -15,8 +15,8 @@ import (
 )
 
 // GraphsyncStorer creates a storer that stores data in the client blockstore
-func GraphsyncStorer(clientBs dtypes.ClientBlockstore) dtypes.GraphsyncStorer {
-	return dtypes.GraphsyncStorer(storeutil.StorerForBlockstore(clientBs))
+func GraphsyncStorer(chainBs dtypes.ChainBlockstore) dtypes.GraphsyncStorer {
+	return dtypes.GraphsyncStorer(storeutil.StorerForBlockstore(chainBs))
 }
 
 // GraphsyncLoader creates a loader that reads from both the chain blockstore and the client blockstore


### PR DESCRIPTION
This gets the TestSyncSimple test working for the chain -- though it appears other tests are still failing and it would be helpful to get insight from those who know the other tests as to why they failing

- store blocks to chain blockstore (ok for now, since storage provider runs in miner process, where storing of data transfers happens)
- simplify request fetching and processing
   - use a special simplified selector for first tipset fetches
   - simplify processing request results. error & results channel always close at the same time internal to graphsyncs code (neither will close until the whole request is complete -- no race), so unless you care about content, you can let a request complete by just listening to one channel till it closes.