### PR TITLE
chainwatch: Capture power from miner and reward actors

### DIFF
--- a/cmd/lotus-chainwatch/main.go
+++ b/cmd/lotus-chainwatch/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		log.Warnf("%+v", err)
-		return
+		os.Exit(1)
 	}
 }
 

--- a/cmd/lotus-chainwatch/storage.go
+++ b/cmd/lotus-chainwatch/storage.go
@@ -305,6 +305,19 @@ create table if not exists chain_power
 	baseline_power text not null
 );
 
+/*
+* captures miner-specific power state for any given stateroot
+*/
+create table if not exists miner_power
+(
+	miner_id text not null,
+	stateroot text not null,
+	raw_bytes_power text not null,
+	quality_adjusted_power text not null,
+	constraint miner_power_pk
+		primary key (miner_id, stateroot)
+);
+
 /* used to tell when a miners sectors (proven-not-yet-expired) changed if the miner_sectors_cid's are different a new sector was added or removed (terminated/expired) */
 create table if not exists miner_sectors_heads
 (
@@ -532,7 +545,7 @@ func (st *storage) storeChainPower(rewardTips map[types.TipSetKey]*rewardStateIn
 			rewardState.stateroot.String(),
 			rewardState.baselinePower.String(),
 		); err != nil {
-			return xerrors.Errorf("exec prepared chain_power: %w", err)
+			log.Errorw("failed to store chain power", "stateroot", rewardState.stateroot, "error", err)
 		}
 	}
 
@@ -656,6 +669,50 @@ func (st *storage) storeMiners(minerTips map[types.TipSetKey][]*minerStateInfo) 
 	}
 
 	return tx.Commit()
