### PR TITLE
feat: bleeding edge conformance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,10 +220,11 @@ jobs:
               equal: [ "", << parameters.vectors-branch >> ]
           steps:
             - run:
-              command: |
-                cd extern/test-vectors
-                git fetch
-                git checkout origin/<< parameters.vectors-branch >>
+                name: checkout vectors branch
+                command: |
+                  cd extern/test-vectors
+                  git fetch
+                  git checkout origin/<< parameters.vectors-branch >>
       - run:
           name: go test
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,15 @@ jobs:
     <<: *test
   test-conformance:
     <<: *test
+    parameters:
+      <<: *test.parameters
+      vectors-branch:
+        type: string
+        default: ""
+        description: |
+          Branch on github.com/filecoin-project/test-vectors to checkout and
+          test with. If empty (the default) the commit defined by the git
+          submodule is used.
     steps:
       - install-deps
       - prepare
@@ -201,6 +210,16 @@ jobs:
           command: make deps lotus
           no_output_timeout: 30m
       - download-params
+      - when:
+          condition:
+            not:
+              equal: [ "", << parameters.vectors-branch >> ]
+          steps:
+            - run:
+              command: |
+                cd extern/test-vectors
+                git fetch
+                git checkout origin/<< parameters.vectors-branch >>
       - run:
           name: go test
           environment:
@@ -361,6 +380,10 @@ workflows:
       - test-conformance:
           test-suite-name: conformance
           packages: "./conformance"
+      - test-conformance-bleeding-edge:
+          test-suite-name: conformance
+          packages: "./conformance"
+          vectors-branch: master
       - build-debug
       - build-all:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,9 @@ jobs:
                   cd extern/test-vectors
                   git fetch
                   git checkout origin/<< parameters.vectors-branch >>
+            - run:
+                name: go get vectors branch
+                command: go get github.com/filecoin-project/test-vectors@<< parameters.vectors-branch >>
       - run:
           name: go test
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
   test: &test
     description: |
       Run tests with gotestsum.
-    parameters:
+    parameters: &test-params
       executor:
         type: executor
         default: golang
@@ -193,9 +193,12 @@ jobs:
   test-window-post:
     <<: *test
   test-conformance:
-    <<: *test
+    description: |
+      Run tests using a corpus of interoperable test vectors for Filecoin 
+      implementations to test their correctness and compliance with the Filecoin
+      specifications.
     parameters:
-      <<: *test.parameters
+      <<: *test-params
       vectors-branch:
         type: string
         default: ""
@@ -203,6 +206,7 @@ jobs:
           Branch on github.com/filecoin-project/test-vectors to checkout and
           test with. If empty (the default) the commit defined by the git
           submodule is used.
+    executor: << parameters.executor >>
     steps:
       - install-deps
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,8 +384,8 @@ workflows:
       - test-conformance:
           test-suite-name: conformance
           packages: "./conformance"
-      - test-conformance-bleeding-edge:
-          test-suite-name: conformance
+      - test-conformance:
+          test-suite-name: conformance bleeding edge
           packages: "./conformance"
           vectors-branch: master
       - build-debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,8 @@ workflows:
           test-suite-name: conformance
           packages: "./conformance"
       - test-conformance:
-          test-suite-name: conformance bleeding edge
+          name: test-conformance-bleeding-edge
+          test-suite-name: conformance-bleeding-edge
           packages: "./conformance"
           vectors-branch: master
       - build-debug


### PR DESCRIPTION
Adds a `vectors-branch` param to the `test-conformance` job that allows it to be used multiple times in the CI workflow, once using the commit specified in the git submodule and again using the master branch of [test-vectors](https://github.com/filecoin-project/test-vectors).