### PR TITLE
allow retrieval miner to enable/disable consideration of retrieval deal proposals

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -57,6 +57,7 @@ type StorageMiner interface {
 	DealsImportData(ctx context.Context, dealPropCid cid.Cid, file string) error
 	DealsList(ctx context.Context) ([]storagemarket.StorageDeal, error)
 	DealsSetAcceptingStorageDeals(context.Context, bool) error
+	DealsSetAcceptingRetrievalDeals(context.Context, bool) error
 	DealsPieceCidBlocklist(context.Context) ([]cid.Cid, error)
 	DealsSetPieceCidBlocklist(context.Context, []cid.Cid) error
 

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -224,11 +224,12 @@ type StorageMinerStruct struct {
 		StorageLock          func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) error                                 `perm:"admin"`
 		StorageTryLock       func(ctx context.Context, sector abi.SectorID, read stores.SectorFileType, write stores.SectorFileType) (bool, error)                         `perm:"admin"`
 
-		DealsImportData               func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
-		DealsList                     func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
-		DealsSetAcceptingStorageDeals func(context.Context, bool) error                                 `perm:"admin"`
-		DealsPieceCidBlocklist        func(context.Context) ([]cid.Cid, error)                          `perm:"admin"`
-		DealsSetPieceCidBlocklist     func(context.Context, []cid.Cid) error                            `perm:"read"`
+		DealsImportData                 func(ctx context.Context, dealPropCid cid.Cid, file string) error `perm:"write"`
+		DealsList                       func(ctx context.Context) ([]storagemarket.StorageDeal, error)    `perm:"read"`
+		DealsSetAcceptingStorageDeals   func(context.Context, bool) error                                 `perm:"admin"`
+		DealsSetAcceptingRetrievalDeals func(context.Context, bool) error                                 `perm:"admin"`
+		DealsPieceCidBlocklist          func(context.Context) ([]cid.Cid, error)                          `perm:"admin"`
+		DealsSetPieceCidBlocklist       func(context.Context, []cid.Cid) error                            `perm:"read"`
 
 		StorageAddLocal func(ctx context.Context, path string) error `perm:"admin"`
 	}
