### PR TITLE
fsm: Recover from errors from VerifySeal in checkCommit

### DIFF
--- a/extern/storage-sealing/checks.go
+++ b/extern/storage-sealing/checks.go
@@ -155,7 +155,7 @@ func (m *Sealing) checkCommit(ctx context.Context, si SectorInfo, proof []byte, 
 		UnsealedCID:           *si.CommD,
 	})
 	if err != nil {
-		return xerrors.Errorf("verify seal: %w", err)
+		return &ErrInvalidProof{xerrors.Errorf("verify seal: %w", err)}
 	}
 	if !ok {
 		return &ErrInvalidProof{xerrors.New("invalid proof (compute error?)")}


### PR DESCRIPTION
Errors like
```
2020-08-16T03:09:43.178+0200	[31mERROR[0m	sectors	storage-fsm/fsm.go:26	unhandled sector error (5237): checkCommit sanity check error (*xerrors.wrapError):
    github.com/filecoin-project/storage-fsm.(*Sealing).handleCommitFailed
        /home/magik6k/github.com/filecoin-project/go-lotus/extern/storage-fsm/states_failed.go:190
  - verify seal:
    github.com/filecoin-project/storage-fsm.(*Sealing).checkCommit
        /home/magik6k/github.com/filecoin-project/go-lotus/extern/storage-fsm/checks.go:158
  - failed to fill whole buffer
    github.com/filecoin-project/filecoin-ffi.VerifySeal
    	/home/magik6k/github.com/filecoin-project/go-lotus/extern/filecoin-ffi/proofs.go:52
    github.com/filecoin-project/sector-storage/ffiwrapper.proofVerifier.VerifySeal
    	/home/magik6k/github.com/filecoin-project/go-lotus/extern/sector-storage/ffiwrapper/verifier_cgo.go:97
    github.com/filecoin-project/storage-fsm.(*Sealing).checkCommit
    	/home/magik6k/github.com/filecoin-project/go-lotus/extern/storage-fsm/checks.go:148
    github.com/filecoin-project/storage-fsm.(*Sealing).handleCommitFailed
    	/home/magik6k/github.com/filecoin-project/go-lotus/extern/storage-fsm/states_failed.go:166
    github.com/filecoin-project/storage-fsm.(*Sealing).Plan.func1
    	/home/magik6k/github.com/filecoin-project/go-lotus/extern/storage-fsm/fsm.go:24
    reflect.Value.call
    	/usr/lib/go/src/reflect/value.go:460
    reflect.Value.Call
    	/usr/lib/go/src/reflect/value.go:321
    github.com/filecoin-project/go-statemachine.(*StateMachine).run.func3
    	/home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/go-statemachine@v0.0.0-20200813232949-df9b130df370/machine.go:102
    runtime.goexit
    	/usr/lib/go/src/runtime/asm_amd64.s:1373
```
Are usually just compute errors

Fixes https://github.com/filecoin-project/lotus/issues/2929
Fixes https://github.com/filecoin-project/lotus/issues/2051