### PR TITLE
Update messagepool republish logic

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-datastore/query"
 	logging "github.com/ipfs/go-log/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	lps "github.com/whyrusleeping/pubsub"
 	"golang.org/x/xerrors"
 
@@ -39,7 +40,7 @@ const futureDebug = false
 
 const RbfDenom = 256
 
-var RepublishInterval = time.Duration(build.BlockDelaySecs+build.PropagationDelaySecs) * time.Second
+var RepublishInterval = pubsub.TimeCacheDuration + time.Duration(5*build.BlockDelaySecs+build.PropagationDelaySecs)*time.Second
 
 var (
 	ErrMessageTooBig = errors.New("message too big")

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -39,6 +39,8 @@ const futureDebug = false
 
 const RbfDenom = 256
 
+var RepublishInterval = time.Duration(build.BlockDelaySecs+build.PropagationDelaySecs) * time.Second
+
 var (
 	ErrMessageTooBig = errors.New("message too big")
 
@@ -156,7 +158,7 @@ func New(api Provider, ds dtypes.MetadataDS, netName dtypes.NetworkName) (*Messa
 	mp := &MessagePool{
 		ds:            ds,
 		closer:        make(chan struct{}),
-		repubTk:       build.Clock.Ticker(time.Duration(build.BlockDelaySecs) * time.Second),
+		repubTk:       build.Clock.Ticker(RepublishInterval),
 		localAddrs:    make(map[address.Address]struct{}),
 		pending:       make(map[address.Address]*msgSet),
 		minGasPrice:   types.NewInt(0),

--- a/chain/messagepool/provider.go
+++ b/chain/messagepool/provider.go
@@ -1,0 +1,76 @@
+package messagepool
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+type Provider interface {
+	SubscribeHeadChanges(func(rev, app []*types.TipSet) error) *types.TipSet
+	PutMessage(m types.ChainMsg) (cid.Cid, error)
+	PubSubPublish(string, []byte) error
+	StateGetActor(address.Address, *types.TipSet) (*types.Actor, error)
+	StateAccountKey(context.Context, address.Address, *types.TipSet) (address.Address, error)
+	MessagesForBlock(*types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error)
+	MessagesForTipset(*types.TipSet) ([]types.ChainMsg, error)
+	LoadTipSet(tsk types.TipSetKey) (*types.TipSet, error)
+	ChainComputeBaseFee(ctx context.Context, ts *types.TipSet) (types.BigInt, error)
+}
+
+type mpoolProvider struct {
+	sm *stmgr.StateManager
+	ps *pubsub.PubSub
+}
+
+func NewProvider(sm *stmgr.StateManager, ps *pubsub.PubSub) Provider {
+	return &mpoolProvider{sm: sm, ps: ps}
+}
+
+func (mpp *mpoolProvider) SubscribeHeadChanges(cb func(rev, app []*types.TipSet) error) *types.TipSet {
+	mpp.sm.ChainStore().SubscribeHeadChanges(cb)
+	return mpp.sm.ChainStore().GetHeaviestTipSet()
+}
+
+func (mpp *mpoolProvider) PutMessage(m types.ChainMsg) (cid.Cid, error) {
+	return mpp.sm.ChainStore().PutMessage(m)
+}
+
+func (mpp *mpoolProvider) PubSubPublish(k string, v []byte) error {
+	return mpp.ps.Publish(k, v)
+}
+
+func (mpp *mpoolProvider) StateGetActor(addr address.Address, ts *types.TipSet) (*types.Actor, error) {
+	var act types.Actor
+	return &act, mpp.sm.WithParentState(ts, mpp.sm.WithActor(addr, stmgr.GetActor(&act)))
+}
+
+func (mpp *mpoolProvider) StateAccountKey(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
+	return mpp.sm.ResolveToKeyAddress(ctx, addr, ts)
+}
+
+func (mpp *mpoolProvider) MessagesForBlock(h *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {
+	return mpp.sm.ChainStore().MessagesForBlock(h)
+}
+
+func (mpp *mpoolProvider) MessagesForTipset(ts *types.TipSet) ([]types.ChainMsg, error) {
+	return mpp.sm.ChainStore().MessagesForTipset(ts)
+}
+
+func (mpp *mpoolProvider) LoadTipSet(tsk types.TipSetKey) (*types.TipSet, error) {
+	return mpp.sm.ChainStore().LoadTipSet(tsk)
+}
+
+func (mpp *mpoolProvider) ChainComputeBaseFee(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
+	baseFee, err := mpp.sm.ChainStore().ComputeBaseFee(ctx, ts)
+	if err != nil {
+		return types.NewInt(0), xerrors.Errorf("computing base fee at %s: %w", ts, err)
+	}
+	return baseFee, nil
+}

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -11,7 +11,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const repubMsgLimit = 5
+const repubMsgLimit = 30
 
 func (mp *MessagePool) republishPendingMessages() error {
 	mp.curTsLk.Lock()

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -1,0 +1,106 @@
+package messagepool
+
+import (
+	"context"
+	"sort"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+const repubMsgLimit = 5
+
+func (mp *MessagePool) republishPendingMessages() error {
+	mp.curTsLk.Lock()
+	ts := mp.curTs
+	mp.curTsLk.Unlock()
+
+	baseFee, err := mp.api.ChainComputeBaseFee(context.TODO(), ts)
+	if err != nil {
+		return xerrors.Errorf("computing basefee: %w", err)
+	}
+
+	pending := make(map[address.Address]map[uint64]*types.SignedMessage)
+	mp.lk.Lock()
+	for actor := range mp.localAddrs {
+		mset, ok := mp.pending[actor]
+		if !ok {
+			continue
+		}
+		if len(mset.msgs) == 0 {
+			continue
+		}
+		// we need to copy this while holding the lock to avoid races with concurrent modification
+		pend := make(map[uint64]*types.SignedMessage, len(mset.msgs))
+		for nonce, m := range mset.msgs {
+			pend[nonce] = m
+		}
+		pending[actor] = pend
+	}
+	mp.lk.Unlock()
+
+	if len(pending) == 0 {
+		return nil
+	}
+
+	var chains []*msgChain
+	for actor, mset := range pending {
+		next := mp.createMessageChains(actor, mset, baseFee, ts)
+		chains = append(chains, next...)
+	}
+
+	if len(chains) == 0 {
+		return nil
+	}
+
+	sort.Slice(chains, func(i, j int) bool {
+		return chains[i].Before(chains[j])
+	})
+
+	// we don't republish negative performing chains; this is an error that will be screamed
+	// at the user
+	if chains[0].gasPerf < 0 {
+		return xerrors.Errorf("skipping republish: all message chains have negative gas performance; best gas performance: %f", chains[0].gasPerf)
+	}
+
+	gasLimit := int64(build.BlockGasLimit)
+	var msgs []*types.SignedMessage
+	for _, chain := range chains {
+		// we can exceed this if we have picked (some) longer chain already
+		if len(msgs) > repubMsgLimit {
+			break
+		}
+
+		// we don't republish negative performing chains, as they won't be included in
+		// a block anyway
+		if chain.gasPerf < 0 {
+			break
+		}
+
+		// we don't exceed the block gasLimit in our republish endeavor
+		if chain.gasLimit > gasLimit {
+			break
+		}
+
+		gasLimit -= chain.gasLimit
+		msgs = append(msgs, chain.msgs...)
+	}
+
+	log.Infof("republishing %d messages", len(msgs))
+	for _, m := range msgs {
+		mb, err := m.Serialize()
+		if err != nil {
+			return xerrors.Errorf("cannot serialize message: %w", err)
+		}
+
+		err = mp.api.PubSubPublish(build.MessagesTopic(mp.netName), mb)
+		if err != nil {
+			return xerrors.Errorf("cannot publish: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -16,10 +16,10 @@ const repubMsgLimit = 30
 func (mp *MessagePool) republishPendingMessages() error {
 	mp.curTsLk.Lock()
 	ts := mp.curTs
-	mp.curTsLk.Unlock()
 
 	baseFee, err := mp.api.ChainComputeBaseFee(context.TODO(), ts)
 	if err != nil {
+		mp.curTsLk.Unlock()
 		return xerrors.Errorf("computing basefee: %w", err)
 	}
 
@@ -41,6 +41,7 @@ func (mp *MessagePool) republishPendingMessages() error {
 		pending[actor] = pend
 	}
 	mp.lk.Unlock()
+	mp.curTsLk.Unlock()
 
 	if len(pending) == 0 {
 		return nil


### PR DESCRIPTION
Republishes performant chains instead of blindly picking the first 5 messages.
Also does a small refactor to move the provider api out of the main messagepool file.