### PR TITLE
add init.State#Remove() for testing.

### DIFF
--- a/chain/actors/builtin/init/init.go
+++ b/chain/actors/builtin/init/init.go
@@ -36,4 +36,9 @@ type State interface {
 	NetworkName() (dtypes.NetworkName, error)
 
 	ForEachActor(func(id abi.ActorID, address address.Address) error) error
+
+	// Remove exists to support tooling that manipulates state for testing.
+	// It should not be used in production code, as init actor entries are
+	// immutable.
+	Remove(addrs ...address.Address) error
 }


### PR DESCRIPTION
As discussed in https://github.com/filecoin-project/oni/pull/260 and off-band. Unfortunately there is no non-intrusive way of doing this. Reflection won't work on private types/fields, and even if we reconstructed the v0 state from scratch, we can't access `NextAddress`.