### PR TITLE
Restore base block reward; capture WinCount w header

### DIFF
--- a/cmd/lotus-chainwatch/processor/reward.go
+++ b/cmd/lotus-chainwatch/processor/reward.go
@@ -118,11 +118,8 @@ func (p *Processor) processRewardActors(ctx context.Context, rewardTips ActorTip
 				return nil, xerrors.Errorf("unmarshal state (@ %s): %w", rw.common.stateroot.String(), err)
 			}
 
-			// TODO: Resolve Actor API shift
-			//rw.baseBlockReward = rewardActorState.LastPerEpochReward
-			//rw.baselinePower = rewardActorState.BaselinePower
-			rw.baseBlockReward = big.Zero()
-			rw.baselinePower = big.Zero()
+			rw.baseBlockReward = rewardActorState.ThisEpochReward
+			rw.baselinePower = rewardActorState.ThisEpochBaselinePower
 			out = append(out, rw)
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/filecoin-project/sentinel/issues/21 and https://github.com/filecoin-project/sentinel/issues/26

This PR:
- Updates RewardActor field names
- Includes WinCount when ElectionProof is present with BlockHeader
- updates schema:
  - column names `eprof` -> `election_proof` on `blocks`
  - add `win_count` on `blocks`

Mea culpa: If the schema name changes are frustrating, let me know and I'll back it out until we have a migration pattern in place. (Soon)
