### PR TITLE
fix very minor bug in repub baseFeeLowerBound

### DIFF
--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -27,7 +27,11 @@ func (mp *MessagePool) republishPendingMessages() error {
 		mp.curTsLk.Unlock()
 		return xerrors.Errorf("computing basefee: %w", err)
 	}
+
 	baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
+	if baseFeeLowerBoundFactor.LessThan(minimumBaseFee) {
+		baseFeeLowerBound = minimumBaseFee
+	}
 
 	pending := make(map[address.Address]map[uint64]*types.SignedMessage)
 	mp.lk.Lock()


### PR DESCRIPTION
this bug cannot be really triggered as messages will not be accepted if the GasFeeCap is less than  minimumBaseFee, but it doesn't hurt to be correct.