### PR TITLE
update devnet docs

### DIFF
--- a/documentation/en/local-dev-net.md
+++ b/documentation/en/local-dev-net.md
@@ -1,5 +1,11 @@
 # Setup Local Devnet
 
+*If you are running your local devnet on **MacOS** and having trouble building, you'll need to set the following ENV variables before running `make 2k`:*
+```
+export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
+export CGO_CFLAGS="-D__BLST_PORTABLE__"
+```
+
 Build the Lotus Binaries in debug mode, This enables the use of 2048 byte sectors.
 
 ```sh


### PR DESCRIPTION
For any version of Lotus post 0.7.0, most MacOS users will need to set env variables in order to run the local devnet. See this thread on Slack: https://filecoinproject.slack.com/archives/CPFTWMY7N/p1601154156051500