### PR TITLE
allow storage miners to manage a blocklist of piece CIDs

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -56,8 +56,8 @@ type StorageMiner interface {
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)
 	DealsSetAcceptingStorageDeals(context.Context, bool) error
-	DealsBlacklist(context.Context) ([]cid.Cid, error)
-	DealsSetBlacklist(context.Context, []cid.Cid) error
+	DealsPieceCidBlacklist(context.Context) ([]cid.Cid, error)
+	DealsSetPieceCidBlacklist(context.Context, []cid.Cid) error
 
 	StorageAddLocal(ctx context.Context, path string) error
 }

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -56,6 +56,8 @@ type StorageMiner interface {
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)
 	DealsSetAcceptingStorageDeals(context.Context, bool) error
+	DealsBlacklist(context.Context) ([]cid.Cid, error)
+	DealsSetBlacklist(context.Context, []cid.Cid) error
 
 	StorageAddLocal(ctx context.Context, path string) error
 }

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -226,6 +226,8 @@ type StorageMinerStruct struct {
 		DealsImportData               func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
 		DealsList                     func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
 		DealsSetAcceptingStorageDeals func(context.Context, bool) error                                 `perm:"admin"`
+		DealsBlacklist                func(context.Context) ([]cid.Cid, error)                          `perm:"admin"`
+		DealsSetBlacklist             func(context.Context, []cid.Cid) error                            `perm:"read"`
 
 		StorageAddLocal func(ctx context.Context, path string) error `perm:"admin"`
 	}
