### PR TITLE
show deal list when StateMarketStorageDeal not found deal

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -974,13 +974,13 @@ var clientListDeals = &cli.Command{
 			} else {
 				onChain, err := api.StateMarketStorageDeal(ctx, v.DealID, head.Key())
 				if err != nil {
-					return err
+					deals = append(deals, deal{ LocalDeal: v, })
+				} else {
+					deals = append(deals, deal{
+						LocalDeal:        v,
+						OnChainDealState: onChain.State,
+					})
 				}
-
-				deals = append(deals, deal{
-					LocalDeal:        v,
-					OnChainDealState: onChain.State,
-				})
 			}
 		}
 


### PR DESCRIPTION
When I exec `lotus client list-deals`, I got the result: `ERROR: deal 6417 not found`, which made me unable to check my other deal.