### PR TITLE
Update documentation about Lotus Seal Worker

### DIFF
--- a/documentation/en/hardware-mining.md
+++ b/documentation/en/hardware-mining.md
@@ -16,7 +16,7 @@ The setup below is a minimal example for sealing 32 GiB sectors on Lotus:
 
 Note that 1GB sectors don't require as high of specs, but are likely to be removed as we improve the performance of 32GB sector sealing.
 
-AMD CPU's are **highly recommended**, because of the `Intel SHA Extensions` instruction set that is available there since the `Zen` microarchitecture. Hence, AMD CPU's seem to perform much better on the testnet than other CPU's. Contrary to what the name implies, this extended instruction set is not available on recent Intel desktop/server chips. 
+AMD CPU's are __highly recommended__, because of the `Intel SHA Extensions` instruction set that is available there since the `Zen` microarchitecture. Hence, AMD CPU's seem to perform much better on the testnet than other CPU's. Contrary to what the name implies, this extended instruction set is not available on recent Intel desktop/server chips. 
 
 ## Testnet discoveries
 

--- a/documentation/en/hardware-mining.md
+++ b/documentation/en/hardware-mining.md
@@ -16,6 +16,8 @@ The setup below is a minimal example for sealing 32 GiB sectors on Lotus:
 
 Note that 1GB sectors don't require as high of specs, but are likely to be removed as we improve the performance of 32GB sector sealing.
 
+AMD CPU's are **highly recommended**, because of the `Intel SHA Extensions` instruction set that is available there since the `Zen` microarchitecture. Hence, AMD CPU's seem to perform much better on the testnet than other CPU's. Contrary to what the name implies, this extended instruction set is not available on recent Intel desktop/server chips. 
+
 ## Testnet discoveries
 
 - If you only have 128GiB of ram, enabling 256GB of **NVMe** swap on an SSD will help you avoid out-of-memory issues while mining.

--- a/documentation/en/hardware-mining.md
+++ b/documentation/en/hardware-mining.md
@@ -16,7 +16,7 @@ The setup below is a minimal example for sealing 32 GiB sectors on Lotus:
 
 Note that 1GB sectors don't require as high of specs, but are likely to be removed as we improve the performance of 32GB sector sealing.
 
-AMD CPU's are __highly recommended__, because of the `Intel SHA Extensions` instruction set that is available there since the `Zen` microarchitecture. Hence, AMD CPU's seem to perform much better on the testnet than other CPU's. Contrary to what the name implies, this extended instruction set is not available on recent Intel desktop/server chips. 
+For the first part of the sealing process, AMD CPU's are __highly recommended__, because of the `Intel SHA Extensions` instruction set that is available there ever since the `Zen` microarchitecture. Hence, AMD CPU's seem to perform much better on the testnet than other CPU's. Contrary to what the name implies, this extended instruction set is not available on recent Intel desktop/server chips. 
 
 ## Testnet discoveries
 
@@ -35,7 +35,7 @@ GPUs are a must for getting **block rewards**. Here are a few that have been con
 
 ## Testing other GPUs
 
-If you want to test a GPU that is not explicitly supported, use the following global**environment variable**:
+If you want to test a GPU that is not explicitly supported, use the following global **environment variable**:
 
 ```sh
 BELLMAN_CUSTOM_GPU="<NAME>:<NUMBER_OF_CORES>"

--- a/documentation/en/mining-lotus-seal-worker.md
+++ b/documentation/en/mining-lotus-seal-worker.md
@@ -68,3 +68,14 @@ Worker 1, host othercomputer
         VMEM: [||||||||||||||                                                  ] 23% 14 GiB/62.7 GiB
         GPU: GeForce RTX 2080, not used
 ```
+
+### Running locally for manually managing process priority
+
+You can also run the **Lotus Seal Worker** on the same machine as your **Lotus Storage Miner**, so you can manually manage the process priority.
+To do so you have to first **disable all seal task types** in the miner config. This is important to prevent conflicts between the two processes.
+
+You can then run the storage miner on your local-loopback interface; 
+
+```sh
+lotus-seal-worker run --address 127.0.0.1:2345
+```

--- a/documentation/en/mining-lotus-seal-worker.md
+++ b/documentation/en/mining-lotus-seal-worker.md
@@ -72,7 +72,7 @@ Worker 1, host othercomputer
 ### Running locally for manually managing process priority
 
 You can also run the **Lotus Seal Worker** on the same machine as your **Lotus Storage Miner**, so you can manually manage the process priority.
-To do so you have to first **disable all seal task types** in the miner config. This is important to prevent conflicts between the two processes.
+To do so you have to first __disable all seal task types__ in the miner config. This is important to prevent conflicts between the two processes.
 
 You can then run the storage miner on your local-loopback interface; 
 

