### PR TITLE
change BlockDelay from const to var

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 // Seconds
-const BlockDelay = 2
+var BlockDelay = 2
 
 const PropagationDelay = 3
 

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -20,6 +20,6 @@ func init() {
 }
 
 // Seconds
-const BlockDelay = builtin.EpochDurationSeconds
+var BlockDelay = builtin.EpochDurationSeconds
 
 const PropagationDelay = 6


### PR DESCRIPTION
It'd be helpful if this param is a `var` so that we can try to use various low values for it, not just 2sec.

So far we've been back-dating the genesis block, and using the mock test miner (`node.Override(new(*miner.Miner), miner.NewTestMiner(mineBlock, minerAddr)),`), but it'd be nice if we can have fast block mining also in the present time.