### PR TITLE
reject explicit "calls" at the upgrade height

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -2,6 +2,7 @@ package stmgr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
@@ -17,16 +18,36 @@ import (
 	"github.com/filecoin-project/lotus/chain/vm"
 )
 
+var ErrWouldFork = errors.New("refusing explicit call due to state fork at epoch")
+
 func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error) {
 	ctx, span := trace.StartSpan(ctx, "statemanager.Call")
 	defer span.End()
 
+	// If no tipset is provided, try to find one without a fork.
 	if ts == nil {
 		ts = sm.cs.GetHeaviestTipSet()
+
+		// Search back till we find a height with no fork, or we reach the beginning.
+		for ts.Height() > 0 && sm.hasStateFork(ctx, ts.Height()-1) {
+			var err error
+			ts, err = sm.cs.GetTipSetFromKey(ts.Parents())
+			if err != nil {
+				return nil, xerrors.Errorf("failed to find a non-forking epoch: %w", err)
+			}
+		}
 	}
 
 	bstate := ts.ParentState()
 	bheight := ts.Height()
+
+	// If we have to run a migration, and we're not at genesis, return an
+	// error because the migration will take too long.
+	//
+	// We allow this at height 0 for at-genesis migrations (for testing).
+	if bheight-1 > 0 && sm.hasStateFork(ctx, bheight-1) {
+		return nil, ErrWouldFork
+	}
 
 	bstate, err := sm.handleStateForks(ctx, bstate, bheight-1, nil, ts)
 	if err != nil {
@@ -106,6 +127,24 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 
 	if ts == nil {
 		ts = sm.cs.GetHeaviestTipSet()
+
+		// Search back till we find a height with no fork, or we reach the beginning.
+		// We need the _previous_ height to have no fork, because we'll
+		// run the fork logic in `sm.TipSetState`. We need the _current_
+		// height to have no fork, because we'll run it inside this
+		// function before executing the given message.
+		for ts.Height() > 0 && (sm.hasStateFork(ctx, ts.Height()) || sm.hasStateFork(ctx, ts.Height()-1)) {
+			var err error
+			ts, err = sm.cs.GetTipSetFromKey(ts.Parents())
+			if err != nil {
+				return nil, xerrors.Errorf("failed to find a non-forking epoch: %w", err)
+			}
+		}
+	}
+
+	// When we're not at the genesis block, make sure we're at a migration height.
+	if ts.Height() > 0 && (sm.hasStateFork(ctx, ts.Height()) || sm.hasStateFork(ctx, ts.Height()-1)) {
+		return nil, ErrWouldFork
 	}
 
 	state, _, err := sm.TipSetState(ctx, ts)

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -65,7 +65,7 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		BaseFee:        types.NewInt(0),
 	}
 
-	vmi, err := vm.NewVM(ctx, vmopt)
+	vmi, err := sm.newVM(ctx, vmopt)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to set up vm: %w", err)
 	}
