### PR TITLE
save tipset more often in sync loop

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1181,6 +1181,10 @@ func (syncer *Syncer) iterFullTipsets(ctx context.Context, headers []*types.TipS
 			if err := copyBlockstore(bs, syncer.store.Blockstore()); err != nil {
 				return xerrors.Errorf("message processing failed: %w", err)
 			}
+
+			if err := syncer.store.PutTipSet(ctx, headers[i]); err != nil {
+				return xerrors.Errorf("put tip set failed: %w", err)
+			}
 		}
 		i -= batchSize
 	}


### PR DESCRIPTION
### Problem

If the local tipset is very far away from target tipset, the tipset is persisted only after ALL messages had been synced and persisted. 

This is problematic when syncing from scratch, when the tipset is behind from target by 20~30k. If the daemon crashes (it *does* quite often), or if user interrupts, the sync process would revalidate blocks from 0 again... this is the case even if the blocks and messages had already been persisted.

Also, if another sync worker is scheduled to sync from another tip, that worker would also have to revalidate blocks from zero.

### Solution

Save the tipset after a height had been validated, it it's heavier. 

This make the synchronization process more incremental. The daemon can exit at anytime, and `collectHeaders` would start from where it was left off.

`PutTipSet` takes about 20ms, and should not affect the sync process by much overall relative to the time it takes for revalidation.

