### PR TITLE
Fix sector-storage: wrong error check causes nil pointer dereference

### DIFF
--- a/extern/sector-storage/ffiwrapper/sealer_cgo.go
+++ b/extern/sector-storage/ffiwrapper/sealer_cgo.go
@@ -546,7 +546,7 @@ func (sb *Sealer) FinalizeSector(ctx context.Context, sector abi.SectorID, keepU
 		defer done()
 
 		pf, err := openPartialFile(maxPieceSize, paths.Unsealed)
-		if xerrors.Is(err, os.ErrNotExist) {
+		if err != nil {
 			return xerrors.Errorf("opening partial file: %w", err)
 		}
 


### PR DESCRIPTION
After a sector finalization failure, the following retry attempt could not open the sector's unsealed form and caused the panic logged below.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xdc7977]

goroutine 2439679 [running]:
github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper.(*partialFile).Free(0x0, 0x8020000, 0x7fe0000, 0x0, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/ffiwrapper/partialfile.go:228 +0x37
github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper.(*Sealer).FinalizeSector(0xc02140cba0, 0x2e04a60, 0xc01f580bc0, 0x3df4, 0x33, 0xc01154c500, 0x7, 0x8, 0x0, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/ffiwrapper/sealer_cgo.go:567 +0x632
github.com/filecoin-project/lotus/extern/sector-storage.(*LocalWorker).FinalizeSector(0xc0008afac0, 0x2e04a60, 0xc01f580bc0, 0x3df4, 0x33, 0xc01154c500, 0x7, 0x8, 0xc0270b36a0, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/localworker.go:178 +0xea
github.com/filecoin-project/lotus/extern/sector-storage.(*trackedWorker).FinalizeSector(0xc0270b36a0, 0x2e04a60, 0xc01f580bc0, 0x3df4, 0x33, 0xc01154c500, 0x7, 0x8, 0x0, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/work_tracker.go:102 +0xfb
github.com/filecoin-project/lotus/extern/sector-storage.(*Manager).FinalizeSector.func1(0x2e04a60, 0xc01f580bc0, 0x2e2c960, 0xc0270b36a0, 0x0, 0x4)
        /home/feel_ua/lotus/extern/sector-storage/manager.go:427 +0x76
github.com/filecoin-project/lotus/extern/sector-storage.(*scheduler).assignWorker.func1.1(0x0, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/sched.go:720 +0x33a
github.com/filecoin-project/lotus/extern/sector-storage.(*activeResources).withResources(0xc0118481e0, 0x0, 0x3ee8db4000, 0x11ffffe000, 0xf60d7000, 0x40, 0xc0110459d0, 0x1, 0x1, 0x0, ...)
        /home/feel_ua/lotus/extern/sector-storage/sched_resources.go:19 +0x25b
github.com/filecoin-project/lotus/extern/sector-storage.(*scheduler).assignWorker.func1(0xc032f566c0, 0xc011818840, 0xc01101cdc0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0008d8300, 0x0)
        /home/feel_ua/lotus/extern/sector-storage/sched.go:708 +0x7e2
created by github.com/filecoin-project/lotus/extern/sector-storage.(*scheduler).assignWorker
        /home/feel_ua/lotus/extern/sector-storage/sched.go:682 +0x223
```