### PR TITLE
Use `window post` for window PoSt related log messages.

### DIFF
--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -554,7 +554,7 @@ func MinerGetBaseInfo(ctx context.Context, sm *StateManager, bcs beacon.Schedule
 
 	sectors, err := GetSectorsForWinningPoSt(ctx, pv, sm, lbst, maddr, prand)
 	if err != nil {
-		return nil, xerrors.Errorf("getting wpost proving set: %w", err)
+		return nil, xerrors.Errorf("getting winning post proving set: %w", err)
 	}
 
 	if len(sectors) == 0 {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -991,7 +991,7 @@ func (syncer *Syncer) VerifyWinningPoStProof(ctx context.Context, h *types.Block
 
 	rand, err := store.DrawRandomness(rbase.Data, crypto.DomainSeparationTag_WinningPoStChallengeSeed, h.Height, buf.Bytes())
 	if err != nil {
-		return xerrors.Errorf("failed to get randomness for verifying winningPost proof: %w", err)
+		return xerrors.Errorf("failed to get randomness for verifying winning post proof: %w", err)
 	}
 
 	mid, err := address.IDFromAddress(h.Miner)

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -387,7 +387,7 @@ var sealBenchCmd = &cli.Command{
 				return err
 			}
 			if !ok {
-				log.Error("post verification failed")
+				log.Error("window post verification failed")
 			}
 
 			verifyWindowpost1 := time.Now()
@@ -403,7 +403,7 @@ var sealBenchCmd = &cli.Command{
 				return err
 			}
 			if !ok {
-				log.Error("post verification failed")
+				log.Error("window post verification failed")
 			}
 
 			verifyWindowpost2 := time.Now()

--- a/storage/addresses.go
+++ b/storage/addresses.go
@@ -60,7 +60,7 @@ func AddressFor(ctx context.Context, a addrSelectApi, mi api.MinerInfo, use Addr
 			return addr, nil
 		}
 
-		log.Warnw("control address didn't have enough funds for PoSt message", "address", addr, "required", types.FIL(minFunds), "balance", types.FIL(b))
+		log.Warnw("control address didn't have enough funds for window post message", "address", addr, "required", types.FIL(minFunds), "balance", types.FIL(b))
 	}
 
 	// Try to use the owner account if we can, fallback to worker if we can't

--- a/storage/wdpost_sched.go
+++ b/storage/wdpost_sched.go
@@ -110,7 +110,7 @@ func (s *WindowPoStScheduler) Run(ctx context.Context) {
 		select {
 		case changes, ok := <-notifs:
 			if !ok {
-				log.Warn("WindowPoStScheduler notifs channel closed")
+				log.Warn("window post scheduler notifs channel closed")
 				notifs = nil
 				continue
 			}
@@ -151,10 +151,10 @@ func (s *WindowPoStScheduler) Run(ctx context.Context) {
 			}
 
 			if err := s.revert(ctx, lowest); err != nil {
-				log.Error("handling head reverts in windowPost sched: %+v", err)
+				log.Error("handling head reverts in window post sched: %+v", err)
 			}
 			if err := s.update(ctx, highest); err != nil {
-				log.Error("handling head updates in windowPost sched: %+v", err)
+				log.Error("handling head updates in window post sched: %+v", err)
 			}
 
 			span.End()
@@ -184,7 +184,7 @@ func (s *WindowPoStScheduler) revert(ctx context.Context, newLowest *types.TipSe
 
 func (s *WindowPoStScheduler) update(ctx context.Context, new *types.TipSet) error {
 	if new == nil {
-		return xerrors.Errorf("no new tipset in WindowPoStScheduler.update")
+		return xerrors.Errorf("no new tipset in window post sched update")
 	}
 
 	di, err := s.api.StateMinerProvingDeadline(ctx, s.actor, new.Key())
@@ -206,7 +206,7 @@ func (s *WindowPoStScheduler) update(ctx context.Context, new *types.TipSet) err
 	//  (Need to get correct deadline above, which is tricky)
 
 	if di.Open+StartConfidence >= new.Height() {
-		log.Info("not starting windowPost yet, waiting for startconfidence", di.Open, di.Open+StartConfidence, new.Height())
+		log.Info("not starting window post yet, waiting for startconfidence", di.Open, di.Open+StartConfidence, new.Height())
 		return nil
 	}
 
@@ -216,7 +216,7 @@ func (s *WindowPoStScheduler) update(ctx context.Context, new *types.TipSet) err
 		s.activeEPS = 0
 	}
 	s.failLk.Unlock()*/
-	log.Infof("at %d, doPost for P %d, dd %d", new.Height(), di.PeriodStart, di.Index)
+	log.Infof("at %d, do window post for P %d, dd %d", new.Height(), di.PeriodStart, di.Index)
 
 	s.doPost(ctx, di, new)
 
@@ -238,7 +238,7 @@ func (s *WindowPoStScheduler) abortActivePoSt() {
 			}
 		})
 
-		log.Warnf("Aborting Window PoSt (Deadline: %+v)", s.activeDeadline)
+		log.Warnf("Aborting window post (Deadline: %+v)", s.activeDeadline)
 	}
 
 	s.activeDeadline = nil


### PR DESCRIPTION
This is to make filter out window PoSt related log messages easier.