### PR TITLE
lotus-pcr: use current tipset during refund

### DIFF
--- a/cmd/lotus-pcr/main.go
+++ b/cmd/lotus-pcr/main.go
@@ -225,7 +225,12 @@ var runCmd = &cli.Command{
 				continue
 			}
 
-			if err := rf.Refund(ctx, tipset, refunds, rounds); err != nil {
+			refundTipset, err := api.ChainHead(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err := rf.Refund(ctx, refundTipset, refunds, rounds); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Using the tipset which is being processed might lead to incorrect gas estimations or balance checking for the wallet.