### PR TITLE
provide an option to disable loading of built-in assets.

### DIFF
--- a/build/bootstrap.go
+++ b/build/bootstrap.go
@@ -13,6 +13,10 @@ import (
 )
 
 func BuiltinBootstrap() ([]peer.AddrInfo, error) {
+	if DisableBuiltinAssets {
+		return nil, nil
+	}
+
 	var out []peer.AddrInfo
 
 	b := rice.MustFindBox("bootstrap")

--- a/build/flags.go
+++ b/build/flags.go
@@ -1,0 +1,15 @@
+package build
+
+// DisableBuiltinAssets disables the resolution of go.rice boxes that store
+// built-in assets, such as proof parameters, bootstrap peers, genesis blocks,
+// etc.
+//
+// When this value is set to true, it is expected that the user will
+// provide any such configurations through the Lotus API itself.
+//
+// This is useful when you're using Lotus as a library, such as to orchestrate
+// test scenarios, or for other purposes where you don't need to use the
+// defaults shipped with the binary.
+//
+// For this flag to be effective, it must be enabled _before_ instantiating Lotus.
+var DisableBuiltinAssets = false

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -75,6 +75,12 @@ func GetParams(sbc *ffiwrapper.Config) error {
 		return err
 	}
 
+	// If built-in assets are disabled, we expect the user to have placed the right
+	// parameters in the right location on the filesystem (/var/tmp/filecoin-proof-parameters).
+	if build.DisableBuiltinAssets {
+		return nil
+	}
+
 	if err := paramfetch.GetParams(context.TODO(), build.ParametersJSON(), uint64(ssize)); err != nil {
 		return xerrors.Errorf("fetching proof parameters: %w", err)
 	}


### PR DESCRIPTION
Project Oni needs to make Lotus friendly to be imported as a library. The go.rice boxes get in the way, as they are appended to the executable, which makes them only accessible when running Lotus from a binary.

We _could_ embed these assets by converting them to Go source (rice embed-go mode). However, that bloats up the source tree considerably, and it's terrible for Git repo sizes over time. See an exploration of that here: https://github.com/filecoin-project/lotus/compare/feat/rice-embed.

When using Lotus as a library, it's also kinda useless to do the "magic" of loading things; this is an advanced mode of use where the developer is likely to pursue a high degree of customisation of things. 

Example: our test plans won't be hitting the public bootstrap peers, won't be using the devnet genesis, nor will we be relying on runtime magic to load the parameters. So ultimately, all the data in those boxes is actually useless to us.

That's why I am submitting this PR, to introduce a flag that our tests can use to bypass built-in asset resolution entirely.

---

cc @nonsense