### PR TITLE
New validation package

### DIFF
--- a/validation/category.go
+++ b/validation/category.go
@@ -1,0 +1,39 @@
+package validation
+
+// Errors extracted from `ValidateBlock` and `checkBlockMessages` and converted
+// into more generic "categories" that are related with each other in a hierarchical
+// fashion and allow to spawn errors from them.
+// Explicitly split into separate `var` declarations instead of having a single
+// block (to avoid `go fmt` potentially changing alignment of all errors and
+// producing harder-to-read diffs).
+// FIXME: How to better express this error hierarchy *without* reflection? (nested packages?)
+
+var InvalidBlock = NewHierarchicalErrorClass("invalid block")
+
+var NilSignature = InvalidBlock.Child("nil signature")
+
+var Timestamp = InvalidBlock.Child("invalid timestamp")
+var BlockFutureTimestamp = Timestamp.Child("ahead of current time")
+
+var BlockMinedEarly = InvalidBlock.Child("block was generated too soon")
+
+var Winner = InvalidBlock.Child("not a winner")
+var SlashedMiner = Winner.Child("slashed or invalid miner")
+var NoCandidates = Winner.Child("no candidates")
+var DuplicateCandidates = Winner.Child("duplicate epost candidates")
+
+// FIXME: Might want to include these in some EPost category.
+
+var Miner = InvalidBlock.Child("invalid miner")
+
+var InvalidMessagesCID = InvalidBlock.Child("messages CID didn't match message root in header")
+
+var InvalidMessage = InvalidBlock.Child("invalid message")
+var InvalidBlsSignature = InvalidMessage.Child("invalid bls aggregate signature")
+var InvalidSecpkSignature = InvalidMessage.Child("invalid secpk signature")
+var EmptyRecipient = InvalidMessage.Child("empty 'To' address")
+var WrongNonce = InvalidMessage.Child("wrong nonce")
+
+// FIXME: Errors from `checkBlockMessages` are too generic and should probably be extracted, is there
+//  another place where we validate them (like the message pool)? In that case we need a different
+//  root category like `InvalidMessage`.

--- a/validation/error.go
+++ b/validation/error.go
@@ -1,0 +1,95 @@
+package validation
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+)
+
+// Hierarchy of error categories to programmatically preserve in the language
+// information linking errors from different contexts. Used inside
+// `ErrorWithCategory`, it complements the standard `xerrors.Errorf` wrapping
+// mechanism that preserves call stack information. This is not an error itself,
+// it explicitly does not implement the interface forcing explicit calls to
+// convert a category into a specific error instance used in validation functions.
+// The hierarchy is implemented through a pointer to a (unique) `parent` category
+// (if any). The `description` string identifies the category and will be used
+// as the error message if one is not explicitly provided (like in `FromString()`).
+// FIXME: This is general enough to be outside of this package.
+type ErrorCategory struct {
+	parent      *ErrorCategory
+	description string
+}
+
+func NewHierarchicalErrorClass(description string) *ErrorCategory {
+	return &ErrorCategory{description: description}
+}
+
+// Creates a new (child) category included in this one.
+func (c *ErrorCategory) Child(description string) *ErrorCategory {
+	return &ErrorCategory{parent: c, description: description}
+}
+
+// Returns a new error with the category description as its message.
+func (c *ErrorCategory) Error() error {
+	return &ErrorWithCategory{category: c, msg: c.description, frame: getCallerFrame()}
+}
+
+// Returns a new error from this category with the specified message.
+func (c *ErrorCategory) FromString(msg string) error {
+	return &ErrorWithCategory{category: c, msg: msg, frame: getCallerFrame()}
+}
+
+// Similar to `Error`, returns an error err.
+func (c *ErrorCategory) WrapError(wrappedError error) error {
+	err := c.Error().(ErrorWithCategory)
+	err.wrappedError = wrappedError
+	return err
+}
+
+// Error implementing the `error` interface providing category information
+// and wrapped error semantics similar to `xerrors.Errorf`, including frame
+// information (based on `xerrors.wrapError`).
+type ErrorWithCategory struct {
+	category *ErrorCategory
+
+	// Copied `xerrors.wrapError` attributes (since its a private structure)
+	wrappedError error
+	msg          string
+	frame        xerrors.Frame
+}
+
+func (e *ErrorWithCategory) Category() *ErrorCategory {
+	return e.category
+}
+
+// FIXME: Why can't it have a pointer receiver to satisfy the `error` interface?
+//  (`xerrors.wrapError` uses pointer)
+func (e ErrorWithCategory) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *ErrorWithCategory) Format(s fmt.State, v rune) { xerrors.FormatError(e, s, v) }
+
+func (e *ErrorWithCategory) FormatError(p xerrors.Printer) (next error) {
+	p.Print(e.msg)
+	// FIXME: If we're using an external string as the error message we should
+	//  probably want to include the category description here.
+	e.frame.Format(p)
+	return e.wrappedError
+}
+
+func (e *ErrorWithCategory) Unwrap() error {
+	return e.wrappedError
+}
+
+func getCallerFrame() xerrors.Frame {
+	frame := xerrors.Frame{}
+	// if internal.EnableTrace {
+	frame = xerrors.Caller(1)
+	// }
+	// FIXME: Can't reference internal package, if the flag is necessary we can extract
+	//  it from an oracle of `xerrors` behavior (hacky).
+
+	return frame
+}


### PR DESCRIPTION
Might need a broader name later, naming it "security" seemed too much.

Encapsulate and extract validation errors (e.g., block, messages) for explicit testing later. One of the objectives is to distinguish between validation errors (e.g., invalid signature) exposed to the consumer and with potential security implications from internal errors (e.g., network timeout). This also allows us to have a central place to control validation checks.

This package should also extract validation logic as well as just errors, starting with the latter simplifies this PR to get something going. The downside is that this incorrect separation boundary causes many ugly `validation.*` imports. Ideally in the future all the validation code should be concentrated and encapsulated to minimize cross-over.
