### PR TITLE
Fix chain import

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -345,6 +345,16 @@ func ImportChain(r repo.Repo, fname string) error {
 		return xerrors.Errorf("importing chain failed: %w", err)
 	}
 
+	gb, err := cst.GetTipsetByHeight(context.TODO(), 0, ts, true)
+	if err != nil {
+		return err
+	}
+
+	err = cst.SetGenesis(gb.Blocks()[0])
+	if err != nil {
+		return err
+	}
+
 	stm := stmgr.NewStateManager(cst)
 
 	log.Infof("validating imported chain...")


### PR DESCRIPTION
The stmgr calls GetGenesis to setup genesis multisigs, which needs to be explicitly set using SetGenesis. This wasn't happening during imports.

Very similar to #2805