### PR TITLE
Disable codecov annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
 comment: off
 ignore:
   - "cbor_gen.go"
+github_checks:
+  annotations: false


### PR DESCRIPTION
This seems to be a new, enabled by default feature of codecov, where it annotates all uncovered lines by default, which in the world of Go makes file views unusable

Exhibit A - https://github.com/filecoin-project/lotus/pull/3497/files#diff-8a8fba801c71449b9064ff7c4592a012

![](https://ipfs.io/ipfs/QmWq5Q69MPu8zzm46EErgDY4uPWHM4tSKbCKkppGFwjCUp/screencap.2020-09-03T13:42:10Z.png)

This PR should disable those