### PR TITLE
tools/dockers: Private DevNet example

### DIFF
--- a/tools/dockers/docker-examples/devnet/Dockerfile
+++ b/tools/dockers/docker-examples/devnet/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:19.10
+MAINTAINER Richard Patel <me@terorie.dev>
+
+RUN apt-get update \
+ && apt-get install -y \
+    s6 ca-certificates curl git bzr tmux \
+    llvm clang \
+    mesa-opencl-icd ocl-icd-opencl-dev \
+    golang-1.13-go \
+ && ln -s /usr/lib/go-1.13/bin/go /usr/bin/go
+
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Download packages first so they can be cached.
+COPY go.mod go.sum /lotus/
+COPY extern/ /lotus/extern/
+RUN cd /lotus \
+ && go mod download
+
+COPY Makefile /lotus
+
+# Because extern/filecoin-ffi building script need to get version number from git
+COPY .git/ /lotus/.git/
+COPY .gitmodules /lotus/
+
+# Download dependencies first
+RUN cd /lotus \
+  && mkdir /lotus/build \
+  && . $HOME/.cargo/env \
+  && make clean \
+  && make deps
+
+
+COPY . /lotus
+
+ARG MAKE_TARGET=debug
+
+# Build the thing.
+RUN cd /lotus \
+  && . $HOME/.cargo/env \
+  && make $MAKE_TARGET \
+  && ln -s -t /usr/local/bin/ /lotus/lotus /lotus/lotus-*
+
+# Symlink devnet environment
+RUN ln -s /lotus/tools/dockers/docker-examples/devnet /devnet
+WORKDIR /devnet
+
+ENTRYPOINT ["/bin/sh"]
+CMD ["/devnet/docker_scripts/start.sh"]
+
+VOLUME ["/var/tmp/filecoin-proof-parameters/"]
+
+EXPOSE \
+    # WS port
+    1234/tcp \
+    # Miner port
+    2345/tcp \
+    # P2P port
+    5678/tcp

--- a/tools/dockers/docker-examples/devnet/Makefile
+++ b/tools/dockers/docker-examples/devnet/Makefile
@@ -1,0 +1,46 @@
+DOCKER=docker
+DOCKER_IMAGE=filecoin-devnet
+DOCKER_CONTAINER=filecoin-devnet
+PROOF_VOLUME=filecoin-proof-params
+
+.PHONY: all build run kill login stop clean clean-all
+
+all: build run login
+
+.ONESHELL:
+build:
+	$(DOCKER) build -t "$(DOCKER_IMAGE)" \
+	  -f ./Dockerfile \
+	  ../../../../
+
+run:
+	@echo "Creating proof params volume: $(PROOF_VOLUME)"
+	-$(DOCKER) volume create "$(PROOF_VOLUME)"
+	@echo "Starting container $(DOCKER_CONTAINER)"
+	$(DOCKER) run -d \
+	  --name "$(DOCKER_CONTAINER)" \
+	  -p "1234:1234" \
+	  -p "5678:5678" \
+	  -p "2345:2345" \
+	  -v "$(PROOF_VOLUME):/var/tmp/filecoin-proof-parameters" \
+	  "$(DOCKER_IMAGE)"
+
+login:
+	$(DOCKER) exec "$(DOCKER_CONTAINER)" \
+	  /lotus/tools/dockers/docker-examples/devnet/docker_scripts/login.sh
+
+restart:
+	$(DOCKER) restart "$(DOCKER_CONTAINER)"
+
+stop:
+	$(DOCKER) stop "$(DOCKER_CONTAINER)"
+
+kill:
+	-$(DOCKER) kill "$(DOCKER_CONTAINER)"
+
+clean: kill
+	-$(DOCKER) rm "$(DOCKER_CONTAINER)"
+
+clean-all: clean
+	-$(DOCKER) volume rm "$(PROOF_VOLUME)"
+	-$(DOCKER) image rm "$(DOCKER_IMAGE)"

