### PR TITLE
lite-mode - market storage and retrieval clients

### DIFF
--- a/api/api_gateway.go
+++ b/api/api_gateway.go
@@ -34,5 +34,6 @@ type GatewayAPI interface {
 	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*MarketDeal, error)
 	StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
 	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
+	StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error)
 	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*MsgLookup, error)
 }

--- a/api/api_gateway.go
+++ b/api/api_gateway.go
@@ -3,12 +3,15 @@ package api
 import (
 	"context"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/network"
+
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/ipfs/go-cid"
 )
 
 type GatewayAPI interface {
@@ -33,6 +36,8 @@ type GatewayAPI interface {
 	StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (MarketBalance, error)
 	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*MarketDeal, error)
 	StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
+	StateMinerProvingDeadline(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*dline.Info, error)
+	StateMinerPower(context.Context, address.Address, types.TipSetKey) (*MinerPower, error)
 	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 	StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error)
 	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*MsgLookup, error)

--- a/api/api_gateway.go
+++ b/api/api_gateway.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 )
@@ -12,15 +14,25 @@ import (
 type GatewayAPI interface {
 	ChainHasObj(context.Context, cid.Cid) (bool, error)
 	ChainHead(ctx context.Context) (*types.TipSet, error)
+	ChainGetBlockMessages(context.Context, cid.Cid) (*BlockMessages, error)
+	ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error)
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
+	ChainNotify(context.Context) (<-chan []*HeadChange, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 	GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
 	MpoolPush(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
 	MsigGetAvailableBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
 	MsigGetVested(ctx context.Context, addr address.Address, start types.TipSetKey, end types.TipSetKey) (types.BigInt, error)
 	StateAccountKey(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (DealCollateralBounds, error)
 	StateGetActor(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
+	StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)
 	StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (MarketBalance, error)
+	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*MarketDeal, error)
+	StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
+	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*MsgLookup, error)
 }

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -393,6 +393,8 @@ type GatewayStruct struct {
 		StateLookupID                     func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
 		StateListMiners                   func(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)
 		StateMinerInfo                    func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
+		StateMinerProvingDeadline         func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*dline.Info, error)
+		StateMinerPower                   func(context.Context, address.Address, types.TipSetKey) (*api.MinerPower, error)
 		StateMarketBalance                func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error)
 		StateMarketStorageDeal            func(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
 		StateNetworkVersion               func(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error)
@@ -1542,6 +1544,14 @@ func (g GatewayStruct) StateMarketStorageDeal(ctx context.Context, dealId abi.De
 
 func (g GatewayStruct) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
 	return g.Internal.StateMinerInfo(ctx, actor, tsk)
+}
+
+func (g GatewayStruct) StateMinerProvingDeadline(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*dline.Info, error) {
+	return g.Internal.StateMinerProvingDeadline(ctx, addr, tsk)
+}
+
+func (g GatewayStruct) StateMinerPower(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*api.MinerPower, error) {
+	return g.Internal.StateMinerPower(ctx, addr, tsk)
 }
 
 func (g GatewayStruct) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error) {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -374,20 +374,29 @@ type WorkerStruct struct {
 
 type GatewayStruct struct {
 	Internal struct {
-		// TODO: does the gateway need perms?
-		ChainHasObj             func(context.Context, cid.Cid) (bool, error)
-		ChainGetTipSet          func(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
-		ChainGetTipSetByHeight  func(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
-		ChainHead               func(ctx context.Context) (*types.TipSet, error)
-		ChainReadObj            func(context.Context, cid.Cid) ([]byte, error)
-		GasEstimateMessageGas   func(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
-		MpoolPush               func(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
-		MsigGetAvailableBalance func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
-		MsigGetVested           func(ctx context.Context, addr address.Address, start types.TipSetKey, end types.TipSetKey) (types.BigInt, error)
-		StateAccountKey         func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
-		StateGetActor           func(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error)
-		StateLookupID           func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
-		StateWaitMsg            func(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
+		ChainGetBlockMessages             func(ctx context.Context, c cid.Cid) (*api.BlockMessages, error)
+		ChainGetMessage                   func(ctx context.Context, mc cid.Cid) (*types.Message, error)
+		ChainGetTipSet                    func(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
+		ChainGetTipSetByHeight            func(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
+		ChainHasObj                       func(context.Context, cid.Cid) (bool, error)
+		ChainHead                         func(ctx context.Context) (*types.TipSet, error)
+		ChainNotify                       func(ctx context.Context) (<-chan []*api.HeadChange, error)
+		ChainReadObj                      func(context.Context, cid.Cid) ([]byte, error)
+		GasEstimateMessageGas             func(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
+		MpoolPush                         func(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
+		MsigGetAvailableBalance           func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
+		MsigGetVested                     func(ctx context.Context, addr address.Address, start types.TipSetKey, end types.TipSetKey) (types.BigInt, error)
+		StateAccountKey                   func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+		StateDealProviderCollateralBounds func(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error)
+		StateGetActor                     func(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error)
+		StateGetReceipt                   func(ctx context.Context, c cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
+		StateLookupID                     func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+		StateListMiners                   func(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)
+		StateMinerInfo                    func(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
+		StateMarketBalance                func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error)
+		StateMarketStorageDeal            func(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
+		StateNetworkVersion               func(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error)
+		StateWaitMsg                      func(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
 	}
 }
 
@@ -1450,12 +1459,12 @@ func (w *WorkerStruct) Closing(ctx context.Context) (<-chan struct{}, error) {
 	return w.Internal.Closing(ctx)
 }
 
-func (g GatewayStruct) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
-	return g.Internal.ChainHasObj(ctx, c)
+func (g GatewayStruct) ChainGetBlockMessages(ctx context.Context, c cid.Cid) (*api.BlockMessages, error) {
+	return g.Internal.ChainGetBlockMessages(ctx, c)
 }
 
-func (g GatewayStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
-	return g.Internal.ChainHead(ctx)
+func (g GatewayStruct) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
+	return g.Internal.ChainGetMessage(ctx, mc)
 }
 
 func (g GatewayStruct) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error) {
@@ -1464,6 +1473,18 @@ func (g GatewayStruct) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) 
 
 func (g GatewayStruct) ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error) {
 	return g.Internal.ChainGetTipSetByHeight(ctx, h, tsk)
+}
+
+func (g GatewayStruct) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
+	return g.Internal.ChainHasObj(ctx, c)
+}
+
+func (g GatewayStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
+	return g.Internal.ChainHead(ctx)
+}
+
+func (g GatewayStruct) ChainNotify(ctx context.Context) (<-chan []*api.HeadChange, error) {
+	return g.Internal.ChainNotify(ctx)
 }
 
 func (g GatewayStruct) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
@@ -1490,12 +1511,40 @@ func (g GatewayStruct) StateAccountKey(ctx context.Context, addr address.Address
 	return g.Internal.StateAccountKey(ctx, addr, tsk)
 }
 
+func (g GatewayStruct) StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error) {
+	return g.Internal.StateDealProviderCollateralBounds(ctx, size, verified, tsk)
+}
+
 func (g GatewayStruct) StateGetActor(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error) {
 	return g.Internal.StateGetActor(ctx, actor, ts)
 }
 
+func (g GatewayStruct) StateGetReceipt(ctx context.Context, c cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
+	return g.Internal.StateGetReceipt(ctx, c, tsk)
+}
+
 func (g GatewayStruct) StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
 	return g.Internal.StateLookupID(ctx, addr, tsk)
+}
+
+func (g GatewayStruct) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	return g.Internal.StateListMiners(ctx, tsk)
+}
+
+func (g GatewayStruct) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error) {
+	return g.Internal.StateMarketBalance(ctx, addr, tsk)
+}
+
+func (g GatewayStruct) StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error) {
+	return g.Internal.StateMarketStorageDeal(ctx, dealId, tsk)
+}
+
+func (g GatewayStruct) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
+	return g.Internal.StateMinerInfo(ctx, actor, tsk)
+}
+
+func (g GatewayStruct) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error) {
+	return g.Internal.StateNetworkVersion(ctx, tsk)
 }
 
 func (g GatewayStruct) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error) {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -396,6 +396,7 @@ type GatewayStruct struct {
 		StateMarketBalance                func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error)
 		StateMarketStorageDeal            func(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
 		StateNetworkVersion               func(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error)
+		StateVerifiedClientStatus         func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error)
 		StateWaitMsg                      func(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
 	}
 }
@@ -1545,6 +1546,10 @@ func (g GatewayStruct) StateMinerInfo(ctx context.Context, actor address.Address
 
 func (g GatewayStruct) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (stnetwork.Version, error) {
 	return g.Internal.StateNetworkVersion(ctx, tsk)
+}
+
+func (g GatewayStruct) StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error) {
+	return g.Internal.StateVerifiedClientStatus(ctx, addr, tsk)
 }
 
 func (g GatewayStruct) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error) {

--- a/api/test/ccupgrade.go
+++ b/api/test/ccupgrade.go
@@ -89,7 +89,7 @@ func testCCUpgrade(t *testing.T, b APIBuilder, blocktime time.Duration, upgradeH
 		t.Fatal(err)
 	}
 
-	makeDeal(t, ctx, 6, client, miner, false, false)
+	MakeDeal(t, ctx, 6, client, miner, false, false)
 
 	// Validate upgrade
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -46,6 +46,8 @@ const LookbackNoLimit = abi.ChainEpoch(-1)
 var log = logging.Logger("statemgr")
 
 type StateManagerAPI interface {
+	Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error)
+	GetPaychState(ctx context.Context, addr address.Address, ts *types.TipSet) (*types.Actor, paych.State, error)
 	LoadActorTsk(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error)
 	LookupID(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error)
 	ResolveToKeyAddress(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error)

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -255,25 +255,6 @@ func GetSectorsForWinningPoSt(ctx context.Context, pv ffiwrapper.Verifier, sm *S
 	return out, nil
 }
 
-func StateMinerInfo(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr address.Address) (*miner.MinerInfo, error) {
-	act, err := sm.LoadActor(ctx, maddr, ts)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to load miner actor: %w", err)
-	}
-
-	mas, err := miner.Load(sm.cs.Store(ctx), act)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to load miner actor state: %w", err)
-	}
-
-	mi, err := mas.Info()
-	if err != nil {
-		return nil, err
-	}
-
-	return &mi, err
-}
-
 func GetMinerSlashed(ctx context.Context, sm *StateManager, ts *types.TipSet, maddr address.Address) (bool, error) {
 	act, err := sm.LoadActor(ctx, power.Address, ts)
 	if err != nil {

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -9,14 +9,14 @@ import (
 	clitest "github.com/filecoin-project/lotus/cli/test"
 )
 
-// TestMultisig does a basic test to exercise the multisig CLI
+// TestClient does a basic test to exercise the client CLI
 // commands
-func TestMultisig(t *testing.T) {
+func TestClient(t *testing.T) {
 	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 	clitest.QuietMiningLogs()
 
 	blocktime := 5 * time.Millisecond
 	ctx := context.Background()
 	clientNode, _ := clitest.StartOneNodeOneMiner(ctx, t, blocktime)
-	clitest.RunMultisigTest(t, Commands, clientNode)
+	clitest.RunClientTest(t, Commands, clientNode)
 }

--- a/cli/test/client.go
+++ b/cli/test/client.go
@@ -1,0 +1,115 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/lotus/api/test"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
+	"github.com/stretchr/testify/require"
+	lcli "github.com/urfave/cli/v2"
+)
+
+// RunClientTest exercises some of the client CLI commands
+func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// Create mock CLI
+	mockCLI := newMockCLI(t, cmds)
+	clientCLI := mockCLI.client(clientNode.ListenAddr)
+
+	// Get the miner address
+	addrs, err := clientNode.StateListMiners(ctx, types.EmptyTSK)
+	require.NoError(t, err)
+	require.Len(t, addrs, 1)
+
+	minerAddr := addrs[0]
+	fmt.Println("Miner:", minerAddr)
+
+	// client query-ask <miner addr>
+	cmd := []string{
+		"client", "query-ask", minerAddr.String(),
+	}
+	out := clientCLI.runCmd(cmd)
+	require.Regexp(t, regexp.MustCompile("Ask:"), out)
+
+	// Create a deal (non-interactive)
+	// client deal <cid> <miner addr> 1000000attofil <duration>
+	res, _, err := test.CreateClientFile(ctx, clientNode, 1)
+	require.NoError(t, err)
+	dataCid := res.Root
+	price := "1000000attofil"
+	duration := fmt.Sprintf("%d", build.MinDealDuration)
+	cmd = []string{
+		"client", "deal", dataCid.String(), minerAddr.String(), price, duration,
+	}
+	out = clientCLI.runCmd(cmd)
+	fmt.Println("client deal", out)
+
+	// Create a deal (interactive)
+	// client deal
+	// <cid>
+	// <duration> (in days)
+	// <miner addr>
+	// "no" (verified client)
+	// "yes" (confirm deal)
+	res, _, err = test.CreateClientFile(ctx, clientNode, 2)
+	require.NoError(t, err)
+	dataCid2 := res.Root
+	duration = fmt.Sprintf("%d", build.MinDealDuration/builtin.EpochsInDay)
+	cmd = []string{
+		"client", "deal",
+	}
+	interactiveCmds := []string{
+		dataCid2.String(),
+		duration,
+		minerAddr.String(),
+		"no",
+		"yes",
+	}
+	out = clientCLI.runInteractiveCmd(cmd, interactiveCmds)
+	fmt.Println("client deal:\n", out)
+
+	// Wait for provider to start sealing deal
+	dealStatus := ""
+	for dealStatus != "StorageDealSealing" {
+		// client list-deals
+		cmd = []string{"client", "list-deals"}
+		out = clientCLI.runCmd(cmd)
+		fmt.Println("list-deals:\n", out)
+
+		lines := strings.Split(out, "\n")
+		require.Len(t, lines, 2)
+		re := regexp.MustCompile(`\s+`)
+		parts := re.Split(lines[1], -1)
+		if len(parts) < 4 {
+			require.Fail(t, "bad list-deals output format")
+		}
+		dealStatus = parts[3]
+		fmt.Println("  Deal status:", dealStatus)
+
+		time.Sleep(time.Second)
+	}
+
+	// Retrieve the first file from the miner
+	// client retrieve <cid> <file path>
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "test-cli-client")
+	require.NoError(t, err)
+	path := filepath.Join(tmpdir, "outfile.dat")
+	cmd = []string{
+		"client", "retrieve", dataCid.String(), path,
+	}
+	out = clientCLI.runCmd(cmd)
+	fmt.Println("retrieve:\n", out)
+	require.Regexp(t, regexp.MustCompile("Success"), out)
+}

--- a/cli/test/mockcli.go
+++ b/cli/test/mockcli.go
@@ -122,3 +122,12 @@ func (c *mockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
 	}
 	return fs
 }
