### PR TITLE
fix unhandled nil return

### DIFF
--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -63,18 +63,21 @@ func (pm *Manager) waitForPaychCreateMsg(ctx context.Context, mcid cid.Cid) {
 
 	if mwait.Receipt.ExitCode != 0 {
 		log.Errorf("payment channel creation failed (exit code %d)", mwait.Receipt.ExitCode)
+		return
 	}
 
 	var decodedReturn init_.ExecReturn
 	err = decodedReturn.UnmarshalCBOR(bytes.NewReader(mwait.Receipt.Return))
 	if err != nil {
 		log.Error(err)
+		return
 	}
 	paychaddr := decodedReturn.RobustAddress
 
 	ci, err := pm.loadOutboundChannelInfo(ctx, paychaddr)
 	if err != nil {
 		log.Errorf("loading channel info: %w", err)
+		return
 	}
 
 	if err := pm.store.trackChannel(ci); err != nil {

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -58,6 +58,7 @@ func (pm *Manager) waitForPaychCreateMsg(ctx context.Context, mcid cid.Cid) {
 	mwait, err := pm.state.StateWaitMsg(ctx, mcid)
 	if err != nil {
 		log.Errorf("wait msg: %w", err)
+		return
 	}
 
 	if mwait.Receipt.ExitCode != 0 {


### PR DESCRIPTION
Fixes #1611 

Should have returned on error != nil, now it does.  I'm not sure what should be done about it from the caller's POV if the message never gets posted though.