### PR TITLE
paych: get available funds by address or by from/to

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -421,7 +421,8 @@ type FullNode interface {
 
 	PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt) (*ChannelInfo, error)
 	PaychGetWaitReady(context.Context, cid.Cid) (address.Address, error)
-	PaychAvailableFunds(from, to address.Address) (*ChannelAvailableFunds, error)
+	PaychAvailableFunds(ch address.Address) (*ChannelAvailableFunds, error)
+	PaychAvailableFundsByFromTo(from, to address.Address) (*ChannelAvailableFunds, error)
 	PaychList(context.Context) ([]address.Address, error)
 	PaychStatus(context.Context, address.Address) (*PaychStatus, error)
 	PaychSettle(context.Context, address.Address) (cid.Cid, error)
@@ -540,7 +541,12 @@ type ChannelInfo struct {
 }
 
 type ChannelAvailableFunds struct {
+	// Channel is the address of the channel
 	Channel *address.Address
+	// From is the from address of the channel (channel creator)
+	From address.Address
+	// To is the to address of the channel
+	To address.Address
 	// ConfirmedAmt is the amount of funds that have been confirmed on-chain
 	// for the channel
 	ConfirmedAmt types.BigInt

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -207,22 +207,23 @@ type FullNodeStruct struct {
 
 		MarketEnsureAvailable func(context.Context, address.Address, address.Address, types.BigInt) (cid.Cid, error) `perm:"sign"`
 
-		PaychGet                   func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
-		PaychGetWaitReady          func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
-		PaychAvailableFunds        func(address.Address, address.Address) (*api.ChannelAvailableFunds, error)                                `perm:"sign"`
-		PaychList                  func(context.Context) ([]address.Address, error)                                                          `perm:"read"`
-		PaychStatus                func(context.Context, address.Address) (*api.PaychStatus, error)                                          `perm:"read"`
-		PaychSettle                func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
-		PaychCollect               func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
-		PaychAllocateLane          func(context.Context, address.Address) (uint64, error)                                                    `perm:"sign"`
-		PaychNewPayment            func(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) `perm:"sign"`
-		PaychVoucherCheck          func(context.Context, *paych.SignedVoucher) error                                                         `perm:"read"`
-		PaychVoucherCheckValid     func(context.Context, address.Address, *paych.SignedVoucher) error                                        `perm:"read"`
-		PaychVoucherCheckSpendable func(context.Context, address.Address, *paych.SignedVoucher, []byte, []byte) (bool, error)                `perm:"read"`
-		PaychVoucherAdd            func(context.Context, address.Address, *paych.SignedVoucher, []byte, types.BigInt) (types.BigInt, error)  `perm:"write"`
-		PaychVoucherCreate         func(context.Context, address.Address, big.Int, uint64) (*api.VoucherCreateResult, error)                 `perm:"sign"`
-		PaychVoucherList           func(context.Context, address.Address) ([]*paych.SignedVoucher, error)                                    `perm:"write"`
-		PaychVoucherSubmit         func(context.Context, address.Address, *paych.SignedVoucher, []byte, []byte) (cid.Cid, error)             `perm:"sign"`
+		PaychGet                    func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
+		PaychGetWaitReady           func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
+		PaychAvailableFunds         func(address.Address) (*api.ChannelAvailableFunds, error)                                                 `perm:"sign"`
+		PaychAvailableFundsByFromTo func(address.Address, address.Address) (*api.ChannelAvailableFunds, error)                                `perm:"sign"`
+		PaychList                   func(context.Context) ([]address.Address, error)                                                          `perm:"read"`
+		PaychStatus                 func(context.Context, address.Address) (*api.PaychStatus, error)                                          `perm:"read"`
+		PaychSettle                 func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
+		PaychCollect                func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
+		PaychAllocateLane           func(context.Context, address.Address) (uint64, error)                                                    `perm:"sign"`
+		PaychNewPayment             func(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) `perm:"sign"`
+		PaychVoucherCheck           func(context.Context, *paych.SignedVoucher) error                                                         `perm:"read"`
+		PaychVoucherCheckValid      func(context.Context, address.Address, *paych.SignedVoucher) error                                        `perm:"read"`
+		PaychVoucherCheckSpendable  func(context.Context, address.Address, *paych.SignedVoucher, []byte, []byte) (bool, error)                `perm:"read"`
+		PaychVoucherAdd             func(context.Context, address.Address, *paych.SignedVoucher, []byte, types.BigInt) (types.BigInt, error)  `perm:"write"`
+		PaychVoucherCreate          func(context.Context, address.Address, big.Int, uint64) (*api.VoucherCreateResult, error)                 `perm:"sign"`
+		PaychVoucherList            func(context.Context, address.Address) ([]*paych.SignedVoucher, error)                                    `perm:"write"`
+		PaychVoucherSubmit          func(context.Context, address.Address, *paych.SignedVoucher, []byte, []byte) (cid.Cid, error)             `perm:"sign"`
 	}
 }
 
