### PR TITLE
update pubsub and bump behaviour penalty threshold to 6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/libp2p/go-libp2p-noise v0.1.1
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.6
-	github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820150332-b7c28b504da7
+	github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820194335-bfc96c2cd081
 	github.com/libp2p/go-libp2p-quic-transport v0.7.1
 	github.com/libp2p/go-libp2p-record v0.1.3
 	github.com/libp2p/go-libp2p-routing-helpers v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -885,8 +885,8 @@ github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1
 github.com/libp2p/go-libp2p-protocol v0.1.0/go.mod h1:KQPHpAabB57XQxGrXCNvbL6UEXfQqUgC/1adR2Xtflk=
 github.com/libp2p/go-libp2p-pubsub v0.1.1/go.mod h1:ZwlKzRSe1eGvSIdU5bD7+8RZN/Uzw0t1Bp9R1znpR/Q=
 github.com/libp2p/go-libp2p-pubsub v0.3.2-0.20200527132641-c0712c6e92cf/go.mod h1:TxPOBuo1FPdsTjFnv+FGZbNbWYsp74Culx+4ViQpato=
-github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820150332-b7c28b504da7 h1:Ze6e0RU+JjLXYZEHUff1ziDC6hrmeMovwXHVpHLeyhc=
-github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820150332-b7c28b504da7/go.mod h1:DTMSVmZZfXodB/pvdTGrY2eHPZ9W2ev7hzTH83OKHrI=
+github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820194335-bfc96c2cd081 h1:OYGkXBqwyy8YExNj1ZNKm8ICeBJu1E40k/qr8rHqmH8=
+github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820194335-bfc96c2cd081/go.mod h1:DTMSVmZZfXodB/pvdTGrY2eHPZ9W2ev7hzTH83OKHrI=
 github.com/libp2p/go-libp2p-quic-transport v0.1.1/go.mod h1:wqG/jzhF3Pu2NrhJEvE+IE0NTHNXslOPn9JQzyCAxzU=
 github.com/libp2p/go-libp2p-quic-transport v0.5.0/go.mod h1:IEcuC5MLxvZ5KuHKjRu+dr3LjCT1Be3rcD/4d8JrX8M=
 github.com/libp2p/go-libp2p-quic-transport v0.7.1 h1:X6Ond9GANspXpgwJlSR9yxcMMD6SLBnGKRtwjBG5awc=

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -112,8 +112,8 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 				// IPColocationFactorWhitelist: map[string]struct{}{},
 
 				// P7: behavioural penalties, decay after 1hr
+				BehaviourPenaltyThreshold: 6,
 				BehaviourPenaltyWeight:    -10,
-				BehaviourPenaltyThreshold: 3,
 				BehaviourPenaltyDecay:     pubsub.ScoreParameterDecay(time.Hour),
 
 				DecayInterval: pubsub.DefaultDecayInterval,


### PR DESCRIPTION
Bug fix in https://github.com/libp2p/go-libp2p-pubsub/pull/378, observed in my node.
The bump is for empirical observations in my node behaviourally penalized nodes rarely exceed 6.