### PR TITLE
add (sub)commands which shut down lotus daemon and storage miner

### DIFF
--- a/api/api_common.go
+++ b/api/api_common.go
@@ -34,6 +34,9 @@ type Common interface {
 
 	LogList(context.Context) ([]string, error)
 	LogSetLevel(context.Context, string, string) error
+
+	// trigger graceful shutdown
+	Shutdown(context.Context) error
 }
 
 // Version provides various build-time information

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -47,6 +47,8 @@ type CommonStruct struct {
 
 		LogList     func(context.Context) ([]string, error)     `perm:"write"`
 		LogSetLevel func(context.Context, string, string) error `perm:"write"`
+
+		Shutdown func(context.Context) error `perm:"admin"`
 	}
 }
 
@@ -291,6 +293,10 @@ func (c *CommonStruct) LogList(ctx context.Context) ([]string, error) {
 
 func (c *CommonStruct) LogSetLevel(ctx context.Context, group, level string) error {
 	return c.Internal.LogSetLevel(ctx, group, level)
+}
+
+func (c *CommonStruct) Shutdown(ctx context.Context) error {
+	return c.Internal.Shutdown(ctx)
 }
 
 // FullNodeStruct

--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -290,7 +290,7 @@ var runCmd = &cli.Command{
 
 		go func() {
 			<-ctx.Done()
-			log.Warn("Shutting down..")
+			log.Warn("Shutting down...")
 			if err := srv.Shutdown(context.TODO()); err != nil {
 				log.Errorf("shutting down RPC server failed: %s", err)
 			}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -27,6 +27,7 @@ func main() {
 		initCmd,
 		rewardsCmd,
 		runCmd,
+		stopCmd,
 		sectorsCmd,
 		storageCmd,
 		setPriceCmd,

--- a/cmd/lotus-storage-miner/run.go
+++ b/cmd/lotus-storage-miner/run.go
@@ -105,7 +105,7 @@ var runCmd = &cli.Command{
 		var minerapi api.StorageMiner
 		stop, err := node.New(ctx,
 			node.StorageMiner(&minerapi),
-			node.Override(new(dtypes.ShutdownCh), shutdownChan),
+			node.Override(new(dtypes.ShutdownChan), shutdownChan),
 			node.Online(),
 			node.Repo(r),
 

--- a/cmd/lotus-storage-miner/stop.go
+++ b/cmd/lotus-storage-miner/stop.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	_ "net/http/pprof"
+
+	"gopkg.in/urfave/cli.v2"
+
+	lcli "github.com/filecoin-project/lotus/cli"
+)
+
+var stopCmd = &cli.Command{
+	Name:  "stop",
+	Usage: "Stop a running lotus storage miner",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		err = api.Shutdown(lcli.ReqContext(cctx))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -44,6 +44,15 @@ const (
 	preTemplateFlag = "genesis-template"
 )
 
+var daemonStopCmd = &cli.Command{
+	Name:  "stop",
+	Usage: "Stop a running lotus daemon",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		panic("wombat attack")
+	},
+}
+
 // DaemonCmd is the `go-lotus daemon` command
 var DaemonCmd = &cli.Command{
 	Name:  "daemon",
@@ -222,6 +231,9 @@ var DaemonCmd = &cli.Command{
 
 		// TODO: properly parse api endpoint (or make it a URL)
 		return serveRPC(api, stop, endpoint)
+	},
+	Subcommands: []*cli.Command{
+		daemonStopCmd,
 	},
 }
 

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -191,7 +191,7 @@ var DaemonCmd = &cli.Command{
 			genesis = node.Override(new(modules.Genesis), testing.MakeGenesis(cctx.String(makeGenFlag), cctx.String(preTemplateFlag)))
 		}
 
-		shutdownCh := make(chan struct{})
+		shutdownChan := make(chan struct{})
 
 		var api api.FullNode
 
@@ -199,7 +199,7 @@ var DaemonCmd = &cli.Command{
 			node.FullAPI(&api),
 
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
-			node.Override(new(dtypes.ShutdownCh), shutdownCh),
+			node.Override(new(dtypes.ShutdownCh), shutdownChan),
 			node.Online(),
 			node.Repo(r),
 
@@ -245,7 +245,7 @@ var DaemonCmd = &cli.Command{
 		}
 
 		// TODO: properly parse api endpoint (or make it a URL)
-		return serveRPC(api, stop, endpoint, shutdownCh)
+		return serveRPC(api, stop, endpoint, shutdownChan)
 	},
 	Subcommands: []*cli.Command{
 		daemonStopCmd,

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -199,7 +199,7 @@ var DaemonCmd = &cli.Command{
 			node.FullAPI(&api),
 
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
-			node.Override(new(dtypes.ShutdownCh), shutdownChan),
+			node.Override(new(dtypes.ShutdownChan), shutdownChan),
 			node.Online(),
 			node.Repo(r),
 

--- a/cmd/lotus/rpc.go
+++ b/cmd/lotus/rpc.go
@@ -28,7 +28,7 @@ import (
 
 var log = logging.Logger("main")
 
-func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr) error {
+func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr, shutdownCh <-chan struct{}) error {
 	rpcServer := jsonrpc.NewServer()
 	rpcServer.Register("Filecoin", apistruct.PermissionedFullAPI(a))
 
@@ -62,17 +62,23 @@ func serveRPC(a api.FullNode, stop node.StopFunc, addr multiaddr.Multiaddr) erro
 
 	srv := &http.Server{Handler: http.DefaultServeMux}
 
-	sigChan := make(chan os.Signal, 2)
+	sigCh := make(chan os.Signal, 2)
 	go func() {
-		<-sigChan
+		select {
+		case <-sigCh:
+		case <-shutdownCh:
+		}
+
+		log.Warn("Shutting down...")
 		if err := srv.Shutdown(context.TODO()); err != nil {
 			log.Errorf("shutting down RPC server failed: %s", err)
 		}
 		if err := stop(context.TODO()); err != nil {
 			log.Errorf("graceful shutting down failed: %s", err)
 		}
+		log.Warn("Graceful shutdown successful")
 	}()
-	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
 	return srv.Serve(manet.NetListener(lst))
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -150,6 +150,7 @@ func defaults() []Option {
 		Override(new(helpers.MetricsCtx), context.Background),
 		Override(new(record.Validator), modules.RecordValidator),
 		Override(new(dtypes.Bootstrapper), dtypes.Bootstrapper(false)),
+		Override(new(dtypes.ShutdownCh), make(chan struct{})),
 
 		// Filecoin modules
 

--- a/node/builder.go
+++ b/node/builder.go
@@ -150,7 +150,7 @@ func defaults() []Option {
 		Override(new(helpers.MetricsCtx), context.Background),
 		Override(new(record.Validator), modules.RecordValidator),
 		Override(new(dtypes.Bootstrapper), dtypes.Bootstrapper(false)),
-		Override(new(dtypes.ShutdownCh), make(chan struct{})),
+		Override(new(dtypes.ShutdownChan), make(chan struct{})),
 
 		// Filecoin modules
 

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -25,9 +25,10 @@ import (
 type CommonAPI struct {
 	fx.In
 
-	APISecret *dtypes.APIAlg
-	Host      host.Host
-	Router    lp2p.BaseIpfsRouting
+	APISecret  *dtypes.APIAlg
+	Host       host.Host
+	Router     lp2p.BaseIpfsRouting
+	ShutdownCh dtypes.ShutdownCh
 }
 
 type jwtPayload struct {
@@ -113,6 +114,11 @@ func (a *CommonAPI) LogList(context.Context) ([]string, error) {
 
 func (a *CommonAPI) LogSetLevel(ctx context.Context, subsystem, level string) error {
 	return logging.SetLogLevel(subsystem, level)
+}
+
+func (a *CommonAPI) Shutdown(ctx context.Context) error {
+	a.ShutdownCh <- struct{}{}
+	return nil
 }
 
 var _ api.Common = &CommonAPI{}

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -28,7 +28,7 @@ type CommonAPI struct {
 	APISecret  *dtypes.APIAlg
 	Host       host.Host
 	Router     lp2p.BaseIpfsRouting
-	ShutdownCh dtypes.ShutdownCh
+	ShutdownCh dtypes.ShutdownChan
 }
 
 type jwtPayload struct {

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -25,10 +25,10 @@ import (
 type CommonAPI struct {
 	fx.In
 
-	APISecret  *dtypes.APIAlg
-	Host       host.Host
-	Router     lp2p.BaseIpfsRouting
-	ShutdownCh dtypes.ShutdownChan
+	APISecret    *dtypes.APIAlg
+	Host         host.Host
+	Router       lp2p.BaseIpfsRouting
+	ShutdownChan dtypes.ShutdownChan
 }
 
 type jwtPayload struct {
@@ -117,7 +117,7 @@ func (a *CommonAPI) LogSetLevel(ctx context.Context, subsystem, level string) er
 }
 
 func (a *CommonAPI) Shutdown(ctx context.Context) error {
-	a.ShutdownCh <- struct{}{}
+	a.ShutdownChan <- struct{}{}
 	return nil
 }
 

--- a/node/modules/dtypes/shutdown.go
+++ b/node/modules/dtypes/shutdown.go
@@ -1,3 +1,5 @@
 package dtypes
 
-type ShutdownCh chan struct{}
+// ShutdownChan is a channel to which you send a value if you intend to shut
+// down the daemon (or storage miner), including the node and RPC server.
+type ShutdownChan chan struct{}

--- a/node/modules/dtypes/shutdown.go
+++ b/node/modules/dtypes/shutdown.go
@@ -1,0 +1,3 @@
+package dtypes
+
+type ShutdownCh chan struct{}


### PR DESCRIPTION
Moving down the list; fixes #1827.

## Why does this PR exist?

We'd like to be able to stop the lotus daemon and storage miners without resorting to `CMD+C` / `SIGTERM` (if foregrounded) or `kill` (if backgrounded).

## What's in this PR?

This PR adds a `lotus daemon stop` command and a `lotus-storage-miner stop` command. Both of these commands require that the RPC server be running; RPC server handles inbound message by sending a value to a channel which, when consumed, shuts down HTTP server and node (or storage miner).