### PR TITLE
Fix: dead lock caused by wndLk and lk

### DIFF
--- a/extern/sector-storage/sched_resources.go
+++ b/extern/sector-storage/sched_resources.go
@@ -110,11 +110,11 @@ func (a *activeResources) utilization(wr storiface.WorkerResources) float64 {
 }
 
 func (wh *workerHandle) utilization() float64 {
+	wh.wndLk.Lock()
 	wh.lk.Lock()
 	u := wh.active.utilization(wh.info.Resources)
 	u += wh.preparing.utilization(wh.info.Resources)
 	wh.lk.Unlock()
-	wh.wndLk.Lock()
 	for _, window := range wh.activeWindows {
 		u += window.allocated.utilization(wh.info.Resources)
 	}


### PR DESCRIPTION
The wndLk and lk is nested lock, this may cause deadlock, then the schedule and the command line may be stucked.