### PR TITLE
conformance: record and feed circulating supply.

### DIFF
--- a/cmd/tvx/extract_many.go
+++ b/cmd/tvx/extract_many.go
@@ -26,7 +26,7 @@ var extractManyFlags struct {
 
 var extractManyCmd = &cli.Command{
 	Name: "extract-many",
-	Description: `generate many test vectors by repeateadly calling tvx extract, using a csv file as input.
+	Description: `generate many test vectors by repeatedly calling tvx extract, using a csv file as input.
 
    The CSV file must have a format just like the following:
 

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -45,6 +45,12 @@ func ExecuteMessageVector(r Reporter, vector *schema.TestVector) {
 	// Create a new Driver.
 	driver := NewDriver(ctx, vector.Selector, DriverOpts{})
 
+	var circSupply *abi.TokenAmount
+	if cs := vector.Pre.CircSupply; cs != nil {
+		ta := abi.NewTokenAmount(*cs)
+		circSupply = &ta
+	}
+
 	// Apply every message.
 	for i, m := range vector.ApplyMessages {
 		msg, err := types.DecodeMessage(m.Bytes)
@@ -59,7 +65,7 @@ func ExecuteMessageVector(r Reporter, vector *schema.TestVector) {
 
 		// Execute the message.
 		var ret *vm.ApplyRet
-		ret, root, err = driver.ExecuteMessage(bs, root, abi.ChainEpoch(epoch), msg)
+		ret, root, err = driver.ExecuteMessage(bs, root, abi.ChainEpoch(epoch), msg, circSupply)
 		if err != nil {
 			r.Fatalf("fatal failure when executing message: %s", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/specs-actors v0.9.11
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
-	github.com/filecoin-project/test-vectors/schema v0.0.1
+	github.com/filecoin-project/test-vectors/schema v0.0.2
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/filecoin-project/specs-actors v0.9.11 h1:TnpG7HAeiUrfj0mJM7UaPW0P2137
 github.com/filecoin-project/specs-actors v0.9.11/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
-github.com/filecoin-project/test-vectors/schema v0.0.1 h1:5fNF76nl4qolEvcIsjc0kUADlTMVHO73tW4kXXPnsus=
-github.com/filecoin-project/test-vectors/schema v0.0.1/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
+github.com/filecoin-project/test-vectors/schema v0.0.2 h1:/Pp//88WBXe0h+ksntdL2HpEgAmbwXrftAfeVG39zdY=
+github.com/filecoin-project/test-vectors/schema v0.0.2/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=


### PR DESCRIPTION
To be merged into the `tvx` branch.

---

The `tvx extract` command now queries the circulating supply at the inclusion tipset, and records it in the vector.

The driver picks up the circulating supply from the vector (if set), and feeds it into the VM. If not set, it uses the total Filecoin ever in supply as a default fallback.