@@ -870,6 +872,14 @@ func (c *StorageMinerStruct) DealsList(ctx context.Context) ([]storagemarket.Sto
 
 func (c *StorageMinerStruct) DealsSetAcceptingStorageDeals(ctx context.Context, b bool) error {
 	return c.Internal.DealsSetAcceptingStorageDeals(ctx, b)
+}
+
+func (c *StorageMinerStruct) DealsBlacklist(ctx context.Context) ([]cid.Cid, error) {
+	return c.Internal.DealsBlacklist(ctx)
+}
+
+func (c *StorageMinerStruct) DealsSetBlacklist(ctx context.Context, cids []cid.Cid) error {
+	return c.Internal.DealsSetBlacklist(ctx, cids)
 }
 
 func (c *StorageMinerStruct) StorageAddLocal(ctx context.Context, path string) error {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -226,8 +226,8 @@ type StorageMinerStruct struct {
 		DealsImportData               func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
 		DealsList                     func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
 		DealsSetAcceptingStorageDeals func(context.Context, bool) error                                 `perm:"admin"`
-		DealsBlacklist                func(context.Context) ([]cid.Cid, error)                          `perm:"admin"`
-		DealsSetBlacklist             func(context.Context, []cid.Cid) error                            `perm:"read"`
+		DealsPieceCidBlacklist        func(context.Context) ([]cid.Cid, error)                          `perm:"admin"`
+		DealsSetPieceCidBlacklist     func(context.Context, []cid.Cid) error                            `perm:"read"`
 
 		StorageAddLocal func(ctx context.Context, path string) error `perm:"admin"`
 	}
@@ -874,12 +874,12 @@ func (c *StorageMinerStruct) DealsSetAcceptingStorageDeals(ctx context.Context, 
 	return c.Internal.DealsSetAcceptingStorageDeals(ctx, b)
 }
 
-func (c *StorageMinerStruct) DealsBlacklist(ctx context.Context) ([]cid.Cid, error) {
-	return c.Internal.DealsBlacklist(ctx)
+func (c *StorageMinerStruct) DealsPieceCidBlacklist(ctx context.Context) ([]cid.Cid, error) {
+	return c.Internal.DealsPieceCidBlacklist(ctx)
 }
 
-func (c *StorageMinerStruct) DealsSetBlacklist(ctx context.Context, cids []cid.Cid) error {
-	return c.Internal.DealsSetBlacklist(ctx, cids)
+func (c *StorageMinerStruct) DealsSetPieceCidBlacklist(ctx context.Context, cids []cid.Cid) error {
+	return c.Internal.DealsSetPieceCidBlacklist(ctx, cids)
 }
 
 func (c *StorageMinerStruct) StorageAddLocal(ctx context.Context, path string) error {

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -293,7 +293,7 @@ var dealsListCmd = &cli.Command{
 
 var getBlacklistCmd = &cli.Command{
 	Name:  "get-blacklist",
-	Usage: "List the CIDs in the storage miner's blacklist",
+	Usage: "List the contents of the storage miner's piece CID blacklist",
 	Flags: []cli.Flag{
 		&CidBaseFlag,
 	},
@@ -304,7 +304,7 @@ var getBlacklistCmd = &cli.Command{
 		}
 		defer closer()
 
-		blacklist, err := api.DealsBlacklist(lcli.DaemonContext(cctx))
+		blacklist, err := api.DealsPieceCidBlacklist(lcli.DaemonContext(cctx))
 		if err != nil {
 			return err
 		}
@@ -324,8 +324,8 @@ var getBlacklistCmd = &cli.Command{
 
 var setBlacklistCmd = &cli.Command{
 	Name:      "set-blacklist",
-	Usage:     "Set the storage miner's list of blacklisted CIDs",
-	ArgsUsage: "[<path-of-file-containing-newline-delimited-CIDs> (optional, will read from stdin if omitted)]",
+	Usage:     "Set the storage miner's list of blacklisted piece CIDs",
+	ArgsUsage: "[<path-of-file-containing-newline-delimited-piece-CIDs> (optional, will read from stdin if omitted)]",
 	Flags:     []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := lcli.GetStorageMinerAPI(cctx)
@@ -365,13 +365,13 @@ var setBlacklistCmd = &cli.Command{
 			return err
 		}
 
-		return api.DealsSetBlacklist(lcli.DaemonContext(cctx), blacklist)
+		return api.DealsSetPieceCidBlacklist(lcli.DaemonContext(cctx), blacklist)
 	},
 }
 
 var resetBlacklistCmd = &cli.Command{
 	Name:  "reset-blacklist",
-	Usage: "Remove all entries from the storage miner's blacklist",
+	Usage: "Remove all entries from the storage miner's piece CID blacklist",
 	Flags: []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := lcli.GetStorageMinerAPI(cctx)
@@ -380,6 +380,6 @@ var resetBlacklistCmd = &cli.Command{
 		}
 		defer closer()
 
-		return api.DealsSetBlacklist(lcli.DaemonContext(cctx), []cid.Cid{})
+		return api.DealsSetPieceCidBlacklist(lcli.DaemonContext(cctx), []cid.Cid{})
 	},
 }

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -140,6 +140,8 @@ var getAskCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.DaemonContext(cctx)
 
+		fmt.Println("wombat")
+
 		fnapi, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -170,8 +170,6 @@ var getAskCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.DaemonContext(cctx)
 
-		fmt.Println("wombat")
-
 		fnapi, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err

--- a/node/builder.go
+++ b/node/builder.go
@@ -314,8 +314,8 @@ func Online() Option {
 
 			Override(new(dtypes.AcceptingStorageDealsConfigFunc), modules.NewAcceptingStorageDealsConfigFunc),
 			Override(new(dtypes.SetAcceptingStorageDealsConfigFunc), modules.NewSetAcceptingStorageDealsConfigFunc),
-			Override(new(dtypes.StorageDealCidBlacklistConfigFunc), modules.NewStorageDealCidBlacklistConfigFunc),
-			Override(new(dtypes.SetStorageDealCidBlacklistConfigFunc), modules.NewSetStorageDealCidBlacklistConfigFunc),
+			Override(new(dtypes.StorageDealPieceCidBlacklistConfigFunc), modules.NewStorageDealPieceCidBlacklistConfigFunc),
+			Override(new(dtypes.SetStorageDealPieceCidBlacklistConfigFunc), modules.NewSetStorageDealPieceCidBlacklistConfigFunc),
 		),
 	)
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -314,6 +314,8 @@ func Online() Option {
 
 			Override(new(dtypes.AcceptingStorageDealsConfigFunc), modules.NewAcceptingStorageDealsConfigFunc),
 			Override(new(dtypes.SetAcceptingStorageDealsConfigFunc), modules.NewSetAcceptingStorageDealsConfigFunc),
+			Override(new(dtypes.StorageDealCidBlacklistConfigFunc), modules.NewStorageDealCidBlacklistConfigFunc),
+			Override(new(dtypes.SetStorageDealCidBlacklistConfigFunc), modules.NewSetStorageDealCidBlacklistConfigFunc),
 		),
 	)
 }

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -35,7 +35,7 @@ type StorageMiner struct {
 
 type DealmakingConfig struct {
 	AcceptingStorageDeals bool
-	Blacklist             []cid.Cid
+	PieceCidBlacklist     []cid.Cid
 }
 
 // API contains configs for API endpoint
@@ -124,7 +124,7 @@ func DefaultStorageMiner() *StorageMiner {
 
 		Dealmaking: DealmakingConfig{
 			AcceptingStorageDeals: true,
-			Blacklist:             []cid.Cid{},
+			PieceCidBlacklist:     []cid.Cid{},
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -4,6 +4,8 @@ import (
 	"encoding"
 	"time"
 
+	"github.com/ipfs/go-cid"
+
 	sectorstorage "github.com/filecoin-project/sector-storage"
 )
 
@@ -33,6 +35,7 @@ type StorageMiner struct {
 
 type DealmakingConfig struct {
 	AcceptingStorageDeals bool
+	Blacklist             []cid.Cid
 }
 
 // API contains configs for API endpoint
@@ -121,6 +124,7 @@ func DefaultStorageMiner() *StorageMiner {
 
 		Dealmaking: DealmakingConfig{
 			AcceptingStorageDeals: true,
+			Blacklist:             []cid.Cid{},
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -43,9 +43,9 @@ type StorageMinerAPI struct {
 	StorageMgr      *sectorstorage.Manager `optional:"true"`
 	*stores.Index
 
-	SetAcceptingStorageDealsConfigFunc   dtypes.SetAcceptingStorageDealsConfigFunc
-	StorageDealCidBlacklistConfigFunc    dtypes.StorageDealCidBlacklistConfigFunc
-	SetStorageDealCidBlacklistConfigFunc dtypes.SetStorageDealCidBlacklistConfigFunc
+	SetAcceptingStorageDealsConfigFunc        dtypes.SetAcceptingStorageDealsConfigFunc
+	StorageDealPieceCidBlacklistConfigFunc    dtypes.StorageDealPieceCidBlacklistConfigFunc
+	SetStorageDealPieceCidBlacklistConfigFunc dtypes.SetStorageDealPieceCidBlacklistConfigFunc
 }
 
 func (sm *StorageMinerAPI) ServeRemote(w http.ResponseWriter, r *http.Request) {
@@ -234,12 +234,12 @@ func (sm *StorageMinerAPI) DealsImportData(ctx context.Context, deal cid.Cid, fn
 	return sm.StorageProvider.ImportDataForDeal(ctx, deal, fi)
 }
 
-func (sm *StorageMinerAPI) DealsBlacklist(ctx context.Context) ([]cid.Cid, error) {
-	return sm.StorageDealCidBlacklistConfigFunc()
+func (sm *StorageMinerAPI) DealsPieceCidBlacklist(ctx context.Context) ([]cid.Cid, error) {
+	return sm.StorageDealPieceCidBlacklistConfigFunc()
 }
 
-func (sm *StorageMinerAPI) DealsSetBlacklist(ctx context.Context, cids []cid.Cid) error {
-	return sm.SetStorageDealCidBlacklistConfigFunc(cids)
+func (sm *StorageMinerAPI) DealsSetPieceCidBlacklist(ctx context.Context, cids []cid.Cid) error {
+	return sm.SetStorageDealPieceCidBlacklistConfigFunc(cids)
 }
 
 func (sm *StorageMinerAPI) StorageAddLocal(ctx context.Context, path string) error {

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -43,7 +43,9 @@ type StorageMinerAPI struct {
 	StorageMgr      *sectorstorage.Manager `optional:"true"`
 	*stores.Index
 
-	SetAcceptingStorageDealsConfigFunc dtypes.SetAcceptingStorageDealsConfigFunc
+	SetAcceptingStorageDealsConfigFunc   dtypes.SetAcceptingStorageDealsConfigFunc
+	StorageDealCidBlacklistConfigFunc    dtypes.StorageDealCidBlacklistConfigFunc
+	SetStorageDealCidBlacklistConfigFunc dtypes.SetStorageDealCidBlacklistConfigFunc
 }
 
 func (sm *StorageMinerAPI) ServeRemote(w http.ResponseWriter, r *http.Request) {
@@ -230,6 +232,14 @@ func (sm *StorageMinerAPI) DealsImportData(ctx context.Context, deal cid.Cid, fn
 	defer fi.Close() //nolint:errcheck
 
 	return sm.StorageProvider.ImportDataForDeal(ctx, deal, fi)
+}
+
+func (sm *StorageMinerAPI) DealsBlacklist(ctx context.Context) ([]cid.Cid, error) {
+	return sm.StorageDealCidBlacklistConfigFunc()
+}
+
+func (sm *StorageMinerAPI) DealsSetBlacklist(ctx context.Context, cids []cid.Cid) error {
+	return sm.SetStorageDealCidBlacklistConfigFunc(cids)
 }
 
 func (sm *StorageMinerAPI) StorageAddLocal(ctx context.Context, path string) error {

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -21,8 +21,8 @@ type SetAcceptingStorageDealsConfigFunc func(bool) error
 // StorageDealCidBlacklistConfigFunc is a function which reads from miner config
 // to obtain a list of CIDs for which the storage miner will not accept storage
 // proposals.
-type StorageDealCidBlacklistConfigFunc func() ([]cid.Cid, error)
+type StorageDealPieceCidBlacklistConfigFunc func() ([]cid.Cid, error)
 
 // SetStorageDealCidBlacklistConfigFunc is a function which is used to set a
 // list of CIDs for which the storage miner will reject deal proposals.
-type SetStorageDealCidBlacklistConfigFunc func([]cid.Cid) error
+type SetStorageDealPieceCidBlacklistConfigFunc func([]cid.Cid) error

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -1,6 +1,8 @@
 package dtypes
 
 import (
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
@@ -15,3 +17,12 @@ type AcceptingStorageDealsConfigFunc func() (bool, error)
 // SetAcceptingStorageDealsFunc is a function which is used to disable or enable
 // storage deal acceptance.
 type SetAcceptingStorageDealsConfigFunc func(bool) error
+
+// StorageDealCidBlacklistConfigFunc is a function which reads from miner config
+// to obtain a list of CIDs for which the storage miner will not accept storage
+// proposals.
+type StorageDealCidBlacklistConfigFunc func() ([]cid.Cid, error)
+
+// SetStorageDealCidBlacklistConfigFunc is a function which is used to set a
+// list of CIDs for which the storage miner will reject deal proposals.
+type SetStorageDealCidBlacklistConfigFunc func([]cid.Cid) error

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -309,7 +309,7 @@ func NewStorageAsk(ctx helpers.MetricsCtx, fapi lapi.FullNode, ds dtypes.Metadat
 	return storedAsk, nil
 }
 
-func StorageProvider(minerAddress dtypes.MinerAddress, ffiConfig *ffiwrapper.Config, storedAsk *storedask.StoredAsk, h host.Host, ds dtypes.MetadataDS, ibs dtypes.StagingBlockstore, r repo.LockedRepo, pieceStore dtypes.ProviderPieceStore, dataTransfer dtypes.ProviderDataTransfer, spn storagemarket.StorageProviderNode, isAcceptingFunc dtypes.AcceptingStorageDealsConfigFunc, blacklistFunc dtypes.StorageDealCidBlacklistConfigFunc) (storagemarket.StorageProvider, error) {
+func StorageProvider(minerAddress dtypes.MinerAddress, ffiConfig *ffiwrapper.Config, storedAsk *storedask.StoredAsk, h host.Host, ds dtypes.MetadataDS, ibs dtypes.StagingBlockstore, r repo.LockedRepo, pieceStore dtypes.ProviderPieceStore, dataTransfer dtypes.ProviderDataTransfer, spn storagemarket.StorageProviderNode, isAcceptingFunc dtypes.AcceptingStorageDealsConfigFunc, blacklistFunc dtypes.StorageDealPieceCidBlacklistConfigFunc) (storagemarket.StorageProvider, error) {
 	net := smnet.NewFromLibp2pHost(h)
 	store, err := piecefilestore.NewLocalFileStore(piecefilestore.OsPath(r.Path()))
 	if err != nil {
@@ -411,19 +411,19 @@ func NewSetAcceptingStorageDealsConfigFunc(r repo.LockedRepo) (dtypes.SetAccepti
 	}, nil
 }
 
-func NewStorageDealCidBlacklistConfigFunc(r repo.LockedRepo) (dtypes.StorageDealCidBlacklistConfigFunc, error) {
+func NewStorageDealPieceCidBlacklistConfigFunc(r repo.LockedRepo) (dtypes.StorageDealPieceCidBlacklistConfigFunc, error) {
 	return func() (out []cid.Cid, err error) {
 		err = readCfg(r, func(cfg *config.StorageMiner) {
-			out = cfg.Dealmaking.Blacklist
+			out = cfg.Dealmaking.PieceCidBlacklist
 		})
 		return
 	}, nil
 }
 
-func NewSetStorageDealCidBlacklistConfigFunc(r repo.LockedRepo) (dtypes.SetStorageDealCidBlacklistConfigFunc, error) {
+func NewSetStorageDealPieceCidBlacklistConfigFunc(r repo.LockedRepo) (dtypes.SetStorageDealPieceCidBlacklistConfigFunc, error) {
 	return func(blacklist []cid.Cid) (err error) {
 		err = mutateCfg(r, func(cfg *config.StorageMiner) {
-			cfg.Dealmaking.Blacklist = blacklist
+			cfg.Dealmaking.PieceCidBlacklist = blacklist
 		})
 		return
 	}, nil


### PR DESCRIPTION
## Why does this PR exist?

Addresses the storage provider side of [this request](https://github.com/filecoin-project/lotus/issues/1920#issuecomment-639007435) from @whyrusleeping.

## What's in this PR?

This PR adds three new commands `lotus-storage-miner deals get-blocklist` (writes the piece CID blacklist to stdout, one per line, using the specified encoding), `lotus-storage-miner deals set-blocklist` (replaces the existing storage miner piece CID-blacklist with the contents of the provided file or the CIDs read from stdin), and `lotus-storage-miner deals reset-blocklist`, which wipes the storage miner's blacklist.

