### PR TITLE
Feat/retrieval market #1552

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.0.0-20200408061858-82c58b423ca6
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-fil-markets v0.0.0-20200413201123-731e6ca89984
+	github.com/filecoin-project/go-fil-markets v0.0.0-20200415011556-4378bd41b91f
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/go-statestore v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/filecoin-project/go-data-transfer v0.0.0-20200408061858-82c58b423ca6/
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200114015428-74d100f305f8/go.mod h1:c8NTjvFVy1Ud02mmGDjOiMeawY2t6ALfrrdvAB01FQc=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200413201123-731e6ca89984 h1:QY5jgd5T4txUEC2k9BPqWRlhDUTdFx5f1z/StOlh92g=
-github.com/filecoin-project/go-fil-markets v0.0.0-20200413201123-731e6ca89984/go.mod h1:vcX3y5FVyuclIZgogPG1uIvJxHLSBU54B1ANJ88uMNk=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200415011556-4378bd41b91f h1:mPmWWrEwc/5zZW2E14m8a7HMrrOWREaflGZL1Iun/Aw=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200415011556-4378bd41b91f/go.mod h1:vcX3y5FVyuclIZgogPG1uIvJxHLSBU54B1ANJ88uMNk=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go
 github.com/filecoin-project/go-fil-markets v0.0.0-20200114015428-74d100f305f8/go.mod h1:c8NTjvFVy1Ud02mmGDjOiMeawY2t6ALfrrdvAB01FQc=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200413201123-731e6ca89984 h1:QY5jgd5T4txUEC2k9BPqWRlhDUTdFx5f1z/StOlh92g=
 github.com/filecoin-project/go-fil-markets v0.0.0-20200413201123-731e6ca89984/go.mod h1:vcX3y5FVyuclIZgogPG1uIvJxHLSBU54B1ANJ88uMNk=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200415011556-4378bd41b91f h1:mPmWWrEwc/5zZW2E14m8a7HMrrOWREaflGZL1Iun/Aw=
+github.com/filecoin-project/go-fil-markets v0.0.0-20200415011556-4378bd41b91f/go.mod h1:vcX3y5FVyuclIZgogPG1uIvJxHLSBU54B1ANJ88uMNk=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=

--- a/markets/retrievaladapter/client.go
+++ b/markets/retrievaladapter/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/node/impl/full"
 	payapi "github.com/filecoin-project/lotus/node/impl/paych"
@@ -29,11 +30,10 @@ func NewRetrievalClientNode(pmgr *paychmgr.Manager, payapi payapi.PaychAPI, chai
 // GetOrCreatePaymentChannel sets up a new payment channel if one does not exist
 // between a client and a miner and ensures the client has the given amount of
 // funds available in the channel.
-func (rcn *retrievalClientNode) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount, tok shared.TipSetToken) (address.Address, error) {
+func (rcn *retrievalClientNode) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount, tok shared.TipSetToken) (address.Address, cid.Cid, error) {
 	// TODO: respect the provided TipSetToken (a serialized TipSetKey) when
 	// querying the chain
-	paych, _, err := rcn.pmgr.GetPaych(ctx, clientAddress, minerAddress, clientFundsAvailable)
-	return paych, err
+	return rcn.pmgr.GetPaych(ctx, clientAddress, minerAddress, clientFundsAvailable)
 }
 
 // Allocate late creates a lane within a payment channel so that calls to
@@ -64,3 +64,12 @@ func (rcn *retrievalClientNode) GetChainHead(ctx context.Context) (shared.TipSet
 
 	return head.Key().Bytes(), head.Height(), nil
 }
+
+func (rcn *retrievalClientNode) WaitForPaymentChannelAddFunds(messageCID cid.Cid) error {
+	panic("implement me")
+}
+
+func (rcn *retrievalClientNode) WaitForPaymentChannelCreation(messageCID cid.Cid) (address.Address, error) {
+	panic("implement me")
+}
+

