### PR TITLE
adjust gossipsub gossip factor

### DIFF
--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -33,6 +33,7 @@ func init() {
 	pubsub.GossipSubDirectConnectInitialDelay = 30 * time.Second
 	pubsub.GossipSubIWantFollowupTime = 5 * time.Second
 	pubsub.GossipSubHistoryLength = 10
+	pubsub.GossipSubGossipFactor = 0.1
 }
 func ScoreKeeper() *dtypes.ScoreKeeper {
 	return new(dtypes.ScoreKeeper)
@@ -248,8 +249,8 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		pubsub.GossipSubDlo = 0
 		pubsub.GossipSubDhi = 0
 		pubsub.GossipSubDout = 0
-		pubsub.GossipSubDlazy = 1024
-		pubsub.GossipSubGossipFactor = 0.5
+		pubsub.GossipSubDlazy = 64
+		pubsub.GossipSubGossipFactor = 0.25
 		pubsub.GossipSubPruneBackoff = 5 * time.Minute
 		// turn on PX
 		options = append(options, pubsub.WithPeerExchange(true))


### PR DESCRIPTION
Reduce from the default 0.25 to 0.1; it comes with a 10x outbound bandwidth reduction, albeit at the cost of somewhat reduced security. The security effect is that the probability of a peer receiving an IHAVE about a particular message drops from 0.57 to 0.27.

Also adjusts gossiping for bootstrappers, so that they use less bandwidth.