### PR TITLE
display a little inline warning if balance is zero

### DIFF
--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -113,7 +113,12 @@ var walletBalance = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("%s\n", types.FIL(balance))
+		if balance.Equals(types.NewInt(0)) {
+			fmt.Printf("%s (warning: may display 0 if chain sync in progress)\n", types.FIL(balance))
+		} else {
+			fmt.Printf("%s\n", types.FIL(balance))
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
Fixes #805.

## Alternatives

1. We could write the warning to stderr instead of stdout
1. I could do something more-sophisticated and try to figure out if the chain needed synchronizing and had (or not) been synchronized.