### PR TITLE
Consider QueryOffer Error & Status

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -461,6 +461,9 @@ var clientRetrieveCmd = &cli.Command{
 				return err
 			}
 		}
+		if offer.Err != "" {
+			return fmt.Errorf("The received offer errored: %s", offer.Err)
+		}
 
 		ref := &lapi.FileRef{
 			Path:  cctx.Args().Get(1),

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -224,6 +224,15 @@ func (a *API) makeRetrievalQuery(ctx context.Context, rp retrievalmarket.Retriev
 	if err != nil {
 		return api.QueryOffer{Err: err.Error(), Miner: rp.Address, MinerPeerID: rp.ID}
 	}
+	var errStr string
+	switch queryResponse.Status {
+	case retrievalmarket.QueryResponseAvailable:
+		errStr = ""
+	case retrievalmarket.QueryResponseUnavailable:
+		errStr = "retrieval query offer was unavailable"
+	case retrievalmarket.QueryResponseError:
+		errStr = "retrieval query offer errored"
+	}
 
 	return api.QueryOffer{
 		Root:                    payload,
@@ -233,6 +242,7 @@ func (a *API) makeRetrievalQuery(ctx context.Context, rp retrievalmarket.Retriev
 		PaymentIntervalIncrease: queryResponse.MaxPaymentIntervalIncrease,
 		Miner:                   queryResponse.PaymentAddress, // TODO: check
 		MinerPeerID:             rp.ID,
+		Err:                     errStr,
 	}
 }
 

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
@@ -229,9 +230,9 @@ func (a *API) makeRetrievalQuery(ctx context.Context, rp retrievalmarket.Retriev
 	case retrievalmarket.QueryResponseAvailable:
 		errStr = ""
 	case retrievalmarket.QueryResponseUnavailable:
-		errStr = "retrieval query offer was unavailable"
+		errStr = fmt.Sprintf("retrieval query offer was unavailable: %s", queryResponse.Message)
 	case retrievalmarket.QueryResponseError:
-		errStr = "retrieval query offer errored"
+		errStr = fmt.Sprintf("retrieval query offer errored: %s", queryResponse.Message)
 	}
 
 	return api.QueryOffer{


### PR DESCRIPTION
Consider `QueryOffer.Status` before calling `ClientRetrieve`, and be aware of non-errored `Retrieval.Query` calls that have non-success `.Status`.

Continuation of #2040
cc @whyrusleeping 