### PR TITLE
Run fork function after cron for null block safety

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -212,7 +212,7 @@ func (sm *StateManager) ApplyBlocks(ctx context.Context, parentEpoch abi.ChainEp
 		if i > parentEpoch {
 			// run cron for null rounds if any
 			if err := runCron(); err != nil {
-				return cid.Cid{}, cid.Cid{}, err
+				return cid.Undef, cid.Undef, err
 			}
 
 			pstate, err = vmi.Flush(ctx)

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -209,6 +209,18 @@ func (sm *StateManager) ApplyBlocks(ctx context.Context, parentEpoch abi.ChainEp
 	}
 
 	for i := parentEpoch; i < epoch; i++ {
+		if i > parentEpoch {
+			// run cron for null rounds if any
+			if err := runCron(); err != nil {
+				return cid.Cid{}, cid.Cid{}, err
+			}
+
+			pstate, err = vmi.Flush(ctx)
+			if err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("flushing vm: %w", err)
+			}
+		}
+
 		// handle state forks
 		// XXX: The state tree
 		newState, err := sm.handleStateForks(ctx, pstate, i, cb, ts)
@@ -220,18 +232,6 @@ func (sm *StateManager) ApplyBlocks(ctx context.Context, parentEpoch abi.ChainEp
 			vmi, err = makeVmWithBaseState(newState)
 			if err != nil {
 				return cid.Undef, cid.Undef, xerrors.Errorf("making vm: %w", err)
-			}
-		}
-
-		if i > parentEpoch {
-			// run cron for null rounds if any
-			if err := runCron(); err != nil {
-				return cid.Cid{}, cid.Cid{}, err
-			}
-
-			newState, err = vmi.Flush(ctx)
-			if err != nil {
-				return cid.Undef, cid.Undef, xerrors.Errorf("flushing vm: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Actors state migrations will take place within a fork function called from `handleStateForks`.  In general migrations need the epoch the transition is run at to work correctly.  We are assuming the epoch passed to any migration function will be the same epoch passed to `handleStateForks`, `i`.

`i` is the fork epoch.  In the common case of no null blocks it is the "previous epoch" in the sense that epoch `i`'s cron has already run as part of processing the parent tipset and state.  

If there are null blocks then for `i > parentEpoch` epoch `i`'s cron will not have run before the fork function because of the current ordering of fork function before cron.  We can't distinguish these two cases from within the migration function so the epoch we are passed in won't be well defined with respect to our state.

The fix is to run cron before the fork function.