@@ -177,7 +177,7 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		NtwkVersion:    sm.GetNtwkVersion,
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 	}
-	vmi, err := vm.NewVM(ctx, vmopt)
+	vmi, err := sm.newVM(ctx, vmopt)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to set up vm: %w", err)
 	}

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -45,6 +45,7 @@ type UpgradeFunc func(ctx context.Context, sm *StateManager, cb ExecCallback, ol
 type Upgrade struct {
 	Height    abi.ChainEpoch
 	Network   network.Version
+	Expensive bool
 	Migration UpgradeFunc
 }
 
@@ -68,6 +69,7 @@ func DefaultUpgradeSchedule() UpgradeSchedule {
 	}, {
 		Height:    build.UpgradeActorsV2Height,
 		Network:   network.Version4,
+		Expensive: true,
 		Migration: UpgradeActorsV2,
 	}, {
 		Height:    build.UpgradeLiftoffHeight,
@@ -124,8 +126,8 @@ func (sm *StateManager) handleStateForks(ctx context.Context, root cid.Cid, heig
 	return retCid, nil
 }
 
-func (sm *StateManager) hasStateFork(ctx context.Context, height abi.ChainEpoch) bool {
-	_, ok := sm.stateMigrations[height]
+func (sm *StateManager) hasExpensiveFork(ctx context.Context, height abi.ChainEpoch) bool {
+	_, ok := sm.expensiveUpgrades[height]
 	return ok
 }
 

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -33,7 +33,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/vm"
 )
 
-// UpgradeFunc is a migration function run ate very upgrade.
+// UpgradeFunc is a migration function run at every upgrade.
 //
 // - The oldState is the state produced by the upgrade epoch.
 // - The returned newState is the new state that will be used by the next epoch.

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -124,6 +124,11 @@ func (sm *StateManager) handleStateForks(ctx context.Context, root cid.Cid, heig
 	return retCid, nil
 }
 
+func (sm *StateManager) hasStateFork(ctx context.Context, height abi.ChainEpoch) bool {
+	_, ok := sm.stateMigrations[height]
+	return ok
+}
+
 func doTransfer(cb ExecCallback, tree types.StateTree, from, to address.Address, amt abi.TokenAmount) error {
 	fromAct, err := tree.GetActor(from)
 	if err != nil {

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -120,7 +120,7 @@ func TestForkHeightTriggers(t *testing.T) {
 			Network: 1,
 			Height:  testForkHeight,
 			Migration: func(ctx context.Context, sm *StateManager, cb ExecCallback,
-				root cid.Cid, ts *types.TipSet) (cid.Cid, error) {
+				root cid.Cid, height abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
 				cst := ipldcbor.NewCborStore(sm.ChainStore().Blockstore())
 
 				st, err := sm.StateTree(root)

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	init0 "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -76,7 +77,7 @@ func (ta testActor) Exports() []interface{} {
 func (ta *testActor) Constructor(rt runtime.Runtime, params *abi.EmptyValue) *abi.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 	rt.StateCreate(&testActorState{11})
-	fmt.Println("NEW ACTOR ADDRESS IS: ", rt.Receiver())
+	//fmt.Println("NEW ACTOR ADDRESS IS: ", rt.Receiver())
 
 	return abi.Empty
 }
@@ -173,7 +174,7 @@ func TestForkHeightTriggers(t *testing.T) {
 
 	var msgs []*types.SignedMessage
 
-	enc, err := actors.SerializeParams(&init_.ExecParams{CodeCID: (testActor{}).Code()})
+	enc, err := actors.SerializeParams(&init0.ExecParams{CodeCID: (testActor{}).Code()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,6 +231,86 @@ func TestForkHeightTriggers(t *testing.T) {
 		_, err = cg.NextTipSet()
 		if err != nil {
 			t.Fatal(err)
+		}
+	}
+}
+
+func TestForkRefuseCall(t *testing.T) {
+	logging.SetAllLoggers(logging.LevelInfo)
+
+	ctx := context.TODO()
+
+	cg, err := gen.NewGenerator()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sm, err := NewStateManagerWithUpgradeSchedule(
+		cg.ChainStore(), UpgradeSchedule{{
+			Network: 1,
+			Height:  testForkHeight,
+			Migration: func(ctx context.Context, sm *StateManager, cb ExecCallback,
+				root cid.Cid, height abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
+				return root, nil
+			}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inv := vm.NewActorRegistry()
+	inv.Register(nil, testActor{})
+
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (*vm.VM, error) {
+		nvm, err := vm.NewVM(ctx, vmopt)
+		if err != nil {
+			return nil, err
+		}
+		nvm.SetInvoker(inv)
+		return nvm, nil
+	})
+
+	cg.SetStateManager(sm)
+
+	enc, err := actors.SerializeParams(&init0.ExecParams{CodeCID: (testActor{}).Code()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &types.Message{
+		From:       cg.Banker(),
+		To:         lotusinit.Address,
+		Method:     builtin.MethodsInit.Exec,
+		Params:     enc,
+		GasLimit:   types.TestGasLimit,
+		Value:      types.NewInt(0),
+		GasPremium: types.NewInt(0),
+		GasFeeCap:  types.NewInt(0),
+	}
+
+	for i := 0; i < 50; i++ {
+		ts, err := cg.NextTipSet()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ret, err := sm.CallWithGas(ctx, m, nil, ts.TipSet.TipSet())
+		switch ts.TipSet.TipSet().Height() {
+		case testForkHeight, testForkHeight + 1:
+			// If I had a fork, or I _will_ have a fork, it should fail.
+			require.Equal(t, ErrWouldFork, err)
+		default:
+			require.NoError(t, err)
+			require.True(t, ret.MsgRct.ExitCode.IsSuccess())
+		}
+		// Call just runs on the parent state for a tipset, so we only
+		// expect an error at the fork height.
+		ret, err = sm.Call(ctx, m, ts.TipSet.TipSet())
+		switch ts.TipSet.TipSet().Height() {
+		case testForkHeight + 1:
+			require.Equal(t, ErrWouldFork, err)
+		default:
+			require.NoError(t, err)
+			require.True(t, ret.MsgRct.ExitCode.IsSuccess())
 		}
 	}
 }

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -247,8 +247,9 @@ func TestForkRefuseCall(t *testing.T) {
 
 	sm, err := NewStateManagerWithUpgradeSchedule(
 		cg.ChainStore(), UpgradeSchedule{{
-			Network: 1,
-			Height:  testForkHeight,
+			Network:   1,
+			Expensive: true,
+			Height:    testForkHeight,
 			Migration: func(ctx context.Context, sm *StateManager, cb ExecCallback,
 				root cid.Cid, height abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
 				return root, nil
@@ -297,7 +298,7 @@ func TestForkRefuseCall(t *testing.T) {
 		switch ts.TipSet.TipSet().Height() {
 		case testForkHeight, testForkHeight + 1:
 			// If I had a fork, or I _will_ have a fork, it should fail.
-			require.Equal(t, ErrWouldFork, err)
+			require.Equal(t, ErrExpensiveFork, err)
 		default:
 			require.NoError(t, err)
 			require.True(t, ret.MsgRct.ExitCode.IsSuccess())
@@ -307,7 +308,7 @@ func TestForkRefuseCall(t *testing.T) {
 		ret, err = sm.Call(ctx, m, ts.TipSet.TipSet())
 		switch ts.TipSet.TipSet().Height() {
 		case testForkHeight + 1:
-			require.Equal(t, ErrWouldFork, err)
+			require.Equal(t, ErrExpensiveFork, err)
 		default:
 			require.NoError(t, err)
 			require.True(t, ret.MsgRct.ExitCode.IsSuccess())

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -387,7 +387,7 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		NtwkVersion:    sm.GetNtwkVersion,
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 	}
-	vmi, err := vm.NewVM(ctx, vmopt)
+	vmi, err := sm.newVM(ctx, vmopt)
 	if err != nil {
 		return cid.Undef, nil, err
 	}

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -160,7 +160,18 @@ func (a *GasAPI) GasEstimateGasLimit(ctx context.Context, msgIn *types.Message, 
 		priorMsgs = append(priorMsgs, m)
 	}
 
-	res, err := a.Stmgr.CallWithGas(ctx, &msg, priorMsgs, ts)
+	// Try calling until we find a height with no migration.
+	var res *api.InvocResult
+	for {
+		res, err = a.Stmgr.CallWithGas(ctx, &msg, priorMsgs, ts)
+		if err != stmgr.ErrWouldFork {
+			break
+		}
+		ts, err = a.Chain.GetTipSetFromKey(ts.Parents())
+		if err != nil {
+			return -1, xerrors.Errorf("getting parent tipset: %w", err)
+		}
+	}
 	if err != nil {
 		return -1, xerrors.Errorf("CallWithGas failed: %w", err)
 	}

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -164,7 +164,7 @@ func (a *GasAPI) GasEstimateGasLimit(ctx context.Context, msgIn *types.Message, 
 	var res *api.InvocResult
 	for {
 		res, err = a.Stmgr.CallWithGas(ctx, &msg, priorMsgs, ts)
-		if err != stmgr.ErrWouldFork {
+		if err != stmgr.ErrExpensiveFork {
 			break
 		}
 		ts, err = a.Chain.GetTipSetFromKey(ts.Parents())

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -307,12 +307,22 @@ func (a *StateAPI) StateMinerPower(ctx context.Context, addr address.Address, ts
 	}, nil
 }
 
-func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (*api.InvocResult, error) {
+func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.TipSetKey) (res *api.InvocResult, err error) {
 	ts, err := a.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return a.StateManager.Call(ctx, msg, ts)
+	for {
+		res, err = a.StateManager.Call(ctx, msg, ts)
+		if err != stmgr.ErrWouldFork {
+			break
+		}
+		ts, err = a.Chain.GetTipSetFromKey(ts.Parents())
+		if err != nil {
+			return nil, xerrors.Errorf("getting parent tipset: %w", err)
+		}
+	}
+	return res, err
 }
 
 func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.Cid) (*api.InvocResult, error) {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -314,7 +314,7 @@ func (a *StateAPI) StateCall(ctx context.Context, msg *types.Message, tsk types.
 	}
 	for {
 		res, err = a.StateManager.Call(ctx, msg, ts)
-		if err != stmgr.ErrWouldFork {
+		if err != stmgr.ErrExpensiveFork {
 			break
 		}
 		ts, err = a.Chain.GetTipSetFromKey(ts.Parents())


### PR DESCRIPTION
Upgrades can be slow.

1. If a nil/empty tipset, use the latest non-fork tipset.
2. If passed an explicit tipset, return an error if it would invoke a fork.
3. When estimating gas, retry on previous tipsets till we find a non-fork tipset.