### PR TITLE
avoid flushing disk when doing state tree snapshots

### DIFF
--- a/chain/state/statetree.go
+++ b/chain/state/statetree.go
@@ -50,6 +50,7 @@ func (ss *stateSnaps) addLayer() {
 }
 
 func (ss *stateSnaps) dropLayer() {
+	ss.layers[len(ss.layers)-1] = nil // allow it to be GCed
 	ss.layers = ss.layers[:len(ss.layers)-1]
 }
 

--- a/chain/state/statetree.go
+++ b/chain/state/statetree.go
@@ -26,7 +26,6 @@ type StateTree struct {
 	root  *hamt.Node
 	Store cbor.IpldStore
 
-	// Maps ID addresses to actors, layered by snapshots
 	snaps *stateSnaps
 }
 

--- a/chain/state/statetree_test.go
+++ b/chain/state/statetree_test.go
@@ -143,8 +143,8 @@ func TestSetCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if outact.Nonce != act.Nonce {
-		t.Error("nonce didn't match")
+	if outact.Nonce == 1 {
+		t.Error("nonce should not have updated")
 	}
 }
 
@@ -205,6 +205,8 @@ func TestSnapshots(t *testing.T) {
 
 		st.ClearSnapshot()
 	}
+
+	st.ClearSnapshot()
 
 	if _, err := st.Flush(ctx); err != nil {
 		t.Fatal(err)

--- a/chain/vm/invoker_test.go
+++ b/chain/vm/invoker_test.go
@@ -84,7 +84,7 @@ func TestInvokerBasic(t *testing.T) {
 		bParam, err := actors.SerializeParams(&basicParams{B: 1})
 		assert.NoError(t, err)
 
-		_, aerr := code[0](nil, &Runtime{}, bParam)
+		_, aerr := code[0](&Runtime{}, bParam)
 
 		assert.Equal(t, exitcode.ExitCode(1), aerrors.RetCode(aerr), "return code should be 1")
 		if aerrors.IsFatal(aerr) {
@@ -96,14 +96,14 @@ func TestInvokerBasic(t *testing.T) {
 		bParam, err := actors.SerializeParams(&basicParams{B: 2})
 		assert.NoError(t, err)
 
-		_, aerr := code[10](nil, &Runtime{}, bParam)
+		_, aerr := code[10](&Runtime{}, bParam)
 		assert.Equal(t, exitcode.ExitCode(12), aerrors.RetCode(aerr), "return code should be 12")
 		if aerrors.IsFatal(aerr) {
 			t.Fatal("err should not be fatal")
 		}
 	}
 
-	_, aerr := code[1](nil, &Runtime{}, []byte{99})
+	_, aerr := code[1](&Runtime{}, []byte{99})
 	if aerrors.IsFatal(aerr) {
 		t.Fatal("err should not be fatal")
 	}

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -599,7 +599,7 @@ func (vm *VM) Invoke(act *types.Actor, rt *Runtime, method abi.MethodNum, params
 	defer func() {
 		rt.ctx = oldCtx
 	}()
-	ret, err := vm.inv.Invoke(act, rt, method, params)
+	ret, err := vm.inv.Invoke(act.Code, rt, method, params)
 	if err != nil {
 		return nil, err
 	}
@@ -611,13 +611,10 @@ func (vm *VM) SetInvoker(i *invoker) {
 }
 
 func (vm *VM) incrementNonce(addr address.Address) error {
-	a, err := vm.cstate.GetActor(addr)
-	if err != nil {
-		return xerrors.Errorf("nonce increment of sender failed")
-	}
-
-	a.Nonce++
-	return nil
+	return vm.cstate.MutateActor(addr, func(a *types.Actor) error {
+		a.Nonce++
+		return nil
+	})
 }
 
 func (vm *VM) transfer(from, to address.Address, amt types.BigInt) error {
@@ -643,6 +640,15 @@ func (vm *VM) transfer(from, to address.Address, amt types.BigInt) error {
 		return err
 	}
 	depositFunds(t, amt)
+
+	if err := vm.cstate.SetActor(from, f); err != nil {
+		return err
+	}
+
+	if err := vm.cstate.SetActor(to, t); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -651,16 +657,13 @@ func (vm *VM) transferToGasHolder(addr address.Address, gasHolder *types.Actor, 
 		return xerrors.Errorf("attempted to transfer negative value to gas holder")
 	}
 
-	a, err := vm.cstate.GetActor(addr)
-	if err != nil {
-		return xerrors.Errorf("transfer to gas holder failed when retrieving sender actor")
-	}
-
-	if err := deductFunds(a, amt); err != nil {
-		return err
-	}
-	depositFunds(gasHolder, amt)
-	return nil
+	return vm.cstate.MutateActor(addr, func(a *types.Actor) error {
+		if err := deductFunds(a, amt); err != nil {
+			return err
+		}
+		depositFunds(gasHolder, amt)
+		return nil
+	})
 }
 
 func (vm *VM) transferFromGasHolder(addr address.Address, gasHolder *types.Actor, amt types.BigInt) error {
@@ -668,16 +671,13 @@ func (vm *VM) transferFromGasHolder(addr address.Address, gasHolder *types.Actor
 		return xerrors.Errorf("attempted to transfer negative value from gas holder")
 	}
 
-	a, err := vm.cstate.GetActor(addr)
-	if err != nil {
-		return xerrors.Errorf("transfer from gas holder failed when retrieving receiver actor")
-	}
-
-	if err := deductFunds(gasHolder, amt); err != nil {
-		return err
-	}
-	depositFunds(a, amt)
-	return nil
+	return vm.cstate.MutateActor(addr, func(a *types.Actor) error {
+		if err := deductFunds(gasHolder, amt); err != nil {
+			return err
+		}
+		depositFunds(a, amt)
+		return nil
+	})
 }
 
 func deductFunds(act *types.Actor, amt types.BigInt) error {


### PR DESCRIPTION
state tree snapshots are currently the number one thing in chain validation profiles, this should improve things a bit