### PR TITLE
Fix/miner remote sealer addr

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -16,7 +16,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	record "github.com/libp2p/go-libp2p-record"
 	"github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
@@ -338,10 +337,7 @@ func ConfigCommon(cfg *config.Common) Option {
 			return lr.SetAPIEndpoint(e)
 		}),
 		Override(new(sectorstorage.URLs), func(e dtypes.APIEndpoint) (sectorstorage.URLs, error) {
-			_, ip, err := manet.DialArgs(e)
-			if err != nil {
-				return nil, xerrors.Errorf("getting api endpoint dial args: %w", err)
-			}
+			ip := cfg.API.RemoteListenAddress
 
 			var urls sectorstorage.URLs
 			urls = append(urls, "http://"+ip+"/remote") // TODO: This makes assumptions, and probably bad ones too

--- a/node/builder.go
+++ b/node/builder.go
@@ -340,7 +340,7 @@ func ConfigCommon(cfg *config.Common) Option {
 			ip := cfg.API.RemoteListenAddress
 
 			var urls sectorstorage.URLs
-			urls = append(urls, "http://"+ip+"/remote") // TODO: This makes assumptions, and probably bad ones too
+			urls = append(urls, "http://"+ip+"/remote") // TODO: This makes no assumptions, and probably could...
 			return urls, nil
 		}),
 		ApplyIf(func(s *Settings) bool { return s.Online },

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"encoding"
-	"github.com/filecoin-project/sector-storage"
 	"time"
+
+	sectorstorage "github.com/filecoin-project/sector-storage"
 )
 
 // Common is common config between full node and miner
@@ -29,8 +30,9 @@ type StorageMiner struct {
 
 // API contains configs for API endpoint
 type API struct {
-	ListenAddress string
-	Timeout       Duration
+	ListenAddress       string
+	RemoteListenAddress string
+	Timeout             Duration
 }
 
 // Libp2p contains configs for libp2p
@@ -55,8 +57,9 @@ type Metrics struct {
 func defCommon() Common {
 	return Common{
 		API: API{
-			ListenAddress: "/ip4/127.0.0.1/tcp/1234/http",
-			Timeout:       Duration(30 * time.Second),
+			ListenAddress:       "/ip4/127.0.0.1/tcp/1234/http",
+			RemoteListenAddress: "127.0.0.1:1234",
+			Timeout:             Duration(30 * time.Second),
 		},
 		Libp2p: Libp2p{
 			ListenAddresses: []string{

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -57,9 +57,8 @@ type Metrics struct {
 func defCommon() Common {
 	return Common{
 		API: API{
-			ListenAddress:       "/ip4/127.0.0.1/tcp/1234/http",
-			RemoteListenAddress: "127.0.0.1:1234",
-			Timeout:             Duration(30 * time.Second),
+			ListenAddress: "/ip4/127.0.0.1/tcp/1234/http",
+			Timeout:       Duration(30 * time.Second),
 		},
 		Libp2p: Libp2p{
 			ListenAddresses: []string{
@@ -75,7 +74,7 @@ func defCommon() Common {
 
 }
 
-// Default returns the default config
+// DefaultFullNode returns the default config
 func DefaultFullNode() *FullNode {
 	return &FullNode{
 		Common: defCommon(),
@@ -93,6 +92,7 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"
+	cfg.Common.API.RemoteListenAddress = "127.0.0.1:2345"
 	return cfg
 }
 


### PR DESCRIPTION
This is a workaround to the issue caused by how the `lotus-seal-worker` retrieve the LAN address of the storage miner. The more robust solution was to have the miner gather all the IPs associated with its configured network interfaces, then have the seal worker ping them to find out which one is usable. I went with the 'I can just tell the miner which address to use' route as it was far simpler and quicker to implement. We can bikeshed the config field name if we want.

I haven't resolved the documentation issue that the `RemoteListenAddress` does nothing if configured on a `lotus` node.