### PR TITLE
Print totals in mpool stat

### DIFF
--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -225,9 +225,18 @@ var mpoolStat = &cli.Command{
 			return out[i].addr < out[j].addr
 		})
 
+		var total mpStat
+
 		for _, stat := range out {
-			fmt.Printf("%s, past: %d, cur: %d, future: %d\n", stat.addr, stat.past, stat.cur, stat.future)
+			total.past += stat.past
+			total.cur += stat.cur
+			total.future += stat.future
+
+			fmt.Printf("%s: past: %d, cur: %d, future: %d\n", stat.addr, stat.past, stat.cur, stat.future)
 		}
+
+		fmt.Println("-----")
+		fmt.Printf("total: past: %d, cur: %d, future: %d\n", total.past, total.cur, total.future)
 
 		return nil
 	},


### PR DESCRIPTION
Example output:
```
[....many lines...]
t3xfrtmseqylkqirpseigbjnzs274angj7odzfapiarzwqjxk2mxsm2pm6gywerqbh467aybq742lzj7y7ryea: past: 0, cur: 1, future: 0
t3xgfxy2crjg6b7l3lgvdl7p75ubucfhrpz4x55qwq5eo52yk2xkbe5ncfalc7yuodchvu3kgmk4okls5m2rhq: past: 0, cur: 0, future: 2
t3xglv457cdnxh3ec72z7ocagm2qhq56pq7wja4pqacl7r5fo3vh3qx7x5jklun2y6wubmq73zjay674gbmaaq: past: 0, cur: 0, future: 1
t3xgtbpdiqdr4a5odmsf6l5yusy6pdfebt2opvpwjj5xnjfl2xjmbitt7c7ijy5me4vqdld4vtqhpfexepqwra: past: 0, cur: 0, future: 2
-----
total: past: 0, cur: 5690, future: 193
```