### PR TITLE
lotus-seed: preserve first peerid during merge

### DIFF
--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -182,7 +182,7 @@ func mergeGenMiners(a, b genesis.Miner) genesis.Miner {
 	return genesis.Miner{
 		Owner:         a.Owner,
 		Worker:        a.Worker,
-		PeerId:        "",
+		PeerId:        a.PeerId,
 		MarketBalance: big.Zero(),
 		PowerBalance:  big.Zero(),
 		SectorSize:    a.SectorSize,


### PR DESCRIPTION
This needs to be some valid PeerId to things marshal correctly. If it's unset `lotus-storage-miner init` fails due to a failure to decode the PeerId.