### PR TITLE
Add some new endpoints for querying Msig info

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -418,6 +418,9 @@ type FullNode interface {
 
 	// MsigGetAvailableBalance returns the portion of a multisig's balance that can be withdrawn or spent
 	MsigGetAvailableBalance(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)
+	// MsigGetLockedBalance returns the locked balance of an msig at a vien epoch.
+	// The return may be greater than the multisig actor's actual balance.
+	MsigGetVestingSchedule(context.Context, address.Address, types.TipSetKey) (MsigVesting, error)
 	// MsigGetVested returns the amount of FIL that vested in a multisig in a certain period.
 	// It takes the following params: <multisig address>, <start epoch>, <end epoch>
 	MsigGetVested(context.Context, address.Address, types.TipSetKey, types.TipSetKey) (types.BigInt, error)
@@ -870,4 +873,16 @@ type Partition struct {
 type Fault struct {
 	Miner address.Address
 	Epoch abi.ChainEpoch
+}
+
+var EmptyVesting = MsigVesting{
+	InitialBalance: types.EmptyInt,
+	StartEpoch:     -1,
+	UnlockDuration: -1,
+}
+
+type MsigVesting struct {
+	InitialBalance abi.TokenAmount
+	StartEpoch     abi.ChainEpoch
+	UnlockDuration abi.ChainEpoch
 }

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -212,6 +212,7 @@ type FullNodeStruct struct {
 		StateNetworkVersion                func(context.Context, types.TipSetKey) (stnetwork.Version, error)                                                   `perm:"read"`
 
 		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)                                                                    `perm:"read"`
+		MsigGetVestingSchedule  func(context.Context, address.Address, types.TipSetKey) (api.MsigVesting, error)                                                                 `perm:"read"`
 		MsigGetVested           func(context.Context, address.Address, types.TipSetKey, types.TipSetKey) (types.BigInt, error)                                                   `perm:"read"`
 		MsigCreate              func(context.Context, uint64, []address.Address, abi.ChainEpoch, types.BigInt, address.Address, types.BigInt) (cid.Cid, error)                   `perm:"sign"`
 		MsigPropose             func(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)                          `perm:"sign"`
@@ -931,6 +932,10 @@ func (c *FullNodeStruct) StateNetworkVersion(ctx context.Context, tsk types.TipS
 
 func (c *FullNodeStruct) MsigGetAvailableBalance(ctx context.Context, a address.Address, tsk types.TipSetKey) (types.BigInt, error) {
 	return c.Internal.MsigGetAvailableBalance(ctx, a, tsk)
+}
+
+func (c *FullNodeStruct) MsigGetVestingSchedule(ctx context.Context, a address.Address, tsk types.TipSetKey) (api.MsigVesting, error) {
+	return c.Internal.MsigGetVestingSchedule(ctx, a, tsk)
 }
 
 func (c *FullNodeStruct) MsigGetVested(ctx context.Context, a address.Address, sTsk types.TipSetKey, eTsk types.TipSetKey) (types.BigInt, error) {

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -87,6 +87,7 @@
   * [MsigCreate](#MsigCreate)
   * [MsigGetAvailableBalance](#MsigGetAvailableBalance)
   * [MsigGetVested](#MsigGetVested)
+  * [MsigGetVestingSchedule](#MsigGetVestingSchedule)
   * [MsigPropose](#MsigPropose)
   * [MsigSwapApprove](#MsigSwapApprove)
   * [MsigSwapCancel](#MsigSwapCancel)
@@ -2142,6 +2143,37 @@ Inputs:
 ```
 
 Response: `"0"`
+
+### MsigGetVestingSchedule
+MsigGetLockedBalance returns the locked balance of an msig at a vien epoch.
+The return may be greater than the multisig actor's actual balance.
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  "f01234",
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ]
+]
+```
+
+Response:
+```json
+{
+  "InitialBalance": "0",
+  "StartEpoch": 10101,
+  "UnlockDuration": 10101
+}
+```
 
 ### MsigPropose
 MsigPropose proposes a multisig message


### PR DESCRIPTION
MsigGetLockedBalance is redundant, since it's always just `actor balance - MsigGetAvailableBalance`, but meaningful enough I guess.

EDIT: Killed MsigGetLockedBalance