### PR TITLE
support extended pubsub peer scores

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 
 	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -40,7 +41,7 @@ type ObjStat struct {
 
 type PubsubScore struct {
 	ID    peer.ID
-	Score float64
+	Score *pubsub.PeerScoreSnapshot
 }
 
 type MinerInfo struct {

--- a/cli/net.go
+++ b/cli/net.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -55,6 +57,12 @@ var netPeers = &cli.Command{
 var netScores = &cli.Command{
 	Name:  "scores",
 	Usage: "Print peers' pubsub scores",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "extended",
+			Usage: "print extended peer scores in json",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := GetAPI(cctx)
 		if err != nil {
@@ -67,8 +75,18 @@ var netScores = &cli.Command{
 			return err
 		}
 
-		for _, peer := range scores {
-			fmt.Printf("%s, %f\n", peer.ID, peer.Score)
+		if cctx.Bool("extended") {
+			enc := json.NewEncoder(os.Stdout)
+			for _, peer := range scores {
+				err := enc.Encode(peer)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			for _, peer := range scores {
+				fmt.Printf("%s, %f\n", peer.ID, peer.Score.Score)
+			}
 		}
 
 		return nil

--- a/node/modules/dtypes/scorekeeper.go
+++ b/node/modules/dtypes/scorekeeper.go
@@ -4,20 +4,21 @@ import (
 	"sync"
 
 	peer "github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
 type ScoreKeeper struct {
 	lk     sync.Mutex
-	scores map[peer.ID]float64
+	scores map[peer.ID]*pubsub.PeerScoreSnapshot
 }
 
-func (sk *ScoreKeeper) Update(scores map[peer.ID]float64) {
+func (sk *ScoreKeeper) Update(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 	sk.lk.Lock()
 	sk.scores = scores
 	sk.lk.Unlock()
 }
 
-func (sk *ScoreKeeper) Get() map[peer.ID]float64 {
+func (sk *ScoreKeeper) Get() map[peer.ID]*pubsub.PeerScoreSnapshot {
 	sk.lk.Lock()
 	defer sk.lk.Unlock()
 	return sk.scores


### PR DESCRIPTION
Adds support for the new extended pubsub score inspection; modifies the score command to accept an `--extended` flag, which will print the extended scores, including internal counters, as json.