--- a/documentation/en/mining-lotus-seal-worker.md
+++ b/documentation/en/mining-lotus-seal-worker.md
@@ -1,6 +1,6 @@
 # Lotus Seal Worker
 
-The **Lotus Seal Worker** is an extra process that can offload heavy processing tasks from your **Lotus Storage Miner**. It can be run on the same machine as your `lotus-storage-miner`, or on another machine communicating over a fast network.
+The **Lotus Seal Worker** is an extra process that can offload heavy processing tasks from your **Lotus Storage Miner**. The sealing process automatically runs in the **Lotus Storage Miner** process, but you can use the Seal Worker on another machine communicating over a fast network to free up resources on the machine running the mining process.
 
 ## Note: Using the Lotus Seal Worker from China
 
@@ -12,39 +12,13 @@ IPFS_GATEWAY="https://proof-parameters.s3.cn-south-1.jdcloud-oss.com/ipfs/"
 
 ## Get Started
 
-Make sure that the `lotus-seal-worker` is installed by running:
+Make sure that the `lotus-seal-worker` is compiled and installed by running:
 
 ```sh
 make lotus-seal-worker
 ```
 
-## Running Alongside Storage Miner
-
-You may wish to run the **Lotus Seal Worker** on the same computer as the **Lotus Storage Miner**. This allows you to easily set the process priority of the sealing tasks to be lower than the priority of your more important storage miner process.
-
-To do this, simply run `lotus-seal-worker run`, and the seal worker will automatically pick up the correct authentication tokens from the `LOTUS_STORAGE_PATH` miner repository.
-
-To check that the **Lotus Seal Worker** is properly connected to your storage miner, run `lotus-storage-miner info` and check that the remote worker count has increased.
-
-```sh
-why@computer ~/lotus> lotus-storage-miner workers list
-Worker 0, host computer
-        CPU:  [                                                                ] 0 core(s) in use
-        RAM:  [||||||||||||||||||                                              ] 28% 18.1 GiB/62.7 GiB
-        VMEM: [||||||||||||||||||                                              ] 28% 18.1 GiB/62.7 GiB
-        GPU: GeForce RTX 2080, not used
-Worker 1, host computer
-        CPU:  [                                                                ] 0 core(s) in use
-        RAM:  [||||||||||||||||||                                              ] 28% 18.1 GiB/62.7 GiB
-        VMEM: [||||||||||||||||||                                              ] 28% 18.1 GiB/62.7 GiB
-        GPU: GeForce RTX 2080, not used
-```
-
-## Running Over the Network
-
-Warning: This setup is a little more complex than running it locally.
-
-To use an entirely separate computer for sealing tasks, you will want to run the `lotus-seal-worker` on a separate machine, connected to your **Lotus Storage Miner** via the local area network.
+## Setting up the Storage Miner
 
 First, you will need to ensure your `lotus-storage-miner`'s API is accessible over the network.
 
@@ -62,7 +36,7 @@ To make your node accessible over the local area network, you will need to deter
 
 A more permissive and less secure option is to change it to `0.0.0.0`. This will allow anyone who can connect to your computer on that port to access the [API](https://docs.lotu.sh/en+api). They will still need an auth token.
 
-`RemoteListenAddress` must be set to an address which other nodes on your network will be able to reach
+`RemoteListenAddress` must be set to an address which other nodes on your network will be able to reach.
 
 Next, you will need to [create an authentication token](https://docs.lotu.sh/en+api-scripting-support#generate-a-jwt-46). All Lotus APIs require authentication tokens to ensure your processes are as secure against attackers attempting to make unauthenticated requests to them.
 
@@ -73,8 +47,10 @@ On the machine that will run `lotus-seal-worker`, set the `STORAGE_API_INFO` env
 Once this is set, run:
 
 ```sh
-lotus-seal-worker run
+lotus-seal-worker run --address 192.168.2.10:2345
 ```
+
+Replace `192.168.2.10:2345` with the proper IP and port.
 
 To check that the **Lotus Seal Worker** is connected to your **Lotus Storage Miner**, run `lotus-storage-miner workers list` and check that the remote worker count has increased.
 


### PR DESCRIPTION
Running the initial command `lotus-seal-worker run` gave an error about `--address` being a required parameter.
After setting that to `127.0.0.1:2345` the miner started to freak out and sectors broke as the mining process locked up.

It seems like in the mean time the sealing work has already been moved into the `lotus-storage-miner` and thus doesn't need to run alongside the miner. 

Changed the docs to what I think is correct now - but please check, I could be horribly wrong :)