@@ -879,6 +880,10 @@ func (c *StorageMinerStruct) DealsList(ctx context.Context) ([]storagemarket.Sto
 
 func (c *StorageMinerStruct) DealsSetAcceptingStorageDeals(ctx context.Context, b bool) error {
 	return c.Internal.DealsSetAcceptingStorageDeals(ctx, b)
+}
+
+func (c *StorageMinerStruct) DealsSetAcceptingRetrievalDeals(ctx context.Context, b bool) error {
+	return c.Internal.DealsSetAcceptingRetrievalDeals(ctx, b)
 }
 
 func (c *StorageMinerStruct) DealsPieceCidBlocklist(ctx context.Context) ([]cid.Cid, error) {

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	local := []*cli.Command{
 		actorCmd,
-		dealsCmd,
+		storageDealsCmd,
 		infoCmd,
 		initCmd,
 		rewardsCmd,

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -24,6 +24,7 @@ func main() {
 	local := []*cli.Command{
 		actorCmd,
 		storageDealsCmd,
+		retrievalDealsCmd,
 		infoCmd,
 		initCmd,
 		rewardsCmd,

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -217,9 +217,9 @@ var getAskCmd = &cli.Command{
 	},
 }
 
-var dealsCmd = &cli.Command{
-	Name:  "deals",
-	Usage: "interact with your deals",
+var storageDealsCmd = &cli.Command{
+	Name:  "storage-deals",
+	Usage: "interact with your storage deals",
 	Subcommands: []*cli.Command{
 		dealsImportDataCmd,
 		dealsListCmd,

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -219,7 +219,7 @@ var getAskCmd = &cli.Command{
 
 var storageDealsCmd = &cli.Command{
 	Name:  "storage-deals",
-	Usage: "interact with your storage deals",
+	Usage: "Manage storage deals and related configuration",
 	Subcommands: []*cli.Command{
 		dealsImportDataCmd,
 		dealsListCmd,

--- a/cmd/lotus-storage-miner/retrieval-deals.go
+++ b/cmd/lotus-storage-miner/retrieval-deals.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+)
+
+var retrievalDealsCmd = &cli.Command{
+	Name:  "retrieval-deals",
+	Usage: "Manage retrieval deals and related configuration",
+	Subcommands: []*cli.Command{
+		enableRetrievalCmd,
+		disableRetrievalCmd,
+	},
+}
+
+var enableRetrievalCmd = &cli.Command{
+	Name:  "enable",
+	Usage: "Configure the miner to consider retrieval deal proposals",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		return api.DealsSetAcceptingRetrievalDeals(lcli.DaemonContext(cctx), true)
+	},
+}
+
+var disableRetrievalCmd = &cli.Command{
+	Name:  "disable",
+	Usage: "Configure the miner to reject all retrieval deal proposals",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		return api.DealsSetAcceptingRetrievalDeals(lcli.DaemonContext(cctx), false)
+	},
+}

--- a/node/builder.go
+++ b/node/builder.go
@@ -313,6 +313,8 @@ func Online() Option {
 			Override(new(gen.WinningPoStProver), storage.NewWinningPoStProver),
 			Override(new(*miner.Miner), modules.SetupBlockProducer),
 
+			Override(new(dtypes.AcceptingRetrievalDealsConfigFunc), modules.NewAcceptingRetrievalDealsConfigFunc),
+			Override(new(dtypes.SetAcceptingRetrievalDealsConfigFunc), modules.NewSetAcceptingRetrievalDealsConfigFunc),
 			Override(new(dtypes.AcceptingStorageDealsConfigFunc), modules.NewAcceptingStorageDealsConfigFunc),
 			Override(new(dtypes.SetAcceptingStorageDealsConfigFunc), modules.NewSetAcceptingStorageDealsConfigFunc),
 			Override(new(dtypes.StorageDealPieceCidBlocklistConfigFunc), modules.NewStorageDealPieceCidBlocklistConfigFunc),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -34,8 +34,9 @@ type StorageMiner struct {
 }
 
 type DealmakingConfig struct {
-	AcceptingStorageDeals bool
-	PieceCidBlocklist     []cid.Cid
+	AcceptingStorageDeals   bool
+	AcceptingRetrievalDeals bool
+	PieceCidBlocklist       []cid.Cid
 }
 
 // API contains configs for API endpoint
@@ -123,8 +124,9 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		Dealmaking: DealmakingConfig{
-			AcceptingStorageDeals: true,
-			PieceCidBlocklist:     []cid.Cid{},
+			AcceptingStorageDeals:   true,
+			AcceptingRetrievalDeals: true,
+			PieceCidBlocklist:       []cid.Cid{},
 		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -44,6 +44,7 @@ type StorageMinerAPI struct {
 	*stores.Index
 
 	SetAcceptingStorageDealsConfigFunc        dtypes.SetAcceptingStorageDealsConfigFunc
+	SetAcceptingRetrievalDealsConfigFunc      dtypes.SetAcceptingRetrievalDealsConfigFunc
 	StorageDealPieceCidBlocklistConfigFunc    dtypes.StorageDealPieceCidBlocklistConfigFunc
 	SetStorageDealPieceCidBlocklistConfigFunc dtypes.SetStorageDealPieceCidBlocklistConfigFunc
 }
@@ -226,6 +227,10 @@ func (sm *StorageMinerAPI) DealsList(ctx context.Context) ([]storagemarket.Stora
 
 func (sm *StorageMinerAPI) DealsSetAcceptingStorageDeals(ctx context.Context, b bool) error {
 	return sm.SetAcceptingStorageDealsConfigFunc(b)
+}
+
+func (sm *StorageMinerAPI) DealsSetAcceptingRetrievalDeals(ctx context.Context, b bool) error {
+	return sm.SetAcceptingRetrievalDealsConfigFunc(b)
 }
 
 func (sm *StorageMinerAPI) DealsImportData(ctx context.Context, deal cid.Cid, fname string) error {

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -10,20 +10,20 @@ import (
 type MinerAddress address.Address
 type MinerID abi.ActorID
 
-// AcceptingStorageDealsFunc is a function which reads from miner config to
-// determine if the user has disabled storage deals (or not).
+// AcceptingStorageDealsConfigFunc is a function which reads from miner config
+// to determine if the user has disabled storage deals (or not).
 type AcceptingStorageDealsConfigFunc func() (bool, error)
 
-// SetAcceptingStorageDealsFunc is a function which is used to disable or enable
-// storage deal acceptance.
+// SetAcceptingStorageDealsConfigFunc is a function which is used to disable or
+// enable storage deal acceptance.
 type SetAcceptingStorageDealsConfigFunc func(bool) error
 
-// AcceptingRetrievalDealsFunc is a function which reads from miner config to
-// determine if the user has disabled retrieval acceptance (or not).
+// AcceptingRetrievalDealsConfigFunc is a function which reads from miner config
+// to determine if the user has disabled retrieval acceptance (or not).
 type AcceptingRetrievalDealsConfigFunc func() (bool, error)
 
-// SetAcceptingRetrievalDealsFunc is a function which is used to disable or enable
-// retrieval deal acceptance.
+// SetAcceptingRetrievalDealsConfigFunc is a function which is used to disable
+// or enable retrieval deal acceptance.
 type SetAcceptingRetrievalDealsConfigFunc func(bool) error
 
 // StorageDealPieceCidBlocklistConfigFunc is a function which reads from miner config

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -18,6 +18,14 @@ type AcceptingStorageDealsConfigFunc func() (bool, error)
 // storage deal acceptance.
 type SetAcceptingStorageDealsConfigFunc func(bool) error
 
+// AcceptingRetrievalDealsFunc is a function which reads from miner config to
+// determine if the user has disabled retrieval acceptance (or not).
+type AcceptingRetrievalDealsConfigFunc func() (bool, error)
+
+// SetAcceptingRetrievalDealsFunc is a function which is used to disable or enable
+// retrieval deal acceptance.
+type SetAcceptingRetrievalDealsConfigFunc func(bool) error
+
 // StorageDealPieceCidBlocklistConfigFunc is a function which reads from miner config
 // to obtain a list of CIDs for which the storage miner will not accept storage
 // proposals.


### PR DESCRIPTION
## Why does this PR exist?

This PR makes incremental progress on #1920 by allowing storage miners operating as retrieval miners to disable/enable consideration of retrieval deals.

## What's in this PR

This PR adds a new configuration option which gates consideration of received retrieval deal proposals. 

**It also replaces the `lotus-storage-miner deals` subcommand with `lotus-storage-miner storage-deals`, and introduces the `lotus-storage-miner retrieval-deals` subcommand.**