### PR TITLE
Actors v2 transition

### DIFF
--- a/api/test/paych.go
+++ b/api/test/paych.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 	"time"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	paych0 "github.com/filecoin-project/specs-actors/actors/builtin/paych"
-
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/ipfs/go-cid"
@@ -22,7 +19,9 @@ import (
 	"github.com/filecoin-project/lotus/api/apibstore"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -228,7 +227,7 @@ func TestPaymentChannels(t *testing.T, b APIBuilder, blocktime time.Duration) {
 	}
 
 	// wait for the settlement period to pass before collecting
-	waitForBlocks(ctx, t, bm, paymentReceiver, receiverAddr, paych0.SettleDelay)
+	waitForBlocks(ctx, t, bm, paymentReceiver, receiverAddr, policy.PaychSettleDelay)
 
 	creatorPreCollectBalance, err := paymentCreator.WalletBalance(ctx, createrAddr)
 	if err != nil {
@@ -284,7 +283,7 @@ func waitForBlocks(ctx context.Context, t *testing.T, bm *BlockMiner, paymentRec
 
 		// Add a real block
 		m, err := paymentReceiver.MpoolPushMessage(ctx, &types.Message{
-			To:    builtin0.BurntFundsActorAddr,
+			To:    builtin.BurntFundsActorAddr,
 			From:  receiverAddr,
 			Value: types.NewInt(0),
 		}, nil)

--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -1,35 +1,12 @@
 package build
 
 import (
-	"sort"
-
 	"github.com/filecoin-project/go-address"
 
 	"github.com/libp2p/go-libp2p-core/protocol"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
-
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
-
-func DefaultSectorSize() abi.SectorSize {
-	szs := make([]abi.SectorSize, 0, len(miner0.SupportedProofTypes))
-	for spt := range miner0.SupportedProofTypes {
-		ss, err := spt.SectorSize()
-		if err != nil {
-			panic(err)
-		}
-
-		szs = append(szs, ss)
-	}
-
-	sort.Slice(szs, func(i, j int) bool {
-		return szs[i] < szs[j]
-	})
-
-	return szs[0]
-}
 
 // Core network constants
 

--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -16,14 +16,6 @@ func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
 	return protocol.ID("/fil/kad/" + string(netName))
 }
 
-func UseNewestNetwork() bool {
-	// TODO: Put these in a container we can iterate over
-	if UpgradeBreezeHeight <= 0 && UpgradeSmokeHeight <= 0 && UpgradeActorsV2Height <= 0 {
-		return true
-	}
-	return false
-}
-
 func SetAddressNetwork(n address.Network) {
 	address.CurrentNetwork = n
 }

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -7,12 +7,12 @@ import (
 	"os"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/lotus/chain/actors/policy"
-
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 )
 
 // /////
@@ -32,7 +32,7 @@ const ActorUpgradeNetworkVersion = network.Version4
 const ForkLengthThreshold = Finality
 
 // Blocks (e)
-var BlocksPerEpoch = uint64(builtin.ExpectedLeadersPerEpoch)
+var BlocksPerEpoch = uint64(builtin2.ExpectedLeadersPerEpoch)
 
 // Epochs
 const Finality = policy.ChainFinality
@@ -116,4 +116,4 @@ const PackingEfficiencyDenom = 5
 
 // Actor consts
 // TODO: Pull from actors when its made not private
-var MinDealDuration = abi.ChainEpoch(180 * builtin.EpochsInDay)
+var MinDealDuration = abi.ChainEpoch(180 * builtin2.EpochsInDay)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 )
@@ -21,14 +22,14 @@ var (
 	UnixfsChunkSize     = uint64(1 << 20)
 	UnixfsLinksPerLevel = 1024
 
-	BlocksPerEpoch        = uint64(builtin.ExpectedLeadersPerEpoch)
+	BlocksPerEpoch        = uint64(builtin2.ExpectedLeadersPerEpoch)
 	BlockMessageLimit     = 512
 	BlockGasLimit         = int64(100_000_000_000)
 	BlockGasTarget        = int64(BlockGasLimit / 2)
 	BaseFeeMaxChangeDenom = int64(8) // 12.5%
 	InitialBaseFee        = int64(100e6)
 	MinimumBaseFee        = int64(100)
-	BlockDelaySecs        = uint64(builtin.EpochDurationSeconds)
+	BlockDelaySecs        = uint64(builtin2.EpochDurationSeconds)
 	PropagationDelaySecs  = uint64(6)
 
 	AllowableClockDriftSecs = uint64(1)
@@ -72,7 +73,7 @@ var (
 
 	// Actor consts
 	// TODO: Pull from actors when its made not private
-	MinDealDuration = abi.ChainEpoch(180 * builtin.EpochsInDay)
+	MinDealDuration = abi.ChainEpoch(180 * builtin2.EpochsInDay)
 
 	PackingEfficiencyNum   int64 = 4
 	PackingEfficiencyDenom int64 = 5

--- a/chain/actors/builtin/account/account.go
+++ b/chain/actors/builtin/account/account.go
@@ -24,6 +24,8 @@ func init() {
 	})
 }
 
+var Methods = builtin2.MethodsAccount
+
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	switch act.Code {
 	case builtin0.AccountActorCodeID:

--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -24,6 +24,15 @@ var BurntFundsActorAddr = builtin0.BurntFundsActorAddr
 var ReserveAddress = makeAddress("t090")
 var RootVerifierAddress = makeAddress("t080")
 
+var (
+	ExpectedLeadersPerEpoch = builtin0.ExpectedLeadersPerEpoch
+)
+
+const (
+	EpochDurationSeconds = builtin0.EpochDurationSeconds
+	EpochsInDay          = builtin0.EpochsInDay
+)
+
 // TODO: Why does actors have 2 different versions of this?
 type SectorInfo = proof0.SectorInfo
 type PoStProof = proof0.PoStProof

--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -33,6 +33,11 @@ const (
 	EpochsInDay          = builtin0.EpochsInDay
 )
 
+const (
+	MethodSend        = builtin2.MethodSend
+	MethodConstructor = builtin2.MethodConstructor
+)
+
 // TODO: Why does actors have 2 different versions of this?
 type SectorInfo = proof0.SectorInfo
 type PoStProof = proof0.PoStProof

--- a/chain/actors/builtin/cron/cron.go
+++ b/chain/actors/builtin/cron/cron.go
@@ -1,0 +1,10 @@
+package cron
+
+import (
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+)
+
+var (
+	Address = builtin2.CronActorAddr
+	Methods = builtin2.MethodsCron
+)

--- a/chain/actors/builtin/init/init.go
+++ b/chain/actors/builtin/init/init.go
@@ -26,7 +26,10 @@ func init() {
 	})
 }
 
-var Address = builtin0.InitActorAddr
+var (
+	Address = builtin2.InitActorAddr
+	Methods = builtin2.MethodsInit
+)
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	switch act.Code {

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -27,7 +27,10 @@ func init() {
 	})
 }
 
-var Address = builtin0.StorageMarketActorAddr
+var (
+	Address = builtin2.StorageMarketActorAddr
+	Methods = builtin2.MethodsMarket
+)
 
 func Load(store adt.Store, act *types.Actor) (st State, err error) {
 	switch act.Code {

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -30,6 +30,8 @@ func init() {
 	})
 }
 
+var Methods = builtin2.MethodsMiner
+
 // Unchanged between v0 and v2 actors
 var WPoStProvingPeriod = miner0.WPoStProvingPeriod
 var WPoStPeriodDeadlines = miner0.WPoStPeriodDeadlines

--- a/chain/actors/builtin/multisig/message.go
+++ b/chain/actors/builtin/multisig/message.go
@@ -9,11 +9,14 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	multisig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
 )
