### PR TITLE
add --api-endpoint flag to cli tools

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -27,6 +27,8 @@ var log = logging.Logger("cli")
 
 const (
 	metadataTraceConetxt = "traceContext"
+
+	FlagApiEndpoint = "api-endpoint"
 )
 
 // custom CLI error
@@ -135,6 +137,10 @@ func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
 }
 
 func GetRawAPI(ctx *cli.Context, t repo.RepoType) (string, http.Header, error) {
+	if addr := ctx.String(FlagApiEndpoint); addr != "" {
+		return addr, http.Header{}, nil
+	}
+
 	ainfo, err := GetAPIInfo(ctx, t)
 	if err != nil {
 		return "", nil, xerrors.Errorf("could not get API info: %w", err)

--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -53,6 +53,10 @@ func main() {
 		Version: build.UserVersion(),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
+				Name:  lcli.FlagApiEndpoint,
+				Value: "",
+			},
+			&cli.StringFlag{
 				Name:    FlagStorageRepo,
 				EnvVars: []string{"WORKER_PATH"},
 				Value:   "~/.lotusworker", // TODO: Consider XDG_DATA_HOME

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/filecoin-project/lotus/build"
+	lcli "github.com/filecoin-project/lotus/cli"
 )
 
 var log = logging.Logger("lotus-shed")
@@ -36,6 +37,10 @@ func main() {
 		Version:  build.BuildVersion,
 		Commands: local,
 		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  lcli.FlagApiEndpoint,
+				Value: "",
+			},
 			&cli.StringFlag{
 				Name:    "repo",
 				EnvVars: []string{"LOTUS_PATH"},

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -63,6 +63,10 @@ func main() {
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
+				Name:  lcli.FlagApiEndpoint,
+				Value: "",
+			},
+			&cli.StringFlag{
 				Name:    "repo",
 				EnvVars: []string{"LOTUS_PATH"},
 				Hidden:  true,

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -56,6 +56,10 @@ func main() {
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
+				Name:  lcli.FlagApiEndpoint,
+				Value: "",
+			},
+			&cli.StringFlag{
 				Name:    "repo",
 				EnvVars: []string{"LOTUS_PATH"},
 				Hidden:  true,


### PR DESCRIPTION
Testground is using Lotus as a library and has also exposed the internal APIs over JSON RPC.

It'd be nice to be able to remotely connect to a Lotus full node or miner node APIs, so I am adding a `--api-endpoint` flag, which would take precedence if specified over the code that loads the repo from the local filesystem.

Then we can do something like:

```
PODNAME="tg-lotus-4aa43ae5308c-miner-0"
kubectl port-forward pods/$PODNAME 1234:1234
ENDPOINT="ws://localhost:1234/rpc/v0"
lotus-storage-miner --api-endpoint=$ENDPOINT storage-deals list
```