### PR TITLE
add on-chain deal information to client list-deals output

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -483,16 +484,49 @@ var clientListDeals = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		deals, err := api.ClientListDeals(ctx)
+		head, err := api.ChainHead(ctx)
 		if err != nil {
 			return err
 		}
 
+		localDeals, err := api.ClientListDeals(ctx)
+		if err != nil {
+			return err
+		}
+
+		var deals []deal
+		for idx := range localDeals {
+			onChain, err := api.StateMarketStorageDeal(ctx, localDeals[idx].DealID, head.Key())
+			if err != nil {
+				return err
+			}
+
+			deals = append(deals, deal{
+				LocalDeal:        localDeals[idx],
+				OnChainDealState: onChain.State,
+			})
+		}
+
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "DealCid\tDealId\tProvider\tState\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
+		fmt.Fprintf(w, "DealCid\tDealId\tProvider\tState\tOn Chain?\tSlashed?\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
 		for _, d := range deals {
-			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%d\t%s\t%d\t%s\n", d.ProposalCid, d.DealID, d.Provider, storagemarket.DealStates[d.State], d.PieceCID, d.Size, d.PricePerEpoch, d.Duration, d.Message)
+			onChain := "N"
+			if d.OnChainDealState.SectorStartEpoch != -1 {
+				onChain = fmt.Sprintf("Y (epoch %d)", d.OnChainDealState.SectorStartEpoch)
+			}
+
+			slashed := "N"
+			if d.OnChainDealState.SlashEpoch != -1 {
+				slashed = fmt.Sprintf("Y (epoch %d)", d.OnChainDealState.SlashEpoch)
+			}
+
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%d\t%s\n", d.LocalDeal.ProposalCid, d.LocalDeal.DealID, d.LocalDeal.Provider, storagemarket.DealStates[d.LocalDeal.State], onChain, slashed, d.LocalDeal.PieceCID, d.LocalDeal.Size, d.LocalDeal.PricePerEpoch, d.LocalDeal.Duration, d.LocalDeal.Message)
 		}
 		return w.Flush()
 	},
+}
+
+type deal struct {
+	LocalDeal        lapi.DealInfo
+	OnChainDealState market.DealState
 }


### PR DESCRIPTION
This PR addresses _Recommendation Z_ [here](https://github.com/filecoin-project/lotus/issues/1518).

## Why does this PR exist?

The existing CLI does not communicate via the `lotus client list-deals` output (and when) their storage deal was slashed. It also doesn't communicate the epoch in which the sector storing their piece was committed to the network. The existing output is constructed only from local (i.e. not on-chain) deal information.

cc @terichadbourne @mishmosh 

## What's in this PR?

This changeset adds two additional columns to the `lotus client list-deals` command:

- `On Chain?`, which shows either `N` (if sector commitment not yet posted), or `Y (epoch 123)` if it was
- `Slashed?`, which shows either `N` (if deal wasn't slashed), or `Y (epoch 567)` if it was

## Example output

```shell
13:33 $ lotus client list-deals
DealCid                                                      DealId  Provider  State              On Chain?     Slashed?  PieceCID                                                       Size  Price    Duration  Message
bafyreiefvrrv5j7omqzfersogg4nqzctyzj66rcmkwkbxxx5prvd5sklci  2       t01000    StorageDealActive  Y (epoch 59)  N         bafk4chzazx6u4luj34azuit37rlylgrcbgkaakqsjt5avsbolxale2igii3q  1016  1000000  2744
```