### PR TITLE
Allow remote IPFS node support & IPFS for data retrieval & automatic env wiring

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -117,7 +117,7 @@ type FullNode interface {
 	ClientListDeals(ctx context.Context) ([]DealInfo, error)
 	ClientHasLocal(ctx context.Context, root cid.Cid) (bool, error)
 	ClientFindData(ctx context.Context, root cid.Cid) ([]QueryOffer, error)
-	ClientRetrieve(ctx context.Context, order RetrievalOrder, ref FileRef) error
+	ClientRetrieve(ctx context.Context, order RetrievalOrder, ref *FileRef) error
 	ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)
 	ClientCalcCommP(ctx context.Context, inpath string, miner address.Address) (*CommPRet, error)
 	ClientGenCar(ctx context.Context, ref FileRef, outpath string) error

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -110,7 +110,7 @@ type FullNodeStruct struct {
 		ClientStartDeal   func(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error)                             `perm:"admin"`
 		ClientGetDealInfo func(context.Context, cid.Cid) (*api.DealInfo, error)                                                `perm:"read"`
 		ClientListDeals   func(ctx context.Context) ([]api.DealInfo, error)                                                    `perm:"write"`
-		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, ref api.FileRef) error                           `perm:"admin"`
+		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error                          `perm:"admin"`
 		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error) `perm:"read"`
 		ClientCalcCommP   func(ctx context.Context, inpath string, miner address.Address) (*api.CommPRet, error)               `perm:"read"`
 		ClientGenCar      func(ctx context.Context, ref api.FileRef, outpath string) error                                     `perm:"write"`
@@ -321,7 +321,7 @@ func (c *FullNodeStruct) ClientListDeals(ctx context.Context) ([]api.DealInfo, e
 	return c.Internal.ClientListDeals(ctx)
 }
 
