### PR TITLE
Improve Fund Manager

### DIFF
--- a/chain/market/fundmgr.go
+++ b/chain/market/fundmgr.go
@@ -2,44 +2,118 @@ package market
 
 import (
 	"context"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"sync"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"go.uber.org/fx"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
-	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/events"
+	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/impl/full"
 )
 
 var log = logging.Logger("market_adapter")
 
-type FundMgr struct {
-	sm    *stmgr.StateManager
-	mpool full.MpoolAPI
+// API is the dependencies need to run a fund manager
+type API struct {
+	fx.In
 
-	lk        sync.Mutex
+	full.ChainAPI
+	full.StateAPI
+	full.MpoolAPI
+}
+
+// FundMgr monitors available balances and adds funds when EnsureAvailable is called
+type FundMgr struct {
+	api fundMgrAPI
+
+	lk        sync.RWMutex
 	available map[address.Address]types.BigInt
 }
 
-func NewFundMgr(sm *stmgr.StateManager, mpool full.MpoolAPI) *FundMgr {
-	return &FundMgr{
-		sm:    sm,
-		mpool: mpool,
+// StartFundManager creates a new fund manager and sets up event hooks to manage state changes
+func StartFundManager(lc fx.Lifecycle, api API) *FundMgr {
+	fm := newFundMgr(&api)
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			ev := events.NewEvents(ctx, &api)
+			preds := state.NewStatePredicates(&api)
+			dealDiffFn := preds.OnStorageMarketActorChanged(preds.OnBalanceChanged(preds.AvailableBalanceChangedForAddresses(fm.getAddresses)))
+			match := func(oldTs, newTs *types.TipSet) (bool, events.StateChange, error) {
+				return dealDiffFn(ctx, oldTs.Key(), newTs.Key())
+			}
+			return ev.StateChanged(fm.checkFunc, fm.stateChanged, fm.revert, int(build.MessageConfidence+1), events.NoTimeout, match)
+		},
+	})
+	return fm
+}
 
+type fundMgrAPI interface {
+	StateMarketBalance(context.Context, address.Address, types.TipSetKey) (api.MarketBalance, error)
+	MpoolPushMessage(context.Context, *types.Message) (*types.SignedMessage, error)
+}
+
+func newFundMgr(api fundMgrAPI) *FundMgr {
+	return &FundMgr{
+		api:       api,
 		available: map[address.Address]types.BigInt{},
 	}
 }
 
