### PR TITLE
Added RPC calls for MsigCreate, MsigPropose, MsigApprove, and MsigCancel

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -147,6 +147,10 @@ type FullNode interface {
 	StateCompute(context.Context, abi.ChainEpoch, []*types.Message, types.TipSetKey) (*ComputeStateOutput, error)
 
 	MsigGetAvailableBalance(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)
+	MsigCreate(context.Context, int64, []address.Address, types.BigInt, address.Address, types.BigInt) (cid.Cid, error)
+	MsigPropose(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)
+	MsigApprove(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)
+	MsigCancel(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)
 
 	MarketEnsureAvailable(context.Context, address.Address, address.Address, types.BigInt) (cid.Cid, error)
 	// MarketFreeBalance
@@ -413,3 +417,10 @@ type HeadChange struct {
 	Type string
 	Val  *types.TipSet
 }
+
+type MsigProposeResponse int
+
+const (
+	MsigApprove MsigProposeResponse = iota
+	MsigCancel
+)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -145,7 +145,11 @@ type FullNodeStruct struct {
 		StateListMessages                 func(ctx context.Context, match *types.Message, tsk types.TipSetKey, toht abi.ChainEpoch) ([]cid.Cid, error)        `perm:"read"`
 		StateCompute                      func(context.Context, abi.ChainEpoch, []*types.Message, types.TipSetKey) (*api.ComputeStateOutput, error)           `perm:"read"`
 
-		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error) `perm:"read"`
+		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)                                                                    `perm:"read"`
+		MsigCreate              func(context.Context, int64, []address.Address, types.BigInt, address.Address, types.BigInt) (cid.Cid, error)                                    `perm:"sign"`
+		MsigPropose             func(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)                          `perm:"sign"`
+		MsigApprove             func(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) `perm:"sign"`
+		MsigCancel              func(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) `perm:"sign"`
 
 		MarketEnsureAvailable func(context.Context, address.Address, address.Address, types.BigInt) (cid.Cid, error) `perm:"sign"`
 
@@ -233,6 +237,8 @@ type WorkerStruct struct {
 	}
 }
 
+// CommonStruct
+
 func (c *CommonStruct) AuthVerify(ctx context.Context, token string) ([]api.Permission, error) {
 	return c.Internal.AuthVerify(ctx, token)
 }
