### PR TITLE
add some commands for interacting with verified registry actor to lot…

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -27,6 +27,7 @@ func main() {
 		commpToCidCmd,
 		fetchParamCmd,
 		proofsCmd,
+		verifRegCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"gopkg.in/urfave/cli.v2"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+)
+
+var verifRegCmd = &cli.Command{
+	Name:  "verifreg",
+	Usage: "Interact with the verified registry actor",
+	Flags: []cli.Flag{},
+	Subcommands: []*cli.Command{
+		verifRegAddVerifierCmd,
+		verifRegVerifyClientCmd,
+	},
+}
+
+var verifRegAddVerifierCmd = &cli.Command{
+	Name:  "add-verifier",
+	Usage: "make a given account a verifier",
+	Action: func(cctx *cli.Context) error {
+		fromk, err := address.NewFromString("t3qfoulel6fy6gn3hjmbhpdpf6fs5aqjb5fkurhtwvgssizq4jey5nw4ptq5up6h7jk7frdvvobv52qzmgjinq")
+		if err != nil {
+			return err
+		}
+
+		if cctx.Args().Len() != 2 {
+			return fmt.Errorf("must specify two arguments: address and allowance")
+		}
+
+		target, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+
+		allowance, err := types.BigFromString(cctx.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		params, err := actors.SerializeParams(&verifreg.AddVerifierParams{Address: target, Allowance: allowance})
+		if err != nil {
+			return err
+		}
+
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+
+		msg := &types.Message{
+			To:       builtin.VerifiedRegistryActorAddr,
+			From:     fromk,
+			Method:   builtin.MethodsVerifiedRegistry.AddVerifier,
+			GasPrice: types.NewInt(1),
+			GasLimit: 300000,
+			Params:   params,
+		}
+
+		smsg, err := api.MpoolPushMessage(ctx, msg)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("message sent, now waiting on cid: %s\n", smsg.Cid())
+
+		mwait, err := api.StateWaitMsg(ctx, smsg.Cid())
+		if err != nil {
+			return err
+		}
+
+		if mwait.Receipt.ExitCode != 0 {
+			return fmt.Errorf("failed to add verifier: %d", mwait.Receipt.ExitCode)
+		}
+
+		return nil
+
+	},
+}
+
+var verifRegVerifyClientCmd = &cli.Command{
+	Name:  "verify-client",
+	Usage: "make a given account a verified client",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "specify your verifier address to send the message from",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		froms := cctx.String("from")
+		if froms == "" {
+			return fmt.Errorf("must specify from address with --from")
+		}
+
+		fromk, err := address.NewFromString(froms)
+		if err != nil {
+			return err
+		}
+
+		if cctx.Args().Len() != 2 {
+			return fmt.Errorf("must specify two arguments: address and allowance")
+		}
+
+		target, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+
+		allowance, err := types.BigFromString(cctx.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		params, err := actors.SerializeParams(&verifreg.AddVerifiedClientParams{Address: target, Allowance: allowance})
+		if err != nil {
+			return err
+		}
+
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+
+		msg := &types.Message{
+			To:       builtin.VerifiedRegistryActorAddr,
+			From:     fromk,
+			Method:   builtin.MethodsVerifiedRegistry.AddVerifiedClient,
+			GasPrice: types.NewInt(1),
+			GasLimit: 300000,
+			Params:   params,
+		}
+
+		smsg, err := api.MpoolPushMessage(ctx, msg)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("message sent, now waiting on cid: %s\n", smsg.Cid())
+
+		mwait, err := api.StateWaitMsg(ctx, smsg.Cid())
+		if err != nil {
+			return err
+		}
+
+		if mwait.Receipt.ExitCode != 0 {
+			return fmt.Errorf("failed to add verified client: %d", mwait.Receipt.ExitCode)
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
```
$ make lotus-shed
$ ./lotus-shed verifreg --help
NAME:
   lotus-shed verifreg - Interact with the verified registry actor

USAGE:
   lotus-shed verifreg command [command options] [arguments...]

COMMANDS:
     add-verifier   make a given account a verifier
     verify-client  make a given account a verified client
     help, h        Shows a list of commands or help for one command

OPTIONS:
   --help, -h     show help (default: false)
   --version, -v  print the version (default: false)

$ ./lotus-shed verifreg verify-client --from=YOURVERIFIERADDR TARGETCLIENT 123123
```