### PR TITLE
storage manager: bail out with an error if unsealed cid is undefined (redux)

### DIFF
--- a/extern/sector-storage/ffiwrapper/sealer_cgo.go
+++ b/extern/sector-storage/ffiwrapper/sealer_cgo.go
@@ -410,7 +410,7 @@ func (sb *Sealer) ReadPiece(ctx context.Context, writer io.Writer, sector abi.Se
 		return false, xerrors.Errorf("closing partial file: %w", err)
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func (sb *Sealer) SealPreCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, pieces []abi.PieceInfo) (out storage.PreCommit1Out, err error) {

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -217,16 +217,11 @@ func (m *Manager) ReadPiece(ctx context.Context, sink io.Writer, sector abi.Sect
 		return xerrors.Errorf("read piece: checking for already existing unsealed sector: %w", err)
 	}
 
+	var readOk bool
 	var selector WorkerSelector
 	if len(best) == 0 { // new
 		selector = newAllocSelector(m.index, stores.FTUnsealed, stores.PathSealing)
 	} else { // append to existing
-		selector = newExistingSelector(m.index, sector, stores.FTUnsealed, false)
-	}
-
-	var readOk bool
-
-	if len(best) > 0 {
 		// There is unsealed sector, see if we can read from it
 
 		selector = newExistingSelector(m.index, sector, stores.FTUnsealed, false)
@@ -257,6 +252,9 @@ func (m *Manager) ReadPiece(ctx context.Context, sink io.Writer, sector abi.Sect
 		return nil
 	}
 
+	if unsealed == cid.Undef {
+		return xerrors.Errorf("cannot unseal piece (sector: %d, offset: %d size: %d) - unsealed cid is undefined", sector, offset, size)
+	}
 	err = m.sched.Schedule(ctx, sector, sealtasks.TTUnseal, selector, unsealFetch, func(ctx context.Context, w Worker) error {
 		return w.UnsealPiece(ctx, sector, offset, size, ticket, unsealed)
 	})

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -272,7 +272,7 @@ func (m *Manager) ReadPiece(ctx context.Context, sink io.Writer, sector abi.Sect
 		return xerrors.Errorf("reading piece from sealed sector: %w", err)
 	}
 
-	if readOk {
+	if !readOk {
 		return xerrors.Errorf("failed to read unsealed piece")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/lotus/issues/3558

The first attempt (https://github.com/filecoin-project/lotus/pull/3615) included an extra logic change that caused some tests to fail. I'm investigating why it causes test failures.

This PR is the same but without the extra change: it just checks if the unsealed cid is undefined, and returns an error if so.
