### PR TITLE
Fix seal-worker init

### DIFF
--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -236,7 +236,7 @@ var runCmd = &cli.Command{
 
 			{
 				// init datastore for r.Exists
-				_, err := lr.Datastore("/")
+				_, err := lr.Datastore("/metadata")
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
`lr.Datastore("/")` broke after the multi-blockstore refactor