### PR TITLE
add deal identity to client list-deals output

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -488,9 +488,9 @@ var clientListDeals = &cli.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "DealCid\tProvider\tState\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
+		fmt.Fprintf(w, "DealCid\tDealId\tProvider\tState\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
 		for _, d := range deals {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%d\t%s\n", d.ProposalCid, d.Provider, storagemarket.DealStates[d.State], d.PieceCID, d.Size, d.PricePerEpoch, d.Duration, d.Message)
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%d\t%s\t%d\t%s\n", d.ProposalCid, d.DealID, d.Provider, storagemarket.DealStates[d.State], d.PieceCID, d.Size, d.PricePerEpoch, d.Duration, d.Message)
 		}
 		return w.Flush()
 	},


### PR DESCRIPTION
## Why does this PR exist?

A storage client that wants to use the `lotus state get-deal` commands needs to know the numerical deal id, and the existing `lotus client list-deals` output does not give them this information.

## What's in this PR?

This PR adds deal id to the `lotus client list-deals` output:

```
DealCid                                                      DealId  Provider  State              PieceCID                                                       Size  Price    Duration  Message
bafyreifva6e2hn4sgwnxo26lssck6a7m42qachu56sp5wq2ioh6ajrxsne  2       t01000    StorageDealActive  bafk4chzaovmkytus7lwq3awuu2tb7txzaakeij76j4ekmanc4cydra5eiuzq  1016  1000000  2744
```