### PR TITLE
Better deal info at the command line

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -178,9 +178,10 @@ type Import struct {
 type DealInfo struct {
 	ProposalCid cid.Cid
 	State       storagemarket.StorageDealStatus
+	Message     string // more information about deal state, particularly errors
 	Provider    address.Address
 
-	PieceRef []byte // cid bytes
+	PieceCID cid.Cid
 	Size     uint64
 
 	PricePerEpoch types.BigInt

--- a/cli/client.go
+++ b/cli/client.go
@@ -429,9 +429,9 @@ var clientListDeals = &cli.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "DealCid\tProvider\tState\tPieceRef\tSize\tPrice\tDuration\n")
+		fmt.Fprintf(w, "DealCid\tProvider\tState\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
 		for _, d := range deals {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%x\t%d\t%s\t%d\n", d.ProposalCid, d.Provider, storagemarket.DealStates[d.State], d.PieceRef, d.Size, d.PricePerEpoch, d.Duration)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%d\t%s\n", d.ProposalCid, d.Provider, storagemarket.DealStates[d.State], d.PieceCID, d.Size, d.PricePerEpoch, d.Duration, d.Message)
 		}
 		return w.Flush()
 	},

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -86,7 +86,7 @@ var dealsListCmd = &cli.Command{
 
 		ctx := lcli.DaemonContext(cctx)
 
-		deals, err := api.DealsList(ctx)
+		deals, err := api.MarketListIncompleteDeals(ctx)
 		if err != nil {
 			return err
 		}

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 	"errors"
-	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"io"
 	"os"
+
+	"github.com/filecoin-project/sector-storage/ffiwrapper"
 
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"golang.org/x/xerrors"
@@ -125,9 +126,10 @@ func (a *API) ClientListDeals(ctx context.Context) ([]api.DealInfo, error) {
 		out[k] = api.DealInfo{
 			ProposalCid: v.ProposalCid,
 			State:       v.State,
+			Message:     v.Message,
 			Provider:    v.Proposal.Provider,
 
-			PieceRef: v.Proposal.PieceCID.Bytes(),
+			PieceCID: v.Proposal.PieceCID,
 			Size:     uint64(v.Proposal.PieceSize.Unpadded()),
 
 			PricePerEpoch: v.Proposal.StoragePricePerEpoch,
@@ -148,8 +150,9 @@ func (a *API) ClientGetDealInfo(ctx context.Context, d cid.Cid) (*api.DealInfo, 
 	return &api.DealInfo{
 		ProposalCid:   v.ProposalCid,
 		State:         v.State,
+		Message:       v.Message,
 		Provider:      v.Proposal.Provider,
-		PieceRef:      v.Proposal.PieceCID.Bytes(),
+		PieceCID:      v.Proposal.PieceCID,
 		Size:          uint64(v.Proposal.PieceSize.Unpadded()),
 		PricePerEpoch: v.Proposal.StoragePricePerEpoch,
 		Duration:      uint64(v.Proposal.Duration()),


### PR DESCRIPTION
# Goals

Provide more useful information at the command line about Deals to folks who can't monitor the logs of their node

# Implementation

Client Deals:
- Pass through the Message parameter from ClientDeal all the way to the command line for `client list-deals` -- this will often contain useful information about the deal status, particularly in the case of an error -- it will show something about WHY the deal failed
- update PieceRef to PieceCID, since that's what it is now

Miner Side:
- have `lotus-storage-miner deals list` call MarketListIncompleteDeals -- this method calls the poorly named (but soon to be renamed) storageprovider.ListIncompleteDeals -- which gives you actually all LOCAL deal state info -- which is way more than storageprovider.ListDeals which provides only what is on chain. this means you can see your deals that aren't posted to the chain (but also those that are, since it's actually all Local deals)