### PR TITLE
Fix more lint warnings.

### DIFF
--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -106,6 +106,7 @@ var mpoolClear = &cli.Command{
 
 		really := cctx.Bool("really-do-it")
 		if !really {
+			//nolint:golint
 			return fmt.Errorf("--really-do-it must be specified for this action to have an effect; you have been warned")
 		}
 

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -10,7 +10,6 @@ import (
 
 	rice "github.com/GeertJohan/go.rice"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
@@ -131,10 +130,7 @@ type handler struct {
 	from           address.Address
 	sendPerRequest types.FIL
 
-	limiter      *Limiter
-	minerLimiter *Limiter
-
-	defaultMinerPeer peer.ID
+	limiter *Limiter
 }
 
 func (h *handler) send(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This way we can keep CI green. Otherwise, nobody looks at CI and bugs slip through.

(can we make these mandatory?)