### PR TITLE
fix a small issue in chain watch

### DIFF
--- a/cmd/lotus-chainwatch/processor/mpool.go
+++ b/cmd/lotus-chainwatch/processor/mpool.go
@@ -30,11 +30,10 @@ func (p *Processor) subMpool(ctx context.Context) {
 
 	loop:
 		for {
-			time.Sleep(10 * time.Millisecond)
 			select {
 			case update := <-sub:
 				updates = append(updates, update)
-			default:
+			case <-time.After(10 * time.Millisecond):
 				break loop
 			}
 		}


### PR DESCRIPTION
move sleep into the select, as it is it simply slows down the writer if there are many messages.