### PR TITLE
implement chain index to make lookbacks faster

### DIFF
--- a/chain/store/index.go
+++ b/chain/store/index.go
@@ -58,7 +58,7 @@ func (ci *ChainIndex) GetTipsetByHeight(ctx context.Context, from *types.TipSet,
 		if lbe.ts.Height() == to || lbe.parentHeight < to {
 			return lbe.ts, nil
 		} else if to > lbe.ts.Height()-ci.skipLength {
-			return ci.walkBack(from, to)
+			return ci.walkBack(lbe.ts, to)
 		}
 
 		cur = lbe.target
@@ -69,6 +69,13 @@ func (ci *ChainIndex) fillCache(tsk types.TipSetKey) (*lbEntry, error) {
 	ts, err := ci.loadTipSet(tsk)
 	if err != nil {
 		return nil, err
+	}
+
+	if ts.Height() == 0 {
+		return &lbEntry{
+			ts:           ts,
+			parentHeight: 0,
+		}, nil
 	}
 
 	// will either be equal to ts.Height, or at least > ts.Parent.Height()

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -962,6 +962,14 @@ func (cs *ChainStore) GetTipsetByHeight(ctx context.Context, h abi.ChainEpoch, t
 		return nil, err
 	}
 
+	if lbts.Height() < h {
+		log.Warnf("chain index returned the wrong tipset at height %d, using slow retrieval", h)
+		lbts, err = cs.cindex.GetTipsetByHeightWithoutCache(ts, h)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if lbts.Height() == h || !prev {
 		return lbts, nil
 	}

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -946,7 +946,7 @@ func (cs *ChainStore) GetTipsetByHeight(ctx context.Context, h abi.ChainEpoch, t
 	}
 
 	if h > ts.Height() {
-		return nil, xerrors.Errorf("looking for tipset with height less than start point")
+		return nil, xerrors.Errorf("looking for tipset with height greater than start point")
 	}
 
 	if h == ts.Height() {


### PR DESCRIPTION
The idea here is to effectively implement a skip list for searching back into the chain. The reason I went with this approach is that you don't have to worry about dealing with forks, the logic works the same no matter what chain swapping you do.

Still need to do a bit of testing here, but all the current tests pass, which implies its at least not blatantly broken.