### PR TITLE
paych: DONT MERGE - check that we can unmarshall old fmt voucher into new fmt voucher

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -36,6 +36,8 @@ func main() {
 		paychmgr.VoucherInfo{},
 		paychmgr.ChannelInfo{},
 		paychmgr.MsgInfo{},
+		paychmgr.OldVoucherInfo{},
+		paychmgr.OldChannelInfo{},
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/paychmgr/cbor_gen.go
+++ b/paychmgr/cbor_gen.go
@@ -838,3 +838,608 @@ func (t *MsgInfo) UnmarshalCBOR(r io.Reader) error {
 
 	return nil
 }
+func (t *OldVoucherInfo) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{162}); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Voucher (paych.SignedVoucher) (struct)
+	if len("Voucher") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Voucher\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Voucher"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Voucher")); err != nil {
+		return err
+	}
+
+	if err := t.Voucher.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Proof ([]uint8) (slice)
+	if len("Proof") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Proof\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Proof"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Proof")); err != nil {
+		return err
+	}
+
+	if len(t.Proof) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Proof was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Proof))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Proof[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *OldVoucherInfo) UnmarshalCBOR(r io.Reader) error {
+	*t = OldVoucherInfo{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("OldVoucherInfo: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Voucher (paych.SignedVoucher) (struct)
+		case "Voucher":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Voucher = new(paych.SignedVoucher)
+					if err := t.Voucher.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Voucher pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Proof ([]uint8) (slice)
+		case "Proof":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.Proof: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.Proof = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(br, t.Proof[:]); err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
+	}
+
+	return nil
+}
+func (t *OldChannelInfo) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{172}); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.ChannelID (string) (string)
+	if len("ChannelID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ChannelID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ChannelID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ChannelID")); err != nil {
+		return err
+	}
+
+	if len(t.ChannelID) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.ChannelID was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.ChannelID))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.ChannelID)); err != nil {
+		return err
+	}
+
+	// t.Channel (address.Address) (struct)
+	if len("Channel") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Channel\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Channel"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Channel")); err != nil {
+		return err
+	}
+
+	if err := t.Channel.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Control (address.Address) (struct)
+	if len("Control") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Control\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Control"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Control")); err != nil {
+		return err
+	}
+
+	if err := t.Control.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Target (address.Address) (struct)
+	if len("Target") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Target\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Target"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Target")); err != nil {
+		return err
+	}
+
+	if err := t.Target.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Direction (uint64) (uint64)
+	if len("Direction") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Direction\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Direction"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Direction")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Direction)); err != nil {
+		return err
+	}
+
+	// t.Vouchers ([]*paychmgr.OldVoucherInfo) (slice)
+	if len("Vouchers") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Vouchers\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Vouchers"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Vouchers")); err != nil {
+		return err
+	}
+
+	if len(t.Vouchers) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Vouchers was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Vouchers))); err != nil {
+		return err
+	}
+	for _, v := range t.Vouchers {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.NextLane (uint64) (uint64)
+	if len("NextLane") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"NextLane\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NextLane"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("NextLane")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.NextLane)); err != nil {
+		return err
+	}
+
+	// t.Amount (big.Int) (struct)
+	if len("Amount") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Amount\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Amount"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Amount")); err != nil {
+		return err
+	}
+
+	if err := t.Amount.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.PendingAmount (big.Int) (struct)
+	if len("PendingAmount") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PendingAmount\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PendingAmount"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PendingAmount")); err != nil {
+		return err
+	}
+
+	if err := t.PendingAmount.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.CreateMsg (cid.Cid) (struct)
+	if len("CreateMsg") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CreateMsg\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CreateMsg"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CreateMsg")); err != nil {
+		return err
+	}
+
+	if t.CreateMsg == nil {
+		if _, err := w.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteCidBuf(scratch, w, *t.CreateMsg); err != nil {
+			return xerrors.Errorf("failed to write cid field t.CreateMsg: %w", err)
+		}
+	}
+
+	// t.AddFundsMsg (cid.Cid) (struct)
+	if len("AddFundsMsg") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AddFundsMsg\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AddFundsMsg"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AddFundsMsg")); err != nil {
+		return err
+	}
+
+	if t.AddFundsMsg == nil {
+		if _, err := w.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteCidBuf(scratch, w, *t.AddFundsMsg); err != nil {
+			return xerrors.Errorf("failed to write cid field t.AddFundsMsg: %w", err)
+		}
+	}
+
+	// t.Settling (bool) (bool)
+	if len("Settling") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Settling\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Settling"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Settling")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteBool(w, t.Settling); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *OldChannelInfo) UnmarshalCBOR(r io.Reader) error {
+	*t = OldChannelInfo{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("OldChannelInfo: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.ChannelID (string) (string)
+		case "ChannelID":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.ChannelID = string(sval)
+			}
+			// t.Channel (address.Address) (struct)
+		case "Channel":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Channel = new(address.Address)
+					if err := t.Channel.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Channel pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Control (address.Address) (struct)
+		case "Control":
+
+			{
+
+				if err := t.Control.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Control: %w", err)
+				}
+
+			}
+			// t.Target (address.Address) (struct)
+		case "Target":
+
+			{
+
+				if err := t.Target.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Target: %w", err)
+				}
+
+			}
+			// t.Direction (uint64) (uint64)
+		case "Direction":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Direction = uint64(extra)
+
+			}
+			// t.Vouchers ([]*paychmgr.OldVoucherInfo) (slice)
+		case "Vouchers":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Vouchers: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Vouchers = make([]*OldVoucherInfo, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				var v OldVoucherInfo
+				if err := v.UnmarshalCBOR(br); err != nil {
+					return err
+				}
+
+				t.Vouchers[i] = &v
+			}
+
+			// t.NextLane (uint64) (uint64)
+		case "NextLane":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.NextLane = uint64(extra)
+
+			}
+			// t.Amount (big.Int) (struct)
+		case "Amount":
+
+			{
+
+				if err := t.Amount.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Amount: %w", err)
+				}
+
+			}
+			// t.PendingAmount (big.Int) (struct)
+		case "PendingAmount":
+
+			{
+
+				if err := t.PendingAmount.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PendingAmount: %w", err)
+				}
+
+			}
+			// t.CreateMsg (cid.Cid) (struct)
+		case "CreateMsg":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.CreateMsg: %w", err)
+					}
+
+					t.CreateMsg = &c
+				}
+
+			}
+			// t.AddFundsMsg (cid.Cid) (struct)
+		case "AddFundsMsg":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.AddFundsMsg: %w", err)
+					}
+
+					t.AddFundsMsg = &c
+				}
+
+			}
+			// t.Settling (bool) (bool)
+		case "Settling":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.Settling = false
+			case 21:
+				t.Settling = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
+	}
+
+	return nil
+}

--- a/paychmgr/store.go
+++ b/paychmgr/store.go
@@ -487,3 +487,23 @@ func unmarshallChannelInfo(stored *ChannelInfo, value []byte) (*ChannelInfo, err
 
 	return stored, nil
 }
+
+type OldVoucherInfo struct {
+	Voucher *paych.SignedVoucher
+	Proof   []byte
+}
+
+type OldChannelInfo struct {
+	ChannelID     string
+	Channel       *address.Address
+	Control       address.Address
+	Target        address.Address
+	Direction     uint64
+	Vouchers      []*OldVoucherInfo
+	NextLane      uint64
+	Amount        types.BigInt
+	PendingAmount types.BigInt
+	CreateMsg     *cid.Cid
+	AddFundsMsg   *cid.Cid
+	Settling      bool
+}


### PR DESCRIPTION
Add a test to make sure that we can unmarshall an old format VoucherInfo into a new format VoucherInfo (that has an extra field: `Submitted`)
See https://github.com/filecoin-project/lotus/pull/3197#discussion_r477346638