+
+func (c *mockCLIClient) runInteractiveCmd(cmd []string, interactive []string) string {
+	c.toStdin(strings.Join(interactive, "\n") + "\n")
+	return c.runCmd(cmd)
+}
+
+func (c *mockCLIClient) toStdin(s string) {
+	c.cctx.App.Metadata["stdin"] = bytes.NewBufferString(s)
+}

--- a/cli/test/multisig.go
+++ b/cli/test/multisig.go
@@ -10,18 +10,9 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api/test"
 	"github.com/filecoin-project/lotus/chain/types"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
 	lcli "github.com/urfave/cli/v2"
 )
-
-func QuietMiningLogs() {
-	logging.SetLogLevel("miner", "ERROR")
-	logging.SetLogLevel("chainstore", "ERROR")
-	logging.SetLogLevel("chain", "ERROR")
-	logging.SetLogLevel("sub", "ERROR")
-	logging.SetLogLevel("storageminer", "ERROR")
-}
 
 func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode) {
 	ctx := context.Background()

--- a/cli/test/net.go
+++ b/cli/test/net.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api/test"
+	test2 "github.com/filecoin-project/lotus/node/test"
+)
+
+func StartOneNodeOneMiner(ctx context.Context, t *testing.T, blocktime time.Duration) (test.TestNode, address.Address) {
+	n, sn := test2.RPCMockSbBuilder(t, test.OneFull, test.OneMiner)
+
+	full := n[0]
+	miner := sn[0]
+
+	// Get everyone connected
+	addrs, err := full.NetAddrsListen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := miner.NetConnect(ctx, addrs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start mining blocks
+	bm := test.NewBlockMiner(ctx, t, miner, blocktime)
+	bm.MineBlocks()
+
+	// Get the full node's wallet address
+	fullAddr, err := full.WalletDefaultAddress(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock CLI
+	return full, fullAddr
+}

--- a/cli/test/util.go
+++ b/cli/test/util.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/ipfs/go-log/v2"
+
+func QuietMiningLogs() {
+	_ = log.SetLogLevel("miner", "ERROR")
+	_ = log.SetLogLevel("chainstore", "ERROR")
+	_ = log.SetLogLevel("chain", "ERROR")
+	_ = log.SetLogLevel("sub", "ERROR")
+	_ = log.SetLogLevel("storageminer", "ERROR")
+	_ = log.SetLogLevel("pubsub", "ERROR")
+}

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -13,9 +13,13 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
+	"github.com/filecoin-project/lotus/chain/actors"
 	types "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 )
@@ -34,6 +38,7 @@ var walletCmd = &cli.Command{
 		walletSign,
 		walletVerify,
 		walletDelete,
+		walletMarket,
 	},
 }
 
@@ -469,5 +474,96 @@ var walletDelete = &cli.Command{
 		}
 
 		return api.WalletDelete(ctx, addr)
+	},
+}
+
+var walletMarket = &cli.Command{
+	Name:  "market",
+	Usage: "Interact with market balances",
+	Subcommands: []*cli.Command{
+		walletMarketWithdraw,
+	},
+}
+
+var walletMarketWithdraw = &cli.Command{
+	Name:      "withdraw",
+	Usage:     "Withdraw funds from the Storage Market Actor",
+	ArgsUsage: "[amount (FIL) optional, otherwise will withdraw max available]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "from",
+			Usage:   "Specify address to withdraw funds from, otherwise it will use the default wallet address",
+			Aliases: []string{"f"},
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return xerrors.Errorf("getting node API: %w", err)
+		}
+		defer closer()
+		ctx := ReqContext(cctx)
+
+		var addr address.Address
+		if cctx.String("from") != "" {
+			addr, err = address.NewFromString(cctx.String("from"))
+			if err != nil {
+				return xerrors.Errorf("parsing from address: %w", err)
+			}
+		} else {
+			addr, err = api.WalletDefaultAddress(ctx)
+			if err != nil {
+				return xerrors.Errorf("getting default wallet address: %w", err)
+			}
+		}
+
+		bal, err := api.StateMarketBalance(ctx, addr, types.EmptyTSK)
+		if err != nil {
+			return xerrors.Errorf("getting market balance for address %s: %w", addr.String(), err)
+		}
+
+		avail := big.Subtract(bal.Escrow, bal.Locked)
+		amt := avail
+
+		if cctx.Args().Present() {
+			f, err := types.ParseFIL(cctx.Args().First())
+			if err != nil {
+				return xerrors.Errorf("parsing 'amount' argument: %w", err)
+			}
+
+			amt = abi.TokenAmount(f)
+		}
+
+		if amt.GreaterThan(avail) {
+			return xerrors.Errorf("can't withdraw more funds than available; requested: %s; available: %s", amt, avail)
+		}
+
+		if avail.IsZero() {
+			return xerrors.Errorf("zero unlocked funds available to withdraw")
+		}
+
+		params, err := actors.SerializeParams(&market.WithdrawBalanceParams{
+			ProviderOrClientAddress: addr,
+			Amount:                  amt,
+		})
+		if err != nil {
+			return xerrors.Errorf("serializing params: %w", err)
+		}
+
+		fmt.Printf("Submitting WithdrawBalance message for amount %s for address %s\n", types.FIL(amt), addr.String())
+		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
+			To:     builtin.StorageMarketActorAddr,
+			From:   addr,
+			Value:  types.NewInt(0),
+			Method: builtin.MethodsMarket.WithdrawBalance,
+			Params: params,
+		}, nil)
+		if err != nil {
+			return xerrors.Errorf("submitting WithdrawBalance message: %w", err)
+		}
+
+		fmt.Printf("WithdrawBalance message cid: %s\n", smsg.Cid())
+
+		return nil
 	},
 }