+// checkFunc tells the events api to simply proceed (we always want to watch)
+func (fm *FundMgr) checkFunc(ts *types.TipSet) (done bool, more bool, err error) {
+	return false, true, nil
+}
+
+// revert handles reverts to balances
+func (fm *FundMgr) revert(ctx context.Context, ts *types.TipSet) error {
+	// TODO: Is it ok to just ignore this?
+	log.Warn("balance change reverted; TODO: actually handle this!")
+	return nil
+}
+
+// stateChanged handles balance changes monitored on the chain from one tipset to the next
+func (fm *FundMgr) stateChanged(ts *types.TipSet, ts2 *types.TipSet, states events.StateChange, h abi.ChainEpoch) (more bool, err error) {
+	changedBalances, ok := states.(state.ChangedBalances)
+	if !ok {
+		panic("Expected state.ChangedBalances")
+	}
+	// overwrite our in memory cache with new values from chain (chain is canonical)
+	fm.lk.Lock()
+	for addr, balanceChange := range changedBalances {
+		fm.available[addr] = balanceChange.To
+	}
+	fm.lk.Unlock()
+	return true, nil
+}
+
+func (fm *FundMgr) getAddresses() []address.Address {
+	fm.lk.RLock()
+	defer fm.lk.RUnlock()
+	addrs := make([]address.Address, 0, len(fm.available))
+	for addr := range fm.available {
+		addrs = append(addrs, addr)
+	}
+	return addrs
+}
+
+// EnsureAvailable looks at the available balance in escrow for a given
+// address, and if less than the passed in amount, adds the difference
 func (fm *FundMgr) EnsureAvailable(ctx context.Context, addr, wallet address.Address, amt types.BigInt) (cid.Cid, error) {
 	fm.lk.Lock()
 	avail, ok := fm.available[addr]
 	if !ok {
-		bal, err := fm.sm.MarketBalance(ctx, addr, nil)
+		bal, err := fm.api.StateMarketBalance(ctx, addr, types.EmptyTSK)
 		if err != nil {
 			fm.lk.Unlock()
 			return cid.Undef, err
@@ -48,38 +122,33 @@ func (fm *FundMgr) EnsureAvailable(ctx context.Context, addr, wallet address.Add
 		avail = types.BigSub(bal.Escrow, bal.Locked)
 	}
 
-	toAdd := types.NewInt(0)
-	avail = types.BigSub(avail, amt)
-	if avail.LessThan(types.NewInt(0)) {
-		// TODO: some rules around adding more to avoid doing stuff on-chain
-		//  all the time
-		toAdd = avail.Neg()
-		avail = types.NewInt(0)
+	toAdd := types.BigSub(amt, avail)
+	if toAdd.LessThan(types.NewInt(0)) {
+		toAdd = types.NewInt(0)
 	}
-	fm.available[addr] = avail
-
+	fm.available[addr] = big.Add(avail, toAdd)
 	fm.lk.Unlock()
 
 	if toAdd.LessThanEqual(big.Zero()) {
 		return cid.Undef, nil
-	} else {
-		var err error
-		params, err := actors.SerializeParams(&addr)
-		if err != nil {
-			return cid.Undef, err
-		}
-
-		smsg, err := fm.mpool.MpoolPushMessage(ctx, &types.Message{
-			To:     builtin.StorageMarketActorAddr,
-			From:   wallet,
-			Value:  toAdd,
-			Method: builtin.MethodsMarket.AddBalance,
-			Params: params,
-		})
-		if err != nil {
-			return cid.Undef, err
-		}
-
-		return smsg.Cid(), nil
 	}
+
+	var err error
+	params, err := actors.SerializeParams(&addr)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	smsg, err := fm.api.MpoolPushMessage(ctx, &types.Message{
+		To:     builtin.StorageMarketActorAddr,
+		From:   wallet,
+		Value:  toAdd,
+		Method: builtin.MethodsMarket.AddBalance,
+		Params: params,
+	})
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return smsg.Cid(), nil
 }

--- a/chain/market/fundmgr_test.go
+++ b/chain/market/fundmgr_test.go
@@ -1,0 +1,172 @@
+package market
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	tutils "github.com/filecoin-project/specs-actors/support/testing"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+type fakeAPI struct {
+	returnedBalance    api.MarketBalance
+	returnedBalanceErr error
+	signature          crypto.Signature
+	receivedMessage    *types.Message
+	pushMessageErr     error
+}
+
+func (fapi *fakeAPI) StateMarketBalance(context.Context, address.Address, types.TipSetKey) (api.MarketBalance, error) {
+	return fapi.returnedBalance, fapi.returnedBalanceErr
+}
+
+func (fapi *fakeAPI) MpoolPushMessage(ctx context.Context, msg *types.Message) (*types.SignedMessage, error) {
+	fapi.receivedMessage = msg
+	return &types.SignedMessage{
+		Message:   *msg,
+		Signature: fapi.signature,
+	}, fapi.pushMessageErr
+}
+
+func addFundsMsg(toAdd abi.TokenAmount, addr address.Address, wallet address.Address) *types.Message {
+	params, _ := actors.SerializeParams(&addr)
+	return &types.Message{
+		To:     builtin.StorageMarketActorAddr,
+		From:   wallet,
+		Value:  toAdd,
+		Method: builtin.MethodsMarket.AddBalance,
+		Params: params,
+	}
+}
+
+type expectedResult struct {
+	addAmt    abi.TokenAmount
+	shouldAdd bool
+	err       error
+}
+
+func TestAddFunds(t *testing.T) {
+	ctx := context.Background()
+	testCases := map[string]struct {
+		returnedBalanceErr error
+		returnedBalance    api.MarketBalance
+		addAmounts         []abi.TokenAmount
+		pushMessageErr     error
+		expectedResults    []expectedResult
+	}{
+		"succeeds, trivial case": {
+			returnedBalance: api.MarketBalance{Escrow: abi.NewTokenAmount(0), Locked: abi.NewTokenAmount(0)},
+			addAmounts:      []abi.TokenAmount{abi.NewTokenAmount(100)},
+			expectedResults: []expectedResult{
+				{
+					addAmt:    abi.NewTokenAmount(100),
+					shouldAdd: true,
+					err:       nil,
+				},
+			},
+		},
+		"succeeds, money already present": {
+			returnedBalance: api.MarketBalance{Escrow: abi.NewTokenAmount(150), Locked: abi.NewTokenAmount(50)},
+			addAmounts:      []abi.TokenAmount{abi.NewTokenAmount(100)},
+			expectedResults: []expectedResult{
+				{
+					shouldAdd: false,
+					err:       nil,
+				},
+			},
+		},
+		"succeeds, multiple adds": {
+			returnedBalance: api.MarketBalance{Escrow: abi.NewTokenAmount(150), Locked: abi.NewTokenAmount(50)},
+			addAmounts:      []abi.TokenAmount{abi.NewTokenAmount(100), abi.NewTokenAmount(200), abi.NewTokenAmount(250), abi.NewTokenAmount(250)},
+			expectedResults: []expectedResult{
+				{
+					shouldAdd: false,
+					err:       nil,
+				},
+				{
+					addAmt:    abi.NewTokenAmount(100),
+					shouldAdd: true,
+					err:       nil,
+				},
+				{
+					addAmt:    abi.NewTokenAmount(50),
+					shouldAdd: true,
+					err:       nil,
+				},
+				{
+					shouldAdd: false,
+					err:       nil,
+				},
+			},
+		},
+		"error on market balance": {
+			returnedBalanceErr: errors.New("something went wrong"),
+			addAmounts:         []abi.TokenAmount{abi.NewTokenAmount(100)},
+			expectedResults: []expectedResult{
+				{
+					err: errors.New("something went wrong"),
+				},
+			},
+		},
+		"error on push message": {
+			returnedBalance: api.MarketBalance{Escrow: abi.NewTokenAmount(0), Locked: abi.NewTokenAmount(0)},
+			pushMessageErr:  errors.New("something went wrong"),
+			addAmounts:      []abi.TokenAmount{abi.NewTokenAmount(100)},
+			expectedResults: []expectedResult{
+				{
+					err: errors.New("something went wrong"),
+				},
+			},
+		},
+	}
+
+	for testCase, data := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			sig := make([]byte, 100)
+			_, err := rand.Read(sig)
+			require.NoError(t, err)
+			fapi := &fakeAPI{
+				returnedBalance:    data.returnedBalance,
+				returnedBalanceErr: data.returnedBalanceErr,
+				signature: crypto.Signature{
+					Type: crypto.SigTypeUnknown,
+					Data: sig,
+				},
+				pushMessageErr: data.pushMessageErr,
+			}
+			fundMgr := newFundMgr(fapi)
+			addr := tutils.NewIDAddr(t, uint64(rand.Uint32()))
+			wallet := tutils.NewIDAddr(t, uint64(rand.Uint32()))
+			for i, amount := range data.addAmounts {
+				fapi.receivedMessage = nil
+				_, err := fundMgr.EnsureAvailable(ctx, addr, wallet, amount)
+				expected := data.expectedResults[i]
+				if expected.err == nil {
+					require.NoError(t, err)
+					if expected.shouldAdd {
+						expectedMessage := addFundsMsg(expected.addAmt, addr, wallet)
+						require.Equal(t, expectedMessage, fapi.receivedMessage)
+					} else {
+						require.Nil(t, fapi.receivedMessage)
+					}
+				} else {
+					require.EqualError(t, err, expected.err.Error())
+				}
+			}
+		})
+	}
+}

