### PR TITLE
add `actor` flag to `lotus-storage-miner` for proving and info calls

### DIFF
--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -44,7 +44,7 @@ var infoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -44,7 +44,7 @@ var infoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
 	"go.opencensus.io/trace"
+	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
@@ -88,4 +92,20 @@ func main() {
 		log.Warnf("%+v", err)
 		os.Exit(1)
 	}
+}
+
+func getActorAddress(ctx context.Context, nodeApi api.StorageMiner, overrideMaddr string) (maddr address.Address, err error) {
+	if overrideMaddr != "" {
+		maddr, err = address.NewFromString(overrideMaddr)
+		if err != nil {
+			return maddr, err
+		}
+	}
+
+	maddr, err = nodeApi.ActorAddress(ctx)
+	if err != nil {
+		return maddr, xerrors.Errorf("getting actor address: %w", err)
+	}
+
+	return maddr, nil
 }

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 }
 
-func getActorAddress(ctx context.Context, nodeApi api.StorageMiner, overrideMaddr string) (maddr address.Address, err error) {
+func getActorAddress(ctx context.Context, nodeAPI api.StorageMiner, overrideMaddr string) (maddr address.Address, err error) {
 	if overrideMaddr != "" {
 		maddr, err = address.NewFromString(overrideMaddr)
 		if err != nil {
@@ -104,7 +104,7 @@ func getActorAddress(ctx context.Context, nodeApi api.StorageMiner, overrideMadd
 		}
 	}
 
-	maddr, err = nodeApi.ActorAddress(ctx)
+	maddr, err = nodeAPI.ActorAddress(ctx)
 	if err != nil {
 		return maddr, xerrors.Errorf("getting actor address: %w", err)
 	}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -67,8 +67,10 @@ func main() {
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:  "maddr",
-				Value: "",
+				Name:    "actor",
+				Value:   "",
+				Usage:   "specify other actor to check state for (read only)",
+				Aliases: []string{"a"},
 			},
 			&cli.StringFlag{
 				Name:    "repo",

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -63,6 +63,10 @@ func main() {
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
+				Name:  "maddr",
+				Value: "",
+			},
+			&cli.StringFlag{
 				Name:    "repo",
 				EnvVars: []string{"LOTUS_PATH"},
 				Hidden:  true,

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -48,7 +48,7 @@ var provingFaultsCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ var provingInfoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,7 @@ var provingDeadlinesCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -51,6 +52,15 @@ var provingFaultsCmd = &cli.Command{
 		maddr, err := nodeApi.ActorAddress(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting actor address: %w", err)
+		}
+
+		// override maddr is specified
+		if cctx.String("maddr") != "" {
+			var err error
+			maddr, err = address.NewFromString(cctx.String("maddr"))
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		var mas miner.State
@@ -119,6 +129,15 @@ var provingInfoCmd = &cli.Command{
 		maddr, err := nodeApi.ActorAddress(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting actor address: %w", err)
+		}
+
+		// override maddr is specified
+		if cctx.String("maddr") != "" {
+			var err error
+			maddr, err = address.NewFromString(cctx.String("maddr"))
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		head, err := api.ChainHead(ctx)
@@ -242,6 +261,15 @@ var provingDeadlinesCmd = &cli.Command{
 		maddr, err := nodeApi.ActorAddress(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting actor address: %w", err)
+		}
+
+		// override maddr is specified
+		if cctx.String("maddr") != "" {
+			var err error
+			maddr, err = address.NewFromString(cctx.String("maddr"))
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		deadlines, err := api.StateMinerDeadlines(ctx, maddr, types.EmptyTSK)

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -10,7 +10,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -49,18 +48,9 @@ var provingFaultsCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
 		if err != nil {
-			return xerrors.Errorf("getting actor address: %w", err)
-		}
-
-		// override maddr is specified
-		if cctx.String("maddr") != "" {
-			var err error
-			maddr, err = address.NewFromString(cctx.String("maddr"))
-			if err != nil {
-				panic(err)
-			}
+			return err
 		}
 
 		var mas miner.State
@@ -126,18 +116,9 @@ var provingInfoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
 		if err != nil {
-			return xerrors.Errorf("getting actor address: %w", err)
-		}
-
-		// override maddr is specified
-		if cctx.String("maddr") != "" {
-			var err error
-			maddr, err = address.NewFromString(cctx.String("maddr"))
-			if err != nil {
-				panic(err)
-			}
+			return err
 		}
 
 		head, err := api.ChainHead(ctx)
@@ -258,18 +239,9 @@ var provingDeadlinesCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("maddr"))
 		if err != nil {
-			return xerrors.Errorf("getting actor address: %w", err)
-		}
-
-		// override maddr is specified
-		if cctx.String("maddr") != "" {
-			var err error
-			maddr, err = address.NewFromString(cctx.String("maddr"))
-			if err != nil {
-				panic(err)
-			}
+			return err
 		}
 
 		deadlines, err := api.StateMinerDeadlines(ctx, maddr, types.EmptyTSK)


### PR DESCRIPTION
I'd like to be able to check the state of a given miner from the perspective of another miner. For example if miner A has sealed a deal with a given client, and then disappears, I want to be able to use the `lotus-storage-miner` tools (`proving info`, `info`, etc.) to visualise that sectors are marked as faulty.

---

Currently this is enabled for:
```
lotus-storage-miner info
lotus-storage-miner proving info
lotus-storage-miner proving deadlines
lotus-storage-miner proving faults
```

Probably we will want to do something similar also for other read-only commands as well in the future.

---

cc @raulk @vyzo @yusefnapora 