### PR TITLE
fix race in unseal

### DIFF
--- a/extern/sector-storage/ffiwrapper/sealer_cgo.go
+++ b/extern/sector-storage/ffiwrapper/sealer_cgo.go
@@ -290,10 +290,6 @@ func (sb *Sealer) UnsealPiece(ctx context.Context, sector abi.SectorID, offset s
 				defer opr.Close() // nolint
 
 				padwriter := fr32.NewPadWriter(out)
-				if err != nil {
-					perr = xerrors.Errorf("creating new padded writer: %w", err)
-					return
-				}
 
 				bsize := uint64(size.Padded())
 				if bsize > uint64(runtime.NumCPU())*fr32.MTTresh {
@@ -302,7 +298,7 @@ func (sb *Sealer) UnsealPiece(ctx context.Context, sector abi.SectorID, offset s
 
 				bw := bufio.NewWriterSize(padwriter, int(abi.PaddedPieceSize(bsize).Unpadded()))
 
-				_, err = io.CopyN(bw, opr, int64(size))
+				_, err := io.CopyN(bw, opr, int64(size))
 				if err != nil {
 					perr = xerrors.Errorf("copying data: %w", err)
 					return


### PR DESCRIPTION
1. Remove an invalid error check.
2. Make sure to shadow the outer error type from within the goroutine instead or reading the outer type.

This may have been causing test issues (caught in TestMinerAllInfo with the race detector).