### PR TITLE
Tweak priority selection to not select negative perfoming chains

### DIFF
--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -108,7 +108,7 @@ func (mp *MessagePool) republishPendingMessages() error {
 
 		// we can't fit the current chain but there is gas to spare
 		// trim it and push it down
-		chain.Trim(gasLimit, mp, baseFee, ts, false)
+		chain.Trim(gasLimit, mp, baseFee, ts)
 		for j := i; j < len(chains)-1; j++ {
 			if chains[j].Before(chains[j+1]) {
 				break

--- a/documentation/en/mpool.md
+++ b/documentation/en/mpool.md
@@ -133,7 +133,7 @@ type MpoolConfig struct {
 
 The meaning of these fields is as follows:
 - `PriorityAddrs` -- these are the addresses of actors whose pending messages should always
-  be included in a block during message selection, regardless of profitability.
+  be included in a block during message selection, as long as they are profitable.
   Miners should configure their own worker addresses so that they include their own messages
   when they produce a new block.
   Default is empty.


### PR DESCRIPTION
as discussed on slack, this turns out to be problematic as miners fill their blocks with penalty inducing chains when the base fee gets high.