### PR TITLE
add error argument to waitFunc callback in miner loop

### DIFF
--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -59,7 +59,7 @@ func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport
 		defer close(done)
 		for atomic.LoadInt64(&mine) == 1 {
 			time.Sleep(blocktime)
-			if err := sn[0].MineOne(ctx, func(bool) {}); err != nil {
+			if err := sn[0].MineOne(ctx, func(bool, error) {}); err != nil {
 				t.Error(err)
 			}
 		}
@@ -97,7 +97,7 @@ func TestDoubleDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
 		defer close(done)
 		for atomic.LoadInt64(&mine) == 1 {
 			time.Sleep(blocktime)
-			if err := sn[0].MineOne(ctx, func(bool) {}); err != nil {
+			if err := sn[0].MineOne(ctx, func(bool, error) {}); err != nil {
 				t.Error(err)
 			}
 		}

--- a/api/test/mining.go
+++ b/api/test/mining.go
@@ -34,7 +34,7 @@ func (ts *testSuite) testMining(t *testing.T) {
 	require.NoError(t, err)
 	<-newHeads
 
-	err = sn[0].MineOne(ctx, func(bool) {})
+	err = sn[0].MineOne(ctx, func(bool, error) {})
 	require.NoError(t, err)
 
 	<-newHeads
@@ -62,7 +62,7 @@ func (ts *testSuite) testMiningReal(t *testing.T) {
 	require.NoError(t, err)
 	<-newHeads
 
-	err = sn[0].MineOne(ctx, func(bool) {})
+	err = sn[0].MineOne(ctx, func(bool, error) {})
 	require.NoError(t, err)
 
 	<-newHeads
@@ -71,7 +71,7 @@ func (ts *testSuite) testMiningReal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, abi.ChainEpoch(1), h2.Height())
 
-	err = sn[0].MineOne(ctx, func(bool) {})
+	err = sn[0].MineOne(ctx, func(bool, error) {})
 	require.NoError(t, err)
 
 	<-newHeads
@@ -132,7 +132,7 @@ func TestDealMining(t *testing.T, b APIBuilder, blocktime time.Duration, carExpo
 		prevExpect := 0
 		for atomic.LoadInt32(&mine) != 0 {
 			wait := make(chan int, 2)
-			mdone := func(mined bool) {
+			mdone := func(mined bool, err error) {
 				go func() {
 					n := 0
 					if mined {

--- a/api/test/test.go
+++ b/api/test/test.go
@@ -18,7 +18,7 @@ type TestNode struct {
 type TestStorageNode struct {
 	api.StorageMiner
 
-	MineOne func(context.Context, func(bool)) error
+	MineOne func(context.Context, func(bool, error)) error
 }
 
 var PresealGenesis = -1

--- a/api/test/window_post.go
+++ b/api/test/window_post.go
@@ -43,7 +43,7 @@ func TestPledgeSector(t *testing.T, b APIBuilder, blocktime time.Duration, nSect
 		defer close(done)
 		for mine {
 			time.Sleep(blocktime)
-			if err := sn[0].MineOne(ctx, func(bool) {}); err != nil {
+			if err := sn[0].MineOne(ctx, func(bool, error) {}); err != nil {
 				t.Error(err)
 			}
 		}
@@ -123,7 +123,7 @@ func TestWindowPost(t *testing.T, b APIBuilder, blocktime time.Duration, nSector
 		defer close(done)
 		for mine {
 			time.Sleep(blocktime)
-			if err := sn[0].MineOne(ctx, func(bool) {}); err != nil {
+			if err := sn[0].MineOne(ctx, func(bool, error) {}); err != nil {
 				t.Error(err)
 			}
 		}

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -90,7 +90,7 @@ var preSealCmd = &cli.Command{
 			Usage: "(optional) Key to use for signing / owner/worker addresses",
 		},
 		&cli.BoolFlag{
-			Name: "fake-sectors",
+			Name:  "fake-sectors",
 			Value: false,
 		},
 	},

--- a/cmd/lotus-seed/seed/seed.go
+++ b/cmd/lotus-seed/seed/seed.go
@@ -186,7 +186,7 @@ func presealSector(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, sid abi.Sector
 }
 
 func presealSectorFake(sbfs *basicfs.Provider, sid abi.SectorID, spt abi.RegisteredSealProof, ssize abi.SectorSize) (*genesis.PreSeal, error) {
-	paths, done, err := sbfs.AcquireSector(context.TODO(), sid, 0, stores.FTSealed | stores.FTCache, true)
+	paths, done, err := sbfs.AcquireSector(context.TODO(), sid, 0, stores.FTSealed|stores.FTCache, true)
 	if err != nil {
 		return nil, xerrors.Errorf("acquire unsealed sector: %w", err)
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -28,7 +28,7 @@ import (
 var log = logging.Logger("miner")
 
 // returns a callback reporting whether we mined a blocks in this round
-type waitFunc func(ctx context.Context, baseTime uint64) (func(bool), error)
+type waitFunc func(ctx context.Context, baseTime uint64) (func(bool, error), error)
 
 func NewMiner(api api.FullNode, epp gen.WinningPoStProver, addr address.Address) *Miner {
 	arc, err := lru.NewARC(10000)
@@ -40,12 +40,12 @@ func NewMiner(api api.FullNode, epp gen.WinningPoStProver, addr address.Address)
 		api:     api,
 		epp:     epp,
 		address: addr,
-		waitFunc: func(ctx context.Context, baseTime uint64) (func(bool), error) {
+		waitFunc: func(ctx context.Context, baseTime uint64) (func(bool, error), error) {
 			// Wait around for half the block time in case other parents come in
 			deadline := baseTime + build.PropagationDelaySecs
 			time.Sleep(time.Until(time.Unix(int64(deadline), 0)))
 
-			return func(bool) {}, nil
+			return func(bool, error) {}, nil
 		},
 		minedBlockHeights: arc,
 	}
@@ -158,12 +158,12 @@ func (m *Miner) mine(ctx context.Context) {
 		if err != nil {
 			log.Errorf("mining block failed: %+v", err)
 			m.niceSleep(time.Second)
-			onDone(false)
+			onDone(false, err)
 			continue
 		}
 		lastBase = *base
 
-		onDone(b != nil)
+		onDone(b != nil, nil)
 
 		if b != nil {
 			btime := time.Unix(int64(b.Header.Timestamp), 0)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -158,6 +158,7 @@ func (m *Miner) mine(ctx context.Context) {
 		if err != nil {
 			log.Errorf("mining block failed: %+v", err)
 			m.niceSleep(time.Second)
+			onDone(false)
 			continue
 		}
 		lastBase = *base

--- a/miner/testminer.go
+++ b/miner/testminer.go
@@ -9,7 +9,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
-func NewTestMiner(nextCh <-chan func(bool), addr address.Address) func(api.FullNode, gen.WinningPoStProver) *Miner {
+func NewTestMiner(nextCh <-chan func(bool, error), addr address.Address) func(api.FullNode, gen.WinningPoStProver) *Miner {
 	return func(api api.FullNode, epp gen.WinningPoStProver) *Miner {
 		arc, err := lru.NewARC(10000)
 		if err != nil {
@@ -31,8 +31,8 @@ func NewTestMiner(nextCh <-chan func(bool), addr address.Address) func(api.FullN
 	}
 }
 
-func chanWaiter(next <-chan func(bool)) func(ctx context.Context, _ uint64) (func(bool), error) {
-	return func(ctx context.Context, _ uint64) (func(bool), error) {
+func chanWaiter(next <-chan func(bool, error)) func(ctx context.Context, _ uint64) (func(bool, error), error) {
+	return func(ctx context.Context, _ uint64) (func(bool, error), error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -116,7 +116,7 @@ func testStorageNode(ctx context.Context, t *testing.T, waddr address.Address, a
 	// start node
 	var minerapi api.StorageMiner
 
-	mineBlock := make(chan func(bool))
+	mineBlock := make(chan func(bool, error))
 	// TODO: use stop
 	_, err = node.New(ctx,
 		node.StorageMiner(&minerapi),
@@ -141,7 +141,7 @@ func testStorageNode(ctx context.Context, t *testing.T, waddr address.Address, a
 
 	err = minerapi.NetConnect(ctx, remoteAddrs)
 	require.NoError(t, err)*/
-	mineOne := func(ctx context.Context, cb func(bool)) error {
+	mineOne := func(ctx context.Context, cb func(bool, error)) error {
 		select {
 		case mineBlock <- cb:
 			return nil


### PR DESCRIPTION
This adds an `error` argument to the callback returned by the mining `waitFunc`, so that we can call it when we get an error mining a block.

This is to fix our synchronized mining setup in testground - it currently gets stuck if there's a mining error because it's waiting for the callback (see https://github.com/filecoin-project/lotus/issues/2193). Adding the error argument lets us invoke the callback in the error case and inform the other end whether we're advancing to a new round or not.

This is a breaking API change for anyone currently using `NewTestMiner` from another project (I updated the call sites here). I can  add a new constructor instead that wraps the two-argument callback if we care about that, but it's a pretty easy fix and should only affect tests.

CI is complaining about linting rules in `tools/stats/main.go`, but I didn't mess with those :)
