### PR TITLE
Paych manager: use special type for wait sentinel

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -396,7 +396,7 @@ type FullNode interface {
 	// The Paych methods are for interacting with and managing payment channels
 
 	PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt) (*ChannelInfo, error)
-	PaychGetWaitReady(context.Context, cid.Cid) (address.Address, error)
+	PaychGetWaitReady(context.Context, PaychWaitSentinel) (address.Address, error)
 	PaychList(context.Context) ([]address.Address, error)
 	PaychStatus(context.Context, address.Address) (*PaychStatus, error)
 	PaychSettle(context.Context, address.Address) (cid.Cid, error)
@@ -506,15 +506,17 @@ type PaychStatus struct {
 	Direction   PCHDir
 }
 
+type PaychWaitSentinel cid.Cid
+
 type ChannelInfo struct {
-	Channel        address.Address
-	ChannelMessage cid.Cid
+	Channel      address.Address
+	WaitSentinel PaychWaitSentinel
 }
 
 type PaymentInfo struct {
-	Channel        address.Address
-	ChannelMessage *cid.Cid
-	Vouchers       []*paych.SignedVoucher
+	Channel      address.Address
+	WaitSentinel PaychWaitSentinel
+	Vouchers     []*paych.SignedVoucher
 }
 
 type VoucherSpec struct {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -191,7 +191,7 @@ type FullNodeStruct struct {
 		MarketEnsureAvailable func(context.Context, address.Address, address.Address, types.BigInt) (cid.Cid, error) `perm:"sign"`
 
 		PaychGet                   func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
-		PaychGetWaitReady          func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
+		PaychGetWaitReady          func(context.Context, api.PaychWaitSentinel) (address.Address, error)                                     `perm:"sign"`
 		PaychList                  func(context.Context) ([]address.Address, error)                                                          `perm:"read"`
 		PaychStatus                func(context.Context, address.Address) (*api.PaychStatus, error)                                          `perm:"read"`
 		PaychSettle                func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
@@ -836,8 +836,8 @@ func (c *FullNodeStruct) PaychGet(ctx context.Context, from, to address.Address,
 	return c.Internal.PaychGet(ctx, from, to, amt)
 }
 
-func (c *FullNodeStruct) PaychGetWaitReady(ctx context.Context, mcid cid.Cid) (address.Address, error) {
-	return c.Internal.PaychGetWaitReady(ctx, mcid)
+func (c *FullNodeStruct) PaychGetWaitReady(ctx context.Context, sentinel api.PaychWaitSentinel) (address.Address, error) {
+	return c.Internal.PaychGetWaitReady(ctx, sentinel)
 }
 
 func (c *FullNodeStruct) PaychList(ctx context.Context) ([]address.Address, error) {

--- a/api/cbor_gen.go
+++ b/api/cbor_gen.go
@@ -14,6 +14,59 @@ import (
 
 var _ = xerrors.Errorf
 
+func (t *PaychWaitSentinel) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{160}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *PaychWaitSentinel) UnmarshalCBOR(r io.Reader) error {
+	*t = PaychWaitSentinel{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("PaychWaitSentinel: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
+	}
+
+	return nil
+}
 func (t *PaymentInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
@@ -41,26 +94,20 @@ func (t *PaymentInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.ChannelMessage (cid.Cid) (struct)
-	if len("ChannelMessage") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"ChannelMessage\" was too long")
+	// t.WaitSentinel (api.PaychWaitSentinel) (struct)
+	if len("WaitSentinel") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"WaitSentinel\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ChannelMessage"))); err != nil {
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("WaitSentinel"))); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, string("ChannelMessage")); err != nil {
+	if _, err := io.WriteString(w, string("WaitSentinel")); err != nil {
 		return err
 	}
 
-	if t.ChannelMessage == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
-			return err
-		}
-	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.ChannelMessage); err != nil {
-			return xerrors.Errorf("failed to write cid field t.ChannelMessage: %w", err)
-		}
+	if err := t.WaitSentinel.MarshalCBOR(w); err != nil {
+		return err
 	}
 
 	// t.Vouchers ([]*paych.SignedVoucher) (slice)
