### PR TITLE
cli: auth api-info

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -1,12 +1,13 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
+	"golang.org/x/xerrors"
 	"gopkg.in/urfave/cli.v2"
 
 	"github.com/filecoin-project/lotus/api/apistruct"
+	"github.com/filecoin-project/lotus/node/repo"
 )
 
 var authCmd = &cli.Command{
@@ -14,6 +15,7 @@ var authCmd = &cli.Command{
 	Usage: "Manage RPC permissions",
 	Subcommands: []*cli.Command{
 		authCreateAdminToken,
+		authApiInfoToken,
 	},
 }
 
@@ -37,7 +39,7 @@ var authCreateAdminToken = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if !cctx.IsSet("perm") {
-			return errors.New("--perm flag not set")
+			return xerrors.New("--perm flag not set")
 		}
 
 		perm := cctx.String("perm")
@@ -61,6 +63,71 @@ var authCreateAdminToken = &cli.Command{
 		// TODO: Log in audit log when it is implemented
 
 		fmt.Println(string(token))
+		return nil
+	},
+}
+
+var authApiInfoToken = &cli.Command{
+	Name:  "api-info",
+	Usage: "Get token with API info required to connect to this node",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "perm",
+			Usage: "permission to assign to the token, one of: read, write, sign, admin",
+		},
+	},
+
+	Action: func(cctx *cli.Context) error {
+		napi, closer, err := GetAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := ReqContext(cctx)
+
+		if !cctx.IsSet("perm") {
+			return xerrors.New("--perm flag not set")
+		}
+
+		perm := cctx.String("perm")
+		idx := 0
+		for i, p := range apistruct.AllPermissions {
+			if perm == p {
+				idx = i + 1
+			}
+		}
+
+		if idx == 0 {
+			return fmt.Errorf("--perm flag has to be one of: %s", apistruct.AllPermissions)
+		}
+
+		// slice on [:idx] so for example: 'sign' gives you [read, write, sign]
+		token, err := napi.AuthNew(ctx, apistruct.AllPermissions[:idx])
+		if err != nil {
+			return err
+		}
+
+		ti, ok := cctx.App.Metadata["repoType"]
+		if !ok {
+			log.Errorf("unknown repo type, are you sure you want to use GetAPI?")
+			ti = repo.FullNode
+		}
+		t, ok := ti.(repo.RepoType)
+		if !ok {
+			log.Errorf("repoType type does not match the type of repo.RepoType")
+		}
+
+		addr, _, err := GetRawAPI(cctx, t)
+		if err != nil {
+			return xerrors.Errorf("getting raw API: %w", err)
+		}
+
+		envVar := envForRepo(t)
+
+		// TODO: Log in audit log when it is implemented
+
+		fmt.Printf("%s=%s:%s\n", envVar, string(token), addr)
 		return nil
 	},
 }


### PR DESCRIPTION
This simplifies roughly 3 steps of remote worker config into one (cat api address, create auth token, manually combine into an env var) into one