### PR TITLE
temporarily allow negative chains

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -81,6 +81,10 @@ const (
 	localUpdates = "update"
 )
 
+// this is *temporary* mutilation until we have implemented uncapped miner penalties -- it will go
+// away in the next fork.
+var allowNegativeChains = true
+
 func init() {
 	// if the republish interval is too short compared to the pubsub timecache, adjust it
 	minInterval := pubsub.TimeCacheDuration + time.Duration(build.PropagationDelaySecs)
@@ -389,7 +393,7 @@ func (mp *MessagePool) verifyMsgBeforeAdd(m *types.SignedMessage, curTs *types.T
 	// Note that for local messages, we always add them so that they can be accepted and republished
 	// automatically.
 	publish := local
-	if len(curTs.Blocks()) > 0 {
+	if !allowNegativeChains && len(curTs.Blocks()) > 0 {
 		baseFee := curTs.Blocks()[0].ParentBaseFee
 		baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
 		if m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -83,7 +83,7 @@ const (
 
 // this is *temporary* mutilation until we have implemented uncapped miner penalties -- it will go
 // away in the next fork.
-var allowNegativeChains = true
+var strictBaseFeeValidation = false
 
 func init() {
 	// if the republish interval is too short compared to the pubsub timecache, adjust it
@@ -393,7 +393,7 @@ func (mp *MessagePool) verifyMsgBeforeAdd(m *types.SignedMessage, curTs *types.T
 	// Note that for local messages, we always add them so that they can be accepted and republished
 	// automatically.
 	publish := local
-	if !allowNegativeChains && len(curTs.Blocks()) > 0 {
+	if strictBaseFeeValidation && len(curTs.Blocks()) > 0 {
 		baseFee := curTs.Blocks()[0].ParentBaseFee
 		baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
 		if m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -100,7 +100,7 @@ loop:
 			// check the baseFee lower bound -- only republish messages that can be included in the chain
 			// within the next 20 blocks.
 			for _, m := range chain.msgs {
-				if !allowNegativeChains && m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {
+				if !allowNegativeChains(ts.Height()) && m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {
 					chain.Invalidate()
 					continue loop
 				}

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -100,7 +100,7 @@ loop:
 			// check the baseFee lower bound -- only republish messages that can be included in the chain
 			// within the next 20 blocks.
 			for _, m := range chain.msgs {
-				if m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {
+				if !allowNegativeChains && m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {
 					chain.Invalidate()
 					continue loop
 				}

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -100,7 +100,7 @@ func (mp *MessagePool) selectMessagesOptimal(curTs, ts *types.TipSet, tq float64
 		return chains[i].Before(chains[j])
 	})
 
-	if len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all messages in mpool have non-positive gas performance", "bestGasPerf", chains[0].gasPerf)
 		return result, nil
 	}
@@ -153,7 +153,7 @@ func (mp *MessagePool) selectMessagesOptimal(curTs, ts *types.TipSet, tq float64
 	last := len(chains)
 	for i, chain := range chains {
 		// did we run out of performing chains?
-		if chain.gasPerf < 0 {
+		if !allowNegativeChains && chain.gasPerf < 0 {
 			break
 		}
 
@@ -217,7 +217,7 @@ tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim if necessary
 		if chains[last].gasLimit > gasLimit {
-			chains[last].Trim(gasLimit, mp, baseFee, false)
+			chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
 		}
 
 		// push down if it hasn't been invalidated
@@ -243,7 +243,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if chain.gasPerf < 0 {
+			if !allowNegativeChains && chain.gasPerf < 0 {
 				break tailLoop
 			}
 
@@ -284,7 +284,7 @@ tailLoop:
 			}
 
 			// dependencies fit, just trim it
-			chain.Trim(gasLimit-depGasLimit, mp, baseFee, false)
+			chain.Trim(gasLimit-depGasLimit, mp, baseFee, allowNegativeChains)
 			last += i
 			continue tailLoop
 		}
@@ -349,7 +349,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 		return chains[i].Before(chains[j])
 	})
 
-	if len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all messages in mpool have non-positive gas performance", "bestGasPerf", chains[0].gasPerf)
 		return result, nil
 	}
@@ -360,7 +360,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 	last := len(chains)
 	for i, chain := range chains {
 		// did we run out of performing chains?
-		if chain.gasPerf < 0 {
+		if !allowNegativeChains && chain.gasPerf < 0 {
 			break
 		}
 
@@ -389,7 +389,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim
-		chains[last].Trim(gasLimit, mp, baseFee, false)
+		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
 
 		// push down if it hasn't been invalidated
 		if chains[last].valid {
@@ -409,7 +409,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if chain.gasPerf < 0 {
+			if !allowNegativeChains && chain.gasPerf < 0 {
 				break tailLoop
 			}
 
@@ -471,7 +471,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 		return chains[i].Before(chains[j])
 	})
 
-	if len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all priority messages in mpool have negative gas performance", "bestGasPerf", chains[0].gasPerf)
 		return nil, gasLimit
 	}
@@ -479,7 +479,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 	// 3. Merge chains until the block limit, as long as they have non-negative gas performance
 	last := len(chains)
 	for i, chain := range chains {
-		if chain.gasPerf < 0 {
+		if !allowNegativeChains && chain.gasPerf < 0 {
 			break
 		}
 
@@ -497,7 +497,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim, discarding negative performing messages
-		chains[last].Trim(gasLimit, mp, baseFee, false)
+		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
 
 		// push down if it hasn't been invalidated
 		if chains[last].valid {
@@ -517,7 +517,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if chain.gasPerf < 0 {
+			if !allowNegativeChains && chain.gasPerf < 0 {
 				break tailLoop
 			}
 

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -22,7 +22,7 @@ var bigBlockGasLimit = big.NewInt(build.BlockGasLimit)
 // this is *temporary* mutilation until we have implemented uncapped miner penalties -- it will go
 // away in the next fork.
 func allowNegativeChains(epoch abi.ChainEpoch) bool {
-	return epoch < 100000000000
+	return epoch < build.BreezeGasTampingDuration+5
 }
 
 const MaxBlocks = 15

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -9,12 +9,12 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	tbig "github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
-	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 var bigBlockGasLimit = big.NewInt(build.BlockGasLimit)

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -14,13 +14,16 @@ import (
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 var bigBlockGasLimit = big.NewInt(build.BlockGasLimit)
 
 // this is *temporary* mutilation until we have implemented uncapped miner penalties -- it will go
 // away in the next fork.
-var allowNegativeChains = true
+func allowNegativeChains(epoch abi.ChainEpoch) bool {
+	return epoch < 100000000000
+}
 
 const MaxBlocks = 15
 
@@ -104,7 +107,7 @@ func (mp *MessagePool) selectMessagesOptimal(curTs, ts *types.TipSet, tq float64
 		return chains[i].Before(chains[j])
 	})
 
-	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains(curTs.Height()) && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all messages in mpool have non-positive gas performance", "bestGasPerf", chains[0].gasPerf)
 		return result, nil
 	}
@@ -157,7 +160,7 @@ func (mp *MessagePool) selectMessagesOptimal(curTs, ts *types.TipSet, tq float64
 	last := len(chains)
 	for i, chain := range chains {
 		// did we run out of performing chains?
-		if !allowNegativeChains && chain.gasPerf < 0 {
+		if !allowNegativeChains(curTs.Height()) && chain.gasPerf < 0 {
 			break
 		}
 
@@ -221,7 +224,7 @@ tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim if necessary
 		if chains[last].gasLimit > gasLimit {
-			chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
+			chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains(curTs.Height()))
 		}
 
 		// push down if it hasn't been invalidated
@@ -247,7 +250,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if !allowNegativeChains && chain.gasPerf < 0 {
+			if !allowNegativeChains(curTs.Height()) && chain.gasPerf < 0 {
 				break tailLoop
 			}
 
@@ -288,7 +291,7 @@ tailLoop:
 			}
 
 			// dependencies fit, just trim it
-			chain.Trim(gasLimit-depGasLimit, mp, baseFee, allowNegativeChains)
+			chain.Trim(gasLimit-depGasLimit, mp, baseFee, allowNegativeChains(curTs.Height()))
 			last += i
 			continue tailLoop
 		}
@@ -353,7 +356,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 		return chains[i].Before(chains[j])
 	})
 
-	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains(curTs.Height()) && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all messages in mpool have non-positive gas performance", "bestGasPerf", chains[0].gasPerf)
 		return result, nil
 	}
@@ -364,7 +367,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 	last := len(chains)
 	for i, chain := range chains {
 		// did we run out of performing chains?
-		if !allowNegativeChains && chain.gasPerf < 0 {
+		if !allowNegativeChains(curTs.Height()) && chain.gasPerf < 0 {
 			break
 		}
 
@@ -393,7 +396,7 @@ func (mp *MessagePool) selectMessagesGreedy(curTs, ts *types.TipSet) ([]*types.S
 tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim
-		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
+		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains(curTs.Height()))
 
 		// push down if it hasn't been invalidated
 		if chains[last].valid {
@@ -413,7 +416,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if !allowNegativeChains && chain.gasPerf < 0 {
+			if !allowNegativeChains(curTs.Height()) && chain.gasPerf < 0 {
 				break tailLoop
 			}
 
@@ -475,7 +478,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 		return chains[i].Before(chains[j])
 	})
 
-	if !allowNegativeChains && len(chains) != 0 && chains[0].gasPerf < 0 {
+	if !allowNegativeChains(ts.Height()) && len(chains) != 0 && chains[0].gasPerf < 0 {
 		log.Warnw("all priority messages in mpool have negative gas performance", "bestGasPerf", chains[0].gasPerf)
 		return nil, gasLimit
 	}
@@ -483,7 +486,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 	// 3. Merge chains until the block limit, as long as they have non-negative gas performance
 	last := len(chains)
 	for i, chain := range chains {
-		if !allowNegativeChains && chain.gasPerf < 0 {
+		if !allowNegativeChains(ts.Height()) && chain.gasPerf < 0 {
 			break
 		}
 
@@ -501,7 +504,7 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 tailLoop:
 	for gasLimit >= minGas && last < len(chains) {
 		// trim, discarding negative performing messages
-		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains)
+		chains[last].Trim(gasLimit, mp, baseFee, allowNegativeChains(ts.Height()))
 
 		// push down if it hasn't been invalidated
 		if chains[last].valid {
@@ -521,7 +524,7 @@ tailLoop:
 			}
 
 			// if gasPerf < 0 we have no more profitable chains
-			if !allowNegativeChains && chain.gasPerf < 0 {
+			if !allowNegativeChains(ts.Height()) && chain.gasPerf < 0 {
 				break tailLoop
 			}
 

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -18,6 +18,10 @@ import (
 
 var bigBlockGasLimit = big.NewInt(build.BlockGasLimit)
 
+// this is *temporary* mutilation until we have implemented uncapped miner penalties -- it will go
+// away in the next fork.
+var allowNegativeChains = true
+
 const MaxBlocks = 15
 
 type msgChain struct {

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -729,10 +729,7 @@ func TestPriorityMessageSelection2(t *testing.T) {
 }
 
 func TestPriorityMessageSelection3(t *testing.T) {
-	allowNegativeChains = false
-	defer func() {
-		allowNegativeChains = true
-	}()
+	t.Skip("reenable after removing allow negative")
 
 	mp, tma := makeTestMpool()
 

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -729,6 +729,11 @@ func TestPriorityMessageSelection2(t *testing.T) {
 }
 
 func TestPriorityMessageSelection3(t *testing.T) {
+	allowNegativeChains = false
+	defer func() {
+		allowNegativeChains = true
+	}()
+
 	mp, tma := makeTestMpool()
 
 	// the actors


### PR DESCRIPTION
On top of #3592 
Temporarily allows negative chains and disables the base fee lower bound check until the next fork.
This mutilation will be undone in Thursday's fork, so we only have to tolerate it for a few days.