### PR TITLE
Fix ask Max and Min piece size being reset on reboot

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -396,11 +396,16 @@ func NewStorageAsk(ctx helpers.MetricsCtx, fapi lapi.FullNode, ds dtypes.Metadat
 	if err != nil {
 		return nil, err
 	}
-	// Hacky way to set max piece size to the sector size
-	a := storedAsk.GetAsk().Ask
-	err = storedAsk.SetAsk(a.Price, a.VerifiedPrice, a.Expiry-a.Timestamp, storagemarket.MaxPieceSize(abi.PaddedPieceSize(mi.SectorSize)))
-	if err != nil {
-		return storedAsk, err
+
+	// Set miner's sector size as MaxPieceSize of the "storage ask" when
+	// not set before (or was default - seq == 0)
+	signedAsk := storedAsk.GetAsk()
+	if signedAsk == nil || signedAsk.Ask == nil || signedAsk.Ask.SeqNo == 0 {
+		a := signedAsk.Ask
+		err = storedAsk.SetAsk(a.Price, a.VerifiedPrice, a.Expiry-a.Timestamp, storagemarket.MaxPieceSize(abi.PaddedPieceSize(mi.SectorSize)))
+		if err != nil {
+			return storedAsk, err
+		}
 	}
 	return storedAsk, nil
 }


### PR DESCRIPTION
`set-ask` for max and min piece sizes only takes effects while the miner
runs. During reboot they are reset to the defaults.

This is because during initialization the miner does a "default set ask" with
the purpose of adjusting the MaxPieceSize to the miners sector-size.

However this should only happen if the miner has never adjusted the ask
themselves, that is, SeqNo is 0.

Additionally, handle the case when the ask is nil, in case markets code
decides to not create a default ask during initialization at some point.