### PR TITLE
stmgr: Allow replacing gas values in WaitMsg

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -465,6 +465,7 @@ type DealInfo struct {
 }
 
 type MsgLookup struct {
+	Message   cid.Cid // Can be different than requested, in case it was replaced, but only gas values changed
 	Receipt   types.MessageReceipt
 	ReturnDec interface{}
 	TipSet    types.TipSetKey

--- a/chain/types/message.go
+++ b/chain/types/message.go
@@ -118,6 +118,17 @@ func (m *Message) Equals(o *Message) bool {
 	return m.Cid() == o.Cid()
 }
 
+func (m *Message) EqualCall(o *Message) bool {
+	m1 := *m
+	m2 := *o
+
+	m1.GasLimit, m2.GasLimit = 0, 0
+	m1.GasFeeCap, m2.GasFeeCap = big.Zero(), big.Zero()
+	m1.GasPremium, m2.GasPremium = big.Zero(), big.Zero()
+
+	return (&m1).Equals(&m2)
+}
+
 func (m *Message) ValidForBlockInclusion(minGas int64) error {
 	if m.Version != 0 {
 		return xerrors.New("'Version' unsupported")

--- a/chain/types/message_test.go
+++ b/chain/types/message_test.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+)
+
+func TestEqualCall(t *testing.T) {
+	m1 := &Message{
+		To:    builtin.StoragePowerActorAddr,
+		From:  builtin.SystemActorAddr,
+		Nonce: 34,
+		Value: big.Zero(),
+
+		GasLimit:   123,
+		GasFeeCap:  big.NewInt(234),
+		GasPremium: big.NewInt(234),
+
+		Method: 6,
+		Params: []byte("hai"),
+	}
+
+	m2 := &Message{
+		To:    builtin.StoragePowerActorAddr,
+		From:  builtin.SystemActorAddr,
+		Nonce: 34,
+		Value: big.Zero(),
+
+		GasLimit:   1236, // changed
+		GasFeeCap:  big.NewInt(234),
+		GasPremium: big.NewInt(234),
+
+		Method: 6,
+		Params: []byte("hai"),
+	}
+
+	m3 := &Message{
+		To:    builtin.StoragePowerActorAddr,
+		From:  builtin.SystemActorAddr,
+		Nonce: 34,
+		Value: big.Zero(),
+
+		GasLimit:   123,
+		GasFeeCap:  big.NewInt(4524), // changed
+		GasPremium: big.NewInt(234),
+
+		Method: 6,
+		Params: []byte("hai"),
+	}
+
+	m4 := &Message{
+		To:    builtin.StoragePowerActorAddr,
+		From:  builtin.SystemActorAddr,
+		Nonce: 34,
+		Value: big.Zero(),
+
+		GasLimit:   123,
+		GasFeeCap:  big.NewInt(4524),
+		GasPremium: big.NewInt(234),
+
+		Method: 5, // changed
+		Params: []byte("hai"),
+	}
+
+	require.True(t, m1.EqualCall(m2))
+	require.True(t, m1.EqualCall(m3))
+	require.False(t, m1.EqualCall(m4))
+}

--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -209,7 +209,7 @@ func (c *ClientNodeAdapter) ValidatePublishedDeal(ctx context.Context, deal stor
 	}
 
 	// TODO: timeout
-	_, ret, err := c.sm.WaitForMessage(ctx, *deal.PublishMessage, build.MessageConfidence)
+	_, ret, _, err := c.sm.WaitForMessage(ctx, *deal.PublishMessage, build.MessageConfidence)
 	if err != nil {
 		return 0, xerrors.Errorf("waiting for deal publish message: %w", err)
 	}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -426,7 +426,7 @@ func (a *StateAPI) MinerCreateBlock(ctx context.Context, bt *api.BlockTemplate) 
 }
 
 func (a *StateAPI) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error) {
-	ts, recpt, err := a.StateManager.WaitForMessage(ctx, msg, confidence)
+	ts, recpt, found, err := a.StateManager.WaitForMessage(ctx, msg, confidence)
 	if err != nil {
 		return nil, err
 	}
@@ -453,6 +453,7 @@ func (a *StateAPI) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uin
 	}
 
 	return &api.MsgLookup{
+		Message:   found,
 		Receipt:   *recpt,
 		ReturnDec: returndec,
 		TipSet:    ts.Key(),
@@ -461,13 +462,14 @@ func (a *StateAPI) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uin
 }
 
 func (a *StateAPI) StateSearchMsg(ctx context.Context, msg cid.Cid) (*api.MsgLookup, error) {
-	ts, recpt, err := a.StateManager.SearchForMessage(ctx, msg)
+	ts, recpt, found, err := a.StateManager.SearchForMessage(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
 
 	if ts != nil {
 		return &api.MsgLookup{
+			Message: found,
 			Receipt: *recpt,
 			TipSet:  ts.Key(),
 			Height:  ts.Height(),


### PR DESCRIPTION
Without this doing `mpool replace` will cause mayhem in most places which care about messages executing (sealing, markets, window post sched, etc..)