### PR TITLE
build: Env var to keep test address output

### DIFF
--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -5,6 +5,8 @@
 package build
 
 import (
+	"os"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -36,7 +38,9 @@ func init() {
 		abi.RegisteredSealProof_StackedDrg64GiBV1,
 	)
 
-	SetAddressNetwork(address.Mainnet)
+	if os.Getenv("LOTUS_USE_TEST_ADDRESSES") != "1" {
+		SetAddressNetwork(address.Mainnet)
+	}
 
 	Devnet = false
 }


### PR DESCRIPTION
Defaulting to f.. addresses may break some integrations, this provides an easy workaround