### PR TITLE
Address potential mpool state inconsistencies

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -184,7 +184,7 @@ type FullNode interface {
 	MpoolGetNonce(context.Context, address.Address) (uint64, error)
 	MpoolSub(context.Context) (<-chan MpoolUpdate, error)
 
-	// MpoolClear clears all pending messages from the mpool
+	// MpoolClear clears pending messages from the mpool
 	MpoolClear(context.Context, bool) error
 
 	// MpoolGetConfig returns (a copy of) the current mpool config

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -496,8 +496,8 @@ func (c *FullNodeStruct) MpoolPending(ctx context.Context, tsk types.TipSetKey) 
 	return c.Internal.MpoolPending(ctx, tsk)
 }
 
-func (c *FullNodeStruct) MpoolClear(ctx context.Context, localonly bool) error {
-	return c.Internal.MpoolClear(ctx, localonly)
+func (c *FullNodeStruct) MpoolClear(ctx context.Context, local bool) error {
+	return c.Internal.MpoolClear(ctx, local)
 }
 
 func (c *FullNodeStruct) MpoolPush(ctx context.Context, smsg *types.SignedMessage) (cid.Cid, error) {

--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -90,7 +90,7 @@ var mpoolClear = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "local",
-			Usage: "clear local messages only",
+			Usage: "also clear local messages",
 		},
 		&cli.BoolFlag{
 			Name:  "really-do-it",

--- a/documentation/en/mpool.md
+++ b/documentation/en/mpool.md
@@ -20,7 +20,7 @@ The full node API defines the following methods for interacting with the mpool:
     MpoolSub(context.Context) (<-chan MpoolUpdate, error)
     MpoolGetConfig(context.Context) (*types.MpoolConfig, error)
     MpoolSetConfig(context.Context, *types.MpoolConfig) error
-    MpoolClear(context.Context, localonly bool) error
+    MpoolClear(context.Context, local bool) error
 ```
 
 ### MpoolPending
@@ -64,7 +64,7 @@ Sets the mpool configuration to (a copy of) the supplied configuration object.
 
 ### MpoolClear
 
-Clears pending messages from the mpool; if `localonly` is `true` then only local messages are cleared.
+Clears pending messages from the mpool; if `local` is `true` then local messages are also cleared and removed from the datastore.
 
 This should be used with extreme care and only in the case of errors during head changes that
 would leave the mpool in an inconsistent state.
@@ -109,11 +109,9 @@ Gets or sets the current mpool configuration.
 
 ### lotus mpool clear
 Unconditionally clears pending messages from the mpool.
-If the `--local` flag is passed, then only local messages are cleared; otherwise all messages
-are cleared.
+If the `--local` flag is passed, then local messages are also cleared; otherwise local messages are retained.
 
-*Warning*: this command should only be used in the case of head change errors leaving the mpool in an
-inconsistent state.
+*Warning*: this command should only be used in the case of head change errors leaving the mpool in an  state.
 
 ## Configuration
 

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -105,8 +105,8 @@ func (a *MpoolAPI) MpoolPending(ctx context.Context, tsk types.TipSetKey) ([]*ty
 	}
 }
 
-func (a *MpoolAPI) MpoolClear(ctx context.Context, localonly bool) error {
-	a.Mpool.Clear(localonly)
+func (a *MpoolAPI) MpoolClear(ctx context.Context, local bool) error {
+	a.Mpool.Clear(local)
 	return nil
 }
 


### PR DESCRIPTION
If revert or apply errors during a HeadChange, the mpool can be left in an inconsistent state.

After discussion with @whyrusleeping and @Kubuxu we decided to improve resilience somewhat, and also add a clear api/command that unconditionally clears the mpool.