### PR TITLE
Miner QueryOffer API & non local-discovery retrieval CLI support

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -118,6 +118,7 @@ type FullNode interface {
 	ClientListDeals(ctx context.Context) ([]DealInfo, error)
 	ClientHasLocal(ctx context.Context, root cid.Cid) (bool, error)
 	ClientFindData(ctx context.Context, root cid.Cid) ([]QueryOffer, error)
+	ClientMinerQueryOffer(ctx context.Context, root cid.Cid, miner address.Address) (QueryOffer, error)
 	ClientRetrieve(ctx context.Context, order RetrievalOrder, ref *FileRef) error
 	ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)
 	ClientCalcCommP(ctx context.Context, inpath string, miner address.Address) (*CommPRet, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -106,17 +106,18 @@ type FullNodeStruct struct {
 		WalletImport         func(context.Context, *types.KeyInfo) (address.Address, error)                       `perm:"admin"`
 		WalletDelete         func(context.Context, address.Address) error                                         `perm:"write"`
 
-		ClientImport      func(ctx context.Context, ref api.FileRef) (cid.Cid, error)                                          `perm:"admin"`
-		ClientListImports func(ctx context.Context) ([]api.Import, error)                                                      `perm:"write"`
-		ClientHasLocal    func(ctx context.Context, root cid.Cid) (bool, error)                                                `perm:"write"`
-		ClientFindData    func(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error)                                    `perm:"read"`
-		ClientStartDeal   func(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error)                             `perm:"admin"`
-		ClientGetDealInfo func(context.Context, cid.Cid) (*api.DealInfo, error)                                                `perm:"read"`
-		ClientListDeals   func(ctx context.Context) ([]api.DealInfo, error)                                                    `perm:"write"`
-		ClientRetrieve    func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error                          `perm:"admin"`
-		ClientQueryAsk    func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error) `perm:"read"`
-		ClientCalcCommP   func(ctx context.Context, inpath string, miner address.Address) (*api.CommPRet, error)               `perm:"read"`
-		ClientGenCar      func(ctx context.Context, ref api.FileRef, outpath string) error                                     `perm:"write"`
+		ClientImport          func(ctx context.Context, ref api.FileRef) (cid.Cid, error)                                          `perm:"admin"`
+		ClientListImports     func(ctx context.Context) ([]api.Import, error)                                                      `perm:"write"`
+		ClientHasLocal        func(ctx context.Context, root cid.Cid) (bool, error)                                                `perm:"write"`
+		ClientFindData        func(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error)                                    `perm:"read"`
+		ClientMinerQueryOffer func(ctx context.Context, root cid.Cid, miner address.Address) (api.QueryOffer, error)               `perm:"read"`
+		ClientStartDeal       func(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error)                             `perm:"admin"`
+		ClientGetDealInfo     func(context.Context, cid.Cid) (*api.DealInfo, error)                                                `perm:"read"`
+		ClientListDeals       func(ctx context.Context) ([]api.DealInfo, error)                                                    `perm:"write"`
+		ClientRetrieve        func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error                          `perm:"admin"`
+		ClientQueryAsk        func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error) `perm:"read"`
+		ClientCalcCommP       func(ctx context.Context, inpath string, miner address.Address) (*api.CommPRet, error)               `perm:"read"`
+		ClientGenCar          func(ctx context.Context, ref api.FileRef, outpath string) error                                     `perm:"write"`
 
 		StateNetworkName                  func(context.Context) (dtypes.NetworkName, error)                                                                   `perm:"read"`
 		StateMinerSectors                 func(context.Context, address.Address, *abi.BitField, bool, types.TipSetKey) ([]*api.ChainSectorInfo, error)        `perm:"read"`
