### PR TITLE
Pset represents the proving sectors, and Sset repensents all sectors

### DIFF
--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -103,11 +103,11 @@ var infoCmd = &cli.Command{
 			fmt.Printf("\tProving: %s\n", types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))))
 		} else {
 			var faultyPercentage float64
-			if secCounts.Pset != 0 {
-				faultyPercentage = float64(10000*uint64(len(faults))/secCounts.Pset) / 100.
+			if secCounts.Sset != 0 {
+				faultyPercentage = float64(10000*uint64(len(faults))/secCounts.Sset) / 100.
 			}
 			fmt.Printf("\tProving: %s (%s Faulty, %.2f%%)\n",
-				types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset-uint64(len(faults))), types.NewInt(uint64(mi.SectorSize)))),
+				types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))),
 				types.SizeStr(types.BigMul(types.NewInt(uint64(len(faults))), types.NewInt(uint64(mi.SectorSize)))),
 				faultyPercentage)
 		}


### PR DESCRIPTION
In my case, the correct information is `Committed 21, Proving 14, 7 Faulty 33%`.
But it shows:
```
Miner: t027999
Sector Size: 64 GiB
Byte Power:   14.2 TiB / 976 TiB (1.4541%)
Actual Power: 14.2 Ti / 899 Ti (1.5780%)
	Committed: 21.2 TiB
	Proving: 7.12 TiB (7.06 TiB Faulty, 49.77%)
```
Faulty is not a part of Proving, it's a part of Committed.