@@ -282,6 +288,8 @@ func (c *CommonStruct) LogList(ctx context.Context) ([]string, error) {
 func (c *CommonStruct) LogSetLevel(ctx context.Context, group, level string) error {
 	return c.Internal.LogSetLevel(ctx, group, level)
 }
+
+// FullNodeStruct
 
 func (c *FullNodeStruct) ClientListImports(ctx context.Context) ([]api.Import, error) {
 	return c.Internal.ClientListImports(ctx)
@@ -621,6 +629,22 @@ func (c *FullNodeStruct) MsigGetAvailableBalance(ctx context.Context, a address.
 	return c.Internal.MsigGetAvailableBalance(ctx, a, tsk)
 }
 
+func (c *FullNodeStruct) MsigCreate(ctx context.Context, req int64, addrs []address.Address, val types.BigInt, src address.Address, gp types.BigInt) (cid.Cid, error) {
+	return c.Internal.MsigCreate(ctx, req, addrs, val, src, gp)
+}
+
+func (c *FullNodeStruct) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	return c.Internal.MsigPropose(ctx, msig, to, amt, src, method, params)
+}
+
+func (c *FullNodeStruct) MsigApprove(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	return c.Internal.MsigApprove(ctx, msig, txID, proposer, to, amt, src, method, params)
+}
+
+func (c *FullNodeStruct) MsigCancel(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	return c.Internal.MsigCancel(ctx, msig, txID, proposer, to, amt, src, method, params)
+}
+
 func (c *FullNodeStruct) MarketEnsureAvailable(ctx context.Context, addr, wallet address.Address, amt types.BigInt) (cid.Cid, error) {
 	return c.Internal.MarketEnsureAvailable(ctx, addr, wallet, amt)
 }
@@ -672,6 +696,8 @@ func (c *FullNodeStruct) PaychNewPayment(ctx context.Context, from, to address.A
 func (c *FullNodeStruct) PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paych.SignedVoucher) (cid.Cid, error) {
 	return c.Internal.PaychVoucherSubmit(ctx, ch, sv)
 }
+
+// StorageMinerStruct
 
 func (c *StorageMinerStruct) ActorAddress(ctx context.Context) (address.Address, error) {
 	return c.Internal.ActorAddress(ctx)
@@ -782,6 +808,8 @@ func (c *StorageMinerStruct) DealsList(ctx context.Context) ([]storagemarket.Sto
 func (c *StorageMinerStruct) StorageAddLocal(ctx context.Context, path string) error {
 	return c.Internal.StorageAddLocal(ctx, path)
 }
+
+// WorkerStruct
 
 func (w *WorkerStruct) Version(ctx context.Context) (build.Version, error) {
 	return w.Internal.Version(ctx)

--- a/node/impl/full.go
+++ b/node/impl/full.go
@@ -21,6 +21,7 @@ type FullNodeAPI struct {
 	market.MarketAPI
 	paych.PaychAPI
 	full.StateAPI
+	full.MsigAPI
 	full.WalletAPI
 	full.SyncAPI
 }

--- a/node/impl/full/multisig.go
+++ b/node/impl/full/multisig.go
@@ -1,0 +1,224 @@
+package full
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	samsig "github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+
+	"github.com/ipfs/go-cid"
+	"github.com/minio/blake2b-simd"
+	"go.uber.org/fx"
+	"golang.org/x/xerrors"
+)
+
+type MsigAPI struct {
+	fx.In
+
+	WalletAPI WalletAPI
+	StateAPI  StateAPI
+	MpoolAPI  MpoolAPI
+}
+
+func (a *MsigAPI) MsigCreate(ctx context.Context, req int64, addrs []address.Address, val types.BigInt, src address.Address, gp types.BigInt) (cid.Cid, error) {
+
+	lenAddrs := int64(len(addrs))
+
+	if lenAddrs < req {
+		return cid.Undef, xerrors.Errorf("cannot require signing of more addresses than provided for multisig")
+	}
+
+	if req == 0 {
+		req = lenAddrs
+	}
+
+	if src == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide source address")
+	}
+
+	if gp == types.EmptyInt {
+		gp = types.NewInt(1)
+	}
+
+	// Set up constructor parameters for multisig
+	msigParams := &samsig.ConstructorParams{
+		Signers:               addrs,
+		NumApprovalsThreshold: req,
+	}
+
+	enc, actErr := actors.SerializeParams(msigParams)
+	if actErr != nil {
+		return cid.Undef, actErr
+	}
+
+	// new actors are created by invoking 'exec' on the init actor with the constructor params
+	execParams := &init_.ExecParams{
+		CodeCID:           builtin.MultisigActorCodeID,
+		ConstructorParams: enc,
+	}
+
+	enc, actErr = actors.SerializeParams(execParams)
+	if actErr != nil {
+		return cid.Undef, actErr
+	}
+
+	// now we create the message to send this with
+	msg := types.Message{
+		To:       builtin.InitActorAddr,
+		From:     src,
+		Method:   builtin.MethodsInit.Exec,
+		Params:   enc,
+		GasPrice: gp,
+		GasLimit: 1000000,
+		Value:    val,
+	}
+
+	// send the message out to the network
+	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, &msg)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return smsg.Cid(), nil
+}
+
+func (a *MsigAPI) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+
+	if msig == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide a multisig address for proposal")
+	}
+
+	if to == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide a target address for proposal")
+	}
+
+	if amt.Sign() == -1 {
+		return cid.Undef, xerrors.Errorf("must provide a positive amount for proposed send")
+	}
+
+	if src == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide source address")
+	}
+
+	enc, actErr := actors.SerializeParams(&samsig.ProposeParams{
+		To:     to,
+		Value:  amt,
+		Method: abi.MethodNum(method),
+		Params: params,
+	})
+	if actErr != nil {
+		return cid.Undef, actErr
+	}
+
+	msg := &types.Message{
+		To:       msig,
+		From:     src,
+		Value:    types.NewInt(0),
+		Method:   builtin.MethodsMultisig.Propose,
+		Params:   enc,
+		GasLimit: 100000,
+		GasPrice: types.NewInt(1),
+	}
+
+	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg)
+	if err != nil {
+		return cid.Undef, nil
+	}
+
+	return smsg.Cid(), nil
+}
+
+func (a *MsigAPI) MsigApprove(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	return a.msigApproveOrCancel(ctx, api.MsigApprove, msig, txID, proposer, to, amt, src, method, params)
+}
+
+func (a *MsigAPI) MsigCancel(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	return a.msigApproveOrCancel(ctx, api.MsigCancel, msig, txID, proposer, to, amt, src, method, params)
+}
+
+func (a *MsigAPI) msigApproveOrCancel(ctx context.Context, operation api.MsigProposeResponse, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+	if msig == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide multisig address")
+	}
+
+	if to == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide proposed target address")
+	}
+
+	if amt.Sign() == -1 {
+		return cid.Undef, xerrors.Errorf("must provide the positive amount that was proposed")
+	}
+
+	if src == address.Undef {
+		return cid.Undef, xerrors.Errorf("must provide source address")
+	}
+
+	if proposer.Protocol() != address.ID {
+		proposerID, err := a.StateAPI.StateLookupID(ctx, proposer, types.EmptyTSK)
+		if err != nil {
+			return cid.Undef, err
+		}
+		proposer = proposerID
+	}
+
+	p := samsig.ProposalHashData{
+		Requester: proposer,
+		To:        to,
+		Value:     amt,
+		Method:    abi.MethodNum(method),
+		Params:    params,
+	}
+
+	pser, err := p.Serialize()
+	if err != nil {
+		return cid.Undef, err
+	}
+	phash := blake2b.Sum256(pser)
+
+	enc, err := actors.SerializeParams(&samsig.TxnIDParams{
+		ID:           samsig.TxnID(txID),
+		ProposalHash: phash[:],
+	})
+
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	var msigResponseMethod abi.MethodNum
+
+	/*
+		We pass in a MsigProposeResponse instead of MethodNum to
+		tighten the possible inputs to just Approve and Cancel.
+	*/
+	switch operation {
+	case api.MsigApprove:
+		msigResponseMethod = builtin.MethodsMultisig.Approve
+	case api.MsigCancel:
+		msigResponseMethod = builtin.MethodsMultisig.Cancel
+	default:
+		return cid.Undef, xerrors.Errorf("Invalid operation for msigApproveOrCancel")
+	}
+
+	msg := &types.Message{
+		To:       msig,
+		From:     src,
+		Value:    types.NewInt(0),
+		Method:   msigResponseMethod,
+		Params:   enc,
+		GasLimit: 100000,
+		GasPrice: types.NewInt(1),
+	}
+
+	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return smsg.Cid(), nil
+}


