### PR TITLE
install jq in /usr/local/bin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,9 +225,8 @@ jobs:
       - run:
           name: Install jq
           command: |
-            mkdir $HOME/.bin
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output $HOME/.bin/jq
-            chmod +x $HOME/.bin/jq
+            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output /usr/local/bin/jq
+            chmod +x /usr/local/bin/jq
       - restore_cache:
           name: restore go mod and cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}


### PR DESCRIPTION
/home/ognots/.bin not in path, causing macos test to fail

test build confirming solution https://circleci.com/gh/filecoin-project/lotus/24644