### PR TITLE
fix(chainwatch): Handle RewardState.EpochSmoothingEstimate == nil

### DIFF
--- a/cmd/lotus-chainwatch/processor/reward.go
+++ b/cmd/lotus-chainwatch/processor/reward.go
@@ -280,6 +280,9 @@ func (p *Processor) storeRewardSmoothingEstimates(rewards []rewardActorInfo) err
 	}
 
 	for _, rewardState := range rewards {
+		if rewardState.epochSmoothingEstimate == nil {
+			continue
+		}
 		if _, err := stmt.Exec(
 			rewardState.common.stateroot.String(),
 			rewardState.epochSmoothingEstimate.PositionEstimate.String(),


### PR DESCRIPTION
I'd be curious to know how this is even possible, though I'm too tired to investigate tonight. This allows chainwatch to proceed instead of panicking like so:

```
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]: github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).storeRewardSmoothingEstimates(0xc000500980, 0xc001644000, 0x1cd, 0x266, 0x4312960, 0x0)
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]:         /home/ubuntu/sentinel/lotus/cmd/lotus-chainwatch/processor/reward.go:285 +0x39b
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]: github.com/filecoin-project/lotus/cmd/lotus-chainwatch/processor.(*Processor).persistRewardActors.func4(0xc0013cdd70, 0x221a628)
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]:         /home/ubuntu/sentinel/lotus/cmd/lotus-chainwatch/processor/reward.go:179 +0x45
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]: golang.org/x/sync/errgroup.(*Group).Go.func1(0xc001702d20, 0xc001702db0)
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]:         /home/ubuntu/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x59
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]: created by golang.org/x/sync/errgroup.(*Group).Go
Aug 20 05:19:09 sentinel-calibration chainwatch[1219]:         /home/ubuntu/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:54 +0x66
```