### PR TITLE
add niceSleep 1 second when drand errors

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -189,6 +189,7 @@ func (m *Miner) mine(ctx context.Context) {
 			_, err = m.api.BeaconGetEntry(ctx, prebase.TipSet.Height()+prebase.NullRounds+1)
 			if err != nil {
 				log.Errorf("failed getting beacon entry: %s", err)
+				m.niceSleep(time.Second)
 				continue
 			}
 


### PR DESCRIPTION
When stopping Drand with Testground on a testnet, I am getting a lot of `failed getting beacon entry` error messages, due to the `for` / `continue` loop.

I suggest we add some kind of delay if `m.api.BeaconGetEntry` fails, although I am not sure if 1 second is not too large.