### PR TITLE
circleci: make lint expend all cores.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ workflows:
   version: 2.1
   ci:
     jobs:
-      - lint-all
+      - lint-all:
           concurrency: 16   # expend all docker 2xlarge CPUs.
       - mod-tidy-check
       - gofmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,7 @@ workflows:
   ci:
     jobs:
       - lint-all
+          concurrency: 16   # expend all docker 2xlarge CPUs.
       - mod-tidy-check
       - gofmt
       - cbor-gen-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ workflows:
   ci:
     jobs:
       - lint-all:
-          concurrency: 16   # expend all docker 2xlarge CPUs.
+          concurrency: "16"   # expend all docker 2xlarge CPUs.
       - mod-tidy-check
       - gofmt
       - cbor-gen-check


### PR DESCRIPTION
Our timeout of 2 minutes is being hit, and we can avoid that if we use all compute power available to us.

This introduces a ~40% gain on wall-clock time for the lint-all target.