### PR TITLE
lotus dev net no longer supports 1024 sectors

### DIFF
--- a/documentation/en/local-dev-net.md
+++ b/documentation/en/local-dev-net.md
@@ -1,20 +1,20 @@
 # Setup Local Devnet
 
-Build the Lotus Binaries in debug mode, This enables the use of 1024 byte sectors.
+Build the Lotus Binaries in debug mode, This enables the use of 2048 byte sectors.
 
 ```sh
 make debug
 ```
 
-Download the 1024 byte parameters:
+Download the 2048 byte parameters:
 ```sh
-./lotus fetch-params --proving-params 1024
+./lotus fetch-params --proving-params 2048
 ```
 
 Pre-seal some sectors:
 
 ```sh
-./lotus-seed pre-seal --sector-size 1024 --num-sectors 2
+./lotus-seed pre-seal --sector-size 2048 --num-sectors 2
 ```
 
 Create the genesis block and start up the first node:


### PR DESCRIPTION
```
$ ./lotus-seed pre-seal --sector-size 1024 --num-sectors 2
2020-05-07T15:27:15.920+0800    WARN    lotus-seed      lotus-seed/main.go:53   unsupported sector size for miner: 1024
```

2048 is ok