+}
+
+// storeMinerPower captures miner actor state as it relates to power per miner captured on-chain
+func (st *storage) storeMinerPower(minerTips map[types.TipSetKey][]*minerStateInfo) error {
+	tx, err := st.db.Begin()
+	if err != nil {
+		return xerrors.Errorf("begin miner_power tx: %w", err)
+	}
+
+	if _, err := tx.Exec(`create temp table mp (like miner_power excluding constraints) on commit drop`); err != nil {
+		return xerrors.Errorf("prep miner_power temp: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`copy cp (miner_id, stateroot, raw_bytes_power, quality_adjusted_power) from STDIN`)
+	if err != nil {
+		return xerrors.Errorf("prepare tmp miner_power: %w", err)
+	}
+
+	for _, miners := range minerTips {
+		for _, minerInfo := range miners {
+			if _, err := stmt.Exec(
+				minerInfo.addr.String(),
+				minerInfo.stateroot.String(),
+				minerInfo.rawPower.String(),
+				minerInfo.qalPower.String(),
+			); err != nil {
+				log.Errorw("failed to store miner power", "miner", minerInfo.addr, "stateroot", minerInfo.stateroot, "error", err)
+			}
+		}
+	}
+
+	if err := stmt.Close(); err != nil {
+		return xerrors.Errorf("close prepared miner_power: %w", err)
+	}
+
+	if _, err := tx.Exec(`insert into miner_power select * from mp on conflict do nothing`); err != nil {
+		return xerrors.Errorf("insert miner_power from tmp: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("commit miner_power tx: %w", err)
+	}
+
+	return nil
 }
 
 func (st *storage) storeMinerSectorsHeads(minerTips map[types.TipSetKey][]*minerStateInfo, api api.FullNode) error {

--- a/cmd/lotus-chainwatch/storage.go
+++ b/cmd/lotus-chainwatch/storage.go
@@ -299,7 +299,7 @@ create table if not exists miner_info
 */
 create table if not exists chain_power
 (
-	stateroot text not null
+	state_root text not null
 		constraint chain_power_pk
 			primary key,
 	baseline_power text not null
@@ -311,11 +311,11 @@ create table if not exists chain_power
 create table if not exists miner_power
 (
 	miner_id text not null,
-	stateroot text not null,
+	state_root text not null,
 	raw_bytes_power text not null,
 	quality_adjusted_power text not null,
 	constraint miner_power_pk
-		primary key (miner_id, stateroot)
+		primary key (miner_id, state_root)
 );
 
 /* used to tell when a miners sectors (proven-not-yet-expired) changed if the miner_sectors_cid's are different a new sector was added or removed (terminated/expired) */
@@ -535,7 +535,7 @@ func (st *storage) storeChainPower(rewardTips map[types.TipSetKey]*rewardStateIn
 		return xerrors.Errorf("prep chain_power temp: %w", err)
 	}
 
-	stmt, err := tx.Prepare(`copy cp (stateroot, baseline_power) from STDIN`)
+	stmt, err := tx.Prepare(`copy cp (state_root, baseline_power) from STDIN`)
 	if err != nil {
 		return xerrors.Errorf("prepare tmp chain_power: %w", err)
 	}
@@ -545,7 +545,7 @@ func (st *storage) storeChainPower(rewardTips map[types.TipSetKey]*rewardStateIn
 			rewardState.stateroot.String(),
 			rewardState.baselinePower.String(),
 		); err != nil {
-			log.Errorw("failed to store chain power", "stateroot", rewardState.stateroot, "error", err)
+			log.Errorw("failed to store chain power", "state_root", rewardState.stateroot, "error", err)
 		}
 	}
 
@@ -682,7 +682,7 @@ func (st *storage) storeMinerPower(minerTips map[types.TipSetKey][]*minerStateIn
 		return xerrors.Errorf("prep miner_power temp: %w", err)
 	}
 
-	stmt, err := tx.Prepare(`copy cp (miner_id, stateroot, raw_bytes_power, quality_adjusted_power) from STDIN`)
+	stmt, err := tx.Prepare(`copy mp (miner_id, state_root, raw_bytes_power, quality_adjusted_power) from STDIN`)
 	if err != nil {
 		return xerrors.Errorf("prepare tmp miner_power: %w", err)
 	}

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -317,7 +317,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 		for addr, m := range actors {
 			for actor, c := range m {
 				// reward actor
-				if actor.Code != builtin.RewardActorCodeID {
+				if actor.Code == builtin.RewardActorCodeID {
 					rewardTips[c.tsKey] = &rewardStateInfo{
 						stateroot:     c.stateroot,
 						baselinePower: big.Zero(),
@@ -326,7 +326,7 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 				}
 
 				// miner actors with head change events
-				if actor.Code != builtin.StorageMinerActorCodeID {
+				if actor.Code == builtin.StorageMinerActorCodeID {
 					if _, found := headsSeen[actor.Head]; found {
 						continue
 					}

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -13,12 +13,14 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
+	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/api"
@@ -51,6 +53,11 @@ func runSyncer(ctx context.Context, api api.FullNode, st *storage, maxBatch int)
 			}
 		}
 	}()
+}
+
+type rewardStateInfo struct {
+	stateroot     cid.Cid
+	baselinePower big.Int
 }
 
 type minerStateInfo struct {
@@ -273,6 +280,8 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 			}
 		})
 
+		// map of tipset to reward state
+		rewardTips := make(map[types.TipSetKey]*rewardStateInfo, len(changes))
 		// map of tipset to all miners that had a head-change at that tipset.
 		minerTips := make(map[types.TipSetKey][]*minerStateInfo, len(changes))
 		// heads we've seen, im being paranoid
@@ -302,39 +311,73 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 			alk.Unlock()
 		})
 
-		log.Infof("Getting miner info")
+		log.Infof("Getting actor change info")
 
 		minerChanges := 0
 		for addr, m := range actors {
 			for actor, c := range m {
+				// reward actor
+				if actor.Code != builtin.RewardActorCodeID {
+					rewardTips[c.tsKey] = &rewardStateInfo{
+						stateroot:     c.stateroot,
+						baselinePower: big.Zero(),
+					}
+					continue
+				}
+
+				// miner actors with head change events
 				if actor.Code != builtin.StorageMinerActorCodeID {
-					continue
+					if _, found := headsSeen[actor.Head]; found {
+						continue
+					}
+					minerChanges++
+
+					minerTips[c.tsKey] = append(minerTips[c.tsKey], &minerStateInfo{
+						addr:      addr,
+						act:       actor,
+						stateroot: c.stateroot,
+
+						tsKey:       c.tsKey,
+						parentTsKey: c.parentTsKey,
+
+						state: miner.State{},
+						info:  miner.MinerInfo{},
+
+						rawPower: big.Zero(),
+						qalPower: big.Zero(),
+					})
+
+					headsSeen[actor.Head] = struct{}{}
 				}
-
-				// only want miner actors with head change events
-				if _, found := headsSeen[actor.Head]; found {
-					continue
-				}
-				minerChanges++
-
-				minerTips[c.tsKey] = append(minerTips[c.tsKey], &minerStateInfo{
-					addr:      addr,
-					act:       actor,
-					stateroot: c.stateroot,
-
-					tsKey:       c.tsKey,
-					parentTsKey: c.parentTsKey,
-
-					state: miner.State{},
-					info:  miner.MinerInfo{},
-
-					rawPower: big.Zero(),
-					qalPower: big.Zero(),
-				})
-
-				headsSeen[actor.Head] = struct{}{}
+				continue
 			}
 		}
+
+		rewardProcessingStartedAt := time.Now()
+		parmap.Par(50, parmap.KVMapArr(rewardTips), func(it func() (types.TipSetKey, *rewardStateInfo)) {
+			tsKey, rewardInfo := it()
+			// get reward actor states at each tipset once for all updates
+			rewardActor, err := api.StateGetActor(ctx, builtin.RewardActorAddr, tsKey)
+			if err != nil {
+				log.Error(xerrors.Errorf("get reward state (@ %s): %w", rewardInfo.stateroot.String(), err))
+				return
+			}
+
+			rewardStateRaw, err := api.ChainReadObj(ctx, rewardActor.Head)
+			if err != nil {
+				log.Error(xerrors.Errorf("read state obj (@ %s): %w", rewardInfo.stateroot.String(), err))
+				return
+			}
+
+			var rewardActorState reward.State
+			if err := rewardActorState.UnmarshalCBOR(bytes.NewReader(rewardStateRaw)); err != nil {
+				log.Error(xerrors.Errorf("unmarshal state (@ %s): %w", rewardInfo.stateroot.String(), err))
+				return
+			}
+
+			rewardInfo.baselinePower = rewardActorState.BaselinePower
+		})
+		log.Infow("Completed Reward Processing", "duration", time.Since(rewardProcessingStartedAt).String(), "processed", len(rewardTips))
 
 		minerProcessingStartedAt := time.Now()
 		log.Infow("Processing miners", "numTips", len(minerTips), "numMinerChanges", minerChanges)
@@ -411,11 +454,16 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 		}
 
 		log.Info("Storing actors")
-
 		if err := st.storeActors(actors); err != nil {
 			log.Error(err)
 			return
 		}
+
+		chainPowerStartedAt := time.Now()
+		if err := st.storeChainPower(rewardTips); err != nil {
+			log.Error(err)
+		}
+		log.Infow("Stored chain power", "duration", time.Since(chainPowerStartedAt).String())
 
 		log.Info("Storing miners")
 		if err := st.storeMiners(minerTips); err != nil {
@@ -423,13 +471,12 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 			return
 		}
 
-		log.Info("Storing miner sectors")
 		sectorStart := time.Now()
 		if err := st.storeSectors(minerTips, api); err != nil {
 			log.Error(err)
 			return
 		}
-		log.Infow("Finished storing miner sectors", "duration", time.Since(sectorStart).String())
+		log.Infow("Stored miner sectors", "duration", time.Since(sectorStart).String())
 
 		log.Info("Storing miner sectors heads")
 		if err := st.storeMinerSectorsHeads(minerTips, api); err != nil {

--- a/cmd/lotus-chainwatch/sync.go
+++ b/cmd/lotus-chainwatch/sync.go
@@ -471,6 +471,12 @@ func syncHead(ctx context.Context, api api.FullNode, st *storage, headTs *types.
 			return
 		}
 
+		minerPowerStartedAt := time.Now()
+		if err := st.storeMinerPower(minerTips); err != nil {
+			log.Error(err)
+		}
+		log.Infow("Stored miner power", "duration", time.Since(minerPowerStartedAt).String())
+
 		sectorStart := time.Now()
 		if err := st.storeSectors(minerTips, api); err != nil {
 			log.Error(err)


### PR DESCRIPTION
Part of https://github.com/filecoin-project/sentinel/issues/22

This PR creates new schema that chainwatch uses to capture:
- chain baseline power from RewardActor
- miner (quality adjusted/raw bytes) power from MinerActor