### PR TITLE
return an error when we fail to find a sector when checking sector expiration

### DIFF
--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
@@ -96,9 +97,7 @@ func (s *state0) NumLiveSectors() (uint64, error) {
 
 // GetSectorExpiration returns the effective expiration of the given sector.
 //
-// If the sector isn't found or has already been terminated, this method returns
-// nil and no error. If the sector does not expire early, the Early expiration
-// field is 0.
+// If the sector does not expire early, the Early expiration field is 0.
 func (s *state0) GetSectorExpiration(num abi.SectorNumber) (*SectorExpiration, error) {
 	dls, err := s.State.LoadDeadlines(s.store)
 	if err != nil {
@@ -161,7 +160,7 @@ func (s *state0) GetSectorExpiration(num abi.SectorNumber) (*SectorExpiration, e
 		return nil, err
 	}
 	if out.Early == 0 && out.OnTime == 0 {
-		return nil, nil
+		return nil, xerrors.Errorf("failed to find sector %d", num)
 	}
 	return &out, nil
 }


### PR DESCRIPTION
Returning nil, nil is a footgun.

fix: https://github.com/filecoin-project/lotus/issues/3984