### PR TITLE
Lotus Param Audits

### DIFF
--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -56,7 +56,19 @@ const MaxSealLookback = SealRandomnessLookbackLimit + 2000 // TODO: Get from spe
 // Epochs
 const TicketRandomnessLookback = abi.ChainEpoch(1)
 
-const WinningPoStSectorSetLookback = abi.ChainEpoch(10)
+// PARAM_SPEC
+// Power Table Lookback for leader election
+// This lookback is used for calculating the eligible power for leader election
+// and the sector set used for WinningPoSt.
+// If this parameter is set to be larger than 0 this has implication on:
+// (1) mantaining pledge longer than expiration
+// (2) mantaining a sector around for longer than expiratin (or WinningPoSt may fail)
+// Motivation: The choice of the value for this parameter guarantees that:
+// (1) a miner could not game the weight function by removing power in other chains
+// (2) the miner could not have changed their miner key to change challenged sectors
+//     or to change the key used in leader election (and increase their probability 
+//     of winning)
+const WinningPoStSectorSetLookback = Finality
 
 // /////
 // Devnet settings

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -21,7 +21,9 @@ const UnixfsLinksPerLevel = 1024
 
 const AllowableClockDriftSecs = uint64(1)
 
-// Epochs
+
+// PARAM_SPEC
+// Forks that differ from the main chain longer than this threshold are rejected.
 const ForkLengthThreshold = Finality
 
 // Blocks (e)


### PR DESCRIPTION
DO NO MERGE

**Lotus scope**
- Drand
  - [x] Checked value
  - [x] Checked usage
- ForkLengthThreshold
  - [x] Checked value
  - [x] Checked usage
- BlocksPerEpoch
  - [x] Checked value
  - [x] Checked usage (EC audit will check [this](https://github.com/filecoin-project/lotus/blob/d124d10f7c9542d80bcecdf427c78b25f449f3e7/chain/store/weight.go#L63)) - all other occurrences are correct (as of ee5639aad915868d67d344f7d71655217ecbddb8)
- WinningPoStSectorSetLookback
  - [x] Checked value
  - [x] Checked usage
- TotalFilecoin
  - [x] Checked value
  - [x] Checked usage
- MiningRewardTotal
  - [x] Checked value
  - [x] Checked usage

**Need Lotus team**
- MessageConfidence
  - [x] Checked value
  - [x] Checked usage 
  - [x] Proposed change for higher message confidence on mining transactions (https://github.com/filecoin-project/lotus/issues/2777)
- TicketRandomnessLookback
  - [ ] Checked value (why is this set to 1?)
  - [ ] Checked usage (the implementation is correct if lookback is 1, however the actual randomness lookback is hardcoded to 1 and changing this var to 0 or >2 will do something incorrect.)
- SealRandomnessLookback (should be changed into: https://github.com/filecoin-project/specs-actors/issues/672)
  - [ ] Checked value (should be taken from specs-actors)
  - [x] Checked usage
- SealRandomnessLookbackLimit (should be changed into: https://github.com/filecoin-project/specs-actors/issues/672)
  - [ ] Checked value (should be taken from specs-actors)
  - [ ] Checked usage
- MaxSealLookback (should be changed into: https://github.com/filecoin-project/specs-actors/issues/672)
  - [ ] Checked value (should be taken from specs-actors)
  - [ ] Checked usage

**Out of scope**
- InitialRewardBalance
- BlockMessageLimit
- WRatioNum, WRationDen


---

**Suggestion:**
- We should use the same variable names from actors and lotus (e.g. BlocksPerEpoch = ExpectedLeadersPerEpoch)