### PR TITLE
Use seal-duration in calculating the earliest StartEpoch

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -473,7 +473,7 @@ func BasicDealFilter(user dtypes.DealFilter) func(onlineOk dtypes.ConsiderOnline
 
 			// Reject if it's more than 7 days in the future
 			// TODO: read from cfg
-			maxStartEpoch := ht + abi.ChainEpoch(7*builtin.EpochsInDay)
+			maxStartEpoch := earliest + abi.ChainEpoch(7*builtin.EpochsInDay)
 			if deal.Proposal.StartEpoch > maxStartEpoch {
 				return false, fmt.Sprintf("deal start epoch is too far in the future: %s > %s", deal.Proposal.StartEpoch, maxStartEpoch), nil
 			}


### PR DESCRIPTION
## Problem
A basic filter was added that would reject storage deals that were more than 7 days in the future from the current chain head, but didn't take into consideration the seal duration configured by the miner.

## Solution
Use the seal duration + 7 days as the first cut rejection criteria.

Addresses https://github.com/filecoin-project/lotus/pull/4173/files#r503249607