### PR TITLE
Payment channels manager: merge queued add funds

### DIFF
--- a/paychmgr/store.go
+++ b/paychmgr/store.go
@@ -328,8 +328,7 @@ func (ps *Store) ByChannelID(channelID string) (*ChannelInfo, error) {
 	return unmarshallChannelInfo(&stored, res)
 }
 
-// CreateChannel creates an outbound channel for the given from / to, ensuring
-// it has a higher sequence number than any existing channel with the same from / to
+// CreateChannel creates an outbound channel for the given from / to
 func (ps *Store) CreateChannel(from address.Address, to address.Address, createMsgCid cid.Cid, amt types.BigInt) (*ChannelInfo, error) {
 	ci := &ChannelInfo{
 		Direction:     DirOutbound,


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/lotus/issues/2912

The tricky part here is that `getPaych(ctx context.Context, from, to address.Address, amt types.BigInt)` takes a context as a parameter.

- The amount for the merged requests is the sum of the amount for each individual request
- When we merge requests, we need to monitor the context for each request in the merge
- If a request context is cancelled we remove the request amount from the total
- If all the contexts in a merge are cancelled, we cancel the merge context