### PR TITLE
paych: fix voucher amount verification

### DIFF
--- a/chain/actors/builtin/paych/mock/mock.go
+++ b/chain/actors/builtin/paych/mock/mock.go
@@ -27,10 +27,9 @@ type mockLaneState struct {
 func NewMockPayChState(from address.Address,
 	to address.Address,
 	settlingAt abi.ChainEpoch,
-	toSend abi.TokenAmount,
 	lanes map[uint64]paych.LaneState,
 ) paych.State {
-	return &mockState{from, to, settlingAt, toSend, lanes}
+	return &mockState{from: from, to: to, settlingAt: settlingAt, toSend: big.NewInt(0), lanes: lanes}
 }
 
 // NewMockLaneState constructs a state for a payment channel lane with the set fixed values

--- a/paychmgr/mock_test.go
+++ b/paychmgr/mock_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/crypto"
-
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -57,6 +56,7 @@ func (sm *mockStateManager) setAccountAddress(a address.Address, lookup address.
 func (sm *mockStateManager) setPaychState(a address.Address, actor *types.Actor, state paych.State) {
 	sm.lk.Lock()
 	defer sm.lk.Unlock()
+
 	sm.paychState[a] = mockPchState{actor, state}
 }
 

--- a/paychmgr/mock_test.go
+++ b/paychmgr/mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/crypto"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -56,7 +57,6 @@ func (sm *mockStateManager) setAccountAddress(a address.Address, lookup address.
 func (sm *mockStateManager) setPaychState(a address.Address, actor *types.Actor, state paych.State) {
 	sm.lk.Lock()
 	defer sm.lk.Unlock()
-
 	sm.paychState[a] = mockPchState{actor, state}
 }
 

--- a/paychmgr/paych.go
+++ b/paychmgr/paych.go
@@ -205,7 +205,7 @@ func (ca *channelAccessor) checkVoucherValidUnlocked(ctx context.Context, ch add
 	}
 
 	// Check the voucher against the highest known voucher nonce / value
-	laneStates, err := ca.laneState(ctx, pchState, ch)
+	laneStates, err := ca.laneState(pchState, ch)
 	if err != nil {
 		return nil, err
 	}
@@ -253,16 +253,9 @@ func (ca *channelAccessor) checkVoucherValidUnlocked(ctx context.Context, ch add
 		return nil, err
 	}
 
-	// Total required balance = total redeemed + toSend
-	// Must not exceed actor balance
-	ts, err := pchState.ToSend()
-	if err != nil {
-		return nil, err
-	}
-
-	newTotal := types.BigAdd(totalRedeemed, ts)
-	if act.Balance.LessThan(newTotal) {
-		return nil, newErrInsufficientFunds(types.BigSub(newTotal, act.Balance))
+	// Total required balance must not exceed actor balance
+	if act.Balance.LessThan(totalRedeemed) {
+		return nil, newErrInsufficientFunds(types.BigSub(totalRedeemed, act.Balance))
 	}
 
 	if len(sv.Merges) != 0 {
@@ -505,7 +498,6 @@ func (ca *channelAccessor) allocateLane(ch address.Address) (uint64, error) {
 	ca.lk.Lock()
 	defer ca.lk.Unlock()
 
-	// TODO: should this take into account lane state?
 	return ca.store.AllocateLane(ch)
 }
 
@@ -520,7 +512,7 @@ func (ca *channelAccessor) listVouchers(ctx context.Context, ch address.Address)
 
 // laneState gets the LaneStates from chain, then applies all vouchers in
 // the data store over the chain state
-func (ca *channelAccessor) laneState(ctx context.Context, state paych.State, ch address.Address) (map[uint64]paych.LaneState, error) {
+func (ca *channelAccessor) laneState(state paych.State, ch address.Address) (map[uint64]paych.LaneState, error) {
 	// TODO: we probably want to call UpdateChannelState with all vouchers to be fully correct
 	//  (but technically dont't need to)
 
@@ -547,14 +539,20 @@ func (ca *channelAccessor) laneState(ctx context.Context, state paych.State, ch 
 		return nil, err
 	}
 
+	// Note: we use a map instead of an array to store laneStates because the
+	// client sets the lane ID (the index) and potentially they could use a
+	// very large index.
 	for _, v := range vouchers {
 		for range v.Voucher.Merges {
 			return nil, xerrors.Errorf("paych merges not handled yet")
 		}
 
-		// If there's a voucher for a lane that isn't in chain state just
-		// create it
+		// Check if there is an existing laneState in the payment channel
+		// for this voucher's lane
 		ls, ok := laneStates[v.Voucher.Lane]
+
+		// If the voucher does not have a higher nonce than the existing
+		// laneState for this lane, ignore it
 		if ok {
 			n, err := ls.Nonce()
 			if err != nil {
@@ -565,6 +563,7 @@ func (ca *channelAccessor) laneState(ctx context.Context, state paych.State, ch 
 			}
 		}
 
+		// Voucher has a higher nonce, so replace laneState with this voucher
 		laneStates[v.Voucher.Lane] = laneState{v.Voucher.Amount, v.Voucher.Nonce}
 	}
 

--- a/paychmgr/paych.go
+++ b/paychmgr/paych.go
@@ -539,9 +539,6 @@ func (ca *channelAccessor) laneState(state paych.State, ch address.Address) (map
 		return nil, err
 	}
 
-	// Note: we use a map instead of an array to store laneStates because the
-	// client sets the lane ID (the index) and potentially they could use a
-	// very large index.
 	for _, v := range vouchers {
 		for range v.Voucher.Merges {
 			return nil, xerrors.Errorf("paych merges not handled yet")

--- a/paychmgr/paych_test.go
+++ b/paychmgr/paych_test.go
@@ -47,7 +47,6 @@ func TestCheckVoucherValid(t *testing.T) {
 		expectError   bool
 		key           []byte
 		actorBalance  big.Int
-		toSend        big.Int
 		voucherAmount big.Int
 		voucherLane   uint64
 		voucherNonce  uint64
@@ -56,35 +55,30 @@ func TestCheckVoucherValid(t *testing.T) {
 		name:          "passes when voucher amount < balance",
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 	}, {
 		name:          "fails when funds too low",
 		expectError:   true,
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(5),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(10),
 	}, {
 		name:          "fails when invalid signature",
 		expectError:   true,
 		key:           randKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 	}, {
 		name:          "fails when signed by channel To account (instead of From account)",
 		expectError:   true,
 		key:           toKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 	}, {
 		name:          "fails when nonce too low",
 		expectError:   true,
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 		voucherLane:   1,
 		voucherNonce:  2,
@@ -95,7 +89,6 @@ func TestCheckVoucherValid(t *testing.T) {
 		name:          "passes when nonce higher",
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 		voucherLane:   1,
 		voucherNonce:  3,
@@ -106,7 +99,6 @@ func TestCheckVoucherValid(t *testing.T) {
 		name:          "passes when nonce for different lane",
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 		voucherLane:   2,
 		voucherNonce:  2,
@@ -118,7 +110,6 @@ func TestCheckVoucherValid(t *testing.T) {
 		expectError:   true,
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(0),
 		voucherAmount: big.NewInt(5),
 		voucherLane:   1,
 		voucherNonce:  3,
@@ -126,24 +117,15 @@ func TestCheckVoucherValid(t *testing.T) {
 			1: paychmock.NewMockLaneState(big.NewInt(6), 2),
 		},
 	}, {
-		name:          "fails when voucher + ToSend > balance",
-		expectError:   true,
-		key:           fromKeyPrivate,
-		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(9),
-		voucherAmount: big.NewInt(2),
-	}, {
 		// voucher supersedes lane 1 redeemed so
 		// lane 1 effective redeemed = voucher amount
 		//
-		// required balance = toSend + total redeemed
-		//                  = 1 + 6 (lane1)
+		// required balance = voucher amt
 		//                  = 7
 		// So required balance: 7 < actor balance: 10
-		name:          "passes when voucher + total redeemed <= balance",
+		name:          "passes when voucher total redeemed <= balance",
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(1),
 		voucherAmount: big.NewInt(6),
 		voucherLane:   1,
 		voucherNonce:  2,
@@ -152,29 +134,68 @@ func TestCheckVoucherValid(t *testing.T) {
 			1: paychmock.NewMockLaneState(big.NewInt(4), 1),
 		},
 	}, {
-		// required balance = toSend + total redeemed
-		//                  = 1 + 4 (lane 2) + 6 (voucher lane 1)
+		// required balance = total redeemed
+		//                  = 6 (voucher lane 1) + 5 (lane 2)
 		//                  = 11
 		// So required balance: 11 > actor balance: 10
-		name:          "fails when voucher + total redeemed > balance",
+		name:          "fails when voucher total redeemed > balance",
 		expectError:   true,
 		key:           fromKeyPrivate,
 		actorBalance:  big.NewInt(10),
-		toSend:        big.NewInt(1),
 		voucherAmount: big.NewInt(6),
 		voucherLane:   1,
 		voucherNonce:  1,
 		laneStates: map[uint64]paych.LaneState{
 			// Lane 2 (different from voucher lane 1)
-			2: paychmock.NewMockLaneState(big.NewInt(4), 1),
+			2: paychmock.NewMockLaneState(big.NewInt(5), 1),
+		},
+	}, {
+		// voucher supersedes lane 1 redeemed so
+		// lane 1 effective redeemed = voucher amount
+		//
+		// required balance = total redeemed
+		//                  = 6 (new voucher lane 1) + 5 (lane 2)
+		//                  = 11
+		// So required balance: 11 > actor balance: 10
+		name:          "fails when voucher total redeemed > balance",
+		expectError:   true,
+		key:           fromKeyPrivate,
+		actorBalance:  big.NewInt(10),
+		voucherAmount: big.NewInt(6),
+		voucherLane:   1,
+		voucherNonce:  2,
+		laneStates: map[uint64]paych.LaneState{
+			// Lane 1 (superseded by new voucher in voucher lane 1)
+			1: paychmock.NewMockLaneState(big.NewInt(5), 1),
+			// Lane 2 (different from voucher lane 1)
+			2: paychmock.NewMockLaneState(big.NewInt(5), 1),
+		},
+	}, {
+		// voucher supersedes lane 1 redeemed so
+		// lane 1 effective redeemed = voucher amount
+		//
+		// required balance = total redeemed
+		//                  = 5 (new voucher lane 1) + 5 (lane 2)
+		//                  = 10
+		// So required balance: 10 <= actor balance: 10
+		name:          "passes when voucher total redeemed <= balance",
+		expectError:   false,
+		key:           fromKeyPrivate,
+		actorBalance:  big.NewInt(10),
+		voucherAmount: big.NewInt(5),
+		voucherLane:   1,
+		voucherNonce:  2,
+		laneStates: map[uint64]paych.LaneState{
+			// Lane 1 (superseded by new voucher in voucher lane 1)
+			1: paychmock.NewMockLaneState(big.NewInt(4), 1),
+			// Lane 2 (different from voucher lane 1)
+			2: paychmock.NewMockLaneState(big.NewInt(5), 1),
 		},
 	}}
 
 	for _, tcase := range tcases {
 		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
-			store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
-
 			// Create an actor for the channel with the test case balance
 			act := &types.Actor{
 				Code:    builtin.AccountActorCodeID,
@@ -184,16 +205,17 @@ func TestCheckVoucherValid(t *testing.T) {
 			}
 
 			mock.setPaychState(ch, act, paychmock.NewMockPayChState(
-				fromAcct, toAcct, abi.ChainEpoch(0), tcase.toSend, tcase.laneStates))
+				fromAcct, toAcct, abi.ChainEpoch(0), tcase.laneStates))
 
 			// Create a manager
+			store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
 			mgr, err := newManager(store, mock)
 			require.NoError(t, err)
 
 			// Add channel To address to wallet
 			mock.addWalletAddress(to)
 
-			// Create a signed voucher
+			// Create the test case signed voucher
 			sv := createTestVoucher(t, ch, tcase.voucherLane, tcase.voucherNonce, tcase.voucherAmount, tcase.key)
 
 			// Check the voucher's validity
@@ -207,135 +229,11 @@ func TestCheckVoucherValid(t *testing.T) {
 	}
 }
 
-func TestCheckVoucherValidCountingAllLanes(t *testing.T) {
-	ctx := context.Background()
-
-	fromKeyPrivate, fromKeyPublic := testGenerateKeyPair(t)
-
-	ch := tutils.NewIDAddr(t, 100)
-	from := tutils.NewSECP256K1Addr(t, string(fromKeyPublic))
-	to := tutils.NewSECP256K1Addr(t, "secpTo")
-	fromAcct := tutils.NewActorAddr(t, "fromAct")
-	toAcct := tutils.NewActorAddr(t, "toAct")
-	minDelta := big.NewInt(0)
-
-	mock := newMockManagerAPI()
-	mock.setAccountAddress(fromAcct, from)
-	mock.setAccountAddress(toAcct, to)
-
-	store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
-
-	actorBalance := big.NewInt(10)
-	toSend := big.NewInt(1)
-	laneStates := map[uint64]paych.LaneState{
-		1: paychmock.NewMockLaneState(big.NewInt(3), 1),
-		2: paychmock.NewMockLaneState(big.NewInt(4), 1),
-	}
-
-	act := &types.Actor{
-		Code:    builtin.AccountActorCodeID,
-		Head:    cid.Cid{},
-		Nonce:   0,
-		Balance: actorBalance,
-	}
-
-	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), toSend, laneStates))
-
-	mgr, err := newManager(store, mock)
-	require.NoError(t, err)
-
-	// Add channel To address to wallet
-	mock.addWalletAddress(to)
-
-	//
-	// Should not be possible to add a voucher with a value such that
-	// <total lane Redeemed> + toSend > <actor balance>
-	//
-	// lane 1 redeemed:                   3
-	// voucher amount (lane 1):           6
-	// lane 1 redeemed (with voucher):    6
-	//
-	// Lane 1:             6
-	// Lane 2:             4
-	// toSend:             1
-	//                     --
-	// total:              11
-	//
-	// actor balance is 10 so total is too high.
-	//
-	voucherLane := uint64(1)
-	voucherNonce := uint64(2)
-	voucherAmount := big.NewInt(6)
-	sv := createTestVoucher(t, ch, voucherLane, voucherNonce, voucherAmount, fromKeyPrivate)
-	err = mgr.CheckVoucherValid(ctx, ch, sv)
-	require.Error(t, err)
-
-	//
-	// lane 1 redeemed:                   3
-	// voucher amount (lane 1):           4
-	// lane 1 redeemed (with voucher):    4
-	//
-	// Lane 1:             4
-	// Lane 2:             4
-	// toSend:             1
-	//                     --
-	// total:              9
-	//
-	// actor balance is 10 so total is ok.
-	//
-	voucherAmount = big.NewInt(4)
-	sv = createTestVoucher(t, ch, voucherLane, voucherNonce, voucherAmount, fromKeyPrivate)
-	err = mgr.CheckVoucherValid(ctx, ch, sv)
-	require.NoError(t, err)
-
-	// Add voucher to lane 1, so Lane 1 effective redeemed
-	// (with first voucher) is now 4
-	_, err = mgr.AddVoucherOutbound(ctx, ch, sv, nil, minDelta)
-	require.NoError(t, err)
-
-	//
-	// lane 1 redeemed:                   4
-	// voucher amount (lane 1):           6
-	// lane 1 redeemed (with voucher):    6
-	//
-	// Lane 1:             6
-	// Lane 2:             4
-	// toSend:             1
-	//                     --
-	// total:              11
-	//
-	// actor balance is 10 so total is too high.
-	//
-	voucherNonce++
-	voucherAmount = big.NewInt(6)
-	sv = createTestVoucher(t, ch, voucherLane, voucherNonce, voucherAmount, fromKeyPrivate)
-	err = mgr.CheckVoucherValid(ctx, ch, sv)
-	require.Error(t, err)
-
-	//
-	// lane 1 redeemed:                   4
-	// voucher amount (lane 1):           5
-	// lane 1 redeemed (with voucher):    5
-	//
-	// Lane 1:             5
-	// Lane 2:             4
-	// toSend:             1
-	//                     --
-	// total:              10
-	//
-	// actor balance is 10 so total is ok.
-	//
-	voucherAmount = big.NewInt(5)
-	sv = createTestVoucher(t, ch, voucherLane, voucherNonce, voucherAmount, fromKeyPrivate)
-	err = mgr.CheckVoucherValid(ctx, ch, sv)
-	require.NoError(t, err)
-}
-
 func TestCreateVoucher(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	// Create a voucher in lane 1
 	voucherLane1Amt := big.NewInt(5)
@@ -400,7 +298,7 @@ func TestAddVoucherDelta(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	voucherLane := uint64(1)
 
@@ -442,7 +340,7 @@ func TestAddVoucherNextLane(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	minDelta := big.NewInt(0)
 	voucherAmount := big.NewInt(2)
@@ -489,10 +387,8 @@ func TestAddVoucherNextLane(t *testing.T) {
 }
 
 func TestAllocateLane(t *testing.T) {
-	ctx := context.Background()
-
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	// First lane should be 0
 	lane, err := s.mgr.AllocateLane(s.ch)
@@ -525,7 +421,6 @@ func TestAllocateLaneWithExistingLaneState(t *testing.T) {
 
 	// Create a channel that will be retrieved from state
 	actorBalance := big.NewInt(10)
-	toSend := big.NewInt(1)
 
 	act := &types.Actor{
 		Code:    builtin.AccountActorCodeID,
@@ -534,7 +429,7 @@ func TestAllocateLaneWithExistingLaneState(t *testing.T) {
 		Balance: actorBalance,
 	}
 
-	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), toSend, make(map[uint64]paych.LaneState)))
+	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), make(map[uint64]paych.LaneState)))
 
 	mgr, err := newManager(store, mock)
 	require.NoError(t, err)
@@ -559,7 +454,7 @@ func TestAddVoucherProof(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	nonce := uint64(1)
 	voucherAmount := big.NewInt(1)
@@ -622,10 +517,11 @@ func TestAddVoucherInboundWalletKey(t *testing.T) {
 	}
 
 	mock := newMockManagerAPI()
+
 	mock.setAccountAddress(fromAcct, from)
 	mock.setAccountAddress(toAcct, to)
 
-	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), types.NewInt(0), make(map[uint64]paych.LaneState)))
+	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), make(map[uint64]paych.LaneState)))
 
 	// Create a manager
 	store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
@@ -660,7 +556,7 @@ func TestBestSpendable(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	// Add vouchers to lane 1 with amounts: [1, 2, 3]
 	voucherLane := uint64(1)
@@ -740,7 +636,7 @@ func TestCheckSpendable(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	// Create voucher with Extra
 	voucherLane := uint64(1)
@@ -821,7 +717,7 @@ func TestSubmitVoucher(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up a manager with a single payment channel
-	s := testSetupMgrWithChannel(ctx, t)
+	s := testSetupMgrWithChannel(t)
 
 	// Create voucher with Extra
 	voucherLane := uint64(1)
@@ -908,7 +804,7 @@ type testScaffold struct {
 	fromKeyPrivate []byte
 }
 
-func testSetupMgrWithChannel(ctx context.Context, t *testing.T) *testScaffold {
+func testSetupMgrWithChannel(t *testing.T) *testScaffold {
 	fromKeyPrivate, fromKeyPublic := testGenerateKeyPair(t)
 
 	ch := tutils.NewIDAddr(t, 100)
@@ -920,6 +816,8 @@ func testSetupMgrWithChannel(ctx context.Context, t *testing.T) *testScaffold {
 	mock := newMockManagerAPI()
 	mock.setAccountAddress(fromAcct, from)
 	mock.setAccountAddress(toAcct, to)
+	//mock.setAccountState(fromAcct, account.State{Address: from})
+	//mock.setAccountState(toAcct, account.State{Address: to})
 
 	// Create channel in state
 	balance := big.NewInt(20)
@@ -929,7 +827,7 @@ func testSetupMgrWithChannel(ctx context.Context, t *testing.T) *testScaffold {
 		Nonce:   0,
 		Balance: balance,
 	}
-	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), big.NewInt(0), make(map[uint64]paych.LaneState)))
+	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), make(map[uint64]paych.LaneState)))
 
 	store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
 	mgr, err := newManager(store, mock)

--- a/paychmgr/paych_test.go
+++ b/paychmgr/paych_test.go
@@ -816,8 +816,6 @@ func testSetupMgrWithChannel(t *testing.T) *testScaffold {
 	mock := newMockManagerAPI()
 	mock.setAccountAddress(fromAcct, from)
 	mock.setAccountAddress(toAcct, to)
-	//mock.setAccountState(fromAcct, account.State{Address: from})
-	//mock.setAccountState(toAcct, account.State{Address: to})
 
 	// Create channel in state
 	balance := big.NewInt(20)

--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -978,7 +978,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 		Nonce:   0,
 		Balance: createAmt,
 	}
-	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), big.NewInt(0), make(map[uint64]paych.LaneState)))
+	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), make(map[uint64]paych.LaneState)))
 	// Send create channel response
 	response := testChannelResponse(t, ch)
 	mock.receiveMsgResponse(createMsgCid, response)