-func (c *FullNodeStruct) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref api.FileRef) error {
+func (c *FullNodeStruct) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error {
 	return c.Internal.ClientRetrieve(ctx, order, ref)
 }
 

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -200,7 +200,7 @@ func testRetrieval(t *testing.T, ctx context.Context, err error, client *impl.Fu
 		t.Fatal(err)
 	}
 
-	ref := api.FileRef{
+	ref := &api.FileRef{
 		Path:  filepath.Join(rpath, "ret"),
 		IsCAR: carExport,
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -384,7 +384,7 @@ var clientRetrieveCmd = &cli.Command{
 			return nil
 		}
 
-		ref := lapi.FileRef{
+		ref := &lapi.FileRef{
 			Path:  cctx.Args().Get(1),
 			IsCAR: cctx.Bool("car"),
 		}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/ipfs/interface-go-ipfs-core v0.2.3
 	github.com/ipld/go-car v0.1.1-0.20200430185908-8ff2e52a4c88
 	github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.2.0
 	github.com/libp2p/go-eventbus v0.1.0
 	github.com/libp2p/go-libp2p v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -482,6 +482,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/lib/ipfsbstore/ipfsbstore.go
+++ b/lib/ipfsbstore/ipfsbstore.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -27,6 +28,18 @@ func NewIpfsBstore(ctx context.Context) (*IpfsBstore, error) {
 	api, err := httpapi.NewLocalApi()
 	if err != nil {
 		return nil, xerrors.Errorf("getting local ipfs api: %w", err)
+	}
+
+	return &IpfsBstore{
+		ctx: ctx,
+		api: api,
+	}, nil
+}
+
+func NewRemoteIpfsBstore(ctx context.Context, maddr multiaddr.Multiaddr) (*IpfsBstore, error) {
+	api, err := httpapi.NewApi(maddr)
+	if err != nil {
+		return nil, xerrors.Errorf("getting remote ipfs api: %w", err)
 	}
 
 	return &IpfsBstore{

--- a/node/builder.go
+++ b/node/builder.go
@@ -378,11 +378,17 @@ func ConfigFullNode(c interface{}) Option {
 		return Error(xerrors.Errorf("invalid config from repo, got: %T", c))
 	}
 
+	remoteIpfsMaddrNotEmpty := func(s *Settings) bool {
+		return len(cfg.Client.RemoteIpfsMAddr) > 0
+	}
+
 	return Options(
 		ConfigCommon(&cfg.Common),
 		If(cfg.Client.UseIpfs,
 			Override(new(dtypes.ClientBlockstore), modules.IpfsClientBlockstore),
 		),
+		ApplyIf(remoteIpfsMaddrNotEmpty,
+			Override(new(dtypes.ClientBlockstore), modules.IpfsRemoteClientBlockstore(cfg.Client.RemoteIpfsMAddr))),
 
 		If(cfg.Metrics.HeadNotifs,
 			Override(HeadMetricsKey, metrics.SendHeadNotifs(cfg.Metrics.Nickname)),

--- a/node/builder.go
+++ b/node/builder.go
@@ -378,18 +378,13 @@ func ConfigFullNode(c interface{}) Option {
 		return Error(xerrors.Errorf("invalid config from repo, got: %T", c))
 	}
 
-	remoteIpfsMaddrNotEmpty := func(s *Settings) bool {
-		return len(cfg.Client.RemoteIpfsMAddr) > 0
-	}
-
+	ipfsMaddr := cfg.Client.IpfsMAddr
+	useForRetrieval := cfg.Client.IpfsUseForRetrieval
 	return Options(
 		ConfigCommon(&cfg.Common),
 		If(cfg.Client.UseIpfs,
-			Override(new(dtypes.ClientBlockstore), modules.IpfsClientBlockstore),
+			Override(new(dtypes.ClientBlockstore), modules.IpfsClientBlockstore(ipfsMaddr, useForRetrieval)),
 		),
-		ApplyIf(remoteIpfsMaddrNotEmpty,
-			Override(new(dtypes.ClientBlockstore), modules.IpfsRemoteClientBlockstore(cfg.Client.RemoteIpfsMAddr))),
-
 		If(cfg.Metrics.HeadNotifs,
 			Override(HeadMetricsKey, metrics.SendHeadNotifs(cfg.Metrics.Nickname)),
 		),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -62,8 +62,9 @@ type Metrics struct {
 }
 
 type Client struct {
-	UseIpfs         bool
-	RemoteIpfsMAddr string
+	UseIpfs             bool
+	IpfsMAddr           string
+	IpfsUseForRetrieval bool
 }
 
 func defCommon() Common {

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -62,7 +62,8 @@ type Metrics struct {
 }
 
 type Client struct {
-	UseIpfs bool
+	UseIpfs         bool
+	RemoteIpfsMAddr string
 }
 
 func defCommon() Common {

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/kelseyhightower/envconfig"
 	"golang.org/x/xerrors"
 )
 
@@ -30,6 +32,11 @@ func FromReader(reader io.Reader, def interface{}) (interface{}, error) {
 	_, err := toml.DecodeReader(reader, cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	err = envconfig.Process("LOTUS", cfg)
+	if err != nil {
+		return nil, fmt.Errorf("processing env vars overrides: %s", err)
 	}
 
 	return cfg, nil

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -302,7 +302,7 @@ func (a *API) ClientListImports(ctx context.Context) ([]api.Import, error) {
 	}
 }
 
-func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref api.FileRef) error {
+func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error {
 	if order.MinerPeerID == "" {
 		mi, err := a.StateMinerInfo(ctx, order.Miner, types.EmptyTSK)
 		if err != nil {
@@ -352,6 +352,11 @@ func (a *API) ClientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 	}
 
 	unsubscribe()
+
+	// If ref is nil, it only fetches the data into the configured blockstore.
+	if ref == nil {
+		return nil
+	}
 
 	if ref.IsCAR {
 		f, err := os.OpenFile(ref.Path, os.O_CREATE|os.O_WRONLY, 0644)

--- a/node/modules/ipfsclient.go
+++ b/node/modules/ipfsclient.go
@@ -20,12 +20,14 @@ import (
 // The flag useForRetrieval indicates if the IPFS node will also be used for storing retrieving deals.
 func IpfsClientBlockstore(ipfsMaddr string, useForRetrieval bool) func(helpers.MetricsCtx, fx.Lifecycle, dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, fstore dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
-		ma, err := multiaddr.NewMultiaddr(ipfsMaddr)
-		if err != nil {
-			return nil, xerrors.Errorf("parsing ipfs multiaddr: %w", err)
-		}
+		var err error
 		var ipfsbs *ipfsbstore.IpfsBstore
 		if ipfsMaddr != "" {
+			var ma multiaddr.Multiaddr
+			ma, err = multiaddr.NewMultiaddr(ipfsMaddr)
+			if err != nil {
+				return nil, xerrors.Errorf("parsing ipfs multiaddr: %w", err)
+			}
 			ipfsbs, err = ipfsbstore.NewRemoteIpfsBstore(helpers.LifecycleCtx(mctx, lc), ma)
 		} else {
 			ipfsbs, err = ipfsbstore.NewIpfsBstore(helpers.LifecycleCtx(mctx, lc))

--- a/node/modules/ipfsclient.go
+++ b/node/modules/ipfsclient.go
@@ -14,32 +14,30 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 )
 
-func IpfsClientBlockstore(mctx helpers.MetricsCtx, lc fx.Lifecycle, fstore dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
-	ipfsbs, err := ipfsbstore.NewIpfsBstore(helpers.LifecycleCtx(mctx, lc))
-	if err != nil {
-		return nil, xerrors.Errorf("constructing ipfs blockstore: %w", err)
-	}
-
-	return bufbstore.NewTieredBstore(
-		ipfsbs,
-		blockstore.NewIdStore((*filestore.Filestore)(fstore)),
-	), nil
-}
-
-func IpfsRemoteClientBlockstore(ipfsMaddr string) func(helpers.MetricsCtx, fx.Lifecycle, dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
+// IpfsClientBlockstore returns a ClientBlockstore implementation backed by an IPFS node.
+// If ipfsMaddr is empty, a local IPFS node is assumed considering IPFS_PATH configuration.
+// If ipfsMaddr is not empty, it will connect to the remote IPFS node with the provided multiaddress.
+// The flag useForRetrieval indicates if the IPFS node will also be used for storing retrieving deals.
+func IpfsClientBlockstore(ipfsMaddr string, useForRetrieval bool) func(helpers.MetricsCtx, fx.Lifecycle, dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, fstore dtypes.ClientFilestore) (dtypes.ClientBlockstore, error) {
 		ma, err := multiaddr.NewMultiaddr(ipfsMaddr)
 		if err != nil {
 			return nil, xerrors.Errorf("parsing ipfs multiaddr: %w", err)
 		}
-		ipfsbs, err := ipfsbstore.NewRemoteIpfsBstore(helpers.LifecycleCtx(mctx, lc), ma)
+		var ipfsbs *ipfsbstore.IpfsBstore
+		if ipfsMaddr != "" {
+			ipfsbs, err = ipfsbstore.NewRemoteIpfsBstore(helpers.LifecycleCtx(mctx, lc), ma)
+		} else {
+			ipfsbs, err = ipfsbstore.NewIpfsBstore(helpers.LifecycleCtx(mctx, lc))
+		}
 		if err != nil {
 			return nil, xerrors.Errorf("constructing ipfs blockstore: %w", err)
 		}
-
-		return bufbstore.NewTieredBstore(
-			ipfsbs,
-			blockstore.NewIdStore((*filestore.Filestore)(fstore)),
-		), nil
+		var ws blockstore.Blockstore
+		ws = ipfsbs
+		if !useForRetrieval {
+			ws = blockstore.NewIdStore((*filestore.Filestore)(fstore))
+		}
+		return bufbstore.NewTieredBstore(ipfsbs, ws), nil
 	}
 }

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -3,14 +3,13 @@ package repo
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/filecoin-project/sector-storage/stores"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-
-	"github.com/filecoin-project/sector-storage/stores"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -277,7 +276,7 @@ func (fsr *fsLockedRepo) Datastore(ns string) (datastore.Batching, error) {
 	return namespace.Wrap(fsr.ds, datastore.NewKey(ns)), nil
 }
 
-func (fsr *fsLockedRepo) Config() (df interface{}, err error) {
+func (fsr *fsLockedRepo) Config() (interface{}, error) {
 	if err := fsr.stillValid(); err != nil {
 		return nil, err
 	}

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -3,13 +3,14 @@ package repo
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/filecoin-project/sector-storage/stores"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/filecoin-project/sector-storage/stores"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -276,7 +277,7 @@ func (fsr *fsLockedRepo) Datastore(ns string) (datastore.Batching, error) {
 	return namespace.Wrap(fsr.ds, datastore.NewKey(ns)), nil
 }
 
-func (fsr *fsLockedRepo) Config() (interface{}, error) {
+func (fsr *fsLockedRepo) Config() (df interface{}, err error) {
 	if err := fsr.stillValid(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR has three changes.

**Automatic environment variables wiring for .toml config file**
Currently, a user can only change configuration attributes in a .toml file. Now a `LOTUS_` prefix is wired to be considered for changing these attributes.
The env variable name respects the logical grouping, some examples of use:
- `LOTUS_API_LISTENADDRESS=...`
- `LOTUS_CLIENT_USEIPFS=...`
- `LOTUS_METRICS_NICKNAME=...`

Environment variables _takes precedence_ over configurations in the .toml file, as usually expected.

**Allow using a remote IPFS node as the underlying blockstore**
This extends the work done #1641. That meant using a local IPFS node as the underlying block storage for getting data to start deals.
This PRs adds two extra features:
- It allows to use of a remote IPFS node providing its multiaddress API.
- It allows to optionally also use IPFS for storing retrieved data from deals.

This is mapped in the following attributes in the .toml file:
```toml
[Client]
# UseIpfs = false
# IpfsMAddr = ""
# IpfsUseForRetrieval = false
```
(by default setup).

The `UseIpfs` flag was done in #1641. Now, if `UseIpfs=true` and want to use a remote IPFS node, its corresponding multiaddr should be set, e.g: `IpfsMAddr=/ip4/172.0.9.1/tcp/5001`.
This will use the IPFS node only as a source of retrieving data to make new deals.
In case you also want to store data in IPFS when data is retrieved from deals, set `IpfsUseForRetrieval=true` (saying it differently, IPFS is the Get&Put blockstore for Lotus).

Considering previous point feature, you can also set via envs: `LOTUS_CLIENT_USEIPFS=true`, `LOTUS_CLIENT_IPFSMADDR=...`, etc.

**Allow "fetching" data instead of necessarily retrieving it to files**
Considering the new feature `IpfsUseForRetrieval`, now allow to "fetch" a Deal data without necessarily dealing with storing the result in files but just feeding IPFS with it.
This basically means that after the call ends, the data will be available in the underlying configured IPFS node for retrieval. This is convenient to avoid dealing with files or duplicating data that we already "fed" into the IPFS node.

To use this feature, call the `ClientRetrieve` API with a `nil` `*apil.FileRef` (now a pointer).


From birds-eye, now Lotus can entirely rely on IPFS for data storage to make deals and retrieve them.

cc @whyrusleeping  @magik6k 
