### PR TITLE
fix GetBestMiningCandidate bug

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -327,6 +327,7 @@ func (m *Miner) GetBestMiningCandidate(ctx context.Context) (*MiningBase, error)
 		}
 		ltsw, err := m.api.ChainTipSetWeight(ctx, m.lastWork.TipSet.Key())
 		if err != nil {
+			m.lastWork = nil
 			return nil, err
 		}
 


### PR DESCRIPTION
If ChainTipSetWeight returns an error, waiting outside for 5 seconds to try again will still report an error, resulting in an infinite loop, the miner can not dig properly block.

the error:
2020-09-01T11:31:50.596+0800	ERROR	miner	miner/miner.go:159	failed to get best mining candidate: loading tipset {bafy2bzacebaq24x6umldnhmr5fdsbd6zd44qqehkrioxavasgkmrqyckpm7es}: get block bafy2bzacebaq24x6umldnhmr5fdsbd6zd44qqehkrioxavasgkmrqyckpm7es: blockstore: block not found