### PR TITLE
VerifyConsensusFault should return an error if no fault is found

### DIFF
--- a/chain/vm/syscalls.go
+++ b/chain/vm/syscalls.go
@@ -146,7 +146,7 @@ func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime.Consen
 
 	// (3) return if no consensus fault by now
 	if consensusFault == nil {
-		return consensusFault, nil
+		return nil, xerrors.Errorf("no consensus fault detected")
 	}
 
 	// else


### PR DESCRIPTION
That's what specky-actory says we should do

Fixes #1981 