### PR TITLE
Change Message.Version to be a uint64

### DIFF
--- a/api/cbor_gen.go
+++ b/api/cbor_gen.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/chain/blocksync/cbor_gen.go
+++ b/chain/blocksync/cbor_gen.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/ipfs/go-cid"
+	types "github.com/filecoin-project/lotus/chain/types"
+	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/chain/types/message.go
+++ b/chain/types/message.go
@@ -25,7 +25,7 @@ type ChainMsg interface {
 }
 
 type Message struct {
-	Version int64
+	Version uint64
 
 	To   address.Address
 	From address.Address

--- a/node/hello/cbor_gen.go
+++ b/node/hello/cbor_gen.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/ipfs/go-cid"
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/paychmgr/cbor_gen.go
+++ b/paychmgr/cbor_gen.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	address "github.com/filecoin-project/go-address"
+	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )


### PR DESCRIPTION
We don't want negative versions, and this will avoid future code needing an explicit validation rule that the value is non-negative. CBOR-encoding should be equivalent for non-negative values, so this is backwards compatible.

There's some noise on the other cbor-gen files since the generated code is slightly out of date with cbor-gen.