### PR TITLE
Fix misspelling in HelloMessage

### DIFF
--- a/node/hello/cbor_gen.go
+++ b/node/hello/cbor_gen.go
@@ -172,13 +172,13 @@ func (t *LatencyMessage) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.TArrial (int64) (int64)
-	if t.TArrial >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.TArrial)); err != nil {
+	// t.TArrival (int64) (int64)
+	if t.TArrival >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.TArrival)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.TArrial-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.TArrival-1)); err != nil {
 			return err
 		}
 	}
@@ -212,7 +212,7 @@ func (t *LatencyMessage) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.TArrial (int64) (int64)
+	// t.TArrival (int64) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
 		var extraI int64
@@ -235,7 +235,7 @@ func (t *LatencyMessage) UnmarshalCBOR(r io.Reader) error {
 			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
 
-		t.TArrial = int64(extraI)
+		t.TArrival = int64(extraI)
 	}
 	// t.TSent (int64) (int64)
 	{

--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -32,8 +32,8 @@ type HelloMessage struct {
 	GenesisHash          cid.Cid
 }
 type LatencyMessage struct {
-	TArrial int64
-	TSent   int64
+	TArrival int64
+	TSent    int64
 }
 
 type NewStreamFunc func(context.Context, peer.ID, ...protocol.ID) (inet.Stream, error)
@@ -84,8 +84,8 @@ func (hs *Service) HandleStream(s inet.Stream) {
 
 		sent := time.Now()
 		msg := &LatencyMessage{
-			TArrial: arrived.UnixNano(),
-			TSent:   sent.UnixNano(),
+			TArrival: arrived.UnixNano(),
+			TSent:    sent.UnixNano(),
 		}
 		if err := cborutil.WriteCborRPC(s, msg); err != nil {
 			log.Debugf("error while responding to latency: %v", err)
@@ -169,8 +169,8 @@ func (hs *Service) SayHello(ctx context.Context, pid peer.ID) error {
 		}
 
 		if err == nil {
-			if lmsg.TArrial != 0 && lmsg.TSent != 0 {
-				t1 := time.Unix(0, lmsg.TArrial)
+			if lmsg.TArrival != 0 && lmsg.TSent != 0 {
+				t1 := time.Unix(0, lmsg.TArrival)
 				t2 := time.Unix(0, lmsg.TSent)
 				offset := t0.Sub(t1) + t3.Sub(t2)
 				offset /= 2


### PR DESCRIPTION
Self-explanatory. `TArrial` should `TArrival`.