### PR DESCRIPTION
I added the RPC commands that correspond to the cli commands and removed duplicate code so the cli refers to the RPC API. 

- `lotus send` -> `Filecoin.Send`
- `lotus msig create` -> `Filecoin.MsigCreate`
- `lotus msig propose` -> `Filecoin.MsigPropose`
- `lotus msig approve` -> `Filecoin.MsigApprove`

The cli behavior should not be affected by this, purely a structural change.

Below I attached two bash scripts that I used to test the changes. [MsigSendExample.sh.txt](https://github.com/filecoin-project/lotus/files/4576999/MsigSendExample.sh.txt) is for cli commands to make sure this change is backwards compatible, and 
[MsigRPCSendExample.sh.txt](https://github.com/filecoin-project/lotus/files/4577013/MsigRPCSendExample.sh.txt) replaces some of the cli commands to test the new RPC calls.

New RPC example calls:

Send:
```
curl -X POST -H "Content-Type: application/json" \
-H "Authorization: Bearer $(cat ~/.lotus/token)" \
--data '{"jsonrpc": "2.0","method":"Filecoin.Send",'\
'"params": ['\
'"t1by5koc5um5hz4rbuerxqf3y6uqp3s7n4txxkhoi", '\
'"1000000000000000000", '\
'"t3viyi4icxrwblk6kuvi4i3lq7x5khedhqrn6iy3x4oqxyzgpday3qca4q5kdxw3l3vkwgqxn2tpxgefsmqbqa", '\
'"0"], '\
'"id":3}' http://0.0.0.0:1511/rpc/v0 | jq
```
Output:
```
{
  "jsonrpc": "2.0",
  "result": {
    "/": "bafy2bzacebw2mou2ks2gpo6yss3fqu3iqmlpqn73k7nnx6hmcjfcseyh4f6m4"
  },
  "id": 3
}
```

MsigCreate:
```
curl -X POST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(cat ~/.lotus/token)" \
--data '{"jsonrpc": "2.0","method":"Filecoin.MsigCreate",'\
'"params": ['\
'2, '\
'["t01001", "t01002", "t01003"], '\
'"1000000000000000000", '\
'"t3viyi4icxrwblk6kuvi4i3lq7x5khedhqrn6iy3x4oqxyzgpday3qca4q5kdxw3l3vkwgqxn2tpxgefsmqbqa", '\
'"0"], '\
'"id":3}' http://0.0.0.0:1511/rpc/v0 | jq
```
Output:
```
{
  "jsonrpc": "2.0",
  "result": {
    "IDAddress": "t01004",
    "RobustAddress": "t2ljbq5usn6wp3m2veyh7qdehzp7hp2hzex52ledi"
  },
  "id": 3
}
```
MsigPropose:
```
curl -X POST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(cat ~/.lotus/token)" \
--data '{"jsonrpc": "2.0","method":"Filecoin.MsigPropose",'\
'"params": ['\
'"t23pwta2z6oezwpsr2glcrqnzuhlilqt2cbfgygmy", '\
'"t1gvza63hsouazauudnq4r7xg44dp6rwymd5ntklq", '\
'"1000000000000000000", '\
'"t01006", '\
'0, '\
'""],'\
' "id":3}' http://0.0.0.0:1511/rpc/v0 | jq
```
Output:
```
{
  "jsonrpc": "2.0",
  "result": {
    "MessageCid": {
      "/": "bafy2bzacediffrqzwsk3oxrga66haitib2jf75z24jcukiss2ejwxnragai2g"
    },
    "TransactionId": 1
  },
  "id": 3
}
```
MsigApprove:
```
curl -X POST \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $(cat ~/.lotus/token)" \
--data '{"jsonrpc": "2.0","method":"Filecoin.MsigApprove",'\
'"params": ['\
'"t23shtwmzzdwo3harzxyyw2noaxppcwvjeptz6ypq", '\
'0, '\
'"t01006", '\
'"t1gvza63hsouazauudnq4r7xg44dp6rwymd5ntklq", '\
'"1000000000000000000", '\
'"t01007", '\
'0, '\
'""], '\
'"id":3}' http://0.0.0.0:1511/rpc/v0 | jq
```
Output:
```
{
  "jsonrpc": "2.0",
  "result": {
    "/": "bafy2bzacedatacqeoicpsh7jpzi76v2gzupqor5gohfkjqlibxp72gupisr3w"
  },
  "id": 3
}
```