### PR TITLE
Add config command that prints the default config file for a storage …

### DIFF
--- a/cmd/lotus-storage-miner/config.go
+++ b/cmd/lotus-storage-miner/config.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/lotus/node/config"
+)
+
+var configCmd = &cli.Command{
+	Name: "config",
+	Usage: "Output default configuration",
+	Action: func(cctx *cli.Context) error {
+		comm, err := config.ConfigComment(config.DefaultStorageMiner())
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(comm))
+		return nil
+	},
+}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -32,6 +32,7 @@ func main() {
 		initCmd,
 		runCmd,
 		stopCmd,
+		configCmd,
 		lcli.WithCategory("chain", actorCmd),
 		lcli.WithCategory("chain", rewardsCmd),
 		lcli.WithCategory("chain", infoCmd),


### PR DESCRIPTION
…miner.

Purpose of this is to provide a way to easily retrieve the latest default config outside of the `lotus-miner init` process. 