### PR TITLE
Change block validation aggregation type from sum to distribution

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -634,10 +634,8 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 
 	validationStart := build.Clock.Now()
 	defer func() {
-		dur := time.Since(validationStart)
-		durMilli := dur.Seconds() * float64(1000)
-		stats.Record(ctx, metrics.BlockValidationDurationMilliseconds.M(durMilli))
-		log.Infow("block validation", "took", dur, "height", b.Header.Height)
+		stats.Record(ctx, metrics.BlockValidationDurationMilliseconds.M(metrics.SinceInMilliseconds(validationStart)))
+		log.Infow("block validation", "took", time.Since(validationStart), "height", b.Header.Height)
 	}()
 
 	ctx, span := trace.StartSpan(ctx, "validateBlock")

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,12 +1,17 @@
 package metrics
 
 import (
+	"time"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
 	rpcmetrics "github.com/filecoin-project/go-jsonrpc/metrics"
 )
+
+// Distribution
+var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
 
 // Global Tags
 var (
@@ -66,7 +71,7 @@ var (
 	}
 	BlockValidationDurationView = &view.View{
 		Measure:     BlockValidationDurationMilliseconds,
-		Aggregation: view.Sum(),
+		Aggregation: defaultMillisecondsDistribution,
 	}
 	MessageReceivedView = &view.View{
 		Measure:     MessageReceived,
@@ -99,4 +104,11 @@ var DefaultViews = append([]*view.View{
 	MessageReceivedView,
 	MessageValidationFailureView,
 	MessageValidationSuccessView,
-	PeerCountView}, rpcmetrics.DefaultViews...)
+	PeerCountView,
+	},
+	rpcmetrics.DefaultViews...)
+
+// SinceInMilliseconds returns the duration of time since the provide time as a float64.
+func SinceInMilliseconds(startTime time.Time) float64 {
+	return float64(time.Since(startTime).Nanoseconds()) / 1e6
+}


### PR DESCRIPTION
@placer14 I changed this stat to a histogram as when the metric is exported to prometheus will be represented as a sum as well as a count and histogram. This allows for quantiles to graphed. The only thing you will need to change is the metric name will now have `_sum` on the end of it.