### PR TITLE
Add nil check in tipset change handler

### DIFF
--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -379,6 +379,11 @@ func (n *ProviderNodeAdapter) OnDealExpiredOrSlashed(ctx context.Context, dealID
 
 	// Called immediately to check if the deal has already expired or been slashed
 	checkFunc := func(ts *types.TipSet) (done bool, more bool, err error) {
+		if ts == nil {
+			// keep listening for events
+			return false, true, nil
+		}
+
 		// Check if the deal has already expired
 		if sd.Proposal.EndEpoch <= ts.Height() {
 			onDealExpired(nil)


### PR DESCRIPTION
## Summary
Add a check for `nil` tipsets in the storage provider adapter.  

Didn't fix the root issue (maybe a race?) as to why we are getting nils back from the `tipSetCache.best()`.

Resolves #2865 