### PR TITLE
fix: actor method params deserialization error exit code

### DIFF
--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -139,7 +139,7 @@ func (*Invoker) transform(instance Invokee) (nativeCode, error) {
 
 				inBytes := in[1].Interface().([]byte)
 				if err := DecodeParams(inBytes, param.Interface()); err != nil {
-					aerr := aerrors.Absorb(err, 1, "failed to decode parameters")
+					aerr := aerrors.Absorb(err, exitcode.ErrSerialization, "failed to decode parameters")
 					return []reflect.Value{
 						reflect.ValueOf([]byte{}),
 						// Below is a hack, fixed in Go 1.13

--- a/chain/vm/invoker_test.go
+++ b/chain/vm/invoker_test.go
@@ -108,6 +108,5 @@ func TestInvokerBasic(t *testing.T) {
 	if aerrors.IsFatal(aerr) {
 		t.Fatal("err should not be fatal")
 	}
-	assert.Equal(t, exitcode.ExitCode(1), aerrors.RetCode(aerr), "return code should be 1")
-
+	assert.Equal(t, exitcode.ErrSerialization, aerrors.RetCode(aerr), "return code should be %s", exitcode.ErrSerialization)
 }


### PR DESCRIPTION
This fixes the exit code for deserializing params for an actor method to be [`ErrSerialization(21)`](https://github.com/filecoin-project/go-state-types/blob/bbd537e93b39321de97b17ec8d726d46c16670fa/exitcode/common.go#L17-L18) not [`SysErrSenderInvalid(1)`](https://github.com/filecoin-project/go-state-types/blob/bbd537e93b39321de97b17ec8d726d46c16670fa/exitcode/reserved.go#L10-L15).

Issue here for context: https://github.com/filecoin-project/test-vectors/issues/93#issuecomment-689593946

I have a [PR open](https://github.com/filecoin-project/test-vectors/pull/133) with interoperable test vectors I've verified will start passing when this change is made.