### PR TITLE
Mute RtRefreshManager logs as they break terminal emulation

### DIFF
--- a/lib/lotuslog/levels.go
+++ b/lib/lotuslog/levels.go
@@ -18,4 +18,6 @@ func SetupLogLevels() {
 		_ = logging.SetLogLevel("stores", "DEBUG")
 		_ = logging.SetLogLevel("nat", "INFO")
 	}
+	// Always mute RtRefreshManager because it breaks terminals
+	_ = logging.SetLogLevel("dht/RtRefreshManager", "FATAL")
 }


### PR DESCRIPTION
RtRefreshManager logs random binary strings, which somtimes might be
partial multi-byte Unicode or ASCI escape codes.