### PR TITLE
fix: clash between daemon --api flag and cli tests

### DIFF
--- a/cli/paych_test.go
+++ b/cli/paych_test.go
@@ -439,12 +439,12 @@ type mockCLI struct {
 }
 
 func newMockCLI(t *testing.T) *mockCLI {
-	// Create a CLI App with an --api flag so that we can specify which node
+	// Create a CLI App with an --api-url flag so that we can specify which node
 	// the command should be executed against
 	app := cli.NewApp()
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:   "api",
+			Name:   "api-url",
 			Hidden: true,
 		},
 	}
@@ -476,8 +476,8 @@ func (c *mockCLIClient) runCmd(cmd *cli.Command, input []string) string {
 }
 
 func (c *mockCLIClient) runCmdRaw(cmd *cli.Command, input []string) (string, error) {
-	// prepend --api=<node api listener address>
-	apiFlag := "--api=" + c.addr.String()
+	// prepend --api-url=<node api listener address>
+	apiFlag := "--api-url=" + c.addr.String()
 	input = append([]string{apiFlag}, input...)
 
 	fs := c.flagSet(cmd)
@@ -493,7 +493,7 @@ func (c *mockCLIClient) runCmdRaw(cmd *cli.Command, input []string) (string, err
 }
 
 func (c *mockCLIClient) flagSet(cmd *cli.Command) *flag.FlagSet {
-	// Apply app level flags (so we can process --api flag)
+	// Apply app level flags (so we can process --api-url flag)
 	fs := &flag.FlagSet{}
 	for _, f := range c.cctx.App.Flags {
 		err := f.Apply(fs)

--- a/cli/pprof.go
+++ b/cli/pprof.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/node/repo"
-	manet "github.com/multiformats/go-multiaddr/net"
 )
 
 var pprofCmd = &cli.Command{
@@ -37,7 +36,7 @@ var PprofGoroutines = &cli.Command{
 		if err != nil {
 			return xerrors.Errorf("could not get API info: %w", err)
 		}
-		_, addr, err := manet.DialArgs(ainfo.Addr)
+		addr, err := ainfo.Host()
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-shed/consensus.go
+++ b/cmd/lotus-shed/consensus.go
@@ -111,7 +111,7 @@ var consensusCheckCmd = &cli.Command{
 			if err != nil {
 				return err
 			}
-			ainfo := lcli.APIInfo{Addr: apima}
+			ainfo := lcli.APIInfo{Addr: apima.String()}
 			addr, err := ainfo.DialArgs()
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently the payment channel CLI tests use a `--api` flag to indicate which server to create a client API against (payment channel creator or payment channel receiver).

`lotus daemon` also takes a `--api` flag that indicates the port on which to start.

This PR fixes the clash by changing the flag that the tests use to `--api-url`

It also makes it possible to specify the api using a regular url (instead of a multiaddress):
`FULLNODE_API_INFO=<token>:/ip4/127.0.0.1/tcp/1234 go run ./cmd/lotus wallet balance t01234`
`FULLNODE_API_INFO="<token>:ws://127.0.0.1:1234" go run ./cmd/lotus wallet balance t01234`

This can be useful for example if a websocket url has a path (currently not possible to represent with a multiaddress).