### PR TITLE
use node type agnostic api getter in log commands

### DIFF
--- a/cli/log.go
+++ b/cli/log.go
@@ -20,7 +20,7 @@ var logList = &cli.Command{
 	Name:  "list",
 	Usage: "List log systems",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := GetFullNodeAPI(cctx)
+		api, closer, err := GetAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,7 @@ var logSetLevel = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := GetFullNodeAPI(cctx)
+		api, closer, err := GetAPI(cctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
previously, we would always be setting the log levels on the lotus daemon, even when running `lotus-miner log set-level` because we were pulling up the api handler for the daemon. This changes it to pull up the right api info for the binary we're running