--- a/node/builder.go
+++ b/node/builder.go
@@ -3,8 +3,9 @@ package node
 import (
 	"context"
 	"errors"
-	"github.com/filecoin-project/lotus/markets/dealfilter"
 	"time"
+
+	"github.com/filecoin-project/lotus/markets/dealfilter"
 
 	logging "github.com/ipfs/go-log"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
@@ -274,7 +275,7 @@ func Online() Option {
 
 			Override(new(*paychmgr.Store), paychmgr.NewStore),
 			Override(new(*paychmgr.Manager), paychmgr.NewManager),
-			Override(new(*market.FundMgr), market.NewFundMgr),
+			Override(new(*market.FundMgr), market.StartFundManager),
 			Override(SettlePaymentChannelsKey, settler.SettlePaymentChannels),
 		),
 


### PR DESCRIPTION
# Goals

Match the operations of the FundMgr comprehensively with the expectations of the markets module.

The markets module is responsible for how much money is needed for deals in progress. The FundMgr now has a single responsibility: track how much is actually in the storage market actor for each address and add funds as needed when EnsureAvailable is called.

# Implementation

- Added a new state predicate for the StateChanged events API to track changes in market balances. This is comprised of StatePredicates.OnBalanceChanged and StatePredicate.AvailableBalanceChangedForAddresses, which compose with each other on top of StatePredicates.OnStorageMarketActorChanged. AvaialbleBalanceChangedForAddresses takes a function which returns an array of addresses to evaluate on each new change in tipset.
- Modified EnsureAvailable to:
   - read the available balance from state as needed
   - calculate the difference in available vs requested to determine if funds are added
   - pre-update available AHEAD of actually receiving a message that the chain message to add went through (if it fails will get reverted by the chain events monitor)
   - not "deduct" from available the amount to add.
- Add a setup function to setup monitoring of balances for the FundMgr
   - when balances change, always overwrite our local value (chain is authoritative)

# For Discussion

There is an edge case not covered here:

StartingTotal = 0,
EnsureAvailable(50)
EnsureAvailable(100)

will submit two messages to the chain, each for 50 (again, available updates ahead of the chain)

if the first submit fails, we end up with only 50 total. Should we track failures and resubmit? Probably. This is still an improvement over previous.