### PR TITLE
[WIP] first take at a `lotus daemon stop` command

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -135,6 +135,11 @@ var DaemonCmd = &cli.Command{
 			return xerrors.Errorf("repo init error: %w", err)
 		}
 
+		err = setDaemonPID(r, os.Getpid())
+		if err != nil {
+			return xerrors.Errorf("setting daemon pid: %w", err)
+		}
+
 		if err := paramfetch.GetParams(build.ParametersJson(), 0); err != nil {
 			return xerrors.Errorf("fetching proof parameters: %w", err)
 		}
@@ -223,19 +228,17 @@ var DaemonCmd = &cli.Command{
 
 		// TODO: properly parse api endpoint (or make it a URL)
 		return serveRPC(api, func(ctx context.Context) error {
-			err = setDaemonPID(r, os.Getpid())
+			err := stop(ctx)
 			if err != nil {
-				return xerrors.Errorf("setting daemon pid: %w", err)
+				return xerrors.Errorf("stopping node: %w", err)
 			}
 
-			return nil
-		}, func(ctx context.Context) error {
 			err = setDaemonPID(r, 0)
 			if err != nil {
 				return xerrors.Errorf("setting daemon pid to zero: %w", err)
 			}
 
-			return stop(ctx)
+			return nil
 		}, endpoint)
 	},
 	Subcommands: []*cli.Command{

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -367,6 +367,6 @@ func setDaemonPID(r repo.Repo, pid int) error {
 	}
 	defer lr.Close()
 
-	log.Info("setting daemon pid to %d", pid)
+	log.Infof("setting daemon pid to %d", pid)
 	return lr.SetDaemonPID(pid)
 }

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -227,19 +227,7 @@ var DaemonCmd = &cli.Command{
 		}
 
 		// TODO: properly parse api endpoint (or make it a URL)
-		return serveRPC(api, func(ctx context.Context) error {
-			err := stop(ctx)
-			if err != nil {
-				return xerrors.Errorf("stopping node: %w", err)
-			}
-
-			err = setDaemonPID(r, 0)
-			if err != nil {
-				return xerrors.Errorf("setting daemon pid to zero: %w", err)
-			}
-
-			return nil
-		}, endpoint)
+		return serveRPC(api, stop, endpoint)
 	},
 	Subcommands: []*cli.Command{
 		daemonStopCmd,

--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -27,7 +27,7 @@ import (
 
 var log = logging.Logger("main")
 
-func serveRPC(a api.FullNode, beforeServerStart, afterServerStop func(context.Context) error, addr multiaddr.Multiaddr) error {
+func serveRPC(a api.FullNode, afterServerStop func(context.Context) error, addr multiaddr.Multiaddr) error {
 	rpcServer := jsonrpc.NewServer()
 	rpcServer.Register("Filecoin", apistruct.PermissionedFullAPI(a))
 
@@ -72,11 +72,6 @@ func serveRPC(a api.FullNode, beforeServerStart, afterServerStop func(context.Co
 		}
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
-
-	err = beforeServerStart(context.TODO())
-	if err != nil {
-		return xerrors.Errorf("before server start func failed: %w", err)
-	}
 
 	return srv.Serve(manet.NetListener(lst))
 }

--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/apistruct"
+	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/impl"
 )
 
 var log = logging.Logger("main")
 
-func serveRPC(a api.FullNode, afterServerStop func(context.Context) error, addr multiaddr.Multiaddr) error {
+func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr) error {
 	rpcServer := jsonrpc.NewServer()
 	rpcServer.Register("Filecoin", apistruct.PermissionedFullAPI(a))
 
@@ -67,7 +68,7 @@ func serveRPC(a api.FullNode, afterServerStop func(context.Context) error, addr 
 		if err := srv.Shutdown(context.TODO()); err != nil {
 			log.Errorf("shutting down RPC server failed: %s", err)
 		}
-		if err := afterServerStop(context.TODO()); err != nil {
+		if err := stop(context.TODO()); err != nil {
 			log.Errorf("graceful shutting down failed: %s", err)
 		}
 	}()

--- a/node/repo/interface.go
+++ b/node/repo/interface.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	ErrNoAPIEndpoint     = errors.New("API not running (no endpoint)")
+	ErrNoDaemonPID       = errors.New("daemon not running (no pid)")
 	ErrNoAPIToken        = errors.New("API token not set")
 	ErrRepoAlreadyLocked = errors.New("repo is already locked (lotus daemon already running)")
 	ErrClosedRepo        = errors.New("repo is no longer open")
@@ -24,6 +25,9 @@ type Repo interface {
 
 	// APIToken returns JWT API Token for use in operations that require auth
 	APIToken() ([]byte, error)
+
+	// DaemonPID returns the process id for the most recently-run daemon.
+	DaemonPID() (int, error)
 
 	// Lock locks the repo for exclusive use.
 	Lock(RepoType) (LockedRepo, error)
@@ -45,6 +49,10 @@ type LockedRepo interface {
 	// SetAPIEndpoint sets the endpoint of the current API
 	// so it can be read by API clients
 	SetAPIEndpoint(multiaddr.Multiaddr) error
+
+	// SetDaemonPID sets the daemon process id in the repo so that it can be
+	// read by the `daemon stop` command.
+	SetDaemonPID(int) error
 
 	// SetAPIToken sets JWT API Token for CLI
 	SetAPIToken([]byte) error


### PR DESCRIPTION
Moving down the list; fixes #1827.

## What's in this PR?

This changeset persists the daemon process id to the repo when the `lotus daemon` command runs (but before the RPC server has started). A new command, `lotus daemon stop`, reads the persisted pid and sends that process a `SIGTERM`.

## Alternatives

An alternative approach might involve a singleton termination channel to which the daemon process sends a value when handling an inbound `lotus daemon stop` RPC. We'd listen for values on that channel in addition to the existing SIGTERM and SIGINT channel, terminating the RPC server if a value was seen. More software, and would involve a global singleton.