### PR TITLE
docker: fix build, upgrade Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 /cmd/lotus-townhall/townhall/node_modules
 /cmd/lotus-townhall/townhall/build
 extern/filecoin-ffi/rust/target
-**/*.h
 **/*.a
 **/*.pc
 /**/*/.DS_STORE

--- a/tools/dockers/docker-examples/basic-miner-busybox/Dockerfile
+++ b/tools/dockers/docker-examples/basic-miner-busybox/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.13-buster
+FROM golang:1.14.1-buster
 MAINTAINER ldoublewood <ldoublewood@gmail.com>
 
 ENV SRC_DIR /lotus
 
-RUN apt-get update && apt-get install -y && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev
+RUN apt-get update && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev jq
 
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION

The `basic-miner-busybox` Dockerfile is currently broken because of two issues.

Issue 1: missing `jq` dep now required to build `extern/filecoin-ffi`:
```bash
touch build/.update-modules
make -C extern/filecoin-ffi/ .install-filcrypto
make[1]: Entering directory '/lotus/extern/filecoin-ffi'
./install-filcrypto
+ auth_header=()
+ '[' -n '' ']'
++ dirname ./install-filcrypto
+ cd .
+ rust_sources_dir=rust
++ jq -r '.[].rustc_target_feature'
./install-filcrypto: line 23: jq: command not found
+ optimized_release_rustc_target_features=
make[1]: Leaving directory '/lotus/extern/filecoin-ffi'
make[1]: *** [Makefile:11: .install-filcrypto] Error 127
make: *** [Makefile:28: build/.filecoin-install] Error 2
The command '/bin/sh -c cd $SRC_DIR   && mkdir $SRC_DIR/build   && . $HOME/.cargo/env   && make clean   && make deps' returned a non-zero code: 2
```

Isse 2: failing `extern/filecoin-ffi` because of a “missing”  C header file:
```bash
---> 90009b27540b
Step 18/40 : RUN cd $SRC_DIR   && . $HOME/.cargo/env   && make $MAKE_TARGET
 ---> Running in 704f07386d7e
rm -f lotus
go build -ldflags=-X="github.com/filecoin-project/lotus/build".CurrentCommit="+gitc9dae720.dirty" -o lotus ./cmd/lotus
# github.com/filecoin-project/filecoin-ffi/generated
extern/filecoin-ffi/generated/cgo_helpers.go:11:10: fatal error: cgo_helpers.h: No such file or directory
 #include "cgo_helpers.h"
          ^~~~~~~~~~~~~~~
compilation terminated.
```

This PR fixes both things making the Dockerfile build successfully.