### PR TITLE
fix: pre-expand filter set when loading sectors

### DIFF
--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -341,16 +341,20 @@ func LoadSectorsFromSet(ctx context.Context, bs blockstore.Blockstore, ssc cid.C
 		return nil, err
 	}
 
+	filterSize, err := filter.Count()
+	if err != nil {
+		return nil, err
+	}
+
+	filterSet, err := filter.AllMap(filterSize)
+	if err != nil {
+		return nil, err
+	}
+
 	var sset []*api.ChainSectorInfo
 	if err := a.ForEach(ctx, func(i uint64, v *cbg.Deferred) error {
-		if filter != nil {
-			set, err := filter.IsSet(i)
-			if err != nil {
-				return xerrors.Errorf("filter check error: %w", err)
-			}
-			if set == filterOut {
-				return nil
-			}
+		if filter != nil && filterSet[i] == filterOut {
+			return nil
 		}
 
 		var oci miner.SectorOnChainInfo


### PR DESCRIPTION
IsSet is, unfortunately, quite slow as it needs to linearly scan and decode the bitfield. Given that the filter set here is usually small, expanding to a map should be faster.

Note: this should be carefully profiled to ensure it doesn't blow up memory too much. However, I doubt that that's an issue in this case.