### PR TITLE
Fixing hamt bittreewidth

### DIFF
--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -852,7 +852,7 @@ func (a *StateAPI) StateVerifiedClientStatus(ctx context.Context, addr address.A
 		return nil, err
 	}
 
-	vh, err := hamt.LoadNode(ctx, cst, st.VerifiedClients)
+	vh, err := hamt.LoadNode(ctx, cst, st.VerifiedClients, hamt.UseTreeBitWidth(5))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Looks like most of these were fixed (or changed) recently, but this one was forgotten.
