### PR TITLE
release: write full sha512sum output to file

### DIFF
--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -45,8 +45,8 @@ do
     popd
     rm -rf "${ARCH}"
 
-    sha512sum "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" | cut -d" " -f1 > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.sha512"
+    sha512sum "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.sha512"
 
-    ipfs add "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" | cut -d" " -f2 > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.cid"
+    ipfs add -q "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.cid"
 done
 popd


### PR DESCRIPTION
With the full output written to the file, users can verify the tar.gz integrity with `sha512sum -c <release>.tar.gz.sha512`