### PR TITLE
introduce separate state-tree versions

### DIFF
--- a/chain/actors/version.go
+++ b/chain/actors/version.go
@@ -9,8 +9,8 @@ import (
 type Version int
 
 const (
-	Version0 = 0
-	Version2 = 2
+	Version0 Version = 0
+	Version2 Version = 2
 )
 
 // Converts a network version into an actors adt version.

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -26,7 +26,6 @@ import (
 	adt0 "github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -117,7 +116,7 @@ func MakeInitialStateTree(ctx context.Context, bs bstore.Blockstore, template ge
 		return nil, nil, xerrors.Errorf("putting empty object: %w", err)
 	}
 
-	state, err := state.NewStateTree(cst, actors.Version0)
+	state, err := state.NewStateTree(cst, types.StateTreeVersion0)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("making new state tree: %w", err)
 	}

--- a/chain/state/statetree_test.go
+++ b/chain/state/statetree_test.go
@@ -13,13 +13,12 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
 func BenchmarkStateTreeSet(b *testing.B) {
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, actors.VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -46,7 +45,7 @@ func BenchmarkStateTreeSet(b *testing.B) {
 
 func BenchmarkStateTreeSetFlush(b *testing.B) {
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, actors.VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -76,7 +75,7 @@ func BenchmarkStateTreeSetFlush(b *testing.B) {
 
 func BenchmarkStateTree10kGetActor(b *testing.B) {
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, actors.VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -118,7 +117,7 @@ func BenchmarkStateTree10kGetActor(b *testing.B) {
 
 func TestSetCache(t *testing.T) {
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, actors.VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func TestSetCache(t *testing.T) {
 func TestSnapshots(t *testing.T) {
 	ctx := context.Background()
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, actors.VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +238,7 @@ func assertNotHas(t *testing.T, st *StateTree, addr address.Address) {
 func TestStateTreeConsistency(t *testing.T) {
 	cst := cbor.NewMemCborStore()
 	// TODO: ActorUpgrade: this test tests pre actors v2
-	st, err := NewStateTree(cst, actors.VersionForNetwork(network.Version3))
+	st, err := NewStateTree(cst, VersionForNetwork(network.Version3))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -494,7 +494,7 @@ func UpgradeActorsV2(ctx context.Context, sm *StateManager, cb ExecCallback, roo
 
 	epoch := ts.Height() - 1
 
-	info, err := store.Put(ctx, new(types.StateInfo))
+	info, err := store.Put(ctx, new(types.StateInfo0))
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to create new state info for actors v2: %w", err)
 	}

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -25,7 +25,6 @@ import (
 	states2 "github.com/filecoin-project/specs-actors/v2/actors/states"
 
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
@@ -518,8 +517,7 @@ func UpgradeActorsV2(ctx context.Context, sm *StateManager, cb ExecCallback, roo
 	}
 
 	newRoot, err := store.Put(ctx, &types.StateRoot{
-		// TODO: ActorUpgrade: should be state-tree specific, not just the actors version.
-		Version: actors.Version2,
+		Version: types.StateTreeVersion1,
 		Actors:  newHamtRoot,
 		Info:    info,
 	})

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -1648,7 +1648,7 @@ func (t *StateRoot) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.Version (uint64) (uint64)
+	// t.Version (types.StateTreeVersion) (uint64)
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Version)); err != nil {
 		return err
@@ -1687,7 +1687,7 @@ func (t *StateRoot) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Version (uint64) (uint64)
+	// t.Version (types.StateTreeVersion) (uint64)
 
 	{
 
@@ -1698,7 +1698,7 @@ func (t *StateRoot) UnmarshalCBOR(r io.Reader) error {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.Version = uint64(extra)
+		t.Version = StateTreeVersion(extra)
 
 	}
 	// t.Actors (cid.Cid) (struct)
@@ -1728,22 +1728,22 @@ func (t *StateRoot) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufStateInfo = []byte{128}
+var lengthBufStateInfo0 = []byte{128}
 
-func (t *StateInfo) MarshalCBOR(w io.Writer) error {
+func (t *StateInfo0) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufStateInfo); err != nil {
+	if _, err := w.Write(lengthBufStateInfo0); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (t *StateInfo) UnmarshalCBOR(r io.Reader) error {
-	*t = StateInfo{}
+func (t *StateInfo0) UnmarshalCBOR(r io.Reader) error {
+	*t = StateInfo0{}
 
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)

--- a/chain/types/state.go
+++ b/chain/types/state.go
@@ -2,9 +2,20 @@ package types
 
 import "github.com/ipfs/go-cid"
 
+// StateTreeVersion is the version of the state tree itself, independent of the
+// network version or the actors version.
+type StateTreeVersion uint64
+
+const (
+	// StateTreeVersion0 corresponds to actors < v2.
+	StateTreeVersion0 StateTreeVersion = iota
+	// StateTreeVersion1 corresponds to actors >= v2.
+	StateTreeVersion1
+)
+
 type StateRoot struct {
-	// State root version. Versioned along with actors (for now).
-	Version uint64
+	// State tree version.
+	Version StateTreeVersion
 	// Actors tree. The structure depends on the state root version.
 	Actors cid.Cid
 	// Info. The structure depends on the state root version.
@@ -12,4 +23,4 @@ type StateRoot struct {
 }
 
 // TODO: version this.
-type StateInfo struct{}
+type StateInfo0 struct{}

--- a/gen/main.go
+++ b/gen/main.go
@@ -27,7 +27,7 @@ func main() {
 		types.ExpTipSet{},
 		types.BeaconEntry{},
 		types.StateRoot{},
-		types.StateInfo{},
+		types.StateInfo0{},
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/lotuspond/front/src/chain/methods.json
+++ b/lotuspond/front/src/chain/methods.json
@@ -176,7 +176,8 @@
     "CompactPartitions",
     "CompactSectorNumbers",
     "ConfirmUpdateWorkerKey",
-    "RepayDebt"
+    "RepayDebt",
+    "ChangeOwnerAddress"
   ],
   "fil/2/storagepower": [
     "Send",


### PR DESCRIPTION
Instead of versioning the state tree along with the actors, version it separately. This structure may not upgrade every time we update actors.