### PR TITLE
Cache tipset validation progress

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -47,6 +47,7 @@ import (
 var log = logging.Logger("chainstore")
 
 var chainHeadKey = dstore.NewKey("head")
+var blockValidationCacheKeyPrefix = dstore.NewKey("blockValidation")
 
 type ChainStore struct {
 	bs bstore.Blockstore
@@ -213,6 +214,22 @@ func (cs *ChainStore) SubHeadChanges(ctx context.Context) chan []*api.HeadChange
 
 func (cs *ChainStore) SubscribeHeadChanges(f func(rev, app []*types.TipSet) error) {
 	cs.headChangeNotifs = append(cs.headChangeNotifs, f)
+}
+
+func (cs *ChainStore) IsBlockValidated(ctx context.Context, blkid cid.Cid) (bool, error) {
+	key := blockValidationCacheKeyPrefix.Instance(blkid.String())
+
+	return cs.ds.Has(key)
+}
+
+func (cs *ChainStore) MarkBlockAsValidated(ctx context.Context, blkid cid.Cid) error {
+	key := blockValidationCacheKeyPrefix.Instance(blkid.String())
+
+	if err := cs.ds.Put(key, []byte{0}); err != nil {
+		return xerrors.Errorf("cache block validation: %w", err)
+	}
+
+	return nil
 }
 
 func (cs *ChainStore) SetGenesis(b *types.BlockHeader) error {


### PR DESCRIPTION
Avoid tipset revalidation to speed up messages synchronization, if the lotus daemon is restarted during the process. This is especially necessary if the synchronization is behind the latest height by a lot.

Resolves: https://github.com/filecoin-project/lotus/issues/1561

This is a new PR, using the approach as discussed in: https://github.com/filecoin-project/lotus/pull/1560

