### PR TITLE
storage: return true from Sealer.ReadPiece() on success

### DIFF
--- a/extern/sector-storage/ffiwrapper/sealer_cgo.go
+++ b/extern/sector-storage/ffiwrapper/sealer_cgo.go
@@ -410,7 +410,7 @@ func (sb *Sealer) ReadPiece(ctx context.Context, writer io.Writer, sector abi.Se
 		return false, xerrors.Errorf("closing partial file: %w", err)
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func (sb *Sealer) SealPreCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, pieces []abi.PieceInfo) (out storage.PreCommit1Out, err error) {

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -272,7 +272,7 @@ func (m *Manager) ReadPiece(ctx context.Context, sink io.Writer, sector abi.Sect
 		return xerrors.Errorf("reading piece from sealed sector: %w", err)
 	}
 
-	if readOk {
+	if !readOk {
 		return xerrors.Errorf("failed to read unsealed piece")
 	}
 


### PR DESCRIPTION
Currently `Sealer.ReadPiece()` always returns `false`. This PR changes it to return `true` on success.