### PR TITLE
chainwatch: add http server for pprof

### DIFF
--- a/cmd/lotus-chainwatch/main.go
+++ b/cmd/lotus-chainwatch/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "net/http/pprof"
 	"os"
 
 	"github.com/filecoin-project/lotus/build"

--- a/cmd/lotus-chainwatch/run.go
+++ b/cmd/lotus-chainwatch/run.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"database/sql"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	_ "github.com/lib/pq"
@@ -25,6 +27,9 @@ var runCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		go func() {
+			http.ListenAndServe(":6060", nil)
+		}()
 		ll := cctx.String("log-level")
 		if err := logging.SetLogLevel("*", ll); err != nil {
 			return err


### PR DESCRIPTION
Happy to throw this behind a flag but I don't believe adding the pprof http package has any performance impact when not handling a request.