### PR TITLE
optimize Settings.nodeType

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -475,12 +475,18 @@ func Repo(r repo.Repo) Option {
 }
 
 func FullAPI(out *api.FullNode) Option {
-	return func(s *Settings) error {
-		resAPI := &impl.FullNodeAPI{}
-		s.invokes[ExtractApiKey] = fx.Extract(resAPI)
-		*out = resAPI
-		return nil
-	}
+	return Options(
+		func(s *Settings) error {
+			s.nodeType = repo.FullNode
+			return nil
+		},
+		func(s *Settings) error {
+			resAPI := &impl.FullNodeAPI{}
+			s.invokes[ExtractApiKey] = fx.Extract(resAPI)
+			*out = resAPI
+			return nil
+		},
+	)
 }
 
 type StopFunc func(context.Context) error
@@ -488,9 +494,8 @@ type StopFunc func(context.Context) error
 // New builds and starts new Filecoin node
 func New(ctx context.Context, opts ...Option) (StopFunc, error) {
 	settings := Settings{
-		modules:  map[interface{}]fx.Option{},
-		invokes:  make([]fx.Option, _nInvokes),
-		nodeType: repo.FullNode,
+		modules: map[interface{}]fx.Option{},
+		invokes: make([]fx.Option, _nInvokes),
 	}
 
 	// apply module options in the right order


### PR DESCRIPTION
func New(ctx context.Context , opts ...Option) (StopFunc, error) in builder.go,  Is a public function, should not have nodeType: repo.FullNode. 