### PR TITLE
fix EnsureAvailable toAdd=0 bug

### DIFF
--- a/chain/market/fundmgr.go
+++ b/chain/market/fundmgr.go
@@ -58,7 +58,9 @@ func (fm *FundMgr) EnsureAvailable(ctx context.Context, addr, wallet address.Add
 	fm.available[addr] = avail
 
 	fm.lk.Unlock()
-
+	if toAdd.Equals(types.NewInt(0)){
+		return cid.Undef, nil
+	}
 	var err error
 	params, err := actors.SerializeParams(&addr)
 	if err != nil {


### PR DESCRIPTION
Not return error when don't need add fund to market

error:

adding market funds failed: estimating gas limit: message execution failed: exit 16, reason: balance to add must be greater than zero (RetCode=16)