### PR TITLE
fix conformance gen

### DIFF
--- a/conformance/chaos/cbor_gen.go
+++ b/conformance/chaos/cbor_gen.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/exitcode"
+	abi "github.com/filecoin-project/go-state-types/abi"
+	exitcode "github.com/filecoin-project/go-state-types/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
-	"golang.org/x/xerrors"
+	xerrors "golang.org/x/xerrors"
 )
 
 var _ = xerrors.Errorf

--- a/conformance/chaos/gen/gen.go
+++ b/conformance/chaos/gen/gen.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	if err := gen.WriteTupleEncodersToFile("../cbor_gen.go", "chaos",
+	if err := gen.WriteTupleEncodersToFile("./cbor_gen.go", "chaos",
 		chaos.State{},
 		chaos.CreateActorArgs{},
 		chaos.ResolveAddressResponse{},


### PR DESCRIPTION
when `make gen` . The cbor_gen.go generated in conformance folder, but it should be in chaos folder.