### PR TITLE
Implement OnDealExpiredOrSlashed

### DIFF
--- a/chain/events/state/predicates.go
+++ b/chain/events/state/predicates.go
@@ -117,6 +117,8 @@ func (sp *StatePredicates) DealStateChangedForIDs(dealIds []abi.DealID) DiffDeal
 		for _, dealID := range dealIds {
 			var oldDealPtr, newDealPtr *market.DealState
 			var oldDeal, newDeal market.DealState
+
+			// If the deal has been removed, we just set it to nil
 			err := oldDealStateRoot.Get(ctx, uint64(dealID), &oldDeal)
 			if err == nil {
 				oldDealPtr = &oldDeal
@@ -129,7 +131,8 @@ func (sp *StatePredicates) DealStateChangedForIDs(dealIds []abi.DealID) DiffDeal
 			} else if _, ok := err.(*amt.ErrNotFound); !ok {
 				return false, nil, err
 			}
-			if oldDealPtr == nil || newDealPtr == nil || oldDeal != newDeal {
+
+			if oldDeal != newDeal {
 				changedDeals[dealID] = DealStateChange{oldDealPtr, newDealPtr}
 			}
 		}

--- a/chain/events/state/predicates_test.go
+++ b/chain/events/state/predicates_test.go
@@ -128,23 +128,11 @@ func TestPredicates(t *testing.T) {
 	}
 
 	// Diff with non-existent deal.
-	// Note that for non existent deals we expect a change with
-	// From and To set to nil. This is to ensure that if a deal expires and is
-	// removed from state we will still find out about the change.
 	noDeal := []abi.DealID{3}
 	diffNoDealFn := preds.OnStorageMarketActorChanged(preds.OnDealStateChanged(preds.DealStateChangedForIDs(noDeal)))
 	changed, val, err = diffNoDealFn(ctx, oldState, newState)
 	require.NoError(t, err)
-	require.True(t, changed)
-
-	changedDeals, ok = val.(ChangedDeals)
-	require.True(t, ok)
-	require.Len(t, changedDeals, 1)
-	require.Contains(t, changedDeals, noDeal[0])
-	deal1 = changedDeals[abi.DealID(1)]
-	if deal1.From != nil || deal1.To != nil {
-		t.Fatal("Expected both from and to to be nil")
-	}
+	require.False(t, changed)
 
 	// Test that OnActorStateChanged does not call the callback if the state has not changed
 	mockAddr, err := address.NewFromString("t01")


### PR DESCRIPTION
Part of https://github.com/filecoin-project/go-fil-markets/issues/278

Implements the lotus side of OnDealExpiredOrSlashed()

Includes the following change to the state api:
When listening for changes to the deal state, we want to detect when a deal has expired / slashed and then been removed.
This change allows for a nil deal state to indicate that the deal was removed.

Depends on https://github.com/filecoin-project/go-fil-markets/pull/284