### PR TITLE
Inline small objects into CIDs

### DIFF
--- a/api/apibstore/apibstore.go
+++ b/api/apibstore/apibstore.go
@@ -5,8 +5,9 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 type ChainIO interface {

--- a/chain/events/state/diff_adt_test.go
+++ b/chain/events/state/diff_adt_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ds "github.com/ipfs/go-datastore"
-	ds_sync "github.com/ipfs/go-datastore/sync"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func TestDiffAdtArray(t *testing.T) {
@@ -146,7 +145,7 @@ func (t *TestAdtDiff) Remove(key uint64, val *typegen.Deferred) error {
 
 func newContextStore() *contextStore {
 	ctx := context.Background()
-	bs := bstore.NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	bs := bstore.NewTemporarySync()
 	store := cbornode.NewCborStore(bs)
 	return &contextStore{
 		ctx: ctx,

--- a/chain/events/state/predicates_test.go
+++ b/chain/events/state/predicates_test.go
@@ -8,9 +8,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/ipfs/go-cid"
-	ds "github.com/ipfs/go-datastore"
-	ds_sync "github.com/ipfs/go-datastore/sync"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/go-address"
@@ -23,6 +20,7 @@ import (
 	tutils "github.com/filecoin-project/specs-actors/support/testing"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var dummyCid cid.Cid
@@ -66,7 +64,7 @@ func (m mockAPI) setActor(tsk types.TipSetKey, act *types.Actor) {
 
 func TestMarketPredicates(t *testing.T) {
 	ctx := context.Background()
-	bs := bstore.NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	bs := bstore.NewTemporarySync()
 	store := adt.WrapStore(ctx, cbornode.NewCborStore(bs))
 
 	oldDeal1 := &market.DealState{
@@ -281,7 +279,7 @@ func TestMarketPredicates(t *testing.T) {
 
 func TestMinerSectorChange(t *testing.T) {
 	ctx := context.Background()
-	bs := bstore.NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	bs := bstore.NewTemporarySync()
 	store := adt.WrapStore(ctx, cbornode.NewCborStore(bs))
 
 	nextID := uint64(0)

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -15,7 +15,6 @@ import (
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	format "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
@@ -35,6 +34,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet"
 	"github.com/filecoin-project/lotus/cmd/lotus-seed/seed"
 	"github.com/filecoin-project/lotus/genesis"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/sigs"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
@@ -112,7 +112,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 		return nil, xerrors.Errorf("failed to get blocks datastore: %w", err)
 	}
 
-	bs := mybs{blockstore.NewIdStore(blockstore.NewBlockstore(bds))}
+	bs := mybs{blockstore.NewBlockstore(bds)}
 
 	ks, err := lr.KeyStore()
 	if err != nil {

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -3,12 +3,12 @@ package genesis
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/filecoin-project/lotus/lib/sigs"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
@@ -28,6 +28,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/genesis"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 const AccountStart = 100

--- a/chain/gen/genesis/t00_system.go
+++ b/chain/gen/genesis/t00_system.go
@@ -2,12 +2,14 @@ package genesis
 
 import (
 	"context"
+
 	"github.com/filecoin-project/specs-actors/actors/builtin/system"
 
-	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupSystemActor(bs bstore.Blockstore) (*types.Actor, error) {

--- a/chain/gen/genesis/t01_init.go
+++ b/chain/gen/genesis/t01_init.go
@@ -9,13 +9,13 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/genesis"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupInitActor(bs bstore.Blockstore, netname string, initialActors []genesis.Actor) (*types.Actor, error) {

--- a/chain/gen/genesis/t02_reward.go
+++ b/chain/gen/genesis/t02_reward.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 
-	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupRewardActor(bs bstore.Blockstore, qaPower big.Int) (*types.Actor, error) {

--- a/chain/gen/genesis/t03_cron.go
+++ b/chain/gen/genesis/t03_cron.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupCronActor(bs bstore.Blockstore) (*types.Actor, error) {

--- a/chain/gen/genesis/t04_power.go
+++ b/chain/gen/genesis/t04_power.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupStoragePowerActor(bs bstore.Blockstore) (*types.Actor, error) {

--- a/chain/gen/genesis/t05_market.go
+++ b/chain/gen/genesis/t05_market.go
@@ -6,10 +6,10 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 func SetupStorageMarketActor(bs bstore.Blockstore) (*types.Actor, error) {

--- a/chain/gen/genesis/t06_vreg.go
+++ b/chain/gen/genesis/t06_vreg.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-address"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -12,6 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var RootVerifierAddr address.Address

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -26,11 +26,11 @@ import (
 	. "github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
 	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
 
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log"
 	cbg "github.com/whyrusleeping/cbor-gen"

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -13,20 +13,22 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
+
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
-	cbg "github.com/whyrusleeping/cbor-gen"
+
 	"golang.org/x/xerrors"
 
 	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"go.opencensus.io/trace"
 )
 

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 
 	cid "github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -38,6 +37,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 

--- a/chain/store/index_test.go
+++ b/chain/store/index_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types/mock"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	datastore "github.com/ipfs/go-datastore"
 	syncds "github.com/ipfs/go-datastore/sync"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,7 +30,7 @@ func TestIndexSeeks(t *testing.T) {
 
 	ctx := context.TODO()
 
-	nbs := blockstore.NewBlockstore(syncds.MutexWrap(datastore.NewMapDatastore()))
+	nbs := blockstore.NewTemporarySync()
 	cs := store.NewChainStore(nbs, syncds.MutexWrap(datastore.NewMapDatastore()), nil)
 
 	_, err = cs.Import(bytes.NewReader(gencar))

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -20,7 +20,9 @@ import (
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/journal"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/metrics"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"go.uber.org/multierr"
@@ -31,8 +33,6 @@ import (
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	dstore "github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	car "github.com/ipld/go-car"
@@ -896,7 +896,7 @@ func (cs *ChainStore) Blockstore() bstore.Blockstore {
 	return cs.bs
 }
 
-func ActorStore(ctx context.Context, bs blockstore.Blockstore) adt.Store {
+func ActorStore(ctx context.Context, bs bstore.Blockstore) adt.Store {
 	return adt.WrapStore(ctx, cbor.NewCborStore(bs))
 }
 
@@ -1019,7 +1019,7 @@ func (cs *ChainStore) GetTipsetByHeight(ctx context.Context, h abi.ChainEpoch, t
 	return cs.LoadTipSet(lbts.Parents())
 }
 
-func recurseLinks(bs blockstore.Blockstore, root cid.Cid, in []cid.Cid) ([]cid.Cid, error) {
+func recurseLinks(bs bstore.Blockstore, root cid.Cid, in []cid.Cid) ([]cid.Cid, error) {
 	if root.Prefix().Codec != cid.DagCBOR {
 		return in, nil
 	}

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	datastore "github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -18,6 +17,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
@@ -100,7 +100,7 @@ func TestChainExportImport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nbs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	nbs := blockstore.NewTemporary()
 	cs := store.NewChainStore(nbs, datastore.NewMapDatastore(), nil)
 
 	root, err := cs.Import(buf)

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -14,8 +14,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/ipfs/go-cid"
-	dstore "github.com/ipfs/go-datastore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	connmgr "github.com/libp2p/go-libp2p-core/connmgr"
@@ -32,6 +30,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/bufbstore"
 	"github.com/filecoin-project/lotus/lib/sigs"
 	"github.com/filecoin-project/lotus/metrics"
@@ -239,7 +238,7 @@ func (bv *BlockValidator) isChainNearSynced() bool {
 
 func (bv *BlockValidator) validateMsgMeta(ctx context.Context, msg *types.BlockMsg) error {
 	// TODO there has to be a simpler way to do this without the blockstore dance
-	store := adt.WrapStore(ctx, cbor.NewCborStore(bstore.NewBlockstore(dstore.NewMapDatastore())))
+	store := adt.WrapStore(ctx, cbor.NewCborStore(blockstore.NewTemporary()))
 	bmArr := adt.MakeEmptyArray(store)
 	smArr := adt.MakeEmptyArray(store)
 

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -13,8 +13,6 @@ import (
 	"github.com/Gurpartap/async"
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
-	dstore "github.com/ipfs/go-datastore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/connmgr"
@@ -44,6 +42,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/sigs"
 	"github.com/filecoin-project/lotus/metrics"
 )
@@ -1394,8 +1393,7 @@ func (syncer *Syncer) iterFullTipsets(ctx context.Context, headers []*types.TipS
 
 		for bsi := 0; bsi < len(bstout); bsi++ {
 			// temp storage so we don't persist data we dont want to
-			ds := dstore.NewMapDatastore()
-			bs := bstore.NewBlockstore(ds)
+			bs := bstore.NewTemporary()
 			blks := cbor.NewCborStore(bs)
 
 			this := headers[i-bsi]

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -11,7 +11,6 @@ import (
 
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 	xerrors "golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -76,8 +75,7 @@ func (blk *BlockHeader) ToStorageBlock() (block.Block, error) {
 		return nil, err
 	}
 
-	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.BLAKE2B_MIN+31)
-	c, err := pref.Sum(data)
+	c, err := abi.CidBuilder.Sum(data)
 	if err != nil {
 		return nil, err
 	}
@@ -145,13 +143,12 @@ func (mm *MsgMeta) Cid() cid.Cid {
 }
 
 func (mm *MsgMeta) ToStorageBlock() (block.Block, error) {
-	buf := new(bytes.Buffer)
-	if err := mm.MarshalCBOR(buf); err != nil {
+	var buf bytes.Buffer
+	if err := mm.MarshalCBOR(&buf); err != nil {
 		return nil, xerrors.Errorf("failed to marshal MsgMeta: %w", err)
 	}
 
-	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.BLAKE2B_MIN+31)
-	c, err := pref.Sum(buf.Bytes())
+	c, err := abi.CidBuilder.Sum(buf.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/message.go
+++ b/chain/types/message.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 	xerrors "golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -89,8 +88,7 @@ func (m *Message) ToStorageBlock() (block.Block, error) {
 		return nil, err
 	}
 
-	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.BLAKE2B_MIN+31)
-	c, err := pref.Sum(data)
+	c, err := abi.CidBuilder.Sum(data)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/signedmessage.go
+++ b/chain/types/signedmessage.go
@@ -3,10 +3,10 @@ package types
 import (
 	"bytes"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 )
 
 func (sm *SignedMessage) ToStorageBlock() (block.Block, error) {
@@ -19,8 +19,7 @@ func (sm *SignedMessage) ToStorageBlock() (block.Block, error) {
 		return nil, err
 	}
 
-	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.BLAKE2B_MIN+31)
-	c, err := pref.Sum(data)
+	c, err := abi.CidBuilder.Sum(data)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/tipset_key.go
+++ b/chain/types/tipset_key.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 )
 
 var EmptyTSK = TipSetKey{}
@@ -15,7 +15,9 @@ var EmptyTSK = TipSetKey{}
 var blockHeaderCIDLen int
 
 func init() {
-	c, err := cid.V1Builder{Codec: cid.DagCBOR, MhType: multihash.BLAKE2B_MIN + 31}.Sum([]byte{})
+	// hash a large string of zeros so we don't estimate based on inlined CIDs.
+	var buf [256]byte
+	c, err := abi.CidBuilder.Sum(buf[:])
 	if err != nil {
 		panic(err)
 	}

--- a/chain/validation/state.go
+++ b/chain/validation/state.go
@@ -3,20 +3,20 @@ package validation
 import (
 	"context"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/xerrors"
 
 	vstate "github.com/filecoin-project/chain-validation/state"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var _ vstate.VMWrapper = &StateWrapper{}
@@ -34,7 +34,7 @@ type StateWrapper struct {
 }
 
 func NewState() *StateWrapper {
-	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	bs := blockstore.NewTemporary()
 	cst := cbor.NewCborStore(bs)
 	// Put EmptyObjectCid value in the store. When an actor is initially created its Head is set to this value.
 	_, err := cst.Put(context.TODO(), map[string]string{})

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -11,7 +11,6 @@ import (
 
 	block "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	mh "github.com/multiformats/go-multihash"
@@ -30,6 +29,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/bufbstore"
 )
 

--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -21,16 +21,17 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
 	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
+
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"golang.org/x/xerrors"
 
 	"github.com/ipfs/go-datastore"
 	badger "github.com/ipfs/go-ds-badger2"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
 )
 
 type TipSetExec struct {

--- a/cmd/lotus-shed/import-car.go
+++ b/cmd/lotus-shed/import-car.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"os"
 
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-car"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
@@ -48,7 +48,6 @@ var importCarCmd = &cli.Command{
 		}
 
 		bs := blockstore.NewBlockstore(ds)
-		bs = blockstore.NewIdStore(bs)
 
 		cr, err := car.NewCarReader(f)
 		if err != nil {

--- a/cmd/lotus-townhall/main.go
+++ b/cmd/lotus-townhall/main.go
@@ -10,14 +10,13 @@ import (
 
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gorilla/websocket"
-	"github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-car"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var topic = "/fil/headnotifs/"
@@ -29,7 +28,7 @@ func init() {
 		return
 	}
 
-	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	bs := blockstore.NewTemporary()
 
 	c, err := car.LoadCar(bs, bytes.NewReader(genBytes))
 	if err != nil {

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 
 	paramfetch "github.com/filecoin-project/go-paramfetch"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
@@ -31,6 +30,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/vm"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/peermgr"
 	"github.com/filecoin-project/lotus/lib/ulimit"
 	"github.com/filecoin-project/lotus/metrics"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200723200950-ed2e57dde6df
-	github.com/filecoin-project/specs-actors v0.8.1-0.20200723200253-a3c01bc62f99
+	github.com/filecoin-project/specs-actors v0.8.1-0.20200724013208-278e08bfe8df
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea
 	github.com/filecoin-project/storage-fsm v0.0.0-20200720190000-2cfe2fe3c334
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
@@ -44,7 +44,7 @@ require (
 	github.com/ipfs/go-bitswap v0.2.8
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834
-	github.com/ipfs/go-cid v0.0.6
+	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-cidutil v0.0.2
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-ds-badger2 v0.1.1-0.20200708190120-187fc06f714e

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/filecoin-project/specs-actors v0.7.3-0.20200716231407-60a2ae96d2e6/go
 github.com/filecoin-project/specs-actors v0.8.1-0.20200720115956-cd051eabf328/go.mod h1:0+CxQ5Jeii3522irTvhKRDpr4GG1bj5Erq3p/d38DzY=
 github.com/filecoin-project/specs-actors v0.8.1-0.20200723200253-a3c01bc62f99 h1:li6OZVhGNrQihzKhUy7x4vwKgUCExnpVSj746VMkq1I=
 github.com/filecoin-project/specs-actors v0.8.1-0.20200723200253-a3c01bc62f99/go.mod h1:TLvIheTVl0EIuyncuKSTVXPULaj7gzhLup5CLZ/S+uM=
+github.com/filecoin-project/specs-actors v0.8.1-0.20200724013208-278e08bfe8df h1:nK7fWhCGJHjNYk1ZVf5YYrwHaHK17VEeELDpUUOsBPw=
+github.com/filecoin-project/specs-actors v0.8.1-0.20200724013208-278e08bfe8df/go.mod h1:TLvIheTVl0EIuyncuKSTVXPULaj7gzhLup5CLZ/S+uM=
 github.com/filecoin-project/specs-storage v0.1.0 h1:PkDgTOT5W5Ao7752onjDl4QSv+sgOVdJbvFjOnD5w94=
 github.com/filecoin-project/specs-storage v0.1.0/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea h1:iixjULRQFPn7Q9KlIqfwLJnlAXO10bbkI+xy5GKGdLY=
@@ -490,6 +492,8 @@ github.com/ipfs/go-cid v0.0.5/go.mod h1:plgt+Y5MnOey4vO4UlUazGqdbEXuFYitED67Fexh
 github.com/ipfs/go-cid v0.0.6-0.20200501230655-7c82f3b81c00/go.mod h1:plgt+Y5MnOey4vO4UlUazGqdbEXuFYitED67FexhXog=
 github.com/ipfs/go-cid v0.0.6 h1:go0y+GcDOGeJIV01FeBsta4FHngoA4Wz7KMeLkXAhMs=
 github.com/ipfs/go-cid v0.0.6/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
+github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
+github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
 github.com/ipfs/go-cidutil v0.0.2 h1:CNOboQf1t7Qp0nuNh8QMmhJs0+Q//bRL1axtCnIB1Yo=
 github.com/ipfs/go-cidutil v0.0.2/go.mod h1:ewllrvrxG6AMYStla3GD7Cqn+XYSLqjK0vc+086tB6s=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/lib/blockstore/blockstore.go
+++ b/lib/blockstore/blockstore.go
@@ -1,0 +1,63 @@
+// blockstore contains all the basic blockstore constructors used by lotus. Any
+// blockstores not ultimately constructed out of the building blocks in this
+// package may not work properly.
+//
+//  * This package correctly wraps blockstores with the IdBlockstore. This blockstore:
+//    * Filters out all puts for blocks with CIDs using the "identity" hash function.
+//    * Extracts inlined blocks from CIDs using the identity hash function and
+//      returns them on get/has, ignoring the contents of the blockstore.
+//  * In the future, this package may enforce additional restrictions on block
+//    sizes, CID validity, etc.
+//
+// To make auditing for misuse of blockstores tractable, this package re-exports
+// parts of the go-ipfs-blockstore package such that no other package needs to
+// import it directly.
+package blockstore
+
+import (
+	"context"
+
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+)
+
+// NewTemporary returns a temporary blockstore.
+func NewTemporary() blockstore.Blockstore {
+	return NewBlockstore(ds.NewMapDatastore())
+}
+
+// NewTemporary returns a thread-safe temporary blockstore.
+func NewTemporarySync() blockstore.Blockstore {
+	return NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
+}
+
+// Wraps the underlying blockstore in an "identity" blockstore.
+func WrapIDStore(bstore blockstore.Blockstore) blockstore.Blockstore {
+	return blockstore.NewIdStore(bstore)
+}
+
+// NewBlockstore creates a new blockstore wrapped by the given datastore.
+func NewBlockstore(dstore ds.Batching) blockstore.Blockstore {
+	return WrapIDStore(blockstore.NewBlockstore(dstore))
+}
+
+// Alias so other packages don't have to import go-ipfs-blockstore
+type Blockstore = blockstore.Blockstore
+type GCBlockstore = blockstore.GCBlockstore
+type CacheOpts = blockstore.CacheOpts
+type GCLocker = blockstore.GCLocker
+
+var NewGCLocker = blockstore.NewGCLocker
+var NewGCBlockstore = blockstore.NewGCBlockstore
+var DefaultCacheOpts = blockstore.DefaultCacheOpts
+var ErrNotFound = blockstore.ErrNotFound
+
+func CachedBlockstore(ctx context.Context, bs Blockstore, opts CacheOpts) (Blockstore, error) {
+	bs, err := blockstore.CachedBlockstore(ctx, bs, opts)
+	if err != nil {
+		return nil, err
+	}
+	return WrapIDStore(bs), nil
+}

--- a/lib/bufbstore/buf_bstore.go
+++ b/lib/bufbstore/buf_bstore.go
@@ -6,9 +6,9 @@ import (
 
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	ds "github.com/ipfs/go-datastore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log/v2"
+
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var log = logging.Logger("bufbs")
@@ -19,7 +19,7 @@ type BufferedBS struct {
 }
 
 func NewBufferedBstore(base bstore.Blockstore) *BufferedBS {
-	buf := bstore.NewBlockstore(ds.NewMapDatastore())
+	buf := bstore.NewTemporary()
 	if os.Getenv("LOTUS_DISABLE_VM_BUF") == "iknowitsabadidea" {
 		log.Warn("VM BLOCKSTORE BUFFERING IS DISABLED")
 		buf = base

--- a/lib/cachebs/cachebs.go
+++ b/lib/cachebs/cachebs.go
@@ -6,9 +6,9 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log/v2"
+
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var log = logging.Logger("cachebs")
@@ -18,15 +18,17 @@ type CacheBS struct {
 	bs    bstore.Blockstore
 }
 
-func NewBufferedBstore(base blockstore.Blockstore, size int) *CacheBS {
+func NewBufferedBstore(base bstore.Blockstore, size int) bstore.Blockstore {
 	c, err := lru.NewARC(size)
 	if err != nil {
 		panic(err)
 	}
-	return &CacheBS{
+	// Wrap this in an ID blockstore to avoid caching blocks inlined into
+	// CIDs.
+	return bstore.WrapIDStore(&CacheBS{
 		cache: c,
 		bs:    base,
-	}
+	})
 }
 
 var _ (bstore.Blockstore) = &CacheBS{}

--- a/lib/ipfsbstore/ipfsbstore.go
+++ b/lib/ipfsbstore/ipfsbstore.go
@@ -12,11 +12,12 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	httpapi "github.com/ipfs/go-ipfs-http-client"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 type IpfsBstore struct {

--- a/node/builder.go
+++ b/node/builder.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -40,6 +39,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/chain/wallet"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/peermgr"
 	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
 	_ "github.com/filecoin-project/lotus/lib/sigs/secp"

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -9,12 +9,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/crypto"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	"go.uber.org/fx"
+	"golang.org/x/xerrors"
+
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -24,15 +23,17 @@ import (
 	"github.com/ipfs/go-path/resolver"
 	mh "github.com/multiformats/go-multihash"
 	cbg "github.com/whyrusleeping/cbor-gen"
-	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 var log = logging.Logger("fullnode")

--- a/node/modules/chain.go
+++ b/node/modules/chain.go
@@ -3,13 +3,11 @@ package modules
 import (
 	"bytes"
 	"context"
-	"github.com/filecoin-project/lotus/chain/vm"
 
 	"github.com/ipfs/go-bitswap"
 	"github.com/ipfs/go-bitswap/network"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-car"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/routing"
@@ -26,6 +24,8 @@ import (
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -72,7 +72,7 @@ func ChainBlockstore(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRepo
 		return nil, err
 	}
 
-	return blockstore.NewIdStore(cbs), nil
+	return cbs, nil
 }
 
 func ChainGCBlockstore(bs dtypes.ChainBlockstore, gcl dtypes.ChainGCLocker) dtypes.ChainGCBlockstore {

--- a/node/modules/client.go
+++ b/node/modules/client.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/lotus/lib/bufbstore"
-	"golang.org/x/xerrors"
-
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/libp2p/go-libp2p-core/host"
 	"go.uber.org/fx"
+	"golang.org/x/xerrors"
 
 	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
 	dtnet "github.com/filecoin-project/go-data-transfer/network"
@@ -26,7 +22,10 @@ import (
 	"github.com/filecoin-project/go-storedcounter"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	"github.com/libp2p/go-libp2p-core/host"
 
+	"github.com/filecoin-project/lotus/lib/blockstore"
+	"github.com/filecoin-project/lotus/lib/bufbstore"
 	"github.com/filecoin-project/lotus/markets/retrievaladapter"
 	"github.com/filecoin-project/lotus/node/impl/full"
 	payapi "github.com/filecoin-project/lotus/node/impl/paych"
@@ -64,9 +63,9 @@ func ClientBlockstore(imgr dtypes.ClientImportMgr) dtypes.ClientBlockstore {
 	// TODO: This isn't.. the best
 	//  - If it's easy to pass per-retrieval blockstores with markets we don't need this
 	//  - If it's not easy, we need to store this in a separate datastore on disk
-	defaultWrite := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	defaultWrite := blockstore.NewTemporary()
 
-	return blockstore.NewIdStore(bufbstore.NewTieredBstore(imgr.Blockstore, defaultWrite))
+	return bufbstore.NewTieredBstore(imgr.Blockstore, defaultWrite)
 }
 
 // RegisterClientValidator is an initialization hook that registers the client

--- a/node/modules/dtypes/storage.go
+++ b/node/modules/dtypes/storage.go
@@ -4,7 +4,6 @@ import (
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-graphsync"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	format "github.com/ipfs/go-ipld-format"
 
@@ -13,6 +12,8 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-statestore"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/node/repo/importmgr"
 )
 

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 	"time"
 
+	"go.uber.org/fx"
+	"go.uber.org/multierr"
+	"golang.org/x/xerrors"
+
 	"github.com/ipfs/go-bitswap"
 	"github.com/ipfs/go-bitswap/network"
 	"github.com/ipfs/go-blockservice"
@@ -16,13 +20,9 @@ import (
 	graphsync "github.com/ipfs/go-graphsync/impl"
 	gsnet "github.com/ipfs/go-graphsync/network"
 	"github.com/ipfs/go-graphsync/storeutil"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipfs/go-merkledag"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/routing"
-	"go.uber.org/fx"
-	"go.uber.org/multierr"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
@@ -42,7 +42,6 @@ import (
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/go-statestore"
 	"github.com/filecoin-project/go-storedcounter"
-	"github.com/filecoin-project/lotus/node/config"
 	sectorstorage "github.com/filecoin-project/sector-storage"
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/sector-storage/stores"
@@ -53,8 +52,10 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/markets/retrievaladapter"
 	"github.com/filecoin-project/lotus/miner"
+	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -252,10 +253,7 @@ func StagingBlockstore(r repo.LockedRepo) (dtypes.StagingBlockstore, error) {
 		return nil, err
 	}
 
-	bs := blockstore.NewBlockstore(stagingds)
-	ibs := blockstore.NewIdStore(bs)
-
-	return ibs, nil
+	return blockstore.NewBlockstore(stagingds), nil
 }
 
 // StagingDAG is a DAGService for the StagingBlockstore

--- a/node/repo/importmgr/mbstore.go
+++ b/node/repo/importmgr/mbstore.go
@@ -8,7 +8,8 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 type multiReadBs struct {

--- a/node/repo/importmgr/mgr.go
+++ b/node/repo/importmgr/mgr.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 type Mgr struct {

--- a/node/repo/importmgr/store.go
+++ b/node/repo/importmgr/store.go
@@ -5,10 +5,11 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-filestore"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
 )
 
 type Store struct {
@@ -31,7 +32,7 @@ func openStore(ds datastore.Batching) (*Store, error) {
 	fm.AllowFiles = true
 
 	fstore := filestore.NewFilestore(bs, fm)
-	ibs := blockstore.NewIdStore(fstore)
+	ibs := blockstore.WrapIDStore(fstore)
 
 	bsvc := blockservice.New(ibs, offline.Exchange(ibs))
 	dag := merkledag.NewDAGService(bsvc)


### PR DESCRIPTION
This PR inlines small blocks (<= 32 bytes) into CIDs, fixing #2320. This should save us at least ~12% of disks space, and make state access cheaper.

This PR also refactors lotus's use of blockstores to centralize all blockstore creation logic into one place. Otherwise, it's difficult to reason about which blockstores have which properties. In the future, we'll also use this to validate additional CID properties.

Before we merge this, it would be nice to verify that it actually improves performance. Any idea how to do that?

Requires https://github.com/filecoin-project/specs-actors/pull/783