### PR TITLE
https://github.com/supranational/blst

### DIFF
--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -153,13 +153,21 @@ func aggregateSignatures(sigs []crypto.Signature) (*crypto.Signature, error) {
 			return nil, xerrors.Errorf("bls.Aggregate returned nil with %d signatures", len(sigs))
 		}
 
-		// Note: for blst this condition should not happen - nil should not be returned
+		// Note: for blst this condition should not happen - nil should not
+		// be returned
 		return &crypto.Signature{
 			Type: crypto.SigTypeBLS,
 			Data: new(bls.Signature).Compress(),
 		}, nil
 	}
-	aggSig := aggregator.ToAffine().Compress()
+	aggSigAff := aggregator.ToAffine()
+	if aggSigAff == nil {
+		return &crypto.Signature{
+			Type: crypto.SigTypeBLS,
+			Data: new(bls.Signature).Compress(),
+		}, nil
+	}
+	aggSig := aggSigAff.Compress()
 	return &crypto.Signature{
 		Type: crypto.SigTypeBLS,
 		Data: aggSig,

--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"context"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	amt "github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	cid "github.com/ipfs/go-cid"
@@ -17,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/chain/wallet"
+	"github.com/filecoin-project/lotus/lib/sigs/bls"
 )
 
 func MinerCreateBlock(ctx context.Context, sm *stmgr.StateManager, w *wallet.Wallet, bt *api.BlockTemplate) (*types.FullBlock, error) {
@@ -142,28 +142,27 @@ func MinerCreateBlock(ctx context.Context, sm *stmgr.StateManager, w *wallet.Wal
 }
 
 func aggregateSignatures(sigs []crypto.Signature) (*crypto.Signature, error) {
-	var blsSigs []bls.Signature
-	for _, s := range sigs {
-		var bsig bls.Signature
-		copy(bsig[:], s.Data)
-		blsSigs = append(blsSigs, bsig)
+	sigsS := make([][]byte, len(sigs))
+	for i := 0; i < len(sigs); i++ {
+		sigsS[i] = sigs[i].Data
 	}
 
-	aggSig := bls.Aggregate(blsSigs)
-	if aggSig == nil {
+	aggregator := new(bls.AggregateSignature).AggregateCompressed(sigsS)
+	if aggregator == nil {
 		if len(sigs) > 0 {
 			return nil, xerrors.Errorf("bls.Aggregate returned nil with %d signatures", len(sigs))
 		}
 
+		// Note: for blst this condition should not happen - nil should not be returned
 		return &crypto.Signature{
 			Type: crypto.SigTypeBLS,
-			Data: new(bls.Signature)[:],
+			Data: new(bls.Signature).Compress(),
 		}, nil
 	}
-
+	aggSig := aggregator.ToAffine().Compress()
 	return &crypto.Signature{
 		Type: crypto.SigTypeBLS,
-		Data: aggSig[:],
+		Data: aggSig,
 	}, nil
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -23,7 +23,6 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
 	"github.com/ipfs/go-cid"
 	hamt "github.com/ipfs/go-hamt-ipld"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -433,7 +432,7 @@ func (sm *StateManager) ResolveToKeyAddress(ctx context.Context, addr address.Ad
 	return vm.ResolveToKeyAddr(tree, cst, addr)
 }
 
-func (sm *StateManager) GetBlsPublicKey(ctx context.Context, addr address.Address, ts *types.TipSet) (pubk bls.PublicKey, err error) {
+func (sm *StateManager) GetBlsPublicKey(ctx context.Context, addr address.Address, ts *types.TipSet) (pubk []byte, err error) {
 	kaddr, err := sm.ResolveToKeyAddress(ctx, addr, ts)
 	if err != nil {
 		return pubk, xerrors.Errorf("failed to resolve address to key address: %w", err)
@@ -443,8 +442,7 @@ func (sm *StateManager) GetBlsPublicKey(ctx context.Context, addr address.Addres
 		return pubk, xerrors.Errorf("address must be BLS address to load bls public key")
 	}
 
-	copy(pubk[:], kaddr.Payload())
-	return pubk, nil
+	return kaddr.Payload(), nil
 }
 
 func (sm *StateManager) LookupID(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -25,7 +25,6 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
 
-	blst "github.com/supranational/blst/bindings/go"
 	"github.com/filecoin-project/go-address"
 	amt "github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
@@ -34,6 +33,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	blst "github.com/supranational/blst/bindings/go"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -25,7 +25,7 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
 
-	bls "github.com/filecoin-project/filecoin-ffi"
+	blst "github.com/supranational/blst/bindings/go"
 	"github.com/filecoin-project/go-address"
 	amt "github.com/filecoin-project/go-amt-ipld/v2"
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
@@ -46,6 +46,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/lib/sigs/bls"
 	"github.com/filecoin-project/lotus/metrics"
 )
 
@@ -915,7 +916,7 @@ func (syncer *Syncer) VerifyWinningPoStProof(ctx context.Context, h *types.Block
 func (syncer *Syncer) checkBlockMessages(ctx context.Context, b *types.FullBlock, baseTs *types.TipSet) error {
 	{
 		var sigCids []cid.Cid // this is what we get for people not wanting the marshalcbor method on the cid type
-		var pubks []bls.PublicKey
+		var pubks [][]byte
 
 		for _, m := range b.BlsMessages {
 			sigCids = append(sigCids, m.Cid())
@@ -1036,24 +1037,28 @@ func (syncer *Syncer) checkBlockMessages(ctx context.Context, b *types.FullBlock
 	return nil
 }
 
-func (syncer *Syncer) verifyBlsAggregate(ctx context.Context, sig *crypto.Signature, msgs []cid.Cid, pubks []bls.PublicKey) error {
+func (syncer *Syncer) verifyBlsAggregate(ctx context.Context, sig *crypto.Signature, msgs []cid.Cid, pubks [][]byte) error {
 	_, span := trace.StartSpan(ctx, "syncer.verifyBlsAggregate")
 	defer span.End()
 	span.AddAttributes(
 		trace.Int64Attribute("msgCount", int64(len(msgs))),
 	)
 
-	bmsgs := make([]bls.Message, len(msgs))
-	for i, m := range msgs {
-		bmsgs[i] = m.Bytes()
+	msgsS := make([]blst.Message, len(msgs))
+	for i := 0; i < len(msgs); i++ {
+		msgsS[i] = msgs[i].Bytes()
 	}
 
-	var bsig bls.Signature
-	copy(bsig[:], sig.Data)
-	if !bls.HashVerify(&bsig, bmsgs, pubks) {
+	// TODO: empty aggregates are considered valid?
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	valid := new(bls.Signature).AggregateVerifyCompressed(sig.Data, pubks,
+		msgsS, []byte(bls.DST))
+	if !valid {
 		return xerrors.New("bls aggregate signature failed to verify")
 	}
-
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/filecoin-project/lotus
 
 go 1.14
 
+replace github.com/supranational/blst => github.com/supranational/blst v0.1.2-alpha.1
+
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
@@ -119,7 +121,7 @@ require (
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
 	go4.org v0.0.0-20190313082347-94abd6928b1d // indirect
-	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
+	github.com/supranational/blst v0.1.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba

--- a/go.sum
+++ b/go.sum
@@ -1316,6 +1316,10 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/supranational/blst v0.1.0 h1:2LzeBbOidhTD87UezqGvIffWZAd3FOCfhi2b7IbJCMc=
+github.com/supranational/blst v0.1.0/go.mod h1:Z70pOaiBHpXP+JFNOwIyCHKjec/He56CC5UdLaYpuzY=
+github.com/supranational/blst v0.1.1 h1:GsK4oq7QZ7yfHI6dCh2NQsUe4imjlFwm5NXF5PWAWoo=
+github.com/supranational/blst v0.1.1/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/go.sum
+++ b/go.sum
@@ -1316,10 +1316,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/supranational/blst v0.1.0 h1:2LzeBbOidhTD87UezqGvIffWZAd3FOCfhi2b7IbJCMc=
-github.com/supranational/blst v0.1.0/go.mod h1:Z70pOaiBHpXP+JFNOwIyCHKjec/He56CC5UdLaYpuzY=
-github.com/supranational/blst v0.1.1 h1:GsK4oq7QZ7yfHI6dCh2NQsUe4imjlFwm5NXF5PWAWoo=
-github.com/supranational/blst v0.1.1/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.1.2-alpha.1 h1:v0UqVlvbRNZIaSeMPr+T01kvTUq1h0EZuZ6gnDR1Mlg=
+github.com/supranational/blst v0.1.2-alpha.1/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
@@ -1567,6 +1565,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/lib/sigs/bls/init.go
+++ b/lib/sigs/bls/init.go
@@ -1,51 +1,57 @@
 package bls
 
 import (
+	"crypto/rand"
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 
-	ffi "github.com/filecoin-project/filecoin-ffi"
+	blst "github.com/supranational/blst/bindings/go"
 
 	"github.com/filecoin-project/lotus/lib/sigs"
 )
 
+const DST = string("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
+
+type SecretKey = blst.SecretKey
+type PublicKey = blst.P1Affine
+type Signature = blst.P2Affine
+type AggregateSignature = blst.P2Aggregate
+
 type blsSigner struct{}
 
 func (blsSigner) GenPrivate() ([]byte, error) {
-	pk := ffi.PrivateKeyGenerate()
-	return pk[:], nil
+	// Generate 32 bytes of randomness
+	var ikm [32]byte
+	_, err := rand.Read(ikm[:])
+	if err != nil {
+		return nil, fmt.Errorf("bls signature error generating random data")
+	}
+	pk := blst.KeyGen(ikm[:]).Serialize()
+	return pk, nil
 }
 
 func (blsSigner) ToPublic(priv []byte) ([]byte, error) {
-	var pk ffi.PrivateKey
-	copy(pk[:], priv)
-	pub := ffi.PrivateKeyPublicKey(pk)
-	return pub[:], nil
+	pk := new(SecretKey).Deserialize(priv)
+	if pk == nil {
+		return nil, fmt.Errorf("bls signature invalid private key")
+	}
+	return new(PublicKey).From(pk).Compress(), nil
 }
 
 func (blsSigner) Sign(p []byte, msg []byte) ([]byte, error) {
-	var pk ffi.PrivateKey
-	copy(pk[:], p)
-	sig := ffi.PrivateKeySign(pk, msg)
-	return sig[:], nil
+	pk := new(SecretKey).Deserialize(p)
+	if pk == nil {
+		return nil, fmt.Errorf("bls signature invalid private key")
+	}
+	return new(Signature).Sign(pk, msg, []byte(DST)).Compress(), nil
 }
 
 func (blsSigner) Verify(sig []byte, a address.Address, msg []byte) error {
-
-	var pubk ffi.PublicKey
-	copy(pubk[:], a.Payload())
-	pubkeys := []ffi.PublicKey{pubk}
-	digests := []ffi.Message{msg}
-
-	var s ffi.Signature
-	copy(s[:], sig)
-
-	if !ffi.HashVerify(&s, digests, pubkeys) {
+	if !new(Signature).VerifyCompressed(sig, a.Payload()[:], msg, []byte(DST)) {
 		return fmt.Errorf("bls signature failed to verify")
 	}
-
 	return nil
 }
 

--- a/lib/sigs/bls/init.go
+++ b/lib/sigs/bls/init.go
@@ -28,21 +28,22 @@ func (blsSigner) GenPrivate() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bls signature error generating random data")
 	}
-	pk := blst.KeyGen(ikm[:]).Serialize()
+	// Note private keys seem to be serialized little-endian!
+	pk := blst.KeyGen(ikm[:]).ToLEndian()
 	return pk, nil
 }
 
 func (blsSigner) ToPublic(priv []byte) ([]byte, error) {
-	pk := new(SecretKey).Deserialize(priv)
-	if pk == nil {
+	pk := new(SecretKey).FromLEndian(priv)
+	if pk == nil || !pk.Valid() {
 		return nil, fmt.Errorf("bls signature invalid private key")
 	}
 	return new(PublicKey).From(pk).Compress(), nil
 }
 
 func (blsSigner) Sign(p []byte, msg []byte) ([]byte, error) {
-	pk := new(SecretKey).Deserialize(p)
-	if pk == nil {
+	pk := new(SecretKey).FromLEndian(p)
+	if pk == nil || !pk.Valid() {
 		return nil, fmt.Errorf("bls signature invalid private key")
 	}
 	return new(Signature).Sign(pk, msg, []byte(DST)).Compress(), nil


### PR DESCRIPTION
This PR replaces the existing BLS signature library with the ‘blst’ library (https://github.com/supranational/blst). 

**About ‘blst’:** ‘blst’ is a BLS signature library focused on security and performance. It currently supports Windows, Mac, and Linux operating systems and the ARM64 and x86_64 architectures. The library is compliant with the in-progress IETF specification and is being tested and integrated by multiple Ethereum clients. The library is currently undergoing formal verification.

**Integration Testing:** This library has been tested with Lotus by creating blocks on a local devnet and has also been able to sync to the public test network. 

**Performance Testing:** Benchmarking was done by comparing the current implementation against blst using https://github.com/filecoin-project/filecoin-ffi/blob/master/bls_test.go. The results for performance critical functions are shown below:

| Benchmark                           | Message Size | blst Library | Current Library | Speedup |
|-------------------------------------|--------------|-----------------|--------------|---------|
| BenchmarkBLSVerify                  |            1 |          941872 |      4837537 |     5.1 |
| BenchmarkBLSVerifyBatch             |           10 |         1606194 |      8781361 |     5.5 |
| BenchmarkBLSVerifyBatch             |           50 |         4602668 |     27021693 |     5.9 |
| BenchmarkBLSVerifyBatch             |          100 |         7865916 |     48911631 |     6.2 |
| BenchmarkBLSVerifyBatch             |          300 |        19550770 |    134919868 |     6.9 |
| BenchmarkBLSVerifyBatch             |         1000 |        59879016 |    441419601 |     7.4 |
| BenchmarkBLSVerifyBatch             |         4000 |       238255028 |   1756039702 |     7.4 |
| BenchmarkBLSHashAndVerify           |              |         1228178 |      6561599 |     5.3 |
| BenchmarkBLSHashVerify              |              |         1127907 |      5623273 |     5.0 |
| BenchmarkBLSHashVerifyBatch/1-16    |            1 |         1125405 |      5607960 |     5.0 |
| BenchmarkBLSHashVerifyBatch/10-16   |           10 |         1914880 |     10266081 |     5.4 |
| BenchmarkBLSHashVerifyBatch/50-16   |           50 |         5913441 |     32618643 |     5.5 |
| BenchmarkBLSHashVerifyBatch/100-16  |          100 |         9805150 |     59240948 |     6.0 |
| BenchmarkBLSHashVerifyBatch/300-16  |          300 |        25441451 |    164415608 |     6.5 |
| BenchmarkBLSHashVerifyBatch/1000-16 |         1000 |        79722351 |    539391840 |     6.8 |
| BenchmarkBLSHashVerifyBatch/4000-16 |         4000 |       313873206 |   2170584254 |     6.9 |
