### PR TITLE
Revert "conformance: add driver for tipset-class vectors."

### DIFF
--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -2,10 +2,7 @@ package conformance
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/filecoin-project/lotus/chain/stmgr"
-	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
@@ -17,10 +14,7 @@ import (
 	"github.com/filecoin-project/test-vectors/chaos"
 	"github.com/filecoin-project/test-vectors/schema"
 
-	"github.com/filecoin-project/go-address"
-
 	"github.com/ipfs/go-cid"
-	ds "github.com/ipfs/go-datastore"
 )
 
 var (
@@ -30,92 +24,16 @@ var (
 )
 
 type Driver struct {
-	ctx      context.Context
-	selector schema.Selector
+	ctx    context.Context
+	vector *schema.TestVector
 }
 
-func NewDriver(ctx context.Context, selector schema.Selector) *Driver {
-	return &Driver{ctx: ctx, selector: selector}
-}
-
-type ExecuteTipsetResult struct {
-	ReceiptsRoot  cid.Cid
-	PostStateRoot cid.Cid
-
-	// AppliedMessages stores the messages that were applied, in the order they
-	// were applied. It includes implicit messages (cron, rewards).
-	AppliedMessages []*types.Message
-	// AppliedResults stores the results of AppliedMessages, in the same order.
-	AppliedResults []*vm.ApplyRet
-}
-
-// ExecuteTipset executes the supplied tipset on top of the state represented
-// by the preroot CID.
-//
-// parentEpoch is the last epoch in which an actual tipset was processed. This
-// is used by Lotus for null block counting and cron firing.
-//
-// This method returns the the receipts root, the poststate root, and the VM
-// message results. The latter _include_ implicit messages, such as cron ticks
-// and reward withdrawal per miner.
-func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, preroot cid.Cid, parentEpoch abi.ChainEpoch, tipset *schema.Tipset) (*ExecuteTipsetResult, error) {
-	var (
-		syscalls = mkFakedSigSyscalls(vm.Syscalls(ffiwrapper.ProofVerifier))
-		vmRand   = new(testRand)
-
-		cs = store.NewChainStore(bs, ds, syscalls)
-		sm = stmgr.NewStateManager(cs)
-	)
-
-	blocks := make([]store.BlockMessages, 0, len(tipset.Blocks))
-	for _, b := range tipset.Blocks {
-		sb := store.BlockMessages{
-			Miner:    b.MinerAddr,
-			WinCount: b.WinCount,
-		}
-		for _, m := range b.Messages {
-			msg, err := types.DecodeMessage(m)
-			if err != nil {
-				return nil, err
-			}
-			switch msg.From.Protocol() {
-			case address.SECP256K1:
-				sb.SecpkMessages = append(sb.SecpkMessages, msg)
-			case address.BLS:
-				sb.BlsMessages = append(sb.BlsMessages, msg)
-			default:
-				return nil, fmt.Errorf("from account is not secpk nor bls: %s", msg.From)
-			}
-		}
-		blocks = append(blocks, sb)
-	}
-
-	var (
-		messages []*types.Message
-		results  []*vm.ApplyRet
-	)
-
-	postcid, receiptsroot, err := sm.ApplyBlocks(context.Background(), parentEpoch, preroot, blocks, tipset.Epoch, vmRand, func(_ cid.Cid, msg *types.Message, ret *vm.ApplyRet) error {
-		messages = append(messages, msg)
-		results = append(results, ret)
-		return nil
-	}, tipset.BaseFee)
-
-	if err != nil {
-		return nil, err
-	}
-
-	ret := &ExecuteTipsetResult{
-		ReceiptsRoot:    receiptsroot,
-		PostStateRoot:   postcid,
-		AppliedMessages: messages,
-		AppliedResults:  results,
-	}
-	return ret, nil
+func NewDriver(ctx context.Context, vector *schema.TestVector) *Driver {
+	return &Driver{ctx: ctx, vector: vector}
 }
 
 // ExecuteMessage executes a conformance test vector message in a temporary VM.
-func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, preroot cid.Cid, epoch abi.ChainEpoch, msg *types.Message) (*vm.ApplyRet, cid.Cid, error) {
+func (d *Driver) ExecuteMessage(msg *types.Message, preroot cid.Cid, bs blockstore.Blockstore, epoch abi.ChainEpoch) (*vm.ApplyRet, cid.Cid, error) {
 	vmOpts := &vm.VMOpts{
 		StateBase:      preroot,
 		Epoch:          epoch,
@@ -134,10 +52,10 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, preroot cid.Cid, epoch
 	invoker := vm.NewInvoker()
 
 	// add support for the puppet and chaos actors.
-	if puppetOn, ok := d.selector["puppet_actor"]; ok && puppetOn == "true" {
+	if puppetOn, ok := d.vector.Selector["puppet_actor"]; ok && puppetOn == "true" {
 		invoker.Register(puppet.PuppetActorCodeID, puppet.Actor{}, puppet.State{})
 	}
-	if chaosOn, ok := d.selector["chaos_actor"]; ok && chaosOn == "true" {
+	if chaosOn, ok := d.vector.Selector["chaos_actor"]; ok && chaosOn == "true" {
 		invoker.Register(chaos.ChaosActorCodeCID, chaos.Actor{}, chaos.State{})
 	}
 

--- a/conformance/runner_test.go
+++ b/conformance/runner_test.go
@@ -6,16 +6,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/ipfs/go-cid"
-	ds "github.com/ipfs/go-datastore"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
@@ -140,8 +135,6 @@ func TestConformance(t *testing.T) {
 			switch vector.Class {
 			case "message":
 				executeMessageVector(t, &vector)
-			case "tipset":
-				executeTipsetVector(t, &vector)
 			default:
 				t.Fatalf("test vector class not supported: %s", vector.Class)
 			}
@@ -157,11 +150,24 @@ func executeMessageVector(t *testing.T, vector *schema.TestVector) {
 		root  = vector.Pre.StateTree.RootCID
 	)
 
-	// Load the CAR into a new temporary Blockstore.
-	bs := loadCAR(t, vector.CAR)
+	bs := blockstore.NewTemporary()
+
+	// Read the base64-encoded CAR from the vector, and inflate the gzip.
+	buf := bytes.NewReader(vector.CAR)
+	r, err := gzip.NewReader(buf)
+	if err != nil {
+		t.Fatalf("failed to inflate gzipped CAR: %s", err)
+	}
+	defer r.Close() // nolint
+
+	// Load the CAR embedded in the test vector into the Blockstore.
+	_, err = car.LoadCar(bs, r)
+	if err != nil {
+		t.Fatalf("failed to load state tree car from test vector: %s", err)
+	}
 
 	// Create a new Driver.
-	driver := NewDriver(ctx, vector.Selector)
+	driver := NewDriver(ctx, vector)
 
 	// Apply every message.
 	for i, m := range vector.ApplyMessages {
@@ -177,128 +183,52 @@ func executeMessageVector(t *testing.T, vector *schema.TestVector) {
 
 		// Execute the message.
 		var ret *vm.ApplyRet
-		ret, root, err = driver.ExecuteMessage(bs, root, epoch, msg)
+		ret, root, err = driver.ExecuteMessage(msg, root, bs, epoch)
 		if err != nil {
 			t.Fatalf("fatal failure when executing message: %s", err)
 		}
 
 		// Assert that the receipt matches what the test vector expects.
-		assertMsgResult(t, vector.Post.Receipts[i], ret, strconv.Itoa(i))
+		receipt := vector.Post.Receipts[i]
+		if expected, actual := receipt.ExitCode, ret.ExitCode; expected != actual {
+			t.Errorf("exit code of msg %d did not match; expected: %s, got: %s", i, expected, actual)
+		}
+		if expected, actual := receipt.GasUsed, ret.GasUsed; expected != actual {
+			t.Errorf("gas used of msg %d did not match; expected: %d, got: %d", i, expected, actual)
+		}
+		if expected, actual := []byte(receipt.ReturnValue), ret.Return; !bytes.Equal(expected, actual) {
+			t.Errorf("return value of msg %d did not match; expected: %s, got: %s", i, base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(actual))
+		}
 	}
 
 	// Once all messages are applied, assert that the final state root matches
 	// the expected postcondition root.
 	if root != vector.Post.StateTree.RootCID {
-		dumpThreeWayStateDiff(t, vector, bs, root)
+		color.NoColor = false // enable colouring.
+
+		t.Errorf("wrong post root cid; expected %v, but got %v", vector.Post.StateTree.RootCID, root)
+
+		var (
+			a  = color.New(color.FgMagenta, color.Bold).Sprint("(A) expected final state")
+			b  = color.New(color.FgYellow, color.Bold).Sprint("(B) actual final state")
+			c  = color.New(color.FgCyan, color.Bold).Sprint("(C) initial state")
+			d1 = color.New(color.FgGreen, color.Bold).Sprint("[Δ1]")
+			d2 = color.New(color.FgGreen, color.Bold).Sprint("[Δ2]")
+			d3 = color.New(color.FgGreen, color.Bold).Sprint("[Δ3]")
+		)
+
+		bold := color.New(color.Bold).SprintfFunc()
+
+		// run state diffs.
+		t.Log(bold("=== dumping 3-way diffs between %s, %s, %s ===", a, b, c))
+
+		t.Log(bold("--- %s left: %s; right: %s ---", d1, a, b))
+		t.Log(statediff.Diff(context.Background(), bs, vector.Post.StateTree.RootCID, root))
+
+		t.Log(bold("--- %s left: %s; right: %s ---", d2, c, b))
+		t.Log(statediff.Diff(context.Background(), bs, vector.Pre.StateTree.RootCID, root))
+
+		t.Log(bold("--- %s left: %s; right: %s ---", d3, c, a))
+		t.Log(statediff.Diff(context.Background(), bs, vector.Pre.StateTree.RootCID, vector.Post.StateTree.RootCID))
 	}
-}
-
-// executeTipsetVector executes a tipset-class test vector.
-func executeTipsetVector(t *testing.T, vector *schema.TestVector) {
-	var (
-		ctx       = context.Background()
-		prevEpoch = vector.Pre.Epoch
-		root      = vector.Pre.StateTree.RootCID
-		tmpds     = ds.NewMapDatastore()
-	)
-
-	// Load the CAR into a new temporary Blockstore.
-	bs := loadCAR(t, vector.CAR)
-
-	// Create a new Driver.
-	driver := NewDriver(ctx, vector.Selector)
-
-	// Apply every tipset.
-	var receiptsIdx int
-	for i, ts := range vector.ApplyTipsets {
-		ts := ts // capture
-		ret, err := driver.ExecuteTipset(bs, tmpds, root, prevEpoch, &ts)
-		if err != nil {
-			t.Fatalf("failed to apply tipset %d message: %s", i, err)
-		}
-
-		for j, v := range ret.AppliedResults {
-			assertMsgResult(t, vector.Post.Receipts[receiptsIdx], v, fmt.Sprintf("%d of tipset %d", j, i))
-			receiptsIdx++
-		}
-
-		// Compare the receipts root.
-		if expected, actual := vector.Post.ReceiptsRoots[i], ret.ReceiptsRoot; expected != actual {
-			t.Errorf("post receipts root doesn't match; expected: %s, was: %s", expected, actual)
-		}
-
-		prevEpoch = ts.Epoch
-		root = ret.PostStateRoot
-	}
-
-	// Once all messages are applied, assert that the final state root matches
-	// the expected postcondition root.
-	if root != vector.Post.StateTree.RootCID {
-		dumpThreeWayStateDiff(t, vector, bs, root)
-	}
-}
-
-// assertMsgResult compares a message result. It takes the expected receipt
-// encoded in the vector, the actual receipt returned by Lotus, and a message
-// label to log in the assertion failure message to facilitate debugging.
-func assertMsgResult(t *testing.T, expected *schema.Receipt, actual *vm.ApplyRet, label string) {
-	t.Helper()
-
-	if expected, actual := expected.ExitCode, actual.ExitCode; expected != actual {
-		t.Errorf("exit code of msg %s did not match; expected: %s, got: %s", label, expected, actual)
-	}
-	if expected, actual := expected.GasUsed, actual.GasUsed; expected != actual {
-		t.Errorf("gas used of msg %s did not match; expected: %d, got: %d", label, expected, actual)
-	}
-	if expected, actual := []byte(expected.ReturnValue), actual.Return; !bytes.Equal(expected, actual) {
-		t.Errorf("return value of msg %s did not match; expected: %s, got: %s", label, base64.StdEncoding.EncodeToString(expected), base64.StdEncoding.EncodeToString(actual))
-	}
-}
-
-func dumpThreeWayStateDiff(t *testing.T, vector *schema.TestVector, bs blockstore.Blockstore, actual cid.Cid) {
-	color.NoColor = false // enable colouring.
-
-	t.Errorf("wrong post root cid; expected %v, but got %v", vector.Post.StateTree.RootCID, actual)
-
-	var (
-		a  = color.New(color.FgMagenta, color.Bold).Sprint("(A) expected final state")
-		b  = color.New(color.FgYellow, color.Bold).Sprint("(B) actual final state")
-		c  = color.New(color.FgCyan, color.Bold).Sprint("(C) initial state")
-		d1 = color.New(color.FgGreen, color.Bold).Sprint("[Δ1]")
-		d2 = color.New(color.FgGreen, color.Bold).Sprint("[Δ2]")
-		d3 = color.New(color.FgGreen, color.Bold).Sprint("[Δ3]")
-	)
-
-	bold := color.New(color.Bold).SprintfFunc()
-
-	// run state diffs.
-	t.Log(bold("=== dumping 3-way diffs between %s, %s, %s ===", a, b, c))
-
-	t.Log(bold("--- %s left: %s; right: %s ---", d1, a, b))
-	t.Log(statediff.Diff(context.Background(), bs, vector.Post.StateTree.RootCID, actual))
-
-	t.Log(bold("--- %s left: %s; right: %s ---", d2, c, b))
-	t.Log(statediff.Diff(context.Background(), bs, vector.Pre.StateTree.RootCID, actual))
-
-	t.Log(bold("--- %s left: %s; right: %s ---", d3, c, a))
-	t.Log(statediff.Diff(context.Background(), bs, vector.Pre.StateTree.RootCID, vector.Post.StateTree.RootCID))
-}
-
-func loadCAR(t *testing.T, vectorCAR schema.Base64EncodedBytes) blockstore.Blockstore {
-	bs := blockstore.NewTemporary()
-
-	// Read the base64-encoded CAR from the vector, and inflate the gzip.
-	buf := bytes.NewReader(vectorCAR)
-	r, err := gzip.NewReader(buf)
-	if err != nil {
-		t.Fatalf("failed to inflate gzipped CAR: %s", err)
-	}
-	defer r.Close() // nolint
-
-	// Load the CAR embedded in the test vector into the Blockstore.
-	_, err = car.LoadCar(bs, r)
-	if err != nil {
-		t.Fatalf("failed to load state tree car from test vector: %s", err)
-	}
-	return bs
 }

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ replace github.com/supranational/blst => github.com/filecoin-project/blst v0.1.2
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
+	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/BurntSushi/toml v0.3.1
 	github.com/GeertJohan/go.rice v1.0.0
 	github.com/Gurpartap/async v0.0.0-20180927173644-4f7f499dd9ee
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
 	github.com/coreos/go-systemd/v22 v22.0.0
+	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/docker/go-units v0.4.0
@@ -39,7 +41,7 @@ require (
 	github.com/filecoin-project/specs-actors v0.9.3
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401
 	github.com/filecoin-project/statediff v0.0.1
-	github.com/filecoin-project/test-vectors v0.0.0-20200901185932-907892394dd8
+	github.com/filecoin-project/test-vectors v0.0.0-20200826113833-9ffe6524729d
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/google/uuid v1.1.1
@@ -117,6 +119,7 @@ require (
 	github.com/whyrusleeping/pubsub v0.0.0-20131020042734-02de8aa2db3d
 	github.com/xorcare/golden v0.6.1-0.20191112154924-b87f686d7542
 	go.opencensus.io v0.22.4
+	go.uber.org/dig v1.10.0 // indirect
 	go.uber.org/fx v1.9.0
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,9 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
+github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -162,8 +163,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
-github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f h1:BOaYiTvg8p9vBUXpklC22XSK/mifLF7lG9jtmYYi3Tc=
 github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
+github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c h1:pFUpOrbxDR6AkioZ1ySsx5yxlDQZ8stG2b88gTPxgJU=
+github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
 github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e h1:lj77EKYUpYXTd8CD/+QMIf8b6OIOTsfEBSXiAzuEHTU=
 github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e/go.mod h1:3ZQK6DMPSz/QZ73jlWxBtUhNA8xZx7LzUFSq/OfP8vk=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
@@ -246,6 +248,7 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1:GxJzR3oRIMTPtpZ0b7QF8FKPK6/iPAc7trhlL5k/g+s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-markets v0.5.6-0.20200814234959-80b1788108ac/go.mod h1:umicPCaN99ysHTiYOmwhuLxTFbOwcsI+mdw/t96vvM4=
+github.com/filecoin-project/go-fil-markets v0.5.6/go.mod h1:SJApXAKr5jyGpbzDEOhvemui0pih7hhT8r2MXJxCP1E=
 github.com/filecoin-project/go-fil-markets v0.5.8 h1:uwl0QNUVmmSlUQfxshpj21Dmhh6WKTQNhnb1GMfdp18=
 github.com/filecoin-project/go-fil-markets v0.5.8/go.mod h1:6ZX1vbZbnukbVQ8tCB/MmEizuW/bmRX7SpGAltU3KVg=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200817153016-2ea5cbaf5ec0/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
@@ -267,8 +270,8 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
+github.com/filecoin-project/lotus v0.4.3-0.20200819134055-b13681df3205/go.mod h1:rooripL/X8ixwUngDPzphAv/RKZXWBprbyxxDW0EJi0=
 github.com/filecoin-project/lotus v0.4.3-0.20200820203717-d1718369a182/go.mod h1:biFZPQ/YyQGfkHUmHMiaNf2hnD6zm1+OAXPQYQ61Zkg=
-github.com/filecoin-project/lotus v0.5.8-0.20200901153315-fa4000663a61/go.mod h1:gs5PdzCNGg5vhLMFh3VnUnyvCYXCKJH6Rw2k/PVz1uU=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a/go.mod h1:oOawOl9Yk+qeytLzzIryjI8iRbqo+qzS6EEeElP4PWA=
 github.com/filecoin-project/sector-storage v0.0.0-20200810171746-eac70842d8e0 h1:E1fZ27fhKK05bhZItfTwqr1i05vXnEZJznQFEYwEEUU=
@@ -893,6 +896,7 @@ github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1
 github.com/libp2p/go-libp2p-protocol v0.1.0/go.mod h1:KQPHpAabB57XQxGrXCNvbL6UEXfQqUgC/1adR2Xtflk=
 github.com/libp2p/go-libp2p-pubsub v0.1.1/go.mod h1:ZwlKzRSe1eGvSIdU5bD7+8RZN/Uzw0t1Bp9R1znpR/Q=
 github.com/libp2p/go-libp2p-pubsub v0.3.2-0.20200527132641-c0712c6e92cf/go.mod h1:TxPOBuo1FPdsTjFnv+FGZbNbWYsp74Culx+4ViQpato=
+github.com/libp2p/go-libp2p-pubsub v0.3.4/go.mod h1:DTMSVmZZfXodB/pvdTGrY2eHPZ9W2ev7hzTH83OKHrI=
 github.com/libp2p/go-libp2p-pubsub v0.3.5-0.20200820194335-bfc96c2cd081/go.mod h1:DTMSVmZZfXodB/pvdTGrY2eHPZ9W2ev7hzTH83OKHrI=
 github.com/libp2p/go-libp2p-pubsub v0.3.6-0.20200901174250-06a12f17b7de h1:Dl0B0x6u+OSKXAa1DeB6xHFsUOBAhjrXJ10zykVSN6Q=
 github.com/libp2p/go-libp2p-pubsub v0.3.6-0.20200901174250-06a12f17b7de/go.mod h1:DTMSVmZZfXodB/pvdTGrY2eHPZ9W2ev7hzTH83OKHrI=
@@ -1493,8 +1497,9 @@ go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/dig v1.8.0 h1:1rR6hnL/bu1EVcjnRDN5kx1vbIjEJDTGhSQ2B3ddpcI=
 go.uber.org/dig v1.8.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
+go.uber.org/dig v1.10.0 h1:yLmDDj9/zuDjv3gz8GQGviXMs9TfysIUMUilCpgzUJY=
+go.uber.org/dig v1.10.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/fx v1.9.0 h1:7OAz8ucp35AU8eydejpYG7QrbE8rLKzGhHbZlJi5LYY=
 go.uber.org/fx v1.9.0/go.mod h1:mFdUyAUuJ3w4jAckiKSKbldsxy1ojpAMJ+dVZg5Y0Aw=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
@@ -1546,6 +1551,7 @@ golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200427165652-729f1e841bcc/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200602180216-279210d13fed/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Reverts filecoin-project/lotus#3449

Latest test-vectors import non-existent lotus revision, which breaks all builds - https://github.com/filecoin-project/test-vectors/blob/master/go.mod#L9

```
go build -ldflags="-X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.dd228c3a" -o lotus ./cmd/lotus
go: github.com/filecoin-project/test-vectors@v0.0.0-20200901185932-907892394dd8 requires
        github.com/filecoin-project/lotus@v0.5.8-0.20200901153315-fa4000663a61: invalid version: unknown revision fa4000663a61
make: *** [Makefile:68: lotus] Error 1

```