### PR TITLE
fix: abort if beneficiary is not found

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -258,6 +258,13 @@ func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 		panic(aerrors.Fatalf("failed to get actor: %s", err))
 	}
 	if !act.Balance.IsZero() {
+		// Ensure the beneficiary exists
+		if _, err := rt.state.GetActor(beneficiary); err != nil {
+			if xerrors.Is(err, types.ErrActorNotFound) {
+				rt.Abortf(exitcode.SysErrorIllegalActor, "failed to load beneficiary actor: %s", err)
+			}
+			panic(aerrors.Fatalf("failed to get beneficiary actor: %s", err))
+		}
 		// Transfer the executing actor's balance to the beneficiary
 		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance); err != nil {
 			panic(aerrors.Fatalf("failed to transfer balance to beneficiary actor: %s", err))


### PR DESCRIPTION
This PR ensures the beneficiary exists before attempting to transfer funds to them and aborts with a `SysErrorIllegalActor` exit code if they're not found.

More context and test vector for this edge case here: https://github.com/filecoin-project/test-vectors/pull/92#discussion_r481181485