### PR TITLE
Fix concurrent map access panic in event API

### DIFF
--- a/chain/events/events_called.go
+++ b/chain/events/events_called.go
@@ -443,8 +443,8 @@ func (we *watcherEvents) StateChanged(check CheckFunc, scHnd StateChangeHandler,
 	}
 
 	we.lk.Lock()
-	we.matchers[id] = mf
 	defer we.lk.Unlock()
+	we.matchers[id] = mf
 
 	return nil
 }
@@ -476,10 +476,11 @@ func (me *messageEvents) checkNewCalls(ts *types.TipSet) (map[triggerID]eventDat
 		return nil, err
 	}
 
+	me.lk.RLock()
+	defer me.lk.RUnlock()
+
 	res := make(map[triggerID]eventData)
 	me.messagesForTs(pts, func(msg *types.Message) {
-		me.lk.RLock()
-		defer me.lk.RUnlock()
 		// TODO: provide receipts
 
 		for tid, matchFns := range me.matchers {


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/lotus/issues/2191

I'm actually not sure why the panic occurred, it seems that we are only accessing the map within locks. But I moved a couple of things around that should help us maintain more strict correctness in any case, so hopefully this will fix it.