### PR TITLE
Fix CLI cmd: paych get

### DIFF
--- a/cli/paych.go
+++ b/cli/paych.go
@@ -58,12 +58,20 @@ var paychGetCmd = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
+		// Send a message to chain to create channel / add funds to existing
+		// channel
 		info, err := api.PaychGet(ctx, from, to, types.BigInt(amt))
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(info.Channel.String())
+		// Wait for the message to be confirmed
+		chAddr, err := api.PaychGetWaitReady(ctx, info.ChannelMessage)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(chAddr)
 		return nil
 	},
 }


### PR DESCRIPTION
Previously if a user ran
`lotus paych get <from> <to> <amt>`
the command would block until the channel was created and then output the created payment channel’s address.

Some blocking has been removed from lotus, so that now this command will return as soon as the message has been sent to chain, so the channel will not have been created and it will return "<empty>".

This PR causes the command to block until the channel is created / funds are available, then return the channel address.

An alternative solution we may want to explore would be:
- `paych get` returns immediately with the message CID of the “create channel” or "add funds" message
- there is an additional command to wait until the funds are available
  Note: We now have a `PaychGetWaitReady` method on the API but it’s not exposed to the CLI