### PR TITLE
use exitcode type from specs actors instead of byte

### DIFF
--- a/chain/actors/aerrors/error.go
+++ b/chain/actors/aerrors/error.go
@@ -3,13 +3,14 @@ package aerrors
 import (
 	"fmt"
 
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"golang.org/x/xerrors"
 )
 
 func IsFatal(err ActorError) bool {
 	return err != nil && err.IsFatal()
 }
-func RetCode(err ActorError) uint8 {
+func RetCode(err ActorError) exitcode.ExitCode {
 	if err == nil {
 		return 0
 	}
@@ -25,12 +26,12 @@ type internalActorError interface {
 type ActorError interface {
 	error
 	IsFatal() bool
-	RetCode() uint8
+	RetCode() exitcode.ExitCode
 }
 
 type actorError struct {
 	fatal   bool
-	retCode uint8
+	retCode exitcode.ExitCode
 
 	msg   string
 	frame xerrors.Frame
@@ -41,7 +42,7 @@ func (e *actorError) IsFatal() bool {
 	return e.fatal
 }
 
-func (e *actorError) RetCode() uint8 {
+func (e *actorError) RetCode() exitcode.ExitCode {
 	return e.retCode
 }
 

--- a/chain/actors/aerrors/error_test.go
+++ b/chain/actors/aerrors/error_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/filecoin-project/lotus/chain/actors/aerrors"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/xerrors"
@@ -31,5 +32,5 @@ func TestAbsorbeError(t *testing.T) {
 	aw3 := Wrap(aw2, "creating miner in storage market")
 	t.Logf("Verbose error: %+v", aw3)
 	t.Logf("Normal error: %v", aw3)
-	assert.Equal(t, uint8(35), RetCode(aw3))
+	assert.Equal(t, exitcode.ExitCode(35), RetCode(aw3))
 }

--- a/chain/actors/aerrors/wrap.go
+++ b/chain/actors/aerrors/wrap.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/xerrors"
 )
 
 // New creates a new non-fatal error
-func New(retCode uint8, message string) ActorError {
+func New(retCode exitcode.ExitCode, message string) ActorError {
 	if retCode == 0 {
 		return &actorError{
 			fatal:   true,
@@ -29,7 +30,7 @@ func New(retCode uint8, message string) ActorError {
 }
 
 // Newf creates a new non-fatal error
-func Newf(retCode uint8, format string, args ...interface{}) ActorError {
+func Newf(retCode exitcode.ExitCode, format string, args ...interface{}) ActorError {
 	if retCode == 0 {
 		return &actorError{
 			fatal:   true,
@@ -49,7 +50,7 @@ func Newf(retCode uint8, format string, args ...interface{}) ActorError {
 }
 
 // todo: bit hacky
-func NewfSkip(skip int, retCode uint8, format string, args ...interface{}) ActorError {
+func NewfSkip(skip int, retCode exitcode.ExitCode, format string, args ...interface{}) ActorError {
 	if retCode == 0 {
 		return &actorError{
 			fatal:   true,
@@ -115,7 +116,7 @@ func Wrapf(err ActorError, format string, args ...interface{}) ActorError {
 }
 
 // Absorb takes and error and makes in not fatal ActorError
-func Absorb(err error, retCode uint8, msg string) ActorError {
+func Absorb(err error, retCode exitcode.ExitCode, msg string) ActorError {
 	if err == nil {
 		return nil
 	}

--- a/chain/blocksync/cbor_gen.go
+++ b/chain/blocksync/cbor_gen.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/filecoin-project/lotus/chain/types"
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/chain/vm/gas_v0.go
+++ b/chain/vm/gas_v0.go
@@ -130,8 +130,7 @@ func (pl *pricelistV0) OnDeleteActor() int64 {
 func (pl *pricelistV0) OnVerifySignature(sigType crypto.SigType, planTextSize int) int64 {
 	costFn, ok := pl.verifySignature[sigType]
 	if !ok {
-		// TODO: fix retcode to be int64
-		panic(aerrors.Newf(uint8(exitcode.SysErrInternal&0xff), "Cost function for signature type %d not supported", sigType))
+		panic(aerrors.Newf(exitcode.SysErrInternal, "Cost function for signature type %d not supported", sigType))
 	}
 	return costFn(int64(planTextSize))
 }

--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -66,10 +66,10 @@ func (inv *invoker) Invoke(act *types.Actor, rt runtime.Runtime, method abi.Meth
 	code, ok := inv.builtInCode[act.Code]
 	if !ok {
 		log.Errorf("no code for actor %s (Addr: %s)", act.Code, rt.Message().Receiver())
-		return nil, aerrors.Newf(byte(exitcode.SysErrorIllegalActor), "no code for actor %s(%d)(%s)", act.Code, method, hex.EncodeToString(params))
+		return nil, aerrors.Newf(exitcode.SysErrorIllegalActor, "no code for actor %s(%d)(%s)", act.Code, method, hex.EncodeToString(params))
 	}
 	if method >= abi.MethodNum(len(code)) || code[method] == nil {
-		return nil, aerrors.Newf(byte(exitcode.SysErrInvalidMethod), "no method %d on actor", method)
+		return nil, aerrors.Newf(exitcode.SysErrInvalidMethod, "no method %d on actor", method)
 	}
 	return code[method](act, rt, params)
 

--- a/chain/vm/invoker_test.go
+++ b/chain/vm/invoker_test.go
@@ -86,7 +86,7 @@ func TestInvokerBasic(t *testing.T) {
 
 		_, aerr := code[0](nil, &Runtime{}, bParam)
 
-		assert.Equal(t, byte(1), aerrors.RetCode(aerr), "return code should be 1")
+		assert.Equal(t, exitcode.ExitCode(1), aerrors.RetCode(aerr), "return code should be 1")
 		if aerrors.IsFatal(aerr) {
 			t.Fatal("err should not be fatal")
 		}
@@ -97,7 +97,7 @@ func TestInvokerBasic(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, aerr := code[10](nil, &Runtime{}, bParam)
-		assert.Equal(t, byte(12), aerrors.RetCode(aerr), "return code should be 12")
+		assert.Equal(t, exitcode.ExitCode(12), aerrors.RetCode(aerr), "return code should be 12")
 		if aerrors.IsFatal(aerr) {
 			t.Fatal("err should not be fatal")
 		}
@@ -107,6 +107,6 @@ func TestInvokerBasic(t *testing.T) {
 	if aerrors.IsFatal(aerr) {
 		t.Fatal("err should not be fatal")
 	}
-	assert.Equal(t, byte(1), aerrors.RetCode(aerr), "return code should be 1")
+	assert.Equal(t, exitcode.ExitCode(1), aerrors.RetCode(aerr), "return code should be 1")
 
 }

--- a/chain/vm/mkactor.go
+++ b/chain/vm/mkactor.go
@@ -33,7 +33,7 @@ var EmptyObjectCid cid.Cid
 func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, aerrors.ActorError) {
 	addrID, err := rt.state.RegisterNewAddress(addr)
 	if err != nil {
-		return nil, aerrors.Absorb(err, byte(exitcode.SysErrInternal), "registering actor address")
+		return nil, aerrors.Absorb(err, exitcode.SysErrInternal, "registering actor address")
 	}
 
 	if err := rt.chargeGasSafe(PricelistByEpoch(rt.height).OnCreateActor()); err != nil {
@@ -46,12 +46,12 @@ func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, aer
 	}
 
 	if err := rt.state.SetActor(addrID, act); err != nil {
-		return nil, aerrors.Absorb(err, byte(exitcode.SysErrInternal), "creating new actor failed")
+		return nil, aerrors.Absorb(err, exitcode.SysErrInternal, "creating new actor failed")
 	}
 
 	p, err := actors.SerializeParams(&addr)
 	if err != nil {
-		return nil, aerrors.Absorb(err, byte(exitcode.SysErrInternal), "registering actor address")
+		return nil, aerrors.Absorb(err, exitcode.SysErrInternal, "registering actor address")
 	}
 	// call constructor on account
 
@@ -62,7 +62,7 @@ func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, aer
 
 	act, err = rt.state.GetActor(addrID)
 	if err != nil {
-		return nil, aerrors.Absorb(err, byte(exitcode.SysErrInternal), "loading newly created actor failed")
+		return nil, aerrors.Absorb(err, exitcode.SysErrInternal, "loading newly created actor failed")
 	}
 	return act, nil
 }

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -239,7 +239,7 @@ func (rt *Runtime) Context() context.Context {
 
 func (rs *Runtime) Abortf(code exitcode.ExitCode, msg string, args ...interface{}) {
 	log.Error("Abortf: ", fmt.Sprintf(msg, args...))
-	panic(aerrors.NewfSkip(2, uint8(code), msg, args...))
+	panic(aerrors.NewfSkip(2, code, msg, args...))
 }
 
 func (rs *Runtime) AbortStateMsg(msg string) {
@@ -428,7 +428,7 @@ func (rt *Runtime) ChargeGas(toUse int64) {
 func (rt *Runtime) chargeGasSafe(toUse int64) aerrors.ActorError {
 	if rt.gasUsed+toUse > rt.gasAvailable {
 		rt.gasUsed = rt.gasAvailable
-		return aerrors.Newf(uint8(exitcode.SysErrOutOfGas), "not enough gas: used=%d, available=%d", rt.gasUsed, rt.gasAvailable)
+		return aerrors.Newf(exitcode.SysErrOutOfGas, "not enough gas: used=%d, available=%d", rt.gasUsed, rt.gasAvailable)
 	}
 	rt.gasUsed += toUse
 	return nil

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -73,7 +73,7 @@ func ResolveToKeyAddr(state types.StateTree, cst cbor.IpldStore, addr address.Ad
 
 	act, err := state.GetActor(addr)
 	if err != nil {
-		return address.Undef, aerrors.Newf(byte(exitcode.SysErrInternal), "failed to find actor: %s", addr)
+		return address.Undef, aerrors.Newf(exitcode.SysErrInternal, "failed to find actor: %s", addr)
 	}
 
 	if act.Code != builtin.AccountActorCodeID {
@@ -386,7 +386,7 @@ func (vm *VM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet,
 		log.Warnw("Send actor error", "from", msg.From, "to", msg.To, "nonce", msg.Nonce, "method", msg.Method, "height", vm.blockHeight, "error", fmt.Sprintf("%+v", actorErr))
 	}
 
-	var errcode uint8
+	var errcode exitcode.ExitCode
 	var gasUsed int64
 
 	if errcode = aerrors.RetCode(actorErr); errcode != 0 {


### PR DESCRIPTION
We thought this was fine before, but apparently theres an exitcode in use that is outside the byte range. So this rips off the bandaid and just uses the exitcode type everywhere