### PR TITLE
fix ClientRetrieve with CAR exporting & add test coverage

### DIFF
--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -377,7 +377,7 @@ func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 	unsubscribe()
 
 	if ref.IsCAR {
-		f, err := os.Open(ref.Path)
+		f, err := os.OpenFile(ref.Path, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return err
 		}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"github.com/filecoin-project/lotus/lib/lotuslog"
-	"github.com/filecoin-project/lotus/storage/mockstorage"
-	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"io/ioutil"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/filecoin-project/lotus/lib/lotuslog"
+	"github.com/filecoin-project/lotus/storage/mockstorage"
+	"github.com/filecoin-project/sector-storage/ffiwrapper"
 
 	"github.com/filecoin-project/go-fil-markets/storedcounter"
 	"github.com/ipfs/go-datastore"
@@ -43,7 +44,7 @@ import (
 	"github.com/filecoin-project/lotus/node/modules"
 	modtest "github.com/filecoin-project/lotus/node/modules/testing"
 	"github.com/filecoin-project/lotus/node/repo"
-	"github.com/filecoin-project/sector-storage"
+	sectorstorage "github.com/filecoin-project/sector-storage"
 	"github.com/filecoin-project/sector-storage/mock"
 )
 
@@ -449,7 +450,11 @@ func TestAPIDealFlow(t *testing.T) {
 	logging.SetLogLevel("sub", "ERROR")
 	logging.SetLogLevel("storageminer", "ERROR")
 
-	test.TestDealFlow(t, mockSbBuilder, 10*time.Millisecond)
+	test.TestDealFlow(t, mockSbBuilder, 10*time.Millisecond, false)
+
+	t.Run("WithExportedCAR", func(t *testing.T) {
+		test.TestDealFlow(t, mockSbBuilder, 10*time.Millisecond, true)
+	})
 }
 
 func TestAPIDealFlowReal(t *testing.T) {
@@ -463,5 +468,5 @@ func TestAPIDealFlowReal(t *testing.T) {
 	logging.SetLogLevel("sub", "ERROR")
 	logging.SetLogLevel("storageminer", "ERROR")
 
-	test.TestDealFlow(t, builder, time.Second)
+	test.TestDealFlow(t, builder, time.Second, false)
 }


### PR DESCRIPTION
While retrieving data with `IsCAR` flag enabled, the miner fails with messages `no such file or directory`. I extended the `TestDealFlow` test to cover this scenario, so it can be used to reproduce the problem, and check that it's working correctly too.

To reproduce the problem, take this PR branch, revert the `client.go` change and run the test. 
Output:
```bash
~/code/lotus jsign/testnet3/badfiledescriptor ❯ go test ./node -run TestAPIDealFlow$  
...
...
--- FAIL: TestAPIDealFlow (6.79s)
    --- FAIL: TestAPIDealFlow/WithExportedCAR (3.31s)
        deals.go:147: open /var/folders/f1/m0gxrgsx7kg53w82gndwr4mc0000gn/T/lotus-retrieve-test-360081011/ret: no such file or directory
FAIL
FAIL    github.com/filecoin-project/lotus/node  7.312s
FAIL
```
Of course, with the `client.go` fix test pass.

The problem is the `os.Open` call, which opens a file in read-only mode when the main intention is writing to a file.

cc @hannahhoward  