--- a/tools/dockers/docker-examples/devnet/README.md
+++ b/tools/dockers/docker-examples/devnet/README.md
@@ -1,0 +1,91 @@
+# Private DevNet Quickstart
+
+Use this to quickly spin up a minimal private development network.
+It includes a seed node and storage miner with 4KB debug parameters.
+
+Requirements:
+ - Docker
+ - A machine with a public IP address
+
+## Setup
+
+#### Building the Docker image
+
+```shell script
+cd tools/dockers/docker-examples/devnet
+make build
+```
+
+#### Starting up the network.
+
+```shell script
+make run
+```
+
+#### Retrieving login parameters
+
+If you just started the network, you might see errors before all services are running.
+
+```shell script
+make login
+```
+
+#### Connecting to the network
+
+To connect another (external) node to the DevNet,
+a few things need to be configured.
+
+##### Setting the bootstrap peer
+
+The node needs to be instructed to connect to the DevNet.
+The bootstrap multiaddr is listed in the `make login` script:
+
+```shell script
+lotus/tools/dockers/docker-examples/devnet $ make login
+
+...
+Seed Peer (up=true)
+FULLNODE_API_INFO="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.BOQBl27LjMFgfgKeB-TJgBL7tsEW8oLycHzQ-YpWASo:/ip4/127.0.0.1/tcp/1234/http"
+# P2P Connection: /ip4/127.0.0.1/tcp/5678
+# Net ID: 12D3KooWFmRZcXx6rqWPsDAZMYxphMYpcjXBPY8kAbZDbX2voswt
+# multiaddr: /ip4/127.0.0.1/tcp/5678/p2p/12D3KooWFmRZcXx6rqWPsDAZMYxphMYpcjXBPY8kAbZDbX2voswt
+...
+```
+
+If the Docker container is on a different host than the external node,
+the IP in the multiaddr needs to be replaced.
+
+Then, set it up in the Lotus config file like so:
+
+```toml
+[Libp2p]
+BootstrapPeers = ["/ip4/127.0.0.1/tcp/5678/p2p/12D3KooWFmRZcXx6rqWPsDAZMYxphMYpcjXBPY8kAbZDbX2voswt"]
+```
+
+##### Getting the genesis block
+
+The generated genesis can be downloaded using `docker cp`:
+
+```shell script
+lotus $ docker cp filecoin-devnet:/lotus/dev.gen dev.gen
+lotus $ ls ./dev.gen
+```
+
+##### Starting the node
+
+```shell script
+# Compile a Lotus node in debug mode
+lotus $ make debug
+...
+lotus $ ./lotus daemon --genesis=dev.gen
+```
+
+#### Other commands
+
+ - `make build`: Rebuilds the `filecoin-devnet` image.
+ - `make stop`: Stops the network container.
+ - `make restart`: Restarts the started or stopped container.
+ - `make kill`: Kills the network container.
+ - `make clean`: Deletes the network container.
+ - `make clean-all`: Deletes everything, including images and volumes.
+ - `docker exec -it filecoin-devnet bash`: Opens a shell inside the container.

--- a/tools/dockers/docker-examples/devnet/docker_scripts/login.sh
+++ b/tools/dockers/docker-examples/devnet/docker_scripts/login.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+devnet=/lotus/tools/dockers/docker-examples/devnet
+
+echo "Waiting for services to start up ..."
+s6-svwait -u -t 10000 "$devnet/miner" "$devnet/seed"
+lotus sync wait
+echo ""
+echo "Seed Peer (up=$(s6-svstat -u "$devnet/seed"))"
+lotus_token=$(lotus auth create-token --perm=admin)
+echo "FULLNODE_API_INFO=\"${lotus_token}:/ip4/127.0.0.1/tcp/1234/http\""
+echo "# P2P Connection: /ip4/127.0.0.1/tcp/5678"
+peer_id=$(lotus net id)
+echo "# Net ID: ${peer_id})"
+echo "# multiaddr: /ip4/127.0.0.1/tcp/5678/${peer_id}"
+echo ""
+echo "Miner (up=$(s6-svstat -u "$devnet/miner"))"
+storage_token=$(lotus-storage-miner auth create-token --perm=admin)
+echo "STORAGE_API_INFO=\"${storage_token}:/ip4/127.0.0.1/tcp/2345/http\""

--- a/tools/dockers/docker-examples/devnet/docker_scripts/start.sh
+++ b/tools/dockers/docker-examples/devnet/docker_scripts/start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+config () {
+    echo "[API]"
+    echo "ListenAddress = \"/ip4/0.0.0.0/tcp/1234/http\""
+    echo "[Libp2p]"
+    echo "ListenAddresses = [\"/ip4/0.0.0.0/tcp/5678\", \"/ip6/::/tcp/5678\"]"
+}
+
+mkdir -p     /root/.lotus/
+chmod -f u+w /root/.lotus/config.toml
+config   >   /root/.lotus/config.toml
+chmod -f  -w /root/.lotus/config.toml
+
+set -e
+
+echo "---"
+echo "Fetching proving params"
+echo "---"
+
+lotus fetch-params \
+  --proving-params=1024
+
+echo "---"
+echo "Presealing sectors"
+echo "---"
+
+mkdir -p /mnt/genesis-sectors
+lotus-seed \
+  --sectorbuilder-dir=/mnt/genesis-sectors \
+  pre-seal \
+  --sector-size=1024 \
+  --num-sectors=2
+
+echo "---"
+echo "Starting services"
+echo "---"
+
+exec s6-svscan /devnet

--- a/tools/dockers/docker-examples/devnet/miner/run
+++ b/tools/dockers/docker-examples/devnet/miner/run
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+# Wait for seed peer to start
+s6-svwait -u -t 360000 ../seed
+# Initialize miner
+if [ ! -d "$HOME/.lotusstorage" ]
+then
+    echo "Initializing storage miner"
+    lotus-storage-miner init \
+        --genesis-miner \
+        --actor=t0101 \
+        --sector-size 1024 \
+        --pre-sealed-sectors=/mnt/genesis-sectors \
+        --nosync
+fi
+# Run miner
+echo "Running miner"
+exec lotus-storage-miner run \
+    --nosync

--- a/tools/dockers/docker-examples/devnet/seed/run
+++ b/tools/dockers/docker-examples/devnet/seed/run
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+# Run seed node
+exec lotus daemon \
+    --lotus-make-random-genesis=/lotus/dev.gen \
+    --genesis-presealed-sectors=/mnt/genesis-sectors/pre-seal-t0101.json \
+    --bootstrap=false


### PR DESCRIPTION
This PR adds directory `tools/dockers/docker-examples/devnet`.

It contains tooling to quickly spin up- and connect to a private, disposable development network running in a Docker container.

@eshon 