### PR TITLE
allow miner to disable/enable consideration of received storage deal proposals

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -54,7 +54,7 @@ type StorageMiner interface {
 
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)
-	DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error
+	DealsSetAcceptingStorageDeals(context.Context, bool) error
 
 	StorageAddLocal(ctx context.Context, path string) error
 }

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -54,6 +54,7 @@ type StorageMiner interface {
 
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)
+	DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error
 
 	StorageAddLocal(ctx context.Context, path string) error
 }

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -220,9 +220,9 @@ type StorageMinerStruct struct {
 		StorageLock          func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) error                             `perm:"admin"`
 		StorageTryLock       func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) (bool, error)                     `perm:"admin"`
 
-		DealsImportData                 func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
-		DealsList                       func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
-		DealsSetIsAcceptingStorageDeals func(ctx context.Context, b bool) error                           `perm:"admin"`
+		DealsImportData               func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
+		DealsList                     func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
+		DealsSetAcceptingStorageDeals func(context.Context, bool) error                                 `perm:"admin"`
 
 		StorageAddLocal func(ctx context.Context, path string) error `perm:"admin"`
 	}
@@ -853,8 +853,8 @@ func (c *StorageMinerStruct) DealsList(ctx context.Context) ([]storagemarket.Sto
 	return c.Internal.DealsList(ctx)
 }
 
-func (c *StorageMinerStruct) DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error {
-	return c.Internal.DealsSetIsAcceptingStorageDeals(ctx, b)
+func (c *StorageMinerStruct) DealsSetAcceptingStorageDeals(ctx context.Context, b bool) error {
+	return c.Internal.DealsSetAcceptingStorageDeals(ctx, b)
 }
 
 func (c *StorageMinerStruct) StorageAddLocal(ctx context.Context, path string) error {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -220,8 +220,9 @@ type StorageMinerStruct struct {
 		StorageLock          func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) error                             `perm:"admin"`
 		StorageTryLock       func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) (bool, error)                     `perm:"admin"`
 
-		DealsImportData func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
-		DealsList       func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
+		DealsImportData                 func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
+		DealsList                       func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
+		DealsSetIsAcceptingStorageDeals func(ctx context.Context, b bool) error                           `perm:"admin"`
 
 		StorageAddLocal func(ctx context.Context, path string) error `perm:"admin"`
 	}
@@ -850,6 +851,10 @@ func (c *StorageMinerStruct) DealsImportData(ctx context.Context, dealPropCid ci
 
 func (c *StorageMinerStruct) DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error) {
 	return c.Internal.DealsList(ctx)
+}
+
+func (c *StorageMinerStruct) DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error {
+	return c.Internal.DealsSetIsAcceptingStorageDeals(ctx, b)
 }
 
 func (c *StorageMinerStruct) StorageAddLocal(ctx context.Context, path string) error {

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -33,6 +33,8 @@ func main() {
 		setPriceCmd,
 		workersCmd,
 		provingCmd,
+		enableCmd,
+		disableCmd,
 	}
 	jaeger := tracing.SetupJaegerTracing("lotus")
 	defer func() {

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -33,8 +33,6 @@ func main() {
 		setPriceCmd,
 		workersCmd,
 		provingCmd,
-		enableCmd,
-		disableCmd,
 	}
 	jaeger := tracing.SetupJaegerTracing("lotus")
 	defer func() {

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -21,7 +21,7 @@ var enableCmd = &cli.Command{
 		}
 		defer closer()
 
-		return api.DealsSetIsAcceptingStorageDeals(lcli.DaemonContext(cctx), true)
+		return api.DealsSetAcceptingStorageDeals(lcli.DaemonContext(cctx), true)
 	},
 }
 
@@ -36,7 +36,7 @@ var disableCmd = &cli.Command{
 		}
 		defer closer()
 
-		return api.DealsSetIsAcceptingStorageDeals(lcli.DaemonContext(cctx), false)
+		return api.DealsSetAcceptingStorageDeals(lcli.DaemonContext(cctx), false)
 	},
 }
 

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -15,7 +15,13 @@ var enableCmd = &cli.Command{
 	Usage: "Configure the miner to consider storage deal proposals",
 	Flags: []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
-		panic("enable storage deals")
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		return api.DealsSetIsAcceptingStorageDeals(lcli.DaemonContext(cctx), true)
 	},
 }
 
@@ -24,7 +30,13 @@ var disableCmd = &cli.Command{
 	Usage: "Configure the miner to reject all storage deal proposals",
 	Flags: []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
-		panic("disable storage deals")
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		return api.DealsSetIsAcceptingStorageDeals(lcli.DaemonContext(cctx), false)
 	},
 }
 
