### PR TITLE
proper genesis block history

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -304,7 +304,8 @@ func (cg *ChainGen) GenesisCar() ([]byte, error) {
 
 func CarWalkFunc(nd format.Node) (out []*format.Link, err error) {
 	for _, link := range nd.Links() {
-		if link.Cid.Prefix().Codec == cid.FilCommitmentSealed || link.Cid.Prefix().Codec == cid.FilCommitmentUnsealed {
+		pref := link.Cid.Prefix()
+		if pref.Codec == cid.FilCommitmentSealed || pref.Codec == cid.FilCommitmentUnsealed {
 			continue
 		}
 		out = append(out, link)

--- a/chain/gen/genesis/genblock.go
+++ b/chain/gen/genesis/genblock.go
@@ -1,0 +1,41 @@
+package genesis
+
+import (
+	"encoding/hex"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+const genesisMultihashString = "1220107d821c25dc0735200249df94a8bebc9c8e489744f86a4ca8919e81f19dcd72"
+const genesisBlockHex = "a5684461746574696d6573323031372d30352d30352030313a32373a3531674e6574776f726b6846696c65636f696e65546f6b656e6846696c65636f696e6c546f6b656e416d6f756e7473a36b546f74616c537570706c796d322c3030302c3030302c303030664d696e6572736d312c3430302c3030302c3030306c50726f746f636f6c4c616273a36b446576656c6f706d656e746b3330302c3030302c3030306b46756e6472616973696e676b3230302c3030302c3030306a466f756e646174696f6e6b3130302c3030302c303030674d657373616765784854686973206973207468652047656e6573697320426c6f636b206f66207468652046696c65636f696e20446563656e7472616c697a65642053746f72616765204e6574776f726b2e"
+
+var cidBuilder = cid.V1Builder{Codec: cid.DagCBOR, MhType: multihash.SHA2_256}
+
+func expectedCid() cid.Cid {
+	mh, err := multihash.FromHexString(genesisMultihashString)
+	if err != nil {
+		panic(err)
+	}
+	return cid.NewCidV1(cidBuilder.Codec, mh)
+}
+
+func getGenesisBlock() (blocks.Block, error) {
+	genesisBlockData, err := hex.DecodeString(genesisBlockHex)
+	if err != nil {
+		return nil, err
+	}
+
+	genesisCid, err := cidBuilder.Sum(genesisBlockData)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := blocks.NewBlockWithCid(genesisBlockData, genesisCid)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -434,10 +434,24 @@ func MakeGenesisBlock(ctx context.Context, bs bstore.Blockstore, sys vm.SyscallB
 		VRFProof: []byte("vrf proof0000000vrf proof0000000"),
 	}
 
+	filecoinGenesisCid, err := cid.Decode("bafyreiaqpwbbyjo4a42saasj36kkrpv4tsherf2e7bvezkert2a7dhonoi")
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decode filecoin genesis block CID: %w", err)
+	}
+
+	gblk, err := getGenesisBlock()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct filecoin genesis block: %w", err)
+	}
+
+	if err := bs.Put(gblk); err != nil {
+		return nil, xerrors.Errorf("failed writing filecoin genesis block to blockstore: %w", err)
+	}
+
 	b := &types.BlockHeader{
 		Miner:                 builtin.SystemActorAddr,
 		Ticket:                genesisticket,
-		Parents:               []cid.Cid{},
+		Parents:               []cid.Cid{filecoinGenesisCid},
 		Height:                0,
 		ParentWeight:          types.NewInt(0),
 		ParentStateRoot:       stateroot,

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -439,9 +439,17 @@ func MakeGenesisBlock(ctx context.Context, bs bstore.Blockstore, sys vm.SyscallB
 		return nil, xerrors.Errorf("failed to decode filecoin genesis block CID: %w", err)
 	}
 
+	if !expectedCid().Equals(filecoinGenesisCid) {
+		return nil, xerrors.Errorf("expectedCid != filecoinGenesisCid")
+	}
+
 	gblk, err := getGenesisBlock()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to construct filecoin genesis block: %w", err)
+	}
+
+	if !filecoinGenesisCid.Equals(gblk.Cid()) {
+		return nil, xerrors.Errorf("filecoinGenesisCid != gblk.Cid")
 	}
 
 	if err := bs.Put(gblk); err != nil {

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -3,8 +3,9 @@ package stmgr
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"sync"
+
+	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
 
@@ -323,7 +324,7 @@ func (sm *StateManager) computeTipSetState(ctx context.Context, ts *types.TipSet
 
 	var parentEpoch abi.ChainEpoch
 	pstate := blks[0].ParentStateRoot
-	if len(blks[0].Parents) > 0 {
+	if blks[0].Height > 0 {
 		parent, err := sm.cs.GetBlock(blks[0].Parents[0])
 		if err != nil {
 			return cid.Undef, cid.Undef, xerrors.Errorf("getting parent block: %w", err)

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1177,13 +1177,18 @@ func (cs *ChainStore) Export(ctx context.Context, ts *types.TipSet, w io.Writer)
 			return xerrors.Errorf("unmarshaling block header (cid=%s): %w", blk, err)
 		}
 
-		for _, p := range b.Parents {
-			blocksToWalk = append(blocksToWalk, p)
-		}
-
 		cids, err := recurseLinks(cs.bs, b.Messages, []cid.Cid{b.Messages})
 		if err != nil {
 			return xerrors.Errorf("recursing messages failed: %w", err)
+		}
+
+		if b.Height > 0 {
+			for _, p := range b.Parents {
+				blocksToWalk = append(blocksToWalk, p)
+			}
+		} else {
+			// include the genesis block
+			cids = append(cids, b.Parents...)
 		}
 
 		out := cids

--- a/cmd/lotus-chainwatch/syncer/sync.go
+++ b/cmd/lotus-chainwatch/syncer/sync.go
@@ -239,7 +239,7 @@ func (s *Syncer) unsyncedBlocks(ctx context.Context, head *types.TipSet, since t
 			log.Debugw("To visit", "toVisit", toVisit.Len(), "toSync", len(toSync), "current_height", bh.Height)
 		}
 
-		if len(bh.Parents) == 0 {
+		if bh.Height == 0 {
 			continue
 		}
 

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -77,7 +77,7 @@ func (a *GasAPI) GasEstimateGasPremium(ctx context.Context, nblocksincl uint64,
 
 	ts := a.Chain.GetHeaviestTipSet()
 	for i := uint64(0); i < nblocksincl*2; i++ {
-		if len(ts.Parents().Cids()) == 0 {
+		if ts.Height() == 0 {
 			break // genesis
 		}
 


### PR DESCRIPTION
This PR adds a link to the original filecoin genesis block from the network launch block. 

The hash of this block was timestamped in [ethereum back in 2017](https://etherscan.io/tx/0xe8f51c9eefb682cd866f059462577b6dd3d2685ff4b6437f6c940ff4f4aaf067) and represents the initial state of the network. 

