### PR TITLE
conformance: record randomness in tvx; replay in driver.

### DIFF
--- a/conformance/rand_record.go
+++ b/conformance/rand_record.go
@@ -1,0 +1,86 @@
+package conformance
+
+import (
+	"context"
+	"sync"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/crypto"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/test-vectors/schema"
+)
+
+type RecordingRand struct {
+	reporter Reporter
+	api      api.FullNode
+
+	lk       sync.Mutex
+	recorded schema.Randomness
+}
+
+var _ vm.Rand = (*RecordingRand)(nil)
+
+// NewRecordingRand returns a vm.Rand implementation that proxies calls to a
+// full Lotus node via JSON-RPC, and records matching rules and responses so
+// they can later be embedded in test vectors.
+func NewRecordingRand(reporter Reporter, api api.FullNode) *RecordingRand {
+	return &RecordingRand{reporter: reporter, api: api}
+}
+
+func (r *RecordingRand) GetChainRandomness(ctx context.Context, pers crypto.DomainSeparationTag, round abi.ChainEpoch, entropy []byte) ([]byte, error) {
+	ret, err := r.api.ChainGetRandomnessFromTickets(ctx, types.EmptyTSK, pers, round, entropy)
+	if err != nil {
+		return ret, err
+	}
+
+	r.reporter.Logf("fetched and recorded chain randomness for: dst=%d, epoch=%d, entropy=%x, result=%x", pers, round, entropy, ret)
+
+	match := schema.RandomnessMatch{
+		On: schema.RandomnessRule{
+			Kind:                schema.RandomnessChain,
+			DomainSeparationTag: int64(pers),
+			Epoch:               int64(round),
+			Entropy:             entropy,
+		},
+		Return: []byte(ret),
+	}
+	r.lk.Lock()
+	r.recorded = append(r.recorded, match)
+	r.lk.Unlock()
+
+	return ret, err
+}
+
+func (r *RecordingRand) GetBeaconRandomness(ctx context.Context, pers crypto.DomainSeparationTag, round abi.ChainEpoch, entropy []byte) ([]byte, error) {
+	ret, err := r.api.ChainGetRandomnessFromBeacon(ctx, types.EmptyTSK, pers, round, entropy)
+	if err != nil {
+		return ret, err
+	}
+
+	r.reporter.Logf("fetched and recorded beacon randomness for: dst=%d, epoch=%d, entropy=%x, result=%x", pers, round, entropy, ret)
+
+	match := schema.RandomnessMatch{
+		On: schema.RandomnessRule{
+			Kind:                schema.RandomnessBeacon,
+			DomainSeparationTag: int64(pers),
+			Epoch:               int64(round),
+			Entropy:             entropy,
+		},
+		Return: []byte(ret),
+	}
+	r.lk.Lock()
+	r.recorded = append(r.recorded, match)
+	r.lk.Unlock()
+
+	return ret, err
+}
+
+func (r *RecordingRand) Recorded() schema.Randomness {
+	r.lk.Lock()
+	defer r.lk.Unlock()
+
+	return r.recorded
+}

