### PR TITLE
Add glif node to bootstrap peers

### DIFF
--- a/build/bootstrap/bootstrappers.pi
+++ b/build/bootstrap/bootstrappers.pi
@@ -4,3 +4,4 @@
 /dns4/bootstrap-4.testnet.fildev.network/tcp/1347/p2p/12D3KooWPkL9LrKRQgHtq7kn9ecNhGU9QaziG8R5tX8v9v7t3h34
 /dns4/bootstrap-3.testnet.fildev.network/tcp/1347/p2p/12D3KooWKYSsbpgZ3HAjax5M1BXCwXLa6gVkUARciz7uN3FNtr7T
 /dns4/bootstrap-5.testnet.fildev.network/tcp/1347/p2p/12D3KooWQYzqnLASJAabyMpPb1GcWZvNSe7JDcRuhdRqonFoiK9W
+/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt


### PR DESCRIPTION
To make network even more resilient we need to increase a number of trusted distributed bootstrap peers. Glif's node can become one of these peers.
CC @momack2