--- a/cmd/lotus-gateway/api.go
+++ b/cmd/lotus-gateway/api.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	LookbackCap            = time.Hour * 24
-	stateWaitLookbackLimit = abi.ChainEpoch(20)
+	StateWaitLookbackLimit = abi.ChainEpoch(20)
 )
 
 var (
@@ -35,20 +35,28 @@ var (
 // (to make it easy to mock for tests)
 type gatewayDepsAPI interface {
 	Version(context.Context) (api.Version, error)
-
-	ChainHasObj(context.Context, cid.Cid) (bool, error)
-	ChainHead(ctx context.Context) (*types.TipSet, error)
+	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
+	ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error)
+	ChainGetNode(ctx context.Context, p string) (*api.IpldObject, error)
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
+	ChainHasObj(context.Context, cid.Cid) (bool, error)
+	ChainHead(ctx context.Context) (*types.TipSet, error)
+	ChainNotify(context.Context) (<-chan []*api.HeadChange, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
-	ChainGetNode(ctx context.Context, p string) (*api.IpldObject, error)
 	GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
 	MpoolPushUntrusted(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
 	MsigGetAvailableBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
 	MsigGetVested(ctx context.Context, addr address.Address, start types.TipSetKey, end types.TipSetKey) (types.BigInt, error)
 	StateAccountKey(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error)
 	StateGetActor(ctx context.Context, actor address.Address, ts types.TipSetKey) (*types.Actor, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
 	StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)
+	StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error)
+	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
+	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 	StateWaitMsgLimited(ctx context.Context, msg cid.Cid, confidence uint64, h abi.ChainEpoch) (*api.MsgLookup, error)
 	StateReadState(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*api.ActorState, error)
 	StateMinerPower(context.Context, address.Address, types.TipSetKey) (*api.MinerPower, error)
@@ -60,22 +68,22 @@ type gatewayDepsAPI interface {
 	StateMinerProvingDeadline(context.Context, address.Address, types.TipSetKey) (*dline.Info, error)
 	StateCirculatingSupply(context.Context, types.TipSetKey) (abi.TokenAmount, error)
 	StateVMCirculatingSupplyInternal(context.Context, types.TipSetKey) (api.CirculatingSupply, error)
-	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 }
 
 type GatewayAPI struct {
-	api         gatewayDepsAPI
-	lookbackCap time.Duration
+	api                    gatewayDepsAPI
+	lookbackCap            time.Duration
+	stateWaitLookbackLimit abi.ChainEpoch
 }
 
 // NewGatewayAPI creates a new GatewayAPI with the default lookback cap
 func NewGatewayAPI(api gatewayDepsAPI) *GatewayAPI {
-	return newGatewayAPI(api, LookbackCap)
+	return newGatewayAPI(api, LookbackCap, StateWaitLookbackLimit)
 }
 
 // used by the tests
-func newGatewayAPI(api gatewayDepsAPI, lookbackCap time.Duration) *GatewayAPI {
-	return &GatewayAPI{api: api, lookbackCap: lookbackCap}
+func newGatewayAPI(api gatewayDepsAPI, lookbackCap time.Duration, stateWaitLookbackLimit abi.ChainEpoch) *GatewayAPI {
+	return &GatewayAPI{api: api, lookbackCap: lookbackCap, stateWaitLookbackLimit: stateWaitLookbackLimit}
 }
 
 func (a *GatewayAPI) checkTipsetKey(ctx context.Context, tsk types.TipSetKey) error {
@@ -122,6 +130,10 @@ func (a *GatewayAPI) Version(ctx context.Context) (api.Version, error) {
 	return a.api.Version(ctx)
 }
 
+func (a *GatewayAPI) ChainGetBlockMessages(ctx context.Context, c cid.Cid) (*api.BlockMessages, error) {
+	return a.api.ChainGetBlockMessages(ctx, c)
+}
+
 func (a *GatewayAPI) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
 	return a.api.ChainHasObj(ctx, c)
 }
@@ -130,6 +142,10 @@ func (a *GatewayAPI) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	// TODO: cache and invalidate cache when timestamp is up (or have internal ChainNotify)
 
 	return a.api.ChainHead(ctx)
+}
+
+func (a *GatewayAPI) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
+	return a.api.ChainGetMessage(ctx, mc)
 }
 
 func (a *GatewayAPI) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error) {
@@ -165,12 +181,16 @@ func (a *GatewayAPI) ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoc
 	return a.api.ChainGetTipSetByHeight(ctx, h, tsk)
 }
 
-func (a *GatewayAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
-	return a.api.ChainReadObj(ctx, c)
-}
-
 func (a *GatewayAPI) ChainGetNode(ctx context.Context, p string) (*api.IpldObject, error) {
 	return a.api.ChainGetNode(ctx, p)
+}
+
+func (a *GatewayAPI) ChainNotify(ctx context.Context) (<-chan []*api.HeadChange, error) {
+	return a.api.ChainNotify(ctx)
+}
+
+func (a *GatewayAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
+	return a.api.ChainReadObj(ctx, c)
 }
 
 func (a *GatewayAPI) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error) {
@@ -213,12 +233,36 @@ func (a *GatewayAPI) StateAccountKey(ctx context.Context, addr address.Address, 
 	return a.api.StateAccountKey(ctx, addr, tsk)
 }
 
+func (a *GatewayAPI) StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return api.DealCollateralBounds{}, err
+	}
+
+	return a.api.StateDealProviderCollateralBounds(ctx, size, verified, tsk)
+}
+
 func (a *GatewayAPI) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
 	if err := a.checkTipsetKey(ctx, tsk); err != nil {
 		return nil, err
 	}
 
 	return a.api.StateGetActor(ctx, actor, tsk)
