### PR TITLE
add ask-manipulating (and printing) deal subcommands

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -51,6 +51,7 @@ type StorageMiner interface {
 	MarketListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error)
 	MarketListIncompleteDeals(ctx context.Context) ([]storagemarket.MinerDeal, error)
 	MarketSetAsk(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error
+	MarketGetAsk(ctx context.Context) (*storagemarket.SignedStorageAsk, error)
 
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -50,7 +50,7 @@ type StorageMiner interface {
 	MarketImportDealData(ctx context.Context, propcid cid.Cid, path string) error
 	MarketListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error)
 	MarketListIncompleteDeals(ctx context.Context) ([]storagemarket.MinerDeal, error)
-	MarketSetPrice(context.Context, types.BigInt) error
+	MarketSetAsk(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error
 
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -192,10 +192,10 @@ type StorageMinerStruct struct {
 
 		MiningBase func(context.Context) (*types.TipSet, error) `perm:"read"`
 
-		MarketImportDealData      func(context.Context, cid.Cid, string) error                   `perm:"write"`
-		MarketListDeals           func(ctx context.Context) ([]storagemarket.StorageDeal, error) `perm:"read"`
-		MarketListIncompleteDeals func(ctx context.Context) ([]storagemarket.MinerDeal, error)   `perm:"read"`
-		MarketSetPrice            func(context.Context, types.BigInt) error                      `perm:"admin"`
+		MarketImportDealData      func(context.Context, cid.Cid, string) error                                                                                                     `perm:"write"`
+		MarketListDeals           func(ctx context.Context) ([]storagemarket.StorageDeal, error)                                                                                   `perm:"read"`
+		MarketListIncompleteDeals func(ctx context.Context) ([]storagemarket.MinerDeal, error)                                                                                     `perm:"read"`
+		MarketSetAsk              func(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error `perm:"admin"`
 
 		PledgeSector func(context.Context) error `perm:"write"`
 
@@ -841,8 +841,8 @@ func (c *StorageMinerStruct) MarketListIncompleteDeals(ctx context.Context) ([]s
 	return c.Internal.MarketListIncompleteDeals(ctx)
 }
 
-func (c *StorageMinerStruct) MarketSetPrice(ctx context.Context, p types.BigInt) error {
-	return c.Internal.MarketSetPrice(ctx, p)
+func (c *StorageMinerStruct) MarketSetAsk(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error {
+	return c.Internal.MarketSetAsk(ctx, price, duration, minPieceSize, maxPieceSize)
 }
 
 func (c *StorageMinerStruct) DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -196,6 +196,7 @@ type StorageMinerStruct struct {
 		MarketListDeals           func(ctx context.Context) ([]storagemarket.StorageDeal, error)                                                                                   `perm:"read"`
 		MarketListIncompleteDeals func(ctx context.Context) ([]storagemarket.MinerDeal, error)                                                                                     `perm:"read"`
 		MarketSetAsk              func(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error `perm:"admin"`
+		MarketGetAsk              func(ctx context.Context) (*storagemarket.SignedStorageAsk, error)                                                                               `perm:"read"`
 
 		PledgeSector func(context.Context) error `perm:"write"`
 
@@ -843,6 +844,10 @@ func (c *StorageMinerStruct) MarketListIncompleteDeals(ctx context.Context) ([]s
 
 func (c *StorageMinerStruct) MarketSetAsk(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error {
 	return c.Internal.MarketSetAsk(ctx, price, duration, minPieceSize, maxPieceSize)
+}
+
+func (c *StorageMinerStruct) MarketGetAsk(ctx context.Context) (*storagemarket.SignedStorageAsk, error) {
+	return c.Internal.MarketGetAsk(ctx)
 }
 
 func (c *StorageMinerStruct) DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error {

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -30,7 +30,6 @@ func main() {
 		stopCmd,
 		sectorsCmd,
 		storageCmd,
-		setPriceCmd,
 		workersCmd,
 		provingCmd,
 	}

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -140,13 +140,19 @@ var getAskCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.DaemonContext(cctx)
 
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		fnapi, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 
-		sask, err := api.MarketGetAsk(ctx)
+		smapi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		sask, err := smapi.MarketGetAsk(ctx)
 		if err != nil {
 			return err
 		}
@@ -164,12 +170,12 @@ var getAskCmd = &cli.Command{
 			return w.Flush()
 		}
 
-		miningBaseTs, err := api.MiningBase(ctx)
+		head, err := fnapi.ChainHead(ctx)
 		if err != nil {
 			return err
 		}
 
-		dlt := ask.Expiry - miningBaseTs.Height()
+		dlt := ask.Expiry - head.Height()
 		rem := "<expired>"
 		if dlt > 0 {
 			rem = (time.Second * time.Duration(dlt*build.BlockDelay)).String()

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/ipfs/go-cid"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
@@ -119,7 +118,7 @@ var setAskCmd = &cli.Command{
 		}
 
 		if max > smax {
-			return errors.Errorf("max piece size (w/bit-padding) %s cannot exceed miner sector size %s", types.SizeStr(types.NewInt(uint64(max))), types.SizeStr(types.NewInt(uint64(smax))))
+			return xerrors.Errorf("max piece size (w/bit-padding) %s cannot exceed miner sector size %s", types.SizeStr(types.NewInt(uint64(max))), types.SizeStr(types.NewInt(uint64(smax))))
 		}
 
 		return api.MarketSetAsk(ctx, pri, dur, abi.PaddedPieceSize(min), abi.PaddedPieceSize(max))

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/filecoin-project/lotus/chain/types"
-	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/docker/go-units"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
 )
 
 var enableCmd = &cli.Command{
@@ -40,29 +43,70 @@ var disableCmd = &cli.Command{
 	},
 }
 
-var setPriceCmd = &cli.Command{
-	Name:  "set-price",
-	Usage: "Set price that miner will accept storage deals at (FIL / GiB / Epoch)",
-	Flags: []cli.Flag{},
+var setAskCmd = &cli.Command{
+	Name:  "set-ask",
+	Usage: "Configure the miner's ask",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name:     "price",
+			Usage:    "Set the price of the ask (specified as FIL / GiB / Epoch) to `PRICE`",
+			Required: true,
+		},
+		&cli.Uint64Flag{
+			Name:        "duration",
+			Usage:       "Set the duration (specified as epochs) of the ask to `DURATION`",
+			DefaultText: "8640000",
+			Value:       8640000,
+		},
+		&cli.StringFlag{
+			Name:        "min-piece-size",
+			Usage:       "Set minimum piece size (without bit-padding, in bytes) in ask to `SIZE`",
+			DefaultText: "254B",
+			Value:       "254B",
+		},
+		&cli.StringFlag{
+			Name:        "max-piece-size",
+			Usage:       "Set maximum piece size (without bit-padding, in bytes) in ask to `SIZE`",
+			DefaultText: "miner sector size, without bit-padding",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
+		ctx := lcli.DaemonContext(cctx)
+
 		api, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 
-		ctx := lcli.DaemonContext(cctx)
+		pri := types.NewInt(cctx.Uint64("price"))
+		dur := abi.ChainEpoch(cctx.Uint64("duration"))
 
-		if !cctx.Args().Present() {
-			return fmt.Errorf("must specify price to set")
-		}
-
-		fp, err := types.ParseFIL(cctx.Args().First())
+		min, err := units.RAMInBytes(cctx.String("min-piece-size"))
 		if err != nil {
 			return err
 		}
 
-		return api.MarketSetPrice(ctx, types.BigInt(fp))
+		max, err := units.RAMInBytes(cctx.String("max-piece-size"))
+		if err != nil {
+			return err
+		}
+
+		if max == 0 {
+			maddr, err := api.ActorAddress(ctx)
+			if err != nil {
+				return err
+			}
+
+			ssize, err := api.ActorSectorSize(ctx, maddr)
+			if err != nil {
+				return err
+			}
+
+			max = int64(abi.PaddedPieceSize(ssize).Unpadded())
+		}
+
+		return api.MarketSetAsk(ctx, pri, dur, abi.UnpaddedPieceSize(min).Padded(), abi.UnpaddedPieceSize(max).Padded())
 	},
 }
 
@@ -74,6 +118,7 @@ var dealsCmd = &cli.Command{
 		dealsListCmd,
 		enableCmd,
 		disableCmd,
+		setAskCmd,
 	},
 }
 

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -59,7 +59,7 @@ var setAskCmd = &cli.Command{
 		},
 		&cli.Uint64Flag{
 			Name:        "duration",
-			Usage:       "Set the duration (specified as epochs) of the ask to `DURATION`",
+			Usage:       "Set the number of epochs (from now) that the ask will expire `DURATION`",
 			DefaultText: "100000",
 			Value:       100000,
 		},

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -138,11 +138,11 @@ var getAskCmd = &cli.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "Price per GiB / Epoch\tMin. Piece Size (bytes, unpadded)\tMax. Piece Size (bytes, unpadded)\tExpiry\tSeq. No.\n")
+		fmt.Fprintf(w, "Price per GiB / Epoch\tMin. Piece Size (unpadded)\tMax. Piece Size (unpadded)\tExpiry\tSeq. No.\n")
 		if ask == nil {
 			fmt.Fprintf(w, "<miner does not have an ask>\n")
 		} else {
-			fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\n", ask.Price, ask.MinPieceSize.Unpadded(), ask.MaxPieceSize.Unpadded(), ask.Expiry, ask.SeqNo)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\n", ask.Price, types.SizeStr(types.NewInt(uint64(ask.MinPieceSize.Unpadded()))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize.Unpadded()))), ask.Expiry, ask.SeqNo)
 		}
 
 		return w.Flush()

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -169,7 +169,11 @@ var getAskCmd = &cli.Command{
 			return err
 		}
 
-		rem := time.Second * time.Duration((ask.Expiry-miningBaseTs.Height())*build.BlockDelay)
+		dlt := ask.Expiry - miningBaseTs.Height()
+		rem := "<expired>"
+		if dlt > 0 {
+			rem = (time.Second * time.Duration(dlt*build.BlockDelay)).String()
+		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%d\n", ask.Price, types.SizeStr(types.NewInt(uint64(ask.MinPieceSize))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize))), ask.Expiry, rem, ask.SeqNo)
 

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/multiformats/go-multibase v0.0.2
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,6 @@ require (
 	github.com/multiformats/go-multibase v0.0.2
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -210,6 +210,10 @@ func (sm *StorageMinerAPI) MarketSetAsk(ctx context.Context, price types.BigInt,
 	return sm.StorageProvider.SetAsk(price, duration, options...)
 }
 
+func (sm *StorageMinerAPI) MarketGetAsk(ctx context.Context) (*storagemarket.SignedStorageAsk, error) {
+	return sm.StorageProvider.GetAsk(), nil
+}
+
 func (sm *StorageMinerAPI) DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error) {
 	return sm.StorageProvider.ListDeals(ctx)
 }

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -201,8 +201,13 @@ func (sm *StorageMinerAPI) MarketListIncompleteDeals(ctx context.Context) ([]sto
 	return sm.StorageProvider.ListLocalDeals()
 }
 
-func (sm *StorageMinerAPI) MarketSetPrice(ctx context.Context, p types.BigInt) error {
-	return sm.StorageProvider.SetAsk(p, 60*60*24*100) // lasts for 100 days?
+func (sm *StorageMinerAPI) MarketSetAsk(ctx context.Context, price types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error {
+	options := []storagemarket.StorageAskOption{
+		storagemarket.MinPieceSize(minPieceSize),
+		storagemarket.MaxPieceSize(maxPieceSize),
+	}
+
+	return sm.StorageProvider.SetAsk(price, duration, options...)
 }
 
 func (sm *StorageMinerAPI) DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error) {


### PR DESCRIPTION
## Why does this PR exist?

Fixes #2027.

Miners need to be able to set their ask's minimum and maximum piece size in addition to price and duration.

## What's in this PR?

This PR replaces the `lotus-storage-miner set-price` command with `lotus-storage-miner deals set-ask` and `lotus-storage-miner deals get-ask` commands.