### PR TITLE
refactor: chaos caller validation

### DIFF
--- a/conformance/chaos/actor.go
+++ b/conformance/chaos/actor.go
@@ -7,8 +7,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/ipfs/go-cid"
-
-	typegen "github.com/whyrusleeping/cbor-gen"
 )
 
 //go:generate go run ./gen
@@ -31,10 +29,14 @@ type Actor struct{}
 type CallerValidationBranch int64
 
 const (
+	// CallerValidationBranchNone causes no caller validation to take place.
 	CallerValidationBranchNone CallerValidationBranch = iota
+	// CallerValidationBranchTwice causes Runtime.ValidateImmediateCallerAcceptAny to be called twice.
 	CallerValidationBranchTwice
-	CallerValidationBranchAddrNilSet
-	CallerValidationBranchTypeNilSet
+	// CallerValidationBranchIs causes caller validation against CallerValidationArgs.Addrs.
+	CallerValidationBranchIs
+	// CallerValidationBranchType causes caller validation against CallerValidationArgs.Types.
+	CallerValidationBranchType
 )
 
 // MutateStateBranch is an enum used to select the type of state mutation to attempt.
@@ -123,23 +125,29 @@ func (a Actor) Constructor(_ runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue
 	panic("constructor should not be called; the Chaos actor is a singleton actor")
 }
 
+// CallerValidationArgs are the arguments to Actor.CallerValidation.
+type CallerValidationArgs struct {
+	Branch CallerValidationBranch
+	Addrs  []address.Address
+	Types  []cid.Cid
+}
+
 // CallerValidation violates VM call validation constraints.
 //
 //  CallerValidationBranchNone performs no validation.
 //  CallerValidationBranchTwice validates twice.