@@ -905,8 +906,12 @@ func (c *FullNodeStruct) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid
 	return c.Internal.PaychGetWaitReady(ctx, sentinel)
 }
 
-func (c *FullNodeStruct) PaychAvailableFunds(from address.Address, to address.Address) (*api.ChannelAvailableFunds, error) {
-	return c.Internal.PaychAvailableFunds(from, to)
+func (c *FullNodeStruct) PaychAvailableFunds(ch address.Address) (*api.ChannelAvailableFunds, error) {
+	return c.Internal.PaychAvailableFunds(ch)
+}
+
+func (c *FullNodeStruct) PaychAvailableFundsByFromTo(from, to address.Address) (*api.ChannelAvailableFunds, error) {
+	return c.Internal.PaychAvailableFundsByFromTo(from, to)
 }
 
 func (c *FullNodeStruct) PaychList(ctx context.Context) ([]address.Address, error) {

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/filecoin-project/lotus/api"
+
 	"github.com/filecoin-project/lotus/paychmgr"
 
 	"github.com/filecoin-project/go-address"
@@ -80,13 +82,13 @@ var paychAddFundsCmd = &cli.Command{
 	},
 }
 
-var paychStatusCmd = &cli.Command{
-	Name:      "status",
-	Usage:     "Show the status of an outbound payment channel between fromAddress and toAddress",
+var paychStatusByFromToCmd = &cli.Command{
+	Name:      "status-by-from-to",
+	Usage:     "Show the status of an active outbound payment channel by from/to addresses",
 	ArgsUsage: "[fromAddress toAddress]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.Args().Len() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <from> <to>"))
+			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <from address> <to address>"))
 		}
 
 		from, err := address.NewFromString(cctx.Args().Get(0))
@@ -105,50 +107,84 @@ var paychStatusCmd = &cli.Command{
 		}
 		defer closer()
 
-		avail, err := api.PaychAvailableFunds(from, to)
+		avail, err := api.PaychAvailableFundsByFromTo(from, to)
 		if err != nil {
 			return err
 		}
 