--- a/paychmgr/paychvoucherfunds_test.go
+++ b/paychmgr/paychvoucherfunds_test.go
@@ -1,0 +1,107 @@
+package paychmgr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/lotus/chain/types"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/builtin/account"
+	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	tutils "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPaychAddVoucherAfterAddFunds tests adding a voucher to a channel with
+// insufficient funds, then adding funds to the channel, then adding the
+// voucher again
+func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+
+	fromKeyPrivate, fromKeyPublic := testGenerateKeyPair(t)
+	ch := tutils.NewIDAddr(t, 100)
+	from := tutils.NewSECP256K1Addr(t, string(fromKeyPublic))
+	to := tutils.NewSECP256K1Addr(t, "secpTo")
+	fromAcct := tutils.NewActorAddr(t, "fromAct")
+	toAcct := tutils.NewActorAddr(t, "toAct")
+
+	mock := newMockManagerAPI()
+	defer mock.close()
+
+	// Add the from signing key to the wallet
+	mock.setAccountState(fromAcct, account.State{Address: from})
+	mock.setAccountState(toAcct, account.State{Address: to})
+	mock.addSigningKey(fromKeyPrivate)
+
+	mgr, err := newManager(store, mock)
+	require.NoError(t, err)
+
+	// Send create message for a channel with value 10
+	createAmt := big.NewInt(10)
+	_, createMsgCid, err := mgr.GetPaych(ctx, from, to, createAmt)
+	require.NoError(t, err)
+
+	// Send create channel response
+	response := testChannelResponse(t, ch)
+	mock.receiveMsgResponse(createMsgCid, response)
+
+	// Create an actor in state for the channel with the initial channel balance
+	act := &types.Actor{
+		Code:    builtin.AccountActorCodeID,
+		Head:    cid.Cid{},
+		Nonce:   0,
+		Balance: createAmt,
+	}
+	mock.setPaychState(ch, act, paych.State{
+		From:            fromAcct,
+		To:              toAcct,
+		SettlingAt:      abi.ChainEpoch(0),
+		MinSettleHeight: abi.ChainEpoch(0),
+	})
+
+	// Wait for create response to be processed by manager
+	_, err = mgr.GetPaychWaitReady(ctx, createMsgCid)
+	require.NoError(t, err)
+
+	// Create a voucher with a value equal to the channel balance
+	voucher := paych.SignedVoucher{Amount: createAmt, Lane: 1}
+	res, err := mgr.CreateVoucher(ctx, ch, voucher)
+	require.NoError(t, err)
+	require.NotNil(t, res.Voucher)
+
+	// Create a voucher in a different lane with an amount that exceeds the
+	// channel balance
+	excessAmt := types.NewInt(5)
+	voucher = paych.SignedVoucher{Amount: excessAmt, Lane: 2}
+	res, err = mgr.CreateVoucher(ctx, ch, voucher)
+	require.NoError(t, err)
+	require.Nil(t, res.Voucher)
+	require.Equal(t, res.Shortfall, excessAmt)
+
+	// Add funds so as to cover the voucher shortfall
+	_, addFundsMsgCid, err := mgr.GetPaych(ctx, from, to, excessAmt)
+	require.NoError(t, err)
+
+	// Trigger add funds confirmation
+	mock.receiveMsgResponse(addFundsMsgCid, types.MessageReceipt{ExitCode: 0})
+
+	// Update actor test case balance to reflect added funds
+	act.Balance = types.BigAdd(createAmt, excessAmt)
+
+	// Wait for add funds confirmation to be processed by manager
+	_, err = mgr.GetPaychWaitReady(ctx, addFundsMsgCid)
+	require.NoError(t, err)
+
+	// Adding same voucher that previously exceeded channel balance
+	// should succeed now that the channel balance has been increased
+	res, err = mgr.CreateVoucher(ctx, ch, voucher)
+	require.NoError(t, err)
+	require.NotNil(t, res.Voucher)
+}