--- a/conformance/rand_replay.go
+++ b/conformance/rand_replay.go
@@ -1,0 +1,78 @@
+package conformance
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/crypto"
+
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/test-vectors/schema"
+)
+
+type ReplayingRand struct {
+	reporter Reporter
+	recorded schema.Randomness
+	fallback vm.Rand
+}
+
+var _ vm.Rand = (*ReplayingRand)(nil)
+
+// NewReplayingRand replays recorded randomness when requested, falling back to
+// fixed randomness if the value cannot be found; hence this is a safe
+// backwards-compatible replacement for fixedRand.
+func NewReplayingRand(reporter Reporter, recorded schema.Randomness) *ReplayingRand {
+	return &ReplayingRand{
+		reporter: reporter,
+		recorded: recorded,
+		fallback: NewFixedRand(),
+	}
+}
+
+func (r *ReplayingRand) match(requested schema.RandomnessRule) ([]byte, bool) {
+	for _, other := range r.recorded {
+		if other.On.Kind == requested.Kind &&
+			other.On.Epoch == requested.Epoch &&
+			other.On.DomainSeparationTag == requested.DomainSeparationTag &&
+			bytes.Equal(other.On.Entropy, requested.Entropy) {
+			return other.Return, true
+		}
+	}
+	return nil, false
+}
+
+func (r *ReplayingRand) GetChainRandomness(ctx context.Context, pers crypto.DomainSeparationTag, round abi.ChainEpoch, entropy []byte) ([]byte, error) {
+	rule := schema.RandomnessRule{
+		Kind:                schema.RandomnessChain,
+		DomainSeparationTag: int64(pers),
+		Epoch:               int64(round),
+		Entropy:             entropy,
+	}
+
+	if ret, ok := r.match(rule); ok {
+		r.reporter.Logf("returning saved chain randomness: dst=%d, epoch=%d, entropy=%x, result=%x", pers, round, entropy, ret)
+		return ret, nil
+	}
+
+	r.reporter.Logf("returning fallback chain randomness: dst=%d, epoch=%d, entropy=%x", pers, round, entropy)
+	return r.fallback.GetChainRandomness(ctx, pers, round, entropy)
+}
+
+func (r *ReplayingRand) GetBeaconRandomness(ctx context.Context, pers crypto.DomainSeparationTag, round abi.ChainEpoch, entropy []byte) ([]byte, error) {
+	rule := schema.RandomnessRule{
+		Kind:                schema.RandomnessBeacon,
+		DomainSeparationTag: int64(pers),
+		Epoch:               int64(round),
+		Entropy:             entropy,
+	}
+
+	if ret, ok := r.match(rule); ok {
+		r.reporter.Logf("returning saved beacon randomness: dst=%d, epoch=%d, entropy=%x, result=%x", pers, round, entropy, ret)
+		return ret, nil
+	}
+
+	r.reporter.Logf("returning fallback beacon randomness: dst=%d, epoch=%d, entropy=%x", pers, round, entropy)
+	return r.fallback.GetBeaconRandomness(ctx, pers, round, entropy)
+
+}

--- a/conformance/rand_replay.go
+++ b/conformance/rand_replay.go
@@ -7,8 +7,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 
-	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/test-vectors/schema"
+
+	"github.com/filecoin-project/lotus/chain/vm"
 )
 
 type ReplayingRand struct {

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -66,6 +66,7 @@ func ExecuteMessageVector(r Reporter, vector *schema.TestVector) {
 			Message:    msg,
 			BaseFee:    BaseFeeOrDefault(vector.Pre.BaseFee),
 			CircSupply: CircSupplyOrDefault(vector.Pre.CircSupply),
+			Rand:       NewReplayingRand(r, vector.Randomness),
 		})
 		if err != nil {
 			r.Fatalf("fatal failure when executing message: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/specs-actors v0.9.11
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
-	github.com/filecoin-project/test-vectors/schema v0.0.3
+	github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/specs-actors v0.9.11
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
-	github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a
+	github.com/filecoin-project/test-vectors/schema v0.0.4
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/filecoin-project/specs-actors v0.9.11 h1:TnpG7HAeiUrfj0mJM7UaPW0P2137
 github.com/filecoin-project/specs-actors v0.9.11/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
-github.com/filecoin-project/test-vectors/schema v0.0.3 h1:1zuBo25B3016inbygYLgYFdpJ2m1BDTbAOCgABRleiU=
-github.com/filecoin-project/test-vectors/schema v0.0.3/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
+github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a h1:2jRLaT3/sHyAinWR2asCAkvzcnOAIi13eTlWf3YEVvY=
+github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/filecoin-project/specs-actors v0.9.11 h1:TnpG7HAeiUrfj0mJM7UaPW0P2137
 github.com/filecoin-project/specs-actors v0.9.11/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
-github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a h1:2jRLaT3/sHyAinWR2asCAkvzcnOAIi13eTlWf3YEVvY=
-github.com/filecoin-project/test-vectors/schema v0.0.4-0.20201007174510-548c9399aa6a/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
+github.com/filecoin-project/test-vectors/schema v0.0.4 h1:QTRd0gb/NP4ZOTM7Dib5U3xE1/ToGDKnYLfxkC3t/m8=
+github.com/filecoin-project/test-vectors/schema v0.0.4/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=


### PR DESCRIPTION
This PR adds the ability to record chain and beacon randomness values when extracting a test vector via `tvx`. It does so via an implementation of `vm.Rand` that proxies over requests for randomness to the Lotus node via JSON-RPC, and then memorises the return value.

When outputting the vector, the randomness values are encoded as a series of rules that match on:

* randomness kind (chain or beacon).
* domain separation tag
* epoch
* entropy

The driver then injects a special implementation of `vm.Rand` into the VM that replays the randomness values encoded in the vector, defaulting to a placeholder 32-byte fixed value, used in vectors built through the builder DSL.