### PR TITLE
chore: update test vectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/filecoin-project/specs-actors v0.9.3
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401
 	github.com/filecoin-project/statediff v0.0.1
-	github.com/filecoin-project/test-vectors v0.0.0-20200903223506-84da0a5ea125
+	github.com/filecoin-project/test-vectors v0.0.0-20200904114255-bce53dfd803c
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
New vectors testing state mutation require additional chaos actor functionality. This PR should keep the bleeding edge test-conformance CI job green.