### PR TITLE
rationalise annoying logs

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -138,6 +138,12 @@ func NewSyncer(sm *stmgr.StateManager, bsync *blocksync.BlockSync, connmgr connm
 		incoming: pubsub.New(50),
 	}
 
+	if build.InsecurePoStValidation {
+		log.Warn("*********************************************************************************************")
+		log.Warn(" [INSECURE-POST-VALIDATION] Insecure test validation is enabled. If you see this outside of a test, it is a severe bug! ")
+		log.Warn("*********************************************************************************************")
+	}
+
 	s.syncmgr = NewSyncManager(s.Sync)
 	return s, nil
 }
@@ -640,10 +646,6 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 
 	ctx, span := trace.StartSpan(ctx, "validateBlock")
 	defer span.End()
-
-	if build.InsecurePoStValidation {
-		log.Warn("[INSECURE-POST-VALIDATION] if you see this outside of a test, it is a severe bug!")
-	}
 
 	if err := blockSanityChecks(b.Header); err != nil {
 		return xerrors.Errorf("incoming header failed basic sanity checks: %w", err)

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -164,6 +164,12 @@ func NewWinningPoStProver(api api.FullNode, prover storage.Prover, verifier ffiw
 		return nil, err
 	}
 
+	if build.InsecurePoStValidation {
+		log.Warn("*****************************************************************************")
+		log.Warn(" Generating fake PoSt proof! You should only see this while running tests! ")
+		log.Warn("*****************************************************************************")
+	}
+
 	return &StorageWpp{prover, verifier, abi.ActorID(miner), wpt}, nil
 }
 
@@ -182,7 +188,6 @@ func (wpp *StorageWpp) GenerateCandidates(ctx context.Context, randomness abi.Po
 
 func (wpp *StorageWpp) ComputeProof(ctx context.Context, ssi []abi.SectorInfo, rand abi.PoStRandomness) ([]abi.PoStProof, error) {
 	if build.InsecurePoStValidation {
-		log.Warn("[INSECURE-POST-VALIDATION] Generating fake PoSt proof! You should only see this while running tests!")
 		return []abi.PoStProof{{ProofBytes: []byte("valid proof")}}, nil
 	}
 


### PR DESCRIPTION
Should be sufficient to log these once prominently at start up, as opposed to on every epoch.

cc @nonsense 