### PR TITLE
Fix some fsm issues

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -323,7 +323,7 @@ type FullNode interface {
 	StateMinerAvailableBalance(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)
 	// StateSectorPreCommitInfo returns the PreCommit info for the specified miner's sector
 	StateSectorPreCommitInfo(context.Context, address.Address, abi.SectorNumber, types.TipSetKey) (miner.SectorPreCommitOnChainInfo, error)
-	// StateSectorGetInfo returns the on-chain info for the specified miner's sector
+	// StateSectorGetInfo returns the on-chain info for the specified miner's sector. Returns null in case the sector info isn't found
 	// NOTE: returned info.Expiration may not be accurate in some cases, use StateSectorExpiration to get accurate
 	// expiration epoch
 	StateSectorGetInfo(context.Context, address.Address, abi.SectorNumber, types.TipSetKey) (*miner.SectorOnChainInfo, error)

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -120,18 +120,18 @@ type SectorLog struct {
 }
 
 type SectorInfo struct {
-	SectorID  abi.SectorNumber
-	State     SectorState
-	CommD     *cid.Cid
-	CommR     *cid.Cid
-	Proof     []byte
-	Deals     []abi.DealID
-	Ticket    SealTicket
-	Seed      SealSeed
+	SectorID     abi.SectorNumber
+	State        SectorState
+	CommD        *cid.Cid
+	CommR        *cid.Cid
+	Proof        []byte
+	Deals        []abi.DealID
+	Ticket       SealTicket
+	Seed         SealSeed
 	PreCommitMsg *cid.Cid
-	CommitMsg *cid.Cid
-	Retries   uint64
-	ToUpgrade bool
+	CommitMsg    *cid.Cid
+	Retries      uint64
+	ToUpgrade    bool
 
 	LastErr string
 

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -128,6 +128,8 @@ type SectorInfo struct {
 	Deals     []abi.DealID
 	Ticket    SealTicket
 	Seed      SealSeed
+	PreCommitMsg *cid.Cid
+	CommitMsg *cid.Cid
 	Retries   uint64
 	ToUpgrade bool
 

--- a/chain/beacon/beacon.go
+++ b/chain/beacon/beacon.go
@@ -37,6 +37,10 @@ func ValidateBlockValues(b RandomBeacon, h *types.BlockHeader, prevEntry types.B
 		return nil
 	}
 
+	if len(h.BeaconEntries) == 0 {
+		return xerrors.Errorf("expected to have beacon entries in this block, but didn't find any")
+	}
+
 	last := h.BeaconEntries[len(h.BeaconEntries)-1]
 	if last.Round != maxRound {
 		return xerrors.Errorf("expected final beacon entry in block to be at round %d, got %d", maxRound, last.Round)

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -157,7 +157,7 @@ func MinerSectorInfo(ctx context.Context, sm *StateManager, maddr address.Addres
 		return nil, err
 	}
 	if !ok {
-		return nil, xerrors.New("sector not found")
+		return nil, nil
 	}
 
 	return sectorInfo, nil

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -247,6 +247,7 @@ var stateList = []stateMeta{
 	{col: color.FgYellow, state: sealing.PreCommitWait},
 	{col: color.FgYellow, state: sealing.WaitSeed},
 	{col: color.FgYellow, state: sealing.Committing},
+	{col: color.FgYellow, state: sealing.SubmitCommit},
 	{col: color.FgYellow, state: sealing.CommitWait},
 	{col: color.FgYellow, state: sealing.FinalizeSector},
 

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -236,8 +236,10 @@ var stateList = []stateMeta{
 	{col: 39, state: "Total"},
 	{col: color.FgGreen, state: sealing.Proving},
 
+	{col: color.FgBlue, state: sealing.Empty},
+	{col: color.FgBlue, state: sealing.WaitDeals},
+
 	{col: color.FgRed, state: sealing.UndefinedSectorState},
-	{col: color.FgYellow, state: sealing.Empty},
 	{col: color.FgYellow, state: sealing.Packing},
 	{col: color.FgYellow, state: sealing.PreCommit1},
 	{col: color.FgYellow, state: sealing.PreCommit2},
@@ -247,6 +249,9 @@ var stateList = []stateMeta{
 	{col: color.FgYellow, state: sealing.Committing},
 	{col: color.FgYellow, state: sealing.CommitWait},
 	{col: color.FgYellow, state: sealing.FinalizeSector},
+
+	{col: color.FgCyan, state: sealing.Removing},
+	{col: color.FgCyan, state: sealing.Removed},
 
 	{col: color.FgRed, state: sealing.FailedUnrecoverable},
 	{col: color.FgRed, state: sealing.SealPreCommit1Failed},
@@ -259,6 +264,7 @@ var stateList = []stateMeta{
 	{col: color.FgRed, state: sealing.Faulty},
 	{col: color.FgRed, state: sealing.FaultReported},
 	{col: color.FgRed, state: sealing.FaultedFinal},
+	{col: color.FgRed, state: sealing.RemoveFailed},
 }
 
 func init() {

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -267,6 +267,7 @@ var stateList = []stateMeta{
 	{col: color.FgRed, state: sealing.FaultedFinal},
 	{col: color.FgRed, state: sealing.RemoveFailed},
 	{col: color.FgRed, state: sealing.DealsExpired},
+	{col: color.FgRed, state: sealing.RecoverDealIDs},
 }
 
 func init() {

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -266,6 +266,7 @@ var stateList = []stateMeta{
 	{col: color.FgRed, state: sealing.FaultReported},
 	{col: color.FgRed, state: sealing.FaultedFinal},
 	{col: color.FgRed, state: sealing.RemoveFailed},
+	{col: color.FgRed, state: sealing.DealsExpired},
 }
 
 func init() {

--- a/cmd/lotus-storage-miner/sealing.go
+++ b/cmd/lotus-storage-miner/sealing.go
@@ -156,7 +156,7 @@ var sealingJobsCmd = &cli.Command{
 		// oldest first
 		sort.Slice(lines, func(i, j int) bool {
 			if lines[i].RunWait != lines[j].RunWait {
-				return !lines[i].RunWait // already running tasks first
+				return lines[i].RunWait < lines[j].RunWait
 			}
 			return lines[i].Start.Before(lines[j].Start)
 		})
@@ -176,9 +176,9 @@ var sealingJobsCmd = &cli.Command{
 		_, _ = fmt.Fprintf(tw, "ID\tSector\tWorker\tHostname\tTask\tState\tTime\n")
 
 		for _, l := range lines {
-			state := "assigned"
-			if !l.RunWait {
-				state = "running"
+			state := "running"
+			if l.RunWait != 0 {
+				state = fmt.Sprintf("assigned(%d)", l.RunWait-1)
 			}
 			_, _ = fmt.Fprintf(tw, "%d\t%d\t%d\t%s\t%s\t%s\t%s\n", l.ID, l.Sector.Number, l.wid, workerHostnames[l.wid], l.Task.Short(), state, time.Now().Sub(l.Start).Truncate(time.Millisecond*100))
 		}

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -97,6 +97,8 @@ var sectorsStatusCmd = &cli.Command{
 		fmt.Printf("TicketH:\t%d\n", status.Ticket.Epoch)
 		fmt.Printf("Seed:\t\t%x\n", status.Seed.Value)
 		fmt.Printf("SeedH:\t\t%d\n", status.Seed.Epoch)
+		fmt.Printf("Precommit:\t%s\n", status.PreCommitMsg)
+		fmt.Printf("Commit:\t\t%s\n", status.CommitMsg)
 		fmt.Printf("Proof:\t\t%x\n", status.Proof)
 		fmt.Printf("Deals:\t\t%v\n", status.Deals)
 		fmt.Printf("Retries:\t%d\n", status.Retries)

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -3603,7 +3603,7 @@ Response:
 ```
 
 ### StateSectorGetInfo
-StateSectorGetInfo returns the on-chain info for the specified miner's sector
+StateSectorGetInfo returns the on-chain info for the specified miner's sector. Returns null in case the sector info isn't found
 NOTE: returned info.Expiration may not be accurate in some cases, use StateSectorExpiration to get accurate
 expiration epoch
 

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/mitchellh/go-homedir"
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/specs-storage/storage"
 
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
+	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
 	"github.com/filecoin-project/lotus/extern/sector-storage/sealtasks"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
@@ -463,25 +464,19 @@ func (m *Manager) Remove(ctx context.Context, sector abi.SectorID) error {
 		return xerrors.Errorf("acquiring sector lock: %w", err)
 	}
 
-	unsealed := stores.FTUnsealed
-	{
-		unsealedStores, err := m.index.StorageFindSector(ctx, sector, stores.FTUnsealed, 0, false)
-		if err != nil {
-			return xerrors.Errorf("finding unsealed sector: %w", err)
-		}
+	var err error
 
-		if len(unsealedStores) == 0 { // can be already removed
-			unsealed = stores.FTNone
-		}
+	if rerr := m.storage.Remove(ctx, sector, stores.FTSealed, true); rerr != nil {
+		err = multierror.Append(err, xerrors.Errorf("removing sector (sealed): %w", rerr))
+	}
+	if rerr := m.storage.Remove(ctx, sector, stores.FTCache, true); rerr != nil {
+		err = multierror.Append(err, xerrors.Errorf("removing sector (cache): %w", rerr))
+	}
+	if rerr := m.storage.Remove(ctx, sector, stores.FTUnsealed, true); rerr != nil {
+		err = multierror.Append(err, xerrors.Errorf("removing sector (unsealed): %w", rerr))
 	}
 
-	selector := newExistingSelector(m.index, sector, stores.FTCache|stores.FTSealed, false)
-
-	return m.sched.Schedule(ctx, sector, sealtasks.TTFinalize, selector,
-		schedFetch(sector, stores.FTCache|stores.FTSealed|unsealed, stores.PathStorage, stores.AcquireMove),
-		func(ctx context.Context, w Worker) error {
-			return w.Remove(ctx, sector)
-		})
+	return err
 }
 
 func (m *Manager) StorageLocal(ctx context.Context) (map[stores.ID]string, error) {

--- a/extern/sector-storage/request_queue.go
+++ b/extern/sector-storage/request_queue.go
@@ -7,6 +7,11 @@ type requestQueue []*workerRequest
 func (q requestQueue) Len() int { return len(q) }
 
 func (q requestQueue) Less(i, j int) bool {
+	oneMuchLess, muchLess := q[i].taskType.MuchLess(q[j].taskType)
+	if oneMuchLess {
+		return muchLess
+	}
+
 	if q[i].priority != q[j].priority {
 		return q[i].priority > q[j].priority
 	}

--- a/extern/sector-storage/resources.go
+++ b/extern/sector-storage/resources.go
@@ -22,17 +22,17 @@ func (r Resources) MultiThread() bool {
 
 var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredSealProof]Resources{
 	sealtasks.TTAddPiece: {
-		abi.RegisteredSealProof_StackedDrg64GiBV1: Resources{ // This is probably a bit conservative
-			MaxMemory: 64 << 30,
-			MinMemory: 64 << 30,
+		abi.RegisteredSealProof_StackedDrg64GiBV1: Resources{
+			MaxMemory: 8 << 30,
+			MinMemory: 8 << 30,
 
 			Threads: 1,
 
 			BaseMinMemory: 1 << 30,
 		},
-		abi.RegisteredSealProof_StackedDrg32GiBV1: Resources{ // This is probably a bit conservative
-			MaxMemory: 32 << 30,
-			MinMemory: 32 << 30,
+		abi.RegisteredSealProof_StackedDrg32GiBV1: Resources{
+			MaxMemory: 4 << 30,
+			MinMemory: 4 << 30,
 
 			Threads: 1,
 

--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -85,7 +85,7 @@ type workerHandle struct {
 
 	lk sync.Mutex
 
-	wndLk sync.Mutex
+	wndLk         sync.Mutex
 	activeWindows []*schedWindow
 
 	// stats / tracking

--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -278,7 +278,6 @@ func (sh *scheduler) runSched() {
 			sh.trySched()
 		}
 
-
 	}
 }
 

--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -359,7 +359,7 @@ func (sh *scheduler) trySched() {
 				}
 
 				// TODO: allow bigger windows
-				if !windows[wnd].allocated.canHandleRequest(needRes, windowRequest.worker, worker.info.Resources) {
+				if !windows[wnd].allocated.canHandleRequest(needRes, windowRequest.worker, "schedAcceptable", worker.info.Resources) {
 					continue
 				}
 
@@ -430,11 +430,11 @@ func (sh *scheduler) trySched() {
 			log.Debugf("SCHED try assign sqi:%d sector %d to window %d", sqi, task.sector.Number, wnd)
 
 			// TODO: allow bigger windows
-			if !windows[wnd].allocated.canHandleRequest(needRes, wid, wr) {
+			if !windows[wnd].allocated.canHandleRequest(needRes, wid, "schedAssign", wr) {
 				continue
 			}
 
-			log.Debugf("SCHED ASSIGNED sqi:%d sector %d to window %d", sqi, task.sector.Number, wnd)
+			log.Debugf("SCHED ASSIGNED sqi:%d sector %d task %s to window %d", sqi, task.sector.Number, task.taskType, wnd)
 
 			windows[wnd].allocated.add(wr, needRes)
 
@@ -577,7 +577,7 @@ func (sh *scheduler) runWorker(wid WorkerID) {
 					worker.lk.Lock()
 					for t, todo := range firstWindow.todo {
 						needRes := ResourceTable[todo.taskType][sh.spt]
-						if worker.preparing.canHandleRequest(needRes, wid, worker.info.Resources) {
+						if worker.preparing.canHandleRequest(needRes, wid, "startPreparing", worker.info.Resources) {
 							tidx = t
 							break
 						}
@@ -628,7 +628,7 @@ func (sh *scheduler) workerCompactWindows(worker *workerHandle, wid WorkerID) in
 
 			for ti, todo := range window.todo {
 				needRes := ResourceTable[todo.taskType][sh.spt]
-				if !lower.allocated.canHandleRequest(needRes, wid, worker.info.Resources) {
+				if !lower.allocated.canHandleRequest(needRes, wid, "compactWindows", worker.info.Resources) {
 					continue
 				}
 

--- a/extern/sector-storage/sched_resources.go
+++ b/extern/sector-storage/sched_resources.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (a *activeResources) withResources(id WorkerID, wr storiface.WorkerResources, r Resources, locker sync.Locker, cb func() error) error {
-	for !a.canHandleRequest(r, id, wr) {
+	for !a.canHandleRequest(r, id, "withResources", wr) {
 		if a.cond == nil {
 			a.cond = sync.NewCond(locker)
 		}
@@ -52,37 +52,37 @@ func (a *activeResources) free(wr storiface.WorkerResources, r Resources) {
 	a.memUsedMax -= r.MaxMemory
 }
 
-func (a *activeResources) canHandleRequest(needRes Resources, wid WorkerID, res storiface.WorkerResources) bool {
+func (a *activeResources) canHandleRequest(needRes Resources, wid WorkerID, caller string, res storiface.WorkerResources) bool {
 
 	// TODO: dedupe needRes.BaseMinMemory per task type (don't add if that task is already running)
 	minNeedMem := res.MemReserved + a.memUsedMin + needRes.MinMemory + needRes.BaseMinMemory
 	if minNeedMem > res.MemPhysical {
-		log.Debugf("sched: not scheduling on worker %d; not enough physical memory - need: %dM, have %dM", wid, minNeedMem/mib, res.MemPhysical/mib)
+		log.Debugf("sched: not scheduling on worker %d for %s; not enough physical memory - need: %dM, have %dM", wid, caller, minNeedMem/mib, res.MemPhysical/mib)
 		return false
 	}
 
 	maxNeedMem := res.MemReserved + a.memUsedMax + needRes.MaxMemory + needRes.BaseMinMemory
 
 	if maxNeedMem > res.MemSwap+res.MemPhysical {
-		log.Debugf("sched: not scheduling on worker %d; not enough virtual memory - need: %dM, have %dM", wid, maxNeedMem/mib, (res.MemSwap+res.MemPhysical)/mib)
+		log.Debugf("sched: not scheduling on worker %d for %s; not enough virtual memory - need: %dM, have %dM", wid, caller, maxNeedMem/mib, (res.MemSwap+res.MemPhysical)/mib)
 		return false
 	}
 
 	if needRes.MultiThread() {
 		if a.cpuUse > 0 {
-			log.Debugf("sched: not scheduling on worker %d; multicore process needs %d threads, %d in use, target %d", wid, res.CPUs, a.cpuUse, res.CPUs)
+			log.Debugf("sched: not scheduling on worker %d for %s; multicore process needs %d threads, %d in use, target %d", wid, caller, res.CPUs, a.cpuUse, res.CPUs)
 			return false
 		}
 	} else {
 		if a.cpuUse+uint64(needRes.Threads) > res.CPUs {
-			log.Debugf("sched: not scheduling on worker %d; not enough threads, need %d, %d in use, target %d", wid, needRes.Threads, a.cpuUse, res.CPUs)
+			log.Debugf("sched: not scheduling on worker %d for %s; not enough threads, need %d, %d in use, target %d", wid, caller, needRes.Threads, a.cpuUse, res.CPUs)
 			return false
 		}
 	}
 
 	if len(res.GPUs) > 0 && needRes.CanGPU {
 		if a.gpuUsed {
-			log.Debugf("sched: not scheduling on worker %d; GPU in use", wid)
+			log.Debugf("sched: not scheduling on worker %d for %s; GPU in use", wid, caller)
 			return false
 		}
 	}

--- a/extern/sector-storage/sched_test.go
+++ b/extern/sector-storage/sched_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/filecoin-project/specs-storage/storage"
 )
 
+func init() {
+	InitWait = 10 * time.Millisecond
+}
+
 func TestWithPriority(t *testing.T) {
 	ctx := context.Background()
 

--- a/extern/sector-storage/sealtasks/task.go
+++ b/extern/sector-storage/sealtasks/task.go
@@ -17,15 +17,15 @@ const (
 )
 
 var order = map[TaskType]int{
-	TTAddPiece:     7,
-	TTPreCommit1:   6,
-	TTPreCommit2:   5,
-	TTCommit2:      4,
-	TTCommit1:      3,
-	TTFetch:        2,
-	TTFinalize:     1,
-	TTUnseal:       0,
-	TTReadUnsealed: 0,
+	TTAddPiece:     6, // least priority
+	TTPreCommit1:   5,
+	TTPreCommit2:   4,
+	TTCommit2:      3,
+	TTCommit1:      2,
+	TTUnseal:       1,
+	TTFetch:        -1,
+	TTReadUnsealed: -1,
+	TTFinalize:     -2, // most priority
 }
 
 var shortNames = map[TaskType]string{
@@ -41,6 +41,12 @@ var shortNames = map[TaskType]string{
 	TTFetch:        "GET",
 	TTUnseal:       "UNS",
 	TTReadUnsealed: "RD ",
+}
+
+func (a TaskType) MuchLess(b TaskType) (bool, bool) {
+	oa, ob := order[a], order[b]
+	oneNegative := oa^ob < 0
+	return oneNegative, oa < ob
 }
 
 func (a TaskType) Less(b TaskType) bool {

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -1,6 +1,8 @@
 package sectorstorage
 
-import "github.com/filecoin-project/lotus/extern/sector-storage/storiface"
+import (
+	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
+)
 
 func (m *Manager) WorkerStats() map[uint64]storiface.WorkerStats {
 	m.sched.workersLk.RLock()
@@ -29,6 +31,20 @@ func (m *Manager) WorkerJobs() map[uint64][]storiface.WorkerJob {
 
 	for id, handle := range m.sched.workers {
 		out[uint64(id)] = handle.wt.Running()
+
+		handle.wndLk.Lock()
+		for _, window := range handle.activeWindows {
+			for _, request := range window.todo {
+				out[uint64(id)] = append(out[uint64(id)], storiface.WorkerJob{
+					ID:      0,
+					Sector:  request.sector,
+					Task:    request.taskType,
+					RunWait: true,
+					Start:   request.start,
+				})
+			}
+		}
+		handle.wndLk.Unlock()
 	}
 
 	return out

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -33,13 +33,13 @@ func (m *Manager) WorkerJobs() map[uint64][]storiface.WorkerJob {
 		out[uint64(id)] = handle.wt.Running()
 
 		handle.wndLk.Lock()
-		for _, window := range handle.activeWindows {
+		for wi, window := range handle.activeWindows {
 			for _, request := range window.todo {
 				out[uint64(id)] = append(out[uint64(id)], storiface.WorkerJob{
 					ID:      0,
 					Sector:  request.sector,
 					Task:    request.taskType,
-					RunWait: true,
+					RunWait: wi + 1,
 					Start:   request.start,
 				})
 			}

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -37,5 +37,6 @@ type WorkerJob struct {
 	Sector abi.SectorID
 	Task   sealtasks.TaskType
 
-	Start time.Time
+	RunWait bool
+	Start   time.Time
 }

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -37,6 +37,6 @@ type WorkerJob struct {
 	Sector abi.SectorID
 	Task   sealtasks.TaskType
 
-	RunWait bool
+	RunWait int // 0 - running, 1+ - assigned
 	Start   time.Time
 }

--- a/extern/storage-sealing/cbor_gen.go
+++ b/extern/storage-sealing/cbor_gen.go
@@ -475,7 +475,7 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{182}); err != nil {
+	if _, err := w.Write([]byte{183}); err != nil {
 		return err
 	}
 
@@ -903,6 +903,29 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		if err := cbg.WriteCidBuf(scratch, w, *t.FaultReportMsg); err != nil {
 			return xerrors.Errorf("failed to write cid field t.FaultReportMsg: %w", err)
 		}
+	}
+
+	// t.Return (sealing.ReturnState) (string)
+	if len("Return") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Return\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Return"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Return")); err != nil {
+		return err
+	}
+
+	if len(t.Return) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Return was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Return))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.Return)); err != nil {
+		return err
 	}
 
 	// t.LastErr (string) (string)
@@ -1406,6 +1429,17 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 					t.FaultReportMsg = &c
 				}
 
+			}
+			// t.Return (sealing.ReturnState) (string)
+		case "Return":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Return = ReturnState(sval)
 			}
 			// t.LastErr (string) (string)
 		case "LastErr":

--- a/extern/storage-sealing/cbor_gen.go
+++ b/extern/storage-sealing/cbor_gen.go
@@ -135,11 +135,33 @@ func (t *DealInfo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{163}); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
+
+	// t.PublishCid (cid.Cid) (struct)
+	if len("PublishCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PublishCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PublishCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PublishCid")); err != nil {
+		return err
+	}
+
+	if t.PublishCid == nil {
+		if _, err := w.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteCidBuf(scratch, w, *t.PublishCid); err != nil {
+			return xerrors.Errorf("failed to write cid field t.PublishCid: %w", err)
+		}
+	}
 
 	// t.DealID (abi.DealID) (uint64)
 	if len("DealID") > cbg.MaxLength {
@@ -224,7 +246,30 @@ func (t *DealInfo) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		switch name {
-		// t.DealID (abi.DealID) (uint64)
+		// t.PublishCid (cid.Cid) (struct)
+		case "PublishCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PublishCid: %w", err)
+					}
+
+					t.PublishCid = &c
+				}
+
+			}
+			// t.DealID (abi.DealID) (uint64)
 		case "DealID":
 
 			{

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -126,7 +126,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 		on(SectorRetryFinalize{}, FinalizeSector),
 	),
 	PackingFailed: planOne(), // TODO: Deprecated, remove
-	DealsExpired: planOne(
+	DealsExpired:  planOne(
 	// SectorRemove (global)
 	),
 	RecoverDealIDs: planOne(

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -143,6 +143,9 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 		on(SectorRemoved{}, Removed),
 		on(SectorRemoveFailed{}, RemoveFailed),
 	),
+	RemoveFailed: planOne(
+	// SectorRemove (global)
+	),
 	Faulty: planOne(
 		on(SectorFaultReported{}, FaultReported),
 	),
@@ -303,6 +306,9 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 		return m.handleRemoving, processed, nil
 	case Removed:
 		return nil, processed, nil
+
+	case RemoveFailed:
+		return m.handleRemoveFailed, processed, nil
 
 		// Faults
 	case Faulty:

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -17,9 +17,9 @@ import (
 )
 
 func (m *Sealing) Plan(events []statemachine.Event, user interface{}) (interface{}, uint64, error) {
-	next, err := m.plan(events, user.(*SectorInfo))
+	next, processed, err := m.plan(events, user.(*SectorInfo))
 	if err != nil || next == nil {
-		return nil, uint64(len(events)), err
+		return nil, processed, err
 	}
 
 	return func(ctx statemachine.Context, si SectorInfo) error {
@@ -30,10 +30,10 @@ func (m *Sealing) Plan(events []statemachine.Event, user interface{}) (interface
 		}
 
 		return nil
-	}, uint64(len(events)), nil // TODO: This processed event count is not very correct
+	}, processed, nil // TODO: This processed event count is not very correct
 }
 
-var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *SectorInfo) error{
+var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *SectorInfo) (uint64, error){
 	// Sealing
 
 	UndefinedSectorState: planOne(
@@ -119,7 +119,6 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	Proving: planOne(
 		on(SectorFaultReported{}, FaultReported),
 		on(SectorFaulty{}, Faulty),
-		on(SectorRemove{}, Removing),
 	),
 	Removing: planOne(
 		on(SectorRemoved{}, Removed),
@@ -133,7 +132,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	Removed:      final,
 }
 
-func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(statemachine.Context, SectorInfo) error, error) {
+func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(statemachine.Context, SectorInfo) error, uint64, error) {
 	/////
 	// First process all events
 
@@ -170,11 +169,12 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 
 	p := fsmPlanners[state.State]
 	if p == nil {
-		return nil, xerrors.Errorf("planner for state %s not found", state.State)
+		return nil, 0, xerrors.Errorf("planner for state %s not found", state.State)
 	}
 
-	if err := p(events, state); err != nil {
-		return nil, xerrors.Errorf("running planner for state %s failed: %w", state.State, err)
+	processed, err := p(events, state)
+	if err != nil {
+		return nil, 0, xerrors.Errorf("running planner for state %s failed: %w", state.State, err)
 	}
 
 	/////
@@ -235,51 +235,51 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 	case WaitDeals:
 		log.Infof("Waiting for deals %d", state.SectorNumber)
 	case Packing:
-		return m.handlePacking, nil
+		return m.handlePacking, processed, nil
 	case PreCommit1:
-		return m.handlePreCommit1, nil
+		return m.handlePreCommit1, processed, nil
 	case PreCommit2:
-		return m.handlePreCommit2, nil
+		return m.handlePreCommit2, processed, nil
 	case PreCommitting:
-		return m.handlePreCommitting, nil
+		return m.handlePreCommitting, processed, nil
 	case PreCommitWait:
-		return m.handlePreCommitWait, nil
+		return m.handlePreCommitWait, processed, nil
 	case WaitSeed:
-		return m.handleWaitSeed, nil
+		return m.handleWaitSeed, processed, nil
 	case Committing:
-		return m.handleCommitting, nil
+		return m.handleCommitting, processed, nil
 	case CommitWait:
-		return m.handleCommitWait, nil
+		return m.handleCommitWait, processed, nil
 	case FinalizeSector:
-		return m.handleFinalizeSector, nil
+		return m.handleFinalizeSector, processed, nil
 
 	// Handled failure modes
 	case SealPreCommit1Failed:
-		return m.handleSealPrecommit1Failed, nil
+		return m.handleSealPrecommit1Failed, processed, nil
 	case SealPreCommit2Failed:
-		return m.handleSealPrecommit2Failed, nil
+		return m.handleSealPrecommit2Failed, processed, nil
 	case PreCommitFailed:
-		return m.handlePreCommitFailed, nil
+		return m.handlePreCommitFailed, processed, nil
 	case ComputeProofFailed:
-		return m.handleComputeProofFailed, nil
+		return m.handleComputeProofFailed, processed, nil
 	case CommitFailed:
-		return m.handleCommitFailed, nil
+		return m.handleCommitFailed, processed, nil
 	case FinalizeFailed:
-		return m.handleFinalizeFailed, nil
+		return m.handleFinalizeFailed, processed, nil
 
 	// Post-seal
 	case Proving:
-		return m.handleProvingSector, nil
+		return m.handleProvingSector, processed, nil
 	case Removing:
-		return m.handleRemoving, nil
+		return m.handleRemoving, processed, nil
 	case Removed:
-		return nil, nil
+		return nil, processed, nil
 
 		// Faults
 	case Faulty:
-		return m.handleFaulty, nil
+		return m.handleFaulty, processed, nil
 	case FaultReported:
-		return m.handleFaultReported, nil
+		return m.handleFaultReported, processed, nil
 
 	// Fatal errors
 	case UndefinedSectorState:
@@ -290,15 +290,15 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 		log.Errorf("unexpected sector update state: %s", state.State)
 	}
 
-	return nil, nil
+	return nil, processed, nil
 }
 
-func planCommitting(events []statemachine.Event, state *SectorInfo) error {
+func planCommitting(events []statemachine.Event, state *SectorInfo) (uint64, error) {
 	for _, event := range events {
 		switch e := event.User.(type) {
 		case globalMutator:
 			if e.applyGlobal(state) {
-				return nil
+				return 1, nil
 			}
 		case SectorCommitted: // the normal case
 			e.apply(state)
@@ -311,7 +311,7 @@ func planCommitting(events []statemachine.Event, state *SectorInfo) error {
 			log.Warnf("planCommitting: commit Seed changed")
 			e.apply(state)
 			state.State = Committing
-			return nil
+			return 1, nil
 		case SectorComputeProofFailed:
 			state.State = ComputeProofFailed
 		case SectorSealPreCommit1Failed:
@@ -321,10 +321,10 @@ func planCommitting(events []statemachine.Event, state *SectorInfo) error {
 		case SectorRetryCommitWait:
 			state.State = CommitWait
 		default:
-			return xerrors.Errorf("planCommitting got event of unknown type %T, events: %+v", event.User, events)
+			return 0, xerrors.Errorf("planCommitting got event of unknown type %T, events: %+v", event.User, events)
 		}
 	}
-	return nil
+	return 1, nil
 }
 
 func (m *Sealing) restartSectors(ctx context.Context) error {
@@ -365,8 +365,8 @@ func (m *Sealing) ForceSectorState(ctx context.Context, id abi.SectorNumber, sta
 	return m.sectors.Send(id, SectorForceState{state})
 }
 
-func final(events []statemachine.Event, state *SectorInfo) error {
-	return xerrors.Errorf("didn't expect any events in state %s, got %+v", state.State, events)
+func final(events []statemachine.Event, state *SectorInfo) (uint64, error) {
+	return 0, xerrors.Errorf("didn't expect any events in state %s, got %+v", state.State, events)
 }
 
 func on(mut mutator, next SectorState) func() (mutator, SectorState) {
@@ -375,21 +375,11 @@ func on(mut mutator, next SectorState) func() (mutator, SectorState) {
 	}
 }
 
-func planOne(ts ...func() (mut mutator, next SectorState)) func(events []statemachine.Event, state *SectorInfo) error {
-	return func(events []statemachine.Event, state *SectorInfo) error {
-		if len(events) != 1 {
-			for _, event := range events {
-				if gm, ok := event.User.(globalMutator); ok {
-					gm.applyGlobal(state)
-					return nil
-				}
-			}
-			return xerrors.Errorf("planner for state %s only has a plan for a single event only, got %+v", state.State, events)
-		}
-
+func planOne(ts ...func() (mut mutator, next SectorState)) func(events []statemachine.Event, state *SectorInfo) (uint64, error) {
+	return func(events []statemachine.Event, state *SectorInfo) (uint64, error) {
 		if gm, ok := events[0].User.(globalMutator); ok {
 			gm.applyGlobal(state)
-			return nil
+			return 1, nil
 		}
 
 		for _, t := range ts {
@@ -405,14 +395,14 @@ func planOne(ts ...func() (mut mutator, next SectorState)) func(events []statema
 
 			events[0].User.(mutator).apply(state)
 			state.State = next
-			return nil
+			return 1, nil
 		}
 
 		_, ok := events[0].User.(Ignorable)
 		if ok {
-			return nil
+			return 1, nil
 		}
 
-		return xerrors.Errorf("planner for state %s received unexpected event %T (%+v)", state.State, events[0].User, events[0])
+		return 0, xerrors.Errorf("planner for state %s received unexpected event %T (%+v)", state.State, events[0].User, events[0])
 	}
 }

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -298,6 +298,8 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 		fallthrough
 	case DealsExpired:
 		return m.handleDealsExpired, processed, nil
+	case RecoverDealIDs:
+		return m.handleRecoverDealIDs, processed, nil
 
 	// Post-seal
 	case Proving:

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -66,6 +66,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	PreCommitWait: planOne(
 		on(SectorChainPreCommitFailed{}, PreCommitFailed),
 		on(SectorPreCommitLanded{}, WaitSeed),
+		on(SectorRetryPreCommit{}, PreCommitting),
 	),
 	WaitSeed: planOne(
 		on(SectorSeedReady{}, Committing),
@@ -79,6 +80,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	CommitWait: planOne(
 		on(SectorProving{}, FinalizeSector),
 		on(SectorCommitFailed{}, CommitFailed),
+		on(SectorRetrySubmitCommit{}, SubmitCommit),
 	),
 
 	FinalizeSector: planOne(

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -267,7 +267,7 @@ type SectorRetryCommitWait struct{}
 
 func (evt SectorRetryCommitWait) apply(state *SectorInfo) {}
 
-type SectorInvalidDealIDs struct{
+type SectorInvalidDealIDs struct {
 	Return ReturnState
 }
 
@@ -275,7 +275,7 @@ func (evt SectorInvalidDealIDs) apply(state *SectorInfo) {
 	state.Return = evt.Return
 }
 
-type SectorUpdateDealIDs struct{
+type SectorUpdateDealIDs struct {
 	Updates map[int]abi.DealID
 }
 

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -274,7 +274,10 @@ type SectorFaultedFinal struct{}
 
 type SectorRemove struct{}
 
-func (evt SectorRemove) apply(state *SectorInfo) {}
+func (evt SectorRemove) applyGlobal(state *SectorInfo) bool {
+	state.State = Removing
+	return true
+}
 
 type SectorRemoved struct{}
 

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -192,12 +192,18 @@ func (evt SectorCommitFailed) FormatError(xerrors.Printer) (next error) { return
 func (evt SectorCommitFailed) apply(*SectorInfo)                        {}
 
 type SectorCommitted struct {
-	Message cid.Cid
-	Proof   []byte
+	Proof []byte
 }
 
 func (evt SectorCommitted) apply(state *SectorInfo) {
 	state.Proof = evt.Proof
+}
+
+type SectorCommitSubmitted struct {
+	Message cid.Cid
+}
+
+func (evt SectorCommitSubmitted) apply(state *SectorInfo) {
 	state.CommitMessage = &evt.Message
 }
 

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -191,6 +191,11 @@ type SectorCommitFailed struct{ error }
 func (evt SectorCommitFailed) FormatError(xerrors.Printer) (next error) { return evt.error }
 func (evt SectorCommitFailed) apply(*SectorInfo)                        {}
 
+type SectorDealsExpired struct{ error }
+
+func (evt SectorDealsExpired) FormatError(xerrors.Printer) (next error) { return evt.error }
+func (evt SectorDealsExpired) apply(*SectorInfo)                        {}
+
 type SectorCommitted struct {
 	Proof []byte
 }

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -101,10 +101,6 @@ func (evt SectorPacked) apply(state *SectorInfo) {
 	}
 }
 
-type SectorPackingFailed struct{ error }
-
-func (evt SectorPackingFailed) apply(*SectorInfo) {}
-
 type SectorPreCommit1 struct {
 	PreCommit1Out storage.PreCommit1Out
 	TicketValue   abi.SealRandomness

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -191,6 +191,10 @@ type SectorCommitFailed struct{ error }
 func (evt SectorCommitFailed) FormatError(xerrors.Printer) (next error) { return evt.error }
 func (evt SectorCommitFailed) apply(*SectorInfo)                        {}
 
+type SectorRetrySubmitCommit struct{}
+
+func (evt SectorRetrySubmitCommit) apply(*SectorInfo) {}
+
 type SectorDealsExpired struct{ error }
 
 func (evt SectorDealsExpired) FormatError(xerrors.Printer) (next error) { return evt.error }

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -271,6 +271,24 @@ type SectorRetryCommitWait struct{}
 
 func (evt SectorRetryCommitWait) apply(state *SectorInfo) {}
 
+type SectorInvalidDealIDs struct{
+	Return ReturnState
+}
+
+func (evt SectorInvalidDealIDs) apply(state *SectorInfo) {
+	state.Return = evt.Return
+}
+
+type SectorUpdateDealIDs struct{
+	Updates map[int]abi.DealID
+}
+
+func (evt SectorUpdateDealIDs) apply(state *SectorInfo) {
+	for i, id := range evt.Updates {
+		state.Pieces[i].DealInfo.DealID = id
+	}
+}
+
 // Faults
 
 type SectorFaulty struct{}

--- a/extern/storage-sealing/fsm_test.go
+++ b/extern/storage-sealing/fsm_test.go
@@ -58,6 +58,9 @@ func TestHappyPath(t *testing.T) {
 	require.Equal(m.t, m.state.State, Committing)
 
 	m.planSingle(SectorCommitted{})
+	require.Equal(m.t, m.state.State, SubmitCommit)
+
+	m.planSingle(SectorCommitSubmitted{})
 	require.Equal(m.t, m.state.State, CommitWait)
 
 	m.planSingle(SectorProving{})
@@ -105,6 +108,9 @@ func TestSeedRevert(t *testing.T) {
 	// not changing the seed this time
 	_, _, err = m.s.plan([]statemachine.Event{{User: SectorSeedReady{SeedValue: nil, SeedEpoch: 5}}, {User: SectorCommitted{}}}, m.state)
 	require.NoError(t, err)
+	require.Equal(m.t, m.state.State, SubmitCommit)
+
+	m.planSingle(SectorCommitSubmitted{})
 	require.Equal(m.t, m.state.State, CommitWait)
 
 	m.planSingle(SectorProving{})

--- a/extern/storage-sealing/fsm_test.go
+++ b/extern/storage-sealing/fsm_test.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 func (t *test) planSingle(evt interface{}) {
-	_, err := t.s.plan([]statemachine.Event{{User: evt}}, t.state)
+	_, _, err := t.s.plan([]statemachine.Event{{User: evt}}, t.state)
 	require.NoError(t.t, err)
 }
 
@@ -98,12 +98,12 @@ func TestSeedRevert(t *testing.T) {
 	m.planSingle(SectorSeedReady{})
 	require.Equal(m.t, m.state.State, Committing)
 
-	_, err := m.s.plan([]statemachine.Event{{User: SectorSeedReady{SeedValue: nil, SeedEpoch: 5}}, {User: SectorCommitted{}}}, m.state)
+	_, _, err := m.s.plan([]statemachine.Event{{User: SectorSeedReady{SeedValue: nil, SeedEpoch: 5}}, {User: SectorCommitted{}}}, m.state)
 	require.NoError(t, err)
 	require.Equal(m.t, m.state.State, Committing)
 
 	// not changing the seed this time
-	_, err = m.s.plan([]statemachine.Event{{User: SectorSeedReady{SeedValue: nil, SeedEpoch: 5}}, {User: SectorCommitted{}}}, m.state)
+	_, _, err = m.s.plan([]statemachine.Event{{User: SectorSeedReady{SeedValue: nil, SeedEpoch: 5}}, {User: SectorCommitted{}}}, m.state)
 	require.NoError(t, err)
 	require.Equal(m.t, m.state.State, CommitWait)
 
@@ -129,7 +129,8 @@ func TestPlanCommittingHandlesSectorCommitFailed(t *testing.T) {
 
 	events := []statemachine.Event{{User: SectorCommitFailed{}}}
 
-	require.NoError(t, planCommitting(events, m.state))
+	_, err := planCommitting(events, m.state)
+	require.NoError(t, err)
 
 	require.Equal(t, CommitFailed, m.state.State)
 }

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -141,7 +141,7 @@ func (m *Sealing) Stop(ctx context.Context) error {
 	return m.sectors.Stop(ctx)
 }
 func (m *Sealing) AddPieceToAnySector(ctx context.Context, size abi.UnpaddedPieceSize, r io.Reader, d DealInfo) (abi.SectorNumber, abi.PaddedPieceSize, error) {
-	log.Infof("Adding piece for deal %d", d.DealID)
+	log.Infof("Adding piece for deal %d (publish msg: %s)", d.DealID, d.PublishCid)
 	if (padreader.PaddedSize(uint64(size))) != size {
 		return 0, 0, xerrors.Errorf("cannot allocate unpadded piece")
 	}

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -28,6 +28,7 @@ const (
 	CommitFailed         SectorState = "CommitFailed"
 	PackingFailed        SectorState = "PackingFailed"
 	FinalizeFailed       SectorState = "FinalizeFailed"
+	DealsExpired         SectorState = "DealsExpired"
 
 	Faulty        SectorState = "Faulty"        // sector is corrupted or gone for some reason
 	FaultReported SectorState = "FaultReported" // sector has been declared as a fault on chain

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -26,7 +26,7 @@ const (
 	PreCommitFailed      SectorState = "PreCommitFailed"
 	ComputeProofFailed   SectorState = "ComputeProofFailed"
 	CommitFailed         SectorState = "CommitFailed"
-	PackingFailed        SectorState = "PackingFailed"
+	PackingFailed        SectorState = "PackingFailed" // TODO: deprecated, remove
 	FinalizeFailed       SectorState = "FinalizeFailed"
 	DealsExpired         SectorState = "DealsExpired"
 	RecoverDealIDs       SectorState = "RecoverDealIDs"

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -29,6 +29,7 @@ const (
 	PackingFailed        SectorState = "PackingFailed"
 	FinalizeFailed       SectorState = "FinalizeFailed"
 	DealsExpired         SectorState = "DealsExpired"
+	RecoverDealIDs       SectorState = "RecoverDealIDs"
 
 	Faulty        SectorState = "Faulty"        // sector is corrupted or gone for some reason
 	FaultReported SectorState = "FaultReported" // sector has been declared as a fault on chain

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -10,12 +10,13 @@ const (
 	WaitDeals      SectorState = "WaitDeals"     // waiting for more pieces (deals) to be added to the sector
 	Packing        SectorState = "Packing"       // sector not in sealStore, and not on chain
 	PreCommit1     SectorState = "PreCommit1"    // do PreCommit1
-	PreCommit2     SectorState = "PreCommit2"    // do PreCommit1
+	PreCommit2     SectorState = "PreCommit2"    // do PreCommit2
 	PreCommitting  SectorState = "PreCommitting" // on chain pre-commit
 	PreCommitWait  SectorState = "PreCommitWait" // waiting for precommit to land on chain
 	WaitSeed       SectorState = "WaitSeed"      // waiting for seed
-	Committing     SectorState = "Committing"
-	CommitWait     SectorState = "CommitWait" // waiting for message to land on chain
+	Committing     SectorState = "Committing"    // compute PoRep
+	SubmitCommit   SectorState = "SubmitCommit"  // send commit message to the chain
+	CommitWait     SectorState = "CommitWait"    // wait for the commit message to land on chain
 	FinalizeSector SectorState = "FinalizeSector"
 	Proving        SectorState = "Proving"
 	// error modes

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -258,7 +258,7 @@ func (m *Sealing) handleDealsExpired(ctx statemachine.Context, sector SectorInfo
 
 	if sector.PreCommitInfo == nil {
 		// TODO: Create a separate state which will remove those pieces, and go back to PC1
-		return xerrors.Errorf("non-precommitted sector with expired deals, can't recover from this yet")
+		log.Errorf("non-precommitted sector with expired deals, can't recover from this yet")
 	}
 
 	// Not much to do here, we can't go back in time to commit this sector

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -294,25 +294,25 @@ func (m *Sealing) handleRecoverDealIDs(ctx statemachine.Context, sector SectorIn
 
 		proposal, err := m.api.StateMarketStorageDeal(ctx.Context(), p.DealInfo.DealID, tok)
 		if err != nil {
-			log.Warn("getting deal %d for piece %d: %+v", p.DealInfo.DealID, i, err)
+			log.Warnf("getting deal %d for piece %d: %+v", p.DealInfo.DealID, i, err)
 			toFix = append(toFix, i)
 			continue
 		}
 
 		if proposal.Provider != m.maddr {
-			log.Warn("piece %d (of %d) of sector %d refers deal %d with wrong provider: %s != %s", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, proposal.Provider, m.maddr)
+			log.Warnf("piece %d (of %d) of sector %d refers deal %d with wrong provider: %s != %s", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, proposal.Provider, m.maddr)
 			toFix = append(toFix, i)
 			continue
 		}
 
 		if proposal.PieceCID != p.Piece.PieceCID {
-			log.Warn("piece %d (of %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, p.Piece.PieceCID, proposal.PieceCID)
+			log.Warnf("piece %d (of %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, p.Piece.PieceCID, proposal.PieceCID)
 			toFix = append(toFix, i)
 			continue
 		}
 
 		if p.Piece.Size != proposal.PieceSize {
-			log.Warn("piece %d (of %d) of sector %d refers deal %d with different size: %d != %d", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, p.Piece.Size, proposal.PieceSize)
+			log.Warnf("piece %d (of %d) of sector %d refers deal %d with different size: %d != %d", i, len(sector.Pieces), sector.SectorNumber, p.DealInfo.DealID, p.Piece.Size, proposal.PieceSize)
 			toFix = append(toFix, i)
 			continue
 		}

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -89,7 +89,7 @@ func (m *Sealing) handlePreCommitFailed(ctx statemachine.Context, sector SectorI
 			return ctx.Send(SectorSealPreCommit1Failed{xerrors.Errorf("bad expired: %w", err)})
 		case *ErrInvalidDeals:
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
-			return ctx.Send(SectorInvalidDealIDs{ Return: RetPreCommitFailed })
+			return ctx.Send(SectorInvalidDealIDs{Return: RetPreCommitFailed})
 		case *ErrExpiredDeals:
 			return ctx.Send(SectorDealsExpired{xerrors.Errorf("sector deals expired: %w", err)})
 		case *ErrNoPrecommit:
@@ -172,7 +172,7 @@ func (m *Sealing) handleCommitFailed(ctx statemachine.Context, sector SectorInfo
 			return ctx.Send(SectorSealPreCommit1Failed{xerrors.Errorf("bad ticket: %w", err)})
 		case *ErrInvalidDeals:
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
-			return ctx.Send(SectorInvalidDealIDs{ Return: RetCommitFailed })
+			return ctx.Send(SectorInvalidDealIDs{Return: RetCommitFailed})
 		case *ErrExpiredDeals:
 			return ctx.Send(SectorDealsExpired{xerrors.Errorf("sector deals expired: %w", err)})
 		case nil:
@@ -211,7 +211,7 @@ func (m *Sealing) handleCommitFailed(ctx statemachine.Context, sector SectorInfo
 			return ctx.Send(SectorRetryPreCommit{})
 		case *ErrInvalidDeals:
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
-			return ctx.Send(SectorInvalidDealIDs{ Return: RetCommitFailed })
+			return ctx.Send(SectorInvalidDealIDs{Return: RetCommitFailed})
 		case *ErrExpiredDeals:
 			return ctx.Send(SectorDealsExpired{xerrors.Errorf("sector deals expired: %w", err)})
 		case *ErrCommitWaitFailed:

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -244,6 +244,14 @@ func (m *Sealing) handleFinalizeFailed(ctx statemachine.Context, sector SectorIn
 	return ctx.Send(SectorRetryFinalize{})
 }
 
+func (m *Sealing) handleRemoveFailed(ctx statemachine.Context, sector SectorInfo) error {
+	if err := failedCooldown(ctx, sector); err != nil {
+		return err
+	}
+
+	return ctx.Send(SectorRemove{})
+}
+
 func (m *Sealing) handleDealsExpired(ctx statemachine.Context, sector SectorInfo) error {
 	// First make vary sure the sector isn't committed
 	si, err := m.api.StateSectorGetInfo(ctx.Context(), m.maddr, sector.SectorNumber, nil)

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -89,7 +89,7 @@ func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) 
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
 			return ctx.Send(SectorInvalidDealIDs{ Return: RetPreCommit1 })
 		case *ErrExpiredDeals: // Probably not much we can do here, maybe re-pack the sector?
-			return ctx.Send(SectorPackingFailed{xerrors.Errorf("expired dealIDs in sector: %w", err)})
+			return ctx.Send(SectorDealsExpired{xerrors.Errorf("expired dealIDs in sector: %w", err)})
 		default:
 			return xerrors.Errorf("checkPieces sanity check error: %w", err)
 		}

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -87,7 +87,7 @@ func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) 
 			return nil
 		case *ErrInvalidDeals:
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
-			return ctx.Send(SectorInvalidDealIDs{ Return: RetPreCommit1 })
+			return ctx.Send(SectorInvalidDealIDs{Return: RetPreCommit1})
 		case *ErrExpiredDeals: // Probably not much we can do here, maybe re-pack the sector?
 			return ctx.Send(SectorDealsExpired{xerrors.Errorf("expired dealIDs in sector: %w", err)})
 		default:
@@ -159,7 +159,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 			return ctx.Send(SectorSealPreCommit1Failed{xerrors.Errorf("bad ticket: %w", err)})
 		case *ErrInvalidDeals:
 			log.Warnf("invalid deals in sector %d: %v", sector.SectorNumber, err)
-			return ctx.Send(SectorInvalidDealIDs{ Return: RetPreCommitting })
+			return ctx.Send(SectorInvalidDealIDs{Return: RetPreCommitting})
 		case *ErrExpiredDeals:
 			return ctx.Send(SectorDealsExpired{xerrors.Errorf("sector deals expired: %w", err)})
 		case *ErrPrecommitOnChain:

--- a/extern/storage-sealing/types.go
+++ b/extern/storage-sealing/types.go
@@ -54,6 +54,14 @@ type Log struct {
 	Kind string
 }
 
+type ReturnState string
+const (
+	RetPreCommit1 = ReturnState(PreCommit1)
+	RetPreCommitting = ReturnState(PreCommitting)
+	RetPreCommitFailed = ReturnState(PreCommitFailed)
+	RetCommitFailed = ReturnState(CommitFailed)
+)
+
 type SectorInfo struct {
 	State        SectorState
 	SectorNumber abi.SectorNumber
@@ -90,6 +98,9 @@ type SectorInfo struct {
 
 	// Faults
 	FaultReportMsg *cid.Cid
+
+	// Recovery
+	Return ReturnState
 
 	// Debug
 	LastErr string

--- a/extern/storage-sealing/types.go
+++ b/extern/storage-sealing/types.go
@@ -55,11 +55,12 @@ type Log struct {
 }
 
 type ReturnState string
+
 const (
-	RetPreCommit1 = ReturnState(PreCommit1)
-	RetPreCommitting = ReturnState(PreCommitting)
+	RetPreCommit1      = ReturnState(PreCommit1)
+	RetPreCommitting   = ReturnState(PreCommitting)
 	RetPreCommitFailed = ReturnState(PreCommitFailed)
-	RetCommitFailed = ReturnState(CommitFailed)
+	RetCommitFailed    = ReturnState(CommitFailed)
 )
 
 type SectorInfo struct {

--- a/extern/storage-sealing/types.go
+++ b/extern/storage-sealing/types.go
@@ -30,6 +30,7 @@ type Piece struct {
 
 // DealInfo is a tuple of deal identity and its schedule
 type DealInfo struct {
+	PublishCid   *cid.Cid
 	DealID       abi.DealID
 	DealSchedule DealSchedule
 	KeepUnsealed bool

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -72,6 +72,10 @@ func (m *Sealing) tryUpgradeSector(ctx context.Context, params *miner.SectorPreC
 			log.Errorf("error calling StateSectorGetInfo for replaced sector: %+v", err)
 			return big.Zero()
 		}
+		if ri == nil {
+			log.Errorf("couldn't find sector info for sector to replace: %+v", replace)
+			return big.Zero()
+		}
 
 		if params.Expiration < ri.Expiration {
 			// TODO: Some limit on this

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v0.6.2
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f
-	github.com/filecoin-project/go-fil-markets v0.5.7
+	github.com/filecoin-project/go-fil-markets v0.5.8-0.20200827230805-30e8f6d42465
 	github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-markets v0.5.6-0.20200814234959-80b1788108ac/go.mod h1:umicPCaN99ysHTiYOmwhuLxTFbOwcsI+mdw/t96vvM4=
 github.com/filecoin-project/go-fil-markets v0.5.6/go.mod h1:SJApXAKr5jyGpbzDEOhvemui0pih7hhT8r2MXJxCP1E=
-github.com/filecoin-project/go-fil-markets v0.5.7 h1:kzyMHqez8ssxchj5s9M1hkC3CTwRGh2MeglJGfUksQU=
-github.com/filecoin-project/go-fil-markets v0.5.7/go.mod h1:KnvFG3kSQ77vKYSY/QdrXET81wVCBByHXjG7AyxnbUw=
+github.com/filecoin-project/go-fil-markets v0.5.8-0.20200827230805-30e8f6d42465 h1:74yonPhkVakfqUHcgfJ+vQOfCJQNiUBKn8XN9Z6F0S0=
+github.com/filecoin-project/go-fil-markets v0.5.8-0.20200827230805-30e8f6d42465/go.mod h1:KnvFG3kSQ77vKYSY/QdrXET81wVCBByHXjG7AyxnbUw=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200817153016-2ea5cbaf5ec0/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52 h1:FXtCp0ybqdQL9knb3OGDpkNTaBbPxgkqPeWKotUwkH0=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -153,6 +153,8 @@ func (sm *StorageMinerAPI) SectorsStatus(ctx context.Context, sid abi.SectorNumb
 			Value: info.SeedValue,
 			Epoch: info.SeedEpoch,
 		},
+		PreCommitMsg: info.PreCommitMessage,
+		CommitMsg: info.CommitMessage,
 		Retries:   info.InvalidProofs,
 		ToUpgrade: sm.Miner.IsMarkedForUpgrade(sid),
 

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -154,9 +154,9 @@ func (sm *StorageMinerAPI) SectorsStatus(ctx context.Context, sid abi.SectorNumb
 			Epoch: info.SeedEpoch,
 		},
 		PreCommitMsg: info.PreCommitMessage,
-		CommitMsg: info.CommitMessage,
-		Retries:   info.InvalidProofs,
-		ToUpgrade: sm.Miner.IsMarkedForUpgrade(sid),
+		CommitMsg:    info.CommitMessage,
+		Retries:      info.InvalidProofs,
+		ToUpgrade:    sm.Miner.IsMarkedForUpgrade(sid),
 
 		LastErr: info.LastErr,
 		Log:     log,

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -177,6 +177,9 @@ func (sm *StorageMinerAPI) SectorsStatus(ctx context.Context, sid abi.SectorNumb
 
 	onChainInfo, err := sm.Full.StateSectorGetInfo(ctx, sm.Miner.Address(), sid, types.EmptyTSK)
 	if err != nil {
+		return sInfo, err
+	}
+	if onChainInfo == nil {
 		return sInfo, nil
 	}
 	sInfo.SealProof = onChainInfo.SealProof

--- a/storage/sectorblocks/blocks.go
+++ b/storage/sectorblocks/blocks.go
@@ -102,6 +102,7 @@ func (st *SectorBlocks) AddPiece(ctx context.Context, size abi.UnpaddedPieceSize
 		return 0, 0, err
 	}
 
+	// TODO: DealID has very low finality here
 	err = st.writeRef(d.DealID, sn, offset, size)
 	if err != nil {
 		return 0, 0, xerrors.Errorf("writeRef: %w", err)


### PR DESCRIPTION
This PR grew a bit bigger than I've originally expected, but it's really just a bunch of smallish fixes, so reviewing commit-by-commit should be pretty easy.

Summary of changes:
* `lotus-miner sectors remove [sid]` now works for sectors in all states
* We now print precommit/commit message CIDs in `lotus-miner sectors status`
* Separate state for sending the Commit message
* Auto-retry sending precommit/commit messages when they hit out-of-gas
* Recover from reorged dealIDs
* Mostly deprecate the PackingFailed state
* Show tasks assigned to worker windows, but not running yet (1)
* More priority to FinalizeSector and other tasks moving data around
* Don't start scheduling tasks for 3s after restart (lets the FSM tasks restart)
* Auto-retry failed sector remove tasks
* Get more pending tasks before calling trySched (should noticeably mitigate its slowness in bigger deployments)
* Compact assigned worker windows
  * In the current scheduling logic, each worker has 2 resource based windows of resources
  * When a window is empty it gets sent to the main scheduler goroutine, and filled with some tasks, then sent back to the worker for processing (the scheduler only holds empty / "open" windows, as soon as at least 1 task is put in a window it's sent to the worker)
  * When the worker gets windows back from the scheduler, it starts executing them sequentially
  * In some scenarios this can lead to wasting a fair bit of resources, as we may be refusing to execute smaller tasks which we could be running, but aren't because it's not in the current window we're executing
  * This change implements logic which will looks at 'newer' windows and if it sees tasks which can fit in the currently executing window, moves them there, to hopefully execute sooner
* (ties in with the above, I'm not sure why this was done this way) Don't require tasks in the currently running window to be executed in order


(1)
```
ID  Sector  Worker  Hostname  Task  State        Time
2   11      2       avocado   PC1   running      45m1.2s
3   27      0       pancetta  GET   running      45m1s
0   62      3       banana    AP    running      3m2.4s
0   31      0       pancetta  AP    assigned(0)  45m1s
0   25      0       pancetta  PC1   assigned(0)  39m5s
0   63      0       pancetta  AP    assigned(0)  3m1.9s
0   64      0       pancetta  AP    assigned(0)  3m1.5s
```