### PR TITLE
Correct initial setup of sector id counter

### DIFF
--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -359,10 +359,8 @@ func migratePreSealMeta(ctx context.Context, api lapi.FullNode, metadata string,
 		}*/
 	}
 
-	log.Infof("Setting next sector ID to %d", maxSectorID+1)
-
 	buf := make([]byte, binary.MaxVarintLen64)
-	size := binary.PutUvarint(buf, uint64(maxSectorID+1))
+	size := binary.PutUvarint(buf, uint64(maxSectorID))
 	return mds.Put(datastore.NewKey(modules.StorageCounterDSPrefix), buf[:size])
 }
 


### PR DESCRIPTION
Without this, if I have 3 pre-sealed sectors and then pledge a new one, my IDs go [0, 1, 2, 4...]