### PR TITLE
Add a maxPrice option to the client retrieval CLI

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -595,7 +595,7 @@ var clientRetrieveCmd = &cli.Command{
 			return fmt.Errorf("The received offer errored: %s", offer.Err)
 		}
 
-		maxPrice := types.NewInt(DefaultMaxRetrievePrice)
+		maxPrice := types.FromFil(DefaultMaxRetrievePrice)
 
 		if cctx.String("maxPrice") != "" {
 			maxPriceFil, err := types.ParseFIL(cctx.String("maxPrice"))


### PR DESCRIPTION
## Summary
- Add a `maxPrice` option to the `client retrieve` CLI
- Use the lowest-priced offer if multiple retrieval offers are returned

Resolves #2151