### PR TITLE
Fix collectHeaders when incoming is partially built on latest tipset

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1265,7 +1265,7 @@ loop:
 	}
 
 	// base is the tipset in the candidate chain at the height equal to our known tipset height.
-	if base := blockSet[len(blockSet)-1]; !types.CidArrsEqual(base.Parents().Cids(), known.Cids()) {
+	if base := blockSet[len(blockSet)-1]; !types.CidArrsSubset(base.Parents().Cids(), known.Cids()) {
 		if base.Parents() == known.Parents() {
 			// common case: receiving a block thats potentially part of the same tipset as our best block
 			return blockSet, nil

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -175,6 +175,21 @@ func CidArrsEqual(a, b []cid.Cid) bool {
 	return true
 }
 
+func CidArrsSubset(a, b []cid.Cid) bool {
+	// order ignoring compare...
+	s := make(map[cid.Cid]bool)
+	for _, c := range b {
+		s[c] = true
+	}
+
+	for _, c := range a {
+		if !s[c] {
+			return false
+		}
+	}
+	return true
+}
+
 func CidArrsContains(a []cid.Cid, b cid.Cid) bool {
 	for _, elem := range a {
 		if elem.Equals(b) {


### PR DESCRIPTION
Without this, we can wind up requesting blocks from peers that we already have (and potentially failing to sync a valid block if that fails for some reason)