### PR TITLE
Use abstract types for Dont recompute post on revert

### DIFF
--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -21,6 +21,10 @@ import (
 // Unchanged between v0 and v1 actors
 var PreCommitChallengeDelay = miner0.PreCommitChallengeDelay
 var WPoStProvingPeriod = miner0.WPoStProvingPeriod
+var WPoStPeriodDeadlines = miner0.WPoStPeriodDeadlines
+var WPoStChallengeWindow = miner0.WPoStChallengeWindow
+var WPoStChallengeLookback = miner0.WPoStChallengeLookback
+var FaultDeclarationCutoff = miner0.FaultDeclarationCutoff
 
 const MinSectorExpiration = miner0.MinSectorExpiration
 

--- a/storage/wdpost_changehandler.go
+++ b/storage/wdpost_changehandler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -529,5 +529,9 @@ func nextDeadline(currentDeadline *dline.Info) *dline.Info {
 		periodStart = periodStart + miner.WPoStProvingPeriod
 	}
 
-	return miner.NewDeadlineInfo(periodStart, newDeadline, currentDeadline.CurrentEpoch)
+	return NewDeadlineInfo(periodStart, newDeadline, currentDeadline.CurrentEpoch)
+}
+
+func NewDeadlineInfo(periodStart abi.ChainEpoch, deadlineIdx uint64, currEpoch abi.ChainEpoch) *dline.Info {
+	return dline.NewInfo(periodStart, deadlineIdx, currEpoch, miner.WPoStPeriodDeadlines, miner.WPoStProvingPeriod, miner.WPoStChallengeWindow, miner.WPoStChallengeLookback, miner.FaultDeclarationCutoff)
 }

--- a/storage/wdpost_changehandler_test.go
+++ b/storage/wdpost_changehandler_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/dline"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 )
 
 var dummyCid cid.Cid
@@ -90,7 +90,7 @@ func (m *mockAPI) getDeadline(currentEpoch abi.ChainEpoch) *dline.Info {
 		close += miner.WPoStChallengeWindow
 		dlIdx++
 	}
-	return miner.NewDeadlineInfo(0, dlIdx, currentEpoch)
+	return NewDeadlineInfo(0, dlIdx, currentEpoch)
 }
 
 func (m *mockAPI) StateMinerProvingDeadline(ctx context.Context, address address.Address, key types.TipSetKey) (*dline.Info, error) {
@@ -355,7 +355,7 @@ func TestChangeHandlerDontStartUntilProvingPeriod(t *testing.T) {
 	periodStart := miner.WPoStProvingPeriod
 	dlIdx := uint64(1)
 	currentEpoch := abi.ChainEpoch(10)
-	di := miner.NewDeadlineInfo(periodStart, dlIdx, currentEpoch)
+	di := NewDeadlineInfo(periodStart, dlIdx, currentEpoch)
 	mock.setDeadline(di)
 
 	defer s.ch.shutdown()
@@ -375,7 +375,7 @@ func TestChangeHandlerDontStartUntilProvingPeriod(t *testing.T) {
 
 	// Advance the head to the next proving period's first epoch
 	currentEpoch = periodStart + miner.WPoStChallengeWindow
-	di = miner.NewDeadlineInfo(periodStart, dlIdx, currentEpoch)
+	di = NewDeadlineInfo(periodStart, dlIdx, currentEpoch)
 	mock.setDeadline(di)
 	go triggerHeadAdvance(t, s, currentEpoch)
 

--- a/storage/wdpost_nextdl_test.go
+++ b/storage/wdpost_nextdl_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 )
 
 func TestNextDeadline(t *testing.T) {
@@ -14,7 +14,7 @@ func TestNextDeadline(t *testing.T) {
 	deadlineIdx := 0
 	currentEpoch := abi.ChainEpoch(10)
 
-	di := miner.NewDeadlineInfo(periodStart, uint64(deadlineIdx), currentEpoch)
+	di := NewDeadlineInfo(periodStart, uint64(deadlineIdx), currentEpoch)
 	require.EqualValues(t, 0, di.Index)
 	require.EqualValues(t, 0, di.PeriodStart)
 	require.EqualValues(t, -20, di.Challenge)


### PR DESCRIPTION
Use abstract types for https://github.com/filecoin-project/lotus/pull/3924 instead of using specs-actors directly.

I put this in a separate PR so that it's easier to modify just this part if needs be.