### PR TITLE
More message pool tests and a couple of bug fixes

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -982,6 +982,7 @@ func (mp *MessagePool) Updates(ctx context.Context) (<-chan api.MpoolUpdate, err
 
 	go func() {
 		defer mp.changes.Unsub(sub, localUpdates)
+		defer close(out)
 
 		for {
 			select {
@@ -990,8 +991,12 @@ func (mp *MessagePool) Updates(ctx context.Context) (<-chan api.MpoolUpdate, err
 				case out <- u.(api.MpoolUpdate):
 				case <-ctx.Done():
 					return
+				case <-mp.closer:
+					return
 				}
 			case <-ctx.Done():
+				return
+			case <-mp.closer:
 				return
 			}
 		}

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -908,8 +908,6 @@ func (mp *MessagePool) runHeadChange(from *types.TipSet, to *types.TipSet, rmsgs
 	}
 
 	for _, ts := range apply {
-		mp.curTs = ts
-
 		for _, b := range ts.Blocks() {
 			bmsgs, smsgs, err := mp.api.MessagesForBlock(b)
 			if err != nil {

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -38,7 +38,7 @@ import (
 
 var log = logging.Logger("messagepool")
 
-const futureDebug = false
+var futureDebug = false
 
 var rbfNumBig = types.NewInt(uint64((ReplaceByFeeRatioDefault - 1) * RbfDenom))
 var rbfDenomBig = types.NewInt(RbfDenom)
@@ -651,6 +651,10 @@ func (mp *MessagePool) Pending() ([]*types.SignedMessage, *types.TipSet) {
 	mp.lk.Lock()
 	defer mp.lk.Unlock()
 
+	return mp.allPending()
+}
+
+func (mp *MessagePool) allPending() ([]*types.SignedMessage, *types.TipSet) {
 	out := make([]*types.SignedMessage, 0)
 	for a := range mp.pending {
 		out = append(out, mp.pendingFor(a)...)
@@ -658,6 +662,7 @@ func (mp *MessagePool) Pending() ([]*types.SignedMessage, *types.TipSet) {
 
 	return out, mp.curTs
 }
+
 func (mp *MessagePool) PendingFor(a address.Address) ([]*types.SignedMessage, *types.TipSet) {
 	mp.curTsLk.Lock()
 	defer mp.curTsLk.Unlock()
@@ -790,7 +795,9 @@ func (mp *MessagePool) HeadChange(revert []*types.TipSet, apply []*types.TipSet)
 	}
 
 	if len(revert) > 0 && futureDebug {
-		msgs, ts := mp.Pending()
+		mp.lk.Lock()
+		msgs, ts := mp.allPending()
+		mp.lk.Unlock()
 
 		buckets := map[address.Address]*statBucket{}
 

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -440,7 +440,10 @@ func TestLoadLocal(t *testing.T) {
 		}
 		msgs[cid] = struct{}{}
 	}
-	mp.Close()
+	err = mp.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mp, err = New(tma, ds, "mptest")
 	if err != nil {
@@ -629,7 +632,11 @@ func TestUpdates(t *testing.T) {
 		}
 	}
 
-	mp.Close()
+	err = mp.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	_, ok := <-ch
 	if ok {
 		t.Fatal("expected closed channel, but got an update instead")

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -281,6 +281,11 @@ func TestMessagePoolMessagesInEachBlock(t *testing.T) {
 }
 
 func TestRevertMessages(t *testing.T) {
+	futureDebug = true
+	defer func() {
+		futureDebug = false
+	}()
+
 	tma := newTestMpoolAPI()
 
 	w, err := wallet.NewWallet(wallet.NewMemKeyStore())

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -32,6 +32,8 @@ type testMpoolAPI struct {
 	balance    map[address.Address]types.BigInt
 
 	tipsets []*types.TipSet
+
+	published int
 }
 
 func newTestMpoolAPI() *testMpoolAPI {
@@ -91,6 +93,7 @@ func (tma *testMpoolAPI) PutMessage(m types.ChainMsg) (cid.Cid, error) {
 }
 
 func (tma *testMpoolAPI) PubSubPublish(string, []byte) error {
+	tma.published++
 	return nil
 }
 

--- a/chain/messagepool/repub_test.go
+++ b/chain/messagepool/repub_test.go
@@ -1,0 +1,66 @@
+package messagepool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
+	"github.com/filecoin-project/lotus/chain/wallet"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	"github.com/ipfs/go-datastore"
+)
+
+func TestRepubMessages(t *testing.T) {
+	tma := newTestMpoolAPI()
+	ds := datastore.NewMapDatastore()
+
+	mp, err := New(tma, ds, "mptest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// the actors
+	w1, err := wallet.NewWallet(wallet.NewMemKeyStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a1, err := w1.GenerateKey(crypto.SigTypeSecp256k1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w2, err := wallet.NewWallet(wallet.NewMemKeyStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a2, err := w2.GenerateKey(crypto.SigTypeSecp256k1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+
+	tma.setBalance(a1, 1) // in FIL
+
+	for i := 0; i < 10; i++ {
+		m := makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
+		_, err := mp.Push(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if tma.published != 10 {
+		t.Fatalf("expected to have published 10 messages, but got %d instead", tma.published)
+	}
+
+	mp.repubTrigger <- struct{}{}
+	time.Sleep(100 * time.Millisecond)
+
+	if tma.published != 20 {
+		t.Fatalf("expected to have published 20 messages, but got %d instead", tma.published)
+	}
+}


### PR DESCRIPTION
Tests to cover some of the red spots in the coverage, and lo and behold some bugs...

Bug fixes:
- the debug code with futureDebug was broken; it was deadlocking.
- the output channel was not closed when exiting the update sub goroutine.
- the sub goroutine didn't respect the closer.
- [IMPORTANT] the new `runHeadChange`, called from selection, was modifying the mpool's current ts.