### PR TITLE
fix StateMinerInitialPledgeCollateral

### DIFF
--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -956,7 +956,7 @@ func (a *StateAPI) StateMinerInitialPledgeCollateral(ctx context.Context, maddr 
 	}
 
 	sectorWeight := miner.QAPowerForWeight(ssize, duration, dealWeights.DealWeight, dealWeights.VerifiedDealWeight)
-	initialPledge := miner.InitialPledgeForPower(sectorWeight, powerState.TotalQualityAdjPower, powerState.TotalPledgeCollateral, reward.BaselinePowerAt(ts.Height()), rewardState.ThisEpochReward, circSupply)
+	initialPledge := miner.InitialPledgeForPower(sectorWeight, powerState.TotalQualityAdjPower, reward.BaselinePowerAt(ts.Height()), powerState.TotalPledgeCollateral, rewardState.ThisEpochReward, circSupply)
 
 	return types.BigDiv(types.BigMul(initialPledge, initialPledgeNum), initialPledgeDen), nil
 }


### PR DESCRIPTION
This likely caused the pledge calc for miner sectors to be waaaay off on reset butterfly