### PR TITLE
using block after nullrounds to find randomness

### DIFF
--- a/chain/beacon/beacon.go
+++ b/chain/beacon/beacon.go
@@ -26,6 +26,7 @@ type RandomBeacon interface {
 	Entry(context.Context, uint64) <-chan Response
 	VerifyEntry(types.BeaconEntry, types.BeaconEntry) error
 	MaxBeaconRoundForEpoch(abi.ChainEpoch, types.BeaconEntry) uint64
+	MinDrandEntryEpoch(filEpoch abi.ChainEpoch) abi.ChainEpoch
 }
 
 func ValidateBlockValues(b RandomBeacon, h *types.BlockHeader, prevEntry types.BeaconEntry) error {

--- a/chain/beacon/drand/drand_test.go
+++ b/chain/beacon/drand/drand_test.go
@@ -3,12 +3,15 @@ package drand
 import (
 	"os"
 	"testing"
+	"time"
 
 	dchain "github.com/drand/drand/chain"
 	hclient "github.com/drand/drand/client/http"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 func TestPrintGroupInfo(t *testing.T) {
@@ -22,4 +25,27 @@ func TestPrintGroupInfo(t *testing.T) {
 	assert.NoError(t, err)
 	err = chain.ToJSON(os.Stdout)
 	assert.NoError(t, err)
+}
+
+func TestDrandBeaconMinDrandEntry(t *testing.T) {
+	db := DrandBeacon{
+		interval:     30 * time.Second,
+		drandGenTime: 666,
+		filGenTime:   1337,
+		filRoundTime: 30,
+	}
+
+	// test for equal frequency
+	in := abi.ChainEpoch(10)
+	res := db.MinDrandEntryEpoch(in)
+	require.Equal(t, in-1, res)
+
+	// test for different frequency
+	// since we give an odd epoch number, the drand entry should have been
+	// inserted in the even epoch number given filecoin is twice faster than
+	// drand
+	db.interval = 60 * time.Second
+	in = abi.ChainEpoch(11)
+	res = db.MinDrandEntryEpoch(in)
+	require.Equal(t, in-1, res)
 }

--- a/chain/beacon/mock.go
+++ b/chain/beacon/mock.go
@@ -61,4 +61,8 @@ func (mb *mockBeacon) MaxBeaconRoundForEpoch(epoch abi.ChainEpoch, prevEntry typ
 	return uint64(epoch)
 }
 
+func (mb *mockBeacon) MinDrandEntryEpoch(filEpoch abi.ChainEpoch) abi.ChainEpoch {
+	return filEpoch
+}
+
 var _ RandomBeacon = (*mockBeacon)(nil)

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1040,7 +1040,7 @@ func (cs *ChainStore) GetBeaconRandomness(ctx context.Context, blks []cid.Cid, p
 		searchHeight = 0
 	}
 
-	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, true)
+	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

**Partially** fix https://github.com/filecoin-project/lotus/issues/3613 

What's left to be done is to 
* Call `e = MinDrandEntryEpoch()` in the chain store
* Look _forward_ on the chain from this epoch `e`

Alternatively, to avoid looking forward (which seems to be complicated), it would be possible to start from the next epoch where drand is inserted, and look backwards until we reach `e` and we need to compare the beacon rounds to make sure we get the right one.

