### PR TITLE
Add get-ask, set-ask retrieval commands

### DIFF
--- a/cmd/lotus-storage-miner/retrieval-deals.go
+++ b/cmd/lotus-storage-miner/retrieval-deals.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/docker/go-units"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 )
 
@@ -17,6 +20,8 @@ var retrievalDealsCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		retrievalDealSelectionCmd,
 		retrievalDealsListCmd,
+		retrievalSetAskCmd,
+		retrievalGetAskCmd,
 	},
 }
 
@@ -152,5 +157,114 @@ var retrievalDealsListCmd = &cli.Command{
 		}
 
 		return w.Flush()
+	},
+}
+
+var retrievalSetAskCmd = &cli.Command{
+	Name:  "set-ask",
+	Usage: "Configure the provider's retrieval ask",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "price",
+			Usage: "Set the price of the ask for retrievals (per byte)",
+		},
+		&cli.StringFlag{
+			Name:  "unseal-price",
+			Usage: "Set the price to unseal",
+		},
+		&cli.StringFlag{
+			Name:        "payment-interval",
+			Usage:       "Set the payment interval (in bytes) for retrieval",
+			DefaultText: "1Mb",
+		},
+		&cli.StringFlag{
+			Name:        "payment-interval-increase",
+			Usage:       "Set the payment interval increase (in bytes) for retrieval",
+			DefaultText: "1Mb",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lcli.DaemonContext(cctx)
+
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ask, err := api.MarketGetRetrievalAsk(ctx)
+		if err != nil {
+			return err
+		}
+
+		if cctx.IsSet("price") {
+			v, err := types.ParseFIL(cctx.String("price"))
+			if err != nil {
+				return err
+			}
+			ask.PricePerByte = abi.TokenAmount(v)
+		}
+
+		if cctx.IsSet("unseal-price") {
+			v, err := types.ParseFIL(cctx.String("unseal-price"))
+			if err != nil {
+				return err
+			}
+			ask.UnsealPrice = abi.TokenAmount(v)
+		}
+
+		if cctx.IsSet("payment-interval") {
+			v, err := units.RAMInBytes(cctx.String("payment-interval"))
+			if err != nil {
+				return err
+			}
+			ask.PaymentInterval = uint64(v)
+		}
+
+		if cctx.IsSet("payment-interval-increase") {
+			v, err := units.RAMInBytes(cctx.String("payment-interval-increase"))
+			if err != nil {
+				return err
+			}
+			ask.PaymentIntervalIncrease = uint64(v)
+		}
+
+		return api.MarketSetRetrievalAsk(ctx, ask)
+	},
+}
+
+var retrievalGetAskCmd = &cli.Command{
+	Name:  "get-ask",
+	Usage: "Get the provider's current retrieval ask",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		ctx := lcli.DaemonContext(cctx)
+
+		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ask, err := api.MarketGetRetrievalAsk(ctx)
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+		fmt.Fprintf(w, "Price per Byte\tUnseal Price\tPayment Interval\tPayment Interval Increase\n")
+		if ask == nil {
+			fmt.Fprintf(w, "<miner does not have an retrieval ask set>\n")
+			return w.Flush()
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			types.FIL(ask.PricePerByte),
+			types.FIL(ask.UnsealPrice),
+			units.BytesSize(float64(ask.PaymentInterval)),
+			units.BytesSize(float64(ask.PaymentIntervalIncrease)),
+		)
+		return w.Flush()
+
 	},
 }

--- a/cmd/lotus-storage-miner/retrieval-deals.go
+++ b/cmd/lotus-storage-miner/retrieval-deals.go
@@ -170,17 +170,17 @@ var retrievalSetAskCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "unseal-price",
-			Usage: "Set the price to unseal",
+			Usage: "Set the price to unseal (FIL/GiB)",
 		},
 		&cli.StringFlag{
 			Name:        "payment-interval",
 			Usage:       "Set the payment interval (in bytes) for retrieval",
-			DefaultText: "1Mb",
+			DefaultText: "1MiB",
 		},
 		&cli.StringFlag{
 			Name:        "payment-interval-increase",
 			Usage:       "Set the payment interval increase (in bytes) for retrieval",
-			DefaultText: "1Mb",
+			DefaultText: "1MiB",
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-storage-miner/retrieval-deals.go
+++ b/cmd/lotus-storage-miner/retrieval-deals.go
@@ -166,11 +166,11 @@ var retrievalSetAskCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "price",
-			Usage: "Set the price of the ask for retrievals (per byte)",
+			Usage: "Set the price of the ask for retrievals (FIL/GiB)",
 		},
 		&cli.StringFlag{
 			Name:  "unseal-price",
-			Usage: "Set the price to unseal (FIL/GiB)",
+			Usage: "Set the price to unseal",
 		},
 		&cli.StringFlag{
 			Name:        "payment-interval",
@@ -202,7 +202,7 @@ var retrievalSetAskCmd = &cli.Command{
 			if err != nil {
 				return err
 			}
-			ask.PricePerByte = abi.TokenAmount(v)
+			ask.PricePerByte = types.BigDiv(types.BigInt(v), types.NewInt(1<<30))
 		}
 
 		if cctx.IsSet("unseal-price") {


### PR DESCRIPTION
## Summary
Expose `MarketGetRetrievalAsk`, `MarketSetRetrievalAsk` APIs via the CLI.

The `set-ask` command allows you to modify any or all parameters of the current ask.

Resolves #3843 