--- a/paychmgr/paychvoucherfunds_test.go
+++ b/paychmgr/paychvoucherfunds_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
+	paychmock "github.com/filecoin-project/lotus/chain/actors/builtin/paych/mock"
+
 	"github.com/filecoin-project/lotus/chain/types"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/builtin/account"
-	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	tutils "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
@@ -36,8 +37,8 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	defer mock.close()
 
 	// Add the from signing key to the wallet
-	mock.setAccountState(fromAcct, account.State{Address: from})
-	mock.setAccountState(toAcct, account.State{Address: to})
+	mock.setAccountAddress(fromAcct, from)
+	mock.setAccountAddress(toAcct, to)
 	mock.addSigningKey(fromKeyPrivate)
 
 	mgr, err := newManager(store, mock)
@@ -59,12 +60,7 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 		Nonce:   0,
 		Balance: createAmt,
 	}
-	mock.setPaychState(ch, act, paych.State{
-		From:            fromAcct,
-		To:              toAcct,
-		SettlingAt:      abi.ChainEpoch(0),
-		MinSettleHeight: abi.ChainEpoch(0),
-	})
+	mock.setPaychState(ch, act, paychmock.NewMockPayChState(fromAcct, toAcct, abi.ChainEpoch(0), make(map[uint64]paych.LaneState)))
 
 	// Wait for create response to be processed by manager
 	_, err = mgr.GetPaychWaitReady(ctx, createMsgCid)

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -312,7 +312,7 @@ func (ca *channelAccessor) currentAvailableFunds(channelID string, queuedAmt typ
 			return nil, err
 		}
 