@@ -133,28 +180,13 @@ func (t *PaymentInfo) UnmarshalCBOR(r io.Reader) error {
 				}
 
 			}
-			// t.ChannelMessage (cid.Cid) (struct)
-		case "ChannelMessage":
+			// t.WaitSentinel (api.PaychWaitSentinel) (struct)
+		case "WaitSentinel":
 
 			{
 
-				pb, err := br.PeekByte()
-				if err != nil {
-					return err
-				}
-				if pb == cbg.CborNull[0] {
-					var nbuf [1]byte
-					if _, err := br.Read(nbuf[:]); err != nil {
-						return err
-					}
-				} else {
-
-					c, err := cbg.ReadCid(br)
-					if err != nil {
-						return xerrors.Errorf("failed to read cid field t.ChannelMessage: %w", err)
-					}
-
-					t.ChannelMessage = &c
+				if err := t.WaitSentinel.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.WaitSentinel: %w", err)
 				}
 
 			}

--- a/api/test/paych.go
+++ b/api/test/paych.go
@@ -74,7 +74,7 @@ func TestPaymentChannels(t *testing.T, b APIBuilder, blocktime time.Duration) {
 		t.Fatal(err)
 	}
 
-	channel, err := paymentCreator.PaychGetWaitReady(ctx, channelInfo.ChannelMessage)
+	channel, err := paymentCreator.PaychGetWaitReady(ctx, channelInfo.WaitSentinel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -66,7 +66,7 @@ var paychGetCmd = &cli.Command{
 		}
 
 		// Wait for the message to be confirmed
-		chAddr, err := api.PaychGetWaitReady(ctx, info.ChannelMessage)
+		chAddr, err := api.PaychGetWaitReady(ctx, info.WaitSentinel)
 		if err != nil {
 			return err
 		}

--- a/gen/main.go
+++ b/gen/main.go
@@ -43,6 +43,7 @@ func main() {
 	}
 
 	err = gen.WriteMapEncodersToFile("./api/cbor_gen.go", "api",
+		api.PaychWaitSentinel{},
 		api.PaymentInfo{},
 		api.SealedRef{},
 		api.SealedRefs{},

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -35,13 +35,13 @@ func (a *PaychAPI) PaychGet(ctx context.Context, from, to address.Address, amt t
 	}
 
 	return &api.ChannelInfo{
-		Channel:        ch,
-		ChannelMessage: mcid,
+		Channel:      ch,
+		WaitSentinel: api.PaychWaitSentinel(mcid),
 	}, nil
 }
 
-func (a *PaychAPI) PaychGetWaitReady(ctx context.Context, mcid cid.Cid) (address.Address, error) {
-	return a.PaychMgr.GetPaychWaitReady(ctx, mcid)
+func (a *PaychAPI) PaychGetWaitReady(ctx context.Context, sentinel api.PaychWaitSentinel) (address.Address, error) {
+	return a.PaychMgr.GetPaychWaitReady(ctx, cid.Cid(sentinel))
 }
 
 func (a *PaychAPI) PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error) {
@@ -84,15 +84,10 @@ func (a *PaychAPI) PaychNewPayment(ctx context.Context, from, to address.Address
 		svs[i] = sv
 	}
 
-	var pchCid *cid.Cid
-	if ch.ChannelMessage != cid.Undef {
-		pchCid = &ch.ChannelMessage
-	}
-
 	return &api.PaymentInfo{
-		Channel:        ch.Channel,
-		ChannelMessage: pchCid,
-		Vouchers:       svs,
+		Channel:      ch.Channel,
+		WaitSentinel: ch.WaitSentinel,
+		Vouchers:     svs,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes point 4 of https://github.com/filecoin-project/lotus/issues/2911

Change the return value from `PaychGet` to be a special "wait sentinel" type instead of a message cid.

Motivation: We don't want API clients to call `StateWaitMsg()` on the value returned from `PaychGet()`. We want them to call `PaychGetWaitReady()` with the wait sentinel.