### PR TITLE
fix crash - segment fault when partialFile.Allocated() is invoked.

### DIFF
--- a/extern/sector-storage/ffiwrapper/sealer_cgo.go
+++ b/extern/sector-storage/ffiwrapper/sealer_cgo.go
@@ -371,7 +371,7 @@ func (sb *Sealer) ReadPiece(ctx context.Context, writer io.Writer, sector abi.Se
 	maxPieceSize := abi.PaddedPieceSize(sb.ssize)
 
 	pf, err := openPartialFile(maxPieceSize, path.Unsealed)
-	if xerrors.Is(err, os.ErrNotExist) {
+	if err != nil {
 		return false, xerrors.Errorf("opening partial file: %w", err)
 	}
 


### PR DESCRIPTION
When openPartialFile is invoked, more errors than "existed error" are
returned. If only existing error is checked, the allocated field of
partialFile may be nil.

Signed-off-by: Star.LI <star@trapdoortech.com>