-		laneStates, err := ca.laneState(ca.chctx, pchState, ch)
+		laneStates, err := ca.laneState(pchState, ch)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Payment channels can be
- Outbound: the payment channel is *from* the local node’s account *to* another account.
  For example when a client wants to retrieve data
  - The client creates an outbound payment channel on-chain to the node that has the data
  - The client creates a voucher locally
  - The client checks that creating the voucher will not exceed the remaining balance in the channel
  - The client sends the voucher directly to the data provider
- Inbound: the payment channel *from* a remote account *to* the local node’s account.
  For example when a data provider receives a voucher on a payment channel
  - The data provider fetches the payment channel for the voucher from chain state
  - The data provider checks that adding the voucher will not exceed the remaining balance in the channel
  - The data provider adds the voucher to its local datastore
  - At some later stage (typically when the channel is Settled) the data provider submits the vouchers on-chain

The payment channel state includes a field `toSend`, which is the sum of submitted vouchers in all lanes.
 
When a voucher is created on an Inbound payment channel or received and added on an Outbound payment channel we:
  - Sum the total voucher amount across all lanes (including the new voucher)
  - Check that the total voucher amount + `toSend` <= channel balance

However `toSend` already includes the amount for submitted vouchers. So in fact we should not include `toSend` when comparing the total voucher amount to the channel balance.

Currently we fetch vouchers from the datastore and from channel state. However in order to reach channel state, the vouchers must have been either
- created by the local node on an Outbound channel
- received and added by the local node on an Inbound channel

~Therefore the vouchers should already be in the datastore, there’s no need to fetch them from channel state. So this PR changes the code to only get vouchers from the datastore.~
*Update: After talking with @magik6k we decided not to change this behaviour*

