### PR TITLE
properly select channel ID to close for handleOutChans

### DIFF
--- a/lib/jsonrpc/rpc_test.go
+++ b/lib/jsonrpc/rpc_test.go
@@ -298,7 +298,7 @@ func (h *ChanHandler) Sub(ctx context.Context, i int, eq int) (<-chan int, error
 		for {
 			select {
 			case <-ctx.Done():
-				fmt.Println("ctxdone1")
+				fmt.Println("ctxdone1", i, eq)
 				return
 			case <-wait:
 			}
@@ -391,6 +391,54 @@ func TestChan(t *testing.T) {
 	serverHandler.wait <- struct{}{}
 	_, ok = <-sub
 	require.Equal(t, false, ok)
+}
+
+func TestChanClosing(t *testing.T) {
+	var client struct {
+		Sub func(context.Context, int, int) (<-chan int, error)
+	}
+
+	serverHandler := &ChanHandler{
+		wait: make(chan struct{}, 5),
+	}
+
+	rpcServer := NewServer()
+	rpcServer.Register("ChanHandler", serverHandler)
+
+	testServ := httptest.NewServer(rpcServer)
+	defer testServ.Close()
+
+	closer, err := NewClient("ws://"+testServ.Listener.Addr().String(), "ChanHandler", &client, nil)
+	require.NoError(t, err)
+
+	defer closer()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+
+	defer cancel2()
+
+	// sub
+
+	sub1, err := client.Sub(ctx1, 2, -1)
+	require.NoError(t, err)
+
+	sub2, err := client.Sub(ctx2, 3, -1)
+	require.NoError(t, err)
+
+	// recv one
+
+	serverHandler.wait <- struct{}{}
+	serverHandler.wait <- struct{}{}
+
+	require.Equal(t, 2, <-sub1)
+	require.Equal(t, 3, <-sub2)
+
+	cancel1()
+
+	serverHandler.wait <- struct{}{}
+	require.Equal(t, 0, <-sub1)
+	require.Equal(t, 6, <-sub2)
 }
 
 func TestChanServerClose(t *testing.T) {

--- a/lib/jsonrpc/websocket.go
+++ b/lib/jsonrpc/websocket.go
@@ -204,13 +204,14 @@ func (c *wsConn) handleOutChans() {
 		if !ok {
 			// Output channel closed, cleanup, and tell remote that this happened
 
+			id := caseToID[chosen-internal]
+
 			n := len(cases) - 1
 			if n > 0 {
 				cases[chosen] = cases[n]
 				caseToID[chosen-internal] = caseToID[n-internal]
 			}
 
-			id := caseToID[chosen-internal]
 			cases = cases[:n]
 			caseToID = caseToID[:n-internal]
 


### PR DESCRIPTION
havent fixed the test yet, but this test shows the simplest failure mode