-		if avail.Channel == nil {
-			if avail.PendingWaitSentinel != nil {
-				fmt.Fprint(cctx.App.Writer, "Creating channel\n")
-				fmt.Fprintf(cctx.App.Writer, "  From:          %s\n", from)
-				fmt.Fprintf(cctx.App.Writer, "  To:            %s\n", to)
-				fmt.Fprintf(cctx.App.Writer, "  Pending Amt:   %d\n", avail.PendingAmt)
-				fmt.Fprintf(cctx.App.Writer, "  Wait Sentinel: %s\n", avail.PendingWaitSentinel)
-				return nil
-			}
-			fmt.Fprint(cctx.App.Writer, "Channel does not exist\n")
-			fmt.Fprintf(cctx.App.Writer, "  From: %s\n", from)
-			fmt.Fprintf(cctx.App.Writer, "  To:   %s\n", to)
-			return nil
-		}
-
-		if avail.PendingWaitSentinel != nil {
-			fmt.Fprint(cctx.App.Writer, "Adding Funds to channel\n")
-		} else {
-			fmt.Fprint(cctx.App.Writer, "Channel exists\n")
-		}
-
-		nameValues := [][]string{
-			{"Channel", avail.Channel.String()},
-			{"From", from.String()},
-			{"To", to.String()},
-			{"Confirmed Amt", fmt.Sprintf("%d", avail.ConfirmedAmt)},
-			{"Pending Amt", fmt.Sprintf("%d", avail.PendingAmt)},
-			{"Queued Amt", fmt.Sprintf("%d", avail.QueuedAmt)},
-			{"Voucher Redeemed Amt", fmt.Sprintf("%d", avail.VoucherReedeemedAmt)},
-		}
-		if avail.PendingWaitSentinel != nil {
-			nameValues = append(nameValues, []string{
-				"Add Funds Wait Sentinel",
-				avail.PendingWaitSentinel.String(),
-			})
-		}
-		fmt.Fprint(cctx.App.Writer, formatNameValues(nameValues))
+		paychStatus(cctx.App.Writer, avail)
 		return nil
 	},
