### PR TITLE
Fix VRF chain randomness

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -358,7 +358,9 @@ func (cg *ChainGen) nextBlockProof(ctx context.Context, pts *types.TipSet, m add
 		return nil, nil, nil, xerrors.Errorf("failed to cbor marshal address: %w", err)
 	}
 
-	buf.Write(pts.MinTicket().VRFProof)
+	if round > build.UpgradeSmokeHeight {
+		buf.Write(pts.MinTicket().VRFProof)
+	}
 
 	ticketRand, err := store.DrawRandomness(rbase.Data, crypto.DomainSeparationTag_TicketProduction, round-build.TicketRandomnessLookback, buf.Bytes())
 	if err != nil {

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -358,9 +358,7 @@ func (cg *ChainGen) nextBlockProof(ctx context.Context, pts *types.TipSet, m add
 		return nil, nil, nil, xerrors.Errorf("failed to cbor marshal address: %w", err)
 	}
 
-	if len(entries) == 0 {
-		buf.Write(pts.MinTicket().VRFProof)
-	}
+	buf.Write(pts.MinTicket().VRFProof)
 
 	ticketRand, err := store.DrawRandomness(rbase.Data, crypto.DomainSeparationTag_TicketProduction, round-build.TicketRandomnessLookback, buf.Bytes())
 	if err != nil {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -891,10 +891,10 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 			return xerrors.Errorf("failed to marshal miner address to cbor: %w", err)
 		}
 
+		buf.Write(baseTs.MinTicket().VRFProof)
+
 		beaconBase := *prevBeacon
-		if len(h.BeaconEntries) == 0 {
-			buf.Write(baseTs.MinTicket().VRFProof)
-		} else {
+		if len(h.BeaconEntries) != 0 {
 			beaconBase = h.BeaconEntries[len(h.BeaconEntries)-1]
 		}
 

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -891,7 +891,9 @@ func (syncer *Syncer) ValidateBlock(ctx context.Context, b *types.FullBlock) (er
 			return xerrors.Errorf("failed to marshal miner address to cbor: %w", err)
 		}
 
-		buf.Write(baseTs.MinTicket().VRFProof)
+		if h.Height > build.UpgradeSmokeHeight {
+			buf.Write(baseTs.MinTicket().VRFProof)
+		}
 
 		beaconBase := *prevBeacon
 		if len(h.BeaconEntries) != 0 {

--- a/cmd/lotus/debug_advance.go
+++ b/cmd/lotus/debug_advance.go
@@ -46,6 +46,7 @@ func init() {
 					return xerrors.Errorf("StateMinerWorker: %w", err)
 				}
 
+				// XXX: This can't be right
 				rand, err := api.ChainGetRandomnessFromTickets(ctx, head.Key(), crypto.DomainSeparationTag_TicketProduction, head.Height(), addr.Bytes())
 				if err != nil {
 					return xerrors.Errorf("failed to get randomness: %w", err)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -447,9 +447,12 @@ func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, bas
 		return nil, xerrors.Errorf("failed to marshal address to cbor: %w", err)
 	}
 
-	buf.Write(base.TipSet.MinTicket().VRFProof)
+	round := base.TipSet.Height() + base.NullRounds + 1
+	if round > build.UpgradeSmokeHeight {
+		buf.Write(base.TipSet.MinTicket().VRFProof)
+	}
 
-	input, err := store.DrawRandomness(brand.Data, crypto.DomainSeparationTag_TicketProduction, base.TipSet.Height()+base.NullRounds+1-build.TicketRandomnessLookback, buf.Bytes())
+	input, err := store.DrawRandomness(brand.Data, crypto.DomainSeparationTag_TicketProduction, round-build.TicketRandomnessLookback, buf.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -362,7 +362,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (*types.BlockMsg,
 		rbase = bvals[len(bvals)-1]
 	}
 
-	ticket, err := m.computeTicket(ctx, &rbase, base, len(bvals) > 0)
+	ticket, err := m.computeTicket(ctx, &rbase, base)
 	if err != nil {
 		return nil, xerrors.Errorf("scratching ticket failed: %w", err)
 	}
@@ -432,7 +432,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (*types.BlockMsg,
 	return b, nil
 }
 
-func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, base *MiningBase, haveNewEntries bool) (*types.Ticket, error) {
+func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, base *MiningBase) (*types.Ticket, error) {
 	mi, err := m.api.StateMinerInfo(ctx, m.address, types.EmptyTSK)
 	if err != nil {
 		return nil, err
@@ -447,9 +447,7 @@ func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, bas
 		return nil, xerrors.Errorf("failed to marshal address to cbor: %w", err)
 	}
 
-	if !haveNewEntries {
-		buf.Write(base.TipSet.MinTicket().VRFProof)
-	}
+	buf.Write(base.TipSet.MinTicket().VRFProof)
 
 	input, err := store.DrawRandomness(brand.Data, crypto.DomainSeparationTag_TicketProduction, base.TipSet.Height()+base.NullRounds+1-build.TicketRandomnessLookback, buf.Bytes())
 	if err != nil {


### PR DESCRIPTION
This change ensures that the VRF is always a chain.

Previous behavior: previous randomness was only used when there were no drand values.

Current correct behavior: VRF ticket is generated this block's drand value and previous tipset's ticket

Fixes #2778 