@@ -60,6 +72,8 @@ var dealsCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		dealsImportDataCmd,
 		dealsListCmd,
+		enableCmd,
+		disableCmd,
 	},
 }
 

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -10,6 +10,24 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var enableCmd = &cli.Command{
+	Name:  "enable",
+	Usage: "Configure the miner to consider storage deal proposals",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		panic("enable storage deals")
+	},
+}
+
+var disableCmd = &cli.Command{
+	Name:  "disable",
+	Usage: "Configure the miner to reject all storage deal proposals",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		panic("disable storage deals")
+	},
+}
+
 var setPriceCmd = &cli.Command{
 	Name:  "set-price",
 	Usage: "Set price that miner will accept storage deals at (FIL / GiB / Epoch)",

--- a/node/builder.go
+++ b/node/builder.go
@@ -313,6 +313,7 @@ func Online() Option {
 			Override(HandleDealsKey, modules.HandleDeals),
 			Override(new(gen.WinningPoStProver), storage.NewWinningPoStProver),
 			Override(new(*miner.Miner), modules.SetupBlockProducer),
+			Override(new(dtypes.IsAcceptingStorageDealsFunc), modules.NewIsAcceptingStorageDealsFunc),
 		),
 	)
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -313,8 +313,9 @@ func Online() Option {
 			Override(HandleDealsKey, modules.HandleDeals),
 			Override(new(gen.WinningPoStProver), storage.NewWinningPoStProver),
 			Override(new(*miner.Miner), modules.SetupBlockProducer),
-			Override(new(dtypes.IsAcceptingStorageDealsFunc), modules.NewIsAcceptingStorageDealsFunc),
-			Override(new(dtypes.SetAcceptingStorageDealsFunc), modules.NewSetAcceptingStorageDealsFunc),
+
+			Override(new(dtypes.AcceptingStorageDealsConfigFunc), modules.NewAcceptingStorageDealsConfigFunc),
+			Override(new(dtypes.SetAcceptingStorageDealsConfigFunc), modules.NewSetAcceptingStorageDealsConfigFunc),
 		),
 	)
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -314,6 +314,7 @@ func Online() Option {
 			Override(new(gen.WinningPoStProver), storage.NewWinningPoStProver),
 			Override(new(*miner.Miner), modules.SetupBlockProducer),
 			Override(new(dtypes.IsAcceptingStorageDealsFunc), modules.NewIsAcceptingStorageDealsFunc),
+			Override(new(dtypes.SetAcceptingStorageDealsFunc), modules.NewSetAcceptingStorageDealsFunc),
 		),
 	)
 }

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -32,7 +32,7 @@ type StorageMiner struct {
 }
 
 type DealmakingConfig struct {
-	IsAcceptingStorageDeals bool
+	AcceptingStorageDeals bool
 }
 
 // API contains configs for API endpoint
