### PR TITLE
Fix PoSt with bad sectors

### DIFF
--- a/api/test/util.go
+++ b/api/test/util.go
@@ -41,13 +41,16 @@ func MineUntilBlock(ctx context.Context, t *testing.T, sn TestStorageNode, cb fu
 		var success bool
 		var err error
 		wait := make(chan struct{})
-		sn.MineOne(ctx, miner.MineReq{
+		mineErr := sn.MineOne(ctx, miner.MineReq{
 			Done: func(win bool, e error) {
 				success = win
 				err = e
 				wait <- struct{}{}
 			},
 		})
+		if mineErr != nil {
+			t.Fatal(mineErr)
+		}
 		<-wait
 		if err != nil {
 			t.Fatal(err)

--- a/api/test/window_post.go
+++ b/api/test/window_post.go
@@ -216,6 +216,10 @@ func TestWindowPost(t *testing.T, b APIBuilder, blocktime time.Duration, nSector
 		sn, err := parts[0].Sectors.First()
 		require.NoError(t, err)
 
+		all, err := parts[0].Sectors.All(2)
+		require.NoError(t, err)
+		fmt.Println("the sectors", all)
+
 		s = abi.SectorID{
 			Miner:  abi.ActorID(mid),
 			Number: abi.SectorNumber(sn),


### PR DESCRIPTION
"skipped" sectors must be replaced with a substitute "good" sector, or the entire partition must be skipped. They should not just be omitted.

This patch also fixes the test to verify the _entire_ proof instead of just verifying that the proof includes the correct sectors.