### PR TITLE
fix: guard against self beneficiary when deleting actor

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -246,7 +246,7 @@ func (rt *Runtime) CreateActor(codeID cid.Cid, address address.Address) {
 
 // DeleteActor deletes the executing actor from the state tree, transferring
 // any balance to beneficiary.
-// Aborts if the beneficiary does not exist.
+// Aborts if the beneficiary does not exist or is the calling actor.
 // May only be called by the actor itself.
 func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 	rt.chargeGas(rt.Pricelist().OnDeleteActor())
@@ -258,6 +258,9 @@ func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 		panic(aerrors.Fatalf("failed to get actor: %s", err))
 	}
 	if !act.Balance.IsZero() {
+		if beneficiary == rt.Message().Receiver() {
+			rt.Abortf(exitcode.SysErrorIllegalArgument, "benefactor cannot be beneficiary")
+		}
 		// Transfer the executing actor's balance to the beneficiary
 		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance); err != nil {
 			panic(aerrors.Fatalf("failed to transfer balance to beneficiary actor: %s", err))

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -258,7 +258,7 @@ func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 		panic(aerrors.Fatalf("failed to get actor: %s", err))
 	}
 	if !act.Balance.IsZero() {
-		if beneficiary == rt.Message().Receiver() {
+		if beneficiary == rt.Receiver() {
 			rt.Abortf(exitcode.SysErrorIllegalArgument, "benefactor cannot be beneficiary")
 		}
 		// Transfer the executing actor's balance to the beneficiary


### PR DESCRIPTION
This adds a check to ensure the calling actor cannot specify themselves as the beneficiary - they're about to be deleted so this stops us from losing their funds.

More context and test vector for this edge case here: https://github.com/filecoin-project/test-vectors/pull/92#discussion_r481180625