### PR TITLE
Increase the number of times precommit2 is attempted before moving back to precommit1

### DIFF
--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -62,7 +62,7 @@ func (m *Sealing) handleSealPrecommit2Failed(ctx statemachine.Context, sector Se
 		return err
 	}
 
-	if sector.PreCommit2Fails > 1 {
+	if sector.PreCommit2Fails > 3 {
 		return ctx.Send(SectorRetrySealPreCommit1{})
 	}
 


### PR DESCRIPTION
Because restarting a precommit2 worker twice during sector data transfer has resulted in them being sent back to precommit1.

Ideally, there would be a subset of errors that cause this counter to increment and not things like the user restarting a worker.