### PR TITLE
Add Kubuxu to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 ## the PR before merging.
 
 ### Global owners.
-*                       @magik6k @whyrusleeping
+*                       @magik6k @whyrusleeping @Kubuxu
 
 ### Conformance testing.
 conformance/            @raulk


### PR DESCRIPTION
3 pairs of eyes are better than two and getting directly notified on PR is what I want (but GH notifications have no repo+PR filter).