### PR TITLE
Update markets to resolve dialing errors

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -8,6 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -523,7 +524,7 @@ type QueryOffer struct {
 	PaymentInterval         uint64
 	PaymentIntervalIncrease uint64
 	Miner                   address.Address
-	MinerPeerID             peer.ID
+	MinerPeer               retrievalmarket.RetrievalPeer
 }
 
 func (o *QueryOffer) Order(client address.Address) RetrievalOrder {
@@ -537,8 +538,8 @@ func (o *QueryOffer) Order(client address.Address) RetrievalOrder {
 		PaymentIntervalIncrease: o.PaymentIntervalIncrease,
 		Client:                  client,
 
-		Miner:       o.Miner,
-		MinerPeerID: o.MinerPeerID,
+		Miner:     o.Miner,
+		MinerPeer: o.MinerPeer,
 	}
 }
 
@@ -564,7 +565,7 @@ type RetrievalOrder struct {
 	PaymentIntervalIncrease uint64
 	Client                  address.Address
 	Miner                   address.Address
-	MinerPeerID             peer.ID
+	MinerPeer               retrievalmarket.RetrievalPeer
 }
 
 type InvocResult struct {

--- a/cli/client.go
+++ b/cli/client.go
@@ -689,10 +689,10 @@ var clientFindCmd = &cli.Command{
 
 		for _, offer := range offers {
 			if offer.Err != "" {
-				fmt.Printf("ERR %s@%s: %s\n", offer.Miner, offer.MinerPeerID, offer.Err)
+				fmt.Printf("ERR %s@%s: %s\n", offer.Miner, offer.MinerPeer.ID, offer.Err)
 				continue
 			}
-			fmt.Printf("RETRIEVAL %s@%s-%s-%s\n", offer.Miner, offer.MinerPeerID, types.FIL(offer.MinPrice), types.SizeStr(types.NewInt(offer.Size)))
+			fmt.Printf("RETRIEVAL %s@%s-%s-%s\n", offer.Miner, offer.MinerPeer.ID, types.FIL(offer.MinPrice), types.SizeStr(types.NewInt(offer.Size)))
 		}
 
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.5.3
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f
-	github.com/filecoin-project/go-fil-markets v0.5.3
+	github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648
 	github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.5.3
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f
-	github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648
+	github.com/filecoin-project/go-fil-markets v0.5.4
 	github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6

--- a/go.sum
+++ b/go.sum
@@ -241,10 +241,8 @@ github.com/filecoin-project/go-data-transfer v0.5.3/go.mod h1:30ROzlBS8tbTkszmW9
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1:GxJzR3oRIMTPtpZ0b7QF8FKPK6/iPAc7trhlL5k/g+s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
-github.com/filecoin-project/go-fil-markets v0.5.3 h1:BjEfUIe/ov95jt7K9m9F/ZEJsvdlJAstSPfNyBXcPd0=
-github.com/filecoin-project/go-fil-markets v0.5.3/go.mod h1:RNaiPhWF8xPrb9oUWJK7FGfD1jkdsk4XjCwczKpwnX0=
-github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648 h1:JdxaUXnFUNLAu6K0ollDponhqg6q4h6vv9IMwtJEEKM=
-github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648/go.mod h1:RNaiPhWF8xPrb9oUWJK7FGfD1jkdsk4XjCwczKpwnX0=
+github.com/filecoin-project/go-fil-markets v0.5.4 h1:FuK7vSpWFN/sD3rMpP33rk8LbCcx/GUdqn4hUI5M+Ys=
+github.com/filecoin-project/go-fil-markets v0.5.4/go.mod h1:RNaiPhWF8xPrb9oUWJK7FGfD1jkdsk4XjCwczKpwnX0=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24 h1:Jc7vkplmZYVuaEcSXGHDwefvZIdoyyaoGDLqSr8Svms=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24/go.mod h1:j6zV//WXIIY5kky873Q3iIKt/ViOE8rcijovmpxrXzM=
 github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-markets v0.5.3 h1:BjEfUIe/ov95jt7K9m9F/ZEJsvdlJAstSPfNyBXcPd0=
 github.com/filecoin-project/go-fil-markets v0.5.3/go.mod h1:RNaiPhWF8xPrb9oUWJK7FGfD1jkdsk4XjCwczKpwnX0=
+github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648 h1:JdxaUXnFUNLAu6K0ollDponhqg6q4h6vv9IMwtJEEKM=
+github.com/filecoin-project/go-fil-markets v0.5.4-0.20200805221213-333079b9f648/go.mod h1:RNaiPhWF8xPrb9oUWJK7FGfD1jkdsk4XjCwczKpwnX0=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24 h1:Jc7vkplmZYVuaEcSXGHDwefvZIdoyyaoGDLqSr8Svms=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24/go.mod h1:j6zV//WXIIY5kky873Q3iIKt/ViOE8rcijovmpxrXzM=
 github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=

--- a/markets/retrievaladapter/client.go
+++ b/markets/retrievaladapter/client.go
@@ -12,24 +12,27 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multiaddr"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/impl/full"
 	payapi "github.com/filecoin-project/lotus/node/impl/paych"
 	"github.com/filecoin-project/lotus/paychmgr"
 )
 
 type retrievalClientNode struct {
-	chainapi full.ChainAPI
+	chainAPI full.ChainAPI
 	pmgr     *paychmgr.Manager
-	payapi   payapi.PaychAPI
+	payAPI   payapi.PaychAPI
+	stateAPI full.StateAPI
 }
 
 // NewRetrievalClientNode returns a new node adapter for a retrieval client that talks to the
 // Lotus Node
-func NewRetrievalClientNode(pmgr *paychmgr.Manager, payapi payapi.PaychAPI, chainapi full.ChainAPI) retrievalmarket.RetrievalClientNode {
-	return &retrievalClientNode{pmgr: pmgr, payapi: payapi, chainapi: chainapi}
+func NewRetrievalClientNode(pmgr *paychmgr.Manager, payAPI payapi.PaychAPI, chainAPI full.ChainAPI, stateAPI full.StateAPI) retrievalmarket.RetrievalClientNode {
+	return &retrievalClientNode{pmgr: pmgr, payAPI: payAPI, chainAPI: chainAPI, stateAPI: stateAPI}
 }
 
 // GetOrCreatePaymentChannel sets up a new payment channel if one does not exist
@@ -54,7 +57,7 @@ func (rcn *retrievalClientNode) AllocateLane(paymentChannel address.Address) (ui
 func (rcn *retrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64, tok shared.TipSetToken) (*paych.SignedVoucher, error) {
 	// TODO: respect the provided TipSetToken (a serialized TipSetKey) when
 	// querying the chain
-	voucher, err := rcn.payapi.PaychVoucherCreate(ctx, paymentChannel, amount, lane)
+	voucher, err := rcn.payAPI.PaychVoucherCreate(ctx, paymentChannel, amount, lane)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +65,7 @@ func (rcn *retrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymen
 }
 
 func (rcn *retrievalClientNode) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
-	head, err := rcn.chainapi.ChainHead(ctx)
+	head, err := rcn.chainAPI.ChainHead(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -73,7 +76,7 @@ func (rcn *retrievalClientNode) GetChainHead(ctx context.Context) (shared.TipSet
 // WaitForPaymentChannelAddFunds waits messageCID to appear on chain. If it doesn't appear within
 // defaultMsgWaitTimeout it returns error
 func (rcn *retrievalClientNode) WaitForPaymentChannelAddFunds(messageCID cid.Cid) error {
-	_, mr, err := rcn.chainapi.StateManager.WaitForMessage(context.TODO(), messageCID, build.MessageConfidence)
+	_, mr, err := rcn.chainAPI.StateManager.WaitForMessage(context.TODO(), messageCID, build.MessageConfidence)
 
 	if err != nil {
 		return err
@@ -85,7 +88,7 @@ func (rcn *retrievalClientNode) WaitForPaymentChannelAddFunds(messageCID cid.Cid
 }
 
 func (rcn *retrievalClientNode) WaitForPaymentChannelCreation(messageCID cid.Cid) (address.Address, error) {
-	_, mr, err := rcn.chainapi.StateManager.WaitForMessage(context.TODO(), messageCID, build.MessageConfidence)
+	_, mr, err := rcn.chainAPI.StateManager.WaitForMessage(context.TODO(), messageCID, build.MessageConfidence)
 
 	if err != nil {
 		return address.Undef, err
@@ -98,4 +101,25 @@ func (rcn *retrievalClientNode) WaitForPaymentChannelCreation(messageCID cid.Cid
 		return address.Undef, err
 	}
 	return retval.RobustAddress, nil
+}
+
+func (rcn *retrievalClientNode) GetKnownAddresses(ctx context.Context, p retrievalmarket.RetrievalPeer, encodedTs shared.TipSetToken) ([]multiaddr.Multiaddr, error) {
+	tsk, err := types.TipSetKeyFromBytes(encodedTs)
+	if err != nil {
+		return nil, err
+	}
+	mi, err := rcn.stateAPI.StateMinerInfo(ctx, p.Address, tsk)
+	if err != nil {
+		return nil, err
+	}
+	multiaddrs := make([]multiaddr.Multiaddr, 0, len(mi.Multiaddrs))
+	for _, a := range mi.Multiaddrs {
+		maddr, err := multiaddr.NewMultiaddrBytes(a)
+		if err != nil {
+			return nil, err
+		}
+		multiaddrs = append(multiaddrs, maddr)
+	}
+
+	return multiaddrs, nil
 }

--- a/node/modules/client.go
+++ b/node/modules/client.go
@@ -141,8 +141,8 @@ func StorageClient(lc fx.Lifecycle, h host.Host, ibs dtypes.ClientBlockstore, md
 }
 
 // RetrievalClient creates a new retrieval client attached to the client blockstore
-func RetrievalClient(lc fx.Lifecycle, h host.Host, mds dtypes.ClientMultiDstore, dt dtypes.ClientDataTransfer, pmgr *paychmgr.Manager, payapi payapi.PaychAPI, resolver retrievalmarket.PeerResolver, ds dtypes.MetadataDS, chainapi full.ChainAPI) (retrievalmarket.RetrievalClient, error) {
-	adapter := retrievaladapter.NewRetrievalClientNode(pmgr, payapi, chainapi)
+func RetrievalClient(lc fx.Lifecycle, h host.Host, mds dtypes.ClientMultiDstore, dt dtypes.ClientDataTransfer, pmgr *paychmgr.Manager, payAPI payapi.PaychAPI, resolver retrievalmarket.PeerResolver, ds dtypes.MetadataDS, chainAPI full.ChainAPI, stateAPI full.StateAPI) (retrievalmarket.RetrievalClient, error) {
+	adapter := retrievaladapter.NewRetrievalClientNode(pmgr, payAPI, chainAPI, stateAPI)
 	network := rmnet.NewFromLibp2pHost(h)
 	sc := storedcounter.New(ds, datastore.NewKey("/retr"))
 	client, err := retrievalimpl.NewClient(network, mds, dt, adapter, resolver, namespace.Wrap(ds, datastore.NewKey("/retrievals/client")), sc)


### PR DESCRIPTION
# Goals

Resolve dialing errors via https://github.com/filecoin-project/go-fil-markets/pull/356

# Implementation

- Implement GetKnownAddresses on RetrievalClientNode adapter
- Convert to passing around the full retrieval peer in the API structs
- Sorry @arajasek it ended up not making sense to have a RetrievalProviderInfo given we already have a RetrievalPeer and it just started to get confusing with too many structs