### PR TITLE
add on-chain-info to lotus-miner sectors status command

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -30,7 +30,7 @@ type StorageMiner interface {
 	PledgeSector(context.Context) error
 
 	// Get the status of a given sector by ID
-	SectorsStatus(context.Context, abi.SectorNumber) (SectorInfo, error)
+	SectorsStatus(ctx context.Context, sid abi.SectorNumber, showOnChainInfo bool) (SectorInfo, error)
 
 	// List all staged sectors
 	SectorsList(context.Context) ([]abi.SectorNumber, error)
@@ -117,6 +117,19 @@ type SectorInfo struct {
 	LastErr string
 
 	Log []SectorLog
+
+	// On Chain Info
+	SealProof          abi.RegisteredSealProof // The seal proof type implies the PoSt proof/s
+	Activation         abi.ChainEpoch  // Epoch during which the sector proof was accepted
+	Expiration         abi.ChainEpoch  // Epoch during which the sector expires
+	DealWeight         abi.DealWeight  // Integral of active deals over sector lifetime
+	VerifiedDealWeight abi.DealWeight  // Integral of active verified deals over sector lifetime
+	InitialPledge      abi.TokenAmount // Pledge collected to commit this sector
+	// Expiration Info
+	OnTime abi.ChainEpoch
+	// non-zero if sector is faulty, epoch at which it will be permanently
+	// removed if it doesn't recover
+	Early abi.ChainEpoch
 }
 
 type SealedRef struct {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -215,7 +215,7 @@ type StorageMinerStruct struct {
 
 		PledgeSector func(context.Context) error `perm:"write"`
 
-		SectorsStatus                 func(context.Context, abi.SectorNumber) (api.SectorInfo, error) `perm:"read"`
+		SectorsStatus                 func(ctx context.Context, sid abi.SectorNumber, showOnChainInfo bool) (api.SectorInfo, error) `perm:"read"`
 		SectorsList                   func(context.Context) ([]abi.SectorNumber, error)               `perm:"read"`
 		SectorsRefs                   func(context.Context) (map[string][]api.SealedRef, error)       `perm:"read"`
 		SectorStartSealing            func(context.Context, abi.SectorNumber) error                   `perm:"write"`
@@ -845,8 +845,8 @@ func (c *StorageMinerStruct) PledgeSector(ctx context.Context) error {
 }
 
 // Get the status of a given sector by ID
-func (c *StorageMinerStruct) SectorsStatus(ctx context.Context, sid abi.SectorNumber) (api.SectorInfo, error) {
-	return c.Internal.SectorsStatus(ctx, sid)
+func (c *StorageMinerStruct) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showOnChainInfo bool) (api.SectorInfo, error) {
+	return c.Internal.SectorsStatus(ctx, sid, showOnChainInfo)
 }
 
 // List all staged sectors

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -192,7 +192,7 @@ func startSealingWaiting(t *testing.T, ctx context.Context, miner TestStorageNod
 	require.NoError(t, err)
 
 	for _, snum := range snums {
-		si, err := miner.SectorsStatus(ctx, snum)
+		si, err := miner.SectorsStatus(ctx, snum, false)
 		require.NoError(t, err)
 
 		t.Logf("Sector state: %s", si.State)

--- a/api/test/window_post.go
+++ b/api/test/window_post.go
@@ -97,7 +97,7 @@ func pledgeSectors(t *testing.T, ctx context.Context, miner TestStorageNode, n i
 
 	for len(toCheck) > 0 {
 		for n := range toCheck {
-			st, err := miner.SectorsStatus(ctx, n)
+			st, err := miner.SectorsStatus(ctx, n, false)
 			require.NoError(t, err)
 			if st.State == api.SectorState(sealing.Proving) {
 				delete(toCheck, n)

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -225,7 +225,7 @@ func sectorsInfo(ctx context.Context, napi api.StorageMiner) error {
 		"Total": len(sectors),
 	}
 	for _, s := range sectors {
-		st, err := napi.SectorsStatus(ctx, s)
+		st, err := napi.SectorsStatus(ctx, s, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
After performing the CC sector upgrade, it seems that the upgrade result cannot be found at present. After adding the sector chain information to the sector status command, it can be found that the `OnTime` in the expiration information has changed. We can use this command to determine whether the CC sector has been upgraded, so as to avoid the launched again upgrade of the sector has been upgraded, while repeating a sector upgrades will not succeed, but is currently only after Committing an error, and before doing PreCommit seal is unnecessary.