### PR TITLE
add sanity check for maximum block size

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -340,6 +340,11 @@ func (bv *BlockValidator) Validate(ctx context.Context, pid peer.ID, msg *pubsub
 func (bv *BlockValidator) validateLocalBlock(ctx context.Context, msg *pubsub.Message) pubsub.ValidationResult {
 	stats.Record(ctx, metrics.BlockPublished.M(1))
 
+	if size := msg.Size(); size > 1<<20-1<<15 {
+		log.Errorf("ignoring oversize block (%dB)", size)
+		return pubsub.ValidationIgnore
+	}
+
 	blk, what, err := bv.decodeAndCheckBlock(msg)
 	if err != nil {
 		log.Errorf("got invalid local block: %s", err)

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -342,6 +342,8 @@ func (bv *BlockValidator) validateLocalBlock(ctx context.Context, msg *pubsub.Me
 
 	if size := msg.Size(); size > 1<<20-1<<15 {
 		log.Errorf("ignoring oversize block (%dB)", size)
+		ctx, _ = tag.New(ctx, tag.Insert(metrics.FailureType, "oversize_block"))
+		stats.Record(ctx, metrics.BlockValidationFailure.M(1))
 		return pubsub.ValidationIgnore
 	}
 


### PR DESCRIPTION
1MB - some space for pubsub metadata; we should not exceed it in practice, but this adds a sanity check to make sure we don't clog the receiver ends in pubsub.