### PR TITLE
Update Ubuntu installation guide (+ bump go version to 1.14 in docs) 

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -412,7 +412,7 @@ var sealBenchCmd = &cli.Command{
 
 			fmt.Println(string(data))
 		} else {
-			fmt.Printf("----\nresults (v26) (%d)\n", sectorSize)
+			fmt.Printf("----\nresults (v27) (%d)\n", sectorSize)
 			if robench == "" {
 				fmt.Printf("seal: addPiece: %s (%s)\n", bo.SealingResults[0].AddPiece, bps(bo.SectorSize, bo.SealingResults[0].AddPiece)) // TODO: average across multiple sealings
 				fmt.Printf("seal: preCommit phase 1: %s (%s)\n", bo.SealingResults[0].PreCommit1, bps(bo.SectorSize, bo.SealingResults[0].PreCommit1))
@@ -569,7 +569,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, mid
 				}
 			}
 
-			err := sb.UnsealPiece(context.TODO(), abi.SectorID{Miner: mid, Number: 1}, 0, abi.UnpaddedPieceSize(sectorSize), ticket, cids.Unsealed)
+			err := sb.UnsealPiece(context.TODO(), abi.SectorID{Miner: mid, Number: 1}, 0, abi.PaddedPieceSize(sectorSize).Unpadded(), ticket, cids.Unsealed)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/documentation/en/install-lotus-ubuntu.md
+++ b/documentation/en/install-lotus-ubuntu.md
@@ -19,7 +19,7 @@ Install dependencies
 
 ```sh
 sudo apt update
-sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config mesa-opencl-icd ocl-icd-opencl-dev
+sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config
 ```
 
 Install Go 1.14

--- a/documentation/en/install-lotus-ubuntu.md
+++ b/documentation/en/install-lotus-ubuntu.md
@@ -2,7 +2,7 @@
 
 These steps will install the following dependencies:
 
-- go (1.13 or higher)
+- go (1.14 or higher)
 - gcc (7.4.0 or higher)
 - git (version 2 or higher)
 - bzr (some go dependency needs this)
@@ -15,29 +15,42 @@ These steps will install the following dependencies:
 - llvm (proofs build)
 - clang (proofs build)
 
-Run
+Install dependencies
 
 ```sh
 sudo apt update
-sudo apt install mesa-opencl-icd ocl-icd-opencl-dev
+sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config mesa-opencl-icd ocl-icd-opencl-dev
 ```
 
-Build
+Install Go 1.14
+
+Find the latest version of Go [on their website](https://golang.org/dl/) and follow the installation instructions. As of now, thats 1.14.4. Extract it to `/usr/local`, and add the go binaries to your `$PATH`.
 
 ```sh
-sudo add-apt-repository ppa:longsleep/golang-backports
-sudo apt update
-sudo apt install golang-go gcc git bzr jq pkg-config mesa-opencl-icd ocl-icd-opencl-dev
+wget -c https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+source ~/.profile
 ```
 
-Clone
+Verify your go installation by running 
+```sh
+go version
+```
+
+Install Rust 
+_(this is an interactive installer)_
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Clone the Lotus repository
 
 ```sh
 git clone https://github.com/filecoin-project/lotus.git
 cd lotus/
 ```
 
-Install
+Build the Lotus binaries from source and install
 
 ```sh
 make clean && make all

--- a/documentation/en/install-lotus-ubuntu.md
+++ b/documentation/en/install-lotus-ubuntu.md
@@ -24,7 +24,7 @@ sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config
 
 Install Go 1.14
 
-Find the latest version of Go [on their website](https://golang.org/dl/) and follow the installation instructions. As of now, thats 1.14.4. Extract it to `/usr/local`, and add the go binaries to your `$PATH`.
+Find the latest version of Go [on their website](https://golang.org/dl/) and follow the installation instructions. At the time of writing this document, thats 1.14.4. Extract it to `/usr/local`, and add the go binaries to your `$PATH`.
 
 ```sh
 wget -c https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local

--- a/documentation/en/install-lotus-ubuntu.md
+++ b/documentation/en/install-lotus-ubuntu.md
@@ -18,23 +18,9 @@ These steps will install the following dependencies:
 Install dependencies
 
 ```sh
+sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt update
-sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config
-```
-
-Install Go 1.14
-
-Find the latest version of Go [on their website](https://golang.org/dl/) and follow the installation instructions. At the time of writing this document, thats 1.14.4. Extract it to `/usr/local`, and add the go binaries to your `$PATH`.
-
-```sh
-wget -c https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
-echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
-source ~/.profile
-```
-
-Verify your go installation by running 
-```sh
-go version
+sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config golang-go
 ```
 
 Install Rust 
@@ -58,3 +44,12 @@ sudo make install
 ```
 
 After installing Lotus, you can run the `lotus` command directly from your CLI to see usage documentation. Next, you can join the [Lotus Testnet](https://docs.lotu.sh/en+join-testnet).
+
+### Interopnet
+
+If you seek a smaller network to test, you can join the `interopnet`. Please note that this network is meant for developers - it resets much more often, and is much smaller. To join this network, checkout the branch `interopnet` instead of `master` before building and installing;
+```
+git checkout interopnet
+```
+
+Please also note that this documentation (if viewed on the website) might not be up to date with the interopnet. For the latest documentation on the interopnet branch, see the [Lotus Documentation Interopnet Branch on GitHub](https://github.com/filecoin-project/lotus/tree/interopnet/documentation/en)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200605171344-fcac609550ca
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/sector-storage v0.0.0-20200608203246-bccaf697129c
+	github.com/filecoin-project/sector-storage v0.0.0-20200609102403-57adda40f9b8
 	github.com/filecoin-project/specs-actors v0.5.6
 	github.com/filecoin-project/specs-storage v0.1.0
 	github.com/filecoin-project/storage-fsm v0.0.0-20200605082304-aa405b2176aa

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZO
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3/go.mod h1:B+xzopr/oWZJz2hBL5Ekb7Obcum5ntmfbaAUlaaho28=
-github.com/filecoin-project/sector-storage v0.0.0-20200608203246-bccaf697129c h1:xWl+lxNnPmRhHPvcIM10AJHHhdAEo8lrJjWdd7kpQzA=
-github.com/filecoin-project/sector-storage v0.0.0-20200608203246-bccaf697129c/go.mod h1:SfaVNw/A6LwqqEt6wEMVBN5Grn3XC50j+yjmegHIe7Y=
+github.com/filecoin-project/sector-storage v0.0.0-20200609102403-57adda40f9b8 h1:1R5yyZR0Y7whEvj71O+vfGov2cHh3aDiK5T5br842Dw=
+github.com/filecoin-project/sector-storage v0.0.0-20200609102403-57adda40f9b8/go.mod h1:SfaVNw/A6LwqqEt6wEMVBN5Grn3XC50j+yjmegHIe7Y=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200409043918-e569f4a2f504/go.mod h1:mdJraXq5vMy0+/FqVQIrnNlpQ/Em6zeu06G/ltQ0/lA=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=


### PR DESCRIPTION
Updates the documentation. This is what I've used to build the project on my freshly installed Ubuntu 20.04 machine.