### PR TITLE
More Chainwatch Improvements

### DIFF
--- a/cmd/lotus-chainwatch/processor/common_actors.go
+++ b/cmd/lotus-chainwatch/processor/common_actors.go
@@ -232,12 +232,12 @@ func (p *Processor) storeActorHeads(actors map[cid.Cid]ActorTips) error {
 		return err
 	}
 	if _, err := tx.Exec(`
-		create temp table a (like actors excluding constraints) on commit drop;
+		create temp table a_tmp (like actors excluding constraints) on commit drop;
 	`); err != nil {
 		return xerrors.Errorf("prep temp: %w", err)
 	}
 
-	stmt, err := tx.Prepare(`copy a (id, code, head, nonce, balance, stateroot) from stdin `)
+	stmt, err := tx.Prepare(`copy a_tmp (id, code, head, nonce, balance, stateroot) from stdin `)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (p *Processor) storeActorHeads(actors map[cid.Cid]ActorTips) error {
 		return err
 	}
 
-	if _, err := tx.Exec(`insert into actors select * from a on conflict do nothing `); err != nil {
+	if _, err := tx.Exec(`insert into actors select * from a_tmp on conflict do nothing `); err != nil {
 		return xerrors.Errorf("actor put: %w", err)
 	}
 
@@ -278,12 +278,12 @@ func (p *Processor) storeActorStates(actors map[cid.Cid]ActorTips) error {
 		return err
 	}
 	if _, err := tx.Exec(`
-		create temp table a (like actor_states excluding constraints) on commit drop;
+		create temp table as_tmp (like actor_states excluding constraints) on commit drop;
 	`); err != nil {
 		return xerrors.Errorf("prep temp: %w", err)
 	}
 
-	stmt, err := tx.Prepare(`copy a (head, code, state) from stdin `)
+	stmt, err := tx.Prepare(`copy as_tmp (head, code, state) from stdin `)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func (p *Processor) storeActorStates(actors map[cid.Cid]ActorTips) error {
 		return err
 	}
 
-	if _, err := tx.Exec(`insert into actor_states select * from a on conflict do nothing `); err != nil {
+	if _, err := tx.Exec(`insert into actor_states select * from as_tmp on conflict do nothing `); err != nil {
 		return xerrors.Errorf("actor put: %w", err)
 	}
 

--- a/cmd/lotus-chainwatch/processor/common_actors.go
+++ b/cmd/lotus-chainwatch/processor/common_actors.go
@@ -16,7 +16,6 @@ import (
 	_init "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-multihash"
 	typegen "github.com/whyrusleeping/cbor-gen"
 )
 
@@ -244,8 +243,8 @@ func (p *Processor) storeActorHeads(actors map[cid.Cid]ActorTips) error {
 
 	for code, actTips := range actors {
 		actorName := code.String()
-		if s, err := multihash.Decode(code.Hash()); err != nil {
-			actorName = string(s.Digest)
+		if builtin.IsBuiltinActor(code) {
+			actorName = builtin.ActorNameByCode(code)
 		}
 		for _, actorInfo := range actTips {
 			for _, a := range actorInfo {
@@ -290,8 +289,8 @@ func (p *Processor) storeActorStates(actors map[cid.Cid]ActorTips) error {
 
 	for code, actTips := range actors {
 		actorName := code.String()
-		if s, err := multihash.Decode(code.Hash()); err != nil {
-			actorName = string(s.Digest)
+		if builtin.IsBuiltinActor(code) {
+			actorName = builtin.ActorNameByCode(code)
 		}
 		for _, actorInfo := range actTips {
 			for _, a := range actorInfo {

--- a/cmd/lotus-chainwatch/processor/processor.go
+++ b/cmd/lotus-chainwatch/processor/processor.go
@@ -336,16 +336,19 @@ where rnk <= $1
 		}
 		var c string
 		if err := rows.Scan(&c); err != nil {
-			return nil, xerrors.Errorf("Failed to scan unprocessed blocks: %w", err)
+			log.Errorf("Failed to scan unprocessed blocks: %s", err.Error())
+			continue
 		}
 		ci, err := cid.Parse(c)
 		if err != nil {
-			return nil, xerrors.Errorf("Failed to parse unprocessed blocks: %w", err)
+			log.Errorf("Failed to parse unprocessed blocks: %s", err.Error())
+			continue
 		}
 		bh, err := p.node.ChainGetBlock(ctx, ci)
 		if err != nil {
 			// this is a pretty serious issue.
-			return nil, xerrors.Errorf("Failed to get block header %s: %w", ci.String(), err)
+			log.Errorf("Failed to get block header %s: %s", ci.String(), err.Error())
+			continue
 		}
 		out[ci] = bh
 		if bh.Height < minBlock {


### PR DESCRIPTION
A few fixes:
- temp table names were colliding and making a mess when running in parallel
- block missing from lookup shouldn't kill the whole group of metrics...let's ignore and come back later
- Attempt to capture actore names (again)