### PR TITLE
Use blake2b, instead of sha256, for ticket creation and verification

### DIFF
--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"github.com/minio/blake2b-simd"
 	"math/big"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -9,7 +10,6 @@ import (
 
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/minio/sha256-simd"
 	"github.com/multiformats/go-multihash"
 	xerrors "golang.org/x/xerrors"
 
@@ -195,7 +195,7 @@ func IsTicketWinner(vrfTicket []byte, mypow BigInt, totpow BigInt) bool {
 
 	*/
 
-	h := sha256.Sum256(vrfTicket)
+	h := blake2b.Sum256(vrfTicket)
 
 	lhs := BigFromBytes(h[:]).Int
 	lhs = lhs.Mul(lhs, totpow.Int)

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/minio/blake2b-simd"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -455,7 +455,7 @@ func runSeals(sb *ffiwrapper.Sealer, numSectors int, mid abi.ActorID, sectorSize
 
 		addpiece := time.Now()
 
-		trand := sha256.Sum256(ticketPreimage)
+		trand := blake2b.Sum256(ticketPreimage)
 		ticket := abi.SealRandomness(trand[:])
 
 		log.Info("Running replication(1)...")

--- a/cmd/lotus-seed/seed/seed.go
+++ b/cmd/lotus-seed/seed/seed.go
@@ -3,10 +3,10 @@ package seed
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/minio/blake2b-simd"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -78,7 +78,7 @@ func PreSeal(maddr address.Address, pt abi.RegisteredProof, offset abi.SectorNum
 			return nil, nil, err
 		}
 
-		trand := sha256.Sum256(preimage)
+		trand := blake2b.Sum256(preimage)
 		ticket := abi.SealRandomness(trand[:])
 
 		fmt.Printf("sector-id: %d, piece info: %v\n", sid, pi)


### PR DESCRIPTION
Tis what go-filecoin does...Spec says use sha, but we use blake2b everywhere else, so I'm guessing this is preferable? 