### PR TITLE
Panic if there's a datastore err when writing state to datastore after chain msg

### DIFF
--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -400,20 +400,20 @@ func (ca *channelAccessor) waitAddFundsMsg(channelID string, mcid cid.Cid) error
 func (ca *channelAccessor) mutateChannelInfo(channelID string, mutate func(*ChannelInfo)) {
 	channelInfo, err := ca.store.ByChannelID(channelID)
 
-	// If there's an error reading or writing to the store just log an error.
+	// Panic if there's an error reading or writing to the store.
 	// For now we're assuming it's unlikely to happen in practice.
 	// Later we may want to implement a transactional approach, whereby
 	// we record to the store that we're going to send a message, send
 	// the message, and then record that the message was sent.
 	if err != nil {
-		log.Errorf("Error reading channel info from store: %s", err)
+		panic(fmt.Sprintf("Error reading channel info from store: %s", err))
 	}
 
 	mutate(channelInfo)
 
 	err = ca.store.putChannelInfo(channelInfo)
 	if err != nil {
-		log.Errorf("Error writing channel info to store: %s", err)
+		panic(fmt.Sprintf("Error writing channel info to store: %s", err))
 	}
 }
 


### PR DESCRIPTION
Currently when we send a create channel or add funds message to chain, we write a record of that message into the datastore, so that if lotus is shutdown or crashes, we can start tracking the message again when lotus comes back up.

Ideally we would have a transactional mechanism in place that would
- write "sending message" to datastore
- send message
- write "message sent" to datastore

and then be able to recover from incomplete states by inspecting the datastore and the chain.

Without having this transactional mechanism in place, the correct solution is probably to panic when there's a datastore error, because otherwise the system will be in an "undefined" state.

Resolves https://github.com/filecoin-project/lotus/pull/2640#pullrequestreview-462083938