### PR TITLE
chain get: @state selector to prettify actor state

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -442,7 +442,8 @@ var chainGetCmd = &cli.Command{
    - /ipfs/[cid]/@Hi:123 - get varint elem 123 from hamt
    - /ipfs/[cid]/@Hu:123 - get uvarint elem 123 from hamt
    - /ipfs/[cid]/@Ha:t01 - get element under Addr(t01).Bytes
-   - /ipfs/[cid]/@A:10 - get 10th amt element
+   - /ipfs/[cid]/@A:10   - get 10th amt element
+   - .../@Ha:t01/@state  - get pretty map-based actor state
 
    List of --as-type types:
    - raw


### PR DESCRIPTION
Now instead of doing `./lotus chain get /pstate/@Ha:t04/1`, and getting:
```
[
        "ADjmwAAAAA==",
        "ADepRTL+AA==",
        "ABGYBgsXYhmCbE0=",
        515,
        {
                "/": "bafy2bzaceboonml5vyodbbod4vxyjxrrmcovmsr2djmcezxtwhxdr6lfpctyc"
        },
        11641,
        {
                "/": "bafy2bzaceb2oxxk6vc6tzangdpr7wjwnzs6pfc3i2k2jwhgldsujzlbepujpu"
        },
        66,
        {
                "/": "bafy2bzaced24ohrb5tw5mqcgsratjechwretpgpcy7mqnyzqn7y3y7qtbxj2s"
        }
]
```

You can do `./lotus chain get /pstate/@Ha:t04/@state`, and get:
```
{
        "Claims": {
                "/": "bafy2bzaceb2oxxk6vc6tzangdpr7wjwnzs6pfc3i2k2jwhgldsujzlbepujpu"
        },
        "CronEventQueue": {
                "/": "bafy2bzacebrjefxtl52sccb6ple6k3gzzwjvtfnqh2opbtiidr4igut3v5blq"
        },
        "LastEpochTick": 11641,
        "MinerCount": 515,
        "NumMinersMeetingMinPower": 66,
        "ProofValidationBatch": {
                "/": "bafy2bzaceae4sjmfoxk4qrcbim32crfdqqbnxyzxhsd56jebfkb7hbvdxurma"
        },
        "TotalPledgeCollateral": "83090176686251618429780",
        "TotalQualityAdjPower": "61200149970432",
        "TotalRawBytePower": "62563714859008"
}

```