+}
+
+func (a *GatewayAPI) StateGetReceipt(ctx context.Context, c cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return nil, err
+	}
+
+	return a.api.StateGetReceipt(ctx, c, tsk)
+}
+
+func (a *GatewayAPI) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return nil, err
+	}
+
+	return a.api.StateListMiners(ctx, tsk)
 }
 
 func (a *GatewayAPI) StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
@@ -229,8 +273,32 @@ func (a *GatewayAPI) StateLookupID(ctx context.Context, addr address.Address, ts
 	return a.api.StateLookupID(ctx, addr, tsk)
 }
 
+func (a *GatewayAPI) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return api.MarketBalance{}, err
+	}
+
+	return a.api.StateMarketBalance(ctx, addr, tsk)
+}
+
+func (a *GatewayAPI) StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return nil, err
+	}
+
+	return a.api.StateMarketStorageDeal(ctx, dealId, tsk)
+}
+
+func (a *GatewayAPI) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return network.VersionMax, err
+	}
+
+	return a.api.StateNetworkVersion(ctx, tsk)
+}
+
 func (a *GatewayAPI) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error) {
-	return a.api.StateWaitMsgLimited(ctx, msg, confidence, stateWaitLookbackLimit)
+	return a.api.StateWaitMsgLimited(ctx, msg, confidence, a.stateWaitLookbackLimit)
 }
 
 func (a *GatewayAPI) StateReadState(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*api.ActorState, error) {
@@ -301,13 +369,6 @@ func (a *GatewayAPI) StateVMCirculatingSupplyInternal(ctx context.Context, tsk t
 		return api.CirculatingSupply{}, err
 	}
 	return a.api.StateVMCirculatingSupplyInternal(ctx, tsk)
-}
-
-func (a *GatewayAPI) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
-	if err := a.checkTipsetKey(ctx, tsk); err != nil {
-		return 0, err
-	}
-	return a.api.StateNetworkVersion(ctx, tsk)
 }
 
 func (a *GatewayAPI) WalletVerify(ctx context.Context, k address.Address, msg []byte, sig *crypto.Signature) (bool, error) {

--- a/cmd/lotus-gateway/api.go
+++ b/cmd/lotus-gateway/api.go
@@ -67,6 +67,7 @@ type gatewayDepsAPI interface {
 	StateMinerAvailableBalance(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)
 	StateMinerProvingDeadline(context.Context, address.Address, types.TipSetKey) (*dline.Info, error)
 	StateCirculatingSupply(context.Context, types.TipSetKey) (abi.TokenAmount, error)
+	StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error)
 	StateVMCirculatingSupplyInternal(context.Context, types.TipSetKey) (api.CirculatingSupply, error)
 }
 
