### PR TITLE
Find out what's up with data transfers!

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -256,7 +256,8 @@ type FullNode interface {
 	ClientGenCar(ctx context.Context, ref FileRef, outpath string) error
 	// ClientDealSize calculates real deal data size
 	ClientDealSize(ctx context.Context, root cid.Cid) (DataSize, error)
-
+	// ClientListTransfers returns the status of all ongoing transfers of data
+	ClientListDataTransfers(ctx context.Context) ([]DataTransferChannel, error)
 	// ClientUnimport removes references to the specified file from filestore
 	//ClientUnimport(path string)
 

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -258,6 +258,8 @@ type FullNode interface {
 	ClientDealSize(ctx context.Context, root cid.Cid) (DataSize, error)
 	// ClientListTransfers returns the status of all ongoing transfers of data
 	ClientListDataTransfers(ctx context.Context) ([]DataTransferChannel, error)
+	ClientDataTransferUpdates(ctx context.Context) (<-chan DataTransferChannel, error)
+
 	// ClientUnimport removes references to the specified file from filestore
 	//ClientUnimport(path string)
 

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -127,22 +127,23 @@ type FullNodeStruct struct {
 		WalletImport         func(context.Context, *types.KeyInfo) (address.Address, error)                       `perm:"admin"`
 		WalletDelete         func(context.Context, address.Address) error                                         `perm:"write"`
 
-		ClientImport             func(ctx context.Context, ref api.FileRef) (*api.ImportRes, error)                                                `perm:"admin"`
-		ClientListImports        func(ctx context.Context) ([]api.Import, error)                                                                   `perm:"write"`
-		ClientRemoveImport       func(ctx context.Context, importID multistore.StoreID) error                                                      `perm:"admin"`
-		ClientHasLocal           func(ctx context.Context, root cid.Cid) (bool, error)                                                             `perm:"write"`
-		ClientFindData           func(ctx context.Context, root cid.Cid, piece *cid.Cid) ([]api.QueryOffer, error)                                 `perm:"read"`
-		ClientMinerQueryOffer    func(ctx context.Context, miner address.Address, root cid.Cid, piece *cid.Cid) (api.QueryOffer, error)            `perm:"read"`
-		ClientStartDeal          func(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error)                                          `perm:"admin"`
-		ClientGetDealInfo        func(context.Context, cid.Cid) (*api.DealInfo, error)                                                             `perm:"read"`
-		ClientListDeals          func(ctx context.Context) ([]api.DealInfo, error)                                                                 `perm:"write"`
-		ClientRetrieve           func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error                                       `perm:"admin"`
-		ClientRetrieveWithEvents func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) (<-chan marketevents.RetrievalEvent, error) `perm:"admin"`
-		ClientQueryAsk           func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)              `perm:"read"`
-		ClientCalcCommP          func(ctx context.Context, inpath string) (*api.CommPRet, error)                                                   `perm:"read"`
-		ClientGenCar             func(ctx context.Context, ref api.FileRef, outpath string) error                                                  `perm:"write"`
-		ClientDealSize           func(ctx context.Context, root cid.Cid) (api.DataSize, error)                                                     `perm:"read"`
-		ClientListDataTransfers  func(ctx context.Context) ([]api.DataTransferChannel, error)                                                      `perm:"write"`
+		ClientImport              func(ctx context.Context, ref api.FileRef) (*api.ImportRes, error)                                                `perm:"admin"`
+		ClientListImports         func(ctx context.Context) ([]api.Import, error)                                                                   `perm:"write"`
+		ClientRemoveImport        func(ctx context.Context, importID multistore.StoreID) error                                                      `perm:"admin"`
+		ClientHasLocal            func(ctx context.Context, root cid.Cid) (bool, error)                                                             `perm:"write"`
+		ClientFindData            func(ctx context.Context, root cid.Cid, piece *cid.Cid) ([]api.QueryOffer, error)                                 `perm:"read"`
+		ClientMinerQueryOffer     func(ctx context.Context, miner address.Address, root cid.Cid, piece *cid.Cid) (api.QueryOffer, error)            `perm:"read"`
+		ClientStartDeal           func(ctx context.Context, params *api.StartDealParams) (*cid.Cid, error)                                          `perm:"admin"`
+		ClientGetDealInfo         func(context.Context, cid.Cid) (*api.DealInfo, error)                                                             `perm:"read"`
+		ClientListDeals           func(ctx context.Context) ([]api.DealInfo, error)                                                                 `perm:"write"`
+		ClientRetrieve            func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) error                                       `perm:"admin"`
+		ClientRetrieveWithEvents  func(ctx context.Context, order api.RetrievalOrder, ref *api.FileRef) (<-chan marketevents.RetrievalEvent, error) `perm:"admin"`
+		ClientQueryAsk            func(ctx context.Context, p peer.ID, miner address.Address) (*storagemarket.SignedStorageAsk, error)              `perm:"read"`
+		ClientCalcCommP           func(ctx context.Context, inpath string) (*api.CommPRet, error)                                                   `perm:"read"`
+		ClientGenCar              func(ctx context.Context, ref api.FileRef, outpath string) error                                                  `perm:"write"`
+		ClientDealSize            func(ctx context.Context, root cid.Cid) (api.DataSize, error)                                                     `perm:"read"`
+		ClientListDataTransfers   func(ctx context.Context) ([]api.DataTransferChannel, error)                                                      `perm:"write"`
+		ClientDataTransferUpdates func(ctx context.Context) (<-chan api.DataTransferChannel, error)                                                 `perm:"write"`
 
 		StateNetworkName                   func(context.Context) (dtypes.NetworkName, error)                                                                   `perm:"read"`
 		StateMinerSectors                  func(context.Context, address.Address, *abi.BitField, bool, types.TipSetKey) ([]*api.ChainSectorInfo, error)        `perm:"read"`
