### PR TITLE
change BlockDelay from const to var

### DIFF
--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -1,0 +1,6 @@
+// +build testground
+
+package build
+
+const BlockDelay = 1
+const PropagationDelay = 6

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -1,5 +1,6 @@
 // +build !debug
 // +build !2k
+// +build !testground
 
 package build
 


### PR DESCRIPTION
~It'd be helpful if this param is a `var` so that we can try to use various low values for it, not just 2sec.~

Changing `BlockDelay` from `const` to `var` is not trivial, as its type is inferred across the codebase.

---

So far we've been back-dating the genesis block, and using the mock test miner (`node.Override(new(*miner.Miner), miner.NewTestMiner(mineBlock, minerAddr)),`), but it'd be nice if we can have fast block mining also in the present time.