### PR TITLE
implement tape upgrade

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -17,9 +17,10 @@ const BreezeGasTampingDuration = 0
 const UpgradeSmokeHeight = -1
 const UpgradeIgnitionHeight = -2
 const UpgradeRefuelHeight = -3
+const UpgradeTapeHeight = -4
 
 var UpgradeActorsV2Height = abi.ChainEpoch(10)
-var UpgradeLiftoffHeight = abi.ChainEpoch(-4)
+var UpgradeLiftoffHeight = abi.ChainEpoch(-5)
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandMainnet,

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -25,7 +25,7 @@ const UnixfsLinksPerLevel = 1024
 // Consensus / Network
 
 const AllowableClockDriftSecs = uint64(1)
-const NewestNetworkVersion = network.Version4
+const NewestNetworkVersion = network.Version5
 const ActorUpgradeNetworkVersion = network.Version4
 
 // Epochs

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -83,14 +83,15 @@ var (
 	UpgradeSmokeHeight    abi.ChainEpoch = -1
 	UpgradeIgnitionHeight abi.ChainEpoch = -2
 	UpgradeRefuelHeight   abi.ChainEpoch = -3
+	UpgradeTapeHeight     abi.ChainEpoch = -4
 	UpgradeActorsV2Height abi.ChainEpoch = 10
-	UpgradeLiftoffHeight  abi.ChainEpoch = -4
+	UpgradeLiftoffHeight  abi.ChainEpoch = -5
 
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 		0: DrandMainnet,
 	}
 
-	NewestNetworkVersion       = network.Version4
+	NewestNetworkVersion       = network.Version5
 	ActorUpgradeNetworkVersion = network.Version4
 
 	Devnet = true

--- a/build/params_testnet.go
+++ b/build/params_testnet.go
@@ -30,6 +30,8 @@ const UpgradeRefuelHeight = 130800
 
 var UpgradeActorsV2Height = abi.ChainEpoch(138720)
 
+const UpgradeTapeHeight = 140760
+
 // This signals our tentative epoch for mainnet launch. Can make it later, but not earlier.
 // Miners, clients, developers, custodians all need time to prepare.
 // We still have upgrades and state changes to do, but can happen after signaling timing here.

--- a/chain/actors/version.go
+++ b/chain/actors/version.go
@@ -18,7 +18,7 @@ func VersionForNetwork(version network.Version) Version {
 	switch version {
 	case network.Version0, network.Version1, network.Version2, network.Version3:
 		return Version0
-	case network.Version4:
+	case network.Version4, network.Version5:
 		return Version2
 	default:
 		panic(fmt.Sprintf("unsupported network version %d", version))

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -80,8 +80,11 @@ func DefaultUpgradeSchedule() UpgradeSchedule {
 		Expensive: true,
 		Migration: UpgradeActorsV2,
 	}, {
+		Height:  build.UpgradeTapeHeight,
+		Network: network.Version5,
+	}, {
 		Height:    build.UpgradeLiftoffHeight,
-		Network:   network.Version4,
+		Network:   network.Version5,
 		Migration: UpgradeLiftoff,
 	}}
 

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -3975,7 +3975,7 @@ Inputs:
 ]
 ```
 
-Response: `4`
+Response: `5`
 
 ### StateReadState
 StateReadState returns the indicated actor's state.

--- a/go.mod
+++ b/go.mod
@@ -34,12 +34,12 @@ require (
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261
-	github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab
+	github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b
 	github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/specs-actors v0.9.12
-	github.com/filecoin-project/specs-actors/v2 v2.0.3
+	github.com/filecoin-project/specs-actors/v2 v2.1.0
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
 	github.com/filecoin-project/test-vectors/schema v0.0.4
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab h1:cEDC5Ei8UuT99hPWhCjA72SM9AuRtnpvdSTIYbnzN8I=
 github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b h1:bMUfG6Sy6YSMbsjQAO1Q2vEZldbSdsbRy/FX3OlTck0=
+github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200714194326-a77c3ae20989/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -276,8 +278,8 @@ github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07
 github.com/filecoin-project/specs-actors v0.9.7/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
-github.com/filecoin-project/specs-actors/v2 v2.0.3 h1:Niy6xncgi8bI8aBCt1McdZfATBfG4Uxytt8KW4s3bAc=
-github.com/filecoin-project/specs-actors/v2 v2.0.3/go.mod h1:v2NZVYinNIKA9acEMBm5wWXxqv5+frFEbekBFemYghY=
+github.com/filecoin-project/specs-actors/v2 v2.1.0 h1:ocEuGz8DG2cUWw32c/tvF8D6xT+dGVWJTr5yDevU00g=
+github.com/filecoin-project/specs-actors/v2 v2.1.0/go.mod h1:E7fAX4CZkDVQvDNRCxfq+hc3nx56KcCKyuZf0hlQJ20=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/test-vectors/schema v0.0.4 h1:QTRd0gb/NP4ZOTM7Dib5U3xE1/ToGDKnYLfxkC3t/m8=


### PR DESCRIPTION
Upgrade to specs-actors v2.1 and network version 5. This fixes the bug where prove commits were not accepted.