### PR TITLE
fix flaky test (miner#TestMessageFiltering).

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	address "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
@@ -588,6 +588,14 @@ func SelectMessages(ctx context.Context, al ActorLookup, ts *types.TipSet, msgs 
 
 	gasLimitLeft := int64(build.BlockGasLimit)
 
+	orderedSenders := make([]address.Address, 0, len(outBySender))
+	for k := range outBySender {
+		orderedSenders = append(orderedSenders, k)
+	}
+	sort.Slice(orderedSenders, func(i, j int) bool {
+		return bytes.Compare(orderedSenders[i].Bytes(), orderedSenders[j].Bytes()) == -1
+	})
+
 	out := make([]*types.SignedMessage, 0, build.BlockMessageLimit)
 	{
 		for {
@@ -596,7 +604,11 @@ func SelectMessages(ctx context.Context, al ActorLookup, ts *types.TipSet, msgs 
 			var bestGasToReward float64
 
 			// TODO: This is O(n^2)-ish, could use something like container/heap to cache this math
-			for sender, meta := range outBySender {
+			for _, sender := range orderedSenders {
+				meta, ok := outBySender[sender]
+				if !ok {
+					continue
+				}
 				for n := range meta.msgs {
 					if meta.gasLimit[n] > gasLimitLeft {
 						break

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
+
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -75,7 +76,7 @@ func TestMessageFiltering(t *testing.T) {
 			To:       a1,
 			Nonce:    2,
 			Value:    types.NewInt(150),
-			GasLimit: (100),
+			GasLimit: 100,
 			GasPrice: types.NewInt(1),
 		},
 	}
@@ -89,8 +90,8 @@ func TestMessageFiltering(t *testing.T) {
 		t.Fatal("filtering didnt work as expected")
 	}
 
-	m1 := outmsgs[2].Message
-	if m1.From != msgs[2].From || m1.Nonce != msgs[2].Nonce {
+	was, expected := outmsgs[0].Message, msgs[2]
+	if was.From != expected.From || was.Nonce != expected.Nonce {
 		t.Fatal("filtering bad")
 	}
 }


### PR DESCRIPTION
This test is flaky on `next`. The reason is that the test expects to find a selected message in a given index, but whether that's true or not will be affected by underlying map access order, which is undefined in Go.

Ordering the key access is probably not how you want to solve this. We could make the test assertion laxer such that it doesn't care where the message is, as long as it's returned. But I don't know if undeterministic result ordering is what you want.

This seems like the safest option (given my lack of understanding of downstream effects that the ordering could have), and it helps me illustrate the problem.

```sh
⟩ go test -count=1000 -run=TestMessageFiltering ./miner
ok  	github.com/filecoin-project/lotus/miner	0.624s
```