### PR TITLE
syncer: make SyncManager an interface.

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -58,7 +58,14 @@ import (
 // the theoretical max height based on systime are quickly rejected
 const MaxHeightDrift = 5
 
-var defaultMessageFetchWindowSize = 200
+var (
+	// LocalIncoming is the _local_ pubsub (unrelated to libp2p pubsub) topic
+	// where the Syncer publishes candidate chain heads to be synced.
+	LocalIncoming = "incoming"
+
+	log                           = logging.Logger("chain")
+	defaultMessageFetchWindowSize = 200
+)
 
 func init() {
 	if s := os.Getenv("LOTUS_BSYNC_MSG_WINDOW"); s != "" {
@@ -70,10 +77,6 @@ func init() {
 		defaultMessageFetchWindowSize = val
 	}
 }
-
-var log = logging.Logger("chain")
-
-var LocalIncoming = "incoming"
 
 // Syncer is in charge of running the chain synchronization logic. As such, it
 // is tasked with these functions, amongst others:
@@ -119,7 +122,7 @@ type Syncer struct {
 
 	self peer.ID
 
-	syncmgr *SyncManager
+	syncmgr SyncManager
 
 	connmgr connmgr.ConnManager
 
@@ -140,8 +143,10 @@ type Syncer struct {
 	ds dtypes.MetadataDS
 }
 
+type SyncManagerCtor func(syncFn SyncFunc) SyncManager
+
 // NewSyncer creates a new Syncer object.
-func NewSyncer(ds dtypes.MetadataDS, sm *stmgr.StateManager, exchange exchange.Client, connmgr connmgr.ConnManager, self peer.ID, beacon beacon.Schedule, verifier ffiwrapper.Verifier) (*Syncer, error) {
+func NewSyncer(ds dtypes.MetadataDS, sm *stmgr.StateManager, exchange exchange.Client, syncMgrCtor SyncManagerCtor, connmgr connmgr.ConnManager, self peer.ID, beacon beacon.Schedule, verifier ffiwrapper.Verifier) (*Syncer, error) {
 	gen, err := sm.ChainStore().GetGenesis()
 	if err != nil {
 		return nil, xerrors.Errorf("getting genesis block: %w", err)
@@ -181,7 +186,7 @@ func NewSyncer(ds dtypes.MetadataDS, sm *stmgr.StateManager, exchange exchange.C
 		log.Warn("*********************************************************************************************")
 	}
 
-	s.syncmgr = NewSyncManager(s.Sync)
+	s.syncmgr = syncMgrCtor(s.Sync)
 	return s, nil
 }
 
@@ -1665,11 +1670,7 @@ func VerifyElectionPoStVRF(ctx context.Context, worker address.Address, rand []b
 }
 
 func (syncer *Syncer) State() []SyncerState {
-	var out []SyncerState
-	for _, ss := range syncer.syncmgr.syncStates {
-		out = append(out, ss.Snapshot())
-	}
-	return out
+	return syncer.syncmgr.State()
 }
 
 // MarkBad manually adds a block to the "bad blocks" cache.

--- a/chain/sync_manager_test.go
+++ b/chain/sync_manager_test.go
@@ -17,7 +17,7 @@ type syncOp struct {
 	done func()
 }
 
-func runSyncMgrTest(t *testing.T, tname string, thresh int, tf func(*testing.T, *SyncManager, chan *syncOp)) {
+func runSyncMgrTest(t *testing.T, tname string, thresh int, tf func(*testing.T, *syncManager, chan *syncOp)) {
 	syncTargets := make(chan *syncOp)
 	sm := NewSyncManager(func(ctx context.Context, ts *types.TipSet) error {
 		ch := make(chan struct{})
@@ -27,7 +27,7 @@ func runSyncMgrTest(t *testing.T, tname string, thresh int, tf func(*testing.T, 
 		}
 		<-ch
 		return nil
-	})
+	}).(*syncManager)
 	sm.bspThresh = thresh
 
 	sm.Start()
@@ -77,12 +77,12 @@ func TestSyncManager(t *testing.T) {
 	c3 := mock.TipSet(mock.MkBlock(b, 3, 5))
 	d := mock.TipSet(mock.MkBlock(c1, 4, 5))
 
-	runSyncMgrTest(t, "testBootstrap", 1, func(t *testing.T, sm *SyncManager, stc chan *syncOp) {
+	runSyncMgrTest(t, "testBootstrap", 1, func(t *testing.T, sm *syncManager, stc chan *syncOp) {
 		sm.SetPeerHead(ctx, "peer1", c1)
 		assertGetSyncOp(t, stc, c1)
 	})
 
-	runSyncMgrTest(t, "testBootstrap", 2, func(t *testing.T, sm *SyncManager, stc chan *syncOp) {
+	runSyncMgrTest(t, "testBootstrap", 2, func(t *testing.T, sm *syncManager, stc chan *syncOp) {
 		sm.SetPeerHead(ctx, "peer1", c1)
 		assertNoOp(t, stc)
 
@@ -90,7 +90,7 @@ func TestSyncManager(t *testing.T) {
 		assertGetSyncOp(t, stc, c1)
 	})
 
-	runSyncMgrTest(t, "testSyncAfterBootstrap", 1, func(t *testing.T, sm *SyncManager, stc chan *syncOp) {
+	runSyncMgrTest(t, "testSyncAfterBootstrap", 1, func(t *testing.T, sm *syncManager, stc chan *syncOp) {
 		sm.SetPeerHead(ctx, "peer1", b)
 		assertGetSyncOp(t, stc, b)
 
@@ -101,7 +101,7 @@ func TestSyncManager(t *testing.T) {
 		assertGetSyncOp(t, stc, c2)
 	})
 
-	runSyncMgrTest(t, "testCoalescing", 1, func(t *testing.T, sm *SyncManager, stc chan *syncOp) {
+	runSyncMgrTest(t, "testCoalescing", 1, func(t *testing.T, sm *syncManager, stc chan *syncOp) {
 		sm.SetPeerHead(ctx, "peer1", a)
 		assertGetSyncOp(t, stc, a)
 
@@ -122,7 +122,7 @@ func TestSyncManager(t *testing.T) {
 		assertGetSyncOp(t, stc, d)
 	})
 
-	runSyncMgrTest(t, "testSyncIncomingTipset", 1, func(t *testing.T, sm *SyncManager, stc chan *syncOp) {
+	runSyncMgrTest(t, "testSyncIncomingTipset", 1, func(t *testing.T, sm *syncManager, stc chan *syncOp) {
 		sm.SetPeerHead(ctx, "peer1", a)
 		assertGetSyncOp(t, stc, a)
 

--- a/node/builder.go
+++ b/node/builder.go
@@ -242,6 +242,9 @@ func Online() Option {
 			Override(new(dtypes.ChainBlockService), modules.ChainBlockService),
 
 			// Filecoin services
+			// We don't want the SyncManagerCtor to be used as an fx constructor, but rather as a value.
+			// It will be called implicitly by the Syncer constructor.
+			Override(new(chain.SyncManagerCtor), func() chain.SyncManagerCtor { return chain.NewSyncManager }),
 			Override(new(*chain.Syncer), modules.NewSyncer),
 			Override(new(exchange.Client), exchange.NewClient),
 			Override(new(*messagepool.MessagePool), modules.MessagePool),

--- a/node/modules/chain.go
+++ b/node/modules/chain.go
@@ -163,8 +163,31 @@ func NetworkName(mctx helpers.MetricsCtx, lc fx.Lifecycle, cs *store.ChainStore,
 	return netName, err
 }
 
-func NewSyncer(lc fx.Lifecycle, ds dtypes.MetadataDS, sm *stmgr.StateManager, exchange exchange.Client, h host.Host, beacon beacon.Schedule, verifier ffiwrapper.Verifier) (*chain.Syncer, error) {
-	syncer, err := chain.NewSyncer(ds, sm, exchange, h.ConnManager(), h.ID(), beacon, verifier)
+type SyncerParams struct {
+	fx.In
+
+	Lifecycle    fx.Lifecycle
+	MetadataDS   dtypes.MetadataDS
+	StateManager *stmgr.StateManager
+	ChainXchg    exchange.Client
+	SyncMgrCtor  chain.SyncManagerCtor
+	Host         host.Host
+	Beacon       beacon.Schedule
+	Verifier     ffiwrapper.Verifier
+}
+
+func NewSyncer(params SyncerParams) (*chain.Syncer, error) {
+	var (
+		lc     = params.Lifecycle
+		ds     = params.MetadataDS
+		sm     = params.StateManager
+		ex     = params.ChainXchg
+		smCtor = params.SyncMgrCtor
+		h      = params.Host
+		b      = params.Beacon
+		v      = params.Verifier
+	)
+	syncer, err := chain.NewSyncer(ds, sm, ex, smCtor, h.ConnManager(), h.ID(), b, v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For the blockseq test vectors, I need to use a simplified sync manager that does no scheduling or peer tracking, and directly proxies `SyncManager#SetPeerHead` calls to `Syncer#Sync`. Alternatively, I could make blockseq vectors call `Syncer#Sync` directly instead of `Syncer#InformNewHead`, but that's not correct as an entrypoint because the latter does validation that the former doesn't.