### PR TITLE
Update allowInternal flag on child runtime for nested calls

### DIFF
--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -220,6 +220,7 @@ func (vm *VM) send(ctx context.Context, msg *types.Message, parent *Runtime,
 	rt := vm.makeRuntime(ctx, msg, origin, on, gasUsed, nac)
 	rt.lastGasChargeTime = start
 	if parent != nil {
+		rt.allowInternal = parent.allowInternal
 		rt.lastGasChargeTime = parent.lastGasChargeTime
 		rt.lastGasCharge = parent.lastGasCharge
 		defer func() {


### PR DESCRIPTION
More a PR for discussion, very minor point (and my intuition would be that this should not be able to be hit) but I'm just being proactive. This flag is set while inside a transaction, which disallows any internal sends, but if the vm.send() is called within that function, then this flag would be ignored. Is this intentional?