### PR TITLE
update scripts and docs to use human-readable sector size

### DIFF
--- a/documentation/en/local-dev-net.md
+++ b/documentation/en/local-dev-net.md
@@ -14,7 +14,7 @@ Download the 2048 byte parameters:
 Pre-seal some sectors:
 
 ```sh
-./lotus-seed pre-seal --sector-size 2048 --num-sectors 2
+./lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
 ```
 
 Create the genesis block and start up the first node:
@@ -34,7 +34,7 @@ Then, in another console, import the genesis miner key:
 Set up the genesis miner:
 
 ```sh
-./lotus-storage-miner init --genesis-miner --actor=t01000 --sector-size=2048 --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
+./lotus-storage-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
 ```
 
 Now, finally, start up the miner:

--- a/documentation/en/mining-troubleshooting.md
+++ b/documentation/en/mining-troubleshooting.md
@@ -51,7 +51,7 @@ If you suspect that your GPU is not being used, first make sure it is properly c
 First, to watch GPU utilization run `nvtop` in one terminal, then in a separate terminal, run:
 
 ```sh
-lotus-bench --sector-size=2048
+lotus-bench --sector-size=2KiB
 ```
 
 This process uses a fair amount of GPU, and generally takes ~4 minutes to complete. If you do not see any activity in nvtop from lotus during the entire process, it is likely something is misconfigured with your GPU.

--- a/scripts/dev/gen-daemon
+++ b/scripts/dev/gen-daemon
@@ -4,7 +4,7 @@ set -o xtrace
 
 export TRUST_PARAMS=1
 
-go run -tags=debug ./cmd/lotus-seed pre-seal --sector-size 2048 --num-sectors 2
+go run -tags=debug ./cmd/lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
 go run -tags=debug ./cmd/lotus-seed genesis new localnet.json
 go run -tags=debug ./cmd/lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json
 go run -tags=debug ./cmd/lotus daemon --lotus-make-genesis=devel.gen --genesis-template=localnet.json --bootstrap=false

--- a/scripts/devnet.bash
+++ b/scripts/devnet.bash
@@ -12,11 +12,11 @@ faucet="http://t01000.miner.interopnet.kittyhawk.wtf"
 
 PLEDGE_COUNT="${1:-20}"
 
-if [ -z "$BRANCH" ]; then 
+if [ -z "$BRANCH" ]; then
   BRANCH="interopnet"
 fi
 
-if [ -z "$BUILD" ]; then 
+if [ -z "$BUILD" ]; then
   BUILD="no"
 fi
 
@@ -65,7 +65,7 @@ cat > "${BASEDIR}/scripts/create_miner.bash" <<EOF
 set -x
 
 lotus wallet import ~/.genesis-sectors/pre-seal-t01000.key
-lotus-storage-miner init --genesis-miner --actor=t01000 --sector-size=2048 --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
+lotus-storage-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
 EOF
 
 cat > "${BASEDIR}/scripts/pledge_sectors.bash" <<EOF

--- a/scripts/init-network.sh
+++ b/scripts/init-network.sh
@@ -3,7 +3,7 @@
 set -xeo
 
 NUM_SECTORS=2
-SECTOR_SIZE=2048
+SECTOR_SIZE=2KiB
 
 
 sdt0111=$(mktemp -d)


### PR DESCRIPTION
Fixes #1174 in combination with commit `fa863595` (already in master).

## Why does this PR exist?

Commit `fa863595` modified various CLI commands to accept a human-readable sector size. We should update docs and scripts, too.