@@ -316,6 +317,10 @@ func (c *FullNodeStruct) ClientHasLocal(ctx context.Context, root cid.Cid) (bool
 
 func (c *FullNodeStruct) ClientFindData(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error) {
 	return c.Internal.ClientFindData(ctx, root)
+}
+
+func (c *FullNodeStruct) ClientMinerQueryOffer(ctx context.Context, root cid.Cid, miner address.Address) (api.QueryOffer, error) {
+	return c.Internal.ClientMinerQueryOffer(ctx, root, miner)
 }
 
 func (c *FullNodeStruct) ClientStartDeal(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 
+	"github.com/filecoin-project/lotus/api"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 )
@@ -391,6 +392,10 @@ var clientRetrieveCmd = &cli.Command{
 			Name:  "car",
 			Usage: "export to a car file instead of a regular file",
 		},
+		&cli.StringFlag{
+			Name:  "miner",
+			Usage: "miner address for retrieval, if not present it'll use local discovery",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
@@ -398,7 +403,7 @@ var clientRetrieveCmd = &cli.Command{
 			return nil
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		fapi, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -409,7 +414,7 @@ var clientRetrieveCmd = &cli.Command{
 		if cctx.String("address") != "" {
 			payer, err = address.NewFromString(cctx.String("address"))
 		} else {
-			payer, err = api.WalletDefaultAddress(ctx)
+			payer, err = fapi.WalletDefaultAddress(ctx)
 		}
 		if err != nil {
 			return err
@@ -432,23 +437,36 @@ var clientRetrieveCmd = &cli.Command{
 			return nil
 		}*/ // TODO: fix
 
-		offers, err := api.ClientFindData(ctx, file)
-		if err != nil {
-			return err
-		}
+		var offer api.QueryOffer
+		minerStrAddr := cctx.String("miner")
+		if minerStrAddr == "" { // Local discovery
+			offers, err := fapi.ClientFindData(ctx, file)
+			if err != nil {
+				return err
+			}
 
-		// TODO: parse offer strings from `client find`, make this smarter
-
-		if len(offers) < 1 {
-			fmt.Println("Failed to find file")
-			return nil
+			// TODO: parse offer strings from `client find`, make this smarter
+			if len(offers) < 1 {
+				fmt.Println("Failed to find file")
+				return nil
+			}
+			offer = offers[0]
+		} else { // Directed retrieval
+			minerAddr, err := address.NewFromString(minerStrAddr)
+			if err != nil {
+				return err
+			}
+			offer, err = fapi.ClientMinerQueryOffer(ctx, file, minerAddr)
+			if err != nil {
+				return err
+			}
 		}
 
 		ref := &lapi.FileRef{
 			Path:  cctx.Args().Get(1),
 			IsCAR: cctx.Bool("car"),
 		}
-		if err := api.ClientRetrieve(ctx, offers[0].Order(payer), ref); err != nil {
+		if err := fapi.ClientRetrieve(ctx, offer.Order(payer), ref); err != nil {
 			return xerrors.Errorf("Retrieval Failed: %w", err)
 		}
 

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -208,8 +208,13 @@ func (a *API) ClientFindData(ctx context.Context, root cid.Cid) ([]api.QueryOffe
 }
 
 func (a *API) ClientMinerQueryOffer(ctx context.Context, payload cid.Cid, miner address.Address) (api.QueryOffer, error) {
+	mi, err := a.StateMinerInfo(ctx, miner, types.EmptyTSK)
+	if err != nil {
+		return api.QueryOffer{}, err
+	}
 	rp := retrievalmarket.RetrievalPeer{
 		Address: miner,
+		ID:      mi.PeerId,
 	}
 	return a.makeRetrievalQuery(ctx, rp, payload, retrievalmarket.QueryParams{}), nil
 }

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -201,23 +201,34 @@ func (a *API) ClientFindData(ctx context.Context, root cid.Cid) ([]api.QueryOffe
 
 	out := make([]api.QueryOffer, len(peers))
 	for k, p := range peers {
-		queryResponse, err := a.Retrieval.Query(ctx, p, root, retrievalmarket.QueryParams{})
-		if err != nil {
-			out[k] = api.QueryOffer{Err: err.Error(), Miner: p.Address, MinerPeerID: p.ID}
-		} else {
-			out[k] = api.QueryOffer{
-				Root:                    root,
-				Size:                    queryResponse.Size,
-				MinPrice:                queryResponse.PieceRetrievalPrice(),
-				PaymentInterval:         queryResponse.MaxPaymentInterval,
-				PaymentIntervalIncrease: queryResponse.MaxPaymentIntervalIncrease,
-				Miner:                   queryResponse.PaymentAddress, // TODO: check
-				MinerPeerID:             p.ID,
-			}
-		}
+		out[k] = a.makeRetrievalQuery(ctx, p, root, retrievalmarket.QueryParams{})
 	}
 
 	return out, nil
+}
+
+func (a *API) ClientMinerQueryOffer(ctx context.Context, payload cid.Cid, miner address.Address) (api.QueryOffer, error) {
+	rp := retrievalmarket.RetrievalPeer{
+		Address: miner,
+	}
+	return a.makeRetrievalQuery(ctx, rp, payload, retrievalmarket.QueryParams{}), nil
+}
+
+func (a *API) makeRetrievalQuery(ctx context.Context, rp retrievalmarket.RetrievalPeer, payload cid.Cid, qp retrievalmarket.QueryParams) api.QueryOffer {
+	queryResponse, err := a.Retrieval.Query(ctx, rp, payload, qp)
+	if err != nil {
+		return api.QueryOffer{Err: err.Error(), Miner: rp.Address, MinerPeerID: rp.ID}
+	}
+
+	return api.QueryOffer{
+		Root:                    payload,
+		Size:                    queryResponse.Size,
+		MinPrice:                queryResponse.PieceRetrievalPrice(),
+		PaymentInterval:         queryResponse.MaxPaymentInterval,
+		PaymentIntervalIncrease: queryResponse.MaxPaymentIntervalIncrease,
+		Miner:                   queryResponse.PaymentAddress, // TODO: check
+		MinerPeerID:             rp.ID,
+	}
 }
 
 func (a *API) ClientImport(ctx context.Context, ref api.FileRef) (cid.Cid, error) {


### PR DESCRIPTION
This PR creates a new `ClientMinerQueryOffer` API and adds support in the CLI for making retrievals for arbitrary deals for the desired miner.

Currently, `lotus client retrieval` searches for miners storing a PayloadCid in a local table. That is, we can only retrieve data if the same Lotus node had made the deals since it's how the local table is kept. When `lotus client retrieval` is executed, it looks for those locally-known miners and selects the first as the retrieval miner for the data.

Now `lotus client retrieval` accepts a `--miner` flag, which indicates that the client want's to retrieve the data from a particular miner. This means it won't rely on _local knowledge_ for the retrieval. This allows to retrieve data made by other Filecoin client, e.g: I tell a friend that my data has a particular _PayloadCid_ and is stored by _t01888_, so it can use this new feature to retrieve the data.

To allow that, I added a new API `ClientMinerQueryOffer` which will return a `QueryOffer` returned by the miner about a particular _PayloadCid_. This API may be useful for other cases than the new CLI feature.