### PR TITLE
Express block validation time via OpenCensus

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -528,8 +528,17 @@ func blockSanityChecks(h *types.BlockHeader) error {
 
 // Should match up with 'Semantical Validation' in validation.md in the spec
 func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) error {
+	validationStart := time.Now()
+	defer func() {
+		dur := time.Since(validationStart)
+		durMilli := dur.Seconds() * float64(1000)
+		stats.Record(ctx, metrics.BlockValidationDurationMilliseconds.M(durMilli))
+		log.Infow("block validation", "took", dur, "height", b.Header.Height)
+	}()
+
 	ctx, span := trace.StartSpan(ctx, "validateBlock")
 	defer span.End()
+
 	if build.InsecurePoStValidation {
 		log.Warn("insecure test validation is enabled, if you see this outside of a test, it is a severe bug!")
 	}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -18,6 +18,7 @@ import (
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
+	"go.opencensus.io/plugin/runmetrics"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -114,6 +115,13 @@ var DaemonCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		err := runmetrics.Enable(runmetrics.RunMetricOptions{
+			EnableCPU:    true,
+			EnableMemory: true,
+		})
+		if err != nil {
+			return xerrors.Errorf("enabling runtime metrics: %w", err)
+		}
 		if prof := cctx.String("pprof"); prof != "" {
 			profile, err := os.Create(prof)
 			if err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -22,16 +22,17 @@ var (
 
 // Measures
 var (
-	LotusInfo                = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
-	ChainNodeHeight          = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
-	ChainNodeWorkerHeight    = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
-	MessageReceived          = stats.Int64("message/received", "Counter for total received messages", stats.UnitDimensionless)
-	MessageValidationFailure = stats.Int64("message/failure", "Counter for message validation failures", stats.UnitDimensionless)
-	MessageValidationSuccess = stats.Int64("message/success", "Counter for message validation successes", stats.UnitDimensionless)
-	BlockReceived            = stats.Int64("block/received", "Counter for total received blocks", stats.UnitDimensionless)
-	BlockValidationFailure   = stats.Int64("block/failure", "Counter for block validation failures", stats.UnitDimensionless)
-	BlockValidationSuccess   = stats.Int64("block/success", "Counter for block validation successes", stats.UnitDimensionless)
-	PeerCount                = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
+	LotusInfo                           = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
+	ChainNodeHeight                     = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	ChainNodeWorkerHeight               = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
+	MessageReceived                     = stats.Int64("message/received", "Counter for total received messages", stats.UnitDimensionless)
+	MessageValidationFailure            = stats.Int64("message/failure", "Counter for message validation failures", stats.UnitDimensionless)
+	MessageValidationSuccess            = stats.Int64("message/success", "Counter for message validation successes", stats.UnitDimensionless)
+	BlockReceived                       = stats.Int64("block/received", "Counter for total received blocks", stats.UnitDimensionless)
+	BlockValidationFailure              = stats.Int64("block/failure", "Counter for block validation failures", stats.UnitDimensionless)
+	BlockValidationSuccess              = stats.Int64("block/success", "Counter for block validation successes", stats.UnitDimensionless)
+	BlockValidationDurationMilliseconds = stats.Float64("block/validation_ms", "Duration for Block Validation in ms", stats.UnitMilliseconds)
+	PeerCount                           = stats.Int64("peer/count", "Current number of FIL peers", stats.UnitDimensionless)
 )
 
 var (
@@ -63,6 +64,10 @@ var (
 		Measure:     BlockValidationSuccess,
 		Aggregation: view.Count(),
 	}
+	BlockValidationDurationView = &view.View{
+		Measure:     BlockValidationDurationMilliseconds,
+		Aggregation: view.Sum(),
+	}
 	MessageReceivedView = &view.View{
 		Measure:     MessageReceived,
 		Aggregation: view.Count(),
@@ -90,6 +95,7 @@ var DefaultViews = append([]*view.View{
 	BlockReceivedView,
 	BlockValidationFailureView,
 	BlockValidationSuccessView,
+	BlockValidationDurationView,
 	MessageReceivedView,
 	MessageValidationFailureView,
 	MessageValidationSuccessView,


### PR DESCRIPTION
Produces additiona output via OpenCensus and Logging:

OpenCensus
```
# HELP lotus_block_validation_ms Duration for Block Validation in ms
# TYPE lotus_block_validation_ms gauge
lotus_block_validation_ms 5547.91
...
# HELP lotus_process_cpu_cgo_calls Number of cgo calls made by the current process
# TYPE lotus_process_cpu_cgo_calls gauge
lotus_process_cpu_cgo_calls 225
# HELP lotus_process_cpu_goroutines Number of goroutines that currently exist
# TYPE lotus_process_cpu_goroutines gauge
lotus_process_cpu_goroutines 629
# HELP lotus_process_heap_alloc Process heap allocation
# TYPE lotus_process_heap_alloc gauge
lotus_process_heap_alloc 8.1291232e+07
# HELP lotus_process_heap_idle Bytes in idle (unused) spans
# TYPE lotus_process_heap_idle gauge
lotus_process_heap_idle 4.4269568e+07
# HELP lotus_process_heap_inuse Bytes in in-use spans
# TYPE lotus_process_heap_inuse gauge
lotus_process_heap_inuse 8.5557248e+07
# HELP lotus_process_heap_objects The number of objects allocated on the heap
# TYPE lotus_process_heap_objects gauge
lotus_process_heap_objects 706433
# HELP lotus_process_heap_release The number of objects released from the heap
# TYPE lotus_process_heap_release gauge
lotus_process_heap_release 4.4138496e+07
# HELP lotus_process_memory_alloc Number of bytes currently allocated in use
# TYPE lotus_process_memory_alloc gauge
lotus_process_memory_alloc 8.1291232e+07
# HELP lotus_process_memory_frees Cumulative count of heap objects freed
# TYPE lotus_process_memory_frees gauge
lotus_process_memory_frees 1.677996e+06
# HELP lotus_process_memory_lookups Number of pointer lookups performed by the runtime
# TYPE lotus_process_memory_lookups gauge
lotus_process_memory_lookups 0
# HELP lotus_process_memory_malloc Cumulative count of heap objects allocated
# TYPE lotus_process_memory_malloc gauge
lotus_process_memory_malloc 2.384429e+06
# HELP lotus_process_stack_inuse Bytes in stack spans
# TYPE lotus_process_stack_inuse gauge
lotus_process_stack_inuse 4.390912e+06
# HELP lotus_process_stack_mcache_inuse Bytes of allocated mcache structures
# TYPE lotus_process_stack_mcache_inuse gauge
lotus_process_stack_mcache_inuse 13888
# HELP lotus_process_stack_mspan_inuse Bytes of allocated mspan structures
# TYPE lotus_process_stack_mspan_inuse gauge
lotus_process_stack_mspan_inuse 911336
# HELP lotus_process_sys_heap Bytes of heap memory obtained from the OS
# TYPE lotus_process_sys_heap gauge
lotus_process_sys_heap 1.29826816e+08
# HELP lotus_process_sys_memory_alloc Number of bytes given to the process to use in total
# TYPE lotus_process_sys_memory_alloc gauge
lotus_process_sys_memory_alloc 1.43001848e+08
# HELP lotus_process_sys_stack The memory used by stack spans and OS thread stacks
# TYPE lotus_process_sys_stack gauge
lotus_process_sys_stack 4.390912e+06
# HELP lotus_process_sys_stack_mcache Bytes of memory obtained from the OS for mcache structures
# TYPE lotus_process_sys_stack_mcache gauge
lotus_process_sys_stack_mcache 16384
# HELP lotus_process_sys_stack_mspan Bytes of memory obtained from the OS for mspan structures
# TYPE lotus_process_sys_stack_mspan gauge
lotus_process_sys_stack_mspan 917504
# HELP lotus_process_total_memory_alloc Number of allocations in total
# TYPE lotus_process_total_memory_alloc gauge
lotus_process_total_memory_alloc 1.7859384e+08
```

Log
```
{"level":"info","ts":"2020-06-04T23:25:48.211Z","logger":"chain","caller":"chain/sync.go:535","msg":"block validation","took":254.352,"height":"72754"}
{"level":"info","ts":"2020-06-04T23:25:48.593Z","logger":"chain","caller":"chain/sync.go:535","msg":"block validation","took":2429.222,"height":"72756"}
{"level":"info","ts":"2020-06-04T23:25:48.727Z","logger":"chain","caller":"chain/sync.go:535","msg":"block validation","took":5050.148,"height":"72753"}
```