### PR TITLE
Use a safe string ellipsis/truncation function for client CLI output

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1060,8 +1060,7 @@ var clientListDeals = &cli.Command{
 			tablewriter.NewLineCol("Message"))
 
 		for _, d := range deals {
-			propcid := d.LocalDeal.ProposalCid.String()
-			propcid = "..." + propcid[len(propcid)-8:]
+			propcid := ellipsis(d.LocalDeal.ProposalCid.String(), 8)
 
 			onChain := "N"
 			if d.OnChainDealState.SectorStartEpoch != -1 {
@@ -1073,8 +1072,7 @@ var clientListDeals = &cli.Command{
 				slashed = fmt.Sprintf("Y (epoch %d)", d.OnChainDealState.SlashEpoch)
 			}
 
-			piece := d.LocalDeal.PieceCID.String()
-			piece = "..." + piece[len(piece)-8:]
+			piece := ellipsis(d.LocalDeal.PieceCID.String(), 8)
 
 			price := types.FIL(types.BigMul(d.LocalDeal.PricePerEpoch, types.NewInt(d.LocalDeal.Duration)))
 
@@ -1352,11 +1350,8 @@ func channelStatusString(useColor bool, status datatransfer.Status) string {
 }
 
 func toChannelOutput(useColor bool, otherPartyColumn string, channel lapi.DataTransferChannel) map[string]interface{} {
-	rootCid := channel.BaseCID.String()
-	rootCid = "..." + rootCid[len(rootCid)-8:]
-
-	otherParty := channel.OtherPeer.String()
-	otherParty = "..." + otherParty[len(otherParty)-8:]
+	rootCid := ellipsis(channel.BaseCID.String(), 8)
+	otherParty := ellipsis(channel.OtherPeer.String(), 8)
 
 	initiated := "N"
 	if channel.IsInitiator {
@@ -1365,7 +1360,7 @@ func toChannelOutput(useColor bool, otherPartyColumn string, channel lapi.DataTr
 
 	voucher := channel.Voucher
 	if len(voucher) > 40 {
-		voucher = "..." + voucher[len(voucher)-37:]
+		voucher = ellipsis(voucher, 37)
 	}
 
 	return map[string]interface{}{
@@ -1378,4 +1373,11 @@ func toChannelOutput(useColor bool, otherPartyColumn string, channel lapi.DataTr
 		"Voucher":        voucher,
 		"Message":        channel.Message,
 	}
+}
+
+func ellipsis(s string, length int) string {
+	if length > 0 && len(s) > length {
+		return "..." + s[len(s)-length:]
+	}
+	return s
 }


### PR DESCRIPTION
## Problem
There were certain instances of OOB errors when truncating strings in CLI output.

## Solution
Add an `ellipsis(string, int)` func which checks bounds.