### PR TITLE
improve DrandConfig dependency injection

### DIFF
--- a/build/params_shared.go
+++ b/build/params_shared.go
@@ -121,4 +121,11 @@ const VerifSigCacheSize = 32000
 const BlockMessageLimit = 512
 const BlockGasLimit = 100_000_000_000
 
-var DrandChain = `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b"}`
+var DrandConfig = dtypes.DrandConfig{
+	Servers: []string{
+		"https://pl-eu.testnet.drand.sh",
+		"https://pl-us.testnet.drand.sh",
+		"https://pl-sin.testnet.drand.sh",
+	},
+	ChainInfoJSON: `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b"}`,
+}

--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -23,14 +23,10 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
 var log = logging.Logger("drand")
-
-type DrandConfig struct {
-	Servers       []string
-	ChainInfoJSON string
-}
 
 type drandPeer struct {
 	addr string
@@ -61,7 +57,7 @@ type DrandBeacon struct {
 	localCache map[uint64]types.BeaconEntry
 }
 
-func NewDrandBeacon(genesisTs, interval uint64, ps *pubsub.PubSub, config DrandConfig) (*DrandBeacon, error) {
+func NewDrandBeacon(genesisTs, interval uint64, ps *pubsub.PubSub, config dtypes.DrandConfig) (*DrandBeacon, error) {
 	if genesisTs == 0 {
 		panic("what are you doing this cant be zero")
 	}

--- a/chain/beacon/drand/drand_test.go
+++ b/chain/beacon/drand/drand_test.go
@@ -7,10 +7,13 @@ import (
 	dchain "github.com/drand/drand/chain"
 	hclient "github.com/drand/drand/client/http"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/lotus/build"
 )
 
 func TestPrintGroupInfo(t *testing.T) {
-	c, err := hclient.New(defaultConfig.Servers[0], nil, nil)
+	server := build.DrandConfig.Servers[0]
+	c, err := hclient.New(server, nil, nil)
 	assert.NoError(t, err)
 	cg := c.(interface {
 		FetchChainInfo(groupHash []byte) (*dchain.Info, error)

--- a/node/builder.go
+++ b/node/builder.go
@@ -218,6 +218,7 @@ func Online() Option {
 
 			Override(new(dtypes.BootstrapPeers), modules.BuiltinBootstrap),
 			Override(new(dtypes.DrandBootstrap), modules.DrandBootstrap),
+			Override(new(dtypes.DrandConfig), modules.BuiltinDrandConfig),
 
 			Override(HandleIncomingMessagesKey, modules.HandleIncomingMessages),
 

--- a/node/modules/dtypes/beacon.go
+++ b/node/modules/dtypes/beacon.go
@@ -1,0 +1,6 @@
+package dtypes
+
+type DrandConfig struct {
+	Servers       []string
+	ChainInfoJSON string
+}

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -44,13 +44,14 @@ type GossipIn struct {
 	Db   dtypes.DrandBootstrap
 	Cfg  *config.Pubsub
 	Sk   *dtypes.ScoreKeeper
+	Dr   dtypes.DrandConfig
 }
 
-func getDrandTopic() (string, error) {
+func getDrandTopic(chainInfoJSON string) (string, error) {
 	var drandInfo = struct {
 		Hash string `json:"hash"`
 	}{}
-	err := json.Unmarshal([]byte(build.DrandChain), &drandInfo)
+	err := json.Unmarshal([]byte(chainInfoJSON), &drandInfo)
 	if err != nil {
 		return "", xerrors.Errorf("could not unmarshal drand chain info: %w", err)
 	}
@@ -68,7 +69,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 	}
 
 	isBootstrapNode := in.Cfg.Bootstrapper
-	drandTopic, err := getDrandTopic()
+	drandTopic, err := getDrandTopic(in.Dr.ChainInfoJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -108,9 +108,13 @@ func RetrievalResolver(l *discovery.Local) retrievalmarket.PeerResolver {
 type RandomBeaconParams struct {
 	fx.In
 
-	DrandConfig *drand.DrandConfig `optional:"true"`
-	PubSub      *pubsub.PubSub     `optional:"true"`
+	PubSub      *pubsub.PubSub `optional:"true"`
 	Cs          *store.ChainStore
+	DrandConfig dtypes.DrandConfig
+}
+
+func BuiltinDrandConfig() dtypes.DrandConfig {
+	return build.DrandConfig
 }
 
 func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.RandomBeacon, error) {
@@ -120,5 +124,9 @@ func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.Random
 	}
 
 	//return beacon.NewMockBeacon(build.BlockDelay * time.Second)
-	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, p.DrandConfig)
+	config := drand.DrandConfig{
+		Servers:       p.DrandConfig.Servers,
+		ChainInfoJSON: p.DrandConfig.ChainInfoJSON,
+	}
+	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, config)
 }

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -124,9 +124,5 @@ func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.Random
 	}
 
 	//return beacon.NewMockBeacon(build.BlockDelay * time.Second)
-	config := drand.DrandConfig{
-		Servers:       p.DrandConfig.Servers,
-		ChainInfoJSON: p.DrandConfig.ChainInfoJSON,
-	}
-	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, config)
+	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, p.DrandConfig)
 }


### PR DESCRIPTION
This is a quick follow up to #2115 that provides the `DrandConfig` using a provider function in `modules/services.go`. It also updates the pubsub constructor to use the Drand chain hash from DI instead of reading from the `build.DrandChain` var directly.
