### PR TITLE
only republish the next few messages from your mempool

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -40,6 +40,8 @@ const futureDebug = false
 
 const ReplaceByFeeRatio = 1.25
 
+const repubMsgLimit = 5
+
 var (
 	rbfNum   = types.NewInt(uint64((ReplaceByFeeRatio - 1) * 256))
 	rbfDenom = types.NewInt(256)
@@ -267,6 +269,10 @@ func (mp *MessagePool) repubLocal() {
 
 			if len(outputMsgs) != 0 {
 				log.Infow("republishing local messages", "n", len(outputMsgs))
+			}
+
+			if len(outputMsgs) > repubMsgLimit {
+				outputMsgs = outputMsgs[:repubMsgLimit]
 			}
 
 			for _, msg := range outputMsgs {


### PR DESCRIPTION
The network is currently DoSing itself by rebroadcasting the entire mempool of 10000 messages every few minutes. This should help, at least a little bit