### PR TITLE
metrics: add expected height metric

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -187,7 +187,7 @@ func (syncer *Syncer) runMetricsTricker(tickerCtx context.Context) {
 			sinceGenesis := build.Clock.Now().Sub(genesisTime)
 			expectedHeight := int64(sinceGenesis.Seconds()) / int64(build.BlockDelaySecs)
 
-			stats.Record(tickerCtx, metrics.ChainNodeHeightExpected.M(int64(expectedHeight)))
+			stats.Record(tickerCtx, metrics.ChainNodeHeightExpected.M(expectedHeight))
 		case <-tickerCtx.Done():
 			return
 		}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -125,6 +125,8 @@ type Syncer struct {
 	verifier ffiwrapper.Verifier
 
 	windowSize int
+
+	tickerCtxCancel context.CancelFunc
 }
 
 // NewSyncer creates a new Syncer object.
@@ -166,11 +168,35 @@ func NewSyncer(sm *stmgr.StateManager, bsync *blocksync.BlockSync, connmgr connm
 }
 
 func (syncer *Syncer) Start() {
+	tickerCtx, tickerCtxCancel := context.WithCancel(context.Background())
 	syncer.syncmgr.Start()
+
+	syncer.tickerCtxCancel = tickerCtxCancel
+
+	go syncer.runMetricsTricker(tickerCtx)
+}
+
+func (syncer *Syncer) runMetricsTricker(tickerCtx context.Context) {
+	genesisTime := time.Unix(int64(syncer.Genesis.MinTimestamp()), 0)
+	ticker := build.Clock.Ticker(time.Duration(build.BlockDelaySecs) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			sinceGenesis := build.Clock.Now().Sub(genesisTime)
+			expectedHeight := int64(sinceGenesis.Seconds()) / int64(build.BlockDelaySecs)
+
+			stats.Record(tickerCtx, metrics.ChainNodeHeightExpected.M(int64(expectedHeight)))
+		case <-tickerCtx.Done():
+			return
+		}
+	}
 }
 
 func (syncer *Syncer) Stop() {
 	syncer.syncmgr.Stop()
+	syncer.tickerCtxCancel()
 }
 
 // InformNewHead informs the syncer about a new potential tipset

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,6 +30,7 @@ var (
 var (
 	LotusInfo                           = stats.Int64("info", "Arbitrary counter to tag lotus info to", stats.UnitDimensionless)
 	ChainNodeHeight                     = stats.Int64("chain/node_height", "Current Height of the node", stats.UnitDimensionless)
+	ChainNodeHeightExpected             = stats.Int64("chain/node_height_expected", "Expected Height of the node", stats.UnitDimensionless)
 	ChainNodeWorkerHeight               = stats.Int64("chain/node_worker_height", "Current Height of workers on the node", stats.UnitDimensionless)
 	MessagePublished                    = stats.Int64("message/published", "Counter for total locally published messages", stats.UnitDimensionless)
 	MessageReceived                     = stats.Int64("message/received", "Counter for total received messages", stats.UnitDimensionless)
@@ -60,6 +61,10 @@ var (
 	}
 	ChainNodeHeightView = &view.View{
 		Measure:     ChainNodeHeight,
+		Aggregation: view.LastValue(),
+	}
+	ChainNodeHeightExpectedView = &view.View{
+		Measure:     ChainNodeHeightExpected,
 		Aggregation: view.LastValue(),
 	}
 	ChainNodeWorkerHeightView = &view.View{
@@ -138,6 +143,7 @@ var (
 var DefaultViews = append([]*view.View{
 	InfoView,
 	ChainNodeHeightView,
+	ChainNodeHeightExpectedView,
 	ChainNodeWorkerHeightView,
 	BlockReceivedView,
 	BlockValidationFailureView,


### PR DESCRIPTION
Exports the expected height of the node based off of the current time, block delay and the genesis timestamp.

Between the following stats we should be able to get some pretty good information about the status of a node with regard to it's chain

```
# HELP lotus_chain_node_height Current Height of the node
# TYPE lotus_chain_node_height gauge
lotus_chain_node_height 35354
# HELP lotus_chain_node_height_expected Expected Height of the node
# TYPE lotus_chain_node_height_expected gauge
lotus_chain_node_height_expected 35354
# HELP lotus_chain_node_worker_height Current Height of workers on the node
# TYPE lotus_chain_node_worker_height gauge
lotus_chain_node_worker_height 35354
```

![image](https://user-images.githubusercontent.com/165274/92318936-9c3bff80-f002-11ea-9790-0684179b6df4.png)
