### PR TITLE
conformance: various changes

### DIFF
--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -2,7 +2,8 @@ package conformance
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/filecoin-project/specs-actors/actors/crypto"
 
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -80,11 +81,14 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, preroot
 			}
 			switch msg.From.Protocol() {
 			case address.SECP256K1:
-				sb.SecpkMessages = append(sb.SecpkMessages, msg)
+				sb.SecpkMessages = append(sb.SecpkMessages, toChainMsg(msg))
 			case address.BLS:
-				sb.BlsMessages = append(sb.BlsMessages, msg)
+				sb.BlsMessages = append(sb.BlsMessages, toChainMsg(msg))
 			default:
-				return nil, fmt.Errorf("from account is not secpk nor bls: %s", msg.From)
+				// sneak in messages originating from other addresses as both kinds.
+				// these should fail, as they are actually invalid senders.
+				sb.SecpkMessages = append(sb.SecpkMessages, msg)
+				sb.BlsMessages = append(sb.BlsMessages, msg)
 			}
 		}
 		blocks = append(blocks, sb)
@@ -143,11 +147,30 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, preroot cid.Cid, epoch
 
 	lvm.SetInvoker(invoker)
 
-	ret, err := lvm.ApplyMessage(d.ctx, msg)
+	ret, err := lvm.ApplyMessage(d.ctx, toChainMsg(msg))
 	if err != nil {
 		return nil, cid.Undef, err
 	}
 
 	root, err := lvm.Flush(d.ctx)
 	return ret, root, err
+}
+
+// toChainMsg injects a synthetic 0-filled signature of the right length to
+// messages that originate from secp256k senders, leaving all
+// others untouched.
+// TODO: generate a signature in the DSL so that it's encoded in
+//  the test vector.
+func toChainMsg(msg *types.Message) (ret types.ChainMsg) {
+	ret = msg
+	if msg.From.Protocol() == address.SECP256K1 {
+		ret = &types.SignedMessage{
+			Message: *msg,
+			Signature: crypto.Signature{
+				Type: crypto.SigTypeSecp256k1,
+				Data: make([]byte, 65),
+			},
+		}
+	}
+	return ret
 }

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/filecoin-project/lotus/lib/blockstore"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/puppet"
 
 	"github.com/filecoin-project/test-vectors/chaos"
 	"github.com/filecoin-project/test-vectors/schema"
@@ -137,10 +136,7 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, preroot cid.Cid, epoch
 
 	invoker := vm.NewInvoker()
 
-	// add support for the puppet and chaos actors.
-	if puppetOn, ok := d.selector["puppet_actor"]; ok && puppetOn == "true" {
-		invoker.Register(puppet.PuppetActorCodeID, puppet.Actor{}, puppet.State{})
-	}
+	// register the chaos actor if required by the vector.
 	if chaosOn, ok := d.selector["chaos_actor"]; ok && chaosOn == "true" {
 		invoker.Register(chaos.ChaosActorCodeCID, chaos.Actor{}, chaos.State{})
 	}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/filecoin-project/specs-actors v0.9.3
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401
 	github.com/filecoin-project/statediff v0.0.1
-	github.com/filecoin-project/test-vectors v0.0.0-20200902131127-9806d09b005d
+	github.com/filecoin-project/test-vectors v0.0.0-20200903223506-84da0a5ea125
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -268,7 +268,7 @@ github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZO
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v0.4.3-0.20200820203717-d1718369a182/go.mod h1:biFZPQ/YyQGfkHUmHMiaNf2hnD6zm1+OAXPQYQ61Zkg=
-github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e/go.mod h1:OkZ5aUqs+fFnJOq9243WJDsTa9c3/Ae67NIAwVhAB+0=
+github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a/go.mod h1:oOawOl9Yk+qeytLzzIryjI8iRbqo+qzS6EEeElP4PWA=
 github.com/filecoin-project/sector-storage v0.0.0-20200810171746-eac70842d8e0 h1:E1fZ27fhKK05bhZItfTwqr1i05vXnEZJznQFEYwEEUU=


### PR DESCRIPTION
* Tipset-class vectors: support sending from actor addresses. This is necessary for some test cases in https://github.com/filecoin-project/test-vectors/pull/108, [that were migrated from chain-validation](https://github.com/filecoin-project/chain-validation/blob/master/suites/tipset/rewards_penalties.go#L133). We test that these sends are disallowed.
* Sign secp256k1 messages with dummy signatures.
* Deprecate the puppet actor, which has now folded (partially) into the chaos actor. The chaos actor now occupies address t98.

⚠️  Merge with merge; do not squash or rebase!