@@ -116,7 +116,7 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		Dealmaking: DealmakingConfig{
-			IsAcceptingStorageDeals: true,
+			AcceptingStorageDeals: true,
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -27,7 +27,12 @@ type FullNode struct {
 type StorageMiner struct {
 	Common
 
-	Storage sectorstorage.SealerConfig
+	StorageDeals StorageDealConfig
+	Storage      sectorstorage.SealerConfig
+}
+
+type StorageDealConfig struct {
+	IsAcceptingStorageDeals bool
 }
 
 // API contains configs for API endpoint

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -27,11 +27,11 @@ type FullNode struct {
 type StorageMiner struct {
 	Common
 
-	StorageDeals StorageDealConfig
-	Storage      sectorstorage.SealerConfig
+	Dealmaking DealmakingConfig
+	Storage    sectorstorage.SealerConfig
 }
 
-type StorageDealConfig struct {
+type DealmakingConfig struct {
 	IsAcceptingStorageDeals bool
 }
 
@@ -113,6 +113,10 @@ func DefaultStorageMiner() *StorageMiner {
 			AllowPreCommit2: true,
 			AllowCommit:     true,
 			AllowUnseal:     true,
+		},
+
+		Dealmaking: DealmakingConfig{
+			IsAcceptingStorageDeals: true,
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -43,7 +43,7 @@ type StorageMinerAPI struct {
 	StorageMgr      *sectorstorage.Manager `optional:"true"`
 	*stores.Index
 
-	SetAcceptingStorageDealsFunc dtypes.SetAcceptingStorageDealsFunc
+	SetAcceptingStorageDealsConfigFunc dtypes.SetAcceptingStorageDealsConfigFunc
 }
 
 func (sm *StorageMinerAPI) ServeRemote(w http.ResponseWriter, r *http.Request) {
@@ -209,8 +209,8 @@ func (sm *StorageMinerAPI) DealsList(ctx context.Context) ([]storagemarket.Stora
 	return sm.StorageProvider.ListDeals(ctx)
 }
 
-func (sm *StorageMinerAPI) DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error {
-	return sm.SetAcceptingStorageDealsFunc(b)
+func (sm *StorageMinerAPI) DealsSetAcceptingStorageDeals(ctx context.Context, b bool) error {
+	return sm.SetAcceptingStorageDealsConfigFunc(b)
 }
 
 func (sm *StorageMinerAPI) DealsImportData(ctx context.Context, deal cid.Cid, fname string) error {

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node/impl/common"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/storage"
 	"github.com/filecoin-project/lotus/storage/sectorblocks"
 )
@@ -41,6 +42,8 @@ type StorageMinerAPI struct {
 	Full            api.FullNode
 	StorageMgr      *sectorstorage.Manager `optional:"true"`
 	*stores.Index
+
+	SetAcceptingStorageDealsFunc dtypes.SetAcceptingStorageDealsFunc
 }
 
 func (sm *StorageMinerAPI) ServeRemote(w http.ResponseWriter, r *http.Request) {
@@ -204,6 +207,10 @@ func (sm *StorageMinerAPI) MarketSetPrice(ctx context.Context, p types.BigInt) e
 
 func (sm *StorageMinerAPI) DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error) {
 	return sm.StorageProvider.ListDeals(ctx)
+}
+
+func (sm *StorageMinerAPI) DealsSetIsAcceptingStorageDeals(ctx context.Context, b bool) error {
+	return sm.SetAcceptingStorageDealsFunc(b)
 }
 
 func (sm *StorageMinerAPI) DealsImportData(ctx context.Context, deal cid.Cid, fname string) error {

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -7,3 +7,7 @@ import (
 
 type MinerAddress address.Address
 type MinerID abi.ActorID
+
+// IsAcceptingStorageDealsFunc is a function which reads from miner config to
+// determine if the user has disabled storage deals (or not).
+type IsAcceptingStorageDealsFunc func() (bool, error)

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -11,3 +11,7 @@ type MinerID abi.ActorID
 // IsAcceptingStorageDealsFunc is a function which reads from miner config to
 // determine if the user has disabled storage deals (or not).
 type IsAcceptingStorageDealsFunc func() (bool, error)
+
+// SetAcceptingStorageDealsFunc is a function which is used to disable or enable
+// storage deal acceptance.
+type SetAcceptingStorageDealsFunc func(bool) error

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -8,10 +8,10 @@ import (
 type MinerAddress address.Address
 type MinerID abi.ActorID
 
-// IsAcceptingStorageDealsFunc is a function which reads from miner config to
+// AcceptingStorageDealsFunc is a function which reads from miner config to
 // determine if the user has disabled storage deals (or not).
-type IsAcceptingStorageDealsFunc func() (bool, error)
+type AcceptingStorageDealsConfigFunc func() (bool, error)
 
 // SetAcceptingStorageDealsFunc is a function which is used to disable or enable
 // storage deal acceptance.
-type SetAcceptingStorageDealsFunc func(bool) error
+type SetAcceptingStorageDealsConfigFunc func(bool) error

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -389,6 +389,6 @@ func NewIsAcceptingStorageDealsFunc(r repo.LockedRepo) (dtypes.IsAcceptingStorag
 			return false, xerrors.New("expected address of config.StorageMiner")
 		}
 
-		return cfg.StorageDeals.IsAcceptingStorageDeals, nil
+		return cfg.Dealmaking.IsAcceptingStorageDeals, nil
 	}, nil
 }

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -315,11 +315,12 @@ func StorageProvider(minerAddress dtypes.MinerAddress, ffiConfig *ffiwrapper.Con
 	opt := storageimpl.CustomDealDecisionLogic(func(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error) {
 		willEntertainProposals, err := isAcceptingStorageDealsFunc()
 		if err != nil {
-			return false, "IsAcceptingStorageDealsFunc error", err
+			return false, "miner error", err
 		}
 
 		if !willEntertainProposals {
-			return false, "user has disabled storage deals", nil
+			log.Warnf("storage deal acceptance disabled; rejecting storage deal proposal from client: %s", deal.Client.String())
+			return false, "miner is not accepting storage deals", nil
 		}
 
 		return true, "", nil


### PR DESCRIPTION
## Why does this PR exist?

This changeset makes incremental progress towards #1920.

## What's in this PR?

This PR adds a `Config` get/set pair to the DI graph for the new `AcceptingStorageDealProposal` bool. The getter always loads config TOML from disk, and is called by the storage deal provider when it receives a storage deal proposal. The setter is called through two new CLI commands: `lotus-storage-miner deals disable` and `lotus-storage-miner deals enable`.

By default, a storage miner is configured to accept storage deals.