### PR TITLE
fix isChainNearSync check in block validator

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"golang.org/x/xerrors"
 
@@ -369,8 +368,8 @@ func (bv *BlockValidator) decodeAndCheckBlock(msg *pubsub.Message) (*types.Block
 func (bv *BlockValidator) isChainNearSynced() bool {
 	ts := bv.chain.GetHeaviestTipSet()
 	timestamp := ts.MinTimestamp()
-	now := build.Clock.Now().UnixNano()
-	cutoff := uint64(now) - uint64(6*time.Hour)
+	now := build.Clock.Now().Unix()
+	cutoff := uint64(now) - uint64(6*3600) // 6 hours
 	return timestamp > cutoff
 }
 

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -368,9 +369,8 @@ func (bv *BlockValidator) decodeAndCheckBlock(msg *pubsub.Message) (*types.Block
 func (bv *BlockValidator) isChainNearSynced() bool {
 	ts := bv.chain.GetHeaviestTipSet()
 	timestamp := ts.MinTimestamp()
-	now := build.Clock.Now().Unix()
-	cutoff := uint64(now) - uint64(6*3600) // 6 hours
-	return timestamp > cutoff
+	timestampTime := time.Unix(int64(timestamp), 0)
+	return build.Clock.Since(timestampTime) < 6*time.Hour
 }
 
 func (bv *BlockValidator) validateMsgMeta(ctx context.Context, msg *types.BlockMsg) error {


### PR DESCRIPTION
Cherry-picked from #3646 where the bug was discovered.
Basically it was a check of seconds (in the timestamp) -vs- nanoseconds from the clock; gah.