### PR TITLE
use SysErrSerialization inside Runtime#Put, as per specs-actors

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -124,7 +125,7 @@ func (rs *Runtime) Put(x vmr.CBORMarshaler) cid.Cid {
 	c, err := rs.cst.Put(context.TODO(), x)
 	if err != nil {
 		if xerrors.As(err, new(cbor.SerializationError)) {
-			panic(aerrors.Newf(exitcode.ErrSerialization, "failed to marshal cbor object %s", err))
+			panic(aerrors.Newf(exitcode.SysErrSerialization, "failed to marshal cbor object %s", err))
 		}
 		panic(aerrors.Fatalf("failed to put cbor object: %s", err))
 	}

--- a/chain/vm/runtime_test.go
+++ b/chain/vm/runtime_test.go
@@ -33,7 +33,7 @@ func TestRuntimePutErrors(t *testing.T) {
 			t.Fatal("expected non-fatal actor error")
 		}
 
-		if aerr.RetCode() != exitcode.ErrSerialization {
+		if aerr.RetCode() != exitcode.SysErrSerialization {
 			t.Fatal("expected serialization error")
 		}
 	}()


### PR DESCRIPTION
## Why does this PR exist?

A CBOR marshaling error produced from `Runtime#Put` aborts an operation with `ErrSerialization`, but it should instead abort with `SysErrSerialization` as per [specs-actors](https://github.com/filecoin-project/specs-actors/blob/d1d76033b266eb40280049f83861cd6f8bc33bb3/actors/runtime/exitcode/reserved.go#L42). 

## What's in this PR?

This PR replaces the `ErrSerialization` with `SysErrSerialization` in `Runtime#Put`.