### PR TITLE
Revise TotalCircSupply

### DIFF
--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -323,13 +323,13 @@ func VerifyPreSealedData(ctx context.Context, cs *store.ChainStore, stateroot ci
 	var sum abi.PaddedPieceSize
 
 	vmopt := vm.VMOpts{
-		StateBase:  stateroot,
-		Epoch:      0,
-		Rand:       &fakeRand{},
-		Bstore:     cs.Blockstore(),
-		Syscalls:   mkFakedSigSyscalls(cs.VMSys()),
-		VestedCalc: nil,
-		BaseFee:    types.NewInt(0),
+		StateBase:      stateroot,
+		Epoch:          0,
+		Rand:           &fakeRand{},
+		Bstore:         cs.Blockstore(),
+		Syscalls:       mkFakedSigSyscalls(cs.VMSys()),
+		CircSupplyCalc: nil,
+		BaseFee:        types.NewInt(0),
 	}
 	vm, err := vm.NewVM(&vmopt)
 	if err != nil {

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -57,7 +57,7 @@ func mkFakedSigSyscalls(base vm.SyscallBuilder) vm.SyscallBuilder {
 }
 
 func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sroot cid.Cid, miners []genesis.Miner) (cid.Cid, error) {
-	vc := func(context.Context, abi.ChainEpoch) (abi.TokenAmount, error) {
+	vc := func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error) {
 		return big.Zero(), nil
 	}
 

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -57,18 +57,18 @@ func mkFakedSigSyscalls(base vm.SyscallBuilder) vm.SyscallBuilder {
 }
 
 func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sroot cid.Cid, miners []genesis.Miner) (cid.Cid, error) {
-	vc := func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error) {
+	csc := func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error) {
 		return big.Zero(), nil
 	}
 
 	vmopt := &vm.VMOpts{
-		StateBase:  sroot,
-		Epoch:      0,
-		Rand:       &fakeRand{},
-		Bstore:     cs.Blockstore(),
-		Syscalls:   mkFakedSigSyscalls(cs.VMSys()),
-		VestedCalc: vc,
-		BaseFee:    types.NewInt(0),
+		StateBase:      sroot,
+		Epoch:          0,
+		Rand:           &fakeRand{},
+		Bstore:         cs.Blockstore(),
+		Syscalls:       mkFakedSigSyscalls(cs.VMSys()),
+		CircSupplyCalc: csc,
+		BaseFee:        types.NewInt(0),
 	}
 
 	vm, err := vm.NewVM(vmopt)

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -23,13 +23,13 @@ func (sm *StateManager) CallRaw(ctx context.Context, msg *types.Message, bstate 
 	defer span.End()
 
 	vmopt := &vm.VMOpts{
-		StateBase:  bstate,
-		Epoch:      bheight,
-		Rand:       r,
-		Bstore:     sm.cs.Blockstore(),
-		Syscalls:   sm.cs.VMSys(),
-		VestedCalc: sm.GetVestedFunds,
-		BaseFee:    types.NewInt(0),
+		StateBase:      bstate,
+		Epoch:          bheight,
+		Rand:           r,
+		Bstore:         sm.cs.Blockstore(),
+		Syscalls:       sm.cs.VMSys(),
+		CircSupplyCalc: sm.GetCirculatingSupply,
+		BaseFee:        types.NewInt(0),
 	}
 
 	vmi, err := vm.NewVM(vmopt)
@@ -124,13 +124,13 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 	}
 
 	vmopt := &vm.VMOpts{
-		StateBase:  state,
-		Epoch:      ts.Height() + 1,
-		Rand:       r,
-		Bstore:     sm.cs.Blockstore(),
-		Syscalls:   sm.cs.VMSys(),
-		VestedCalc: sm.GetVestedFunds,
-		BaseFee:    ts.Blocks()[0].ParentBaseFee,
+		StateBase:      state,
+		Epoch:          ts.Height() + 1,
+		Rand:           r,
+		Bstore:         sm.cs.Blockstore(),
+		Syscalls:       sm.cs.VMSys(),
+		CircSupplyCalc: sm.GetCirculatingSupply,
+		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 	}
 	vmi, err := vm.NewVM(vmopt)
 	if err != nil {

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -914,16 +914,17 @@ func (sm *StateManager) GetFilVested(ctx context.Context, height abi.ChainEpoch,
 }
 
 func GetFilMined(ctx context.Context, st *state.StateTree) (abi.TokenAmount, error) {
-	rew, err := st.GetActor(builtin.RewardActorAddr)
+	ractor, err := st.GetActor(builtin.RewardActorAddr)
 	if err != nil {
 		return big.Zero(), xerrors.Errorf("failed to load reward actor state: %w", err)
 	}
 
-	fm := types.BigSub(types.FromFil(build.FilAllocStorageMining), rew.Balance)
-	if fm.LessThan(big.Zero()) {
-		fm = big.Zero()
+	var rst reward.State
+	if err := st.Store.Get(ctx, ractor.Head, &rst); err != nil {
+		return big.Zero(), xerrors.Errorf("failed to load reward state: %w", err)
 	}
-	return fm, nil
+
+	return rst.TotalMined, nil
 }
 
 func getFilMarketLocked(ctx context.Context, st *state.StateTree) (abi.TokenAmount, error) {

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -441,13 +441,13 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 
 	r := store.NewChainRand(sm.cs, ts.Cids(), height)
 	vmopt := &vm.VMOpts{
-		StateBase:  base,
-		Epoch:      height,
-		Rand:       r,
-		Bstore:     sm.cs.Blockstore(),
-		Syscalls:   sm.cs.VMSys(),
-		VestedCalc: sm.GetVestedFunds,
-		BaseFee:    ts.Blocks()[0].ParentBaseFee,
+		StateBase:      base,
+		Epoch:          height,
+		Rand:           r,
+		Bstore:         sm.cs.Blockstore(),
+		Syscalls:       sm.cs.VMSys(),
+		CircSupplyCalc: sm.GetCirculatingSupply,
+		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 	}
 	vmi, err := vm.NewVM(vmopt)
 	if err != nil {
@@ -605,13 +605,13 @@ func (sm *StateManager) CirculatingSupply(ctx context.Context, ts *types.TipSet)
 
 	r := store.NewChainRand(sm.cs, ts.Cids(), ts.Height())
 	vmopt := &vm.VMOpts{
-		StateBase:  st,
-		Epoch:      ts.Height(),
-		Rand:       r,
-		Bstore:     sm.cs.Blockstore(),
-		Syscalls:   sm.cs.VMSys(),
-		VestedCalc: sm.GetVestedFunds,
-		BaseFee:    ts.Blocks()[0].ParentBaseFee,
+		StateBase:      st,
+		Epoch:          ts.Height(),
+		Rand:           r,
+		Bstore:         sm.cs.Blockstore(),
+		Syscalls:       sm.cs.VMSys(),
+		CircSupplyCalc: sm.GetCirculatingSupply,
+		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 	}
 	vmi, err := vm.NewVM(vmopt)
 	if err != nil {
@@ -692,31 +692,4 @@ func MinerHasMinPower(ctx context.Context, sm *StateManager, addr address.Addres
 	}
 
 	return ps.MinerNominalPowerMeetsConsensusMinimum(sm.ChainStore().Store(ctx), addr)
-}
-
-func GetCirculatingSupply(ctx context.Context, sm *StateManager, ts *types.TipSet) (abi.TokenAmount, error) {
-	if ts == nil {
-		ts = sm.cs.GetHeaviestTipSet()
-	}
-
-	r := store.NewChainRand(sm.cs, ts.Cids(), ts.Height())
-	vmopt := &vm.VMOpts{
-		StateBase:  ts.ParentState(),
-		Epoch:      ts.Height(),
-		Rand:       r,
-		Bstore:     sm.cs.Blockstore(),
-		Syscalls:   sm.cs.VMSys(),
-		VestedCalc: sm.GetVestedFunds,
-		BaseFee:    ts.Blocks()[0].ParentBaseFee,
-	}
-	vmi, err := vm.NewVM(vmopt)
-	if err != nil {
-		return abi.NewTokenAmount(0), err
-	}
-
-	uvm := &vm.UnsafeVM{vmi}
-
-	rt := uvm.MakeRuntime(ctx, &types.Message{From: builtin.InitActorAddr, GasLimit: 10000000}, builtin.InitActorAddr, 0, 0, 0)
-
-	return rt.TotalFilCircSupply(), nil
 }

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
@@ -591,40 +590,6 @@ func MinerGetBaseInfo(ctx context.Context, sm *StateManager, bcn beacon.RandomBe
 		BeaconEntries:   entries,
 		HasMinPower:     hmp,
 	}, nil
-}
-
-func (sm *StateManager) CirculatingSupply(ctx context.Context, ts *types.TipSet) (abi.TokenAmount, error) {
-	if ts == nil {
-		ts = sm.cs.GetHeaviestTipSet()
-	}
-
-	st, _, err := sm.TipSetState(ctx, ts)
-	if err != nil {
-		return big.Zero(), err
-	}
-
-	r := store.NewChainRand(sm.cs, ts.Cids(), ts.Height())
-	vmopt := &vm.VMOpts{
-		StateBase:      st,
-		Epoch:          ts.Height(),
-		Rand:           r,
-		Bstore:         sm.cs.Blockstore(),
-		Syscalls:       sm.cs.VMSys(),
-		CircSupplyCalc: sm.GetCirculatingSupply,
-		BaseFee:        ts.Blocks()[0].ParentBaseFee,
-	}
-	vmi, err := vm.NewVM(vmopt)
-	if err != nil {
-		return big.Zero(), err
-	}
-
-	unsafeVM := &vm.UnsafeVM{VM: vmi}
-	rt := unsafeVM.MakeRuntime(ctx, &types.Message{
-		GasLimit: 100e6,
-		From:     builtin.SystemActorAddr,
-	}, builtin.SystemActorAddr, 0, 0, 0)
-
-	return rt.TotalFilCircSupply(), nil
 }
 
 type methodMeta struct {

--- a/chain/validation/applier.go
+++ b/chain/validation/applier.go
@@ -148,13 +148,13 @@ func (a *Applier) applyMessage(epoch abi.ChainEpoch, lm types.ChainMsg) (vtypes.
 	base := a.stateWrapper.Root()
 
 	vmopt := &vm.VMOpts{
-		StateBase:  base,
-		Epoch:      epoch,
-		Rand:       &vmRand{},
-		Bstore:     a.stateWrapper.bs,
-		Syscalls:   a.syscalls,
-		VestedCalc: nil,
-		BaseFee:    abi.NewTokenAmount(100),
+		StateBase:      base,
+		Epoch:          epoch,
+		Rand:           &vmRand{},
+		Bstore:         a.stateWrapper.bs,
+		Syscalls:       a.syscalls,
+		CircSupplyCalc: nil,
+		BaseFee:        abi.NewTokenAmount(100),
 	}
 
 	lotusVM, err := vm.NewVM(vmopt)

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -140,7 +140,7 @@ func (vm *UnsafeVM) MakeRuntime(ctx context.Context, msg *types.Message, origin 
 	return vm.VM.makeRuntime(ctx, msg, origin, originNonce, usedGas, nac)
 }
 
-type VestedCalculator func(context.Context, abi.ChainEpoch) (abi.TokenAmount, error)
+type VestedCalculator func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error)
 
 type VM struct {
 	cstate      *state.StateTree
@@ -715,7 +715,7 @@ func (vm *VM) SetInvoker(i *Invoker) {
 }
 
 func (vm *VM) GetVestedFunds(ctx context.Context) (abi.TokenAmount, error) {
-	return vm.vc(ctx, vm.blockHeight)
+	return vm.vc(ctx, vm.blockHeight, vm.cstate)
 }
 
 func (vm *VM) incrementNonce(addr address.Address) error {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1193,5 +1193,13 @@ func (a *StateAPI) StateCirculatingSupply(ctx context.Context, tsk types.TipSetK
 		return abi.TokenAmount{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
 
-	return stmgr.GetCirculatingSupply(ctx, a.StateManager, ts)
+	st, _, err := a.StateManager.TipSetState(ctx, ts)
+	if err != nil {
+		return big.Zero(), err
+	}
+
+	cst := cbor.NewCborStore(a.Chain.Blockstore())
+	sTree, err := state.LoadStateTree(cst, st)
+
+	return a.StateManager.GetCirculatingSupply(ctx, ts.Height(), sTree)
 }

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1071,7 +1071,7 @@ func (a *StateAPI) StateMinerInitialPledgeCollateral(ctx context.Context, maddr 
 
 	duration := pci.Expiration - ts.Height() // NB: not exactly accurate, but should always lead us to *over* estimate, not under
 
-	circSupply, err := a.StateManager.CirculatingSupply(ctx, ts)
+	circSupply, err := a.StateCirculatingSupply(ctx, ts.Key())
 	if err != nil {
 		return big.Zero(), xerrors.Errorf("getting circulating supply: %w", err)
 	}
@@ -1175,7 +1175,7 @@ func (a *StateAPI) StateDealProviderCollateralBounds(ctx context.Context, size a
 		return api.DealCollateralBounds{}, xerrors.Errorf("getting power and reward actor states: %w")
 	}
 
-	circ, err := a.StateManager.CirculatingSupply(ctx, ts)
+	circ, err := a.StateCirculatingSupply(ctx, ts.Key())
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("getting total circulating supply: %w")
 	}


### PR DESCRIPTION
TotalCircSupply is still calculated as `filVested + filMined - filBurnt - filLocked`, but these values are now obtained as follows:

- `filVested = multisigVested + accountVested + genesisLocked`, where `multisigVested` is the total vested funds of the genesis multisigs at a given epoch, `accountVested` is the sum over all **account** actors in the genesis state of `max(currBalance - genesisBalance, 0)`, and `genesisLocked` is the locked funds in the power and market actor at genesis.
- `filMined` is now obtained from the Reward Actor state (https://github.com/filecoin-project/lotus/pull/2605#discussion_r461976438).
- `filBurnt` is (still) just the balance of the Burnt Funds actor. We may want to change it to be the Burnt Funds currBalance - genesisBalance if there's a possibility that it's genesis balance could be non-zero.
- `filLocked` is the locked funds in the power and market states at the given height.

We might wanna update the CE supply doc to spell this out. 