### PR TITLE
fix select message bug

### DIFF
--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -454,6 +454,9 @@ func (mp *MessagePool) createMessageChains(actor address.Address, mset map[uint6
 	} else {
 		return nil
 	}
+	if len(msgs) == 0 {
+		return nil
+	}
 
 	// ok, now we can construct the chains using the messages we have
 	// invariant: each chain has a bigger gasPerf than the next -- otherwise they can be merged


### PR DESCRIPTION
file select message panic bug

https://filecoinproject.slack.com/archives/C017CCH1MHB/p1597027516371100

when the the number of message is zero, there will return nil chain node because the following code.

https://github.com/filecoin-project/lotus/blob/next/chain/messagepool/selection.go#L500