@@ -362,6 +363,13 @@ func (a *GatewayAPI) StateCirculatingSupply(ctx context.Context, tsk types.TipSe
 	}
 	return a.api.StateCirculatingSupply(ctx, tsk)
 
+}
+
+func (a *GatewayAPI) StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error) {
+	if err := a.checkTipsetKey(ctx, tsk); err != nil {
+		return nil, err
+	}
+	return a.api.StateVerifiedClientStatus(ctx, addr, tsk)
 }
 
 func (a *GatewayAPI) StateVMCirculatingSupplyInternal(ctx context.Context, tsk types.TipSetKey) (api.CirculatingSupply, error) {

--- a/cmd/lotus-gateway/api_test.go
+++ b/cmd/lotus-gateway/api_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+
 	"github.com/filecoin-project/lotus/build"
 
 	"github.com/stretchr/testify/require"
@@ -116,6 +119,38 @@ func (m *mockGatewayDepsAPI) ChainHasObj(context.Context, cid.Cid) (bool, error)
 	panic("implement me")
 }
 
+func (m *mockGatewayDepsAPI) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
+	panic("implement me")
+}
+
+func (m *mockGatewayDepsAPI) StateNetworkVersion(ctx context.Context, key types.TipSetKey) (network.Version, error) {
+	panic("implement me")
+}
+
 func (m *mockGatewayDepsAPI) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	m.lk.RLock()
 	defer m.lk.RUnlock()
