### PR TITLE
Remove use of exitcode.SysErrInvalidParameters

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -342,7 +342,7 @@ func (rt *Runtime) Send(to address.Address, method abi.MethodNum, m vmr.CBORMars
 	if m != nil {
 		buf := new(bytes.Buffer)
 		if err := m.MarshalCBOR(buf); err != nil {
-			rt.Abortf(exitcode.SysErrInvalidParameters, "failed to marshal input parameters: %s", err)
+			rt.Abortf(exitcode.ErrSerialization, "failed to marshal input parameters: %s", err)
 		}
 		params = buf.Bytes()
 	}

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -40,23 +40,23 @@ var actorLog = logging.Logger("actors")
 var gasOnActorExec = newGasCharge("OnActorExec", 0, 0)
 
 // ResolveToKeyAddr returns the public key type of address (`BLS`/`SECP256K1`) of an account actor identified by `addr`.
-func ResolveToKeyAddr(state types.StateTree, cst cbor.IpldStore, addr address.Address) (address.Address, aerrors.ActorError) {
+func ResolveToKeyAddr(state types.StateTree, cst cbor.IpldStore, addr address.Address) (address.Address, error) {
 	if addr.Protocol() == address.BLS || addr.Protocol() == address.SECP256K1 {
 		return addr, nil
 	}
 
 	act, err := state.GetActor(addr)
 	if err != nil {
-		return address.Undef, aerrors.Newf(exitcode.SysErrInvalidParameters, "failed to find actor: %s", addr)
+		return address.Undef, xerrors.Errorf("failed to find actor: %s", addr)
 	}
 
 	if act.Code != builtin.AccountActorCodeID {
-		return address.Undef, aerrors.Newf(exitcode.SysErrInvalidParameters, "address %s was not for an account actor", addr)
+		return address.Undef, xerrors.Errorf("address %s was not for an account actor", addr)
 	}
 
 	var aast account.State
 	if err := cst.Get(context.TODO(), act.Head, &aast); err != nil {
-		return address.Undef, aerrors.Absorb(err, exitcode.SysErrInvalidParameters, fmt.Sprintf("failed to get account actor state for %s", addr))
+		return address.Undef, xerrors.Errorf("failed to get account actor state for %s: %w", addr, err)
 	}
 
 	return aast.Address, nil


### PR DESCRIPTION
`SysErrInvalidParameters` is deprecated, there's no case where it should be used.

FYI @raulk 