### PR TITLE
Unconditionally disable relay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/libp2p/go-eventbus v0.1.0
 	github.com/libp2p/go-libp2p v0.9.2
-	github.com/libp2p/go-libp2p-circuit v0.2.2
 	github.com/libp2p/go-libp2p-connmgr v0.2.3
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/libp2p/go-libp2p-discovery v0.4.0

--- a/node/builder.go
+++ b/node/builder.go
@@ -169,7 +169,7 @@ func libp2p() Option {
 		Override(DiscoveryHandlerKey, lp2p.DiscoveryHandler),
 		Override(AddrsFactoryKey, lp2p.AddrsFactory(nil, nil)),
 		Override(SmuxTransportKey, lp2p.SmuxTransport(true)),
-		Override(RelayKey, lp2p.Relay(true, false)),
+		Override(RelayKey, lp2p.NoRelay()),
 		Override(SecurityKey, lp2p.Security(true, true)),
 
 		Override(BaseRoutingKey, lp2p.BaseRouting),


### PR DESCRIPTION
It's an attack vector for cheap eclipse attacks. Plus we really don't need relay for a storage network.