### PR TITLE
Remove redundant glossary item

### DIFF
--- a/documentation/en/.glossary.json
+++ b/documentation/en/.glossary.json
@@ -63,10 +63,6 @@
     "title": "Proof-of-Spacetime(s)",
     "value": "Filecoin is a protocol token whose blockchain runs on a novel proof, called Proof-of-Spacetime, where blocks are created by miners that are storing data."
   },
-  "lotus-testnet": {
-    "title": "Filecoin Testnet",
-    "value": "Until we launch, we are making lots of changes to Lotus. The Testnet is expected to bring a few significant fixes/improvements. During Testnet, you can retrieve test filecoin from our network faucet to use as collateral to start mining. Test filecoin do not have any value – the official filecoin tokens will not be released until Mainnet launch."
-  },
   "filecoin-testnet": {
     "title": "Filecoin Testnet",
     "value": "Until we launch, we are making lots of changes to Lotus. The Testnet is expected to bring a few significant fixes/improvements. During Testnet, you can retrieve test filecoin from our network faucet to use as collateral to start mining. Test filecoin do not have any value – the official filecoin tokens will not be released until Mainnet launch."


### PR DESCRIPTION
The excised entry previously rendered twice in the glossary under two different keys. This commit removes one of those KV pairs to avoid that.

See the duplicate "Filecoin Testnet" entries in the screenshot below:

<img width="1440" alt="Screen Shot 2020-06-18 at 9 32 00 PM" src="https://user-images.githubusercontent.com/5316207/85087337-439b5a00-b1ab-11ea-992b-6a491ad11859.png">
