### PR TITLE
refactor getBaseFeeLowerBound, use it to prune less aggressively

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -399,7 +399,7 @@ func (mp *MessagePool) verifyMsgBeforeAdd(m *types.SignedMessage, curTs *types.T
 	publish := local
 	if strictBaseFeeValidation && len(curTs.Blocks()) > 0 {
 		baseFee := curTs.Blocks()[0].ParentBaseFee
-		baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
+		baseFeeLowerBound := getBaseFeeLowerBound(baseFee)
 		if m.Message.GasFeeCap.LessThan(baseFeeLowerBound) {
 			if local {
 				log.Warnf("local message will not be immediately published because GasFeeCap doesn't meet the lower bound for inclusion in the next 20 blocks (GasFeeCap: %s, baseFeeLowerBound: %s)",
@@ -1281,4 +1281,13 @@ func (mp *MessagePool) Clear(local bool) {
 		}
 		delete(mp.pending, a)
 	}
+}
+
+func getBaseFeeLowerBound(baseFee types.BigInt) types.BigInt {
+	baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
+	if baseFeeLowerBound.LessThan(minimumBaseFee) {
+		baseFeeLowerBound = minimumBaseFee
+	}
+
+	return baseFeeLowerBound
 }

--- a/chain/messagepool/pruning.go
+++ b/chain/messagepool/pruning.go
@@ -46,6 +46,7 @@ func (mp *MessagePool) pruneMessages(ctx context.Context, ts *types.TipSet) erro
 	if err != nil {
 		return xerrors.Errorf("computing basefee: %w", err)
 	}
+	baseFeeLowerBound := getBaseFeeLowerBound(baseFee)
 
 	pending, _ := mp.getPendingMessages(ts, ts)
 
@@ -72,7 +73,7 @@ func (mp *MessagePool) pruneMessages(ctx context.Context, ts *types.TipSet) erro
 		for _, m := range mset {
 			pruneMsgs[m.Message.Cid()] = m
 		}
-		actorChains := mp.createMessageChains(actor, mset, baseFee, ts)
+		actorChains := mp.createMessageChains(actor, mset, baseFeeLowerBound, ts)
 		chains = append(chains, actorChains...)
 	}
 

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -27,11 +27,7 @@ func (mp *MessagePool) republishPendingMessages() error {
 		mp.curTsLk.Unlock()
 		return xerrors.Errorf("computing basefee: %w", err)
 	}
-
-	baseFeeLowerBound := types.BigDiv(baseFee, baseFeeLowerBoundFactor)
-	if baseFeeLowerBoundFactor.LessThan(minimumBaseFee) {
-		baseFeeLowerBound = minimumBaseFee
-	}
+	baseFeeLowerBound := getBaseFeeLowerBound(baseFee)
 
 	pending := make(map[address.Address]map[uint64]*types.SignedMessage)
 	mp.lk.Lock()


### PR DESCRIPTION
Also fixes clown shoes check in repub; emacs M-/ auto completed to baseFeeLowerBoundFactor... so we ended up (potentially) republishing everything, not just the near-profitable messages.