### PR TITLE
fix(chainwatch): Miner partition processing panics on nil bitfiled

### DIFF
--- a/cmd/lotus-chainwatch/processor/miner.go
+++ b/cmd/lotus-chainwatch/processor/miner.go
@@ -776,10 +776,10 @@ func (p *Processor) diffPartition(prevPart, curPart miner.Partition) (*Partition
 	}
 
 	expired := abi.NewBitField()
-	var bf *abi.BitField
-	if err := terminatedEarlyArr.ForEach(bf, func(i int64) error {
+	var bf abi.BitField
+	if err := terminatedEarlyArr.ForEach(&bf, func(i int64) error {
 		// expired = all removals - termination
-		expirations, err := bitfield.SubtractBitField(allRemovedSectors, bf)
+		expirations, err := bitfield.SubtractBitField(allRemovedSectors, &bf)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Panic:
```
2020-07-31T17:22:28.635-0700    INFO    processor       processor/processor.go:354      Gathered Blocks to Process      {"start": "10071", "end": "10071"}
2020-07-31T17:22:28.916-0700    INFO    processor       processor/processor.go:132      Collected Actor Changes {"MarketChanges": 1, "MinerChanges": 1, "RewardChanges": 1, "AccountChanges": 1, "nullRounds": 0}
2020-07-31T17:22:28.947-0700    INFO    processor       processor/processor.go:161      Processed Reward Changes
2020-07-31T17:22:28.972-0700    INFO    processor       processor/processor.go:169      Processed Message Changes
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa43e03]

goroutine 132349068 [running]:
github.com/filecoin-project/go-bitfield.(*BitField).UnmarshalCBOR(0x0, 0x2242340, 0xc0009e0cc0, 0x1, 0xc000789700)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-bitfield@v0.1.1/bitfield.go:450 +0x233
github.com/filecoin-project/specs-actors/actors/util/adt.(*Array).ForEach.func1(0x1a1e, 0xc00050fd20, 0xf571eb, 0xc00076e280)
        /home/frrist/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200728182452-1476088f645b/actors/util/adt/array.go:87 +0x14a
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc00076e280, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x0, 0x0, 0x1a18, 0xc000555480, 0x30, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:274 +0x419
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc00012fc80, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x1, 0x0, 0x1a00, 0xc000555480, 0x30, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:306 +0x1e5
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc00012f880, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x2, 0x0, 0x1a00, 0xc000555480, 0x30, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:306 +0x1e5
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc00012e800, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x3, 0x0, 0x1000, 0xc000555480, 0xc0005b8180, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:306 +0x1e5
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc001c940b0, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x4, 0x0, 0x0, 0xc000555480, 0x0, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:306 +0x1e5
github.com/filecoin-project/go-amt-ipld/v2.(*Root).ForEach(...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:256
github.com/filecoin-project/specs-actors/actors/util/adt.(*Array).ForEach(0xc0016a15c0, 0x2242920, 0x0, 0xc000555520, 0xc0016a15c0, 0x0)
        /home/frrist/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200728182452-1476088f645b/actors/util/adt/array.go:82 +0xe6
github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).diffPartition(0xc00047fe90, 0xc001f1e600, 0xc001f1e640, 0xc001f1e680, 0xc001f1e6c0, 0xc001e8bdd0, 0x26, 0xc001e8be30, 0x26, 0xc001d3ae80, ...)
        /home/frrist/src/github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor/miner.go:799 +0x13c
github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).diffMinerPartitions.func1(0x0, 0x2242340, 0xc0004b88d0)
        /home/frrist/src/github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor/miner.go:720 +0x175
github.com/filecoin-project/specs-actors/actors/util/adt.(*Array).ForEach.func1(0x0, 0xc001eab840, 0xf571eb, 0xc00012f100)
        /home/frrist/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200728182452-1476088f645b/actors/util/adt/array.go:91 +0x84
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc00012f100, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x0, 0x0, 0x0, 0xc000555a30, 0xc00040b180, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:274 +0x419
github.com/filecoin-project/go-amt-ipld/v2.(*Node).forEachAt(0xc000431c30, 0x2260000, 0xc0000478c0, 0x7f15157f1c10, 0xc00050e280, 0x1, 0x0, 0x0, 0xc000555a30, 0x0, ...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:306 +0x1e5
github.com/filecoin-project/go-amt-ipld/v2.(*Root).ForEach(...)
        /home/frrist/pkg/mod/github.com/filecoin-project/go-amt-ipld/v2@v2.1.0/amt.go:256
github.com/filecoin-project/specs-actors/actors/util/adt.(*Array).ForEach(0xc000d2c440, 0x2242ec0, 0xc001f0ff80, 0xc000555b78, 0xc001f1b0e0, 0x0)
        /home/frrist/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200728182452-1476088f645b/actors/util/adt/array.go:82 +0xe6
github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).diffMinerPartitions(0xc00047fe90, 0x2260000, 0xc000047fc0, 0xc0007d2ec0, 0x16, 0xc00022f350, 0x26, 0x0, 0xc00066c920, 0xc0003544e0, ...)
        /home/frrist/src/github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor/miner.go:713 +0x443
github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).getMinerPartitionsDifferences.func1(0xc00108dfc8, 0xe4ee7a)
        /home/frrist/src/github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor/miner.go:520 +0xbb
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0006f0b10, 0xc0006f1e30)
        /home/frrist/pkg/mod/golang.org/x/sync@v0.0.0-20200317015054-43a5402ce75a/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
        /home/frrist/pkg/mod/golang.org/x/sync@v0.0.0-20200317015054-43a5402ce75a/errgroup/errgroup.go:54 +0x66
```