### PR TITLE
add filecoin-project oni as submodule and compile lotus-soup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,6 +447,7 @@ workflows:
           test-suite-name: conformance-bleeding-edge
           packages: "./conformance"
           vectors-branch: master
+      - test-lotus-soup
       - build-debug
       - build-all:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,25 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
+  test-lotus-soup:
+    description: |
+      Compile `lotus-soup` Testground test plan using the current version of Lotus.
+    parameters:
+      <<: *test-params
+    executor: << parameters.executor >>
+    steps:
+      - install-deps
+      - prepare
+      - run: cd extern/oni && git submodule sync
+      - run: cd extern/oni && git submodule update --init
+      - run: cd extern/oni/extra/filecoin-ffi && make
+      - run:
+          name: "update lotus-soup dependency to lotus"
+          command: pushd extern/oni/lotus-soup && echo 'replace github.com/filecoin-project/lotus => ../../../' >> go.mod
+      - run:
+          name: "build lotus-soup testplan"
+          command: pushd extern/oni/lotus-soup && go build -tags=testground .
+
 
   build-macos:
     description: build darwin lotus binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,10 +265,10 @@ jobs:
       - prepare
       - run: cd extern/oni && git submodule sync
       - run: cd extern/oni && git submodule update --init
-      - run: cd extern/oni/extra/filecoin-ffi && make
+      - run: cd extern/filecoin-ffi && make
       - run:
-          name: "update lotus-soup dependency to lotus"
-          command: pushd extern/oni/lotus-soup && echo 'replace github.com/filecoin-project/lotus => ../../../' >> go.mod
+          name: "replace lotus and filecoin-ffi deps"
+          command: pushd extern/oni/lotus-soup && go mod edit -replace github.com/filecoin-project/lotus=../../../ && go mod edit -replace github.com/filecoin-project/filecoin-ffi=../../filecoin-ffi
       - run:
           name: "build lotus-soup testplan"
           command: pushd extern/oni/lotus-soup && go build -tags=testground .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
-  test-lotus-soup:
+  build-lotus-soup:
     description: |
       Compile `lotus-soup` Testground test plan using the current version of Lotus.
     parameters:
@@ -447,7 +447,7 @@ workflows:
           test-suite-name: conformance-bleeding-edge
           packages: "./conformance"
           vectors-branch: master
-      - test-lotus-soup
+      - build-lotus-soup
       - build-debug
       - build-all:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,8 +267,8 @@ jobs:
       - run: cd extern/oni && git submodule update --init
       - run: cd extern/filecoin-ffi && make
       - run:
-          name: "replace lotus and filecoin-ffi deps"
-          command: pushd extern/oni/lotus-soup && go mod edit -replace github.com/filecoin-project/lotus=../../../ && go mod edit -replace github.com/filecoin-project/filecoin-ffi=../../filecoin-ffi
+          name: "replace lotus, filecoin-ffi, blst and fil-blst deps"
+          command: cd extern/oni/lotus-soup && go mod edit -replace github.com/filecoin-project/lotus=../../../ && go mod edit -replace github.com/filecoin-project/filecoin-ffi=../../filecoin-ffi && go mod edit -replace github.com/supranational/blst=../../fil-blst/blst && go mod edit -replace github.com/filecoin-project/fil-blst=../../fil-blst
       - run:
           name: "build lotus-soup testplan"
           command: pushd extern/oni/lotus-soup && go build -tags=testground .

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "extern/fil-blst"]
 	path = extern/fil-blst
 	url = https://github.com/filecoin-project/fil-blst.git
+[submodule "extern/oni"]
+	path = extern/oni
+	url = https://github.com/filecoin-project/oni


### PR DESCRIPTION
This PR is adding `filecoin-project/oni` as a submodule to `lotus` and running a compilation step on every commit for `lotus-soup` test plan, so that we have the test plan in sync with the Lotus code base.

---

The idea of this PR is to make sure that `lotus-soup` test plan stays compatible with `filecoin-project/lotus` and we can run the test plan with a specific schedule (nightly, or every 6 hours, or whatever) based on `lotus` `master` branch.