### PR TITLE
Create an api.MinerInfo that has peerID as a Peer ID

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -146,7 +146,7 @@ type FullNode interface {
 	StateMinerProvingSet(context.Context, address.Address, types.TipSetKey) ([]*ChainSectorInfo, error)
 	StateMinerProvingDeadline(context.Context, address.Address, types.TipSetKey) (*miner.DeadlineInfo, error)
 	StateMinerPower(context.Context, address.Address, types.TipSetKey) (*MinerPower, error)
-	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (miner.MinerInfo, error)
+	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (MinerInfo, error)
 	StateMinerDeadlines(context.Context, address.Address, types.TipSetKey) (*miner.Deadlines, error)
 	StateMinerFaults(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)
 	// Returns all non-expired Faults that occur within lookback epochs of the given tipset
@@ -297,6 +297,39 @@ type VoucherSpec struct {
 type MinerPower struct {
 	MinerPower power.Claim
 	TotalPower power.Claim
+}
+
+type MinerInfo struct {
+	Owner                      address.Address // Must be an ID-address.
+	Worker                     address.Address // Must be an ID-address.
+	NewWorker                  address.Address // Must be an ID-address.
+	WorkerChangeEpoch          abi.ChainEpoch
+	PeerId                     peer.ID
+	Multiaddrs                 []abi.Multiaddrs
+	SealProofType              abi.RegisteredProof
+	SectorSize                 abi.SectorSize
+	WindowPoStPartitionSectors uint64
+}
+
+func NewApiMinerInfo(info miner.MinerInfo) MinerInfo {
+	mi := MinerInfo{
+		Owner:                      info.Owner,
+		Worker:                     info.Worker,
+		NewWorker:                  address.Undef,
+		WorkerChangeEpoch:          -1,
+		PeerId:                     peer.ID(info.PeerId),
+		Multiaddrs:                 info.Multiaddrs,
+		SealProofType:              info.SealProofType,
+		SectorSize:                 info.SectorSize,
+		WindowPoStPartitionSectors: info.WindowPoStPartitionSectors,
+	}
+
+	if info.PendingWorkerKey != nil {
+		mi.NewWorker = info.PendingWorkerKey.NewWorker
+		mi.WorkerChangeEpoch = info.PendingWorkerKey.EffectiveAt
+	}
+
+	return mi
 }
 
 type QueryOffer struct {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -125,7 +125,7 @@ type FullNodeStruct struct {
 		StateMinerProvingSet              func(context.Context, address.Address, types.TipSetKey) ([]*api.ChainSectorInfo, error)                             `perm:"read"`
 		StateMinerProvingDeadline         func(context.Context, address.Address, types.TipSetKey) (*miner.DeadlineInfo, error)                                `perm:"read"`
 		StateMinerPower                   func(context.Context, address.Address, types.TipSetKey) (*api.MinerPower, error)                                    `perm:"read"`
-		StateMinerInfo                    func(context.Context, address.Address, types.TipSetKey) (miner.MinerInfo, error)                                    `perm:"read"`
+		StateMinerInfo                    func(context.Context, address.Address, types.TipSetKey) (api.MinerInfo, error)                                      `perm:"read"`
 		StateMinerDeadlines               func(context.Context, address.Address, types.TipSetKey) (*miner.Deadlines, error)                                   `perm:"read"`
 		StateMinerFaults                  func(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)                                      `perm:"read"`
 		StateAllMinerFaults               func(context.Context, abi.ChainEpoch, types.TipSetKey) ([]*api.Fault, error)                                        `perm:"read"`
@@ -552,7 +552,7 @@ func (c *FullNodeStruct) StateMinerPower(ctx context.Context, a address.Address,
 	return c.Internal.StateMinerPower(ctx, a, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
+func (c *FullNodeStruct) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (api.MinerInfo, error) {
 	return c.Internal.StateMinerInfo(ctx, actor, tsk)
 }
 

--- a/cli/state.go
+++ b/cli/state.go
@@ -145,22 +145,10 @@ var stateMinerInfo = &cli.Command{
 			return err
 		}
 
-		act, err := api.StateGetActor(ctx, addr, ts.Key())
+		mi, err := api.StateMinerInfo(ctx, addr, ts.Key())
 		if err != nil {
 			return err
 		}
-
-		aso, err := api.ChainReadObj(ctx, act.Head)
-		if err != nil {
-			return err
-		}
-
-		var mst miner2.State
-		if err := mst.UnmarshalCBOR(bytes.NewReader(aso)); err != nil {
-			return err
-		}
-
-		mi := mst.Info
 
 		fmt.Printf("Owner:\t%s\n", mi.Owner)
 		fmt.Printf("Worker:\t%s\n", mi.Worker)

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -77,12 +77,17 @@ func (a *StateAPI) StateMinerProvingSet(ctx context.Context, addr address.Addres
 	return stmgr.GetProvingSetRaw(ctx, a.StateManager, mas)
 }
 
-func (a *StateAPI) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
+func (a *StateAPI) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (api.MinerInfo, error) {
 	ts, err := a.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
-		return miner.MinerInfo{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
+		return api.MinerInfo{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return stmgr.StateMinerInfo(ctx, a.StateManager, ts, actor)
+
+	mi, err := stmgr.StateMinerInfo(ctx, a.StateManager, ts, actor)
+	if err != nil {
+		return api.MinerInfo{}, err
+	}
+	return api.NewApiMinerInfo(mi), nil
 }
 
 func (a *StateAPI) StateMinerDeadlines(ctx context.Context, m address.Address, tsk types.TipSetKey) (*miner.Deadlines, error) {

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -51,7 +51,7 @@ type storageMinerApi interface {
 	StateMinerSectors(context.Context, address.Address, *abi.BitField, bool, types.TipSetKey) ([]*api.ChainSectorInfo, error)
 	StateSectorPreCommitInfo(context.Context, address.Address, abi.SectorNumber, types.TipSetKey) (miner.SectorPreCommitOnChainInfo, error)
 	StateSectorGetInfo(context.Context, address.Address, abi.SectorNumber, types.TipSetKey) (*miner.SectorOnChainInfo, error)
-	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (miner.MinerInfo, error)
+	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (api.MinerInfo, error)
 	StateMinerProvingDeadline(context.Context, address.Address, types.TipSetKey) (*miner.DeadlineInfo, error)
 	StateMinerInitialPledgeCollateral(context.Context, address.Address, abi.SectorNumber, types.TipSetKey) (types.BigInt, error)
 	StateWaitMsg(ctx context.Context, cid cid.Cid, confidence uint64) (*api.MsgLookup, error) // TODO: removeme eventually


### PR DESCRIPTION
specs actor's Miner state now has Peer ID as a byte array, so we create a new API type that has peer id as a peer.ID.

Also haul the CLI's miner-info to use the API method instead of doing the work itself.

Closes #1943 