### PR TITLE
Make libp2p swarm Announce / NoAnnounce addresses configurable

### DIFF
--- a/documentation/en/setting-a-static-port.md
+++ b/documentation/en/setting-a-static-port.md
@@ -15,6 +15,20 @@ To change the port to `1347`:
 
 After changing the port value, restart your **daemon**.
 
+## Announce Addresses
+
+If the **swarm port** is port-forwarded from another address, it is possible to control what addresses
+are announced to the network.
+
+```sh
+[Libp2p]
+  AnnounceAddresses = ["/ip4/<public-ip>/tcp/1347"]
+```
+
+If non-empty, this array specifies the swarm addresses to announce to the network. If empty, the daemon will announce inferred swarm addresses.
+
+Similarly, it is possible to set `NoAnnounceAddresses` with an array of addresses to not announce to the network.
+
 ## Ubuntu's Uncomplicated Firewall
 
 Open firewall manually:

--- a/node/builder.go
+++ b/node/builder.go
@@ -371,6 +371,9 @@ func ConfigCommon(cfg *config.Common) Option {
 				Override(new(dtypes.BootstrapPeers), modules.ConfigBootstrap(cfg.Libp2p.BootstrapPeers)),
 			),
 		),
+		Override(AddrsFactoryKey, lp2p.AddrsFactory(
+			cfg.Libp2p.AnnounceAddresses,
+			cfg.Libp2p.NoAnnounceAddresses)),
 	)
 }
 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -39,9 +39,11 @@ type API struct {
 
 // Libp2p contains configs for libp2p
 type Libp2p struct {
-	ListenAddresses []string
-	BootstrapPeers  []string
-	ProtectedPeers  []string
+	ListenAddresses     []string
+	AnnounceAddresses   []string
+	NoAnnounceAddresses []string
+	BootstrapPeers      []string
+	ProtectedPeers      []string
 
 	ConnMgrLow   uint
 	ConnMgrHigh  uint
@@ -78,6 +80,8 @@ func defCommon() Common {
 				"/ip4/0.0.0.0/tcp/0",
 				"/ip6/::/tcp/0",
 			},
+			AnnounceAddresses:   []string{},
+			NoAnnounceAddresses: []string{},
 
 			ConnMgrLow:   150,
 			ConnMgrHigh:  180,


### PR DESCRIPTION
In go-ipfs, it is possible to manually configure addresses to announce
or not announce to the swarm.

https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#addressesannounce

This PR adds the same feature to Lotus. It can be configured from the [libp2p]
section of either the .lotus or .lotusstorage config.toml file. Example:

[Libp2p]
  ListenAddresses = ["/ip4/0.0.0.0/tcp/34515", "/ip6/::/tcp/34515"]
  AnnounceAddresses = ["/ip4/52.13.91.110/tcp/34515"]