### PR TITLE
Feat/ntwk calibration: unspecified address in lotus-worker run address

### DIFF
--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -95,6 +95,7 @@ var runCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:  "address",
 			Usage: "Locally reachable address",
+			Value: "0.0.0.0",
 		},
 		&cli.BoolFlag{
 			Name:  "no-local-storage",
@@ -121,10 +122,6 @@ var runCmd = &cli.Command{
 			if err := os.Setenv("BELLMAN_NO_GPU", "true"); err != nil {
 				return xerrors.Errorf("could not set no-gpu env: %+v", err)
 			}
-		}
-
-		if cctx.String("address") == "" {
-			return xerrors.Errorf("--address flag is required")
 		}
 
 		// Connect to storage-miner


### PR DESCRIPTION
allow operators to set an unspecified address - 0.0.0.0 - when setting address flag in 'lotus-worker run'
to extract worker ip, dial the miner api.
if the dial succeeds, a valid route between miner and worker can be inferred

relates to https://github.com/filecoin-project/lotus/issues/2515