### PR TITLE
Feat/ux enhancements

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1144,7 +1144,7 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 
 	if verbose {
 		w := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "Created\tDealCid\tDealId\tProvider\tState\tOn Chain?\tSlashed?\tPieceCID\tSize\tPrice\tDuration\tMessage\n")
+		fmt.Fprintf(w, "Created\tDealCid\tDealId\tProvider\tState\tOn Chain?\tSlashed?\tPieceCID\tSize\tPrice\tDuration\tVerified\tMessage\n")
 		for _, d := range deals {
 			onChain := "N"
 			if d.OnChainDealState.SectorStartEpoch != -1 {
@@ -1157,7 +1157,7 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 			}
 
 			price := types.FIL(types.BigMul(d.LocalDeal.PricePerEpoch, types.NewInt(d.LocalDeal.Duration)))
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", d.LocalDeal.CreationTime.Format(time.Stamp), d.LocalDeal.ProposalCid, d.LocalDeal.DealID, d.LocalDeal.Provider, dealStateString(color, d.LocalDeal.State), onChain, slashed, d.LocalDeal.PieceCID, types.SizeStr(types.NewInt(d.LocalDeal.Size)), price, d.LocalDeal.Duration, d.LocalDeal.Message)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%v\t%s\n", d.LocalDeal.CreationTime.Format(time.Stamp), d.LocalDeal.ProposalCid, d.LocalDeal.DealID, d.LocalDeal.Provider, dealStateString(color, d.LocalDeal.State), onChain, slashed, d.LocalDeal.PieceCID, types.SizeStr(types.NewInt(d.LocalDeal.Size)), price, d.LocalDeal.Duration, d.LocalDeal.Verified, d.LocalDeal.Message)
 		}
 		return w.Flush()
 	}
@@ -1172,6 +1172,7 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 		tablewriter.Col("Size"),
 		tablewriter.Col("Price"),
 		tablewriter.Col("Duration"),
+		tablewriter.Col("Verified"),
 		tablewriter.NewLineCol("Message"))
 
 	for _, d := range deals {
@@ -1201,6 +1202,7 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 			"PieceCID":  piece,
 			"Size":      types.SizeStr(types.NewInt(d.LocalDeal.Size)),
 			"Price":     price,
+			"Verified":  d.LocalDeal.Verified,
 			"Duration":  d.LocalDeal.Duration,
 			"Message":   d.LocalDeal.Message,
 		})

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -154,14 +154,14 @@ var setAskCmd = &cli.Command{
 	Name:  "set-ask",
 	Usage: "Configure the miner's ask",
 	Flags: []cli.Flag{
-		&cli.Uint64Flag{
+		&cli.StringFlag{
 			Name:     "price",
-			Usage:    "Set the price of the ask for unverified deals (specified as attoFIL / GiB / Epoch) to `PRICE`",
+			Usage:    "Set the price of the ask for unverified deals (specified as FIL / GiB / Epoch) to `PRICE`.",
 			Required: true,
 		},
-		&cli.Uint64Flag{
+		&cli.StringFlag{
 			Name:     "verified-price",
-			Usage:    "Set the price of the ask for verified deals (specified as attoFIL / GiB / Epoch) to `PRICE`",
+			Usage:    "Set the price of the ask for verified deals (specified as FIL / GiB / Epoch) to `PRICE`",
 			Required: true,
 		},
 		&cli.StringFlag{
@@ -185,8 +185,15 @@ var setAskCmd = &cli.Command{
 		}
 		defer closer()
 
-		pri := types.NewInt(cctx.Uint64("price"))
-		vpri := types.NewInt(cctx.Uint64("verified-price"))
+		pri, err := types.ParseFIL(cctx.String("price"))
+		if err != nil {
+			return err
+		}
+
+		vpri, err := types.ParseFIL(cctx.String("verified-price"))
+		if err != nil {
+			return err
+		}
 
 		dur, err := time.ParseDuration("720h0m0s")
 		if err != nil {
@@ -229,7 +236,7 @@ var setAskCmd = &cli.Command{
 			return xerrors.Errorf("max piece size (w/bit-padding) %s cannot exceed miner sector size %s", types.SizeStr(types.NewInt(uint64(max))), types.SizeStr(types.NewInt(uint64(smax))))
 		}
 
-		return api.MarketSetAsk(ctx, pri, vpri, abi.ChainEpoch(qty), abi.PaddedPieceSize(min), abi.PaddedPieceSize(max))
+		return api.MarketSetAsk(ctx, types.BigInt(pri), types.BigInt(vpri), abi.ChainEpoch(qty), abi.PaddedPieceSize(min), abi.PaddedPieceSize(max))
 	},
 }
 

--- a/cmd/lotus-storage-miner/market.go
+++ b/cmd/lotus-storage-miner/market.go
@@ -288,7 +288,7 @@ var getAskCmd = &cli.Command{
 			rem = (time.Second * time.Duration(int64(dlt)*int64(build.BlockDelaySecs))).String()
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%d\n", ask.Price, ask.VerifiedPrice, types.SizeStr(types.NewInt(uint64(ask.MinPieceSize))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize))), ask.Expiry, rem, ask.SeqNo)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\t%d\n", types.FIL(ask.Price), types.FIL(ask.VerifiedPrice), types.SizeStr(types.NewInt(uint64(ask.MinPieceSize))), types.SizeStr(types.NewInt(uint64(ask.MaxPieceSize))), ask.Expiry, rem, ask.SeqNo)
 
 		return w.Flush()
 	},


### PR DESCRIPTION
## Summary
Couple of small UX changes:
- Use standard FIL parsing for `price` and `verified-price` params of `storage-deals set-ask`
- Filter failed deals from `client list-deals`, and add `show-failed` option
- Show verified status in `client-list-deals`

Resolves #4172, #4129 