### PR TITLE
update chain-val syscalls interface

### DIFF
--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/puppet"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/ipfs/go-cid"
 
 	vtypes "github.com/filecoin-project/chain-validation/chain/types"
@@ -24,12 +25,13 @@ import (
 // Applier applies messages to state trees and storage.
 type Applier struct {
 	stateWrapper *StateWrapper
+	syscalls     runtime.Syscalls
 }
 
 var _ vstate.Applier = &Applier{}
 
-func NewApplier(sw *StateWrapper) *Applier {
-	return &Applier{sw}
+func NewApplier(sw *StateWrapper, syscalls runtime.Syscalls) *Applier {
+	return &Applier{sw, syscalls}
 }
 
 func (a *Applier) ApplyMessage(epoch abi.ChainEpoch, message *vtypes.Message) (vtypes.ApplyMessageResult, error) {
@@ -65,7 +67,7 @@ func (a *Applier) ApplySignedMessage(epoch abi.ChainEpoch, msg *vtypes.SignedMes
 }
 
 func (a *Applier) ApplyTipSetMessages(epoch abi.ChainEpoch, blocks []vtypes.BlockMessagesInfo, rnd vstate.RandomnessSource) (vtypes.ApplyTipSetResult, error) {
-	cs := store.NewChainStore(a.stateWrapper.bs, a.stateWrapper.ds, vdrivers.NewChainValidationSyscalls())
+	cs := store.NewChainStore(a.stateWrapper.bs, a.stateWrapper.ds, a.syscalls)
 	sm := stmgr.NewStateManager(cs)
 
 	var bms []stmgr.BlockMessages

--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipfs/go-cid"
 
 	vtypes "github.com/filecoin-project/chain-validation/chain/types"
-	vdrivers "github.com/filecoin-project/chain-validation/drivers"
 	vstate "github.com/filecoin-project/chain-validation/state"
 
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -136,7 +135,7 @@ func (a *Applier) applyMessage(epoch abi.ChainEpoch, lm types.ChainMsg) (vtypes.
 	ctx := context.TODO()
 	base := a.stateWrapper.Root()
 
-	lotusVM, err := vm.NewVM(base, epoch, &vmRand{}, a.stateWrapper.bs, vdrivers.NewChainValidationSyscalls())
+	lotusVM, err := vm.NewVM(base, epoch, &vmRand{}, a.stateWrapper.bs, a.syscalls)
 	// need to modify the VM invoker to add the puppet actor
 	chainValInvoker := vm.NewInvoker()
 	chainValInvoker.Register(puppet.PuppetActorCodeID, puppet.Actor{}, puppet.State{})

--- a/chain/validation/factories.go
+++ b/chain/validation/factories.go
@@ -1,11 +1,9 @@
 package validation
 
 import (
-	"context"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
 
 	vstate "github.com/filecoin-project/chain-validation/state"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
 )
 
 type Factories struct {
@@ -18,24 +16,13 @@ func NewFactories() *Factories {
 	return &Factories{}
 }
 
-func (f *Factories) NewStateAndApplier() (vstate.VMWrapper, vstate.Applier) {
+func (f *Factories) NewStateAndApplier(syscalls runtime.Syscalls) (vstate.VMWrapper, vstate.Applier) {
 	st := NewState()
-	return st, NewApplier(st)
+	return st, NewApplier(st, syscalls)
 }
 
 func (f *Factories) NewKeyManager() vstate.KeyManager {
 	return newKeyManager()
-}
-
-type fakeRandSrc struct {
-}
-
-func (r fakeRandSrc) Randomness(_ context.Context, _ acrypto.DomainSeparationTag, _ abi.ChainEpoch, _ []byte) (abi.Randomness, error) {
-	return abi.Randomness("sausages"), nil
-}
-
-func (f *Factories) NewRandomnessSource() vstate.RandomnessSource {
-	return &fakeRandSrc{}
 }
 
 func (f *Factories) NewValidationConfig() vstate.ValidationConfig {

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/drand/drand v0.8.2-0.20200518165838-d61135e6e2c8
 	github.com/fatih/color v1.8.0
-	github.com/filecoin-project/chain-validation v0.0.6-0.20200518190139-483332336e8e
-	github.com/filecoin-project/filecoin-ffi v0.0.0-20200427223233-a0014b17f124
+	github.com/filecoin-project/chain-validation v0.0.6-0.20200526171800-c56c1882dc99
+	github.com/filecoin-project/filecoin-ffi v0.26.1-0.20200508175440-05b30afeb00d
 	github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef
 	github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2
 	github.com/filecoin-project/go-bitfield v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:Jp
 github.com/fatih/color v1.8.0 h1:5bzFgL+oy7JITMTxUPJ00n7VxmYd/PdMp5mHFX40/RY=
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
-github.com/filecoin-project/chain-validation v0.0.6-0.20200518190139-483332336e8e h1:3x2eL2t3ZkMOHt1b5WS5aVWyJeo5+WjWCT77QdPGSwk=
-github.com/filecoin-project/chain-validation v0.0.6-0.20200518190139-483332336e8e/go.mod h1:6B3uenDcH8n+PKqgzUtZmgyCzKy4qpiLwJ5aw7Rj2xQ=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200526171800-c56c1882dc99 h1:jVuyHbsCX/w4vZ+3pO0cqzOyqvwfo8tB94wzmcwaD2k=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200526171800-c56c1882dc99/go.mod h1:hMqMCTt3z+wZ+GL74uy7X4NptnucZTTrb5SUTt1L/0g=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef h1:Wi5E+P1QfHP8IF27eUiTx5vYfqQZwfPxzq3oFEq8w8U=


### PR DESCRIPTION
### Motivation
required for https://github.com/filecoin-project/chain-validation/pull/208

### Whats left
- [x] merge chain-validation https://github.com/filecoin-project/chain-validation/pull/208 and update go.mod with version.
- [ ] figure out if the linter error `ERRO Timeout exceeded: try increasing it by passing --timeout option` was caused by a change here or something else.