### PR TITLE
wdpost: Don't return nil from checkSectors

### DIFF
--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -99,10 +99,6 @@ func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check *abi.BitFi
 
 	log.Warnw("Checked sectors", "checked", len(tocheck), "good", len(sectors))
 
-	if len(sectors) == 0 { // nothing to recover
-		return nil, nil
-	}
-
 	sbf := bitfield.New()
 	for s := range sectors {
 		(&sbf).Set(uint64(s.Number))


### PR DESCRIPTION
This caused panics when all sectors were faulty