### PR TITLE
feat: track miner precommit

### DIFF
--- a/cmd/lotus-chainwatch/processor/processor.go
+++ b/cmd/lotus-chainwatch/processor/processor.go
@@ -29,6 +29,8 @@ type Processor struct {
 
 	node api.FullNode
 
+	genesisTs *types.TipSet
+
 	// number of blocks processed at a time
 	batch int
 }
@@ -85,6 +87,12 @@ func (p *Processor) Start(ctx context.Context) {
 
 	if err := p.setupSchemas(); err != nil {
 		log.Fatalw("Failed to setup processor", "error", err)
+	}
+
+	var err error
+	p.genesisTs, err = p.node.ChainGetGenesis(ctx)
+	if err != nil {
+		log.Fatalw("Failed to get genesis state from lotus", "error", err.Error())
 	}
 
 	go p.subMpool(ctx)
@@ -167,6 +175,10 @@ func (p *Processor) Start(ctx context.Context) {
 
 func (p *Processor) refreshViews() error {
 	if _, err := p.db.Exec(`refresh materialized view state_heights`); err != nil {
+		return err
+	}
+
+	if _, err := p.db.Exec(`refresh materialized view miner_sectors_view`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Corresponding issue: https://github.com/filecoin-project/sentinel/issues/25

Chain-watch now:
- capture sector precommit information in miner_precommits 
- maintains a materialized view combining the information in miner_sectors and miner_precommits 
- renames ADDED to COMMIT in miner_sector_event table
- extend miner_sector_event table to contain a PRECOMMIT event for sector precommits (note this field will be null for genesis miners)
- populate miner_sector_events table with COMMIT events from genesis miners (required special casing)