### PR TITLE
Fix payment channel status commands

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -452,8 +452,8 @@ type FullNode interface {
 
 	PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt) (*ChannelInfo, error)
 	PaychGetWaitReady(context.Context, cid.Cid) (address.Address, error)
-	PaychAvailableFunds(ch address.Address) (*ChannelAvailableFunds, error)
-	PaychAvailableFundsByFromTo(from, to address.Address) (*ChannelAvailableFunds, error)
+	PaychAvailableFunds(ctx context.Context, ch address.Address) (*ChannelAvailableFunds, error)
+	PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*ChannelAvailableFunds, error)
 	PaychList(context.Context) ([]address.Address, error)
 	PaychStatus(context.Context, address.Address) (*PaychStatus, error)
 	PaychSettle(context.Context, address.Address) (cid.Cid, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -219,8 +219,8 @@ type FullNodeStruct struct {
 
 		PaychGet                    func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
 		PaychGetWaitReady           func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
-		PaychAvailableFunds         func(address.Address) (*api.ChannelAvailableFunds, error)                                                 `perm:"sign"`
-		PaychAvailableFundsByFromTo func(address.Address, address.Address) (*api.ChannelAvailableFunds, error)                                `perm:"sign"`
+		PaychAvailableFunds         func(context.Context, address.Address) (*api.ChannelAvailableFunds, error)                                `perm:"sign"`
+		PaychAvailableFundsByFromTo func(context.Context, address.Address, address.Address) (*api.ChannelAvailableFunds, error)               `perm:"sign"`
 		PaychList                   func(context.Context) ([]address.Address, error)                                                          `perm:"read"`
 		PaychStatus                 func(context.Context, address.Address) (*api.PaychStatus, error)                                          `perm:"read"`
 		PaychSettle                 func(context.Context, address.Address) (cid.Cid, error)                                                   `perm:"sign"`
@@ -944,12 +944,12 @@ func (c *FullNodeStruct) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid
 	return c.Internal.PaychGetWaitReady(ctx, sentinel)
 }
 
-func (c *FullNodeStruct) PaychAvailableFunds(ch address.Address) (*api.ChannelAvailableFunds, error) {
-	return c.Internal.PaychAvailableFunds(ch)
+func (c *FullNodeStruct) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
+	return c.Internal.PaychAvailableFunds(ctx, ch)
 }
 
-func (c *FullNodeStruct) PaychAvailableFundsByFromTo(from, to address.Address) (*api.ChannelAvailableFunds, error) {
-	return c.Internal.PaychAvailableFundsByFromTo(from, to)
+func (c *FullNodeStruct) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
+	return c.Internal.PaychAvailableFundsByFromTo(ctx, from, to)
 }
 
 func (c *FullNodeStruct) PaychList(ctx context.Context) ([]address.Address, error) {

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -29,6 +29,7 @@ var paychCmd = &cli.Command{
 		paychVoucherCmd,
 		paychSettleCmd,
 		paychStatusCmd,
+		paychStatusByFromToCmd,
 		paychCloseCmd,
 	},
 }

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -103,6 +103,7 @@ var paychStatusByFromToCmd = &cli.Command{
 		if cctx.Args().Len() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <from address> <to address>"))
 		}
+		ctx := ReqContext(cctx)
 
 		from, err := address.NewFromString(cctx.Args().Get(0))
 		if err != nil {
@@ -120,7 +121,7 @@ var paychStatusByFromToCmd = &cli.Command{
 		}
 		defer closer()
 
-		avail, err := api.PaychAvailableFundsByFromTo(from, to)
+		avail, err := api.PaychAvailableFundsByFromTo(ctx, from, to)
 		if err != nil {
 			return err
 		}
@@ -138,6 +139,7 @@ var paychStatusCmd = &cli.Command{
 		if cctx.Args().Len() != 1 {
 			return ShowHelp(cctx, fmt.Errorf("must pass an argument: <channel address>"))
 		}
+		ctx := ReqContext(cctx)
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
 		if err != nil {
@@ -150,7 +152,7 @@ var paychStatusCmd = &cli.Command{
 		}
 		defer closer()
 
-		avail, err := api.PaychAvailableFunds(ch)
+		avail, err := api.PaychAvailableFunds(ctx, ch)
 		if err != nil {
 			return err
 		}

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -2375,7 +2375,12 @@ There are not yet any comments for this method.
 
 Perms: sign
 
-Inputs: `null`
+Inputs:
+```json
+[
+  "t01234"
+]
+```
 
 Response:
 ```json
@@ -2399,6 +2404,7 @@ Perms: sign
 Inputs:
 ```json
 [
+  "t01234",
   "t01234"
 ]
 ```

--- a/markets/retrievaladapter/client.go
+++ b/markets/retrievaladapter/client.go
@@ -80,7 +80,7 @@ func (rcn *retrievalClientNode) WaitForPaymentChannelReady(ctx context.Context, 
 
 func (rcn *retrievalClientNode) CheckAvailableFunds(ctx context.Context, paymentChannel address.Address) (retrievalmarket.ChannelAvailableFunds, error) {
 
-	channelAvailableFunds, err := rcn.payAPI.PaychAvailableFunds(paymentChannel)
+	channelAvailableFunds, err := rcn.payAPI.PaychAvailableFunds(ctx, paymentChannel)
 	if err != nil {
 		return retrievalmarket.ChannelAvailableFunds{}, err
 	}

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -39,11 +39,11 @@ func (a *PaychAPI) PaychGet(ctx context.Context, from, to address.Address, amt t
 	}, nil
 }
 
-func (a *PaychAPI) PaychAvailableFunds(ch address.Address) (*api.ChannelAvailableFunds, error) {
+func (a *PaychAPI) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
 	return a.PaychMgr.AvailableFunds(ch)
 }
 
-func (a *PaychAPI) PaychAvailableFundsByFromTo(from, to address.Address) (*api.ChannelAvailableFunds, error) {
+func (a *PaychAPI) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
 	return a.PaychMgr.AvailableFundsByFromTo(from, to)
 }
 


### PR DESCRIPTION
# Goals

Fix a couple bugs preventing the use of payment channel status commands

# Implementation

- add context to payment channel commands in API
- add status-from-to to commands list