### PR TITLE
Fix two races

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1726,7 +1726,7 @@ func VerifyElectionPoStVRF(ctx context.Context, worker address.Address, rand []b
 	return gen.VerifyVRF(ctx, worker, rand, evrf)
 }
 
-func (syncer *Syncer) State() []SyncerState {
+func (syncer *Syncer) State() []SyncerStateSnapshot {
 	return syncer.syncmgr.State()
 }
 

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -42,11 +42,13 @@ func RunHello(mctx helpers.MetricsCtx, lc fx.Lifecycle, h host.Host, svc *hello.
 		return xerrors.Errorf("failed to subscribe to event bus: %w", err)
 	}
 
+	ctx := helpers.LifecycleCtx(mctx, lc)
+
 	go func() {
 		for evt := range sub.Out() {
 			pic := evt.(event.EvtPeerIdentificationCompleted)
 			go func() {
-				if err := svc.SayHello(helpers.LifecycleCtx(mctx, lc), pic.Peer); err != nil {
+				if err := svc.SayHello(ctx, pic.Peer); err != nil {
 					protos, _ := h.Peerstore().GetProtocols(pic.Peer)
 					agent, _ := h.Peerstore().Get(pic.Peer, "AgentVersion")
 					if protosContains(protos, hello.ProtocolID) {


### PR DESCRIPTION
## Lifecycle

LifecycleCtx can _only_ be called during startup as it appends an fx hook. Worse, this was causing us to append an fx hook on every single hello message, leaking memory (and probably causing other shutdown issues...).

## Sync Manager

1. SyncerState contains a mutex and should never be copied. Honestly, this case was probably fine but it's just as easy to create a separate snapshot type and easier to reason about.

2. We need to initialize the syncStates array once at start, before accessing it. By each syncer state inside each worker, we were racing with calls to `State()`. Again, this was probably benign, but I don't trust optimizing compilers.