+
+var Methods = builtin2.MethodsMultisig
 
 func Message(version actors.Version, from address.Address) MessageBuilder {
 	switch version {

--- a/chain/actors/builtin/paych/message.go
+++ b/chain/actors/builtin/paych/message.go
@@ -7,7 +7,11 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
+
+var Methods = builtin2.MethodsPaych
 
 func Message(version actors.Version, from address.Address) MessageBuilder {
 	switch version {

--- a/chain/actors/builtin/power/power.go
+++ b/chain/actors/builtin/power/power.go
@@ -25,7 +25,10 @@ func init() {
 	})
 }
 
-var Address = builtin0.StoragePowerActorAddr
+var (
+	Address = builtin2.StoragePowerActorAddr
+	Methods = builtin2.MethodsPower
+)
 
 func Load(store adt.Store, act *types.Actor) (st State, err error) {
 	switch act.Code {

--- a/chain/actors/builtin/reward/reward.go
+++ b/chain/actors/builtin/reward/reward.go
@@ -24,7 +24,10 @@ func init() {
 	})
 }
 
-var Address = builtin0.RewardActorAddr
+var (
+	Address = builtin2.RewardActorAddr
+	Methods = builtin2.MethodsReward
+)
 
 func Load(store adt.Store, act *types.Actor) (st State, err error) {
 	switch act.Code {

--- a/chain/actors/builtin/verifreg/verifreg.go
+++ b/chain/actors/builtin/verifreg/verifreg.go
@@ -24,7 +24,10 @@ func init() {
 	})
 }
 
-var Address = builtin0.VerifiedRegistryActorAddr
+var (
+	Address = builtin2.VerifiedRegistryActorAddr
+	Methods = builtin2.MethodsVerifiedRegistry
+)
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	switch act.Code {

--- a/chain/actors/policy/policy_test.go
+++ b/chain/actors/policy/policy_test.go
@@ -6,9 +6,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	paych0 "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	verifreg0 "github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	paych2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/paych"
 	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 )
 
@@ -42,9 +46,25 @@ func TestSupportedProofTypes(t *testing.T) {
 func TestAssumptions(t *testing.T) {
 	require.EqualValues(t, miner0.SupportedProofTypes, miner2.SupportedProofTypes)
 	require.Equal(t, miner0.PreCommitChallengeDelay, miner2.PreCommitChallengeDelay)
+	require.Equal(t, miner0.MaxSectorExpirationExtension, miner2.MaxSectorExpirationExtension)
 	require.Equal(t, miner0.ChainFinality, miner2.ChainFinality)
 	require.Equal(t, miner0.WPoStChallengeWindow, miner2.WPoStChallengeWindow)
 	require.Equal(t, miner0.WPoStProvingPeriod, miner2.WPoStProvingPeriod)
 	require.Equal(t, miner0.WPoStPeriodDeadlines, miner2.WPoStPeriodDeadlines)
+	require.Equal(t, miner0.AddressedSectorsMax, miner2.AddressedSectorsMax)
+	require.Equal(t, paych0.SettleDelay, paych2.SettleDelay)
 	require.True(t, verifreg0.MinVerifiedDealSize.Equals(verifreg2.MinVerifiedDealSize))
+}
+
+func TestPartitionSizes(t *testing.T) {
+	for p := range abi.PoStSealProofTypes {
+		sizeNew, err := builtin2.PoStProofWindowPoStPartitionSectors(p)
+		require.NoError(t, err)
+		sizeOld, err := builtin0.PoStProofWindowPoStPartitionSectors(p)
+		if err != nil {
+			// new proof type.
+			continue
+		}
+		require.Equal(t, sizeOld, sizeNew)
+	}
 }

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -8,8 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
-	"github.com/google/uuid"
+	proof2 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -49,7 +48,7 @@ const msgsPerBlock = 20
 //nolint:deadcode,varcheck
 var log = logging.Logger("gen")
 
-var ValidWpostForTesting = []proof.PoStProof{{
+var ValidWpostForTesting = []proof2.PoStProof{{
 	ProofBytes: []byte("valid proof"),
 }}
 
@@ -225,7 +224,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 		},
 		VerifregRootKey:  DefaultVerifregRootkeyActor,
 		RemainderAccount: DefaultRemainderAccountActor,
-		NetworkName:      uuid.New().String(),
+		NetworkName:      "",
 		Timestamp:        uint64(build.Clock.Now().Add(-500 * time.Duration(build.BlockDelaySecs) * time.Second).Unix()),
 	}
 
@@ -459,7 +458,7 @@ func (cg *ChainGen) NextTipSetFromMinersWithMessages(base *types.TipSet, miners 
 
 func (cg *ChainGen) makeBlock(parents *types.TipSet, m address.Address, vrfticket *types.Ticket,
 	eticket *types.ElectionProof, bvals []types.BeaconEntry, height abi.ChainEpoch,
-	wpost []proof.PoStProof, msgs []*types.SignedMessage) (*types.FullBlock, error) {
+	wpost []proof2.PoStProof, msgs []*types.SignedMessage) (*types.FullBlock, error) {
 
 	var ts uint64
 	if cg.Timestamper != nil {
@@ -593,7 +592,7 @@ func (mca mca) WalletSign(ctx context.Context, a address.Address, v []byte) (*cr
 
 type WinningPoStProver interface {
 	GenerateCandidates(context.Context, abi.PoStRandomness, uint64) ([]uint64, error)
-	ComputeProof(context.Context, []proof.SectorInfo, abi.PoStRandomness) ([]proof.PoStProof, error)
+	ComputeProof(context.Context, []proof2.SectorInfo, abi.PoStRandomness) ([]proof2.PoStProof, error)
 }
 
 type wppProvider struct{}
@@ -602,7 +601,7 @@ func (wpp *wppProvider) GenerateCandidates(ctx context.Context, _ abi.PoStRandom
 	return []uint64{0}, nil
 }
 
-func (wpp *wppProvider) ComputeProof(context.Context, []proof.SectorInfo, abi.PoStRandomness) ([]proof.PoStProof, error) {
+func (wpp *wppProvider) ComputeProof(context.Context, []proof2.SectorInfo, abi.PoStRandomness) ([]proof2.PoStProof, error) {
 	return ValidWpostForTesting, nil
 }
 
@@ -669,15 +668,15 @@ type genFakeVerifier struct{}
 
 var _ ffiwrapper.Verifier = (*genFakeVerifier)(nil)
 
-func (m genFakeVerifier) VerifySeal(svi proof.SealVerifyInfo) (bool, error) {
+func (m genFakeVerifier) VerifySeal(svi proof2.SealVerifyInfo) (bool, error) {
 	return true, nil
 }
 
-func (m genFakeVerifier) VerifyWinningPoSt(ctx context.Context, info proof.WinningPoStVerifyInfo) (bool, error) {
+func (m genFakeVerifier) VerifyWinningPoSt(ctx context.Context, info proof2.WinningPoStVerifyInfo) (bool, error) {
 	panic("not supported")
 }
 
-func (m genFakeVerifier) VerifyWindowPoSt(ctx context.Context, info proof.WindowPoStVerifyInfo) (bool, error) {
+func (m genFakeVerifier) VerifyWindowPoSt(ctx context.Context, info proof2.WindowPoStVerifyInfo) (bool, error) {
 	panic("not supported")
 }
 

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	proof2 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	"github.com/google/uuid"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -224,7 +225,7 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 		},
 		VerifregRootKey:  DefaultVerifregRootkeyActor,
 		RemainderAccount: DefaultRemainderAccountActor,
-		NetworkName:      "",
+		NetworkName:      uuid.New().String(),
 		Timestamp:        uint64(build.Clock.Now().Add(-500 * time.Duration(build.BlockDelaySecs) * time.Second).Unix()),
 	}
 

--- a/chain/gen/genesis/util.go
+++ b/chain/gen/genesis/util.go
@@ -50,12 +50,27 @@ func doExecValue(ctx context.Context, vm *vm.VM, to, from address.Address, value
 	return ret.Return, nil
 }
 
-var GenesisNetworkVersion = func() network.Version { // TODO: Get from build/
-	if build.UseNewestNetwork() { // TODO: Get from build/
-		return build.NewestNetworkVersion // TODO: Get from build/
-	} // TODO: Get from build/
-	return network.Version1 // TODO: Get from build/
-}() // TODO: Get from build/
+// TODO: Get from build
+// TODO: make a list/schedule of these.
+var GenesisNetworkVersion = func() network.Version {
+	// returns the version _before_ the first upgrade.
+	if build.UpgradeBreezeHeight >= 0 {
+		return network.Version0
+	}
+	if build.UpgradeSmokeHeight >= 0 {
+		return network.Version1
+	}
+	if build.UpgradeIgnitionHeight >= 0 {
+		return network.Version2
+	}
+	if build.UpgradeActorsV2Height >= 0 {
+		return network.Version3
+	}
+	if build.UpgradeLiftoffHeight >= 0 {
+		return network.Version3
+	}
+	return build.ActorUpgradeNetworkVersion - 1 // genesis requires actors v0.
+}()
 
 func genesisNetworkVersion(context.Context, abi.ChainEpoch) network.Version { // TODO: Get from build/
 	return GenesisNetworkVersion // TODO: Get from build/

--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/specs-actors/actors/util/adt"
+	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	cid "github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -180,8 +180,8 @@ func aggregateSignatures(sigs []crypto.Signature) (*crypto.Signature, error) {
 	}, nil
 }
 
-func toArray(store adt.Store, cids []cid.Cid) (cid.Cid, error) {
-	arr := adt.MakeEmptyArray(store)
+func toArray(store blockadt.Store, cids []cid.Cid) (cid.Cid, error) {
+	arr := blockadt.MakeEmptyArray(store)
 	for i, c := range cids {
 		oc := cbg.CborCid(c)
 		if err := arr.Set(uint64(i), &oc); err != nil {

--- a/chain/market/fundmgr.go
+++ b/chain/market/fundmgr.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"sync"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"go.uber.org/fx"
-
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
+	"go.uber.org/fx"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
@@ -155,7 +153,7 @@ func (fm *FundMgr) EnsureAvailable(ctx context.Context, addr, wallet address.Add
 		To:     market.Address,
 		From:   wallet,
 		Value:  toAdd,
-		Method: builtin2.MethodsMarket.AddBalance,
+		Method: market.Methods.AddBalance,
 		Params: params,
 	}, nil)
 	if err != nil {

--- a/chain/market/fundmgr.go
+++ b/chain/market/fundmgr.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"go.uber.org/fx"
 
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 
@@ -155,7 +155,7 @@ func (fm *FundMgr) EnsureAvailable(ctx context.Context, addr, wallet address.Add
 		To:     market.Address,
 		From:   wallet,
 		Value:  toAdd,
-		Method: builtin.MethodsMarket.AddBalance,
+		Method: builtin2.MethodsMarket.AddBalance,
 		Params: params,
 	}, nil)
 	if err != nil {

--- a/chain/market/fundmgr_test.go
+++ b/chain/market/fundmgr_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	tutils "github.com/filecoin-project/specs-actors/support/testing"
+
+	tutils "github.com/filecoin-project/specs-actors/v2/support/testing"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -51,7 +51,7 @@ func addFundsMsg(toAdd abi.TokenAmount, addr address.Address, wallet address.Add
 		To:     market.Address,
 		From:   wallet,
 		Value:  toAdd,
-		Method: builtin.MethodsMarket.AddBalance,
+		Method: market.Methods.AddBalance,
 		Params: params,
 	}
 }

--- a/chain/messagepool/gasguess/guessgas.go
+++ b/chain/messagepool/gasguess/guessgas.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
 
 	"github.com/filecoin-project/go-address"
@@ -68,7 +69,7 @@ func failedGuess(msg *types.SignedMessage) int64 {
 
 func GuessGasUsed(ctx context.Context, tsk types.TipSetKey, msg *types.SignedMessage, al ActorLookup) (int64, error) {
 	// MethodSend is the same in all versions.
-	if msg.Message.Method == builtin0.MethodSend {
+	if msg.Message.Method == builtin.MethodSend {
 		switch msg.Message.From.Protocol() {
 		case address.BLS:
 			return 1298450, nil

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -9,16 +9,18 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/mock"
 	"github.com/filecoin-project/lotus/chain/wallet"
 	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
 	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
-	logging "github.com/ipfs/go-log/v2"
 )
 
 func init() {
@@ -143,7 +145,7 @@ func (tma *testMpoolAPI) GetActorAfter(addr address.Address, ts *types.TipSet) (
 	}
 
 	return &types.Actor{
-		Code:    builtin.StorageMarketActorCodeID,
+		Code:    builtin2.StorageMarketActorCodeID,
 		Nonce:   nonce,
 		Balance: balance,
 	}, nil
@@ -450,7 +452,7 @@ func TestLoadLocal(t *testing.T) {
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 	msgs := make(map[cid.Cid]struct{})
 	for i := 0; i < 10; i++ {
 		m := makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
@@ -522,7 +524,7 @@ func TestClearAll(t *testing.T) {
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 	for i := 0; i < 10; i++ {
 		m := makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
 		_, err := mp.Push(m)
@@ -577,7 +579,7 @@ func TestClearNonLocal(t *testing.T) {
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 	for i := 0; i < 10; i++ {
 		m := makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
 		_, err := mp.Push(m)
@@ -643,7 +645,7 @@ func TestUpdates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL

--- a/chain/messagepool/repub_test.go
+++ b/chain/messagepool/repub_test.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/ipfs/go-datastore"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/wallet"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/ipfs/go-datastore"
 )
 
 func TestRepubMessages(t *testing.T) {
@@ -47,7 +49,7 @@ func TestRepubMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -15,18 +15,20 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/mock"
 	"github.com/filecoin-project/lotus/chain/wallet"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 
 	_ "github.com/filecoin-project/lotus/lib/sigs/bls"
 	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
-	logging "github.com/ipfs/go-log"
 )
 
 func init() {
@@ -93,7 +95,7 @@ func TestMessageChains(t *testing.T) {
 	block := tma.nextBlock()
 	ts := mock.TipSet(block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 
@@ -331,7 +333,7 @@ func TestMessageChainSkipping(t *testing.T) {
 	block := tma.nextBlock()
 	ts := mock.TipSet(block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 	baseFee := types.NewInt(0)
 
 	tma.setBalance(a1, 1) // in FIL
@@ -408,7 +410,7 @@ func TestBasicMessageSelection(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -552,7 +554,7 @@ func TestMessageSelectionTrimming(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -615,7 +617,7 @@ func TestPriorityMessageSelection(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -694,7 +696,7 @@ func TestPriorityMessageSelection2(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -763,7 +765,7 @@ func TestPriorityMessageSelection3(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -860,7 +862,7 @@ func TestOptimalMessageSelection1(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -927,7 +929,7 @@ func TestOptimalMessageSelection2(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	tma.setBalance(a1, 1) // in FIL
 	tma.setBalance(a2, 1) // in FIL
@@ -1005,7 +1007,7 @@ func TestOptimalMessageSelection3(t *testing.T) {
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 
 	for _, a := range actors {
 		tma.setBalance(a, 1) // in FIL
@@ -1085,7 +1087,7 @@ func testCompetitiveMessageSelection(t *testing.T, rng *rand.Rand, getPremium fu
 	ts := mock.TipSet(block)
 	tma.applyBlock(t, block)
 
-	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin.StorageMarketActorCodeID, M: 2}]
+	gasLimit := gasguess.Costs[gasguess.CostKey{Code: builtin2.StorageMarketActorCodeID, M: 2}]
 	baseFee := types.NewInt(0)
 
 	for _, a := range actors {

--- a/chain/state/statetree_test.go
+++ b/chain/state/statetree_test.go
@@ -10,7 +10,7 @@ import (
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -18,7 +18,7 @@ import (
 
 func BenchmarkStateTreeSet(b *testing.B) {
 	cst := cbor.NewMemCborStore()
-	st, err := NewStateTree(cst, VersionForNetwork(build.NewestNetworkVersion))
+	st, err := NewStateTree(cst, types.StateTreeVersion1)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -33,8 +33,8 @@ func BenchmarkStateTreeSet(b *testing.B) {
 		}
 		err = st.SetActor(a, &types.Actor{
 			Balance: types.NewInt(1258812523),
-			Code:    builtin.StorageMinerActorCodeID,
-			Head:    builtin.AccountActorCodeID,
+			Code:    builtin2.StorageMinerActorCodeID,
+			Head:    builtin2.AccountActorCodeID,
 			Nonce:   uint64(i),
 		})
 		if err != nil {
@@ -60,8 +60,8 @@ func BenchmarkStateTreeSetFlush(b *testing.B) {
 		}
 		err = st.SetActor(a, &types.Actor{
 			Balance: types.NewInt(1258812523),
-			Code:    builtin.StorageMinerActorCodeID,
-			Head:    builtin.AccountActorCodeID,
+			Code:    builtin2.StorageMinerActorCodeID,
+			Head:    builtin2.AccountActorCodeID,
 			Nonce:   uint64(i),
 		})
 		if err != nil {
@@ -86,8 +86,8 @@ func BenchmarkStateTree10kGetActor(b *testing.B) {
 		}
 		err = st.SetActor(a, &types.Actor{
 			Balance: types.NewInt(1258812523 + uint64(i)),
-			Code:    builtin.StorageMinerActorCodeID,
-			Head:    builtin.AccountActorCodeID,
+			Code:    builtin2.StorageMinerActorCodeID,
+			Head:    builtin2.AccountActorCodeID,
 			Nonce:   uint64(i),
 		})
 		if err != nil {
@@ -129,8 +129,8 @@ func TestSetCache(t *testing.T) {
 
 	act := &types.Actor{
 		Balance: types.NewInt(0),
-		Code:    builtin.StorageMinerActorCodeID,
-		Head:    builtin.AccountActorCodeID,
+		Code:    builtin2.StorageMinerActorCodeID,
+		Head:    builtin2.AccountActorCodeID,
 		Nonce:   0,
 	}
 
@@ -173,7 +173,7 @@ func TestSnapshots(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := st.SetActor(addrs[0], &types.Actor{Code: builtin.AccountActorCodeID, Head: builtin.AccountActorCodeID, Balance: types.NewInt(55)}); err != nil {
+	if err := st.SetActor(addrs[0], &types.Actor{Code: builtin2.AccountActorCodeID, Head: builtin2.AccountActorCodeID, Balance: types.NewInt(55)}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -182,7 +182,7 @@ func TestSnapshots(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := st.SetActor(addrs[1], &types.Actor{Code: builtin.AccountActorCodeID, Head: builtin.AccountActorCodeID, Balance: types.NewInt(77)}); err != nil {
+		if err := st.SetActor(addrs[1], &types.Actor{Code: builtin2.AccountActorCodeID, Head: builtin2.AccountActorCodeID, Balance: types.NewInt(77)}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -193,7 +193,7 @@ func TestSnapshots(t *testing.T) {
 	}
 
 	// more operations in top level call...
-	if err := st.SetActor(addrs[2], &types.Actor{Code: builtin.AccountActorCodeID, Head: builtin.AccountActorCodeID, Balance: types.NewInt(123)}); err != nil {
+	if err := st.SetActor(addrs[2], &types.Actor{Code: builtin2.AccountActorCodeID, Head: builtin2.AccountActorCodeID, Balance: types.NewInt(123)}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,7 +202,7 @@ func TestSnapshots(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := st.SetActor(addrs[3], &types.Actor{Code: builtin.AccountActorCodeID, Head: builtin.AccountActorCodeID, Balance: types.NewInt(5)}); err != nil {
+		if err := st.SetActor(addrs[3], &types.Actor{Code: builtin2.AccountActorCodeID, Head: builtin2.AccountActorCodeID, Balance: types.NewInt(5)}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -512,17 +512,17 @@ func UpgradeIgnition(ctx context.Context, sm *StateManager, cb ExecCallback, roo
 		return cid.Undef, xerrors.Errorf("second split address: %w", err)
 	}
 
-	err = resetGenesisMsigs(ctx, sm, store, tree, build.UpgradeLiftoffHeight)
+	err = resetGenesisMsigs0(ctx, sm, store, tree, build.UpgradeLiftoffHeight)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("resetting genesis msig start epochs: %w", err)
 	}
 
-	err = splitGenesisMultisig(ctx, cb, split1, store, tree, 50)
+	err = splitGenesisMultisig0(ctx, cb, split1, store, tree, 50)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("splitting first msig: %w", err)
 	}
 
-	err = splitGenesisMultisig(ctx, cb, split2, store, tree, 50)
+	err = splitGenesisMultisig0(ctx, cb, split2, store, tree, 50)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("splitting second msig: %w", err)
 	}
@@ -548,17 +548,17 @@ func UpgradeRefuel(ctx context.Context, sm *StateManager, cb ExecCallback, root 
 		return cid.Undef, xerrors.Errorf("getting address: %w", err)
 	}
 
-	err = resetMultisigVesting(ctx, store, tree, addr, 0, 0, big.Zero())
+	err = resetMultisigVesting0(ctx, store, tree, addr, 0, 0, big.Zero())
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("tweaking msig vesting: %w", err)
 	}
 
-	err = resetMultisigVesting(ctx, store, tree, builtin.ReserveAddress, 0, 0, big.Zero())
+	err = resetMultisigVesting0(ctx, store, tree, builtin.ReserveAddress, 0, 0, big.Zero())
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("tweaking msig vesting: %w", err)
 	}
 
-	err = resetMultisigVesting(ctx, store, tree, builtin.RootVerifierAddress, 0, 0, big.Zero())
+	err = resetMultisigVesting0(ctx, store, tree, builtin.RootVerifierAddress, 0, 0, big.Zero())
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("tweaking msig vesting: %w", err)
 	}
@@ -666,7 +666,7 @@ func setNetworkName(ctx context.Context, store adt.Store, tree *state.StateTree,
 	return nil
 }
 
-func splitGenesisMultisig(ctx context.Context, cb ExecCallback, addr address.Address, store adt0.Store, tree *state.StateTree, portions uint64) error {
+func splitGenesisMultisig0(ctx context.Context, cb ExecCallback, addr address.Address, store adt0.Store, tree *state.StateTree, portions uint64) error {
 	if portions < 1 {
 		return xerrors.Errorf("cannot split into 0 portions")
 	}
@@ -784,7 +784,7 @@ func makeKeyAddr(splitAddr address.Address, count uint64) (address.Address, erro
 }
 
 // TODO: After the Liftoff epoch, refactor this to use resetMultisigVesting
-func resetGenesisMsigs(ctx context.Context, sm *StateManager, store adt0.Store, tree *state.StateTree, startEpoch abi.ChainEpoch) error {
+func resetGenesisMsigs0(ctx context.Context, sm *StateManager, store adt0.Store, tree *state.StateTree, startEpoch abi.ChainEpoch) error {
 	gb, err := sm.cs.GetGenesis()
 	if err != nil {
 		return xerrors.Errorf("getting genesis block: %w", err)
@@ -834,7 +834,7 @@ func resetGenesisMsigs(ctx context.Context, sm *StateManager, store adt0.Store, 
 	return nil
 }
 
-func resetMultisigVesting(ctx context.Context, store adt0.Store, tree *state.StateTree, addr address.Address, startEpoch abi.ChainEpoch, duration abi.ChainEpoch, balance abi.TokenAmount) error {
+func resetMultisigVesting0(ctx context.Context, store adt0.Store, tree *state.StateTree, addr address.Address, startEpoch abi.ChainEpoch, duration abi.ChainEpoch, balance abi.TokenAmount) error {
 	act, err := tree.GetActor(addr)
 	if err != nil {
 		return xerrors.Errorf("getting actor: %w", err)

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	init0 "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
+	init2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
@@ -174,7 +174,7 @@ func TestForkHeightTriggers(t *testing.T) {
 
 	var msgs []*types.SignedMessage
 
-	enc, err := actors.SerializeParams(&init0.ExecParams{CodeCID: (testActor{}).Code()})
+	enc, err := actors.SerializeParams(&init2.ExecParams{CodeCID: (testActor{}).Code()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +272,7 @@ func TestForkRefuseCall(t *testing.T) {
 
 	cg.SetStateManager(sm)
 
-	enc, err := actors.SerializeParams(&init0.ExecParams{CodeCID: (testActor{}).Code()})
+	enc, err := actors.SerializeParams(&init2.ExecParams{CodeCID: (testActor{}).Code()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
+	// Used for genesis.
 	msig0 "github.com/filecoin-project/specs-actors/actors/builtin/multisig"
 
 	"github.com/ipfs/go-cid"
@@ -26,6 +26,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
@@ -235,20 +236,20 @@ func (sm *StateManager) ApplyBlocks(ctx context.Context, parentEpoch abi.ChainEp
 
 	runCron := func() error {
 		// TODO: this nonce-getting is a tiny bit ugly
-		ca, err := vmi.StateTree().GetActor(builtin0.SystemActorAddr)
+		ca, err := vmi.StateTree().GetActor(builtin2.SystemActorAddr)
 		if err != nil {
 			return err
 		}
 
 		cronMsg := &types.Message{
-			To:         builtin0.CronActorAddr,
-			From:       builtin0.SystemActorAddr,
+			To:         builtin2.CronActorAddr,
+			From:       builtin2.SystemActorAddr,
 			Nonce:      ca.Nonce,
 			Value:      types.NewInt(0),
 			GasFeeCap:  types.NewInt(0),
 			GasPremium: types.NewInt(0),
 			GasLimit:   build.BlockGasLimit * 10000, // Make super sure this is never too little
-			Method:     builtin0.MethodsCron.EpochTick,
+			Method:     builtin2.MethodsCron.EpochTick,
 			Params:     nil,
 		}
 		ret, err := vmi.ApplyImplicitMessage(ctx, cronMsg)
@@ -336,20 +337,20 @@ func (sm *StateManager) ApplyBlocks(ctx context.Context, parentEpoch abi.ChainEp
 			return cid.Undef, cid.Undef, xerrors.Errorf("failed to serialize award params: %w", err)
 		}
 
-		sysAct, actErr := vmi.StateTree().GetActor(builtin0.SystemActorAddr)
+		sysAct, actErr := vmi.StateTree().GetActor(builtin2.SystemActorAddr)
 		if actErr != nil {
 			return cid.Undef, cid.Undef, xerrors.Errorf("failed to get system actor: %w", actErr)
 		}
 
 		rwMsg := &types.Message{
-			From:       builtin0.SystemActorAddr,
+			From:       builtin2.SystemActorAddr,
 			To:         reward.Address,
 			Nonce:      sysAct.Nonce,
 			Value:      types.NewInt(0),
 			GasFeeCap:  types.NewInt(0),
 			GasPremium: types.NewInt(0),
 			GasLimit:   1 << 30,
-			Method:     builtin0.MethodsReward.AwardBlockReward,
+			Method:     builtin2.MethodsReward.AwardBlockReward,
 			Params:     params,
 		}
 		ret, actErr := vmi.ApplyImplicitMessage(ctx, rwMsg)
@@ -953,7 +954,7 @@ func (sm *StateManager) setupGenesisActors(ctx context.Context) error {
 		} else if builtin.IsAccountActor(act.Code) {
 			// should exclude burnt funds actor and "remainder account actor"
 			// should only ever be "faucet" accounts in testnets
-			if kaddr == builtin0.BurntFundsActorAddr {
+			if kaddr == builtin2.BurntFundsActorAddr {
 				return nil
 			}
 
@@ -1031,24 +1032,24 @@ func (sm *StateManager) setupPreIgnitionGenesisActorsTestnet(ctx context.Context
 	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
 
 	// 6 months
-	sixMonths := abi.ChainEpoch(183 * builtin0.EpochsInDay)
+	sixMonths := abi.ChainEpoch(183 * builtin2.EpochsInDay)
 	totalsByEpoch[sixMonths] = big.NewInt(49_929_341)
 	totalsByEpoch[sixMonths] = big.Add(totalsByEpoch[sixMonths], big.NewInt(32_787_700))
 
 	// 1 year
-	oneYear := abi.ChainEpoch(365 * builtin0.EpochsInDay)
+	oneYear := abi.ChainEpoch(365 * builtin2.EpochsInDay)
 	totalsByEpoch[oneYear] = big.NewInt(22_421_712)
 
 	// 2 years
-	twoYears := abi.ChainEpoch(2 * 365 * builtin0.EpochsInDay)
+	twoYears := abi.ChainEpoch(2 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[twoYears] = big.NewInt(7_223_364)
 
 	// 3 years
-	threeYears := abi.ChainEpoch(3 * 365 * builtin0.EpochsInDay)
+	threeYears := abi.ChainEpoch(3 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[threeYears] = big.NewInt(87_637_883)
 
 	// 6 years
-	sixYears := abi.ChainEpoch(6 * 365 * builtin0.EpochsInDay)
+	sixYears := abi.ChainEpoch(6 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[sixYears] = big.NewInt(100_000_000)
 	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(300_000_000))
 
@@ -1108,24 +1109,24 @@ func (sm *StateManager) setupPostIgnitionGenesisActors(ctx context.Context) erro
 	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
 
 	// 6 months
-	sixMonths := abi.ChainEpoch(183 * builtin0.EpochsInDay)
+	sixMonths := abi.ChainEpoch(183 * builtin2.EpochsInDay)
 	totalsByEpoch[sixMonths] = big.NewInt(49_929_341)
 	totalsByEpoch[sixMonths] = big.Add(totalsByEpoch[sixMonths], big.NewInt(32_787_700))
 
 	// 1 year
-	oneYear := abi.ChainEpoch(365 * builtin0.EpochsInDay)
+	oneYear := abi.ChainEpoch(365 * builtin2.EpochsInDay)
 	totalsByEpoch[oneYear] = big.NewInt(22_421_712)
 
 	// 2 years
-	twoYears := abi.ChainEpoch(2 * 365 * builtin0.EpochsInDay)
+	twoYears := abi.ChainEpoch(2 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[twoYears] = big.NewInt(7_223_364)
 
 	// 3 years
-	threeYears := abi.ChainEpoch(3 * 365 * builtin0.EpochsInDay)
+	threeYears := abi.ChainEpoch(3 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[threeYears] = big.NewInt(87_637_883)
 
 	// 6 years
-	sixYears := abi.ChainEpoch(6 * 365 * builtin0.EpochsInDay)
+	sixYears := abi.ChainEpoch(6 * 365 * builtin2.EpochsInDay)
 	totalsByEpoch[sixYears] = big.NewInt(100_000_000)
 	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(300_000_000))
 
@@ -1259,7 +1260,7 @@ func (sm *StateManager) GetFilLocked(ctx context.Context, st *state.StateTree) (
 }
 
 func GetFilBurnt(ctx context.Context, st *state.StateTree) (abi.TokenAmount, error) {
-	burnt, err := st.GetActor(builtin0.BurntFundsActorAddr)
+	burnt, err := st.GetActor(builtin2.BurntFundsActorAddr)
 	if err != nil {
 		return big.Zero(), xerrors.Errorf("failed to load burnt actor: %w", err)
 	}

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/actors/policy"
 
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -24,16 +23,17 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/rt"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 	exported0 "github.com/filecoin-project/specs-actors/actors/builtin/exported"
 	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
 	exported2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/exported"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -548,8 +548,7 @@ func init() {
 		methods := make(map[abi.MethodNum]MethodMeta, len(exports))
 
 		// Explicitly add send, it's special.
-		// Note that builtin2.MethodSend = builtin0.MethodSend = 0.
-		methods[builtin0.MethodSend] = MethodMeta{
+		methods[builtin.MethodSend] = MethodMeta{
 			Name:   "Send",
 			Params: reflect.TypeOf(new(abi.EmptyValue)),
 			Ret:    reflect.TypeOf(new(abi.EmptyValue)),
@@ -573,11 +572,9 @@ func init() {
 			fnName = strings.TrimSuffix(fnName[strings.LastIndexByte(fnName, '.')+1:], "-fm")
 
 			switch abi.MethodNum(number) {
-			case builtin0.MethodSend:
-				// Note that builtin2.MethodSend = builtin0.MethodSend = 0.
+			case builtin.MethodSend:
 				panic("method 0 is reserved for Send")
-			case builtin0.MethodConstructor:
-				// Note that builtin2.MethodConstructor = builtin0.MethodConstructor = 1.
+			case builtin.MethodConstructor:
 				if fnName != "Constructor" {
 					panic("method 1 is reserved for Constructor")
 				}

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -19,7 +19,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	adt0 "github.com/filecoin-project/specs-actors/actors/util/adt"
+	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
@@ -760,7 +760,7 @@ func (cs *ChainStore) GetSignedMessage(c cid.Cid) (*types.SignedMessage, error) 
 func (cs *ChainStore) readAMTCids(root cid.Cid) ([]cid.Cid, error) {
 	ctx := context.TODO()
 	// block headers use adt0, for now.
-	a, err := adt0.AsArray(cs.Store(ctx), root)
+	a, err := blockadt.AsArray(cs.Store(ctx), root)
 	if err != nil {
 		return nil, xerrors.Errorf("amt load: %w", err)
 	}
@@ -954,7 +954,7 @@ func (cs *ChainStore) MessagesForBlock(b *types.BlockHeader) ([]*types.Message, 
 func (cs *ChainStore) GetParentReceipt(b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
 	ctx := context.TODO()
 	// block headers use adt0, for now.
-	a, err := adt0.AsArray(cs.Store(ctx), b.ParentMessageReceipts)
+	a, err := blockadt.AsArray(cs.Store(ctx), b.ParentMessageReceipts)
 	if err != nil {
 		return nil, xerrors.Errorf("amt load: %w", err)
 	}

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -23,7 +23,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 
-	adt0 "github.com/filecoin-project/specs-actors/actors/util/adt"
+	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
@@ -386,9 +386,9 @@ func (bv *BlockValidator) isChainNearSynced() bool {
 func (bv *BlockValidator) validateMsgMeta(ctx context.Context, msg *types.BlockMsg) error {
 	// TODO there has to be a simpler way to do this without the blockstore dance
 	// block headers use adt0
-	store := adt0.WrapStore(ctx, cbor.NewCborStore(blockstore.NewTemporary()))
-	bmArr := adt0.MakeEmptyArray(store)
-	smArr := adt0.MakeEmptyArray(store)
+	store := blockadt.WrapStore(ctx, cbor.NewCborStore(blockstore.NewTemporary()))
+	bmArr := blockadt.MakeEmptyArray(store)
+	smArr := blockadt.MakeEmptyArray(store)
 
 	for i, m := range msg.BlsMessages {
 		c := cbg.CborCid(m)

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
-
 	"github.com/ipfs/go-cid"
 
 	ds "github.com/ipfs/go-datastore"
@@ -19,6 +17,8 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
@@ -469,8 +469,8 @@ func (wpp badWpp) GenerateCandidates(context.Context, abi.PoStRandomness, uint64
 	return []uint64{1}, nil
 }
 
-func (wpp badWpp) ComputeProof(context.Context, []proof.SectorInfo, abi.PoStRandomness) ([]proof.PoStProof, error) {
-	return []proof.PoStProof{
+func (wpp badWpp) ComputeProof(context.Context, []proof2.SectorInfo, abi.PoStRandomness) ([]proof2.PoStProof, error) {
+	return []proof2.PoStProof{
 		{
 			PoStProof:  abi.RegisteredPoStProof_StackedDrgWinning2KiBV1,
 			ProofBytes: []byte("evil"),

--- a/chain/vm/gas_v0.go
+++ b/chain/vm/gas_v0.go
@@ -3,12 +3,12 @@ package vm
 import (
 	"fmt"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
 type scalingCost struct {
@@ -112,14 +112,14 @@ func (pl *pricelistV0) OnMethodInvocation(value abi.TokenAmount, methodNum abi.M
 
 	if big.Cmp(value, abi.NewTokenAmount(0)) != 0 {
 		ret += pl.sendTransferFunds
-		if methodNum == builtin0.MethodSend {
+		if methodNum == builtin2.MethodSend {
 			// transfer only
 			ret += pl.sendTransferOnlyPremium
 		}
 		extra += "t"
 	}
 
-	if methodNum != builtin0.MethodSend {
+	if methodNum != builtin2.MethodSend {
 		extra += "i"
 		// running actors is cheaper becase we hand over to actors
 		ret += pl.sendInvokeMethod
@@ -175,14 +175,14 @@ func (pl *pricelistV0) OnComputeUnsealedSectorCid(proofType abi.RegisteredSealPr
 }
 
 // OnVerifySeal
-func (pl *pricelistV0) OnVerifySeal(info proof.SealVerifyInfo) GasCharge {
+func (pl *pricelistV0) OnVerifySeal(info proof2.SealVerifyInfo) GasCharge {
 	// TODO: this needs more cost tunning, check with @lotus
 	// this is not used
 	return newGasCharge("OnVerifySeal", pl.verifySealBase, 0)
 }
 
 // OnVerifyPost
-func (pl *pricelistV0) OnVerifyPost(info proof.WindowPoStVerifyInfo) GasCharge {
+func (pl *pricelistV0) OnVerifyPost(info proof2.WindowPoStVerifyInfo) GasCharge {
 	sectorSize := "unknown"
 	var proofType abi.RegisteredPoStProof
 

--- a/chain/vm/gas_v0.go
+++ b/chain/vm/gas_v0.go
@@ -3,12 +3,13 @@ package vm
 import (
 	"fmt"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 )
 
 type scalingCost struct {
@@ -112,14 +113,14 @@ func (pl *pricelistV0) OnMethodInvocation(value abi.TokenAmount, methodNum abi.M
 
 	if big.Cmp(value, abi.NewTokenAmount(0)) != 0 {
 		ret += pl.sendTransferFunds
-		if methodNum == builtin2.MethodSend {
+		if methodNum == builtin.MethodSend {
 			// transfer only
 			ret += pl.sendTransferOnlyPremium
 		}
 		extra += "t"
 	}
 
-	if methodNum != builtin2.MethodSend {
+	if methodNum != builtin.MethodSend {
 		extra += "i"
 		// running actors is cheaper becase we hand over to actors
 		ret += pl.sendInvokeMethod

--- a/chain/vm/invoker_test.go
+++ b/chain/vm/invoker_test.go
@@ -5,16 +5,17 @@ import (
 	"io"
 	"testing"
 
-	"github.com/filecoin-project/go-state-types/abi"
-
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/assert"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/exitcode"
+
+	runtime2 "github.com/filecoin-project/specs-actors/v2/actors/runtime"
+
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 )
 
 type basicContract struct{}
@@ -61,17 +62,17 @@ func (b basicContract) Exports() []interface{} {
 	}
 }
 
-func (basicContract) InvokeSomething0(rt runtime.Runtime, params *basicParams) *abi.EmptyValue {
+func (basicContract) InvokeSomething0(rt runtime2.Runtime, params *basicParams) *abi.EmptyValue {
 	rt.Abortf(exitcode.ExitCode(params.B), "params.B")
 	return nil
 }
 
-func (basicContract) BadParam(rt runtime.Runtime, params *basicParams) *abi.EmptyValue {
+func (basicContract) BadParam(rt runtime2.Runtime, params *basicParams) *abi.EmptyValue {
 	rt.Abortf(255, "bad params")
 	return nil
 }
 
-func (basicContract) InvokeSomething10(rt runtime.Runtime, params *basicParams) *abi.EmptyValue {
+func (basicContract) InvokeSomething10(rt runtime2.Runtime, params *basicParams) *abi.EmptyValue {
 	rt.Abortf(exitcode.ExitCode(params.B+10), "params.B")
 	return nil
 }

--- a/chain/vm/mkactor.go
+++ b/chain/vm/mkactor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/account"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -57,7 +58,7 @@ func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, add
 	}
 	// call constructor on account
 
-	_, aerr = rt.internalSend(builtin.SystemActorAddr, addrID, builtin2.MethodsAccount.Constructor, big.Zero(), p)
+	_, aerr = rt.internalSend(builtin.SystemActorAddr, addrID, account.Methods.Constructor, big.Zero(), p)
 	if aerr != nil {
 		return nil, address.Undef, aerrors.Wrap(aerr, "failed to invoke account constructor")
 	}

--- a/chain/vm/mkactor.go
+++ b/chain/vm/mkactor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -56,7 +57,7 @@ func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, add
 	}
 	// call constructor on account
 
-	_, aerr = rt.internalSend(builtin0.SystemActorAddr, addrID, builtin0.MethodsAccount.Constructor, big.Zero(), p)
+	_, aerr = rt.internalSend(builtin.SystemActorAddr, addrID, builtin2.MethodsAccount.Constructor, big.Zero(), p)
 	if aerr != nil {
 		return nil, address.Undef, aerrors.Wrap(aerr, "failed to invoke account constructor")
 	}

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -53,8 +53,8 @@ func (m *Message) ValueReceived() abi.TokenAmount {
 var EnableGasTracing = false
 
 type Runtime struct {
-	rt0.Message
-	rt0.Syscalls
+	rt2.Message
+	rt2.Syscalls
 
 	ctx context.Context
 

--- a/chain/vm/syscalls.go
+++ b/chain/vm/syscalls.go
@@ -7,8 +7,6 @@ import (
 	goruntime "runtime"
 	"sync"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -23,7 +21,9 @@ import (
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/sigs"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
+
+	runtime2 "github.com/filecoin-project/specs-actors/v2/actors/runtime"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
 )
@@ -34,10 +34,10 @@ func init() {
 
 // Actual type is defined in chain/types/vmcontext.go because the VMContext interface is there
 
-type SyscallBuilder func(ctx context.Context, cstate *state.StateTree, cst cbor.IpldStore) runtime.Syscalls
+type SyscallBuilder func(ctx context.Context, cstate *state.StateTree, cst cbor.IpldStore) runtime2.Syscalls
 
 func Syscalls(verifier ffiwrapper.Verifier) SyscallBuilder {
-	return func(ctx context.Context, cstate *state.StateTree, cst cbor.IpldStore) runtime.Syscalls {
+	return func(ctx context.Context, cstate *state.StateTree, cst cbor.IpldStore) runtime2.Syscalls {
 		return &syscallShim{
 			ctx: ctx,
 
@@ -79,7 +79,7 @@ func (ss *syscallShim) HashBlake2b(data []byte) [32]byte {
 // Checks validity of the submitted consensus fault with the two block headers needed to prove the fault
 // and an optional extra one to check common ancestry (as needed).
 // Note that the blocks are ordered: the method requires a.Epoch() <= b.Epoch().
-func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime.ConsensusFault, error) {
+func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime2.ConsensusFault, error) {
 	// Note that block syntax is not validated. Any validly signed block will be accepted pursuant to the below conditions.
 	// Whether or not it could ever have been accepted in a chain is not checked/does not matter here.
 	// for that reason when checking block parent relationships, rather than instantiating a Tipset to do so
@@ -115,14 +115,14 @@ func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime.Consen
 	}
 
 	// (2) check for the consensus faults themselves
-	var consensusFault *runtime.ConsensusFault
+	var consensusFault *runtime2.ConsensusFault
 
 	// (a) double-fork mining fault
 	if blockA.Height == blockB.Height {
-		consensusFault = &runtime.ConsensusFault{
+		consensusFault = &runtime2.ConsensusFault{
 			Target: blockA.Miner,
 			Epoch:  blockB.Height,
-			Type:   runtime.ConsensusFaultDoubleForkMining,
+			Type:   runtime2.ConsensusFaultDoubleForkMining,
 		}
 	}
 
@@ -130,10 +130,10 @@ func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime.Consen
 	// strictly speaking no need to compare heights based on double fork mining check above,
 	// but at same height this would be a different fault.
 	if types.CidArrsEqual(blockA.Parents, blockB.Parents) && blockA.Height != blockB.Height {
-		consensusFault = &runtime.ConsensusFault{
+		consensusFault = &runtime2.ConsensusFault{
 			Target: blockA.Miner,
 			Epoch:  blockB.Height,
-			Type:   runtime.ConsensusFaultTimeOffsetMining,
+			Type:   runtime2.ConsensusFaultTimeOffsetMining,
 		}
 	}
 
@@ -153,10 +153,10 @@ func (ss *syscallShim) VerifyConsensusFault(a, b, extra []byte) (*runtime.Consen
 
 		if types.CidArrsEqual(blockA.Parents, blockC.Parents) && blockA.Height == blockC.Height &&
 			types.CidArrsContains(blockB.Parents, blockC.Cid()) && !types.CidArrsContains(blockB.Parents, blockA.Cid()) {
-			consensusFault = &runtime.ConsensusFault{
+			consensusFault = &runtime2.ConsensusFault{
 				Target: blockA.Miner,
 				Epoch:  blockB.Height,
-				Type:   runtime.ConsensusFaultParentGrinding,
+				Type:   runtime2.ConsensusFaultParentGrinding,
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (ss *syscallShim) VerifyBlockSig(blk *types.BlockHeader) error {
 	return nil
 }
 
-func (ss *syscallShim) VerifyPoSt(proof proof.WindowPoStVerifyInfo) error {
+func (ss *syscallShim) VerifyPoSt(proof proof2.WindowPoStVerifyInfo) error {
 	ok, err := ss.verifier.VerifyWindowPoSt(context.TODO(), proof)
 	if err != nil {
 		return err
@@ -226,7 +226,7 @@ func (ss *syscallShim) VerifyPoSt(proof proof.WindowPoStVerifyInfo) error {
 	return nil
 }
 
-func (ss *syscallShim) VerifySeal(info proof.SealVerifyInfo) error {
+func (ss *syscallShim) VerifySeal(info proof2.SealVerifyInfo) error {
 	//_, span := trace.StartSpan(ctx, "ValidatePoRep")
 	//defer span.End()
 
@@ -266,7 +266,7 @@ func (ss *syscallShim) VerifySignature(sig crypto.Signature, addr address.Addres
 
 var BatchSealVerifyParallelism = goruntime.NumCPU()
 
-func (ss *syscallShim) BatchVerifySeals(inp map[address.Address][]proof.SealVerifyInfo) (map[address.Address][]bool, error) {
+func (ss *syscallShim) BatchVerifySeals(inp map[address.Address][]proof2.SealVerifyInfo) (map[address.Address][]bool, error) {
 	out := make(map[address.Address][]bool)
 
 	sema := make(chan struct{}, BatchSealVerifyParallelism)
@@ -278,7 +278,7 @@ func (ss *syscallShim) BatchVerifySeals(inp map[address.Address][]proof.SealVeri
 
 		for i, s := range seals {
 			wg.Add(1)
-			go func(ma address.Address, ix int, svi proof.SealVerifyInfo, res []bool) {
+			go func(ma address.Address, ix int, svi proof2.SealVerifyInfo, res []bool) {
 				defer wg.Done()
 				sema <- struct{}{}
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/fatih/color"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-cidutil/cidenc"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -529,8 +529,8 @@ func interactiveDeal(cctx *cli.Context) error {
 				continue
 			}
 
-			if days < int(build.MinDealDuration/builtin.EpochsInDay) {
-				printErr(xerrors.Errorf("minimum duration is %d days", int(build.MinDealDuration/builtin.EpochsInDay)))
+			if days < int(build.MinDealDuration/builtin0.EpochsInDay) {
+				printErr(xerrors.Errorf("minimum duration is %d days", int(build.MinDealDuration/builtin0.EpochsInDay)))
 				continue
 			}
 

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -24,8 +24,8 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
-	init0 "github.com/filecoin-project/specs-actors/actors/builtin/init"
-	msig0 "github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	init2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/init"
+	msig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
 	"github.com/filecoin-project/lotus/api/apibstore"
 	"github.com/filecoin-project/lotus/build"
@@ -154,7 +154,7 @@ var msigCreateCmd = &cli.Command{
 
 		// get address of newly created miner
 
-		var execreturn init0.ExecReturn
+		var execreturn init2.ExecReturn
 		if err := execreturn.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ var msigProposeCmd = &cli.Command{
 			return fmt.Errorf("proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
-		var retval msig0.ProposeReturn
+		var retval msig2.ProposeReturn
 		if err := retval.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
 			return fmt.Errorf("failed to unmarshal propose return value: %w", err)
 		}
@@ -1022,7 +1022,7 @@ var msigLockProposeCmd = &cli.Command{
 			from = defaddr
 		}
 
-		params, actErr := actors.SerializeParams(&msig0.LockBalanceParams{
+		params, actErr := actors.SerializeParams(&msig2.LockBalanceParams{
 			StartEpoch:     abi.ChainEpoch(start),
 			UnlockDuration: abi.ChainEpoch(duration),
 			Amount:         abi.NewTokenAmount(amount.Int64()),
@@ -1119,7 +1119,7 @@ var msigLockApproveCmd = &cli.Command{
 			from = defaddr
 		}
 
-		params, actErr := actors.SerializeParams(&msig0.LockBalanceParams{
+		params, actErr := actors.SerializeParams(&msig2.LockBalanceParams{
 			StartEpoch:     abi.ChainEpoch(start),
 			UnlockDuration: abi.ChainEpoch(duration),
 			Amount:         abi.NewTokenAmount(amount.Int64()),
@@ -1211,7 +1211,7 @@ var msigLockCancelCmd = &cli.Command{
 			from = defaddr
 		}
 
-		params, actErr := actors.SerializeParams(&msig0.LockBalanceParams{
+		params, actErr := actors.SerializeParams(&msig2.LockBalanceParams{
 			StartEpoch:     abi.ChainEpoch(start),
 			UnlockDuration: abi.ChainEpoch(duration),
 			Amount:         abi.NewTokenAmount(amount.Int64()),

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"text/tabwriter"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
-
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -1032,7 +1030,7 @@ var msigLockProposeCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigPropose(ctx, msig, msig, big.Zero(), from, uint64(builtin2.MethodsMultisig.LockBalance), params)
+		msgCid, err := api.MsigPropose(ctx, msig, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}
@@ -1129,7 +1127,7 @@ var msigLockApproveCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigApprove(ctx, msig, txid, prop, msig, big.Zero(), from, uint64(builtin2.MethodsMultisig.LockBalance), params)
+		msgCid, err := api.MsigApprove(ctx, msig, txid, prop, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}
@@ -1221,7 +1219,7 @@ var msigLockCancelCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigCancel(ctx, msig, txid, msig, big.Zero(), from, uint64(builtin2.MethodsMultisig.LockBalance), params)
+		msgCid, err := api.MsigCancel(ctx, msig, txid, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-bench/caching_verifier.go
+++ b/cmd/lotus-bench/caching_verifier.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 	"github.com/ipfs/go-datastore"
 	"github.com/minio/blake2b-simd"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -78,15 +79,17 @@ func (cv cachingVerifier) withCache(execute func() (bool, error), param cbg.CBOR
 	}
 }
 
-func (cv *cachingVerifier) VerifySeal(svi proof.SealVerifyInfo) (bool, error) {
+func (cv *cachingVerifier) VerifySeal(svi proof2.SealVerifyInfo) (bool, error) {
 	return cv.withCache(func() (bool, error) {
 		return cv.backend.VerifySeal(svi)
 	}, &svi)
 }
-func (cv *cachingVerifier) VerifyWinningPoSt(ctx context.Context, info proof.WinningPoStVerifyInfo) (bool, error) {
+
+// FIXME: https://github.com/filecoin-project/specs-actors/pull/1227
+func (cv *cachingVerifier) VerifyWinningPoSt(ctx context.Context, info proof0.WinningPoStVerifyInfo) (bool, error) {
 	return cv.backend.VerifyWinningPoSt(ctx, info)
 }
-func (cv *cachingVerifier) VerifyWindowPoSt(ctx context.Context, info proof.WindowPoStVerifyInfo) (bool, error) {
+func (cv *cachingVerifier) VerifyWindowPoSt(ctx context.Context, info proof2.WindowPoStVerifyInfo) (bool, error) {
 	return cv.withCache(func() (bool, error) {
 		return cv.backend.VerifyWindowPoSt(ctx, info)
 	}, &info)

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
-	saproof "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	saproof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
 
 	"github.com/docker/go-units"
 	logging "github.com/ipfs/go-log/v2"
@@ -237,7 +237,7 @@ var sealBenchCmd = &cli.Command{
 		}
 
 		var sealTimings []SealingResult
-		var sealedSectors []saproof.SectorInfo
+		var sealedSectors []saproof0.SectorInfo
 
 		if robench == "" {
 			var err error
@@ -280,7 +280,7 @@ var sealBenchCmd = &cli.Command{
 			}
 
 			for _, s := range genm.Sectors {
-				sealedSectors = append(sealedSectors, saproof.SectorInfo{
+				sealedSectors = append(sealedSectors, saproof0.SectorInfo{
 					SealedCID:    s.CommR,
 					SectorNumber: s.SectorID,
 					SealProof:    s.ProofType,
@@ -305,7 +305,7 @@ var sealBenchCmd = &cli.Command{
 				return err
 			}
 
-			candidates := make([]saproof.SectorInfo, len(fcandidates))
+			candidates := make([]saproof0.SectorInfo, len(fcandidates))
 			for i, fcandidate := range fcandidates {
 				candidates[i] = sealedSectors[fcandidate]
 			}
@@ -328,7 +328,7 @@ var sealBenchCmd = &cli.Command{
 
 			winnningpost2 := time.Now()
 
-			pvi1 := saproof.WinningPoStVerifyInfo{
+			pvi1 := saproof0.WinningPoStVerifyInfo{
 				Randomness:        abi.PoStRandomness(challenge[:]),
 				Proofs:            proof1,
 				ChallengedSectors: candidates,
@@ -344,7 +344,7 @@ var sealBenchCmd = &cli.Command{
 
 			verifyWinningPost1 := time.Now()
 
-			pvi2 := saproof.WinningPoStVerifyInfo{
+			pvi2 := saproof0.WinningPoStVerifyInfo{
 				Randomness:        abi.PoStRandomness(challenge[:]),
 				Proofs:            proof2,
 				ChallengedSectors: candidates,
@@ -376,7 +376,7 @@ var sealBenchCmd = &cli.Command{
 
 			windowpost2 := time.Now()
 
-			wpvi1 := saproof.WindowPoStVerifyInfo{
+			wpvi1 := saproof0.WindowPoStVerifyInfo{
 				Randomness:        challenge[:],
 				Proofs:            wproof1,
 				ChallengedSectors: sealedSectors,
@@ -392,7 +392,7 @@ var sealBenchCmd = &cli.Command{
 
 			verifyWindowpost1 := time.Now()
 
-			wpvi2 := saproof.WindowPoStVerifyInfo{
+			wpvi2 := saproof0.WindowPoStVerifyInfo{
 				Randomness:        challenge[:],
 				Proofs:            wproof2,
 				ChallengedSectors: sealedSectors,
@@ -464,10 +464,10 @@ type ParCfg struct {
 	Commit     int
 }
 
-func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par ParCfg, mid abi.ActorID, sectorSize abi.SectorSize, ticketPreimage []byte, saveC2inp string, skipc2, skipunseal bool) ([]SealingResult, []saproof.SectorInfo, error) {
+func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par ParCfg, mid abi.ActorID, sectorSize abi.SectorSize, ticketPreimage []byte, saveC2inp string, skipc2, skipunseal bool) ([]SealingResult, []saproof0.SectorInfo, error) {
 	var pieces []abi.PieceInfo
 	sealTimings := make([]SealingResult, numSectors)
-	sealedSectors := make([]saproof.SectorInfo, numSectors)
+	sealedSectors := make([]saproof0.SectorInfo, numSectors)
 
 	preCommit2Sema := make(chan struct{}, par.PreCommit2)
 	commitSema := make(chan struct{}, par.Commit)
@@ -537,7 +537,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 					precommit2 := time.Now()
 					<-preCommit2Sema
 
-					sealedSectors[ix] = saproof.SectorInfo{
+					sealedSectors[ix] = saproof0.SectorInfo{
 						SealProof:    sb.SealProofType(),
 						SectorNumber: i,
 						SealedCID:    cids.Sealed,
@@ -589,7 +589,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 					<-commitSema
 
 					if !skipc2 {
-						svi := saproof.SealVerifyInfo{
+						svi := saproof0.SealVerifyInfo{
 							SectorID:              abi.SectorID{Miner: mid, Number: i},
 							SealedCID:             cids.Sealed,
 							SealProof:             sb.SealProofType(),

--- a/cmd/lotus-pcr/main.go
+++ b/cmd/lotus-pcr/main.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 
 	"github.com/filecoin-project/go-state-types/network"
@@ -870,7 +869,7 @@ func (r *refunder) processTipsetStorageMarketActor(ctx context.Context, tipset *
 	var messageMethod string
 
 	switch m.Method {
-	case builtin2.MethodsMarket.PublishStorageDeals:
+	case market.Methods.PublishStorageDeals:
 		if !r.publishStorageDealsEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -895,7 +894,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 	var messageMethod string
 
 	switch m.Method {
-	case builtin2.MethodsMiner.SubmitWindowedPoSt:
+	case miner.Methods.SubmitWindowedPoSt:
 		if !r.windowedPoStEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -908,7 +907,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 		}
 
 		refundValue = types.BigMul(types.NewInt(uint64(recp.GasUsed)), tipset.Blocks()[0].ParentBaseFee)
-	case builtin2.MethodsMiner.ProveCommitSector:
+	case miner.Methods.ProveCommitSector:
 		if !r.proveCommitEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -964,7 +963,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 		if r.refundPercent > 0 {
 			refundValue = types.BigMul(types.BigDiv(refundValue, types.NewInt(100)), types.NewInt(uint64(r.refundPercent)))
 		}
-	case builtin2.MethodsMiner.PreCommitSector:
+	case miner.Methods.PreCommitSector:
 		if !r.preCommitEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}

--- a/cmd/lotus-pcr/main.go
+++ b/cmd/lotus-pcr/main.go
@@ -16,9 +16,8 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 
 	"github.com/filecoin-project/go-state-types/network"
 
@@ -871,7 +870,7 @@ func (r *refunder) processTipsetStorageMarketActor(ctx context.Context, tipset *
 	var messageMethod string
 
 	switch m.Method {
-	case builtin0.MethodsMarket.PublishStorageDeals:
+	case builtin2.MethodsMarket.PublishStorageDeals:
 		if !r.publishStorageDealsEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -896,7 +895,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 	var messageMethod string
 
 	switch m.Method {
-	case builtin0.MethodsMiner.SubmitWindowedPoSt:
+	case builtin2.MethodsMiner.SubmitWindowedPoSt:
 		if !r.windowedPoStEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -909,7 +908,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 		}
 
 		refundValue = types.BigMul(types.NewInt(uint64(recp.GasUsed)), tipset.Blocks()[0].ParentBaseFee)
-	case builtin0.MethodsMiner.ProveCommitSector:
+	case builtin2.MethodsMiner.ProveCommitSector:
 		if !r.proveCommitEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}
@@ -928,7 +927,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 
 		var sn abi.SectorNumber
 
-		var proveCommitSector miner0.ProveCommitSectorParams
+		var proveCommitSector miner2.ProveCommitSectorParams
 		if err := proveCommitSector.UnmarshalCBOR(bytes.NewBuffer(m.Params)); err != nil {
 			log.Warnw("failed to decode provecommit params", "err", err, "method", messageMethod, "cid", msg.Cid, "miner", m.To)
 			return false, messageMethod, types.NewInt(0), nil
@@ -965,7 +964,7 @@ func (r *refunder) processTipsetStorageMinerActor(ctx context.Context, tipset *t
 		if r.refundPercent > 0 {
 			refundValue = types.BigMul(types.BigDiv(refundValue, types.NewInt(100)), types.NewInt(uint64(r.refundPercent)))
 		}
-	case builtin0.MethodsMiner.PreCommitSector:
+	case builtin2.MethodsMiner.PreCommitSector:
 		if !r.preCommitEnabled {
 			return false, messageMethod, types.NewInt(0), nil
 		}

--- a/cmd/lotus-seed/seed/seed.go
+++ b/cmd/lotus-seed/seed/seed.go
@@ -23,7 +23,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/lotus/extern/sector-storage/zerocomm"
-	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
@@ -253,7 +254,7 @@ func WriteGenesisMiner(maddr address.Address, sbroot string, gm *genesis.Miner, 
 
 func createDeals(m *genesis.Miner, k *wallet.Key, maddr address.Address, ssize abi.SectorSize) error {
 	for i, sector := range m.Sectors {
-		proposal := &market.DealProposal{
+		proposal := &market2.DealProposal{
 			PieceCID:             sector.CommD,
 			PieceSize:            abi.PaddedPieceSize(ssize),
 			Client:               k.Address,

--- a/cmd/lotus-shed/mempool-stats.go
+++ b/cmd/lotus-shed/mempool-stats.go
@@ -14,7 +14,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/actors/builtin"
 
 	"github.com/filecoin-project/go-address"
 	lapi "github.com/filecoin-project/lotus/api"
@@ -145,7 +145,7 @@ var mpoolStatsCmd = &cli.Command{
 						seen: time.Now(),
 					}
 
-					if u.Message.Message.Method == builtin0.MethodsMiner.SubmitWindowedPoSt {
+					if u.Message.Message.Method == builtin2.MethodsMiner.SubmitWindowedPoSt {
 
 						miner, err := isMiner(u.Message.Message.To)
 						if err != nil {

--- a/cmd/lotus-shed/mempool-stats.go
+++ b/cmd/lotus-shed/mempool-stats.go
@@ -14,11 +14,10 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	builtin2 "github.com/filecoin-project/specs-actors/actors/builtin"
-
 	"github.com/filecoin-project/go-address"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 )
@@ -145,7 +144,7 @@ var mpoolStatsCmd = &cli.Command{
 						seen: time.Now(),
 					}
 
-					if u.Message.Message.Method == builtin2.MethodsMiner.SubmitWindowedPoSt {
+					if u.Message.Message.Method == miner.Methods.SubmitWindowedPoSt {
 
 						miner, err := isMiner(u.Message.Message.To)
 						if err != nil {

--- a/cmd/lotus-shed/proofs.go
+++ b/cmd/lotus-shed/proofs.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	saproof "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/urfave/cli/v2"
 
@@ -84,7 +84,7 @@ var verifySealProofCmd = &cli.Command{
 
 		snum := abi.SectorNumber(cctx.Uint64("sector-id"))
 
-		ok, err := ffi.VerifySeal(saproof.SealVerifyInfo{
+		ok, err := ffi.VerifySeal(proof2.SealVerifyInfo{
 			SectorID: abi.SectorID{
 				Miner:  abi.ActorID(mid),
 				Number: snum,

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 
 	"github.com/filecoin-project/lotus/api/apibstore"
@@ -80,7 +79,7 @@ var verifRegAddVerifierCmd = &cli.Command{
 			return err
 		}
 
-		smsg, err := api.MsigPropose(ctx, vrk, verifreg.Address, big.Zero(), sender, uint64(builtin2.MethodsVerifiedRegistry.AddVerifier), params)
+		smsg, err := api.MsigPropose(ctx, vrk, verifreg.Address, big.Zero(), sender, uint64(verifreg.Methods.AddVerifier), params)
 		if err != nil {
 			return err
 		}
@@ -151,7 +150,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 		msg := &types.Message{
 			To:     verifreg.Address,
 			From:   fromk,
-			Method: builtin2.MethodsVerifiedRegistry.AddVerifiedClient,
+			Method: verifreg.Methods.AddVerifiedClient,
 			Params: params,
 		}
 

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -11,8 +11,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	verifreg0 "github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	verifreg2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/verifreg"
 
 	"github.com/filecoin-project/lotus/api/apibstore"
 	"github.com/filecoin-project/lotus/build"
@@ -63,7 +63,7 @@ var verifRegAddVerifierCmd = &cli.Command{
 		}
 
 		// TODO: ActorUpgrade: Abstract
-		params, err := actors.SerializeParams(&verifreg0.AddVerifierParams{Address: verifier, Allowance: allowance})
+		params, err := actors.SerializeParams(&verifreg2.AddVerifierParams{Address: verifier, Allowance: allowance})
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ var verifRegAddVerifierCmd = &cli.Command{
 			return err
 		}
 
-		smsg, err := api.MsigPropose(ctx, vrk, verifreg.Address, big.Zero(), sender, uint64(builtin0.MethodsVerifiedRegistry.AddVerifier), params)
+		smsg, err := api.MsigPropose(ctx, vrk, verifreg.Address, big.Zero(), sender, uint64(builtin2.MethodsVerifiedRegistry.AddVerifier), params)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 			return err
 		}
 
-		params, err := actors.SerializeParams(&verifreg0.AddVerifiedClientParams{Address: target, Allowance: allowance})
+		params, err := actors.SerializeParams(&verifreg2.AddVerifiedClientParams{Address: target, Allowance: allowance})
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 		msg := &types.Message{
 			To:     verifreg.Address,
 			From:   fromk,
-			Method: builtin0.MethodsVerifiedRegistry.AddVerifiedClient,
+			Method: builtin2.MethodsVerifiedRegistry.AddVerifiedClient,
 			Params: params,
 		}
 

--- a/cmd/lotus-storage-miner/actor.go
+++ b/cmd/lotus-storage-miner/actor.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/filecoin-project/lotus/build"
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/fatih/color"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -18,8 +17,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -92,7 +91,7 @@ var actorSetAddrsCmd = &cli.Command{
 			return err
 		}
 
-		params, err := actors.SerializeParams(&miner0.ChangeMultiaddrsParams{NewMultiaddrs: addrs})
+		params, err := actors.SerializeParams(&miner2.ChangeMultiaddrsParams{NewMultiaddrs: addrs})
 		if err != nil {
 			return err
 		}
@@ -104,7 +103,7 @@ var actorSetAddrsCmd = &cli.Command{
 			From:     minfo.Worker,
 			Value:    types.NewInt(0),
 			GasLimit: gasLimit,
-			Method:   builtin.MethodsMiner.ChangeMultiaddrs,
+			Method:   builtin2.MethodsMiner.ChangeMultiaddrs,
 			Params:   params,
 		}, nil)
 		if err != nil {
@@ -157,7 +156,7 @@ var actorSetPeeridCmd = &cli.Command{
 			return err
 		}
 
-		params, err := actors.SerializeParams(&miner0.ChangePeerIDParams{NewID: abi.PeerID(pid)})
+		params, err := actors.SerializeParams(&miner2.ChangePeerIDParams{NewID: abi.PeerID(pid)})
 		if err != nil {
 			return err
 		}
@@ -169,7 +168,7 @@ var actorSetPeeridCmd = &cli.Command{
 			From:     minfo.Worker,
 			Value:    types.NewInt(0),
 			GasLimit: gasLimit,
-			Method:   builtin.MethodsMiner.ChangePeerID,
+			Method:   builtin2.MethodsMiner.ChangePeerID,
 			Params:   params,
 		}, nil)
 		if err != nil {
@@ -230,7 +229,7 @@ var actorWithdrawCmd = &cli.Command{
 			}
 		}
 
-		params, err := actors.SerializeParams(&miner0.WithdrawBalanceParams{
+		params, err := actors.SerializeParams(&miner2.WithdrawBalanceParams{
 			AmountRequested: amount, // Default to attempting to withdraw all the extra funds in the miner actor
 		})
 		if err != nil {
@@ -241,7 +240,7 @@ var actorWithdrawCmd = &cli.Command{
 			To:     maddr,
 			From:   mi.Owner,
 			Value:  types.NewInt(0),
-			Method: builtin.MethodsMiner.WithdrawBalance,
+			Method: builtin2.MethodsMiner.WithdrawBalance,
 			Params: params,
 		}, nil)
 		if err != nil {
@@ -455,7 +454,7 @@ var actorControlSet = &cli.Command{
 			return nil
 		}
 
-		cwp := &miner0.ChangeWorkerAddressParams{
+		cwp := &miner2.ChangeWorkerAddressParams{
 			NewWorker:       mi.Worker,
 			NewControlAddrs: toSet,
 		}
@@ -468,7 +467,7 @@ var actorControlSet = &cli.Command{
 		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
 			From:   mi.Owner,
 			To:     maddr,
-			Method: builtin.MethodsMiner.ChangeWorkerAddress,
+			Method: builtin2.MethodsMiner.ChangeWorkerAddress,
 
 			Value:  big.Zero(),
 			Params: sp,

--- a/cmd/lotus-storage-miner/actor.go
+++ b/cmd/lotus-storage-miner/actor.go
@@ -17,10 +17,10 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
@@ -103,7 +103,7 @@ var actorSetAddrsCmd = &cli.Command{
 			From:     minfo.Worker,
 			Value:    types.NewInt(0),
 			GasLimit: gasLimit,
-			Method:   builtin2.MethodsMiner.ChangeMultiaddrs,
+			Method:   miner.Methods.ChangeMultiaddrs,
 			Params:   params,
 		}, nil)
 		if err != nil {
@@ -168,7 +168,7 @@ var actorSetPeeridCmd = &cli.Command{
 			From:     minfo.Worker,
 			Value:    types.NewInt(0),
 			GasLimit: gasLimit,
-			Method:   builtin2.MethodsMiner.ChangePeerID,
+			Method:   miner.Methods.ChangePeerID,
 			Params:   params,
 		}, nil)
 		if err != nil {
@@ -240,7 +240,7 @@ var actorWithdrawCmd = &cli.Command{
 			To:     maddr,
 			From:   mi.Owner,
 			Value:  types.NewInt(0),
-			Method: builtin2.MethodsMiner.WithdrawBalance,
+			Method: miner.Methods.WithdrawBalance,
 			Params: params,
 		}, nil)
 		if err != nil {
@@ -467,7 +467,7 @@ var actorControlSet = &cli.Command{
 		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
 			From:   mi.Owner,
 			To:     maddr,
-			Method: builtin2.MethodsMiner.ChangeWorkerAddress,
+			Method: miner.Methods.ChangeWorkerAddress,
 
 			Value:  big.Zero(),
 			Params: sp,
@@ -545,7 +545,7 @@ var actorSetOwnerCmd = &cli.Command{
 		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
 			From:   mi.Owner,
 			To:     maddr,
-			Method: builtin2.MethodsMiner.ChangeOwnerAddress,
+			Method: miner.Methods.ChangeOwnerAddress,
 			Value:  big.Zero(),
 			Params: sp,
 		}, nil)
@@ -570,7 +570,7 @@ var actorSetOwnerCmd = &cli.Command{
 		smsg, err = api.MpoolPushMessage(ctx, &types.Message{
 			From:   newAddr,
 			To:     maddr,
-			Method: builtin2.MethodsMiner.ChangeOwnerAddress,
+			Method: miner.Methods.ChangeOwnerAddress,
 			Value:  big.Zero(),
 			Params: sp,
 		}, nil)

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -40,6 +40,8 @@ import (
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -47,7 +49,7 @@ import (
 	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
 	"github.com/filecoin-project/lotus/genesis"
 	"github.com/filecoin-project/lotus/journal"
-	"github.com/filecoin-project/lotus/miner"
+	storageminer "github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -471,7 +473,7 @@ func storageMinerInit(ctx context.Context, cctx *cli.Context, api lapi.FullNode,
 				return fmt.Errorf("failed to open filesystem journal: %w", err)
 			}
 
-			m := miner.NewMiner(api, epp, a, slashfilter.New(mds))
+			m := storageminer.NewMiner(api, epp, a, slashfilter.New(mds))
 			{
 				if err := m.Start(ctx); err != nil {
 					return xerrors.Errorf("failed to start up genesis miner: %w", err)
@@ -579,7 +581,7 @@ func configureStorageMiner(ctx context.Context, api lapi.FullNode, addr address.
 	msg := &types.Message{
 		To:         addr,
 		From:       mi.Worker,
-		Method:     builtin2.MethodsMiner.ChangePeerID,
+		Method:     miner.Methods.ChangePeerID,
 		Params:     enc,
 		Value:      types.NewInt(0),
 		GasPremium: gasPrice,
@@ -662,7 +664,7 @@ func createStorageMiner(ctx context.Context, api lapi.FullNode, peerid peer.ID, 
 		From:  sender,
 		Value: big.Zero(),
 
-		Method: builtin2.MethodsPower.CreateMiner,
+		Method: power.Methods.CreateMiner,
 		Params: params,
 
 		GasLimit:   0,

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -32,14 +32,15 @@ import (
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
-	power0 "github.com/filecoin-project/specs-actors/actors/builtin/power"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
@@ -83,7 +84,7 @@ var initCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:  "sector-size",
 			Usage: "specify sector size to use",
-			Value: units.BytesSize(float64(build.DefaultSectorSize())),
+			Value: units.BytesSize(float64(policy.GetDefaultSectorSize())),
 		},
 		&cli.StringSliceFlag{
 			Name:  "pre-sealed-sectors",
@@ -376,7 +377,7 @@ func migratePreSealMeta(ctx context.Context, api lapi.FullNode, metadata string,
 	return mds.Put(datastore.NewKey(modules.StorageCounterDSPrefix), buf[:size])
 }
 
-func findMarketDealID(ctx context.Context, api lapi.FullNode, deal market0.DealProposal) (abi.DealID, error) {
+func findMarketDealID(ctx context.Context, api lapi.FullNode, deal market2.DealProposal) (abi.DealID, error) {
 	// TODO: find a better way
 	//  (this is only used by genesis miners)
 
@@ -570,7 +571,7 @@ func configureStorageMiner(ctx context.Context, api lapi.FullNode, addr address.
 		return xerrors.Errorf("getWorkerAddr returned bad address: %w", err)
 	}
 
-	enc, err := actors.SerializeParams(&miner0.ChangePeerIDParams{NewID: abi.PeerID(peerid)})
+	enc, err := actors.SerializeParams(&miner2.ChangePeerIDParams{NewID: abi.PeerID(peerid)})
 	if err != nil {
 		return err
 	}
@@ -578,7 +579,7 @@ func configureStorageMiner(ctx context.Context, api lapi.FullNode, addr address.
 	msg := &types.Message{
 		To:         addr,
 		From:       mi.Worker,
-		Method:     builtin0.MethodsMiner.ChangePeerID,
+		Method:     builtin2.MethodsMiner.ChangePeerID,
 		Params:     enc,
 		Value:      types.NewInt(0),
 		GasPremium: gasPrice,
@@ -637,7 +638,7 @@ func createStorageMiner(ctx context.Context, api lapi.FullNode, peerid peer.ID, 
 		return address.Undef, err
 	}
 
-	params, err := actors.SerializeParams(&power0.CreateMinerParams{
+	params, err := actors.SerializeParams(&power2.CreateMinerParams{
 		Owner:         owner,
 		Worker:        worker,
 		SealProofType: spt,
@@ -657,11 +658,11 @@ func createStorageMiner(ctx context.Context, api lapi.FullNode, peerid peer.ID, 
 	}
 
 	createStorageMinerMsg := &types.Message{
-		To:    builtin0.StoragePowerActorAddr,
+		To:    builtin2.StoragePowerActorAddr,
 		From:  sender,
 		Value: big.Zero(),
 
-		Method: builtin0.MethodsPower.CreateMiner,
+		Method: builtin2.MethodsPower.CreateMiner,
 		Params: params,
 
 		GasLimit:   0,
@@ -685,7 +686,7 @@ func createStorageMiner(ctx context.Context, api lapi.FullNode, peerid peer.ID, 
 		return address.Undef, xerrors.Errorf("create miner failed: exit code %d", mw.Receipt.ExitCode)
 	}
 
-	var retval power0.CreateMinerReturn
+	var retval power2.CreateMinerReturn
 	if err := retval.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
 		return address.Undef, err
 	}

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -15,10 +15,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
-
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 
@@ -463,7 +462,7 @@ var sectorsCapacityCollateralCmd = &cli.Command{
 			Expiration: abi.ChainEpoch(cctx.Uint64("expiration")),
 		}
 		if pci.Expiration == 0 {
-			pci.Expiration = miner0.MaxSectorExpirationExtension
+			pci.Expiration = policy.GetMaxSectorExpirationExtension()
 		}
 		pc, err := nApi.StateMinerInitialPledgeCollateral(ctx, maddr, pci, types.EmptyTSK)
 		if err != nil {

--- a/cmd/tvx/extract.go
+++ b/cmd/tvx/extract.go
@@ -14,14 +14,13 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/reward"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/conformance"
-
-	"github.com/filecoin-project/specs-actors/actors/builtin"
 
 	"github.com/filecoin-project/test-vectors/schema"
 

--- a/conformance/chaos/actor.go
+++ b/conformance/chaos/actor.go
@@ -6,9 +6,10 @@ import (
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/rt"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/ipfs/go-cid"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	runtime2 "github.com/filecoin-project/specs-actors/v2/actors/runtime"
 )
 
 //go:generate go run ./gen
@@ -55,7 +56,7 @@ const (
 
 const (
 	_                      = 0 // skip zero iota value; first usage of iota gets 1.
-	MethodCallerValidation = builtin.MethodConstructor + iota
+	MethodCallerValidation = builtin2.MethodConstructor + iota
 	MethodCreateActor
 	MethodResolveAddress
 	// MethodDeleteActor is the identifier for the method that deletes this actor.
@@ -76,15 +77,15 @@ const (
 // Exports defines the methods this actor exposes publicly.
 func (a Actor) Exports() []interface{} {
 	return []interface{}{
-		builtin.MethodConstructor: a.Constructor,
-		MethodCallerValidation:    a.CallerValidation,
-		MethodCreateActor:         a.CreateActor,
-		MethodResolveAddress:      a.ResolveAddress,
-		MethodDeleteActor:         a.DeleteActor,
-		MethodSend:                a.Send,
-		MethodMutateState:         a.MutateState,
-		MethodAbortWith:           a.AbortWith,
-		MethodInspectRuntime:      a.InspectRuntime,
+		builtin2.MethodConstructor: a.Constructor,
+		MethodCallerValidation:     a.CallerValidation,
+		MethodCreateActor:          a.CreateActor,
+		MethodResolveAddress:       a.ResolveAddress,
+		MethodDeleteActor:          a.DeleteActor,
+		MethodSend:                 a.Send,
+		MethodMutateState:          a.MutateState,
+		MethodAbortWith:            a.AbortWith,
+		MethodInspectRuntime:       a.InspectRuntime,
 	}
 }
 
@@ -104,19 +105,19 @@ type SendArgs struct {
 
 // SendReturn is the return values for the Send method.
 type SendReturn struct {
-	Return runtime.CBORBytes
+	Return builtin2.CBORBytes
 	Code   exitcode.ExitCode
 }
 
 // Send requests for this actor to send a message to an actor with the
 // passed parameters.
-func (a Actor) Send(rt runtime.Runtime, args *SendArgs) *SendReturn {
+func (a Actor) Send(rt runtime2.Runtime, args *SendArgs) *SendReturn {
 	rt.ValidateImmediateCallerAcceptAny()
-	var out runtime.CBORBytes
+	var out builtin2.CBORBytes
 	code := rt.Send(
 		args.To,
 		args.Method,
-		runtime.CBORBytes(args.Params),
+		builtin2.CBORBytes(args.Params),
 		args.Value,
 		&out,
 	)
@@ -127,7 +128,7 @@ func (a Actor) Send(rt runtime.Runtime, args *SendArgs) *SendReturn {
 }
 
 // Constructor will panic because the Chaos actor is a singleton.
-func (a Actor) Constructor(_ runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
+func (a Actor) Constructor(_ runtime2.Runtime, _ *abi.EmptyValue) *abi.EmptyValue {
 	panic("constructor should not be called; the Chaos actor is a singleton actor")
 }
 
@@ -144,7 +145,7 @@ type CallerValidationArgs struct {
 //  CallerValidationBranchTwice validates twice.
 //  CallerValidationBranchIsAddress validates caller against CallerValidationArgs.Addrs.
 //  CallerValidationBranchIsType validates caller against CallerValidationArgs.Types.
-func (a Actor) CallerValidation(rt runtime.Runtime, args *CallerValidationArgs) *abi.EmptyValue {
+func (a Actor) CallerValidation(rt runtime2.Runtime, args *CallerValidationArgs) *abi.EmptyValue {
 	switch args.Branch {
 	case CallerValidationBranchNone:
 	case CallerValidationBranchTwice:
@@ -174,7 +175,7 @@ type CreateActorArgs struct {
 }
 
 // CreateActor creates an actor with the supplied CID and Address.
-func (a Actor) CreateActor(rt runtime.Runtime, args *CreateActorArgs) *abi.EmptyValue {
+func (a Actor) CreateActor(rt runtime2.Runtime, args *CreateActorArgs) *abi.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 
 	var (
@@ -199,7 +200,7 @@ type ResolveAddressResponse struct {
 	Success bool
 }
 
-func (a Actor) ResolveAddress(rt runtime.Runtime, args *address.Address) *ResolveAddressResponse {
+func (a Actor) ResolveAddress(rt runtime2.Runtime, args *address.Address) *ResolveAddressResponse {
 	rt.ValidateImmediateCallerAcceptAny()
 
 	resolvedAddr, ok := rt.ResolveAddress(*args)
@@ -212,7 +213,7 @@ func (a Actor) ResolveAddress(rt runtime.Runtime, args *address.Address) *Resolv
 
 // DeleteActor deletes the executing actor from the state tree, transferring any
 // balance to beneficiary.
-func (a Actor) DeleteActor(rt runtime.Runtime, beneficiary *address.Address) *abi.EmptyValue {
+func (a Actor) DeleteActor(rt runtime2.Runtime, beneficiary *address.Address) *abi.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 	rt.DeleteActor(*beneficiary)
 	return nil
@@ -226,7 +227,7 @@ type MutateStateArgs struct {
 }
 
 // MutateState attempts to mutate a state value in the actor.
-func (a Actor) MutateState(rt runtime.Runtime, args *MutateStateArgs) *abi.EmptyValue {
+func (a Actor) MutateState(rt runtime2.Runtime, args *MutateStateArgs) *abi.EmptyValue {
 	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	switch args.Branch {
@@ -257,7 +258,7 @@ type AbortWithArgs struct {
 }
 
 // AbortWith simply causes a panic with the passed exit code.
-func (a Actor) AbortWith(rt runtime.Runtime, args *AbortWithArgs) *abi.EmptyValue {
+func (a Actor) AbortWith(rt runtime2.Runtime, args *AbortWithArgs) *abi.EmptyValue {
 	if args.Uncontrolled { // uncontrolled abort: directly panic
 		panic(args.Message)
 	} else {
@@ -277,7 +278,7 @@ type InspectRuntimeReturn struct {
 }
 
 // InspectRuntime returns a copy of the serializable values available in the Runtime.
-func (a Actor) InspectRuntime(rt runtime.Runtime, _ *abi.EmptyValue) *InspectRuntimeReturn {
+func (a Actor) InspectRuntime(rt runtime2.Runtime, _ *abi.EmptyValue) *InspectRuntimeReturn {
 	rt.ValidateImmediateCallerAcceptAny()
 	var st State
 	rt.StateReadonly(&st)

--- a/conformance/chaos/actor.go
+++ b/conformance/chaos/actor.go
@@ -6,6 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/rt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/ipfs/go-cid"
 
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -56,7 +57,7 @@ const (
 
 const (
 	_                      = 0 // skip zero iota value; first usage of iota gets 1.
-	MethodCallerValidation = builtin2.MethodConstructor + iota
+	MethodCallerValidation = builtin.MethodConstructor + iota
 	MethodCreateActor
 	MethodResolveAddress
 	// MethodDeleteActor is the identifier for the method that deletes this actor.
@@ -77,15 +78,15 @@ const (
 // Exports defines the methods this actor exposes publicly.
 func (a Actor) Exports() []interface{} {
 	return []interface{}{
-		builtin2.MethodConstructor: a.Constructor,
-		MethodCallerValidation:     a.CallerValidation,
-		MethodCreateActor:          a.CreateActor,
-		MethodResolveAddress:       a.ResolveAddress,
-		MethodDeleteActor:          a.DeleteActor,
-		MethodSend:                 a.Send,
-		MethodMutateState:          a.MutateState,
-		MethodAbortWith:            a.AbortWith,
-		MethodInspectRuntime:       a.InspectRuntime,
+		builtin.MethodConstructor: a.Constructor,
+		MethodCallerValidation:    a.CallerValidation,
+		MethodCreateActor:         a.CreateActor,
+		MethodResolveAddress:      a.ResolveAddress,
+		MethodDeleteActor:         a.DeleteActor,
+		MethodSend:                a.Send,
+		MethodMutateState:         a.MutateState,
+		MethodAbortWith:           a.AbortWith,
+		MethodInspectRuntime:      a.InspectRuntime,
 	}
 }
 

--- a/conformance/chaos/actor_test.go
+++ b/conformance/chaos/actor_test.go
@@ -7,15 +7,16 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/support/mock"
-	atesting "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	mock2 "github.com/filecoin-project/specs-actors/v2/support/mock"
+	atesting2 "github.com/filecoin-project/specs-actors/v2/support/testing"
 )
 
 func TestSingleton(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -28,8 +29,8 @@ func TestSingleton(t *testing.T) {
 }
 
 func TestCallerValidationNone(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -39,19 +40,19 @@ func TestCallerValidationNone(t *testing.T) {
 }
 
 func TestCallerValidationIs(t *testing.T) {
-	caller := atesting.NewIDAddr(t, 100)
-	receiver := atesting.NewIDAddr(t, 101)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	caller := atesting2.NewIDAddr(t, 100)
+	receiver := atesting2.NewIDAddr(t, 101)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
-	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.SetCaller(caller, builtin2.AccountActorCodeID)
 	var a Actor
 
-	caddrs := []address.Address{atesting.NewIDAddr(t, 101)}
+	caddrs := []address.Address{atesting2.NewIDAddr(t, 101)}
 
 	rt.ExpectValidateCallerAddr(caddrs...)
-	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1155
-	rt.ExpectAbort(exitcode.ErrForbidden, func() {
+	// fixed in: https://github.com/filecoin-project/specs-actors/pull/1155
+	rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 		rt.Call(a.CallerValidation, &CallerValidationArgs{
 			Branch: CallerValidationBranchIsAddress,
 			Addrs:  caddrs,
@@ -68,35 +69,34 @@ func TestCallerValidationIs(t *testing.T) {
 }
 
 func TestCallerValidationType(t *testing.T) {
-	caller := atesting.NewIDAddr(t, 100)
-	receiver := atesting.NewIDAddr(t, 101)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	caller := atesting2.NewIDAddr(t, 100)
+	receiver := atesting2.NewIDAddr(t, 101)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
-	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.SetCaller(caller, builtin2.AccountActorCodeID)
 	var a Actor
 
-	rt.ExpectValidateCallerType(builtin.CronActorCodeID)
-	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1155
-	rt.ExpectAbort(exitcode.ErrForbidden, func() {
+	rt.ExpectValidateCallerType(builtin2.CronActorCodeID)
+	rt.ExpectAbort(exitcode.SysErrForbidden, func() {
 		rt.Call(a.CallerValidation, &CallerValidationArgs{
 			Branch: CallerValidationBranchIsType,
-			Types:  []cid.Cid{builtin.CronActorCodeID},
+			Types:  []cid.Cid{builtin2.CronActorCodeID},
 		})
 	})
 	rt.Verify()
 
-	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin2.AccountActorCodeID)
 	rt.Call(a.CallerValidation, &CallerValidationArgs{
 		Branch: CallerValidationBranchIsType,
-		Types:  []cid.Cid{builtin.AccountActorCodeID},
+		Types:  []cid.Cid{builtin2.AccountActorCodeID},
 	})
 	rt.Verify()
 }
 
 func TestCallerValidationInvalidBranch(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -108,9 +108,9 @@ func TestCallerValidationInvalidBranch(t *testing.T) {
 }
 
 func TestDeleteActor(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	beneficiary := atesting.NewIDAddr(t, 101)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	beneficiary := atesting2.NewIDAddr(t, 101)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -122,8 +122,8 @@ func TestDeleteActor(t *testing.T) {
 }
 
 func TestMutateStateInTransaction(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -148,8 +148,8 @@ func TestMutateStateInTransaction(t *testing.T) {
 }
 
 func TestMutateStateAfterTransaction(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -175,8 +175,8 @@ func TestMutateStateAfterTransaction(t *testing.T) {
 }
 
 func TestMutateStateReadonly(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -201,8 +201,8 @@ func TestMutateStateReadonly(t *testing.T) {
 }
 
 func TestMutateStateInvalidBranch(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -215,8 +215,8 @@ func TestMutateStateInvalidBranch(t *testing.T) {
 }
 
 func TestAbortWith(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -233,8 +233,8 @@ func TestAbortWith(t *testing.T) {
 }
 
 func TestAbortWithUncontrolled(t *testing.T) {
-	receiver := atesting.NewIDAddr(t, 100)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	receiver := atesting2.NewIDAddr(t, 100)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
 	var a Actor
@@ -250,12 +250,12 @@ func TestAbortWithUncontrolled(t *testing.T) {
 }
 
 func TestInspectRuntime(t *testing.T) {
-	caller := atesting.NewIDAddr(t, 100)
-	receiver := atesting.NewIDAddr(t, 101)
-	builder := mock.NewBuilder(context.Background(), receiver)
+	caller := atesting2.NewIDAddr(t, 100)
+	receiver := atesting2.NewIDAddr(t, 101)
+	builder := mock2.NewBuilder(context.Background(), receiver)
 
 	rt := builder.Build(t)
-	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.SetCaller(caller, builtin2.AccountActorCodeID)
 	rt.StateCreate(&State{})
 	var a Actor
 

--- a/conformance/chaos/cbor_gen.go
+++ b/conformance/chaos/cbor_gen.go
@@ -587,7 +587,7 @@ func (t *SendReturn) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.Return (runtime.CBORBytes) (slice)
+	// t.Return (builtin.CBORBytes) (slice)
 	if len(t.Return) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Return was too long")
 	}
@@ -631,7 +631,7 @@ func (t *SendReturn) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Return (runtime.CBORBytes) (slice)
+	// t.Return (builtin.CBORBytes) (slice)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 	if err != nil {

--- a/extern/sector-storage/ffiwrapper/sealer_test.go
+++ b/extern/sector-storage/ffiwrapper/sealer_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	saproof "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/ipfs/go-cid"
 
@@ -93,7 +93,7 @@ func (s *seal) commit(t *testing.T, sb *Sealer, done func()) {
 		t.Fatalf("%+v", err)
 	}
 
-	ok, err := ProofVerifier.VerifySeal(saproof.SealVerifyInfo{
+	ok, err := ProofVerifier.VerifySeal(proof2.SealVerifyInfo{
 		SectorID:              s.id,
 		SealedCID:             s.cids.Sealed,
 		SealProof:             sealProofType,
@@ -171,9 +171,9 @@ func (s *seal) unseal(t *testing.T, sb *Sealer, sp *basicfs.Provider, si abi.Sec
 func post(t *testing.T, sealer *Sealer, skipped []abi.SectorID, seals ...seal) {
 	randomness := abi.PoStRandomness{0, 9, 2, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 45, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 7}
 
-	sis := make([]saproof.SectorInfo, len(seals))
+	sis := make([]proof2.SectorInfo, len(seals))
 	for i, s := range seals {
-		sis[i] = saproof.SectorInfo{
+		sis[i] = proof2.SectorInfo{
 			SealProof:    sealProofType,
 			SectorNumber: s.id.Number,
 			SealedCID:    s.cids.Sealed,
@@ -191,7 +191,7 @@ func post(t *testing.T, sealer *Sealer, skipped []abi.SectorID, seals ...seal) {
 		t.Fatalf("%+v", err)
 	}
 
-	ok, err := ProofVerifier.VerifyWindowPoSt(context.TODO(), saproof.WindowPoStVerifyInfo{
+	ok, err := ProofVerifier.VerifyWindowPoSt(context.TODO(), proof2.WindowPoStVerifyInfo{
 		Randomness:        randomness,
 		Proofs:            proofs,
 		ChallengedSectors: sis,

--- a/extern/sector-storage/ffiwrapper/types.go
+++ b/extern/sector-storage/ffiwrapper/types.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"io"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/ipfs/go-cid"
 
@@ -35,9 +36,10 @@ type Storage interface {
 }
 
 type Verifier interface {
-	VerifySeal(proof.SealVerifyInfo) (bool, error)
-	VerifyWinningPoSt(ctx context.Context, info proof.WinningPoStVerifyInfo) (bool, error)
-	VerifyWindowPoSt(ctx context.Context, info proof.WindowPoStVerifyInfo) (bool, error)
+	VerifySeal(proof2.SealVerifyInfo) (bool, error)
+	// FIXME: https://github.com/filecoin-project/specs-actors/pull/1227
+	VerifyWinningPoSt(ctx context.Context, info proof0.WinningPoStVerifyInfo) (bool, error)
+	VerifyWindowPoSt(ctx context.Context, info proof2.WindowPoStVerifyInfo) (bool, error)
 
 	GenerateWinningPoStSectorChallenge(context.Context, abi.RegisteredPoStProof, abi.ActorID, abi.PoStRandomness, uint64) ([]uint64, error)
 }

--- a/extern/sector-storage/ffiwrapper/verifier_cgo.go
+++ b/extern/sector-storage/ffiwrapper/verifier_cgo.go
@@ -5,7 +5,8 @@ package ffiwrapper
 import (
 	"context"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"golang.org/x/xerrors"
 
@@ -18,7 +19,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func (sb *Sealer) GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, error) {
+func (sb *Sealer) GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) ([]proof2.PoStProof, error) {
 	randomness[31] &= 0x3f
 	privsectors, skipped, done, err := sb.pubSectorToPriv(ctx, minerID, sectorInfo, nil, abi.RegisteredSealProof.RegisteredWinningPoStProof) // TODO: FAULTS?
 	if err != nil {
@@ -32,7 +33,7 @@ func (sb *Sealer) GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, 
 	return ffi.GenerateWinningPoSt(minerID, privsectors, randomness)
 }
 
-func (sb *Sealer) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, []abi.SectorID, error) {
+func (sb *Sealer) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) ([]proof2.PoStProof, []abi.SectorID, error) {
 	randomness[31] &= 0x3f
 	privsectors, skipped, done, err := sb.pubSectorToPriv(ctx, minerID, sectorInfo, nil, abi.RegisteredSealProof.RegisteredWindowPoStProof)
 	if err != nil {
@@ -57,7 +58,7 @@ func (sb *Sealer) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, s
 	return proof, faultyIDs, err
 }
 
-func (sb *Sealer) pubSectorToPriv(ctx context.Context, mid abi.ActorID, sectorInfo []proof.SectorInfo, faults []abi.SectorNumber, rpt func(abi.RegisteredSealProof) (abi.RegisteredPoStProof, error)) (ffi.SortedPrivateSectorInfo, []abi.SectorID, func(), error) {
+func (sb *Sealer) pubSectorToPriv(ctx context.Context, mid abi.ActorID, sectorInfo []proof2.SectorInfo, faults []abi.SectorNumber, rpt func(abi.RegisteredSealProof) (abi.RegisteredPoStProof, error)) (ffi.SortedPrivateSectorInfo, []abi.SectorID, func(), error) {
 	fmap := map[abi.SectorNumber]struct{}{}
 	for _, fault := range faults {
 		fmap[fault] = struct{}{}
@@ -110,11 +111,12 @@ type proofVerifier struct{}
 
 var ProofVerifier = proofVerifier{}
 
-func (proofVerifier) VerifySeal(info proof.SealVerifyInfo) (bool, error) {
+func (proofVerifier) VerifySeal(info proof2.SealVerifyInfo) (bool, error) {
 	return ffi.VerifySeal(info)
 }
 
-func (proofVerifier) VerifyWinningPoSt(ctx context.Context, info proof.WinningPoStVerifyInfo) (bool, error) {
+// FIXME: https://github.com/filecoin-project/specs-actors/pull/1227
+func (proofVerifier) VerifyWinningPoSt(ctx context.Context, info proof0.WinningPoStVerifyInfo) (bool, error) {
 	info.Randomness[31] &= 0x3f
 	_, span := trace.StartSpan(ctx, "VerifyWinningPoSt")
 	defer span.End()
@@ -122,7 +124,7 @@ func (proofVerifier) VerifyWinningPoSt(ctx context.Context, info proof.WinningPo
 	return ffi.VerifyWinningPoSt(info)
 }
 
-func (proofVerifier) VerifyWindowPoSt(ctx context.Context, info proof.WindowPoStVerifyInfo) (bool, error) {
+func (proofVerifier) VerifyWindowPoSt(ctx context.Context, info proof2.WindowPoStVerifyInfo) (bool, error) {
 	info.Randomness[31] &= 0x3f
 	_, span := trace.StartSpan(ctx, "VerifyWindowPoSt")
 	defer span.End()

--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -9,7 +9,8 @@ import (
 	"math/rand"
 	"sync"
 
-	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -280,12 +281,12 @@ func AddOpFinish(ctx context.Context) (context.Context, func()) {
 	}
 }
 
-func (mgr *SectorMgr) GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, error) {
+func (mgr *SectorMgr) GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) ([]proof2.PoStProof, error) {
 	return generateFakePoSt(sectorInfo, abi.RegisteredSealProof.RegisteredWinningPoStProof, randomness), nil
 }
 
-func (mgr *SectorMgr) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, []abi.SectorID, error) {
-	si := make([]proof.SectorInfo, 0, len(sectorInfo))
+func (mgr *SectorMgr) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) ([]proof2.PoStProof, []abi.SectorID, error) {
+	si := make([]proof2.SectorInfo, 0, len(sectorInfo))
 	var skipped []abi.SectorID
 
 	var err error
@@ -313,7 +314,7 @@ func (mgr *SectorMgr) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorI
 	return generateFakePoSt(si, abi.RegisteredSealProof.RegisteredWindowPoStProof, randomness), skipped, nil
 }
 
-func generateFakePoStProof(sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) []byte {
+func generateFakePoStProof(sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) []byte {
 	hasher := sha256.New()
 	_, _ = hasher.Write(randomness)
 	for _, info := range sectorInfo {
@@ -326,13 +327,13 @@ func generateFakePoStProof(sectorInfo []proof.SectorInfo, randomness abi.PoStRan
 
 }
 
-func generateFakePoSt(sectorInfo []proof.SectorInfo, rpt func(abi.RegisteredSealProof) (abi.RegisteredPoStProof, error), randomness abi.PoStRandomness) []proof.PoStProof {
+func generateFakePoSt(sectorInfo []proof2.SectorInfo, rpt func(abi.RegisteredSealProof) (abi.RegisteredPoStProof, error), randomness abi.PoStRandomness) []proof2.PoStProof {
 	wp, err := rpt(sectorInfo[0].SealProof)
 	if err != nil {
 		panic(err)
 	}
 
-	return []proof.PoStProof{
+	return []proof2.PoStProof{
 		{
 			PoStProof:  wp,
 			ProofBytes: generateFakePoStProof(sectorInfo, randomness),
@@ -406,7 +407,7 @@ func (mgr *SectorMgr) CheckProvable(ctx context.Context, spt abi.RegisteredSealP
 	return bad, nil
 }
 
-func (m mockVerif) VerifySeal(svi proof.SealVerifyInfo) (bool, error) {
+func (m mockVerif) VerifySeal(svi proof2.SealVerifyInfo) (bool, error) {
 	if len(svi.Proof) != 32 { // Real ones are longer, but this should be fine
 		return false, nil
 	}
@@ -420,11 +421,12 @@ func (m mockVerif) VerifySeal(svi proof.SealVerifyInfo) (bool, error) {
 	return true, nil
 }
 
-func (m mockVerif) VerifyWinningPoSt(ctx context.Context, info proof.WinningPoStVerifyInfo) (bool, error) {
+// FIXME: https://github.com/filecoin-project/specs-actors/pull/1227
+func (m mockVerif) VerifyWinningPoSt(ctx context.Context, info proof0.WinningPoStVerifyInfo) (bool, error) {
 	return true, nil
 }
 
-func (m mockVerif) VerifyWindowPoSt(ctx context.Context, info proof.WindowPoStVerifyInfo) (bool, error) {
+func (m mockVerif) VerifyWindowPoSt(ctx context.Context, info proof2.WindowPoStVerifyInfo) (bool, error) {
 	if len(info.Proofs) != 1 {
 		return false, xerrors.Errorf("expected 1 proof entry")
 	}

--- a/extern/storage-sealing/checks.go
+++ b/extern/storage-sealing/checks.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 
-	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"golang.org/x/xerrors"
 
@@ -179,7 +179,7 @@ func (m *Sealing) checkCommit(ctx context.Context, si SectorInfo, proof []byte, 
 		log.Warn("on-chain sealed CID doesn't match!")
 	}
 
-	ok, err := m.verif.VerifySeal(proof0.SealVerifyInfo{
+	ok, err := m.verif.VerifySeal(proof2.SealVerifyInfo{
 		SectorID:              m.minerSector(si.SectorNumber),
 		SealedCID:             pci.Info.SealedCID,
 		SealProof:             spt,

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -16,8 +16,6 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-statemachine"
 	"github.com/filecoin-project/specs-storage/storage"
-
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
 
 var DealSectorPriority = 1024
@@ -221,7 +219,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 	deposit := big.Max(depositMinimum, collateral)
 
 	log.Infof("submitting precommit for sector %d (deposit: %s): ", sector.SectorNumber, deposit)
-	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin2.MethodsMiner.PreCommitSector, deposit, m.feeCfg.MaxPreCommitGasFee, enc.Bytes())
+	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, miner.Methods.PreCommitSector, deposit, m.feeCfg.MaxPreCommitGasFee, enc.Bytes())
 	if err != nil {
 		if params.ReplaceCapacity {
 			m.remarkForUpgrade(params.ReplaceSectorNumber)
@@ -402,7 +400,7 @@ func (m *Sealing) handleSubmitCommit(ctx statemachine.Context, sector SectorInfo
 	}
 
 	// TODO: check seed / ticket / deals are up to date
-	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin2.MethodsMiner.ProveCommitSector, collateral, m.feeCfg.MaxCommitGasFee, enc.Bytes())
+	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, miner.Methods.ProveCommitSector, collateral, m.feeCfg.MaxCommitGasFee, enc.Bytes())
 	if err != nil {
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("pushing message to mpool: %w", err)})
 	}

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -15,8 +15,9 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-statemachine"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-storage/storage"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
 
 var DealSectorPriority = 1024
@@ -220,7 +221,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 	deposit := big.Max(depositMinimum, collateral)
 
 	log.Infof("submitting precommit for sector %d (deposit: %s): ", sector.SectorNumber, deposit)
-	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin.MethodsMiner.PreCommitSector, deposit, m.feeCfg.MaxPreCommitGasFee, enc.Bytes())
+	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin2.MethodsMiner.PreCommitSector, deposit, m.feeCfg.MaxPreCommitGasFee, enc.Bytes())
 	if err != nil {
 		if params.ReplaceCapacity {
 			m.remarkForUpgrade(params.ReplaceSectorNumber)
@@ -401,7 +402,7 @@ func (m *Sealing) handleSubmitCommit(ctx statemachine.Context, sector SectorInfo
 	}
 
 	// TODO: check seed / ticket / deals are up to date
-	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin.MethodsMiner.ProveCommitSector, collateral, m.feeCfg.MaxCommitGasFee, enc.Bytes())
+	mcid, err := m.api.SendMsg(ctx.Context(), waddr, m.maddr, builtin2.MethodsMiner.ProveCommitSector, collateral, m.feeCfg.MaxCommitGasFee, enc.Bytes())
 	if err != nil {
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("pushing message to mpool: %w", err)})
 	}

--- a/extern/storage-sealing/types.go
+++ b/extern/storage-sealing/types.go
@@ -9,9 +9,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-storage/storage"
 
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	sectorstorage "github.com/filecoin-project/lotus/extern/sector-storage"
 	"github.com/filecoin-project/lotus/extern/storage-sealing/sealiface"
 )
@@ -82,7 +82,7 @@ type SectorInfo struct {
 	CommR *cid.Cid
 	Proof []byte
 
-	PreCommitInfo    *miner0.SectorPreCommitInfo
+	PreCommitInfo    *miner.SectorPreCommitInfo
 	PreCommitDeposit big.Int
 	PreCommitMessage *cid.Cid
 	PreCommitTipSet  TipSetToken

--- a/extern/storage-sealing/types_test.go
+++ b/extern/storage-sealing/types_test.go
@@ -8,7 +8,7 @@ import (
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 )
 
 func TestSectorInfoSelialization(t *testing.T) {
@@ -22,7 +22,7 @@ func TestSectorInfoSelialization(t *testing.T) {
 		},
 	}
 
-	dummyCid := builtin.AccountActorCodeID
+	dummyCid := builtin2.AccountActorCodeID
 
 	si := &SectorInfo{
 		State:        "stateful",

--- a/genesis/types.go
+++ b/genesis/types.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 )
 
 type ActorType string
@@ -21,7 +22,7 @@ type PreSeal struct {
 	CommR     cid.Cid
 	CommD     cid.Cid
 	SectorID  abi.SectorNumber
-	Deal      market.DealProposal
+	Deal      market2.DealProposal
 	ProofType abi.RegisteredSealProof
 }
 

--- a/markets/storageadapter/client.go
+++ b/markets/storageadapter/client.go
@@ -7,8 +7,8 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-state-types/big"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"golang.org/x/xerrors"
 
@@ -101,10 +101,10 @@ func (c *ClientNodeAdapter) VerifySignature(ctx context.Context, sig crypto.Sign
 func (c *ClientNodeAdapter) AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) (cid.Cid, error) {
 	// (Provider Node API)
 	smsg, err := c.MpoolPushMessage(ctx, &types.Message{
-		To:     miner0.StorageMarketActorAddr,
+		To:     miner2.StorageMarketActorAddr,
 		From:   addr,
 		Value:  amount,
-		Method: miner0.MethodsMarket.AddBalance,
+		Method: miner2.MethodsMarket.AddBalance,
 	}, nil)
 	if err != nil {
 		return cid.Undef, err
@@ -155,15 +155,15 @@ func (c *ClientNodeAdapter) ValidatePublishedDeal(ctx context.Context, deal stor
 		return 0, xerrors.Errorf("deal wasn't published by storage provider: from=%s, provider=%s", pubmsg.From, deal.Proposal.Provider)
 	}
 
-	if pubmsg.To != miner0.StorageMarketActorAddr {
+	if pubmsg.To != miner2.StorageMarketActorAddr {
 		return 0, xerrors.Errorf("deal publish message wasn't set to StorageMarket actor (to=%s)", pubmsg.To)
 	}
 
-	if pubmsg.Method != miner0.MethodsMarket.PublishStorageDeals {
+	if pubmsg.Method != miner2.MethodsMarket.PublishStorageDeals {
 		return 0, xerrors.Errorf("deal publish message called incorrect method (method=%s)", pubmsg.Method)
 	}
 
-	var params market0.PublishStorageDealsParams
+	var params market2.PublishStorageDealsParams
 	if err := params.UnmarshalCBOR(bytes.NewReader(pubmsg.Params)); err != nil {
 		return 0, err
 	}
@@ -195,7 +195,7 @@ func (c *ClientNodeAdapter) ValidatePublishedDeal(ctx context.Context, deal stor
 		return 0, xerrors.Errorf("deal publish failed: exit=%d", ret.ExitCode)
 	}
 
-	var res market0.PublishStorageDealsReturn
+	var res market2.PublishStorageDealsReturn
 	if err := res.UnmarshalCBOR(bytes.NewReader(ret.Return)); err != nil {
 		return 0, err
 	}
@@ -273,7 +273,7 @@ func (c *ClientNodeAdapter) OnDealSectorCommitted(ctx context.Context, provider 
 		}
 
 		switch msg.Method {
-		case miner0.MethodsMiner.PreCommitSector:
+		case miner2.MethodsMiner.PreCommitSector:
 			var params miner.SectorPreCommitInfo
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("unmarshal pre commit: %w", err)
@@ -288,7 +288,7 @@ func (c *ClientNodeAdapter) OnDealSectorCommitted(ctx context.Context, provider 
 			}
 
 			return true, false, nil
-		case miner0.MethodsMiner.ProveCommitSector:
+		case miner2.MethodsMiner.ProveCommitSector:
 			var params miner.ProveCommitSectorParams
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("failed to unmarshal prove commit sector params: %w", err)
@@ -410,7 +410,7 @@ func (c *ClientNodeAdapter) OnDealExpiredOrSlashed(ctx context.Context, dealID a
 	return nil
 }
 
-func (c *ClientNodeAdapter) SignProposal(ctx context.Context, signer address.Address, proposal market0.DealProposal) (*market0.ClientDealProposal, error) {
+func (c *ClientNodeAdapter) SignProposal(ctx context.Context, signer address.Address, proposal market2.DealProposal) (*market2.ClientDealProposal, error) {
 	// TODO: output spec signed proposal
 	buf, err := cborutil.Dump(&proposal)
 	if err != nil {
@@ -427,7 +427,7 @@ func (c *ClientNodeAdapter) SignProposal(ctx context.Context, signer address.Add
 		return nil, err
 	}
 
-	return &market0.ClientDealProposal{
+	return &market2.ClientDealProposal{
 		Proposal:        proposal,
 		ClientSignature: *sig,
 	}, nil

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -12,7 +12,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/go-address"
@@ -92,7 +91,7 @@ func (n *ProviderNodeAdapter) PublishDeals(ctx context.Context, deal storagemark
 		To:     market.Address,
 		From:   mi.Worker,
 		Value:  types.NewInt(0),
-		Method: builtin2.MethodsMarket.PublishStorageDeals,
+		Method: market.Methods.PublishStorageDeals,
 		Params: params,
 	}, n.publishSpec)
 	if err != nil {
@@ -192,7 +191,7 @@ func (n *ProviderNodeAdapter) AddFunds(ctx context.Context, addr address.Address
 		To:     market.Address,
 		From:   addr,
 		Value:  amount,
-		Method: builtin2.MethodsMarket.AddBalance,
+		Method: market.Methods.AddBalance,
 	}, n.addBalanceSpec)
 	if err != nil {
 		return cid.Undef, err
@@ -314,7 +313,7 @@ func (n *ProviderNodeAdapter) OnDealSectorCommitted(ctx context.Context, provide
 		}
 
 		switch msg.Method {
-		case builtin2.MethodsMiner.PreCommitSector:
+		case miner.Methods.PreCommitSector:
 			var params miner.SectorPreCommitInfo
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("unmarshal pre commit: %w", err)
@@ -329,7 +328,7 @@ func (n *ProviderNodeAdapter) OnDealSectorCommitted(ctx context.Context, provide
 			}
 
 			return true, false, nil
-		case builtin2.MethodsMiner.ProveCommitSector:
+		case miner.Methods.ProveCommitSector:
 			var params miner.ProveCommitSectorParams
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("failed to unmarshal prove commit sector params: %w", err)

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -12,8 +12,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/shared"
@@ -79,8 +79,8 @@ func (n *ProviderNodeAdapter) PublishDeals(ctx context.Context, deal storagemark
 		return cid.Undef, err
 	}
 
-	params, err := actors.SerializeParams(&market0.PublishStorageDealsParams{
-		Deals: []market0.ClientDealProposal{deal.ClientDealProposal},
+	params, err := actors.SerializeParams(&market2.PublishStorageDealsParams{
+		Deals: []market2.ClientDealProposal{deal.ClientDealProposal},
 	})
 
 	if err != nil {
@@ -92,7 +92,7 @@ func (n *ProviderNodeAdapter) PublishDeals(ctx context.Context, deal storagemark
 		To:     market.Address,
 		From:   mi.Worker,
 		Value:  types.NewInt(0),
-		Method: builtin0.MethodsMarket.PublishStorageDeals,
+		Method: builtin2.MethodsMarket.PublishStorageDeals,
 		Params: params,
 	}, n.publishSpec)
 	if err != nil {
@@ -192,7 +192,7 @@ func (n *ProviderNodeAdapter) AddFunds(ctx context.Context, addr address.Address
 		To:     market.Address,
 		From:   addr,
 		Value:  amount,
-		Method: builtin0.MethodsMarket.AddBalance,
+		Method: builtin2.MethodsMarket.AddBalance,
 	}, n.addBalanceSpec)
 	if err != nil {
 		return cid.Undef, err
@@ -314,7 +314,7 @@ func (n *ProviderNodeAdapter) OnDealSectorCommitted(ctx context.Context, provide
 		}
 
 		switch msg.Method {
-		case builtin0.MethodsMiner.PreCommitSector:
+		case builtin2.MethodsMiner.PreCommitSector:
 			var params miner.SectorPreCommitInfo
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("unmarshal pre commit: %w", err)
@@ -329,7 +329,7 @@ func (n *ProviderNodeAdapter) OnDealSectorCommitted(ctx context.Context, provide
 			}
 
 			return true, false, nil
-		case builtin0.MethodsMiner.ProveCommitSector:
+		case builtin2.MethodsMiner.ProveCommitSector:
 			var params miner.ProveCommitSectorParams
 			if err := params.UnmarshalCBOR(bytes.NewReader(msg.Params)); err != nil {
 				return true, false, xerrors.Errorf("failed to unmarshal prove commit sector params: %w", err)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
 
@@ -489,7 +489,7 @@ func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, bas
 }
 
 func (m *Miner) createBlock(base *MiningBase, addr address.Address, ticket *types.Ticket,
-	eproof *types.ElectionProof, bvals []types.BeaconEntry, wpostProof []proof0.PoStProof, msgs []*types.SignedMessage) (*types.BlockMsg, error) {
+	eproof *types.ElectionProof, bvals []types.BeaconEntry, wpostProof []proof2.PoStProof, msgs []*types.SignedMessage) (*types.BlockMsg, error) {
 	uts := base.TipSet.MinTimestamp() + build.BlockDelaySecs*(uint64(base.NullRounds)+1)
 
 	nheight := base.TipSet.Height() + base.NullRounds + 1

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
@@ -198,7 +198,7 @@ func (a *GasAPI) GasEstimateGasLimit(ctx context.Context, msgIn *types.Message, 
 	if !builtin.IsPaymentChannelActor(act.Code) {
 		return res.MsgRct.GasUsed, nil
 	}
-	if msgIn.Method != builtin0.MethodsPaych.Collect {
+	if msgIn.Method != builtin2.MethodsPaych.Collect {
 		return res.MsgRct.GasUsed, nil
 	}
 

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
@@ -15,8 +16,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
@@ -198,7 +197,7 @@ func (a *GasAPI) GasEstimateGasLimit(ctx context.Context, msgIn *types.Message, 
 	if !builtin.IsPaymentChannelActor(act.Code) {
 		return res.MsgRct.GasUsed, nil
 	}
-	if msgIn.Method != builtin2.MethodsPaych.Collect {
+	if msgIn.Method != paych.Methods.Collect {
 		return res.MsgRct.GasUsed, nil
 	}
 

--- a/node/impl/full/multisig.go
+++ b/node/impl/full/multisig.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
 	"github.com/filecoin-project/lotus/chain/types"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	multisig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
 	"github.com/ipfs/go-cid"
@@ -86,7 +85,7 @@ func (a *MsigAPI) MsigAddPropose(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
+	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
@@ -95,7 +94,7 @@ func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
+	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (cid.Cid, error) {
@@ -104,7 +103,7 @@ func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src a
 		return cid.Undef, actErr
 	}
 
-	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
+	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -113,7 +112,7 @@ func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src
 		return cid.Undef, actErr
 	}
 
-	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
+	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -122,7 +121,7 @@ func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src
 		return cid.Undef, actErr
 	}
 
-	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
+	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -131,7 +130,7 @@ func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
+	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigApprove(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {

--- a/node/impl/full/multisig.go
+++ b/node/impl/full/multisig.go
@@ -12,8 +12,8 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
 	"github.com/filecoin-project/lotus/chain/types"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	multisig0 "github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	multisig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
 	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
@@ -86,7 +86,7 @@ func (a *MsigAPI) MsigAddPropose(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.AddSigner), enc)
+	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
@@ -95,7 +95,7 @@ func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.AddSigner), enc)
+	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (cid.Cid, error) {
@@ -104,7 +104,7 @@ func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src a
 		return cid.Undef, actErr
 	}
 
-	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.AddSigner), enc)
+	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.AddSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -113,7 +113,7 @@ func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src
 		return cid.Undef, actErr
 	}
 
-	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.SwapSigner), enc)
+	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -122,7 +122,7 @@ func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src
 		return cid.Undef, actErr
 	}
 
-	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.SwapSigner), enc)
+	return a.MsigApprove(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
@@ -131,7 +131,7 @@ func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src 
 		return cid.Undef, actErr
 	}
 
-	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin0.MethodsMultisig.SwapSigner), enc)
+	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(builtin2.MethodsMultisig.SwapSigner), enc)
 }
 
 func (a *MsigAPI) MsigApprove(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
@@ -194,7 +194,7 @@ func (a *MsigAPI) msigApproveOrCancel(ctx context.Context, operation api.MsigPro
 }
 
 func serializeAddParams(new address.Address, inc bool) ([]byte, error) {
-	enc, actErr := actors.SerializeParams(&multisig0.AddSignerParams{
+	enc, actErr := actors.SerializeParams(&multisig2.AddSignerParams{
 		Signer:   new,
 		Increase: inc,
 	})
@@ -206,7 +206,7 @@ func serializeAddParams(new address.Address, inc bool) ([]byte, error) {
 }
 
 func serializeSwapParams(old address.Address, new address.Address) ([]byte, error) {
-	enc, actErr := actors.SerializeParams(&multisig0.SwapSignerParams{
+	enc, actErr := actors.SerializeParams(&multisig2.SwapSignerParams{
 		From: old,
 		To:   new,
 	})

--- a/node/modules/chain.go
+++ b/node/modules/chain.go
@@ -157,14 +157,18 @@ func SetGenesis(cs *store.ChainStore, g Genesis) (dtypes.AfterGenesisSet, error)
 	return dtypes.AfterGenesisSet{}, cs.SetGenesis(genesis)
 }
 
-func NetworkName(mctx helpers.MetricsCtx, lc fx.Lifecycle, cs *store.ChainStore, _ dtypes.AfterGenesisSet) (dtypes.NetworkName, error) {
+func NetworkName(mctx helpers.MetricsCtx, lc fx.Lifecycle, cs *store.ChainStore, us stmgr.UpgradeSchedule, _ dtypes.AfterGenesisSet) (dtypes.NetworkName, error) {
 	if !build.Devnet {
 		return "testnetnet", nil
 	}
 
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
-	netName, err := stmgr.GetNetworkName(ctx, stmgr.NewStateManager(cs), cs.GetHeaviestTipSet().ParentState())
+	sm, err := stmgr.NewStateManagerWithUpgradeSchedule(cs, us)
+	if err != nil {
+		return "", xerrors.Errorf("failed to construct state manager: %w", err)
+	}
+	netName, err := stmgr.GetNetworkName(ctx, sm, cs.GetHeaviestTipSet().ParentState())
 	return netName, err
 }
 

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -44,7 +44,6 @@ import (
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-storedcounter"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
 
 	sectorstorage "github.com/filecoin-project/lotus/extern/sector-storage"
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
@@ -56,6 +55,7 @@ import (
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
 	"github.com/filecoin-project/lotus/chain/types"

--- a/node/test/builder.go
+++ b/node/test/builder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/api/test"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/gen"
 	genesis2 "github.com/filecoin-project/lotus/chain/gen/genesis"
@@ -37,7 +38,6 @@ import (
 	testing2 "github.com/filecoin-project/lotus/node/modules/testing"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/lotus/storage/mockstorage"
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-core/crypto"
@@ -90,7 +90,7 @@ func CreateTestStorageNode(ctx context.Context, t *testing.T, waddr address.Addr
 	msg := &types.Message{
 		To:     act,
 		From:   waddr,
-		Method: builtin2.MethodsMiner.ChangePeerID,
+		Method: miner.Methods.ChangePeerID,
 		Params: enc,
 		Value:  types.NewInt(0),
 	}

--- a/paychmgr/paych_test.go
+++ b/paychmgr/paych_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	tutils "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	paych2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/paych"
+	tutils "github.com/filecoin-project/specs-actors/v2/support/testing"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
@@ -237,7 +237,7 @@ func TestCreateVoucher(t *testing.T) {
 
 	// Create a voucher in lane 1
 	voucherLane1Amt := big.NewInt(5)
-	voucher := paych2.SignedVoucher{
+	voucher := paych.SignedVoucher{
 		Lane:   1,
 		Amount: voucherLane1Amt,
 	}
@@ -252,7 +252,7 @@ func TestCreateVoucher(t *testing.T) {
 
 	// Create a voucher in lane 1 again, with a higher amount
 	voucherLane1Amt = big.NewInt(8)
-	voucher = paych2.SignedVoucher{
+	voucher = paych.SignedVoucher{
 		Lane:   1,
 		Amount: voucherLane1Amt,
 	}
@@ -267,7 +267,7 @@ func TestCreateVoucher(t *testing.T) {
 	// Create a voucher in lane 2 that covers all the remaining funds
 	// in the channel
 	voucherLane2Amt := big.Sub(s.amt, voucherLane1Amt)
-	voucher = paych2.SignedVoucher{
+	voucher = paych.SignedVoucher{
 		Lane:   2,
 		Amount: voucherLane2Amt,
 	}
@@ -281,7 +281,7 @@ func TestCreateVoucher(t *testing.T) {
 	// Create a voucher in lane 2 that exceeds the remaining funds in the
 	// channel
 	voucherLane2Amt = big.Add(voucherLane2Amt, big.NewInt(1))
-	voucher = paych2.SignedVoucher{
+	voucher = paych.SignedVoucher{
 		Lane:   2,
 		Amount: voucherLane2Amt,
 	}

--- a/paychmgr/paychvoucherfunds_test.go
+++ b/paychmgr/paychvoucherfunds_test.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
-	paychmock "github.com/filecoin-project/lotus/chain/actors/builtin/paych/mock"
-
-	"github.com/filecoin-project/lotus/chain/types"
-
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-	tutils "github.com/filecoin-project/specs-actors/support/testing"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
+
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	tutils2 "github.com/filecoin-project/specs-actors/v2/support/testing"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
+	paychmock "github.com/filecoin-project/lotus/chain/actors/builtin/paych/mock"
+	"github.com/filecoin-project/lotus/chain/types"
 )
 
 // TestPaychAddVoucherAfterAddFunds tests adding a voucher to a channel with
@@ -27,11 +27,11 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	store := NewStore(ds_sync.MutexWrap(ds.NewMapDatastore()))
 
 	fromKeyPrivate, fromKeyPublic := testGenerateKeyPair(t)
-	ch := tutils.NewIDAddr(t, 100)
-	from := tutils.NewSECP256K1Addr(t, string(fromKeyPublic))
-	to := tutils.NewSECP256K1Addr(t, "secpTo")
-	fromAcct := tutils.NewActorAddr(t, "fromAct")
-	toAcct := tutils.NewActorAddr(t, "toAct")
+	ch := tutils2.NewIDAddr(t, 100)
+	from := tutils2.NewSECP256K1Addr(t, string(fromKeyPublic))
+	to := tutils2.NewSECP256K1Addr(t, "secpTo")
+	fromAcct := tutils2.NewActorAddr(t, "fromAct")
+	toAcct := tutils2.NewActorAddr(t, "toAct")
 
 	mock := newMockManagerAPI()
 	defer mock.close()
@@ -55,7 +55,7 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 
 	// Create an actor in state for the channel with the initial channel balance
 	act := &types.Actor{
-		Code:    builtin.AccountActorCodeID,
+		Code:    builtin2.AccountActorCodeID,
 		Head:    cid.Cid{},
 		Nonce:   0,
 		Balance: createAmt,

--- a/paychmgr/settler/settler.go
+++ b/paychmgr/settler/settler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
@@ -107,7 +107,7 @@ func (pcs *paymentChannelSettler) revertHandler(ctx context.Context, ts *types.T
 
 func (pcs *paymentChannelSettler) matcher(msg *types.Message) (matchOnce bool, matched bool, err error) {
 	// Check if this is a settle payment channel message
-	if msg.Method != builtin0.MethodsPaych.Settle {
+	if msg.Method != builtin2.MethodsPaych.Settle {
 		return false, false, nil
 	}
 	// Check if this payment channel is of concern to this node (i.e. tracked in payment channel store),

--- a/paychmgr/settler/settler.go
+++ b/paychmgr/settler/settler.go
@@ -14,8 +14,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
-
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
@@ -107,7 +105,7 @@ func (pcs *paymentChannelSettler) revertHandler(ctx context.Context, ts *types.T
 
 func (pcs *paymentChannelSettler) matcher(msg *types.Message) (matchOnce bool, matched bool, err error) {
 	// Check if this is a settle payment channel message
-	if msg.Method != builtin2.MethodsPaych.Settle {
+	if msg.Method != paych.Methods.Settle {
 		return false, false, nil
 	}
 	// Check if this payment channel is of concern to this node (i.e. tracked in payment channel store),

--- a/storage/adapter_storage_miner.go
+++ b/storage/adapter_storage_miner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/lotus/api"
@@ -150,7 +149,7 @@ func (s SealingAPIAdapter) StateComputeDataCommitment(ctx context.Context, maddr
 		To:     market.Address,
 		From:   maddr,
 		Value:  types.NewInt(0),
-		Method: builtin2.MethodsMarket.ComputeDataCommitment,
+		Method: market.Methods.ComputeDataCommitment,
 		Params: ccparams,
 	}
 	r, err := s.delegate.StateCall(ctx, ccmt, tsk)

--- a/storage/adapter_storage_miner.go
+++ b/storage/adapter_storage_miner.go
@@ -15,8 +15,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
 
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/apibstore"
@@ -138,7 +138,7 @@ func (s SealingAPIAdapter) StateComputeDataCommitment(ctx context.Context, maddr
 		return cid.Undef, xerrors.Errorf("failed to unmarshal TipSetToken to TipSetKey: %w", err)
 	}
 
-	ccparams, err := actors.SerializeParams(&market0.ComputeDataCommitmentParams{
+	ccparams, err := actors.SerializeParams(&market2.ComputeDataCommitmentParams{
 		DealIDs:    deals,
 		SectorType: sectorType,
 	})
@@ -150,7 +150,7 @@ func (s SealingAPIAdapter) StateComputeDataCommitment(ctx context.Context, maddr
 		To:     market.Address,
 		From:   maddr,
 		Value:  types.NewInt(0),
-		Method: builtin0.MethodsMarket.ComputeDataCommitment,
+		Method: builtin2.MethodsMarket.ComputeDataCommitment,
 		Params: ccparams,
 	}
 	r, err := s.delegate.StateCall(ctx, ccmt, tsk)

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"time"
 
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
-	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
-
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/go-state-types/dline"
@@ -29,7 +26,9 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -147,7 +146,7 @@ func (m *Miner) Run(ctx context.Context) error {
 	evts := events.NewEvents(ctx, m.api)
 	adaptedAPI := NewSealingAPIAdapter(m.api)
 	// TODO: Maybe we update this policy after actor upgrades?
-	pcp := sealing.NewBasicPreCommitPolicy(adaptedAPI, miner0.MaxSectorExpirationExtension-(miner0.WPoStProvingPeriod*2), md.PeriodStart%miner0.WPoStProvingPeriod)
+	pcp := sealing.NewBasicPreCommitPolicy(adaptedAPI, policy.GetMaxSectorExpirationExtension()-(md.WPoStProvingPeriod*2), md.PeriodStart%md.WPoStProvingPeriod)
 	m.sealing = sealing.New(adaptedAPI, fc, NewEventsAdapter(evts), m.maddr, m.ds, m.sealer, m.sc, m.verif, &pcp, sealing.GetSealingConfigFunc(m.getSealConfig), m.handleSealingNotifications)
 
 	go m.sealing.Run(ctx) //nolint:errcheck // logged intside the function
@@ -235,9 +234,9 @@ func (wpp *StorageWpp) GenerateCandidates(ctx context.Context, randomness abi.Po
 	return cds, nil
 }
 
-func (wpp *StorageWpp) ComputeProof(ctx context.Context, ssi []proof0.SectorInfo, rand abi.PoStRandomness) ([]proof0.PoStProof, error) {
+func (wpp *StorageWpp) ComputeProof(ctx context.Context, ssi []builtin.SectorInfo, rand abi.PoStRandomness) ([]builtin.PoStProof, error) {
 	if build.InsecurePoStValidation {
-		return []proof0.PoStProof{{ProofBytes: []byte("valid proof")}}, nil
+		return []builtin.PoStProof{{ProofBytes: []byte("valid proof")}}, nil
 	}
 
 	log.Infof("Computing WinningPoSt ;%+v; %v", ssi, rand)

--- a/storage/mockstorage/preseal.go
+++ b/storage/mockstorage/preseal.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/lotus/extern/sector-storage/mock"
 
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
@@ -49,7 +49,7 @@ func PreSeal(ssize abi.SectorSize, maddr address.Address, sectors int) (*genesis
 		r := mock.CommDR(d)
 		preseal.CommR, _ = commcid.ReplicaCommitmentV1ToCID(r[:])
 		preseal.SectorID = abi.SectorNumber(i + 1)
-		preseal.Deal = market0.DealProposal{
+		preseal.Deal = market2.DealProposal{
 			PieceCID:             preseal.CommD,
 			PieceSize:            abi.PaddedPieceSize(ssize),
 			Client:               k.Address,

--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -17,7 +17,6 @@ import (
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
 
-	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/api"
@@ -291,7 +290,7 @@ func (s *WindowPoStScheduler) checkNextRecoveries(ctx context.Context, dlIdx uin
 	msg := &types.Message{
 		To:     s.actor,
 		From:   s.worker,
-		Method: builtin2.MethodsMiner.DeclareFaultsRecovered,
+		Method: miner.Methods.DeclareFaultsRecovered,
 		Params: enc,
 		Value:  types.NewInt(0),
 	}
@@ -375,7 +374,7 @@ func (s *WindowPoStScheduler) checkNextFaults(ctx context.Context, dlIdx uint64,
 	msg := &types.Message{
 		To:     s.actor,
 		From:   s.worker,
-		Method: builtin2.MethodsMiner.DeclareFaults,
+		Method: miner.Methods.DeclareFaults,
 		Params: enc,
 		Value:  types.NewInt(0), // TODO: Is there a fee?
 	}
@@ -715,7 +714,7 @@ func (s *WindowPoStScheduler) submitPost(ctx context.Context, proof *miner.Submi
 	msg := &types.Message{
 		To:     s.actor,
 		From:   s.worker,
-		Method: builtin2.MethodsMiner.SubmitWindowedPoSt,
+		Method: miner.Methods.SubmitWindowedPoSt,
 		Params: enc,
 		Value:  types.NewInt(0),
 	}

--- a/storage/wdpost_run_test.go
+++ b/storage/wdpost_run_test.go
@@ -186,7 +186,7 @@ func TestWDPostDoPost(t *testing.T) {
 	// Read the window PoST messages
 	for i := 0; i < expectedMsgCount; i++ {
 		msg := <-mockStgMinerAPI.pushedMessages
-		require.Equal(t, builtin2.MethodsMiner.SubmitWindowedPoSt, msg.Method)
+		require.Equal(t, miner.Methods.SubmitWindowedPoSt, msg.Method)
 		var params miner.SubmitWindowedPoStParams
 		err := params.UnmarshalCBOR(bytes.NewReader(msg.Params))
 		require.NoError(t, err)

--- a/storage/wdpost_run_test.go
+++ b/storage/wdpost_run_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/network"
-	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
-	miner0 "github.com/filecoin-project/specs-actors/actors/builtin/miner"
-	proof0 "github.com/filecoin-project/specs-actors/actors/runtime/proof"
-	tutils "github.com/filecoin-project/specs-actors/support/testing"
+	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
+	tutils "github.com/filecoin-project/specs-actors/v2/support/testing"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
@@ -97,12 +97,12 @@ func (m *mockStorageMinerAPI) StateWaitMsg(ctx context.Context, cid cid.Cid, con
 type mockProver struct {
 }
 
-func (m *mockProver) GenerateWinningPoSt(context.Context, abi.ActorID, []proof0.SectorInfo, abi.PoStRandomness) ([]proof0.PoStProof, error) {
+func (m *mockProver) GenerateWinningPoSt(context.Context, abi.ActorID, []proof2.SectorInfo, abi.PoStRandomness) ([]proof2.PoStProof, error) {
 	panic("implement me")
 }
 
-func (m *mockProver) GenerateWindowPoSt(ctx context.Context, aid abi.ActorID, sis []proof0.SectorInfo, pr abi.PoStRandomness) ([]proof0.PoStProof, []abi.SectorID, error) {
-	return []proof0.PoStProof{
+func (m *mockProver) GenerateWindowPoSt(ctx context.Context, aid abi.ActorID, sis []proof2.SectorInfo, pr abi.PoStRandomness) ([]proof2.PoStProof, []abi.SectorID, error) {
+	return []proof2.PoStProof{
 		{
 			PoStProof:  abi.RegisteredPoStProof_StackedDrgWindow2KiBV1,
 			ProofBytes: []byte("post-proof"),
@@ -131,13 +131,13 @@ func TestWDPostDoPost(t *testing.T) {
 	mockStgMinerAPI := newMockStorageMinerAPI()
 
 	// Get the number of sectors allowed in a partition for this proof type
-	sectorsPerPartition, err := builtin0.PoStProofWindowPoStPartitionSectors(proofType)
+	sectorsPerPartition, err := builtin2.PoStProofWindowPoStPartitionSectors(proofType)
 	require.NoError(t, err)
 	// Work out the number of partitions that can be included in a message
 	// without exceeding the message sector limit
 
 	require.NoError(t, err)
-	partitionsPerMsg := int(miner0.AddressedSectorsMax / sectorsPerPartition)
+	partitionsPerMsg := int(miner2.AddressedSectorsMax / sectorsPerPartition)
 
 	// Enough partitions to fill expectedMsgCount-1 messages
 	partitionCount := (expectedMsgCount - 1) * partitionsPerMsg
@@ -171,11 +171,11 @@ func TestWDPostDoPost(t *testing.T) {
 	}
 
 	di := &dline.Info{
-		WPoStPeriodDeadlines:   miner0.WPoStPeriodDeadlines,
-		WPoStProvingPeriod:     miner0.WPoStProvingPeriod,
-		WPoStChallengeWindow:   miner0.WPoStChallengeWindow,
-		WPoStChallengeLookback: miner0.WPoStChallengeLookback,
-		FaultDeclarationCutoff: miner0.FaultDeclarationCutoff,
+		WPoStPeriodDeadlines:   miner2.WPoStPeriodDeadlines,
+		WPoStProvingPeriod:     miner2.WPoStProvingPeriod,
+		WPoStChallengeWindow:   miner2.WPoStChallengeWindow,
+		WPoStChallengeLookback: miner2.WPoStChallengeLookback,
+		FaultDeclarationCutoff: miner2.FaultDeclarationCutoff,
 	}
 	ts := mockTipSet(t)
 
@@ -186,7 +186,7 @@ func TestWDPostDoPost(t *testing.T) {
 	// Read the window PoST messages
 	for i := 0; i < expectedMsgCount; i++ {
 		msg := <-mockStgMinerAPI.pushedMessages
-		require.Equal(t, builtin0.MethodsMiner.SubmitWindowedPoSt, msg.Method)
+		require.Equal(t, builtin2.MethodsMiner.SubmitWindowedPoSt, msg.Method)
 		var params miner.SubmitWindowedPoStParams
 		err := params.UnmarshalCBOR(bytes.NewReader(msg.Params))
 		require.NoError(t, err)
@@ -252,11 +252,11 @@ func (m *mockStorageMinerAPI) StateMinerProvingDeadline(ctx context.Context, add
 		Close:                  0,
 		Challenge:              0,
 		FaultCutoff:            0,
-		WPoStPeriodDeadlines:   miner0.WPoStPeriodDeadlines,
-		WPoStProvingPeriod:     miner0.WPoStProvingPeriod,
-		WPoStChallengeWindow:   miner0.WPoStChallengeWindow,
-		WPoStChallengeLookback: miner0.WPoStChallengeLookback,
-		FaultDeclarationCutoff: miner0.FaultDeclarationCutoff,
+		WPoStPeriodDeadlines:   miner2.WPoStPeriodDeadlines,
+		WPoStProvingPeriod:     miner2.WPoStProvingPeriod,
+		WPoStChallengeWindow:   miner2.WPoStChallengeWindow,
+		WPoStChallengeLookback: miner2.WPoStChallengeLookback,
+		FaultDeclarationCutoff: miner2.FaultDeclarationCutoff,
 	}, nil
 }
 
@@ -274,7 +274,7 @@ func (m *mockStorageMinerAPI) StateSearchMsg(ctx context.Context, cid cid.Cid) (
 
 func (m *mockStorageMinerAPI) StateGetActor(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error) {
 	return &types.Actor{
-		Code: builtin0.StorageMinerActorCodeID,
+		Code: builtin2.StorageMinerActorCodeID,
 	}, nil
 }
 


### PR DESCRIPTION
This patch set:

1. Replaces many direct actor imports with actor abstraction imports.
  1. It aliases Method objects into the actor abstraction. Ideally we'd use a message sending abstraction, but we're not there yet.
  2. Adds a few more constants/variables to the policy/builtin packages. It also extends the policy tests to make sure we don't change these constants.
2. Switches remaining actors to v2 where possible. This will make (some) more tests run against actors v2.

Remaining v0 imports:

* Proofs v0: https://github.com/filecoin-project/specs-actors/pull/1227
* Imports inside the actors abstractions themselves.
* ADTs used in the _chain_ (message arrays). These explicitly use actors v0.
  * NOTE: we can probably switch to actors v2 as this shouldn't break consensus (no AMT changes), but one thing at a time.
  * We'll eventually need an abstraction here.
* extern & cbor gen things
* cli/chain.go (still somewhat broken post upgrade)
* VM/state manager imports to explicitly load v0 actors.
* Genesis (no v2 support yet).