### PR TITLE
Parse amount as FIL in paych get

### DIFF
--- a/cli/paych.go
+++ b/cli/paych.go
@@ -29,7 +29,7 @@ var paychGetCmd = &cli.Command{
 	ArgsUsage: "[fromAddress toAddress amount]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.Args().Len() != 3 {
-			return fmt.Errorf("must pass three arguments: <from> <to> <available funds>")
+			return fmt.Errorf("must pass three arguments: <from> <to> <available funds in FIL>")
 		}
 
 		from, err := address.NewFromString(cctx.Args().Get(0))
@@ -42,9 +42,9 @@ var paychGetCmd = &cli.Command{
 			return fmt.Errorf("failed to parse to address: %s", err)
 		}
 
-		amt, err := types.BigFromString(cctx.Args().Get(2))
+		amt, err := types.ParseFIL(cctx.Args().Get(2))
 		if err != nil {
-			return fmt.Errorf("parsing amount failed: %s", err)
+			return fmt.Errorf("parsing amount as whole FIL failed: %s", err)
 		}
 
 		api, closer, err := GetFullNodeAPI(cctx)
@@ -55,7 +55,7 @@ var paychGetCmd = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		info, err := api.PaychGet(ctx, from, to, amt)
+		info, err := api.PaychGet(ctx, from, to, types.BigInt(amt))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/2579.

Note that with this PR `lotus paych get <from> <to> 0.5` will correctly parse the decimal argument.  Actual payment channel creation may still fail because of #2580.