### PR TITLE
fix(api): Filter malformed peer ID before RPC marshaling

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -50,7 +50,7 @@ type MinerInfo struct {
 	Worker                     address.Address // Must be an ID-address.
 	NewWorker                  address.Address // Must be an ID-address.
 	WorkerChangeEpoch          abi.ChainEpoch
-	PeerId                     peer.ID
+	PeerId                     *peer.ID
 	Multiaddrs                 []abi.Multiaddrs
 	SealProofType              abi.RegisteredSealProof
 	SectorSize                 abi.SectorSize
@@ -58,12 +58,17 @@ type MinerInfo struct {
 }
 
 func NewApiMinerInfo(info *miner.MinerInfo) MinerInfo {
+	var pid *peer.ID
+	if peerID, err := peer.IDFromBytes(info.PeerId); err == nil {
+		pid = &peerID
+	}
+
 	mi := MinerInfo{
 		Owner:                      info.Owner,
 		Worker:                     info.Worker,
 		NewWorker:                  address.Undef,
 		WorkerChangeEpoch:          -1,
-		PeerId:                     peer.ID(info.PeerId),
+		PeerId:                     pid,
 		Multiaddrs:                 info.Multiaddrs,
 		SealProofType:              info.SealProofType,
 		SectorSize:                 info.SectorSize,

--- a/cli/client.go
+++ b/cli/client.go
@@ -550,7 +550,7 @@ func interactiveDeal(cctx *cli.Context) error {
 				continue
 			}
 
-			a, err := api.ClientQueryAsk(ctx, mi.PeerId, maddr)
+			a, err := api.ClientQueryAsk(ctx, *mi.PeerId, maddr)
 			if err != nil {
 				printErr(xerrors.Errorf("failed to query ask: %w", err))
 				state = "miner"
@@ -926,11 +926,11 @@ var clientQueryAskCmd = &cli.Command{
 				return xerrors.Errorf("failed to get peerID for miner: %w", err)
 			}
 
-			if peer.ID(mi.PeerId) == peer.ID("SETME") {
+			if peer.ID(*mi.PeerId) == peer.ID("SETME") {
 				return fmt.Errorf("the miner hasn't initialized yet")
 			}
 
-			pid = peer.ID(mi.PeerId)
+			pid = peer.ID(*mi.PeerId)
 		}
 
 		ask, err := api.ClientQueryAsk(ctx, pid, maddr)

--- a/cmd/lotus-chainwatch/processor/miner.go
+++ b/cmd/lotus-chainwatch/processor/miner.go
@@ -879,11 +879,15 @@ func (p *Processor) storeMinersActorInfoState(ctx context.Context, miners []mine
 				return err
 			}
 		}
+		var pid string
+		if mi.PeerId != nil {
+			pid = mi.PeerId.String()
+		}
 		if _, err := stmt.Exec(
 			m.common.addr.String(),
 			mi.Owner.String(),
 			mi.Worker.String(),
-			mi.PeerId.String(),
+			pid,
 			mi.SectorSize.ShortString(),
 		); err != nil {
 			log.Errorw("failed to store miner state", "state", m.state, "info", m.state.Info, "error", err)

--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -514,7 +514,7 @@ func (c *ClientNodeAdapter) GetMinerInfo(ctx context.Context, addr address.Addre
 		return nil, err
 	}
 
-	out := utils.NewStorageProviderInfo(addr, mi.Worker, mi.SectorSize, mi.PeerId, mi.Multiaddrs)
+	out := utils.NewStorageProviderInfo(addr, mi.Worker, mi.SectorSize, *mi.PeerId, mi.Multiaddrs)
 	return &out, nil
 }
 

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -137,7 +137,7 @@ func (a *API) ClientStartDeal(ctx context.Context, params *api.StartDealParams) 
 		return nil, xerrors.New("data doesn't fit in a sector")
 	}
 
-	providerInfo := utils.NewStorageProviderInfo(params.Miner, mi.Worker, mi.SectorSize, mi.PeerId, mi.Multiaddrs)
+	providerInfo := utils.NewStorageProviderInfo(params.Miner, mi.Worker, mi.SectorSize, *mi.PeerId, mi.Multiaddrs)
 
 	dealStart := params.DealStartEpoch
 	if dealStart <= 0 { // unset, or explicitly 'epoch undefined'
@@ -255,7 +255,7 @@ func (a *API) ClientMinerQueryOffer(ctx context.Context, miner address.Address, 
 	}
 	rp := rm.RetrievalPeer{
 		Address: miner,
-		ID:      mi.PeerId,
+		ID:      *mi.PeerId,
 	}
 	return a.makeRetrievalQuery(ctx, rp, root, piece, rm.QueryParams{}), nil
 }
@@ -443,7 +443,7 @@ func (a *API) clientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 		}
 
 		order.MinerPeer = retrievalmarket.RetrievalPeer{
-			ID:      mi.PeerId,
+			ID:      *mi.PeerId,
 			Address: order.Miner,
 		}
 	}


### PR DESCRIPTION
This attempts to fix reports of `2020-08-17T19:36:51.965+0200    FATAL   processor       processor/miner.go:193  Failed to persist miner actors  {"error": "RPC client error: unmarshaling result: failed to parse peer ID: cid too short"}` on Calibration net.

Unsure if this fix works until my node syncs again...

Detail of issue running `chainwatch@2570712a`:
```
2020-08-18T17:54:08.387Z        INFO    chainwatch      lotus-chainwatch/main.go:17     Starting chainwatch v0.4.6+git.9d79e619.dirty
2020-08-18T17:54:08.389Z        INFO    chainwatch      lotus-chainwatch/run.go:54      Remote version: 0.4.5+git.700bcedb.dirty
2020-08-18T17:54:09.811Z        INFO    processor       processor/processor.go:361      Gathered Blocks to Process      {"start": "1550", "end": "1587"}
2020-08-18T17:54:19.573Z        INFO    processor       processor/processor.go:136      Collected Actor Changes {"MarketChanges": 37, "MinerChanges": 37, "RewardChanges": 37, "AccountChanges": 31, "nullRounds": 0}
2020-08-18T17:54:20.184Z        INFO    processor       processor/processor.go:165      Processed Reward Changes
2020-08-18T17:54:20.421Z        INFO    processor       processor/processor.go:181      Processed CommonActor Changes
2020-08-18T17:54:21.467Z        INFO    processor       processor/processor.go:173      Processed Message Changes
2020-08-18T17:54:51.307Z        INFO    processor       processor/processor.go:149      Processed Market Changes
2020-08-18T17:55:37.398Z        FATAL   processor       processor/miner.go:193  Failed to persist miner actors  {"error": "RPC client error: unmarshaling result: failed to parse peer ID: cid too short"}
```