### PR TITLE
mpool: Fix SelectMessages hanging

### DIFF
--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -117,7 +117,7 @@ tailLoop:
 				continue
 			}
 			// this chain needs to be trimmed
-			last = i
+			last += i
 			continue tailLoop
 		}
 


### PR DESCRIPTION
We need to add to the previous `last` value, as we are iterating over a sub-slice:
```
for i, chain := range chains[last:]
```

Without this we trim the same thing in an infinite loop