### PR TITLE
genesis: set deals to end on sector expiry

### DIFF
--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -146,6 +146,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sroot cid.Cid
 			params := &market.PublishStorageDealsParams{}
 			for _, preseal := range m.Sectors {
 				preseal.Deal.VerifiedDeal = true
+				preseal.Deal.EndEpoch = minerInfos[i].presealExp
 				params.Deals = append(params.Deals, market.ClientDealProposal{
 					Proposal:        preseal.Deal,
 					ClientSignature: crypto.Signature{Type: crypto.SigTypeBLS}, // TODO: do we want to sign these? Or do we want to fake signatures for genesis setup?


### PR DESCRIPTION
Setting the deal to end on the sector expiry ensures we get the full quality adjustment of power for the full sector.

Resolves #2404