### PR TITLE
optimize BlocksTopic

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -278,6 +278,7 @@ func Online() Option {
 			Override(SetGenesisKey, modules.DoSetGenesis),
 
 			Override(new(dtypes.NetworkName), modules.NetworkName),
+			Override(new(*dtypes.BlocksTopic), modules.BlocksTopic),
 			Override(new(*hello.Service), hello.NewHelloService),
 			Override(new(exchange.Server), exchange.NewServer),
 			Override(new(*peermgr.PeerMgr), peermgr.NewPeerMgr),

--- a/node/impl/full/sync.go
+++ b/node/impl/full/sync.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -21,8 +20,7 @@ type SyncAPI struct {
 
 	SlashFilter *slashfilter.SlashFilter
 	Syncer      *chain.Syncer
-	PubSub      *pubsub.PubSub
-	NetName     dtypes.NetworkName
+	Topic       *dtypes.BlocksTopic
 }
 
 func (a *SyncAPI) SyncState(ctx context.Context) (*api.SyncState, error) {
@@ -89,8 +87,7 @@ func (a *SyncAPI) SyncSubmitBlock(ctx context.Context, blk *types.BlockMsg) erro
 	if err != nil {
 		return xerrors.Errorf("serializing block for pubsub publishing failed: %w", err)
 	}
-
-	return a.PubSub.Publish(build.BlocksTopic(a.NetName), b) //nolint:staticcheck
+	return (*pubsub.Topic)(a.Topic).Publish(ctx, b)
 }
 
 func (a *SyncAPI) SyncIncomingBlocks(ctx context.Context) (<-chan *types.BlockHeader, error) {

--- a/node/modules/chain.go
+++ b/node/modules/chain.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
 
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/exchange"
@@ -161,6 +162,14 @@ func NetworkName(mctx helpers.MetricsCtx, lc fx.Lifecycle, cs *store.ChainStore,
 
 	netName, err := stmgr.GetNetworkName(ctx, stmgr.NewStateManager(cs), cs.GetHeaviestTipSet().ParentState())
 	return netName, err
+}
+
+func BlocksTopic(ps *pubsub.PubSub, nn dtypes.NetworkName) (*dtypes.BlocksTopic, error) {
+	topic, err := ps.Join(build.BlocksTopic(nn))
+	if err != nil {
+		return nil, err
+	}
+	return (*dtypes.BlocksTopic)(topic), nil
 }
 
 type SyncerParams struct {

--- a/node/modules/dtypes/chain.go
+++ b/node/modules/dtypes/chain.go
@@ -1,4 +1,7 @@
 package dtypes
 
+import pubsub "github.com/libp2p/go-libp2p-pubsub"
+
 type NetworkName string
 type AfterGenesisSet struct{}
+type BlocksTopic pubsub.Topic

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -78,10 +78,10 @@ func RunChainExchange(h host.Host, svc exchange.Server) {
 	h.SetStreamHandler(exchange.ChainExchangeProtocolID, svc.HandleStream) // new
 }
 
-func HandleIncomingBlocks(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.PubSub, s *chain.Syncer, bserv dtypes.ChainBlockService, chain *store.ChainStore, stmgr *stmgr.StateManager, h host.Host, nn dtypes.NetworkName) {
+func HandleIncomingBlocks(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.PubSub, s *chain.Syncer, bserv dtypes.ChainBlockService, chain *store.ChainStore, stmgr *stmgr.StateManager, h host.Host, topic *dtypes.BlocksTopic) {
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
-	blocksub, err := ps.Subscribe(build.BlocksTopic(nn)) //nolint
+	blocksub, err := (*pubsub.Topic)(topic).Subscribe()
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +93,7 @@ func HandleIncomingBlocks(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub.P
 			h.ConnManager().TagPeer(p, "badblock", -1000)
 		})
 
-	if err := ps.RegisterTopicValidator(build.BlocksTopic(nn), v.Validate); err != nil {
+	if err := ps.RegisterTopicValidator((*pubsub.Topic)(topic).String(), v.Validate); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
// Deprecated: use pubsub.Join() and topic.Subscribe() instead
func (p *PubSub) Subscribe(topic string, opts ...SubOpt) (*Subscription, error)

// Deprecated: use pubsub.Join() and topic.Publish() instead
func (p *PubSub) Publish(topic string, data []byte, opts ...PubOpt)

add optimize BlocksTopic

optimize MessagesTopic  later