### PR TITLE
allow overriding drand config

### DIFF
--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -28,7 +28,7 @@ import (
 var log = logging.Logger("drand")
 
 type DrandConfig struct {
-	Servers []string
+	Servers   []string
 	ChainInfo *dchain.Info
 }
 

--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -27,18 +27,22 @@ import (
 
 var log = logging.Logger("drand")
 
-var drandServers = []string{
-	"https://pl-eu.testnet.drand.sh",
-	"https://pl-us.testnet.drand.sh",
-	"https://pl-sin.testnet.drand.sh",
+type DrandConfig struct {
+	Servers []string
+	ChainInfo *dchain.Info
 }
 
-var drandChain *dchain.Info
+var defaultConfig = DrandConfig{
+	Servers: []string{
+		"https://pl-eu.testnet.drand.sh",
+		"https://pl-us.testnet.drand.sh",
+		"https://pl-sin.testnet.drand.sh",
+	},
+}
 
 func init() {
-
 	var err error
-	drandChain, err = dchain.InfoFromJSON(bytes.NewReader([]byte(build.DrandChain)))
+	defaultConfig.ChainInfo, err = dchain.InfoFromJSON(bytes.NewReader([]byte(build.DrandChain)))
 	if err != nil {
 		panic("could not unmarshal chain info: " + err.Error())
 	}
@@ -73,16 +77,21 @@ type DrandBeacon struct {
 	localCache map[uint64]types.BeaconEntry
 }
 
-func NewDrandBeacon(genesisTs, interval uint64, ps *pubsub.PubSub) (*DrandBeacon, error) {
+func NewDrandBeacon(genesisTs, interval uint64, ps *pubsub.PubSub, config *DrandConfig) (*DrandBeacon, error) {
 	if genesisTs == 0 {
 		panic("what are you doing this cant be zero")
 	}
+
+	if config == nil {
+		config = &defaultConfig
+	}
+	drandChain := config.ChainInfo
 
 	dlogger := dlog.NewKitLoggerFrom(kzap.NewZapSugarLogger(
 		log.SugaredLogger.Desugar(), zapcore.InfoLevel))
 
 	var clients []dclient.Client
-	for _, url := range drandServers {
+	for _, url := range config.Servers {
 		hc, err := hclient.NewWithInfo(url, drandChain, nil)
 		if err != nil {
 			return nil, xerrors.Errorf("could not create http drand client: %w", err)

--- a/chain/beacon/drand/drand_test.go
+++ b/chain/beacon/drand/drand_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPrintGroupInfo(t *testing.T) {
-	c, err := hclient.New(drandServers[0], nil, nil)
+	c, err := hclient.New(defaultConfig.Servers[0], nil, nil)
 	assert.NoError(t, err)
 	cg := c.(interface {
 		FetchChainInfo(groupHash []byte) (*dchain.Info, error)

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -108,6 +108,7 @@ func RetrievalResolver(l *discovery.Local) retrievalmarket.PeerResolver {
 type RandomBeaconParams struct {
 	fx.In
 
+	DrandConfig *drand.DrandConfig `optional:"true"`
 	PubSub *pubsub.PubSub `optional:"true"`
 	Cs     *store.ChainStore
 }
@@ -119,5 +120,5 @@ func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.Random
 	}
 
 	//return beacon.NewMockBeacon(build.BlockDelay * time.Second)
-	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub)
+	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, p.DrandConfig)
 }

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -109,8 +109,8 @@ type RandomBeaconParams struct {
 	fx.In
 
 	DrandConfig *drand.DrandConfig `optional:"true"`
-	PubSub *pubsub.PubSub `optional:"true"`
-	Cs     *store.ChainStore
+	PubSub      *pubsub.PubSub     `optional:"true"`
+	Cs          *store.ChainStore
 }
 
 func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.RandomBeacon, error) {


### PR DESCRIPTION
This exposes a `DrandConfig` struct that contains the drand server URLs and chain info, so that we can override in testground to point at a test drand deployment. 

This is in service of https://github.com/filecoin-project/oni/issues/15

@Kubuxu I'm still getting up to speed with the lotus dependency injection. Is this all I need to do in order to be able to set my own `DrandConfig` with `node.Override`?  

And to actually do the override, it would be something like `node.Override(new(drand.DrandConfig), myConfigProviderFunc)` maybe?