### PR TITLE
use abs path to construct FileManager

### DIFF
--- a/node/modules/client.go
+++ b/node/modules/client.go
@@ -44,7 +44,12 @@ func ClientFstore(r repo.LockedRepo) (dtypes.ClientFilestore, error) {
 	}
 	blocks := namespace.Wrap(clientds, datastore.NewKey("blocks"))
 
-	fm := filestore.NewFileManager(clientds, filepath.Dir(r.Path()))
+	absPath, err := filepath.Abs(r.Path())
+	if err != nil {
+		return nil, err
+	}
+
+	fm := filestore.NewFileManager(clientds, filepath.Dir(absPath))
 	fm.AllowFiles = true
 	// TODO: fm.AllowUrls (needs more code in client import)
 


### PR DESCRIPTION
https://github.com/ipfs/go-filestore/blob/master/fsrefstore.go#L293-L295
this check fails if i run something like below:

```
IPFS_PATH=./repo lotus client generate-car ./repo/hello.txt ./repo/hello.txt.car
```

since `FileManager.root` is relative here, and `FilestoreNode.PosInfo.FullPath` is always abs