### PR TITLE
Replace pubsub.Subscribe() with pubsub.Join() and topic.Subscribe()

### DIFF
--- a/chain/metrics/consensus.go
+++ b/chain/metrics/consensus.go
@@ -44,7 +44,11 @@ func SendHeadNotifs(nickname string) func(mctx helpers.MetricsCtx, lc fx.Lifecyc
 					}
 				}()
 				go func() {
-					sub, err := ps.Subscribe(topic) //nolint
+					topic, err := ps.Join(topic)
+					if err != nil {
+						return
+					}
+					sub, err := topic.Subscribe()
 					if err != nil {
 						return
 					}

--- a/cmd/lotus-townhall/main.go
+++ b/cmd/lotus-townhall/main.go
@@ -106,7 +106,11 @@ func handler(ps *pubsub.PubSub) func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		sub, err := ps.Subscribe(topic) //nolint
+		topic, err := ps.Join(topic)
+		if err != nil {
+			return
+		}
+		sub, err := topic.Subscribe()
 		if err != nil {
 			return
 		}

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -81,7 +81,12 @@ func RunChainExchange(h host.Host, svc exchange.Server) {
 func HandleIncomingBlocks(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.PubSub, s *chain.Syncer, bserv dtypes.ChainBlockService, chain *store.ChainStore, stmgr *stmgr.StateManager, h host.Host, nn dtypes.NetworkName) {
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
-	blocksub, err := ps.Subscribe(build.BlocksTopic(nn)) //nolint
+	topic, err := ps.Join(build.BlocksTopic(nn))
+	if err != nil {
+		panic(err)
+	}
+
+	blocksub, err := topic.Subscribe()
 	if err != nil {
 		panic(err)
 	}
@@ -103,7 +108,11 @@ func HandleIncomingBlocks(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.P
 func HandleIncomingMessages(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.PubSub, mpool *messagepool.MessagePool, h host.Host, nn dtypes.NetworkName) {
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
-	msgsub, err := ps.Subscribe(build.MessagesTopic(nn)) //nolint:staticcheck
+	topic, err := ps.Join(build.BlocksTopic(nn))
+	if err != nil {
+		panic(err)
+	}
+	msgsub, err := topic.Subscribe()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
// Deprecated: use pubsub.Join() and topic.Subscribe() instead
func (p *PubSub) Subscribe(topic string, opts ...SubOpt) (*Subscription, error)

Tested handleincomingblocks function, the test passed.