### PR TITLE
check underlying datastore for objects before putting to bufbstore

### DIFF
--- a/lib/bufbstore/buf_bstore.go
+++ b/lib/bufbstore/buf_bstore.go
@@ -108,6 +108,15 @@ func (bs *BufferedBS) GetSize(c cid.Cid) (int, error) {
 }
 
 func (bs *BufferedBS) Put(blk block.Block) error {
+	has, err := bs.read.Has(blk.Cid())
+	if err != nil {
+		return err
+	}
+
+	if has {
+		return nil
+	}
+
 	return bs.write.Put(blk)
 }
 


### PR DESCRIPTION
This should actually significantly improve perf sync. We are seeing a lot of time spent just checking if a given object exists in the has-caching wrapped badger datastore. Doing this both means fewer objects that we need to check for, and it also means that most of the cids will likely end up in the 'has cache', making that faster in general.
![2020-07-02-164912_1527x1774_scrot](https://user-images.githubusercontent.com/1243164/86418121-fe375c00-bc83-11ea-9fc9-62f01e67b4e5.png)
