### PR TITLE
Update filecoin docs correction

### DIFF
--- a/documentation/en/updating-lotus.md
+++ b/documentation/en/updating-lotus.md
@@ -10,5 +10,5 @@ git pull origin master
 make clean && make build
 
 # instal binaries in correct location
-make install // or sudo make install if necessary
+make install # or sudo make install if necessary
 ```

--- a/documentation/en/updating-lotus.md
+++ b/documentation/en/updating-lotus.md
@@ -10,5 +10,5 @@ git pull origin master
 make clean && make build
 
 # instal binaries in correct location
-make install
+make install // or sudo make install if necessary
 ```

--- a/documentation/en/updating-lotus.md
+++ b/documentation/en/updating-lotus.md
@@ -8,4 +8,7 @@ git pull origin master
 
 # clean and remake the binaries
 make clean && make build
+
+# instal binaries in correct location
+make install
 ```


### PR DESCRIPTION
Without running `make install` it is possible to have multiple versions of the binary which could cause confusion. 