### PR TITLE
fix: error when actor panics directly

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -122,7 +122,11 @@ func (rt *Runtime) shimCall(f func() interface{}) (rval []byte, aerr aerrors.Act
 			//log.Desugar().WithOptions(zap.AddStacktrace(zapcore.ErrorLevel)).
 			//Sugar().Errorf("spec actors failure: %s", r)
 			log.Errorf("spec actors failure: %s", r)
-			aerr = aerrors.Newf(1, "spec actors failure: %s", r)
+			if rt.NetworkVersion() <= network.Version3 {
+				aerr = aerrors.Newf(1, "spec actors failure: %s", r)
+			} else {
+				aerr = aerrors.Newf(exitcode.SysErrReserved1, "spec actors failure: %s", r)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Attempting to resolve https://github.com/filecoin-project/test-vectors/issues/87, quoting @anorth:

> If an actor implementation panics directly (rather than calling Abortf) then the evaluation is undefined. There is no exit code corresponding to this. The result should not go on chain. A panic (which could also come from some actor dependency) may indicate a transient state or error that cannot be replicated by other nodes and thus cannot form part of consensus. E.g. an out-of-memory.

I believe that returning a "fatal" `ActorError` instead of `SysErrSenderInvalid(1)` prevents the message from being recorded on chain since it's caught in [ApplyMessage here](https://github.com/filecoin-project/lotus/blob/de772bf1f9e5e2e38feaf1655a889e77c8126d74/chain/vm/vm.go#L451).