@@ -163,10 +198,6 @@ func (m *mockGatewayDepsAPI) ChainGetTipSetByHeight(ctx context.Context, h abi.C
 	defer m.lk.Unlock()
 
 	return m.tipsets[h], nil
-}
-
-func (m *mockGatewayDepsAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
-	panic("implement me")
 }
 
 func (m *mockGatewayDepsAPI) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error) {

--- a/node/builder.go
+++ b/node/builder.go
@@ -250,7 +250,6 @@ func Online() Option {
 			Override(new(*store.ChainStore), modules.ChainStore),
 			Override(new(stmgr.UpgradeSchedule), stmgr.DefaultUpgradeSchedule()),
 			Override(new(*stmgr.StateManager), stmgr.NewStateManagerWithUpgradeSchedule),
-			Override(new(stmgr.StateManagerAPI), From(new(*stmgr.StateManager))),
 			Override(new(*wallet.LocalWallet), wallet.NewWallet),
 			Override(new(wallet.Default), From(new(*wallet.LocalWallet))),
 			Override(new(api.WalletAPI), From(new(wallet.MultiWallet))),

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -65,9 +65,9 @@ type API struct {
 	fx.In
 
 	full.ChainAPI
-	full.StateAPI
 	full.WalletAPI
 	paych.PaychAPI
+	full.StateAPI
 
 	SMDealClient storagemarket.StorageClient
 	RetDiscovery discovery.PeerResolver
@@ -117,7 +117,7 @@ func (a *API) ClientStartDeal(ctx context.Context, params *api.StartDealParams) 
 		}
 	}
 
-	walletKey, err := a.StateAPI.StateManager.ResolveToKeyAddress(ctx, params.Wallet, nil)
+	walletKey, err := a.StateAccountKey(ctx, params.Wallet, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("failed resolving params.Wallet addr: %w", params.Wallet)
 	}

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -40,8 +40,11 @@ import (
 var log = logging.Logger("fullnode")
 
 type ChainModuleAPI interface {
+	ChainNotify(context.Context) (<-chan []*api.HeadChange, error)
+	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
 	ChainHasObj(context.Context, cid.Cid) (bool, error)
 	ChainHead(context.Context) (*types.TipSet, error)
+	ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error)
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
@@ -67,8 +70,8 @@ type ChainAPI struct {
 	Chain *store.ChainStore
 }
 
-func (a *ChainAPI) ChainNotify(ctx context.Context) (<-chan []*api.HeadChange, error) {
-	return a.Chain.SubHeadChanges(ctx), nil
+func (m *ChainModule) ChainNotify(ctx context.Context) (<-chan []*api.HeadChange, error) {
+	return m.Chain.SubHeadChanges(ctx), nil
 }
 
 func (m *ChainModule) ChainHead(context.Context) (*types.TipSet, error) {
@@ -101,13 +104,13 @@ func (m *ChainModule) ChainGetTipSet(ctx context.Context, key types.TipSetKey) (
 	return m.Chain.LoadTipSet(key)
 }
 
-func (a *ChainAPI) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error) {
-	b, err := a.Chain.GetBlock(msg)
+func (m *ChainModule) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error) {
+	b, err := m.Chain.GetBlock(msg)
 	if err != nil {
 		return nil, err
 	}
 
-	bmsgs, smsgs, err := a.Chain.MessagesForBlock(b)
+	bmsgs, smsgs, err := m.Chain.MessagesForBlock(b)
 	if err != nil {
 		return nil, err
 	}
@@ -532,8 +535,8 @@ func (a *ChainAPI) ChainGetNode(ctx context.Context, p string) (*api.IpldObject,
 	}, nil
 }
 
-func (a *ChainAPI) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
-	cm, err := a.Chain.GetCMessage(mc)
+func (m *ChainModule) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
+	cm, err := m.Chain.GetCMessage(mc)
 	if err != nil {
 		return nil, err
 	}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -52,6 +52,7 @@ type StateModuleAPI interface {
 	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
 	StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
 	StateNetworkVersion(ctx context.Context, key types.TipSetKey) (network.Version, error)
+	StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error)
 	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
 }
 
@@ -1165,19 +1166,19 @@ func (a *StateAPI) StateVerifierStatus(ctx context.Context, addr address.Address
 // StateVerifiedClientStatus returns the data cap for the given address.
 // Returns zero if there is no entry in the data cap table for the
 // address.
-func (a *StateAPI) StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error) {
-	act, err := a.StateGetActor(ctx, verifreg.Address, tsk)
+func (m *StateModule) StateVerifiedClientStatus(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*abi.StoragePower, error) {
+	act, err := m.StateGetActor(ctx, verifreg.Address, tsk)
 	if err != nil {
 		return nil, err
 	}
 
-	aid, err := a.StateLookupID(ctx, addr, tsk)
+	aid, err := m.StateLookupID(ctx, addr, tsk)
 	if err != nil {
 		log.Warnf("lookup failure %v", err)
 		return nil, err
 	}
 
-	vrs, err := verifreg.Load(a.StateManager.ChainStore().Store(ctx), act)
+	vrs, err := verifreg.Load(m.StateManager.ChainStore().Store(ctx), act)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load verified registry state: %w", err)
 	}

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -40,12 +40,19 @@ import (
 )
 
 type StateModuleAPI interface {
-	StateAccountKey(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
-	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
-	StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
-	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
 	MsigGetAvailableBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
 	MsigGetVested(ctx context.Context, addr address.Address, start types.TipSetKey, end types.TipSetKey) (types.BigInt, error)
+	StateAccountKey(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error)
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
+	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
+	StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)
+	StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error)
+	StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error)
+	StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error)
+	StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error)
+	StateNetworkVersion(ctx context.Context, key types.TipSetKey) (network.Version, error)
+	StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64) (*api.MsgLookup, error)
 }
 
 // StateModule provides a default implementation of StateModuleAPI.
