### PR TITLE
add paych status command to list

### DIFF
--- a/cli/paych.go
+++ b/cli/paych.go
@@ -28,6 +28,7 @@ var paychCmd = &cli.Command{
 		paychListCmd,
 		paychVoucherCmd,
 		paychSettleCmd,
+		paychStatusCmd,
 		paychCloseCmd,
 	},
 }


### PR DESCRIPTION
The `paych status` command is not accessible cause while it's written it wasn't added to the list of commands for payment channels.