### PR TITLE
Fix panic in OnDealExpiredSlashed

### DIFF
--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -351,6 +351,11 @@ func (c *ClientNodeAdapter) OnDealExpiredOrSlashed(ctx context.Context, dealID a
 
 	// Called immediately to check if the deal has already expired or been slashed
 	checkFunc := func(ts *types.TipSet) (done bool, more bool, err error) {
+		if ts == nil {
+			// keep listening for events
+			return false, true, nil
+		}
+
 		// Check if the deal has already expired
 		if sd.Proposal.EndEpoch <= ts.Height() {
 			onDealExpired(nil)


### PR DESCRIPTION
# Goals

The markets client node adapter is crashing in OnDealExpiredSlashed when a nil tipset is passed to check func

# Implementation

Just  skip checkFunc logic when nil tipset is passed -- similar to https://github.com/filecoin-project/lotus/pull/3011

We should figure out why the events_called interface is passing nil tipsets to CheckFunc. I think there may be a bug in the tipset cache logic