### PR TITLE
ignore, don't reject messages with nonce that is too low

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -546,7 +546,11 @@ func (mv *MessageValidator) Validate(ctx context.Context, pid peer.ID, msg *pubs
 		)
 		stats.Record(ctx, metrics.MessageValidationFailure.M(1))
 		switch {
-		case xerrors.Is(err, messagepool.ErrBroadcastAnyway) || xerrors.Is(err, messagepool.ErrRBFTooLowPremium):
+		case xerrors.Is(err, messagepool.ErrBroadcastAnyway):
+			fallthrough
+		case xerrors.Is(err, messagepool.ErrRBFTooLowPremium):
+			fallthrough
+		case xerrors.Is(err, messagepool.ErrNonceTooLow):
 			return pubsub.ValidationIgnore
 		default:
 			return pubsub.ValidationReject


### PR DESCRIPTION
we seem to have a problem with this leading to many rejected messages and negative scores for
potentially innocent peers who are republishing their messages.