### PR TITLE
Graceful shutdown of PeerMgr

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -91,11 +91,12 @@ func (m *Miner) Start(ctx context.Context) error {
 
 func (m *Miner) Stop(ctx context.Context) error {
 	m.lk.Lock()
-	defer m.lk.Unlock()
 
 	m.stopping = make(chan struct{})
 	stopping := m.stopping
 	close(m.stop)
+
+	m.lk.Unlock()
 
 	select {
 	case <-stopping:


### PR DESCRIPTION
1. I noticed that `PeerMgr.Run` continues to run, even after calling `fx.app.Stop`, so I am adding it to the lifecycle and stopping the `pmgr.expandPeers()` on `Stop`.
2. I am attempting to fix the deadlock found at https://github.com/filecoin-project/lotus/issues/2406 - I don't see a reason to continue to hold the mutex while waiting on `stopping` or `ctx.Done()`.