### PR TITLE
make system constants configurable as vars.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,12 @@ health:
 .PHONY: health
 BINS+=health
 
+testground:
+	go build -tags testground -o /dev/null ./cmd/lotus
+
+.PHONY: testground
+BINS+=testground
+
 # MISC
 
 buildall: $(BINS)

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 // Seconds
-const BlockDelay = 2
+const BlockDelaySecs = 2
 
 const PropagationDelay = 3
 

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -20,7 +20,6 @@ func init() {
 	BuildType |= Build2k
 }
 
-// Seconds
 const BlockDelaySecs = 2
 
 const PropagationDelay = 3

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -20,9 +20,9 @@ func init() {
 	BuildType |= Build2k
 }
 
-const BlockDelaySecs = 2
+const BlockDelaySecs = uint64(2)
 
-const PropagationDelay = 3
+const PropagationDelay = uint64(3)
 
 // SlashablePowerDelay is the number of epochs after ElectionPeriodStart, after
 // which the miner is slashed

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -22,7 +22,7 @@ func init() {
 
 const BlockDelaySecs = uint64(2)
 
-const PropagationDelay = uint64(3)
+const PropagationDelaySecs = uint64(3)
 
 // SlashablePowerDelay is the number of epochs after ElectionPeriodStart, after
 // which the miner is slashed

--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -1,0 +1,38 @@
+package build
+
+import (
+	"sort"
+
+	"github.com/libp2p/go-libp2p-core/protocol"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+)
+
+func DefaultSectorSize() abi.SectorSize {
+	szs := make([]abi.SectorSize, 0, len(miner.SupportedProofTypes))
+	for spt := range miner.SupportedProofTypes {
+		ss, err := spt.SectorSize()
+		if err != nil {
+			panic(err)
+		}
+
+		szs = append(szs, ss)
+	}
+
+	sort.Slice(szs, func(i, j int) bool {
+		return szs[i] < szs[j]
+	})
+
+	return szs[0]
+}
+
+// Core network constants
+
+func BlocksTopic(netName dtypes.NetworkName) string   { return "/fil/blocks/" + string(netName) }
+func MessagesTopic(netName dtypes.NetworkName) string { return "/fil/msgs/" + string(netName) }
+func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
+	return protocol.ID("/fil/kad/" + string(netName))
+}

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -5,6 +5,7 @@ package build
 import (
 	"math/big"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 
@@ -21,7 +22,7 @@ const UnixfsLinksPerLevel = 1024
 // Consensus / Network
 
 // Seconds
-const AllowableClockDrift = 1
+const AllowableClockDrift = uint64(1)
 
 // Epochs
 const ForkLengthThreshold = Finality
@@ -31,12 +32,12 @@ var BlocksPerEpoch = uint64(builtin.ExpectedLeadersPerEpoch)
 
 // Epochs
 const Finality = miner.ChainFinalityish
-const MessageConfidence = 5
+const MessageConfidence = uint64(5)
 
 // constants for Weight calculation
 // The ratio of weight contributed by short-term vs long-term factors in a given round
 const WRatioNum = int64(1)
-const WRatioDen = 2
+const WRatioDen = uint64(2)
 
 // /////
 // Proofs
@@ -54,25 +55,25 @@ const MaxSealLookback = SealRandomnessLookbackLimit + 2000 // TODO: Get from spe
 // Mining
 
 // Epochs
-const TicketRandomnessLookback = 1
+const TicketRandomnessLookback = abi.ChainEpoch(1)
 
-const WinningPoStSectorSetLookback = 10
+const WinningPoStSectorSetLookback = abi.ChainEpoch(10)
 
 // /////
 // Devnet settings
 
-const TotalFilecoin = 2_000_000_000
-const MiningRewardTotal = 1_400_000_000
+const TotalFilecoin = uint64(2_000_000_000)
+const MiningRewardTotal = uint64(1_400_000_000)
 
-const FilecoinPrecision = 1_000_000_000_000_000_000
+const FilecoinPrecision = uint64(1_000_000_000_000_000_000)
 
 var InitialRewardBalance *big.Int
 
 // TODO: Move other important consts here
 
 func init() {
-	InitialRewardBalance = big.NewInt(MiningRewardTotal)
-	InitialRewardBalance = InitialRewardBalance.Mul(InitialRewardBalance, big.NewInt(FilecoinPrecision))
+	InitialRewardBalance = big.NewInt(int64(MiningRewardTotal))
+	InitialRewardBalance = InitialRewardBalance.Mul(InitialRewardBalance, big.NewInt(int64(FilecoinPrecision)))
 }
 
 // Sync

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -21,8 +21,7 @@ const UnixfsLinksPerLevel = 1024
 // /////
 // Consensus / Network
 
-// Seconds
-const AllowableClockDrift = uint64(1)
+const AllowableClockDriftSecs = uint64(1)
 
 // Epochs
 const ForkLengthThreshold = Finality

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -1,43 +1,15 @@
+// +build !testground
+
 package build
 
 import (
 	"math/big"
-	"sort"
 
-	"github.com/libp2p/go-libp2p-core/protocol"
-
-	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
-
-func DefaultSectorSize() abi.SectorSize {
-	szs := make([]abi.SectorSize, 0, len(miner.SupportedProofTypes))
-	for spt := range miner.SupportedProofTypes {
-		ss, err := spt.SectorSize()
-		if err != nil {
-			panic(err)
-		}
-
-		szs = append(szs, ss)
-	}
-
-	sort.Slice(szs, func(i, j int) bool {
-		return szs[i] < szs[j]
-	})
-
-	return szs[0]
-}
-
-// Core network constants
-
-func BlocksTopic(netName dtypes.NetworkName) string   { return "/fil/blocks/" + string(netName) }
-func MessagesTopic(netName dtypes.NetworkName) string { return "/fil/msgs/" + string(netName) }
-func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
-	return protocol.ID("/fil/kad/" + string(netName))
-}
 
 // /////
 // Storage

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -32,6 +32,9 @@ var (
 	Finality            = miner.ChainFinalityish
 	ForkLengthThreshold = Finality
 
+	SlashablePowerDelay        = 20
+	InteractivePoRepConfidence = 6
+
 	MessageConfidence uint64 = 5
 
 	WRatioNum = int64(1)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -21,11 +21,11 @@ var (
 	UnixfsChunkSize     = uint64(1 << 20)
 	UnixfsLinksPerLevel = 1024
 
-	BlocksPerEpoch    = uint64(builtin.ExpectedLeadersPerEpoch)
-	BlockMessageLimit = 512
-	BlockGasLimit     = int64(100_000_000_000)
-	BlockDelaySecs    = uint64(builtin.EpochDurationSeconds)
-	PropagationDelay  = uint64(6)
+	BlocksPerEpoch       = uint64(builtin.ExpectedLeadersPerEpoch)
+	BlockMessageLimit    = 512
+	BlockGasLimit        = int64(100_000_000_000)
+	BlockDelaySecs       = uint64(builtin.EpochDurationSeconds)
+	PropagationDelaySecs = uint64(6)
 
 	AllowableClockDriftSecs = uint64(1)
 

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -24,7 +24,7 @@ var (
 	BlocksPerEpoch    = uint64(builtin.ExpectedLeadersPerEpoch)
 	BlockMessageLimit = 512
 	BlockGasLimit     = int64(100_000_000_000)
-	BlockDelay        = uint64(builtin.EpochDurationSeconds)
+	BlockDelaySecs    = uint64(builtin.EpochDurationSeconds)
 	PropagationDelay  = uint64(6)
 
 	AllowableClockDrift = uint64(1)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -1,0 +1,70 @@
+// +build testground
+
+// This file makes hardcoded parameters (const) configurable as vars.
+//
+// Its purpose is to unlock various degrees of flexibility and parametrization
+// when writing Testground plans for Lotus.
+//
+package build
+
+import (
+	"math/big"
+
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+)
+
+var (
+	UnixfsChunkSize     = uint64(1 << 20)
+	UnixfsLinksPerLevel = 1024
+
+	BlocksPerEpoch    = uint64(builtin.ExpectedLeadersPerEpoch)
+	BlockMessageLimit = 512
+	BlockGasLimit     = int64(100_000_000_000)
+	BlockDelay        = uint64(builtin.EpochDurationSeconds)
+	PropagationDelay  = uint64(6)
+
+	AllowableClockDrift = uint64(1)
+
+	Finality            = miner.ChainFinalityish
+	ForkLengthThreshold = Finality
+
+	MessageConfidence uint64 = 5
+
+	WRatioNum = int64(1)
+	WRatioDen = uint64(2)
+
+	BadBlockCacheSize     = 1 << 15
+	BlsSignatureCacheSize = 40000
+	VerifSigCacheSize     = 32000
+
+	SealRandomnessLookback      = Finality
+	SealRandomnessLookbackLimit = SealRandomnessLookback + 2000
+	MaxSealLookback             = SealRandomnessLookbackLimit + 2000
+
+	TicketRandomnessLookback     = abi.ChainEpoch(1)
+	WinningPoStSectorSetLookback = abi.ChainEpoch(10)
+
+	TotalFilecoin     uint64 = 2_000_000_000
+	MiningRewardTotal uint64 = 1_400_000_000
+
+	FilecoinPrecision uint64 = 1_000_000_000_000_000_000
+
+	InitialRewardBalance = func() *big.Int {
+		v := big.NewInt(int64(MiningRewardTotal))
+		v = v.Mul(v, big.NewInt(int64(FilecoinPrecision)))
+		return v
+	}()
+
+	DrandConfig = dtypes.DrandConfig{
+		Servers: []string{
+			"https://pl-eu.testnet.drand.sh",
+			"https://pl-us.testnet.drand.sh",
+			"https://pl-sin.testnet.drand.sh",
+		},
+		ChainInfoJSON: `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b"}`,
+	}
+)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -27,7 +27,7 @@ var (
 	BlockDelaySecs    = uint64(builtin.EpochDurationSeconds)
 	PropagationDelay  = uint64(6)
 
-	AllowableClockDrift = uint64(1)
+	AllowableClockDriftSecs = uint64(1)
 
 	Finality            = miner.ChainFinalityish
 	ForkLengthThreshold = Finality

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -20,7 +20,6 @@ func init() {
 	}
 }
 
-// Seconds
-const BlockDelaySecs = builtin.EpochDurationSeconds
+const BlockDelaySecs = uint64(builtin.EpochDurationSeconds)
 
-const PropagationDelay = 6
+const PropagationDelay = uint64(6)

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -1,5 +1,6 @@
 // +build !debug
 // +build !2k
+// +build !testground
 
 package build
 

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -21,6 +21,6 @@ func init() {
 }
 
 // Seconds
-const BlockDelay = builtin.EpochDurationSeconds
+const BlockDelaySecs = builtin.EpochDurationSeconds
 
 const PropagationDelay = 6

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -22,4 +22,4 @@ func init() {
 
 const BlockDelaySecs = uint64(builtin.EpochDurationSeconds)
 
-const PropagationDelay = uint64(6)
+const PropagationDelaySecs = uint64(6)

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -414,7 +414,7 @@ func (cg *ChainGen) makeBlock(parents *types.TipSet, m address.Address, vrfticke
 	if cg.Timestamper != nil {
 		ts = cg.Timestamper(parents, height-parents.Height())
 	} else {
-		ts = parents.MinTimestamp() + uint64(height-parents.Height())*uint64(build.BlockDelaySecs)
+		ts = parents.MinTimestamp() + uint64(height-parents.Height())*build.BlockDelaySecs
 	}
 
 	fblk, err := MinerCreateBlock(context.TODO(), cg.sm, cg.w, &api.BlockTemplate{

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -196,7 +196,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 			*genm2,
 		},
 		NetworkName: "",
-		Timestamp:   uint64(time.Now().Add(-500 * time.Duration(build.BlockDelay) * time.Second).Unix()),
+		Timestamp:   uint64(time.Now().Add(-500 * time.Duration(build.BlockDelaySecs) * time.Second).Unix()),
 	}
 
 	genb, err := genesis2.MakeGenesisBlock(context.TODO(), bs, sys, tpl)
@@ -223,7 +223,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 	miners := []address.Address{maddr1, maddr2}
 
 	beac := beacon.NewMockBeacon(time.Second)
-	//beac, err := drand.NewDrandBeacon(tpl.Timestamp, build.BlockDelay)
+	//beac, err := drand.NewDrandBeacon(tpl.Timestamp, build.BlockDelaySecs)
 	//if err != nil {
 	//return nil, xerrors.Errorf("creating drand beacon: %w", err)
 	//}
@@ -414,7 +414,7 @@ func (cg *ChainGen) makeBlock(parents *types.TipSet, m address.Address, vrfticke
 	if cg.Timestamper != nil {
 		ts = cg.Timestamper(parents, height-parents.Height())
 	} else {
-		ts = parents.MinTimestamp() + uint64(height-parents.Height())*uint64(build.BlockDelay)
+		ts = parents.MinTimestamp() + uint64(height-parents.Height())*uint64(build.BlockDelaySecs)
 	}
 
 	fblk, err := MinerCreateBlock(context.TODO(), cg.sm, cg.w, &api.BlockTemplate{

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -196,7 +196,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 			*genm2,
 		},
 		NetworkName: "",
-		Timestamp:   uint64(time.Now().Add(-500 * build.BlockDelay * time.Second).Unix()),
+		Timestamp:   uint64(time.Now().Add(-500 * time.Duration(build.BlockDelay) * time.Second).Unix()),
 	}
 
 	genb, err := genesis2.MakeGenesisBlock(context.TODO(), bs, sys, tpl)
@@ -414,7 +414,7 @@ func (cg *ChainGen) makeBlock(parents *types.TipSet, m address.Address, vrfticke
 	if cg.Timestamper != nil {
 		ts = cg.Timestamper(parents, height-parents.Height())
 	} else {
-		ts = parents.MinTimestamp() + uint64((height-parents.Height())*build.BlockDelay)
+		ts = parents.MinTimestamp() + uint64(height-parents.Height())*uint64(build.BlockDelay)
 	}
 
 	fblk, err := MinerCreateBlock(context.TODO(), cg.sm, cg.w, &api.BlockTemplate{

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -187,7 +187,7 @@ func New(api Provider, ds dtypes.MetadataDS, netName dtypes.NetworkName) (*Messa
 
 	mp := &MessagePool{
 		closer:        make(chan struct{}),
-		repubTk:       time.NewTicker(build.BlockDelay * 10 * time.Second),
+		repubTk:       time.NewTicker(time.Duration(build.BlockDelay) * 10 * time.Second),
 		localAddrs:    make(map[address.Address]struct{}),
 		pending:       make(map[address.Address]*msgSet),
 		minGasPrice:   types.NewInt(0),

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -187,7 +187,7 @@ func New(api Provider, ds dtypes.MetadataDS, netName dtypes.NetworkName) (*Messa
 
 	mp := &MessagePool{
 		closer:        make(chan struct{}),
-		repubTk:       time.NewTicker(time.Duration(build.BlockDelay) * 10 * time.Second),
+		repubTk:       time.NewTicker(time.Duration(build.BlockDelaySecs) * 10 * time.Second),
 		localAddrs:    make(map[address.Address]struct{}),
 		pending:       make(map[address.Address]*msgSet),
 		minGasPrice:   types.NewInt(0),

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -657,7 +657,7 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 	// fast checks first
 
 	now := uint64(time.Now().Unix())
-	if h.Timestamp > now+build.AllowableClockDrift {
+	if h.Timestamp > now+build.AllowableClockDriftSecs {
 		return xerrors.Errorf("block was from the future (now=%d, blk=%d): %w", now, h.Timestamp, ErrTemporal)
 	}
 	if h.Timestamp > now {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -664,11 +664,11 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 		log.Warn("Got block from the future, but within threshold", h.Timestamp, time.Now().Unix())
 	}
 
-	if h.Timestamp < baseTs.MinTimestamp()+(build.BlockDelay*uint64(h.Height-baseTs.Height())) {
+	if h.Timestamp < baseTs.MinTimestamp()+(build.BlockDelaySecs*uint64(h.Height-baseTs.Height())) {
 		log.Warn("timestamp funtimes: ", h.Timestamp, baseTs.MinTimestamp(), h.Height, baseTs.Height())
-		diff := (baseTs.MinTimestamp() + (build.BlockDelay * uint64(h.Height-baseTs.Height()))) - h.Timestamp
+		diff := (baseTs.MinTimestamp() + (build.BlockDelaySecs * uint64(h.Height-baseTs.Height()))) - h.Timestamp
 
-		return xerrors.Errorf("block was generated too soon (h.ts:%d < base.mints:%d + BLOCK_DELAY:%d * deltaH:%d; diff %d)", h.Timestamp, baseTs.MinTimestamp(), build.BlockDelay, h.Height-baseTs.Height(), diff)
+		return xerrors.Errorf("block was generated too soon (h.ts:%d < base.mints:%d + BLOCK_DELAY:%d * deltaH:%d; diff %d)", h.Timestamp, baseTs.MinTimestamp(), build.BlockDelaySecs, h.Height-baseTs.Height(), diff)
 	}
 
 	msgsCheck := async.Err(func() error {

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -408,7 +408,7 @@ func TestSyncBadTimestamp(t *testing.T) {
 
 	base := tu.g.CurTipset
 	tu.g.Timestamper = func(pts *types.TipSet, tl abi.ChainEpoch) uint64 {
-		return pts.MinTimestamp() + (build.BlockDelay / 2)
+		return pts.MinTimestamp() + (build.BlockDelaySecs / 2)
 	}
 
 	fmt.Println("BASE: ", base.Cids())

--- a/chain/types/fil.go
+++ b/chain/types/fil.go
@@ -11,7 +11,7 @@ import (
 type FIL BigInt
 
 func (f FIL) String() string {
-	r := new(big.Rat).SetFrac(f.Int, big.NewInt(build.FilecoinPrecision))
+	r := new(big.Rat).SetFrac(f.Int, big.NewInt(int64(build.FilecoinPrecision)))
 	if r.Sign() == 0 {
 		return "0"
 	}
@@ -33,7 +33,7 @@ func ParseFIL(s string) (FIL, error) {
 		return FIL{}, fmt.Errorf("failed to parse %q as a decimal number", s)
 	}
 
-	r = r.Mul(r, big.NewRat(build.FilecoinPrecision, 1))
+	r = r.Mul(r, big.NewRat(int64(build.FilecoinPrecision), 1))
 	if !r.IsInt() {
 		return FIL{}, fmt.Errorf("invalid FIL value: %q", s)
 	}

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -186,7 +186,7 @@ func SyncWait(ctx context.Context, napi api.FullNode) error {
 
 		fmt.Printf("\r\x1b[2KWorker %d: Target: %s\tState: %s\tHeight: %d", working, target, chain.SyncStageString(ss.Stage), ss.Height)
 
-		if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelay) {
+		if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelaySecs) {
 			fmt.Println("\nDone!")
 			return nil
 		}

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -186,7 +186,7 @@ func SyncWait(ctx context.Context, napi api.FullNode) error {
 
 		fmt.Printf("\r\x1b[2KWorker %d: Target: %s\tState: %s\tHeight: %d", working, target, chain.SyncStageString(ss.Stage), ss.Height)
 
-		if time.Now().Unix()-int64(head.MinTimestamp()) < build.BlockDelay {
+		if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelay) {
 			fmt.Println("\nDone!")
 			return nil
 		}

--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -63,7 +63,7 @@ var watchHeadCmd = &cli.Command{
 		},
 		&cli.IntFlag{
 			Name:  "interval",
-			Value: build.BlockDelay,
+			Value: int(build.BlockDelay),
 			Usage: "interval in seconds between chain head checks",
 		},
 		&cli.StringFlag{
@@ -72,8 +72,9 @@ var watchHeadCmd = &cli.Command{
 			Usage: "systemd unit name to restart on health check failure",
 		},
 		&cli.IntFlag{
-			Name:  "api-timeout",
-			Value: build.BlockDelay,
+			Name: "api-timeout",
+			// TODO: this default value seems spurious.
+			Value: int(build.BlockDelay),
 			Usage: "timeout between API retries",
 		},
 		&cli.IntFlag{
@@ -236,7 +237,7 @@ func waitForSyncComplete(ctx context.Context, a api.FullNode, r int, t time.Dura
 				return err
 			}
 
-			if time.Now().Unix()-int64(head.MinTimestamp()) < build.BlockDelay {
+			if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelay) {
 				return nil
 			}
 		}

--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -63,7 +63,7 @@ var watchHeadCmd = &cli.Command{
 		},
 		&cli.IntFlag{
 			Name:  "interval",
-			Value: int(build.BlockDelay),
+			Value: int(build.BlockDelaySecs),
 			Usage: "interval in seconds between chain head checks",
 		},
 		&cli.StringFlag{
@@ -74,7 +74,7 @@ var watchHeadCmd = &cli.Command{
 		&cli.IntFlag{
 			Name: "api-timeout",
 			// TODO: this default value seems spurious.
-			Value: int(build.BlockDelay),
+			Value: int(build.BlockDelaySecs),
 			Usage: "timeout between API retries",
 		},
 		&cli.IntFlag{
@@ -237,7 +237,7 @@ func waitForSyncComplete(ctx context.Context, a api.FullNode, r int, t time.Dura
 				return err
 			}
 
-			if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelay) {
+			if time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelaySecs) {
 				return nil
 			}
 		}

--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -124,7 +124,7 @@ var genesisAddMinerCmd = &cli.Command{
 			log.Infof("Giving %s some initial balance", miner.Owner)
 			template.Accounts = append(template.Accounts, genesis.Actor{
 				Type:    genesis.TAccount,
-				Balance: big.Mul(big.NewInt(50_000_000), big.NewInt(build.FilecoinPrecision)),
+				Balance: big.Mul(big.NewInt(50_000_000), big.NewInt(int64(build.FilecoinPrecision))),
 				Meta:    (&genesis.AccountMeta{Owner: miner.Owner}).ActorMeta(),
 			})
 		}

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -128,7 +128,7 @@ var infoCmd = &cli.Command{
 				if expWinChance > 1 {
 					expWinChance = 1
 				}
-				winRate := time.Duration(float64(time.Second*time.Duration(build.BlockDelay)) / expWinChance)
+				winRate := time.Duration(float64(time.Second*time.Duration(build.BlockDelaySecs)) / expWinChance)
 				winPerDay := float64(time.Hour*24) / float64(winRate)
 
 				fmt.Print("Expected block win rate: ")

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -128,7 +128,7 @@ var infoCmd = &cli.Command{
 				if expWinChance > 1 {
 					expWinChance = 1
 				}
-				winRate := time.Duration(float64(time.Second*build.BlockDelay) / expWinChance)
+				winRate := time.Duration(float64(time.Second*time.Duration(build.BlockDelay)) / expWinChance)
 				winPerDay := float64(time.Hour*24) / float64(winRate)
 
 				fmt.Print("Expected block win rate: ")

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -123,7 +123,7 @@ var setAskCmd = &cli.Command{
 			return xerrors.Errorf("cannot parse duration: %w", err)
 		}
 
-		qty := dur.Seconds() / float64(build.BlockDelay)
+		qty := dur.Seconds() / float64(build.BlockDelaySecs)
 
 		min, err := units.RAMInBytes(cctx.String("min-piece-size"))
 		if err != nil {
@@ -208,7 +208,7 @@ var getAskCmd = &cli.Command{
 		dlt := ask.Expiry - head.Height()
 		rem := "<expired>"
 		if dlt > 0 {
-			rem = (time.Second * time.Duration(int64(dlt)*int64(build.BlockDelay))).String()
+			rem = (time.Second * time.Duration(int64(dlt)*int64(build.BlockDelaySecs))).String()
 		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%d\n", ask.Price, types.SizeStr(types.NewInt(uint64(ask.MinPieceSize))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize))), ask.Expiry, rem, ask.SeqNo)

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -123,7 +123,7 @@ var setAskCmd = &cli.Command{
 			return xerrors.Errorf("cannot parse duration: %w", err)
 		}
 
-		qty := dur.Seconds() / build.BlockDelay
+		qty := dur.Seconds() / float64(build.BlockDelay)
 
 		min, err := units.RAMInBytes(cctx.String("min-piece-size"))
 		if err != nil {
@@ -208,7 +208,7 @@ var getAskCmd = &cli.Command{
 		dlt := ask.Expiry - head.Height()
 		rem := "<expired>"
 		if dlt > 0 {
-			rem = (time.Second * time.Duration(dlt*build.BlockDelay)).String()
+			rem = (time.Second * time.Duration(int64(dlt)*int64(build.BlockDelay))).String()
 		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%d\n", ask.Price, types.SizeStr(types.NewInt(uint64(ask.MinPieceSize))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize))), ask.Expiry, rem, ask.SeqNo)

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -211,11 +211,11 @@ var provingInfoCmd = &cli.Command{
 func epochTime(curr, e abi.ChainEpoch) string {
 	switch {
 	case curr > e:
-		return fmt.Sprintf("%d (%s ago)", e, time.Second*time.Duration(build.BlockDelay*(curr-e)))
+		return fmt.Sprintf("%d (%s ago)", e, time.Second*time.Duration(int64(build.BlockDelay)*int64(curr-e)))
 	case curr == e:
 		return fmt.Sprintf("%d (now)", e)
 	case curr < e:
-		return fmt.Sprintf("%d (in %s)", e, time.Second*time.Duration(build.BlockDelay*(e-curr)))
+		return fmt.Sprintf("%d (in %s)", e, time.Second*time.Duration(int64(build.BlockDelay)*int64(e-curr)))
 	}
 
 	panic("math broke")

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -211,11 +211,11 @@ var provingInfoCmd = &cli.Command{
 func epochTime(curr, e abi.ChainEpoch) string {
 	switch {
 	case curr > e:
-		return fmt.Sprintf("%d (%s ago)", e, time.Second*time.Duration(int64(build.BlockDelay)*int64(curr-e)))
+		return fmt.Sprintf("%d (%s ago)", e, time.Second*time.Duration(int64(build.BlockDelaySecs)*int64(curr-e)))
 	case curr == e:
 		return fmt.Sprintf("%d (now)", e)
 	case curr < e:
-		return fmt.Sprintf("%d (in %s)", e, time.Second*time.Duration(int64(build.BlockDelay)*int64(e-curr)))
+		return fmt.Sprintf("%d (in %s)", e, time.Second*time.Duration(int64(build.BlockDelaySecs)*int64(e-curr)))
 	}
 
 	panic("math broke")

--- a/cmd/lotus/debug_advance.go
+++ b/cmd/lotus/debug_advance.go
@@ -69,7 +69,7 @@ func init() {
 			}
 			// TODO: beacon
 
-			uts := head.MinTimestamp() + uint64(build.BlockDelay)
+			uts := head.MinTimestamp() + uint64(build.BlockDelaySecs)
 			nheight := head.Height() + 1
 			blk, err := api.MinerCreateBlock(ctx, &lapi.BlockTemplate{
 				addr, head.Key(), ticket, &types.ElectionProof{}, nil, msgs, nheight, uts, gen.ValidWpostForTesting,

--- a/documentation/en/block-validation.md
+++ b/documentation/en/block-validation.md
@@ -43,7 +43,7 @@ Assemble a `FullTipSet` populated with the single block received earlier.
 This function contains most of the validation logic grouped in separate closures that run asynchronously, this list does not reflect validation order then.
 
 `V:` Block `Timestamp`:
-  * Is not bigger than current time plus `AllowableClockDrift`.
+  * Is not bigger than current time plus `AllowableClockDriftSecs`.
   * Is not smaller than previous block's `Timestamp` plus `BlockDelay` (including null blocks).
 
 ### Messages

--- a/go.sum
+++ b/go.sum
@@ -259,7 +259,6 @@ github.com/filecoin-project/sector-storage v0.0.0-20200625154333-98ef8e4ef246/go
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.6.0/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
-github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-actors v0.6.2-0.20200617175406-de392ca14121 h1:oRA+b4iN4H86xXDXbU3TOyvmBZp7//c5VqTc0oJ6nLg=
 github.com/filecoin-project/specs-actors v0.6.2-0.20200617175406-de392ca14121/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-storage v0.1.0 h1:PkDgTOT5W5Ao7752onjDl4QSv+sgOVdJbvFjOnD5w94=

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,7 @@ github.com/filecoin-project/sector-storage v0.0.0-20200625154333-98ef8e4ef246/go
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.6.0/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
+github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-actors v0.6.2-0.20200617175406-de392ca14121 h1:oRA+b4iN4H86xXDXbU3TOyvmBZp7//c5VqTc0oJ6nLg=
 github.com/filecoin-project/specs-actors v0.6.2-0.20200617175406-de392ca14121/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-storage v0.1.0 h1:PkDgTOT5W5Ao7752onjDl4QSv+sgOVdJbvFjOnD5w94=

--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -330,7 +330,7 @@ func (c *ClientNodeAdapter) OnDealSectorCommitted(ctx context.Context, provider 
 		}
 	}
 
-	if err := c.ev.Called(checkFunc, called, revert, build.MessageConfidence+1, build.SealRandomnessLookbackLimit, matchEvent); err != nil {
+	if err := c.ev.Called(checkFunc, called, revert, int(build.MessageConfidence+1), build.SealRandomnessLookbackLimit, matchEvent); err != nil {
 		return xerrors.Errorf("failed to set up called handler: %w", err)
 	}
 

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -321,7 +321,7 @@ func (n *ProviderNodeAdapter) OnDealSectorCommitted(ctx context.Context, provide
 
 	}
 
-	if err := n.ev.Called(checkFunc, called, revert, build.MessageConfidence+1, build.SealRandomnessLookbackLimit, matchEvent); err != nil {
+	if err := n.ev.Called(checkFunc, called, revert, int(build.MessageConfidence+1), build.SealRandomnessLookbackLimit, matchEvent); err != nil {
 		return xerrors.Errorf("failed to set up called handler: %w", err)
 	}
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -150,7 +150,7 @@ func (m *Miner) mine(ctx context.Context) {
 		}
 		if base.TipSet.Equals(lastBase.TipSet) && lastBase.NullRounds == base.NullRounds {
 			log.Warnf("BestMiningCandidate from the previous round: %s (nulls:%d)", lastBase.TipSet.Cids(), lastBase.NullRounds)
-			m.niceSleep(build.BlockDelay * time.Second)
+			m.niceSleep(time.Duration(build.BlockDelay) * time.Second)
 			continue
 		}
 
@@ -194,7 +194,7 @@ func (m *Miner) mine(ctx context.Context) {
 			// has enough time to form.
 			//
 			// See:  https://github.com/filecoin-project/lotus/issues/1845
-			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+uint64(build.BlockDelay*base.NullRounds))+int64(build.PropagationDelay), 0)
+			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+build.BlockDelay*uint64(base.NullRounds))+int64(build.PropagationDelay), 0)
 
 			select {
 			case <-time.After(time.Until(nextRound)):
@@ -255,12 +255,16 @@ func (m *Miner) hasPower(ctx context.Context, addr address.Address, ts *types.Ti
 	return mpower.MinerPower.QualityAdjPower.GreaterThanEqual(power.ConsensusMinerMinPower), nil
 }
 
-// mineOne mines a single block, and does so synchronously, if and only if we
-// have won the current round.
+// mineOne attempts to mine a single block, and does so synchronously, if and
+// only if we are eligible to mine.
 //
 // {hint/landmark}: This method coordinates all the steps involved in mining a
 // block, including the condition of whether mine or not at all depending on
 // whether we win the round or not.
+//
+// This method does the following:
+//
+//  1.
 func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (*types.BlockMsg, error) {
 	log.Debugw("attempting to mine a block", "tipset", types.LogCids(base.TipSet.Cids()))
 	start := time.Now()
@@ -352,7 +356,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (*types.BlockMsg,
 	tCreateBlock := time.Now()
 	dur := tCreateBlock.Sub(start)
 	log.Infow("mined new block", "cid", b.Cid(), "height", b.Header.Height, "took", dur)
-	if dur > time.Second*build.BlockDelay {
+	if dur > time.Second*time.Duration(build.BlockDelay) {
 		log.Warn("CAUTION: block production took longer than the block delay. Your computer may not be fast enough to keep up")
 
 		log.Warnw("tMinerBaseInfo ", "duration", tMBI.Sub(start))
@@ -413,7 +417,7 @@ func (m *Miner) createBlock(base *MiningBase, addr address.Address, ticket *type
 		msgs = msgs[:build.BlockMessageLimit]
 	}
 
-	uts := base.TipSet.MinTimestamp() + uint64(build.BlockDelay*(base.NullRounds+1))
+	uts := base.TipSet.MinTimestamp() + build.BlockDelay*(uint64(base.NullRounds)+1)
 
 	nheight := base.TipSet.Height() + base.NullRounds + 1
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -150,7 +150,7 @@ func (m *Miner) mine(ctx context.Context) {
 		}
 		if base.TipSet.Equals(lastBase.TipSet) && lastBase.NullRounds == base.NullRounds {
 			log.Warnf("BestMiningCandidate from the previous round: %s (nulls:%d)", lastBase.TipSet.Cids(), lastBase.NullRounds)
-			m.niceSleep(time.Duration(build.BlockDelay) * time.Second)
+			m.niceSleep(time.Duration(build.BlockDelaySecs) * time.Second)
 			continue
 		}
 
@@ -194,7 +194,7 @@ func (m *Miner) mine(ctx context.Context) {
 			// has enough time to form.
 			//
 			// See:  https://github.com/filecoin-project/lotus/issues/1845
-			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+build.BlockDelay*uint64(base.NullRounds))+int64(build.PropagationDelay), 0)
+			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+build.BlockDelaySecs*uint64(base.NullRounds))+int64(build.PropagationDelay), 0)
 
 			select {
 			case <-time.After(time.Until(nextRound)):
@@ -356,7 +356,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (*types.BlockMsg,
 	tCreateBlock := time.Now()
 	dur := tCreateBlock.Sub(start)
 	log.Infow("mined new block", "cid", b.Cid(), "height", b.Header.Height, "took", dur)
-	if dur > time.Second*time.Duration(build.BlockDelay) {
+	if dur > time.Second*time.Duration(build.BlockDelaySecs) {
 		log.Warn("CAUTION: block production took longer than the block delay. Your computer may not be fast enough to keep up")
 
 		log.Warnw("tMinerBaseInfo ", "duration", tMBI.Sub(start))
@@ -417,7 +417,7 @@ func (m *Miner) createBlock(base *MiningBase, addr address.Address, ticket *type
 		msgs = msgs[:build.BlockMessageLimit]
 	}
 
-	uts := base.TipSet.MinTimestamp() + build.BlockDelay*(uint64(base.NullRounds)+1)
+	uts := base.TipSet.MinTimestamp() + build.BlockDelaySecs*(uint64(base.NullRounds)+1)
 
 	nheight := base.TipSet.Height() + base.NullRounds + 1
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -42,7 +42,7 @@ func NewMiner(api api.FullNode, epp gen.WinningPoStProver, addr address.Address)
 		address: addr,
 		waitFunc: func(ctx context.Context, baseTime uint64) (func(bool), error) {
 			// Wait around for half the block time in case other parents come in
-			deadline := baseTime + build.PropagationDelay
+			deadline := baseTime + build.PropagationDelaySecs
 			time.Sleep(time.Until(time.Unix(int64(deadline), 0)))
 
 			return func(bool) {}, nil
@@ -194,7 +194,7 @@ func (m *Miner) mine(ctx context.Context) {
 			// has enough time to form.
 			//
 			// See:  https://github.com/filecoin-project/lotus/issues/1845
-			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+build.BlockDelaySecs*uint64(base.NullRounds))+int64(build.PropagationDelay), 0)
+			nextRound := time.Unix(int64(base.TipSet.MinTimestamp()+build.BlockDelaySecs*uint64(base.NullRounds))+int64(build.PropagationDelaySecs), 0)
 
 			select {
 			case <-time.After(time.Until(nextRound)):

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -122,7 +122,7 @@ func (a *CommonAPI) Version(context.Context) (api.Version, error) {
 		Version:    build.UserVersion(),
 		APIVersion: build.APIVersion,
 
-		BlockDelay: uint64(build.BlockDelaySecs),
+		BlockDelay: build.BlockDelaySecs,
 	}, nil
 }
 

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -122,7 +122,7 @@ func (a *CommonAPI) Version(context.Context) (api.Version, error) {
 		Version:    build.UserVersion(),
 		APIVersion: build.APIVersion,
 
-		BlockDelay: build.BlockDelay,
+		BlockDelay: uint64(build.BlockDelay),
 	}, nil
 }
 

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -122,7 +122,7 @@ func (a *CommonAPI) Version(context.Context) (api.Version, error) {
 		Version:    build.UserVersion(),
 		APIVersion: build.APIVersion,
 
-		BlockDelay: uint64(build.BlockDelay),
+		BlockDelay: uint64(build.BlockDelaySecs),
 	}, nil
 }
 

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -123,6 +123,6 @@ func RandomBeacon(p RandomBeaconParams, _ dtypes.AfterGenesisSet) (beacon.Random
 		return nil, err
 	}
 
-	//return beacon.NewMockBeacon(build.BlockDelay * time.Second)
-	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelay, p.PubSub, p.DrandConfig)
+	//return beacon.NewMockBeacon(build.BlockDelaySecs * time.Second)
+	return drand.NewDrandBeacon(gen.Timestamp, build.BlockDelaySecs, p.PubSub, p.DrandConfig)
 }

--- a/node/modules/testing/beacon.go
+++ b/node/modules/testing/beacon.go
@@ -8,5 +8,5 @@ import (
 )
 
 func RandomBeacon() (beacon.RandomBeacon, error) {
-	return beacon.NewMockBeacon(time.Duration(build.BlockDelay) * time.Second), nil
+	return beacon.NewMockBeacon(time.Duration(build.BlockDelaySecs) * time.Second), nil
 }

--- a/node/modules/testing/beacon.go
+++ b/node/modules/testing/beacon.go
@@ -8,5 +8,5 @@ import (
 )
 
 func RandomBeacon() (beacon.RandomBeacon, error) {
-	return beacon.NewMockBeacon(build.BlockDelay * time.Second), nil
+	return beacon.NewMockBeacon(time.Duration(build.BlockDelay) * time.Second), nil
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -349,7 +349,7 @@ func mockSbBuilder(t *testing.T, nFull int, storage []test.StorageMiner) ([]test
 	templ := &genesis.Template{
 		Accounts:  genaccs,
 		Miners:    genms,
-		Timestamp: uint64(time.Now().Unix() - (build.BlockDelaySecs * 20000)),
+		Timestamp: uint64(time.Now().Unix()) - (build.BlockDelaySecs * 20000),
 	}
 
 	// END PRESEAL SECTION

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -349,7 +349,7 @@ func mockSbBuilder(t *testing.T, nFull int, storage []test.StorageMiner) ([]test
 	templ := &genesis.Template{
 		Accounts:  genaccs,
 		Miners:    genms,
-		Timestamp: uint64(time.Now().Unix() - (build.BlockDelay * 20000)),
+		Timestamp: uint64(time.Now().Unix() - (build.BlockDelaySecs * 20000)),
 	}
 
 	// END PRESEAL SECTION

--- a/tools/stats/rpc.go
+++ b/tools/stats/rpc.go
@@ -114,7 +114,7 @@ sync_complete:
 			// If we get within 20 blocks of the current exected block height we
 			// consider sync complete. Block propagation is not always great but we still
 			// want to be recording stats as soon as we can
-			if timestampDelta < int64(build.BlockDelay)*20 {
+			if timestampDelta < int64(build.BlockDelaySecs)*20 {
 				return nil
 			}
 		}

--- a/tools/stats/rpc.go
+++ b/tools/stats/rpc.go
@@ -114,7 +114,7 @@ sync_complete:
 			// If we get within 20 blocks of the current exected block height we
 			// consider sync complete. Block propagation is not always great but we still
 			// want to be recording stats as soon as we can
-			if timestampDelta < build.BlockDelay*20 {
+			if timestampDelta < int64(build.BlockDelay)*20 {
 				return nil
 			}
 		}


### PR DESCRIPTION
This configurability is unlocked through the `testground` build tag, which Project Oni uses.

The reason we need to tinker with these parameters is to test scenarios like forking, chain halting, ill syncing, etc. in an accelerated manner.

Changes in the usage places of these relaxed constants were required due to the fact that Golang constants are untyped, but vars aren't.

Read https://blog.golang.org/constants for more info.