### PR TITLE
Stop requiring miner address / sector size for `lotus client commP`

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -243,8 +243,8 @@ type FullNode interface {
 	ClientRetrieve(ctx context.Context, order RetrievalOrder, ref *FileRef) (<-chan marketevents.RetrievalEvent, error)
 	// ClientQueryAsk returns a signed StorageAsk from the specified miner.
 	ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)
-	// ClientCalcCommP calculates the CommP for a specified file, based on the sector size of the provided miner.
-	ClientCalcCommP(ctx context.Context, inpath string, miner address.Address) (*CommPRet, error)
+	// ClientCalcCommP calculates the CommP for a specified file
+	ClientCalcCommP(ctx context.Context, inpath string) (*CommPRet, error)
 	// ClientGenCar generates a CAR file for the specified file.
 	ClientGenCar(ctx context.Context, ref FileRef, outpath string) error
 	// ClientDealSize calculates real deal data size

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -137,7 +137,7 @@ type FullNodeStruct struct {
 		ClientListDeals       func(ctx context.Context) ([]api.DealInfo, error)                                                                 `perm:"write"`
 		ClientRetrieve        func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) (<-chan marketevents.RetrievalEvent, error) `perm:"admin"`
 		ClientQueryAsk        func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)              `perm:"read"`
-		ClientCalcCommP       func(ctx context.Context, inpath string, miner address.Address) (*api.CommPRet, error)                            `perm:"read"`
+		ClientCalcCommP       func(ctx context.Context, inpath string) (*api.CommPRet, error)                                                   `perm:"read"`
 		ClientGenCar          func(ctx context.Context, ref api.FileRef, outpath string) error                                                  `perm:"write"`
 		ClientDealSize        func(ctx context.Context, root cid.Cid) (api.DataSize, error)                                                     `perm:"read"`
 
@@ -426,8 +426,8 @@ func (c *FullNodeStruct) ClientRetrieve(ctx context.Context, order api.Retrieval
 func (c *FullNodeStruct) ClientQueryAsk(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error) {
 	return c.Internal.ClientQueryAsk(ctx, p, miner)
 }
-func (c *FullNodeStruct) ClientCalcCommP(ctx context.Context, inpath string, miner address.Address) (*api.CommPRet, error) {
-	return c.Internal.ClientCalcCommP(ctx, inpath, miner)
+func (c *FullNodeStruct) ClientCalcCommP(ctx context.Context, inpath string) (*api.CommPRet, error) {
+	return c.Internal.ClientCalcCommP(ctx, inpath)
 }
 
 func (c *FullNodeStruct) ClientGenCar(ctx context.Context, ref api.FileRef, outpath string) error {

--- a/cli/client.go
+++ b/cli/client.go
@@ -174,7 +174,7 @@ var clientDropCmd = &cli.Command{
 var clientCommPCmd = &cli.Command{
 	Name:      "commP",
 	Usage:     "Calculate the piece-cid (commP) of a CAR file",
-	ArgsUsage: "[inputFile minerAddress]",
+	ArgsUsage: "[inputFile]",
 	Flags: []cli.Flag{
 		&CidBaseFlag,
 	},
@@ -186,16 +186,11 @@ var clientCommPCmd = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() != 2 {
-			return fmt.Errorf("usage: commP <inputPath> <minerAddr>")
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("usage: commP <inputPath>")
 		}
 
-		miner, err := address.NewFromString(cctx.Args().Get(1))
-		if err != nil {
-			return err
-		}
-
-		ret, err := api.ClientCalcCommP(ctx, cctx.Args().Get(0), miner)
+		ret, err := api.ClientCalcCommP(ctx, cctx.Args().Get(0))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
At present, and at least for the medium term (even with the transition to NSE) the structure of a piece (and thus commP) will remain identical for every size of sector.
 
The offline deal flow would benefit greatly if the `lotus client commP` interface is able to calculate commP without having access to a fully synced chain, or without even being online.

This is particularly important for filecoin-discover, as we want to allow miners to spot-check their purchased HDDs, way before they need to accept the mainnet deal proposals.

See [comment/links in node/impl/client/client.go](https://github.com/filecoin-project/lotus/compare/next...feat/offline_commp_calculation?expand=1#diff-9a3e728363a090aba64a476fe19672b5) for details on code flow