### PR TITLE
Fix bug with paych allocate lane

### DIFF
--- a/paychmgr/state.go
+++ b/paychmgr/state.go
@@ -2,7 +2,6 @@ package paychmgr
 
 import (
 	"context"
-	"errors"
 
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
@@ -78,18 +77,15 @@ func (ca *stateAccessor) nextLaneFromState(ctx context.Context, st *paych.State)
 		return 0, nil
 	}
 
-	nextID := int64(0)
-	stopErr := errors.New("stop")
+	maxID := int64(0)
 	if err := laneStates.ForEach(nil, func(i int64) error {
-		if nextID < i {
-			// We've found a hole. Stop here.
-			return stopErr
+		if i > maxID {
+			maxID = i
 		}
-		nextID++
 		return nil
-	}); err != nil && err != stopErr {
+	}); err != nil {
 		return 0, err
 	}
 
-	return uint64(nextID), nil
+	return uint64(maxID + 1), nil
 }


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/filecoin-project/lotus/pull/2991:
- client calls `PaychVoucherAdd()` with an existing channel that has one voucher on lane 1
- client calls `AllocateLane()`: allocates lane 0
- client calls `AllocateLane()`: allocates lane 1 (clashing with existing lane 1)

https://github.com/filecoin-project/lotus/pull/2991 attempts to fix "holes" in lane allocation, eg if a client adds a voucher for lane 1 (leaving a hole for lane 0), it would allocate the next lane to be 0, then 2, then 3, then 4 etc.

In practice I don't think we need to worry about that because the client can just use the AllocateLane() function which should not cause any holes. If they decide to use some other scheme that creates holes, they can use their scheme to keep track of where the holes are.

In practice I don't think this is an urgent issue because the bug should only occur when calling AllocateLane() on an Inbound channel, and normally AllocateLane() is only called on Outbound channels.