### PR TITLE
cli: Improve lotus helptext

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -210,28 +210,33 @@ func ReqContext(cctx *cli.Context) context.Context {
 }
 
 var CommonCommands = []*cli.Command{
-	authCmd,
-	fetchParamCmd,
 	netCmd,
-	versionCmd,
+	authCmd,
 	logCmd,
 	waitApiCmd,
+	fetchParamCmd,
+	versionCmd,
 }
 
 var Commands = []*cli.Command{
-	authCmd,
-	chainCmd,
-	clientCmd,
-	fetchParamCmd,
-	mpoolCmd,
-	multisigCmd,
-	netCmd,
-	paychCmd,
-	sendCmd,
-	stateCmd,
-	syncCmd,
+	withCategory("basic", sendCmd),
+	withCategory("basic", walletCmd),
+	withCategory("basic", clientCmd),
+	withCategory("basic", multisigCmd),
+	withCategory("basic", paychCmd),
+	withCategory("developer", authCmd),
+	withCategory("developer", mpoolCmd),
+	withCategory("developer", stateCmd),
+	withCategory("developer", chainCmd),
+	withCategory("developer", logCmd),
+	withCategory("developer", waitApiCmd),
+	withCategory("developer", fetchParamCmd),
+	withCategory("network", netCmd),
+	withCategory("network", syncCmd),
 	versionCmd,
-	walletCmd,
-	logCmd,
-	waitApiCmd,
+}
+
+func withCategory(cat string, cmd *cli.Command) *cli.Command {
+	cmd.Category = cat
+	return cmd
 }


### PR DESCRIPTION
This makes `./lotus` look like this:
```
NAME:
   lotus - Filecoin decentralized storage network client

USAGE:
   lotus [global options] command [command options] [arguments...]

VERSION:
   0.3.0

COMMANDS:
     daemon   Start a lotus daemon process
     version  Print version
     help, h  Shows a list of commands or help for one command
   basic:
     send    Send funds between accounts
     wallet  Manage wallet
     client  Make deals, store data, retrieve data
     msig    Interact with a multisig wallet
     paych   Manage payment channels
   developer:
     auth          Manage RPC permissions
     mpool         Manage message pool
     state         Interact with and query filecoin chain state
     chain         Interact with filecoin blockchain
     log           Manage logging
     wait-api      Wait for lotus api to come online
     fetch-params  Fetch proving parameters
   network:
     net   Manage P2P Network
     sync  Inspect or interact with the chain syncer


```