### PR TITLE
bump from 3 to 4 digits in format-string used by types.SizeStr

### DIFF
--- a/chain/types/bigint.go
+++ b/chain/types/bigint.go
@@ -76,7 +76,7 @@ func SizeStr(bi BigInt) string {
 	}
 
 	f, _ := r.Float64()
-	return fmt.Sprintf("%.3g %s", f, byteSizeUnits[i])
+	return fmt.Sprintf("%.4g %s", f, byteSizeUnits[i])
 }
 
 var deciUnits = []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"}

--- a/chain/types/bigint_test.go
+++ b/chain/types/bigint_test.go
@@ -3,7 +3,12 @@ package types
 import (
 	"bytes"
 	"math/big"
+	"math/rand"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/docker/go-units"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -60,14 +65,32 @@ func TestSizeStr(t *testing.T) {
 	}{
 		{0, "0 B"},
 		{1, "1 B"},
+		{1016, "1016 B"},
 		{1024, "1 KiB"},
-		{2000, "1.95 KiB"},
+		{1000 * 1024, "1000 KiB"},
+		{2000, "1.953 KiB"},
 		{5 << 20, "5 MiB"},
 		{11 << 60, "11 EiB"},
 	}
 
 	for _, c := range cases {
 		assert.Equal(t, c.out, SizeStr(NewInt(c.in)), "input %+v, produced wrong result", c)
+	}
+}
+
+func TestSizeStrUnitsSymmetry(t *testing.T) {
+	s := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(s)
+
+	for i := 0; i < 1000000; i++ {
+		n := r.Uint64()
+		l := strings.ReplaceAll(units.BytesSize(float64(n)), " ", "")
+		r := strings.ReplaceAll(SizeStr(NewInt(n)), " ", "")
+
+		assert.NotContains(t, l, "e+")
+		assert.NotContains(t, r, "e+")
+
+		assert.Equal(t, l, r, "wrong formatting for %d", n)
 	}
 }
 


### PR DESCRIPTION
Fixes #1993

@magik6k @arajasek - The [`SizeStr`](https://github.com/filecoin-project/lotus/blob/ffa7be86fe6ee738ab4b095469029b9fac51e090/chain/types/bigint.go#L79) function used the format string `"%.3g %s"`, so the rounding and scientific notation make sense (given the format string).

We have a few options:

1. (contained in this PR) We can bump from 3 digits to 4
1. (seems bad) We can leave things as they are
1. (seems bad) We can replace the `%g` verb with `%f` (decimal point but no exponent, e.g. `1016.000 B`)

As you might expect, this problematic behavior manifests with other values. For example `1024000` bytes displays as `1e+03 KiB`.

## What's in this PR?

This PR bumps from 3 to 4 digits, and adds a test which asserts that our `SizeStr` function behaves more or less identically to the `units.BytesSize` function.
