### PR TITLE
increase gas limit during genesis generation

### DIFF
--- a/chain/gen/genesis/util.go
+++ b/chain/gen/genesis/util.go
@@ -36,7 +36,7 @@ func doExecValue(ctx context.Context, vm *vm.VM, to, from address.Address, value
 		From:     from,
 		Method:   method,
 		Params:   params,
-		GasLimit: 1000000,
+		GasLimit: 1_000_000_000_000_000,
 		GasPrice: types.NewInt(0),
 		Value:    value,
 		Nonce:    act.Nonce,


### PR DESCRIPTION
Small GasLimit here gets in the way when trying to generate a genesis with many sectors.