### PR TITLE
sealing sched: Fix deadlock in worker watcher

### DIFF
--- a/extern/sector-storage/sched_watch.go
+++ b/extern/sector-storage/sched_watch.go
@@ -87,11 +87,14 @@ func (sh *scheduler) runWorkerWatcher() {
 			}
 
 			log.Warnf("worker %d dropped", wid)
-			select {
-			case sh.workerClosing <- wid:
-			case <-sh.closing:
-				return
-			}
+			// send in a goroutine to avoid a deadlock between workerClosing / watchClosing
+			go func() {
+				select {
+				case sh.workerClosing <- wid:
+				case <-sh.closing:
+					return
+				}
+			}()
 		}
 	}
 }


### PR DESCRIPTION
Occasionally when one worker drops, and at the same time another one joins, things can deadlock betweed the worker watcher goroutine and the main sealing scheduler goroutine. This should fix that

Fixes https://github.com/filecoin-project/lotus/issues/3001