### PR TITLE
Fix import

### DIFF
--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -104,6 +104,16 @@ var importBenchCmd = &cli.Command{
 			return err
 		}
 
+		gb, err := cs.GetTipsetByHeight(context.TODO(), 0, head, true)
+		if err != nil {
+			return err
+		}
+
+		err = cs.SetGenesis(gb.Blocks()[0])
+		if err != nil {
+			return err
+		}
+
 		if h := cctx.Int64("height"); h != 0 {
 			tsh, err := cs.GetTipsetByHeight(context.TODO(), abi.ChainEpoch(h), head, true)
 			if err != nil {


### PR DESCRIPTION
The stmgr calls `GetGenesis` to setup genesis multisigs, which needs to be explicitly set using `SetGenesis`. This wasn't happening during imports.
