### PR TITLE
docs: add a note about open files limit

### DIFF
--- a/documentation/en/join-testnet.md
+++ b/documentation/en/join-testnet.md
@@ -28,6 +28,8 @@ lotus net peers | wc -l
 
 In order to connect to the network, you need to be connected to at least 1 peer. If you’re seeing 0 peers, read our [troubleshooting notes](https://docs.lotu.sh/en+setup-troubleshooting).
 
+Make sure that you have a reasonable "open files limit" set on your machine, such as 10000. If you're seeing a lower value, such as 256 (default on macOS), read our [troubleshooting notes](https://docs.lotu.sh/en+setup-troubleshooting) on how to update it prior to starting the Lotus daemon.
+
 ## Chain sync
 
 While the daemon is running, the next requirement is to sync the chain. Run the command below to view the chain sync progress. To see current chain height, visit the [network stats page](https://stats.testnet.filecoin.io/).

--- a/documentation/en/setup-troubleshooting.md
+++ b/documentation/en/setup-troubleshooting.md
@@ -30,3 +30,17 @@ ERROR hello hello/hello.go:81 other peer has different genesis!
 ```
 
 - You already have another lotus daemon running.
+
+## Config: Open files limit
+
+On most systems you can check the open files limit with:
+
+```sh
+ulimit -n
+```
+
+You can also modify this number by using the `ulimit` command. It gives you the ability to control the resources available for the shell or process started by it. If the number is below 10000, you can change it with the following command prior to starting the Lotus daemon:
+
+```sh
+ulimit -n 10000
+```


### PR DESCRIPTION
When running `lotus` from scratch on my macOS laptop, I noticed a bunch a warnings in the logs about Badger not being able to run compaction, due to hitting the open files limit.

On my machine (macOS 10.15.5):
```
$ ulimit -n
256
```

So I suggest adding a note about it in the docs, maybe even worth checking it when booting up Lotus?