### PR TITLE
avoid dividing by zero if pset is empty

### DIFF
--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -102,10 +102,14 @@ var infoCmd = &cli.Command{
 		if len(faults) == 0 {
 			fmt.Printf("\tProving: %s\n", types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))))
 		} else {
+			var faultyPercentage float64
+			if secCounts.Pset != 0 {
+				faultyPercentage = float64(10000*uint64(len(faults))/secCounts.Pset) / 100.
+			}
 			fmt.Printf("\tProving: %s (%s Faulty, %.2f%%)\n",
 				types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset-uint64(len(faults))), types.NewInt(uint64(mi.SectorSize)))),
 				types.SizeStr(types.BigMul(types.NewInt(uint64(len(faults))), types.NewInt(uint64(mi.SectorSize)))),
-				float64(10000*uint64(len(faults))/secCounts.Pset)/100.)
+				faultyPercentage)
 		}
 
 		fmt.Println()


### PR DESCRIPTION
Should hopefully resolve this:

```
lotus-storage-miner info
Miner: t01002
Sector Size: 32 GiB
Byte Power:   0 B / 563 TiB (0.0000%)
Actual Power: 0  / 518 Ti (0.0000%)
	Committed: 11.2 TiB
panic: runtime error: integer divide by zero

goroutine 1 [running]:
main.glob..func1(0xc000467b90, 0x0, 0x0)
	/opt/filecoin/cmd/lotus-storage-miner/info.go:108 +0x19bb
gopkg.in/urfave/cli%2ev2.(*Command).Run(0x43feee0, 0xc000467b30, 0x0, 0x0)
	/go/pkg/mod/gopkg.in/urfave/cli.v2@v2.0.0-20180128182452-d3ae77c26ac8/command.go:167 +0x6cf
gopkg.in/urfave/cli%2ev2.(*App).Run(0xc000001800, 0xc0000c2020, 0x2, 0x2, 0x0, 0x0)
	/go/pkg/mod/gopkg.in/urfave/cli.v2@v2.0.0-20180128182452-d3ae77c26ac8/app.go:261 +0x68c
main.main()
	/opt/filecoin/cmd/lotus-storage-miner/main.go:81 +0x696
```