### PR TITLE
expose config-setting through Repo interface

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -412,7 +412,7 @@ func Repo(r repo.Repo) Option {
 		if err != nil {
 			return err
 		}
-		c, err := lr.GetConfig()
+		c, err := lr.Config()
 		if err != nil {
 			return err
 		}

--- a/node/builder.go
+++ b/node/builder.go
@@ -412,7 +412,7 @@ func Repo(r repo.Repo) Option {
 		if err != nil {
 			return err
 		}
-		c, err := lr.Config()
+		c, err := lr.GetConfig()
 		if err != nil {
 			return err
 		}

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -12,7 +12,7 @@ import (
 )
 
 // FromFile loads config from a specified file overriding defaults specified in
-// the def parameter. If file does not exist or is empty defaults are asummed.
+// the def parameter. If file does not exist or is empty defaults are assumed.
 func FromFile(path string, def interface{}) (interface{}, error) {
 	file, err := os.Open(path)
 	switch {

--- a/node/repo/interface.go
+++ b/node/repo/interface.go
@@ -37,7 +37,8 @@ type LockedRepo interface {
 	Datastore(namespace string) (datastore.Batching, error)
 
 	// Returns config in this repo
-	GetConfig() (interface{}, error)
+	Config() (interface{}, error)
+	SetConfig(interface{}) error
 
 	GetStorage() (stores.StorageConfig, error)
 	SetStorage(func(*stores.StorageConfig)) error

--- a/node/repo/interface.go
+++ b/node/repo/interface.go
@@ -38,7 +38,7 @@ type LockedRepo interface {
 
 	// Returns config in this repo
 	Config() (interface{}, error)
-	SetConfig(interface{}) error
+	SetConfig(func(interface{})) error
 
 	GetStorage() (stores.StorageConfig, error)
 	SetStorage(func(*stores.StorageConfig)) error

--- a/node/repo/interface.go
+++ b/node/repo/interface.go
@@ -37,7 +37,7 @@ type LockedRepo interface {
 	Datastore(namespace string) (datastore.Batching, error)
 
 	// Returns config in this repo
-	Config() (interface{}, error)
+	GetConfig() (interface{}, error)
 
 	GetStorage() (stores.StorageConfig, error)
 	SetStorage(func(*stores.StorageConfig)) error

--- a/node/repo/memrepo.go
+++ b/node/repo/memrepo.go
@@ -217,7 +217,7 @@ func (lmem *lockedMemRepo) Datastore(ns string) (datastore.Batching, error) {
 	return namespace.Wrap(lmem.mem.datastore, datastore.NewKey(ns)), nil
 }
 
-func (lmem *lockedMemRepo) Config() (interface{}, error) {
+func (lmem *lockedMemRepo) GetConfig() (interface{}, error) {
 	if err := lmem.checkToken(); err != nil {
 		return nil, err
 	}

--- a/node/repo/repo_test.go
+++ b/node/repo/repo_test.go
@@ -54,9 +54,10 @@ func basicTest(t *testing.T, repo Repo) {
 	assert.NoError(t, err, "config should not error")
 
 	// mutate config and persist back to repo
-	cfg1 := c1.(*config.FullNode)
-	cfg1.Client.IpfsMAddr = "duvall"
-	err = lrepo.SetConfig(cfg1)
+	err = lrepo.SetConfig(func(c interface{}) {
+		cfg := c.(*config.FullNode)
+		cfg.Client.IpfsMAddr = "duvall"
+	})
 	assert.NoError(t, err)
 
 	// load config and verify changes

--- a/node/repo/repo_test.go
+++ b/node/repo/repo_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/config"
+
+	"github.com/stretchr/testify/require"
 )
 
 func basicTest(t *testing.T, repo Repo) {
@@ -47,9 +49,21 @@ func basicTest(t *testing.T, repo Repo) {
 	assert.NoError(t, err, "setting multiaddr shouldn't error")
 	assert.Equal(t, ma, apima, "returned API multiaddr should be the same")
 
-	cfg, err := lrepo.Config()
-	assert.Equal(t, config.DefaultFullNode(), cfg, "there should be a default config")
+	c1, err := lrepo.Config()
+	assert.Equal(t, config.DefaultFullNode(), c1, "there should be a default config")
 	assert.NoError(t, err, "config should not error")
+
+	// mutate config and persist back to repo
+	cfg1 := c1.(*config.FullNode)
+	cfg1.Client.IpfsMAddr = "duvall"
+	err = lrepo.SetConfig(cfg1)
+	assert.NoError(t, err)
+
+	// load config and verify changes
+	c2, err := lrepo.Config()
+	require.NoError(t, err)
+	cfg2 := c2.(*config.FullNode)
+	require.Equal(t, cfg2.Client.IpfsMAddr, "duvall")
 
 	err = lrepo.Close()
 	assert.NoError(t, err, "should be able to close")


### PR DESCRIPTION
## Why does this PR exist?

We want some CLI stuff which will allow an operator to fiddle with various config options (e.g. whether the storage miner is accepting storage deal proposals). 

## What's in this PR?

This PR adds a `SetConfig` method, which accepts (you guessed it) a config object-mutator. The mutator is applied to the current config object which is then TOML-encodes and written to the repo. The `Config` method continues to decode these TOML bytes into a Go struct on the way out.