### PR TITLE
Check for p2p protocol in miner set-addrs

### DIFF
--- a/cmd/lotus-storage-miner/actor.go
+++ b/cmd/lotus-storage-miner/actor.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
@@ -52,6 +52,15 @@ var actorSetAddrsCmd = &cli.Command{
 			maddr, err := ma.NewMultiaddr(a)
 			if err != nil {
 				return fmt.Errorf("failed to parse %q as a multiaddr: %w", a, err)
+			}
+
+			_, err = maddr.ValueForProtocol(ma.P_P2P)
+			switch err {
+			case ma.ErrProtocolNotFound:
+				return xerrors.Errorf("multiaddr must end with /p2p/[PeerID]")
+			case nil:
+			default:
+				return xerrors.Errorf("looking for /p2p/ protocol in multiaddr: %w", err)
 			}
 
 			addrs = append(addrs, maddr.Bytes())


### PR DESCRIPTION
_Should guard from some user error_

_(alternatively we could auto-append /p2p/peerid using miner info)_

---

Actually digging into this, those seem to be passed straight into `Peerstore().AddAddrs(p peer.ID, addrs []ma.Multiaddr, ttl time.Duration)`, and I'm not 100% sure if that needs the /p2p/ prefix (or if it maybe even expects it to not be there)

(plus leaving out /p2p/ makes sense anyways, as we basically duplicate the PeerID on chain)