### PR TITLE
Add link to new conceptual docs site

### DIFF
--- a/documentation/en/getting-started.md
+++ b/documentation/en/getting-started.md
@@ -2,7 +2,7 @@
 
 Lotus is an implementation of the **Filecoin Distributed Storage Network**. You can run the Lotus software client to join the **Filecoin Testnet**.
 
-For more details about Filecoin, check out the [Filecoin Spec](https://github.com/filecoin-project/specs).
+For more details about Filecoin, check out the [Filecoin Docs](https://docs.filecoin.io) and [Filecoin Spec](https://github.com/filecoin-project/specs).
 
 ## What can I learn here?
 


### PR DESCRIPTION
Adding a suggested link to the new Filecoin docs site (docs.filecoin.io) to learn about Filecoin concepts. 