### PR TITLE
Update specs-actors to 0.9.10

### DIFF
--- a/chain/events/state/diff_adt.go
+++ b/chain/events/state/diff_adt.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	typegen "github.com/whyrusleeping/cbor-gen"
 )
@@ -69,7 +70,7 @@ func DiffAdtArray(preArr, curArr *adt.Array, out AdtArrayDiff) error {
 // Modify should be called when a value is modified in the map
 // Remove should be called when a value is removed from the map
 type AdtMapDiff interface {
-	AsKey(key string) (adt.Keyer, error)
+	AsKey(key string) (abi.Keyer, error)
 	Add(key string, val *typegen.Deferred) error
 	Modify(key string, from, to *typegen.Deferred) error
 	Remove(key string, val *typegen.Deferred) error

--- a/chain/events/state/diff_adt_test.go
+++ b/chain/events/state/diff_adt_test.go
@@ -11,6 +11,7 @@ import (
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	typegen "github.com/whyrusleeping/cbor-gen"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
@@ -78,21 +79,21 @@ func TestDiffAdtMap(t *testing.T) {
 	mapA := adt.MakeEmptyMap(ctxstoreA)
 	mapB := adt.MakeEmptyMap(ctxstoreB)
 
-	require.NoError(t, mapA.Put(adt.UIntKey(0), runtime.CBORBytes([]byte{0}))) // delete
+	require.NoError(t, mapA.Put(abi.UIntKey(0), runtime.CBORBytes([]byte{0}))) // delete
 
-	require.NoError(t, mapA.Put(adt.UIntKey(1), runtime.CBORBytes([]byte{0}))) // modify
-	require.NoError(t, mapB.Put(adt.UIntKey(1), runtime.CBORBytes([]byte{1})))
+	require.NoError(t, mapA.Put(abi.UIntKey(1), runtime.CBORBytes([]byte{0}))) // modify
+	require.NoError(t, mapB.Put(abi.UIntKey(1), runtime.CBORBytes([]byte{1})))
 
-	require.NoError(t, mapA.Put(adt.UIntKey(2), runtime.CBORBytes([]byte{1}))) // delete
+	require.NoError(t, mapA.Put(abi.UIntKey(2), runtime.CBORBytes([]byte{1}))) // delete
 
-	require.NoError(t, mapA.Put(adt.UIntKey(3), runtime.CBORBytes([]byte{0}))) // noop
-	require.NoError(t, mapB.Put(adt.UIntKey(3), runtime.CBORBytes([]byte{0})))
+	require.NoError(t, mapA.Put(abi.UIntKey(3), runtime.CBORBytes([]byte{0}))) // noop
+	require.NoError(t, mapB.Put(abi.UIntKey(3), runtime.CBORBytes([]byte{0})))
 
-	require.NoError(t, mapA.Put(adt.UIntKey(4), runtime.CBORBytes([]byte{0}))) // modify
-	require.NoError(t, mapB.Put(adt.UIntKey(4), runtime.CBORBytes([]byte{6})))
+	require.NoError(t, mapA.Put(abi.UIntKey(4), runtime.CBORBytes([]byte{0}))) // modify
+	require.NoError(t, mapB.Put(abi.UIntKey(4), runtime.CBORBytes([]byte{6})))
 
-	require.NoError(t, mapB.Put(adt.UIntKey(5), runtime.CBORBytes{8})) // add
-	require.NoError(t, mapB.Put(adt.UIntKey(6), runtime.CBORBytes{9})) // add
+	require.NoError(t, mapB.Put(abi.UIntKey(5), runtime.CBORBytes{8})) // add
+	require.NoError(t, mapB.Put(abi.UIntKey(6), runtime.CBORBytes{9})) // add
 
 	changes := new(TestDiffMap)
 
@@ -134,12 +135,12 @@ type TestDiffMap struct {
 
 var _ AdtMapDiff = &TestDiffMap{}
 
-func (t *TestDiffMap) AsKey(key string) (adt.Keyer, error) {
-	k, err := adt.ParseUIntKey(key)
+func (t *TestDiffMap) AsKey(key string) (abi.Keyer, error) {
+	k, err := abi.ParseUIntKey(key)
 	if err != nil {
 		return nil, err
 	}
-	return adt.UIntKey(k), nil
+	return abi.UIntKey(k), nil
 }
 
 func (t *TestDiffMap) Add(key string, val *typegen.Deferred) error {
@@ -148,7 +149,7 @@ func (t *TestDiffMap) Add(key string, val *typegen.Deferred) error {
 	if err != nil {
 		return err
 	}
-	k, err := adt.ParseUIntKey(key)
+	k, err := abi.ParseUIntKey(key)
 	if err != nil {
 		return err
 	}
@@ -172,7 +173,7 @@ func (t *TestDiffMap) Modify(key string, from, to *typegen.Deferred) error {
 		return err
 	}
 
-	k, err := adt.ParseUIntKey(key)
+	k, err := abi.ParseUIntKey(key)
 	if err != nil {
 		return err
 	}
@@ -198,7 +199,7 @@ func (t *TestDiffMap) Remove(key string, val *typegen.Deferred) error {
 	if err != nil {
 		return err
 	}
-	k, err := adt.ParseUIntKey(key)
+	k, err := abi.ParseUIntKey(key)
 	if err != nil {
 		return err
 	}

--- a/chain/events/state/predicates.go
+++ b/chain/events/state/predicates.go
@@ -537,8 +537,8 @@ type MinerPreCommitChanges struct {
 	Removed []miner.SectorPreCommitOnChainInfo
 }
 
-func (m *MinerPreCommitChanges) AsKey(key string) (adt.Keyer, error) {
-	sector, err := adt.ParseUIntKey(key)
+func (m *MinerPreCommitChanges) AsKey(key string) (abi.Keyer, error) {
+	sector, err := abi.ParseUIntKey(key)
 	if err != nil {
 		return nil, err
 	}
@@ -662,12 +662,12 @@ type AddressChange struct {
 
 type DiffInitActorStateFunc func(ctx context.Context, oldState *init_.State, newState *init_.State) (changed bool, user UserData, err error)
 
-func (i *InitActorAddressChanges) AsKey(key string) (adt.Keyer, error) {
+func (i *InitActorAddressChanges) AsKey(key string) (abi.Keyer, error) {
 	addr, err := address.NewFromBytes([]byte(key))
 	if err != nil {
 		return nil, err
 	}
-	return adt.AddrKey(addr), nil
+	return abi.AddrKey(addr), nil
 }
 
 func (i *InitActorAddressChanges) Add(key string, val *typegen.Deferred) error {

--- a/chain/gen/genesis/t01_init.go
+++ b/chain/gen/genesis/t01_init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -50,7 +51,7 @@ func SetupInitActor(bs bstore.Blockstore, netname string, initialActors []genesi
 				fmt.Printf("init set %s t0%d\n", e, counter)
 
 				value := cbg.CborInt(counter)
-				if err := amap.Put(adt.AddrKey(e), &value); err != nil {
+				if err := amap.Put(abi.AddrKey(e), &value); err != nil {
 					return 0, nil, nil, err
 				}
 				counter = counter + 1
@@ -77,7 +78,7 @@ func SetupInitActor(bs bstore.Blockstore, netname string, initialActors []genesi
 		fmt.Printf("init set %s t0%d\n", ainfo.Owner, counter)
 
 		value := cbg.CborInt(counter)
-		if err := amap.Put(adt.AddrKey(ainfo.Owner), &value); err != nil {
+		if err := amap.Put(abi.AddrKey(ainfo.Owner), &value); err != nil {
 			return 0, nil, nil, err
 		}
 		counter = counter + 1
@@ -95,7 +96,7 @@ func SetupInitActor(bs bstore.Blockstore, netname string, initialActors []genesi
 			return 0, nil, nil, xerrors.Errorf("unmarshaling account meta: %w", err)
 		}
 		value := cbg.CborInt(80)
-		if err := amap.Put(adt.AddrKey(ainfo.Owner), &value); err != nil {
+		if err := amap.Put(abi.AddrKey(ainfo.Owner), &value); err != nil {
 			return 0, nil, nil, err
 		}
 	} else if rootVerifier.Type == genesis.TMultisig {
@@ -110,7 +111,7 @@ func SetupInitActor(bs bstore.Blockstore, netname string, initialActors []genesi
 			fmt.Printf("init set %s t0%d\n", e, counter)
 
 			value := cbg.CborInt(counter)
-			if err := amap.Put(adt.AddrKey(e), &value); err != nil {
+			if err := amap.Put(abi.AddrKey(e), &value); err != nil {
 				return 0, nil, nil, err
 			}
 			counter = counter + 1

--- a/chain/state/statetree.go
+++ b/chain/state/statetree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 
@@ -209,7 +210,7 @@ func (st *StateTree) GetActor(addr address.Address) (*types.Actor, error) {
 	}
 
 	var act types.Actor
-	if found, err := st.root.Get(adt.AddrKey(addr), &act); err != nil {
+	if found, err := st.root.Get(abi.AddrKey(addr), &act); err != nil {
 		return nil, xerrors.Errorf("hamt find failed: %w", err)
 	} else if !found {
 		return nil, types.ErrActorNotFound
@@ -254,11 +255,11 @@ func (st *StateTree) Flush(ctx context.Context) (cid.Cid, error) {
 
 	for addr, sto := range st.snaps.layers[0].actors {
 		if sto.Delete {
-			if err := st.root.Delete(adt.AddrKey(addr)); err != nil {
+			if err := st.root.Delete(abi.AddrKey(addr)); err != nil {
 				return cid.Undef, err
 			}
 		} else {
-			if err := st.root.Put(adt.AddrKey(addr), &sto.Act); err != nil {
+			if err := st.root.Put(abi.AddrKey(addr), &sto.Act); err != nil {
 				return cid.Undef, err
 			}
 		}

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -120,7 +120,7 @@ func GetPowerRaw(ctx context.Context, sm *StateManager, st cid.Cid, maddr addres
 		}
 
 		var claim power.Claim
-		if _, err := cm.Get(adt.AddrKey(maddr), &claim); err != nil {
+		if _, err := cm.Get(abi.AddrKey(maddr), &claim); err != nil {
 			return power.Claim{}, power.Claim{}, err
 		}
 
@@ -312,7 +312,7 @@ func GetMinerSlashed(ctx context.Context, sm *StateManager, ts *types.TipSet, ma
 		return false, err
 	}
 
-	ok, err := claims.Get(power.AddrKey(maddr), nil)
+	ok, err := claims.Get(abi.AddrKey(maddr), nil)
 	if err != nil {
 		return false, err
 	}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -648,7 +648,7 @@ func (syncer *Syncer) minerIsValid(ctx context.Context, maddr address.Address, b
 	}
 
 	var claim power.Claim
-	exist, err := cm.Get(adt.AddrKey(maddr), &claim)
+	exist, err := cm.Get(abi.AddrKey(maddr), &claim)
 	if err != nil {
 		return err
 	}

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -659,7 +659,7 @@ func handleHamtEpoch(ctx context.Context, api api.FullNode, r cid.Cid) error {
 	}
 
 	return mp.ForEach(nil, func(key string) error {
-		ik, err := adt.ParseIntKey(key)
+		ik, err := abi.ParseIntKey(key)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-chainwatch/processor/miner.go
+++ b/cmd/lotus-chainwatch/processor/miner.go
@@ -221,7 +221,7 @@ func (p *Processor) processMiners(ctx context.Context, minerTips map[types.TipSe
 			var claim power.Claim
 			// get miner claim from power actors claim map and store if found, else the miner had no claim at
 			// this tipset
-			found, err := minersClaims.Get(adt.AddrKey(act.addr), &claim)
+			found, err := minersClaims.Get(abi.AddrKey(act.addr), &claim)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
@@ -336,7 +337,7 @@ var verifRegCheckVerifierCmd = &cli.Command{
 		}
 
 		var dcap verifreg.DataCap
-		if found, err := vh.Get(adt.AddrKey(vaddr), &dcap); err != nil {
+		if found, err := vh.Get(abi.AddrKey(vaddr), &dcap); err != nil {
 			return err
 		} else if !found {
 			return fmt.Errorf("not found")

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/filecoin-project/go-statemachine v0.0.0-20200813232949-df9b130df370
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/specs-actors v0.9.9
+	github.com/filecoin-project/specs-actors v0.9.10
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
 	github.com/filecoin-project/test-vectors/schema v0.0.1
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b 
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.7/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
-github.com/filecoin-project/specs-actors v0.9.9 h1:hc1iCks6dv7mpGQXcbYU3hL1WfBRZaVTYE4x2d1l2yw=
-github.com/filecoin-project/specs-actors v0.9.9/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
+github.com/filecoin-project/specs-actors v0.9.10 h1:gU0TrRhgkCsBEOP42sGDE7RQuR0Cov9hJhBqq+RJmjU=
+github.com/filecoin-project/specs-actors v0.9.10/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/test-vectors/schema v0.0.1 h1:5fNF76nl4qolEvcIsjc0kUADlTMVHO73tW4kXXPnsus=

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -300,7 +300,7 @@ func resolveOnce(bs blockstore.Blockstore) func(ctx context.Context, ds ipld.Nod
 				return nil, nil, xerrors.Errorf("parsing int64: %w", err)
 			}
 
-			ik := adt.IntKey(i)
+			ik := abi.IntKey(i)
 
 			names[0] = "@H:" + ik.Key()
 		}
@@ -311,7 +311,7 @@ func resolveOnce(bs blockstore.Blockstore) func(ctx context.Context, ds ipld.Nod
 				return nil, nil, xerrors.Errorf("parsing uint64: %w", err)
 			}
 
-			ik := adt.UIntKey(i)
+			ik := abi.UIntKey(i)
 
 			names[0] = "@H:" + ik.Key()
 		}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -509,7 +509,7 @@ func (a *StateAPI) StateMarketParticipants(ctx context.Context, tsk types.TipSet
 			return err
 		}
 
-		if found, err := locked.Get(adt.AddrKey(a), &lk); err != nil {
+		if found, err := locked.Get(abi.AddrKey(a), &lk); err != nil {
 			return err
 		} else if !found {
 			return fmt.Errorf("locked funds not found")
@@ -604,7 +604,7 @@ func (a *StateAPI) StateChangedActors(ctx context.Context, old cid.Cid, new cid.
 			return xerrors.Errorf("address in state tree was not valid: %w", err)
 		}
 
-		found, err := oh.Get(adt.AddrKey(addr), &ocval)
+		found, err := oh.Get(abi.AddrKey(addr), &ocval)
 		if err != nil {
 			return err
 		}
@@ -1150,7 +1150,7 @@ func (a *StateAPI) StateVerifiedClientStatus(ctx context.Context, addr address.A
 	}
 
 	var dcap verifreg.DataCap
-	if found, err := vh.Get(adt.AddrKey(aid), &dcap); err != nil {
+	if found, err := vh.Get(abi.AddrKey(aid), &dcap); err != nil {
 		return nil, err
 	} else if !found {
 		return nil, nil

--- a/storage/adapter_storage_miner.go
+++ b/storage/adapter_storage_miner.go
@@ -195,7 +195,7 @@ func (s SealingAPIAdapter) StateSectorPreCommitInfo(ctx context.Context, maddr a
 	}
 
 	var pci miner.SectorPreCommitOnChainInfo
-	ok, err := precommits.Get(adt.UIntKey(uint64(sectorNumber)), &pci)
+	ok, err := precommits.Get(abi.UIntKey(uint64(sectorNumber)), &pci)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Moves the Keyer type (and helpers) into go-state-types.