--- a/markets/retrievaladapter/client.go
+++ b/markets/retrievaladapter/client.go
@@ -65,11 +65,13 @@ func (rcn *retrievalClientNode) GetChainHead(ctx context.Context) (shared.TipSet
 	return head.Key().Bytes(), head.Height(), nil
 }
 
+// WaitForPaymentChannelAddFunds waits for messageCID to appear on chain.
 func (rcn *retrievalClientNode) WaitForPaymentChannelAddFunds(messageCID cid.Cid) error {
-	panic("implement me")
+	return rcn.pmgr.WaitForAddFundsMsg(context.TODO(), messageCID)
 }
 
+// WaitForPaymentChannelCreation waits for messageCID to appear on chain and returns
+// the address of the payment channel
 func (rcn *retrievalClientNode) WaitForPaymentChannelCreation(messageCID cid.Cid) (address.Address, error) {
-	panic("implement me")
+	return rcn.pmgr.WaitForPaychCreateMsg(context.TODO(), messageCID)
 }
-

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -116,7 +116,7 @@ func (pm *Manager) waitForAddFundsMsg(ctx context.Context, mcid cid.Cid) {
 }
 
 func (pm *Manager) GetPaych(ctx context.Context, from, to address.Address, ensureFree types.BigInt) (address.Address, cid.Cid, error) {
-	pm.store.lk.Lock()  // unlock only on err; wait funcs will defer unlock
+	pm.store.lk.Lock() // unlock only on err; wait funcs will defer unlock
 	var mcid cid.Cid
 	ch, err := pm.store.findChan(func(ci *ChannelInfo) bool {
 		if ci.Direction != DirOutbound {

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -74,6 +74,8 @@ func (pm *Manager) waitForPaychCreateMsg(ctx context.Context, mcid cid.Cid) (add
 	if err := pm.store.trackChannel(ci); err != nil {
 		return address.Undef, xerrors.Errorf("tracking channel: %w", err)
 	}
+
+	return paychaddr, nil
 }
 
 func (pm *Manager) addFunds(ctx context.Context, ch address.Address, from address.Address, amt types.BigInt) (cid.Cid, error) {

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -49,7 +49,9 @@ func (pm *Manager) createPaych(ctx context.Context, from, to address.Address, am
 	return smsg.Cid(), nil
 }
 
-func (pm *Manager) waitForPaychCreateMsg(ctx context.Context, mcid cid.Cid) (address.Address, error) {
+// WaitForPaychCreateMsg waits for mcid to appear on chain and returns the robust address of the
+// created payment channel
+func (pm *Manager) WaitForPaychCreateMsg(ctx context.Context, mcid cid.Cid) (address.Address, error) {
 	mwait, err := pm.state.StateWaitMsg(ctx, mcid)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("wait msg: %w", err)
@@ -95,7 +97,8 @@ func (pm *Manager) addFunds(ctx context.Context, ch address.Address, from addres
 	return smsg.Cid(), nil
 }
 
-func (pm *Manager) waitForAddFundsMsg(ctx context.Context, mcid cid.Cid) error {
+// WaitForAddFundsMsg waits for mcid to appear on chain and returns error, if any
+func (pm *Manager) WaitForAddFundsMsg(ctx context.Context, mcid cid.Cid) error {
 
 	mwait, err := pm.state.StateWaitMsg(ctx, mcid) // TODO: wait outside the store lock!
 	if err != nil {


### PR DESCRIPTION
Closes #1552 

Support non-blocking creation of payment channel and adding funds via implementing the new go-fil-markets API, namely:

* `GetOrCreatePaymentChannel` now should
    1. If the payment channel doesn't exist:
         1. initiate payment channel creation and return `address.Undef` + message CID to wait for
         1. Allow a retrieval client to wait for this message CID and receive the new payment channel address when complete
    1. Otherwise add the value provided to the existing payment channel

* New API methods: `WaitForPaymentChannelCreation, WaitForPaymentChannelAddFunds`