### PR TITLE
make sure lotus compiles with +testground build flag

### DIFF
--- a/tools/stats/metrics.go
+++ b/tools/stats/metrics.go
@@ -189,7 +189,7 @@ func RecordTipsetPoints(ctx context.Context, api api.FullNode, pl *PointList, ti
 		pl.AddPoint(p)
 	}
 	{
-		blks := len(cids)
+		blks := int64(len(cids))
 		p = NewPoint("chain.gas_fill_ratio", float64(totalGasLimit)/float64(blks*build.BlockGasTarget))
 		pl.AddPoint(p)
 		p = NewPoint("chain.gas_capacity_ratio", float64(totalUniqGasLimit)/float64(blks*build.BlockGasTarget))


### PR DESCRIPTION
When compiling with the `+testground` build flag, `build.BlockGasTarget` is `var` of type `int64`, so compilation fails (see https://app.circleci.com/pipelines/github/filecoin-project/lotus/9331/workflows/a5f2a904-452e-4853-80a2-5325b7bbc3df/jobs/60386)