### PR TITLE
Pass bitfields by-value

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -274,11 +274,11 @@ type FullNode interface {
 	// StateMinerPartitions loads miner partitions for the specified miner/deadline
 	StateMinerPartitions(context.Context, address.Address, uint64, types.TipSetKey) ([]*miner.Partition, error)
 	// StateMinerFaults returns a bitfield indicating the faulty sectors of the given miner
-	StateMinerFaults(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)
+	StateMinerFaults(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)
 	// StateAllMinerFaults returns all non-expired Faults that occur within lookback epochs of the given tipset
 	StateAllMinerFaults(ctx context.Context, lookback abi.ChainEpoch, ts types.TipSetKey) ([]*Fault, error)
 	// StateMinerRecoveries returns a bitfield indicating the recovering sectors of the given miner
-	StateMinerRecoveries(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)
+	StateMinerRecoveries(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)
 	// StateMinerInitialPledgeCollateral returns the precommit deposit for the specified miner's sector
 	StateMinerPreCommitDepositForPower(context.Context, address.Address, miner.SectorPreCommitInfo, types.TipSetKey) (types.BigInt, error)
 	// StateMinerInitialPledgeCollateral returns the initial pledge collateral for the specified miner's sector

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -139,9 +139,9 @@ type FullNodeStruct struct {
 		StateMinerInfo                     func(context.Context, address.Address, types.TipSetKey) (api.MinerInfo, error)                                      `perm:"read"`
 		StateMinerDeadlines                func(context.Context, address.Address, types.TipSetKey) ([]*miner.Deadline, error)                                  `perm:"read"`
 		StateMinerPartitions               func(context.Context, address.Address, uint64, types.TipSetKey) ([]*miner.Partition, error)                         `perm:"read"`
-		StateMinerFaults                   func(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)                                      `perm:"read"`
+		StateMinerFaults                   func(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)                                       `perm:"read"`
 		StateAllMinerFaults                func(context.Context, abi.ChainEpoch, types.TipSetKey) ([]*api.Fault, error)                                        `perm:"read"`
-		StateMinerRecoveries               func(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)                                      `perm:"read"`
+		StateMinerRecoveries               func(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)                                       `perm:"read"`
 		StateMinerPreCommitDepositForPower func(context.Context, address.Address, miner.SectorPreCommitInfo, types.TipSetKey) (types.BigInt, error)            `perm:"read"`
 		StateMinerInitialPledgeCollateral  func(context.Context, address.Address, miner.SectorPreCommitInfo, types.TipSetKey) (types.BigInt, error)            `perm:"read"`
 		StateMinerAvailableBalance         func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)                                       `perm:"read"`
@@ -641,7 +641,7 @@ func (c *FullNodeStruct) StateMinerPartitions(ctx context.Context, m address.Add
 	return c.Internal.StateMinerPartitions(ctx, m, dlIdx, tsk)
 }
 
-func (c *FullNodeStruct) StateMinerFaults(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*abi.BitField, error) {
+func (c *FullNodeStruct) StateMinerFaults(ctx context.Context, actor address.Address, tsk types.TipSetKey) (abi.BitField, error) {
 	return c.Internal.StateMinerFaults(ctx, actor, tsk)
 }
 
@@ -649,7 +649,7 @@ func (c *FullNodeStruct) StateAllMinerFaults(ctx context.Context, cutoff abi.Cha
 	return c.Internal.StateAllMinerFaults(ctx, cutoff, endTsk)
 }
 
-func (c *FullNodeStruct) StateMinerRecoveries(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*abi.BitField, error) {
+func (c *FullNodeStruct) StateMinerRecoveries(ctx context.Context, actor address.Address, tsk types.TipSetKey) (abi.BitField, error) {
 	return c.Internal.StateMinerRecoveries(ctx, actor, tsk)
 }
 

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -175,7 +175,7 @@ func GetMinerSectorSet(ctx context.Context, sm *StateManager, ts *types.TipSet, 
 }
 
 func GetSectorsForWinningPoSt(ctx context.Context, pv ffiwrapper.Verifier, sm *StateManager, st cid.Cid, maddr address.Address, rand abi.PoStRandomness) ([]abi.SectorInfo, error) {
-	var partsProving []*abi.BitField
+	var partsProving []abi.BitField
 	var mas *miner.State
 	var info *miner.MinerInfo
 

--- a/cmd/lotus-chainwatch/processor/miner.go
+++ b/cmd/lotus-chainwatch/processor/miner.go
@@ -166,11 +166,11 @@ type SectorDealEvent struct {
 }
 
 type PartitionStatus struct {
-	Terminated *abi.BitField
-	Expired    *abi.BitField
-	Faulted    *abi.BitField
-	InRecovery *abi.BitField
-	Recovered  *abi.BitField
+	Terminated abi.BitField
+	Expired    abi.BitField
+	Faulted    abi.BitField
+	InRecovery abi.BitField
+	Recovered  abi.BitField
 }
 
 type minerActorInfo struct {
@@ -798,7 +798,7 @@ func (p *Processor) diffPartition(prevPart, curPart miner.Partition) (*Partition
 	var bf abi.BitField
 	if err := terminatedEarlyArr.ForEach(&bf, func(i int64) error {
 		// expired = all removals - termination
-		expirations, err := bitfield.SubtractBitField(allRemovedSectors, &bf)
+		expirations, err := bitfield.SubtractBitField(allRemovedSectors, bf)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200716204036-cddc56607e1d
 	github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.1-0.20200731171407-e559a0579161 // indirect
-	github.com/filecoin-project/go-bitfield v0.1.2
+	github.com/filecoin-project/go-bitfield v0.1.3-0.20200805071222-16784e5f3968
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.5.3
@@ -35,7 +35,7 @@ require (
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200803184904-3cab915fd225
-	github.com/filecoin-project/specs-actors v0.8.6
+	github.com/filecoin-project/specs-actors v0.8.7-0.20200805072549-147f83952ccd
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea
 	github.com/filecoin-project/storage-fsm v0.0.0-20200730122205-d423ae90d8d4
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/filecoin-project/go-bitfield v0.0.3/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4G
 github.com/filecoin-project/go-bitfield v0.0.4-0.20200703174658-f4a5758051a1/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
 github.com/filecoin-project/go-bitfield v0.1.2 h1:TjLregCoyP1/5lm7WCM0axyV1myIHwbjGa21skuu5tk=
 github.com/filecoin-project/go-bitfield v0.1.2/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
+github.com/filecoin-project/go-bitfield v0.1.3-0.20200805071222-16784e5f3968 h1:Vvs2Pv1eopwSOC5XyPfsscaoIjjyQjOY888ipNJxh1U=
+github.com/filecoin-project/go-bitfield v0.1.3-0.20200805071222-16784e5f3968/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
@@ -271,8 +273,8 @@ github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8o
 github.com/filecoin-project/specs-actors v0.7.3-0.20200716231407-60a2ae96d2e6/go.mod h1:JOMUa7EijvpOO4ofD1yeHNmqohkmmnhTvz/IpB6so4c=
 github.com/filecoin-project/specs-actors v0.8.2/go.mod h1:Q3ACV5kBLvqPaYbthc/J1lGMJ5OwogmD9pzdtPRMdCw=
 github.com/filecoin-project/specs-actors v0.8.5/go.mod h1:Q3ACV5kBLvqPaYbthc/J1lGMJ5OwogmD9pzdtPRMdCw=
-github.com/filecoin-project/specs-actors v0.8.6 h1:EnmrHqpzURzGeSDbeui/snQTVzl/RXoSEgAf5xMREaI=
-github.com/filecoin-project/specs-actors v0.8.6/go.mod h1:QRihI/fadrhWzt7HH6mT32upOdDFpSYCFnr3JEI1L50=
+github.com/filecoin-project/specs-actors v0.8.7-0.20200805072549-147f83952ccd h1:AQCvF/q+zNiCPBBy2aDlxkSwu3cTMfoGoGNdrtyNt1Q=
+github.com/filecoin-project/specs-actors v0.8.7-0.20200805072549-147f83952ccd/go.mod h1:d3wWKFGO9LR89j5u3yaSJucKD7r8SrBCHEoPW1lHc9g=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea h1:iixjULRQFPn7Q9KlIqfwLJnlAXO10bbkI+xy5GKGdLY=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=
 github.com/filecoin-project/storage-fsm v0.0.0-20200730122205-d423ae90d8d4 h1:Eg7Ia3iRWKMXpS7bU8ufarQJyGsBor7eGgfrAHfn8HA=

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -74,7 +74,7 @@ func (a *StateAPI) StateMinerActiveSectors(ctx context.Context, maddr address.Ad
 	err := a.StateManager.WithParentStateTsk(tsk,
 		a.StateManager.WithActor(maddr,
 			a.StateManager.WithActorState(ctx, func(store adt.Store, mas *miner.State) error {
-				var allActive []*abi.BitField
+				var allActive []abi.BitField
 
 				err := a.StateManager.WithDeadlines(
 					a.StateManager.WithEachDeadline(
@@ -96,7 +96,7 @@ func (a *StateAPI) StateMinerActiveSectors(ctx context.Context, maddr address.Ad
 					return xerrors.Errorf("merging active sector bitfields: %w", err)
 				}
 
-				out, err = stmgr.LoadSectorsFromSet(ctx, a.Chain.Blockstore(), mas.Sectors, active, false)
+				out, err = stmgr.LoadSectorsFromSet(ctx, a.Chain.Blockstore(), mas.Sectors, &active, false)
 				return err
 			})))
 	if err != nil {
@@ -160,7 +160,7 @@ func (a *StateAPI) StateMinerProvingDeadline(ctx context.Context, addr address.A
 	return mas.DeadlineInfo(ts.Height()).NextNotElapsed(), nil
 }
 
-func (a *StateAPI) StateMinerFaults(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.BitField, error) {
+func (a *StateAPI) StateMinerFaults(ctx context.Context, addr address.Address, tsk types.TipSetKey) (abi.BitField, error) {
 	out := abi.NewBitField()
 
 	err := a.StateManager.WithParentStateTsk(tsk,
@@ -173,7 +173,7 @@ func (a *StateAPI) StateMinerFaults(ctx context.Context, addr address.Address, t
 							return err
 						}))))))
 	if err != nil {
-		return nil, err
+		return bitfield.BitField{}, err
 	}
 
 	return out, err
@@ -203,7 +203,7 @@ func (a *StateAPI) StateAllMinerFaults(ctx context.Context, lookback abi.ChainEp
 			return nil, xerrors.Errorf("failed to load miner actor state %s: %w", m, err)
 		}
 
-		err = mas.ForEachFaultEpoch(a.Chain.Store(ctx), func(faultStart abi.ChainEpoch, faults *abi.BitField) error {
+		err = mas.ForEachFaultEpoch(a.Chain.Store(ctx), func(faultStart abi.ChainEpoch, faults abi.BitField) error {
 			if faultStart >= cutoff {
 				allFaults = append(allFaults, &api.Fault{
 					Miner: m,
@@ -222,7 +222,7 @@ func (a *StateAPI) StateAllMinerFaults(ctx context.Context, lookback abi.ChainEp
 	return allFaults, nil*/
 }
 
-func (a *StateAPI) StateMinerRecoveries(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.BitField, error) {
+func (a *StateAPI) StateMinerRecoveries(ctx context.Context, addr address.Address, tsk types.TipSetKey) (abi.BitField, error) {
 	out := abi.NewBitField()
 
 	err := a.StateManager.WithParentStateTsk(tsk,
@@ -235,7 +235,7 @@ func (a *StateAPI) StateMinerRecoveries(ctx context.Context, addr address.Addres
 							return err
 						}))))))
 	if err != nil {
-		return nil, err
+		return bitfield.BitField{}, err
 	}
 
 	return out, err
@@ -666,7 +666,7 @@ func (a *StateAPI) StateMinerSectorCount(ctx context.Context, addr address.Addre
 	err := a.StateManager.WithParentStateTsk(tsk,
 		a.StateManager.WithActor(addr,
 			a.StateManager.WithActorState(ctx, func(store adt.Store, mas *miner.State) error {
-				var allActive []*abi.BitField
+				var allActive []abi.BitField
 
 				err := a.StateManager.WithDeadlines(
 					a.StateManager.WithEachDeadline(

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -62,8 +62,8 @@ type storageMinerApi interface {
 	StateGetActor(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error)
 	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
 	StateMarketStorageDeal(context.Context, abi.DealID, types.TipSetKey) (*api.MarketDeal, error)
-	StateMinerFaults(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)
-	StateMinerRecoveries(context.Context, address.Address, types.TipSetKey) (*abi.BitField, error)
+	StateMinerFaults(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)
+	StateMinerRecoveries(context.Context, address.Address, types.TipSetKey) (abi.BitField, error)
 
 	MpoolPushMessage(context.Context, *types.Message) (*types.SignedMessage, error)
 

--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -63,15 +63,15 @@ func (s *WindowPoStScheduler) doPost(ctx context.Context, deadline *miner.Deadli
 	}()
 }
 
-func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check *abi.BitField) (*abi.BitField, error) {
+func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check abi.BitField) (abi.BitField, error) {
 	spt, err := s.proofType.RegisteredSealProof()
 	if err != nil {
-		return nil, xerrors.Errorf("getting seal proof type: %w", err)
+		return bitfield.BitField{}, xerrors.Errorf("getting seal proof type: %w", err)
 	}
 
 	mid, err := address.IDFromAddress(s.actor)
 	if err != nil {
-		return nil, err
+		return bitfield.BitField{}, err
 	}
 
 	sectors := make(map[abi.SectorID]struct{})
@@ -87,12 +87,12 @@ func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check *abi.BitFi
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("iterating over bitfield: %w", err)
+		return bitfield.BitField{}, xerrors.Errorf("iterating over bitfield: %w", err)
 	}
 
 	bad, err := s.faultTracker.CheckProvable(ctx, spt, tocheck)
 	if err != nil {
-		return nil, xerrors.Errorf("checking provable sectors: %w", err)
+		return bitfield.BitField{}, xerrors.Errorf("checking provable sectors: %w", err)
 	}
 	for _, id := range bad {
 		delete(sectors, id)
@@ -102,10 +102,10 @@ func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check *abi.BitFi
 
 	sbf := bitfield.New()
 	for s := range sectors {
-		(&sbf).Set(uint64(s.Number))
+		sbf.Set(uint64(s.Number))
 	}
 
-	return &sbf, nil
+	return sbf, nil
 }
 
 func (s *WindowPoStScheduler) checkNextRecoveries(ctx context.Context, dlIdx uint64, partitions []*miner.Partition) error {
@@ -427,8 +427,8 @@ func (s *WindowPoStScheduler) runPost(ctx context.Context, di miner.DeadlineInfo
 	return params, nil
 }
 
-func (s *WindowPoStScheduler) sectorInfo(ctx context.Context, deadlineSectors *abi.BitField, ts *types.TipSet) ([]abi.SectorInfo, error) {
-	sset, err := s.api.StateMinerSectors(ctx, s.actor, deadlineSectors, false, ts.Key())
+func (s *WindowPoStScheduler) sectorInfo(ctx context.Context, deadlineSectors abi.BitField, ts *types.TipSet) ([]abi.SectorInfo, error) {
+	sset, err := s.api.StateMinerSectors(ctx, s.actor, &deadlineSectors, false, ts.Key())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This ensures we can't end up decoding nil bitfields from clients when not expecting them.

Part of https://github.com/filecoin-project/specs-actors/issues/895. Please see this issue for details and leave any comments there.

Depends on https://github.com/filecoin-project/specs-actors/pull/900.