@@ -452,6 +453,10 @@ func (c *FullNodeStruct) ClientDealSize(ctx context.Context, root cid.Cid) (api.
 
 func (c *FullNodeStruct) ClientListDataTransfers(ctx context.Context) ([]api.DataTransferChannel, error) {
 	return c.Internal.ClientListDataTransfers(ctx)
+}
+
+func (c *FullNodeStruct) ClientDataTransferUpdates(ctx context.Context) (<-chan api.DataTransferChannel, error) {
+	return c.Internal.ClientDataTransferUpdates(ctx)
 }
 
 func (c *FullNodeStruct) GasEstimateGasPremium(ctx context.Context, nblocksincl uint64,

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -142,6 +142,7 @@ type FullNodeStruct struct {
 		ClientCalcCommP          func(ctx context.Context, inpath string) (*api.CommPRet, error)                                                   `perm:"read"`
 		ClientGenCar             func(ctx context.Context, ref api.FileRef, outpath string) error                                                  `perm:"write"`
 		ClientDealSize           func(ctx context.Context, root cid.Cid) (api.DataSize, error)                                                     `perm:"read"`
+		ClientListDataTransfers  func(ctx context.Context) ([]api.DataTransferChannel, error)                                                      `perm:"write"`
 
 		StateNetworkName                   func(context.Context) (dtypes.NetworkName, error)                                                                   `perm:"read"`
 		StateMinerSectors                  func(context.Context, address.Address, *abi.BitField, bool, types.TipSetKey) ([]*api.ChainSectorInfo, error)        `perm:"read"`
@@ -447,6 +448,10 @@ func (c *FullNodeStruct) ClientGenCar(ctx context.Context, ref api.FileRef, outp
 
 func (c *FullNodeStruct) ClientDealSize(ctx context.Context, root cid.Cid) (api.DataSize, error) {
 	return c.Internal.ClientDealSize(ctx, root)
+}
+
+func (c *FullNodeStruct) ClientListDataTransfers(ctx context.Context) ([]api.DataTransferChannel, error) {
+	return c.Internal.ClientListDataTransfers(ctx)
 }
 
 func (c *FullNodeStruct) GasEstimateGasPremium(ctx context.Context, nblocksincl uint64,

--- a/api/types.go
+++ b/api/types.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"encoding/json"
+
 	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/ipfs/go-cid"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -97,4 +100,16 @@ func (ms *MessageSendSpec) Get() MessageSendSpec {
 	}
 
 	return *ms
+}
+
+type DataTransferChannel struct {
+	TransferID  datatransfer.TransferID
+	Status      datatransfer.Status
+	BaseCID     cid.Cid
+	IsInitiator bool
+	IsSender    bool
+	VoucherJSON string
+	Message     string
+	OtherPeer   peer.ID
+	Transferred uint64
 }

--- a/api/types.go
+++ b/api/types.go
@@ -108,7 +108,7 @@ type DataTransferChannel struct {
 	BaseCID     cid.Cid
 	IsInitiator bool
 	IsSender    bool
-	VoucherJSON string
+	Voucher     string
 	Message     string
 	OtherPeer   peer.ID
 	Transferred uint64

--- a/cli/client.go
+++ b/cli/client.go
@@ -1247,21 +1247,29 @@ var clientListTransfers = &cli.Command{
 		fmt.Fprintf(os.Stdout, "Sending Channels\n\n")
 		w := tablewriter.New(tablewriter.Col("ID"),
 			tablewriter.Col("Status"),
-			tablewriter.Col("Other Party"),
+			tablewriter.Col("Sending To"),
 			tablewriter.Col("Root Cid"),
 			tablewriter.Col("Initiated?"),
 			tablewriter.Col("Transferred"),
-			tablewriter.NewLineCol("Voucher"),
+			tablewriter.Col("Voucher"),
 			tablewriter.NewLineCol("Message"))
 		for _, channel := range sendingChannels {
-			w.Write(toChannelOutput(color, channel))
+			w.Write(toChannelOutput(color, "Sending To", channel))
 		}
 		w.Flush(os.Stdout)
 
 		fmt.Fprintf(os.Stdout, "\nReceiving Channels\n\n")
+		w = tablewriter.New(tablewriter.Col("ID"),
+			tablewriter.Col("Status"),
+			tablewriter.Col("Receiving From"),
+			tablewriter.Col("Root Cid"),
+			tablewriter.Col("Initiated?"),
+			tablewriter.Col("Transferred"),
+			tablewriter.Col("Voucher"),
+			tablewriter.NewLineCol("Message"))
 		for _, channel := range receivingChannels {
 
-			w.Write(toChannelOutput(color, channel))
+			w.Write(toChannelOutput(color, "Receiving From", channel))
 		}
 		return w.Flush(os.Stdout)
 	},
@@ -1283,7 +1291,7 @@ func channelStatusString(useColor bool, status datatransfer.Status) string {
 	}
 }
 
-func toChannelOutput(useColor bool, channel api.DataTransferChannel) map[string]interface{} {
+func toChannelOutput(useColor bool, otherPartyColumn string, channel api.DataTransferChannel) map[string]interface{} {
 	rootCid := channel.BaseCID.String()
 	rootCid = "..." + rootCid[len(rootCid)-8:]
 
@@ -1295,14 +1303,19 @@ func toChannelOutput(useColor bool, channel api.DataTransferChannel) map[string]
 		initiated = "Y"
 	}
 
+	voucher := channel.VoucherJSON
+	if len(voucher) > 40 {
+		voucher = "..." + voucher[len(voucher)-37:]
+	}
+
 	return map[string]interface{}{
-		"ID":          channel.TransferID,
-		"Status":      channelStatusString(useColor, channel.Status),
-		"Other Party": otherParty,
-		"Root Cid":    rootCid,
-		"Initiated?":  initiated,
-		"Transferred": channel.Transferred,
-		"Voucher":     channel.VoucherJSON,
-		"Message":     channel.Message,
+		"ID":             channel.TransferID,
+		"Status":         channelStatusString(useColor, channel.Status),
+		otherPartyColumn: otherParty,
+		"Root Cid":       rootCid,
+		"Initiated?":     initiated,
+		"Transferred":    channel.Transferred,
+		"Voucher":        voucher,
+		"Message":        channel.Message,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Gurpartap/async v0.0.0-20180927173644-4f7f499dd9ee
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e
 	github.com/dgraph-io/badger/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129 h1:gfAMKE626QEuKG3si0pdTRcr/YEbBoxY+3GOH3gWvl4=
+github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129/go.mod h1:u9UyCz2eTrSGy6fbupqJ54eY5c4IC8gREQ1053dK12U=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"golang.org/x/xerrors"
 
@@ -470,11 +471,15 @@ func (a *API) clientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 	unsubscribe := a.Retrieval.SubscribeToEvents(func(event rm.ClientEvent, state rm.ClientDealState) {
 		if state.PayloadCID.Equals(order.Root) {
 
-			events <- marketevents.RetrievalEvent{
+			select {
+			case <-ctx.Done():
+				return
+			case events <- marketevents.RetrievalEvent{
 				Event:         event,
 				Status:        state.Status,
 				BytesReceived: state.TotalReceived,
 				FundsSpent:    state.FundsSpent,
+			}:
 			}
 
 			switch state.Status {
@@ -767,29 +772,59 @@ func (a *API) ClientListDataTransfers(ctx context.Context) ([]api.DataTransferCh
 	}
 
 	apiChannels := make([]api.DataTransferChannel, 0, len(inProgressChannels))
-	for channelID, channelState := range inProgressChannels {
-		channel := api.DataTransferChannel{
-			TransferID:  channelState.TransferID(),
-			Status:      channelState.Status(),
-			BaseCID:     channelState.BaseCID(),
-			IsInitiator: channelID.Initiator == a.Host.ID(),
-			IsSender:    channelState.Sender() == a.Host.ID(),
-			Message:     channelState.Message(),
-		}
-		voucherJSON, err := json.Marshal(channelState.Voucher())
-		if err != nil {
-			return nil, err
-		}
-		channel.VoucherJSON = string(voucherJSON)
-		if channel.IsSender {
-			channel.Transferred = channelState.Sent()
-			channel.OtherPeer = channelState.Recipient()
-		} else {
-			channel.Transferred = channelState.Received()
-			channel.OtherPeer = channelState.Sender()
-		}
-		apiChannels = append(apiChannels, channel)
+	for _, channelState := range inProgressChannels {
+		apiChannels = append(apiChannels, toAPIChannel(a.Host.ID(), channelState))
 	}
 
 	return apiChannels, nil
+}
+
+func (a *API) ClientDataTransferUpdates(ctx context.Context) (<-chan api.DataTransferChannel, error) {
+	channels := make(chan api.DataTransferChannel)
+
+	unsub := a.DataTransfer.SubscribeToEvents(func(evt datatransfer.Event, channelState datatransfer.ChannelState) {
+		channel := toAPIChannel(a.Host.ID(), channelState)
+		select {
+		case <-ctx.Done():
+		case channels <- channel:
+		}
+	})
+
+	go func() {
+		defer unsub()
+		<-ctx.Done()
+	}()
+
+	return channels, nil
+}
+
+func toAPIChannel(hostID peer.ID, channelState datatransfer.ChannelState) api.DataTransferChannel {
+	channel := api.DataTransferChannel{
+		TransferID: channelState.TransferID(),
+		Status:     channelState.Status(),
+		BaseCID:    channelState.BaseCID(),
+		IsSender:   channelState.Sender() == hostID,
+		Message:    channelState.Message(),
+	}
+	stringer, ok := channelState.Voucher().(fmt.Stringer)
+	if ok {
+		channel.Voucher = stringer.String()
+	} else {
+		voucherJSON, err := json.Marshal(channelState.Voucher())
+		if err != nil {
+			channel.Voucher = fmt.Errorf("Voucher Serialization: %w", err).Error()
+		} else {
+			channel.Voucher = string(voucherJSON)
+		}
+	}
+	if channel.IsSender {
+		channel.IsInitiator = !channelState.IsPull()
+		channel.Transferred = channelState.Sent()
+		channel.OtherPeer = channelState.Recipient()
+	} else {
+		channel.IsInitiator = channelState.IsPull()
+		channel.Transferred = channelState.Received()
+		channel.OtherPeer = channelState.Sender()
+	}
+	return channel
 }


### PR DESCRIPTION
# Goals

This started as helping me understand what was happening with data transfers... and turned into something that I think will be super useful for all.

It adds `lotus client list-transfers` along with `lotus client list-transfers --watch` which allows you to watch data transfers in real time.

This is a screen shot as about 6 128MB pieces are sent over the wire...
![acto2r](https://user-images.githubusercontent.com/1450680/90582982-f2e0b700-e183-11ea-993b-8ad88ceb1b7d.gif)

# Implementation

In addition to the CLI, there are two new APIs:
- ClientListDataTransfers which gets the current list of transfers
- ClientDataTransferUpdates which returns a channel of updates to data transfers

- also defines a data type api.DataTransferChannel which collects the most relevant information from the overall data transfer channel state and outputs to the channel
- voucher output will improve with a future update to go-fil-markets so the storage and retrieval vouchers have string form

Note: not trying to force this into calibnet or space race, though it should be very non-breaking (just code adds). I'd really like to get in for mainnet though. In the meantime I can just cherry-pick a squashed commit but I imagine this will be very useful to many.
