### PR TITLE
Fix proposal CID in `lotus-miner storage-deals list`

### DIFF
--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -357,11 +357,7 @@ var dealsListCmd = &cli.Command{
 		_, _ = fmt.Fprintf(w, "ProposalCid\tDealId\tState\tClient\tSize\tPrice\tDuration\n")
 
 		for _, deal := range deals {
-			pc, err := deal.Proposal.Cid()
-			if err != nil {
-				return err
-			}
-			propcid := pc.String()
+			propcid := deal.ProposalCid.String()
 			propcid = "..." + propcid[len(propcid)-8:]
 
 			fil := types.FIL(types.BigMul(deal.Proposal.StoragePricePerEpoch, types.NewInt(uint64(deal.Proposal.Duration()))))


### PR DESCRIPTION
# Goals

Fix a bug where the deal CID output in `lotus-miner storage-deals list` was incorrect.

# Implementation

The deal CID is the CID of the *signed* deal proposal. Previously, we were taking the CID of just the proposal itself, as opposed to the signed proposal, which, due to the additional bytes is different. We already have the CID for the signed proposal directly in the deal struct so we just use that.