### PR TITLE
break out of mining loop when stop is called during niceSleep

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -139,7 +139,7 @@ func (m *Miner) niceSleep(d time.Duration) bool {
 	case <-build.Clock.After(d):
 		return true
 	case <-m.stop:
-		log.Infow("recieved interrupt while trying to sleep in mining cycle")
+		log.Infow("received interrupt while trying to sleep in mining cycle")
 		return false
 	}
 }


### PR DESCRIPTION
I received 4MM logs of `failed to get best mining candidate: RPC client error: sendRequest failed: websocket routine exiting` in 60 seconds after the lotus daemon died.

Probably not the correct way to handle this but we need to handle this better.