### PR TITLE
sink message topic deliveries

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -143,6 +143,13 @@ func (bv *BlockValidator) flagPeer(p peer.ID) {
 }
 
 func (bv *BlockValidator) Validate(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+	// track validation time
+	begin := time.Now()
+	defer func() {
+		end := time.Now()
+		log.Infof("block validation time: %s", end.Sub(begin))
+	}()
+
 	stats.Record(ctx, metrics.BlockReceived.M(1))
 
 	recordFailure := func(what string) {

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -127,7 +127,8 @@ func GossipSub(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host, nn dtyp
 						// deliveries decay after 10min, cap at 1000 tx
 						FirstMessageDeliveriesWeight: 0.5, // max value is 500
 						FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(10 * time.Minute),
-						FirstMessageDeliveriesCap:    1000,
+						//FirstMessageDeliveriesCap:    1000,
+						FirstMessageDeliveriesCap: 1, // we can't yet properly validate them so only confer a tiny boost from delivery
 
 						// Mesh Delivery Failure is currently turned off for messages
 						// This is on purpose as the network is still too small, which results in


### PR DESCRIPTION
@schomatis suggested that we can't really validate them (yet), so we shouldn't confer any meaningful score advantage for first message deliveries in the `msgs` topic.

This sets the cap to the minimal value of 1, so that message deliveries confer at most a tiny (0.025) score advantage.

Also adds a log for the block validation time, as this appears to be an issue.