+}
+
+var paychStatusCmd = &cli.Command{
+	Name:      "status",
+	Usage:     "Show the status of an outbound payment channel",
+	ArgsUsage: "[channelAddress]",
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Len() != 1 {
+			return ShowHelp(cctx, fmt.Errorf("must pass an argument: <channel address>"))
+		}
+
+		ch, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return ShowHelp(cctx, fmt.Errorf("failed to parse channel address: %s", err))
+		}
+
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		avail, err := api.PaychAvailableFunds(ch)
+		if err != nil {
+			return err
+		}
+
+		paychStatus(cctx.App.Writer, avail)
+		return nil
+	},
+}
+
+func paychStatus(writer io.Writer, avail *api.ChannelAvailableFunds) {
+	if avail.Channel == nil {
+		if avail.PendingWaitSentinel != nil {
+			fmt.Fprint(writer, "Creating channel\n")
+			fmt.Fprintf(writer, "  From:          %s\n", avail.From)
+			fmt.Fprintf(writer, "  To:            %s\n", avail.To)
+			fmt.Fprintf(writer, "  Pending Amt:   %d\n", avail.PendingAmt)
+			fmt.Fprintf(writer, "  Wait Sentinel: %s\n", avail.PendingWaitSentinel)
+			return
+		}
+		fmt.Fprint(writer, "Channel does not exist\n")
+		fmt.Fprintf(writer, "  From: %s\n", avail.From)
+		fmt.Fprintf(writer, "  To:   %s\n", avail.To)
+		return
+	}
+
+	if avail.PendingWaitSentinel != nil {
+		fmt.Fprint(writer, "Adding Funds to channel\n")
+	} else {
+		fmt.Fprint(writer, "Channel exists\n")
+	}
+
+	nameValues := [][]string{
+		{"Channel", avail.Channel.String()},
+		{"From", avail.From.String()},
+		{"To", avail.To.String()},
+		{"Confirmed Amt", fmt.Sprintf("%d", avail.ConfirmedAmt)},
+		{"Pending Amt", fmt.Sprintf("%d", avail.PendingAmt)},
+		{"Queued Amt", fmt.Sprintf("%d", avail.QueuedAmt)},
+		{"Voucher Redeemed Amt", fmt.Sprintf("%d", avail.VoucherReedeemedAmt)},
+	}
+	if avail.PendingWaitSentinel != nil {
+		nameValues = append(nameValues, []string{
+			"Add Funds Wait Sentinel",
+			avail.PendingWaitSentinel.String(),
+		})
+	}
+	fmt.Fprint(writer, formatNameValues(nameValues))
 }
 
 func formatNameValues(nameValues [][]string) string {

--- a/cli/paych_test.go
+++ b/cli/paych_test.go
@@ -117,7 +117,7 @@ func TestPaymentChannelStatus(t *testing.T) {
 	creatorCLI := mockCLI.client(paymentCreator.ListenAddr)
 
 	cmd := []string{creatorAddr.String(), receiverAddr.String()}
-	out := creatorCLI.runCmd(paychStatusCmd, cmd)
+	out := creatorCLI.runCmd(paychStatusByFromToCmd, cmd)
 	fmt.Println(out)
 	noChannelState := "Channel does not exist"
 	require.Regexp(t, regexp.MustCompile(noChannelState), out)
@@ -125,15 +125,15 @@ func TestPaymentChannelStatus(t *testing.T) {
 	channelAmt := uint64(100)
 	create := make(chan string)
 	go func() {
-		// creator: paych get <creator> <receiver> <amount>
+		// creator: paych add-funds <creator> <receiver> <amount>
 		cmd = []string{creatorAddr.String(), receiverAddr.String(), fmt.Sprintf("%d", channelAmt)}
-		create <- creatorCLI.runCmd(paychGetCmd, cmd)
+		create <- creatorCLI.runCmd(paychAddFundsCmd, cmd)
 	}()
 
 	// Wait for the output to stop being "Channel does not exist"
 	for regexp.MustCompile(noChannelState).MatchString(out) {
 		cmd = []string{creatorAddr.String(), receiverAddr.String()}
-		out = creatorCLI.runCmd(paychStatusCmd, cmd)
+		out = creatorCLI.runCmd(paychStatusByFromToCmd, cmd)
 	}
 	fmt.Println(out)
 
@@ -153,7 +153,7 @@ func TestPaymentChannelStatus(t *testing.T) {
 	// Wait for create channel to complete
 	chstr := <-create
 
-	cmd = []string{creatorAddr.String(), receiverAddr.String()}
+	cmd = []string{chstr}
 	out = creatorCLI.runCmd(paychStatusCmd, cmd)
 	fmt.Println(out)
 	// Output should have the channel address
@@ -169,7 +169,7 @@ func TestPaymentChannelStatus(t *testing.T) {
 	cmd = []string{chAddr.String(), fmt.Sprintf("%d", voucherAmt)}
 	creatorCLI.runCmd(paychVoucherCreateCmd, cmd)
 
-	cmd = []string{creatorAddr.String(), receiverAddr.String()}
+	cmd = []string{chstr}
 	out = creatorCLI.runCmd(paychStatusCmd, cmd)
 	fmt.Println(out)
 	voucherAmtAtto := types.BigMul(types.NewInt(voucherAmt), types.NewInt(build.FilecoinPrecision))
@@ -344,10 +344,10 @@ func TestPaymentChannelVoucherCreateShortfall(t *testing.T) {
 	mockCLI := newMockCLI(t)
 	creatorCLI := mockCLI.client(paymentCreator.ListenAddr)
 
-	// creator: paych get <creator> <receiver> <amount>
+	// creator: paych add-funds <creator> <receiver> <amount>
 	channelAmt := 100
 	cmd := []string{creatorAddr.String(), receiverAddr.String(), fmt.Sprintf("%d", channelAmt)}
-	chstr := creatorCLI.runCmd(paychGetCmd, cmd)
+	chstr := creatorCLI.runCmd(paychAddFundsCmd, cmd)
 
 	chAddr, err := address.NewFromString(chstr)
 	require.NoError(t, err)

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -98,6 +98,7 @@
 * [Paych](#Paych)
   * [PaychAllocateLane](#PaychAllocateLane)
   * [PaychAvailableFunds](#PaychAvailableFunds)
+  * [PaychAvailableFundsByFromTo](#PaychAvailableFundsByFromTo)
   * [PaychCollect](#PaychCollect)
   * [PaychGet](#PaychGet)
   * [PaychGetWaitReady](#PaychGetWaitReady)
@@ -2239,6 +2240,27 @@ There are not yet any comments for this method.
 
 Perms: sign
 
+Inputs: `null`
+
+Response:
+```json
+{
+  "Channel": "\u003cempty\u003e",
+  "From": "t01234",
+  "To": "t01234",
+  "ConfirmedAmt": "0",
+  "PendingAmt": "0",
+  "PendingWaitSentinel": null,
+  "QueuedAmt": "0",
+  "VoucherReedeemedAmt": "0"
+}
+```
+
+### PaychAvailableFundsByFromTo
+There are not yet any comments for this method.
+
+Perms: sign
+
 Inputs:
 ```json
 [
@@ -2250,6 +2272,8 @@ Response:
 ```json
 {
   "Channel": "\u003cempty\u003e",
+  "From": "t01234",
+  "To": "t01234",
   "ConfirmedAmt": "0",
   "PendingAmt": "0",
   "PendingWaitSentinel": null,

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -39,8 +39,12 @@ func (a *PaychAPI) PaychGet(ctx context.Context, from, to address.Address, amt t
 	}, nil
 }
 
-func (a *PaychAPI) PaychAvailableFunds(from, to address.Address) (*api.ChannelAvailableFunds, error) {
-	return a.PaychMgr.AvailableFunds(from, to)
+func (a *PaychAPI) PaychAvailableFunds(ch address.Address) (*api.ChannelAvailableFunds, error) {
+	return a.PaychMgr.AvailableFunds(ch)
+}
+
+func (a *PaychAPI) PaychAvailableFundsByFromTo(from, to address.Address) (*api.ChannelAvailableFunds, error) {
+	return a.PaychMgr.AvailableFundsByFromTo(from, to)
 }
 
 func (a *PaychAPI) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error) {

--- a/paychmgr/manager.go
+++ b/paychmgr/manager.go
@@ -141,13 +141,48 @@ func (pm *Manager) GetPaych(ctx context.Context, from, to address.Address, amt t
 	return chanAccessor.getPaych(ctx, amt)
 }
 
-func (pm *Manager) AvailableFunds(from address.Address, to address.Address) (*api.ChannelAvailableFunds, error) {
-	chanAccessor, err := pm.accessorByFromTo(from, to)
+func (pm *Manager) AvailableFunds(ch address.Address) (*api.ChannelAvailableFunds, error) {
+	ca, err := pm.accessorByAddress(ch)
 	if err != nil {
 		return nil, err
 	}
 
-	return chanAccessor.availableFunds()
+	ci, err := ca.getChannelInfo(ch)
+	if err != nil {
+		return nil, err
+	}
+
+	return ca.availableFunds(ci.ChannelID)
+}
+
+func (pm *Manager) AvailableFundsByFromTo(from address.Address, to address.Address) (*api.ChannelAvailableFunds, error) {
+	ca, err := pm.accessorByFromTo(from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	ci, err := ca.outboundActiveByFromTo(from, to)
+	if err == ErrChannelNotTracked {
+		// If there is no active channel between from / to we still want to
+		// return an empty ChannelAvailableFunds, so that clients can check
+		// for the existence of a channel between from / to without getting
+		// an error.
+		return &api.ChannelAvailableFunds{
+			Channel:             nil,
+			From:                from,
+			To:                  to,
+			ConfirmedAmt:        types.NewInt(0),
+			PendingAmt:          types.NewInt(0),
+			PendingWaitSentinel: nil,
+			QueuedAmt:           types.NewInt(0),
+			VoucherReedeemedAmt: types.NewInt(0),
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return ca.availableFunds(ci.ChannelID)
 }
 
 // GetPaychWaitReady waits until the create channel / add funds message with the

--- a/paychmgr/paych.go
+++ b/paychmgr/paych.go
@@ -20,7 +20,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
-	xerrors "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 )
 
 // insufficientFundsErr indicates that there are not enough funds in the
@@ -79,6 +79,13 @@ func (ca *channelAccessor) getChannelInfo(addr address.Address) (*ChannelInfo, e
 	defer ca.lk.Unlock()
 
 	return ca.store.ByAddress(addr)
+}
+
+func (ca *channelAccessor) outboundActiveByFromTo(from, to address.Address) (*ChannelInfo, error) {
+	ca.lk.Lock()
+	defer ca.lk.Unlock()
+
+	return ca.store.OutboundActiveByFromTo(from, to)
 }
 
 // createVoucher creates a voucher with the given specification, setting its

--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -921,7 +921,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 	require.NoError(t, err)
 
 	// No channel created yet so available funds should be all zeroes
-	av, err := mgr.AvailableFunds(from, to)
+	av, err := mgr.AvailableFundsByFromTo(from, to)
 	require.NoError(t, err)
 	require.Nil(t, av.Channel)
 	require.Nil(t, av.PendingWaitSentinel)
@@ -936,7 +936,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Available funds should reflect create channel message sent
-	av, err = mgr.AvailableFunds(from, to)
+	av, err = mgr.AvailableFundsByFromTo(from, to)
 	require.NoError(t, err)
 	require.Nil(t, av.Channel)
 	require.EqualValues(t, 0, av.ConfirmedAmt.Int64())
@@ -964,7 +964,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 	waitForQueueSize(t, mgr, from, to, 1)
 
 	// Available funds should now include queued funds
-	av, err = mgr.AvailableFunds(from, to)
+	av, err = mgr.AvailableFundsByFromTo(from, to)
 	require.NoError(t, err)
 	require.Nil(t, av.Channel)
 	require.NotNil(t, av.PendingWaitSentinel)
@@ -1009,7 +1009,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 
 	// Available funds should now include the channel and also a wait sentinel
 	// for the add funds message
-	av, err = mgr.AvailableFunds(from, to)
+	av, err = mgr.AvailableFunds(ch)
 	require.NoError(t, err)
 	require.NotNil(t, av.Channel)
 	require.NotNil(t, av.PendingWaitSentinel)
@@ -1031,7 +1031,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Available funds should no longer have a wait sentinel
-	av, err = mgr.AvailableFunds(from, to)
+	av, err = mgr.AvailableFunds(ch)
 	require.NoError(t, err)
 	require.NotNil(t, av.Channel)
 	require.Nil(t, av.PendingWaitSentinel)
@@ -1052,7 +1052,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 	_, err = mgr.AddVoucherOutbound(ctx, ch, voucher, nil, types.NewInt(0))
 	require.NoError(t, err)
 
-	av, err = mgr.AvailableFunds(from, to)
+	av, err = mgr.AvailableFunds(ch)
 	require.NoError(t, err)
 	require.NotNil(t, av.Channel)
 	require.Nil(t, av.PendingWaitSentinel)

--- a/paychmgr/store.go
+++ b/paychmgr/store.go
@@ -86,6 +86,20 @@ type ChannelInfo struct {
 	Settling bool
 }
 
+func (ci *ChannelInfo) from() address.Address {
+	if ci.Direction == DirOutbound {
+		return ci.Control
+	}
+	return ci.Target
+}
+
+func (ci *ChannelInfo) to() address.Address {
+	if ci.Direction == DirOutbound {
+		return ci.Target
+	}
+	return ci.Control
+}
+
 // infoForVoucher gets the VoucherInfo for the given voucher.
 // returns nil if the channel doesn't have the voucher.
 func (ci *ChannelInfo) infoForVoucher(sv *paych.SignedVoucher) (*VoucherInfo, error) {


### PR DESCRIPTION
Previously we had a method to get available funds for a channel by from/to, which makes sense from CLI. However for [markets non-blocking retrieval](https://github.com/filecoin-project/go-fil-markets/pull/392) it makes more sense to get funds by channel address.
This PR adds a new API method to get available funds by channel address. So now there are two API methods to get available funds for a channel:
```go
PaychAvailableFunds(ch address.Address) (*ChannelAvailableFunds, error)
PaychAvailableFundsByFromTo(from, to address.Address) (*ChannelAvailableFunds, error)
```