### PR TITLE
allow a storage client to evict data by cid from its filestore

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -178,6 +178,8 @@ type FullNode interface {
 
 	// ClientImport imports file under the specified path into filestore
 	ClientImport(ctx context.Context, ref FileRef) (cid.Cid, error)
+	// ClientDelete removes data with the specified CID from the filestore
+	ClientDelete(context.Context, cid.Cid) error
 	// ClientStartDeal proposes a deal with a miner
 	ClientStartDeal(ctx context.Context, params *StartDealParams) (*cid.Cid, error)
 	// ClientGetDeal info returns the latest information about a given deal

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -110,6 +110,7 @@ type FullNodeStruct struct {
 		WalletDelete         func(context.Context, address.Address) error                                         `perm:"write"`
 
 		ClientImport          func(ctx context.Context, ref api.FileRef) (cid.Cid, error)                                          `perm:"admin"`
+		ClientDelete          func(ctx context.Context, dataCid cid.Cid) error                                                     `perm:"admin"`
 		ClientListImports     func(ctx context.Context) ([]api.Import, error)                                                      `perm:"write"`
 		ClientHasLocal        func(ctx context.Context, root cid.Cid) (bool, error)                                                `perm:"write"`
 		ClientFindData        func(ctx context.Context, root cid.Cid) ([]api.QueryOffer, error)                                    `perm:"read"`
@@ -330,6 +331,10 @@ func (c *FullNodeStruct) ClientListImports(ctx context.Context) ([]api.Import, e
 
 func (c *FullNodeStruct) ClientImport(ctx context.Context, ref api.FileRef) (cid.Cid, error) {
 	return c.Internal.ClientImport(ctx, ref)
+}
+
+func (c *FullNodeStruct) ClientDelete(ctx context.Context, dataCid cid.Cid) error {
+	return c.Internal.ClientDelete(ctx, dataCid)
 }
 
 func (c *FullNodeStruct) ClientHasLocal(ctx context.Context, root cid.Cid) (bool, error) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -128,7 +128,7 @@ var clientDeleteDataCmd = &cli.Command{
 
 		dataCid, err := cid.Parse(cctx.Args().Get(0))
 		if err != nil {
-			return err
+			return xerrors.Errorf("could not parse argument %s to CID: %w", cctx.Args().Get(0), err)
 		}
 
 		err = api.ClientDelete(ReqContext(cctx), dataCid)

--- a/cli/client.go
+++ b/cli/client.go
@@ -63,6 +63,7 @@ var clientCmd = &cli.Command{
 		clientQueryAskCmd,
 		clientListDeals,
 		clientCarGenCmd,
+		clientDeleteDataCmd,
 	},
 }
 
@@ -104,6 +105,36 @@ var clientImportCmd = &cli.Command{
 		}
 
 		fmt.Println(encoder.Encode(c))
+
+		return nil
+	},
+}
+
+var clientDeleteDataCmd = &cli.Command{
+	Name:      "delete-data",
+	Usage:     "Delete previously-imported data by its CID",
+	ArgsUsage: "[dataCid]",
+	Flags:     []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		if cctx.NArg() != 1 {
+			return xerrors.New("expected 1 arg: dataCid")
+		}
+
+		dataCid, err := cid.Parse(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+
+		err = api.ClientDelete(ReqContext(cctx), dataCid)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	},

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -259,6 +259,10 @@ func (a *API) ClientImport(ctx context.Context, ref api.FileRef) (cid.Cid, error
 	return nd, nil
 }
 
+func (a *API) ClientDelete(ctx context.Context, dataCid cid.Cid) error {
+	return a.LocalDAG.Remove(ctx, dataCid)
+}
+
 func (a *API) ClientImportLocal(ctx context.Context, f io.Reader) (cid.Cid, error) {
 	file := files.NewReaderFile(f)
 


### PR DESCRIPTION
## Why does this PR exist?

A storage client, after `lotus client import`'ing a file, has no CLI which allows them to remove said file (say, after storage deal consummation).

## What's in this PR?

This PR adds a simple `lotus client delete-data <dataCid>` command, which does what you expect (removes from local store).