### PR TITLE
fix --actor flag for `lotus-storage-miner info`

### DIFF
--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -24,9 +24,6 @@ import (
 var infoCmd = &cli.Command{
 	Name:  "info",
 	Usage: "Print miner info",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "color"},
-	},
 	Action: func(cctx *cli.Context) error {
 		color.NoColor = !cctx.Bool("color")
 

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -76,6 +76,9 @@ func main() {
 				Usage:   "specify other actor to check state for (read only)",
 				Aliases: []string{"a"},
 			},
+			&cli.BoolFlag{
+				Name: "color",
+			},
 			&cli.StringFlag{
 				Name:    "repo",
 				EnvVars: []string{"LOTUS_PATH"},
@@ -108,6 +111,7 @@ func getActorAddress(ctx context.Context, nodeAPI api.StorageMiner, overrideMadd
 		if err != nil {
 			return maddr, err
 		}
+		return
 	}
 
 	maddr, err = nodeAPI.ActorAddress(ctx)

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
@@ -32,6 +33,8 @@ var provingFaultsCmd = &cli.Command{
 	Name:  "faults",
 	Usage: "View the currently known proving faulty sectors information",
 	Action: func(cctx *cli.Context) error {
+		color.NoColor = !cctx.Bool("color")
+
 		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
@@ -65,6 +68,8 @@ var provingFaultsCmd = &cli.Command{
 				return err
 			}
 		}
+
+		fmt.Printf("Miner: %s\n", color.BlueString("%s", maddr))
 
 		head, err := api.ChainHead(ctx)
 		if err != nil {
@@ -101,6 +106,8 @@ var provingInfoCmd = &cli.Command{
 	Name:  "info",
 	Usage: "View current state information",
 	Action: func(cctx *cli.Context) error {
+		color.NoColor = !cctx.Bool("color")
+
 		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
@@ -134,6 +141,8 @@ var provingInfoCmd = &cli.Command{
 		if err != nil {
 			return xerrors.Errorf("getting miner deadlines: %w", err)
 		}
+
+		fmt.Printf("Miner: %s\n", color.BlueString("%s", maddr))
 
 		var mas miner.State
 		{
@@ -240,6 +249,8 @@ var provingDeadlinesCmd = &cli.Command{
 	Name:  "deadlines",
 	Usage: "View the current proving period deadlines information",
 	Action: func(cctx *cli.Context) error {
+		color.NoColor = !cctx.Bool("color")
+
 		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
@@ -283,6 +294,8 @@ var provingDeadlinesCmd = &cli.Command{
 				return err
 			}
 		}
+
+		fmt.Printf("Miner: %s\n", color.BlueString("%s", maddr))
 
 		tw := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 		_, _ = fmt.Fprintln(tw, "deadline\tpartitions\tsectors\tproven")


### PR DESCRIPTION
The `--actor` flag was added in https://github.com/filecoin-project/lotus/pull/2252

Due to additional flags set as part of `lotus-storage-miner info` (`--color`), the `--actor` is actually ignored on `lotus-storage-miner`. So I am moving `--color` as a global flag, and also printing the miner we are querying as part of the `lotus-storage-miner proving *` commands.

---

Also fixing a bug in `getActorAddress` where we should return early when the actor address override is set.