@@ -112,13 +119,13 @@ func (a *StateAPI) StateMinerActiveSectors(ctx context.Context, maddr address.Ad
 	return stmgr.GetMinerSectorSet(ctx, a.StateManager, ts, maddr, &activeSectors)
 }
 
-func (a *StateAPI) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
-	act, err := a.StateManager.LoadActorTsk(ctx, actor, tsk)
+func (m *StateModule) StateMinerInfo(ctx context.Context, actor address.Address, tsk types.TipSetKey) (miner.MinerInfo, error) {
+	act, err := m.StateManager.LoadActorTsk(ctx, actor, tsk)
 	if err != nil {
 		return miner.MinerInfo{}, xerrors.Errorf("failed to load miner actor: %w", err)
 	}
 
-	mas, err := miner.Load(a.StateManager.ChainStore().Store(ctx), act)
+	mas, err := miner.Load(m.StateManager.ChainStore().Store(ctx), act)
 	if err != nil {
 		return miner.MinerInfo{}, xerrors.Errorf("failed to load miner actor state: %w", err)
 	}
@@ -563,20 +570,20 @@ func (a *StateAPI) StateSearchMsg(ctx context.Context, msg cid.Cid) (*api.MsgLoo
 	return nil, nil
 }
 
-func (a *StateAPI) StateGetReceipt(ctx context.Context, msg cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateGetReceipt(ctx context.Context, msg cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return a.StateManager.GetReceipt(ctx, msg, ts)
+	return m.StateManager.GetReceipt(ctx, msg, ts)
 }
 
-func (a *StateAPI) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateListMiners(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return stmgr.ListMinerActors(ctx, a.StateManager, ts)
+	return stmgr.ListMinerActors(ctx, m.StateManager, ts)
 }
 
 func (a *StateAPI) StateListActors(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
@@ -587,12 +594,12 @@ func (a *StateAPI) StateListActors(ctx context.Context, tsk types.TipSetKey) ([]
 	return a.StateManager.ListAllActors(ctx, ts)
 }
 
-func (a *StateAPI) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateMarketBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (api.MarketBalance, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return api.MarketBalance{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return a.StateManager.MarketBalance(ctx, addr, ts)
+	return m.StateManager.MarketBalance(ctx, addr, ts)
 }
 
 func (a *StateAPI) StateMarketParticipants(ctx context.Context, tsk types.TipSetKey) (map[string]api.MarketBalance, error) {
@@ -676,12 +683,12 @@ func (a *StateAPI) StateMarketDeals(ctx context.Context, tsk types.TipSetKey) (m
 	return out, nil
 }
 
-func (a *StateAPI) StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateMarketStorageDeal(ctx context.Context, dealId abi.DealID, tsk types.TipSetKey) (*api.MarketDeal, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
-	return stmgr.GetStorageDeal(ctx, a.StateManager, dealId, ts)
+	return stmgr.GetStorageDeal(ctx, m.StateManager, dealId, ts)
 }
 
 func (a *StateAPI) StateChangedActors(ctx context.Context, old cid.Cid, new cid.Cid) (map[string]types.Actor, error) {
@@ -1205,33 +1212,33 @@ var dealProviderCollateralDen = types.NewInt(100)
 
 // StateDealProviderCollateralBounds returns the min and max collateral a storage provider
 // can issue. It takes the deal size and verified status as parameters.
-func (a *StateAPI) StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateDealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, verified bool, tsk types.TipSetKey) (api.DealCollateralBounds, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
 
-	pact, err := a.StateGetActor(ctx, power.Address, tsk)
+	pact, err := m.StateGetActor(ctx, power.Address, tsk)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("failed to load power actor: %w", err)
 	}
 
-	ract, err := a.StateGetActor(ctx, reward.Address, tsk)
+	ract, err := m.StateGetActor(ctx, reward.Address, tsk)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("failed to load reward actor: %w", err)
 	}
 
-	pst, err := power.Load(a.StateManager.ChainStore().Store(ctx), pact)
+	pst, err := power.Load(m.StateManager.ChainStore().Store(ctx), pact)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("failed to load power actor state: %w", err)
 	}
 
-	rst, err := reward.Load(a.StateManager.ChainStore().Store(ctx), ract)
+	rst, err := reward.Load(m.StateManager.ChainStore().Store(ctx), ract)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("failed to load reward actor state: %w", err)
 	}
 
-	circ, err := a.StateVMCirculatingSupplyInternal(ctx, ts.Key())
+	circ, err := stateVMCirculatingSupplyInternal(ctx, ts.Key(), m.Chain, m.StateManager)
 	if err != nil {
 		return api.DealCollateralBounds{}, xerrors.Errorf("getting total circulating supply: %w", err)
 	}
@@ -1252,7 +1259,7 @@ func (a *StateAPI) StateDealProviderCollateralBounds(ctx context.Context, size a
 		powClaim.QualityAdjPower,
 		rewPow,
 		circ.FilCirculating,
-		a.StateManager.GetNtwkVersion(ctx, ts.Height()))
+		m.StateManager.GetNtwkVersion(ctx, ts.Height()))
 	return api.DealCollateralBounds{
 		Min: types.BigDiv(types.BigMul(min, dealProviderCollateralNum), dealProviderCollateralDen),
 		Max: max,
@@ -1273,23 +1280,32 @@ func (a *StateAPI) StateCirculatingSupply(ctx context.Context, tsk types.TipSetK
 }
 
 func (a *StateAPI) StateVMCirculatingSupplyInternal(ctx context.Context, tsk types.TipSetKey) (api.CirculatingSupply, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+	return stateVMCirculatingSupplyInternal(ctx, tsk, a.Chain, a.StateManager)
+}
+func stateVMCirculatingSupplyInternal(
+	ctx context.Context,
+	tsk types.TipSetKey,
+	cstore *store.ChainStore,
+	smgr *stmgr.StateManager,
+) (api.CirculatingSupply, error) {
+	ts, err := cstore.GetTipSetFromKey(tsk)
 	if err != nil {
 		return api.CirculatingSupply{}, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
 
-	sTree, err := a.stateForTs(ctx, ts)
+	sTree, err := stateForTs(ctx, ts, cstore, smgr)
 	if err != nil {
 		return api.CirculatingSupply{}, err
 	}
-	return a.StateManager.GetVMCirculatingSupplyDetailed(ctx, ts.Height(), sTree)
+
+	return smgr.GetVMCirculatingSupplyDetailed(ctx, ts.Height(), sTree)
 }
 
-func (a *StateAPI) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
-	ts, err := a.Chain.GetTipSetFromKey(tsk)
+func (m *StateModule) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
+	ts, err := m.Chain.GetTipSetFromKey(tsk)
 	if err != nil {
 		return network.VersionMax, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
 
-	return a.StateManager.GetNtwkVersion(ctx, ts.Height()), nil
+	return m.StateManager.GetNtwkVersion(ctx, ts.Height()), nil
 }

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -13,16 +13,11 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/types"
-	full "github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/paychmgr"
 )
 
 type PaychAPI struct {
 	fx.In
-
-	full.MpoolAPI
-	full.WalletAPI
-	full.ChainAPI
 
 	PaychMgr *paychmgr.Manager
 }

--- a/node/modules/rpcstatemanager.go
+++ b/node/modules/rpcstatemanager.go
@@ -3,19 +3,40 @@ package modules
 import (
 	"context"
 
-	"github.com/filecoin-project/lotus/api"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/apibstore"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
+	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
 type RPCStateManager struct {
-	gapi api.GatewayAPI
+	gapi   api.GatewayAPI
+	cstore *cbor.BasicIpldStore
 }
 
 func NewRPCStateManager(api api.GatewayAPI) *RPCStateManager {
-	return &RPCStateManager{gapi: api}
+	cstore := cbor.NewCborStore(apibstore.NewAPIBlockstore(api))
+	return &RPCStateManager{gapi: api, cstore: cstore}
+}
+
+func (s *RPCStateManager) GetPaychState(ctx context.Context, addr address.Address, ts *types.TipSet) (*types.Actor, paych.State, error) {
+	act, err := s.gapi.StateGetActor(ctx, addr, ts.Key())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	actState, err := paych.Load(adt.WrapStore(ctx, s.cstore), act)
+	if err != nil {
+		return nil, nil, err
+	}
+	return act, actState, nil
+
 }
 
 func (s *RPCStateManager) LoadActorTsk(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error) {
@@ -28,6 +49,10 @@ func (s *RPCStateManager) LookupID(ctx context.Context, addr address.Address, ts
 
 func (s *RPCStateManager) ResolveToKeyAddress(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
 	return s.gapi.StateAccountKey(ctx, addr, ts.Key())
+}
+
+func (s *RPCStateManager) Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error) {
+	return nil, xerrors.Errorf("RPCStateManager does not implement StateManager.Call")
 }
 
 var _ stmgr.StateManagerAPI = (*RPCStateManager)(nil)

--- a/paychmgr/manager.go
+++ b/paychmgr/manager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -61,12 +60,8 @@ type managerAPI interface {
 
 // managerAPIImpl is used to create a composite that implements managerAPI
 type managerAPIImpl struct {
-	*stmgr.StateManager
+	stmgr.StateManagerAPI
 	paychAPI
-}
-
-func (m *managerAPIImpl) AdtStore(ctx context.Context) adt.Store {
-	return m.ChainStore().Store(ctx)
 }
 
 type Manager struct {
@@ -82,11 +77,11 @@ type Manager struct {
 	channels map[string]*channelAccessor
 }
 
-func NewManager(mctx helpers.MetricsCtx, lc fx.Lifecycle, sm *stmgr.StateManager, pchstore *Store, api PaychAPI) *Manager {
+func NewManager(mctx helpers.MetricsCtx, lc fx.Lifecycle, sm stmgr.StateManagerAPI, pchstore *Store, api PaychAPI) *Manager {
 	ctx := helpers.LifecycleCtx(mctx, lc)
 	ctx, shutdown := context.WithCancel(ctx)
 
-	impl := &managerAPIImpl{StateManager: sm, paychAPI: &api}
+	impl := &managerAPIImpl{StateManagerAPI: sm, paychAPI: &api}
 	return &Manager{
 		ctx:      ctx,
 		shutdown: shutdown,


### PR DESCRIPTION
Depends on https://github.com/filecoin-project/lotus/pull/4095

Implements market storage and retrieval clients for lotus "lite" mode

TODO:
- [x] Create connection from lotus-lite -> gateway -> lotus and use with deal tests
- [x] Get deal tests working