-//  CallerValidationBranchAddrNilSet validates against an empty caller
-//  address set.
-//  CallerValidationBranchTypeNilSet validates against an empty caller type set.
-func (a Actor) CallerValidation(rt runtime.Runtime, branch *typegen.CborInt) *abi.EmptyValue {
-	switch CallerValidationBranch(*branch) {
+//  CallerValidationBranchIs validates caller against CallerValidationArgs.Addrs.
+//  CallerValidationBranchType validates caller against CallerValidationArgs.Types.
+func (a Actor) CallerValidation(rt runtime.Runtime, args *CallerValidationArgs) *abi.EmptyValue {
+	switch args.Branch {
 	case CallerValidationBranchNone:
 	case CallerValidationBranchTwice:
 		rt.ValidateImmediateCallerAcceptAny()
 		rt.ValidateImmediateCallerAcceptAny()
-	case CallerValidationBranchAddrNilSet:
-		rt.ValidateImmediateCallerIs()
-	case CallerValidationBranchTypeNilSet:
-		rt.ValidateImmediateCallerType()
+	case CallerValidationBranchIs:
+		rt.ValidateImmediateCallerIs(args.Addrs...)
+	case CallerValidationBranchType:
+		rt.ValidateImmediateCallerType(args.Types...)
 	default:
 		panic("invalid branch passed to CallerValidation")
 	}

--- a/conformance/chaos/actor.go
+++ b/conformance/chaos/actor.go
@@ -35,6 +35,8 @@ const (
 	CallerValidationBranchTwice
 	// CallerValidationBranchIs causes caller validation against CallerValidationArgs.Addrs.
 	CallerValidationBranchIs
+	// CallerValidationBranchIsReceiver causes validation that the caller was also the receiver.
+	CallerValidationBranchIsReceiver
 	// CallerValidationBranchType causes caller validation against CallerValidationArgs.Types.
 	CallerValidationBranchType
 )
@@ -146,6 +148,8 @@ func (a Actor) CallerValidation(rt runtime.Runtime, args *CallerValidationArgs) 
 		rt.ValidateImmediateCallerAcceptAny()
 	case CallerValidationBranchIs:
 		rt.ValidateImmediateCallerIs(args.Addrs...)
+	case CallerValidationBranchIsReceiver:
+		rt.ValidateImmediateCallerIs(rt.Message().Receiver())
 	case CallerValidationBranchType:
 		rt.ValidateImmediateCallerType(args.Types...)
 	default:

--- a/conformance/chaos/actor_test.go
+++ b/conformance/chaos/actor_test.go
@@ -2,15 +2,15 @@ package chaos
 
 import (
 	"context"
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/ipfs/go-cid"
 	"testing"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/support/mock"
 	atesting "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/ipfs/go-cid"
 )
 
 func TestSingleton(t *testing.T) {

--- a/conformance/chaos/actor_test.go
+++ b/conformance/chaos/actor_test.go
@@ -2,6 +2,9 @@ package chaos
 
 import (
 	"context"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/ipfs/go-cid"
 	"testing"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -20,6 +23,108 @@ func TestSingleton(t *testing.T) {
 	msg := "constructor should not be called; the Chaos actor is a singleton actor"
 	rt.ExpectAssertionFailure(msg, func() {
 		rt.Call(a.Constructor, abi.Empty)
+	})
+	rt.Verify()
+}
+
+func TestCallerValidationNone(t *testing.T) {
+	receiver := atesting.NewIDAddr(t, 100)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	var a Actor
+
+	rt.Call(a.CallerValidation, &CallerValidationArgs{Branch: CallerValidationBranchNone})
+	rt.Verify()
+}
+
+func TestCallerValidationIs(t *testing.T) {
+	caller := atesting.NewIDAddr(t, 100)
+	receiver := atesting.NewIDAddr(t, 101)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	var a Actor
+
+	caddrs := []address.Address{atesting.NewIDAddr(t, 101)}
+
+	rt.ExpectValidateCallerAddr(caddrs...)
+	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1155
+	rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.Call(a.CallerValidation, &CallerValidationArgs{
+			Branch: CallerValidationBranchIs,
+			Addrs:  caddrs,
+		})
+	})
+	rt.Verify()
+
+	rt.ExpectValidateCallerAddr(caller)
+	rt.Call(a.CallerValidation, &CallerValidationArgs{
+		Branch: CallerValidationBranchIs,
+		Addrs:  []address.Address{caller},
+	})
+	rt.Verify()
+}
+
+func TestCallerValidationIsReceiver(t *testing.T) {
+	caller := atesting.NewIDAddr(t, 100)
+	receiver := atesting.NewIDAddr(t, 101)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	var a Actor
+
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(receiver)
+	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1155
+	rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.Call(a.CallerValidation, &CallerValidationArgs{Branch: CallerValidationBranchIsReceiver})
+	})
+	rt.Verify()
+
+	rt.SetCaller(receiver, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(receiver)
+	rt.Call(a.CallerValidation, &CallerValidationArgs{Branch: CallerValidationBranchIsReceiver})
+	rt.Verify()
+}
+
+func TestCallerValidationType(t *testing.T) {
+	caller := atesting.NewIDAddr(t, 100)
+	receiver := atesting.NewIDAddr(t, 101)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	var a Actor
+
+	rt.ExpectValidateCallerType(builtin.CronActorCodeID)
+	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1155
+	rt.ExpectAbort(exitcode.ErrForbidden, func() {
+		rt.Call(a.CallerValidation, &CallerValidationArgs{
+			Branch: CallerValidationBranchType,
+			Types:  []cid.Cid{builtin.CronActorCodeID},
+		})
+	})
+	rt.Verify()
+
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.Call(a.CallerValidation, &CallerValidationArgs{
+		Branch: CallerValidationBranchType,
+		Types:  []cid.Cid{builtin.AccountActorCodeID},
+	})
+	rt.Verify()
+}
+
+func TestCallerValidationInvalidBranch(t *testing.T) {
+	receiver := atesting.NewIDAddr(t, 100)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	var a Actor
+
+	rt.ExpectAssertionFailure("invalid branch passed to CallerValidation", func() {
+		rt.Call(a.CallerValidation, &CallerValidationArgs{Branch: -1})
 	})
 	rt.Verify()
 }
@@ -114,6 +219,20 @@ func TestMutateStateReadonly(t *testing.T) {
 		t.Fatal("state was not expected to be updated")
 	}
 
+	rt.Verify()
+}
+
+func TestMutateStateInvalidBranch(t *testing.T) {
+	receiver := atesting.NewIDAddr(t, 100)
+	builder := mock.NewBuilder(context.Background(), receiver)
+
+	rt := builder.Build(t)
+	var a Actor
+
+	rt.ExpectValidateCallerAny()
+	rt.ExpectAssertionFailure("unknown mutation type", func() {
+		rt.Call(a.MutateState, &MutateStateArgs{Branch: -1})
+	})
 	rt.Verify()
 }
 

--- a/conformance/chaos/cbor_gen.go
+++ b/conformance/chaos/cbor_gen.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 
+	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	exitcode "github.com/filecoin-project/go-state-types/exitcode"
+	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )
@@ -110,6 +112,163 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.Unmarshallable[i] = &v
+	}
+
+	return nil
+}
+
+var lengthBufCallerValidationArgs = []byte{131}
+
+func (t *CallerValidationArgs) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCallerValidationArgs); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Branch (chaos.CallerValidationBranch) (int64)
+	if t.Branch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Branch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Branch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Addrs ([]address.Address) (slice)
+	if len(t.Addrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Addrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Addrs))); err != nil {
+		return err
+	}
+	for _, v := range t.Addrs {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.Types ([]cid.Cid) (slice)
+	if len(t.Types) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Types was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Types))); err != nil {
+		return err
+	}
+	for _, v := range t.Types {
+		if err := cbg.WriteCidBuf(scratch, w, v); err != nil {
+			return xerrors.Errorf("failed writing cid field t.Types: %w", err)
+		}
+	}
+	return nil
+}
+
+func (t *CallerValidationArgs) UnmarshalCBOR(r io.Reader) error {
+	*t = CallerValidationArgs{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Branch (chaos.CallerValidationBranch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Branch = CallerValidationBranch(extraI)
+	}
+	// t.Addrs ([]address.Address) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Addrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Addrs = make([]address.Address, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v address.Address
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Addrs[i] = v
+	}
+
+	// t.Types ([]cid.Cid) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Types: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Types = make([]cid.Cid, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("reading cid field t.Types failed: %w", err)
+		}
+		t.Types[i] = c
 	}
 
 	return nil

--- a/conformance/chaos/gen/gen.go
+++ b/conformance/chaos/gen/gen.go
@@ -9,6 +9,7 @@ import (
 func main() {
 	if err := gen.WriteTupleEncodersToFile("../cbor_gen.go", "chaos",
 		chaos.State{},
+		chaos.CallerValidationArgs{},
 		chaos.CreateActorArgs{},
 		chaos.ResolveAddressResponse{},
 		chaos.SendArgs{},


### PR DESCRIPTION
This PR refactors the `CallerValidation` method in the chaos actor allowing it to accept caller addresses and caller type CIDs. It also adds a new branch that allows testing caller validation for internal sends to self and additionally that `Runtime.Message().Receiver()` returns ID addresses not robust addresses.

This allows us to create test vectors for https://github.com/filecoin-project/test-vectors/issues/128 and also allows us to add a few vectors that test caller validation for non-nil addresses and type cids.