### PR TITLE
lotus-pcr: ignore all other market messages

### DIFF
--- a/cmd/lotus-pcr/main.go
+++ b/cmd/lotus-pcr/main.go
@@ -884,6 +884,8 @@ func (r *refunder) processTipsetStorageMarketActor(ctx context.Context, tipset *
 		}
 
 		refundValue = types.BigMul(types.NewInt(uint64(recp.GasUsed)), tipset.Blocks()[0].ParentBaseFee)
+	default:
+		return false, messageMethod, types.NewInt(0), nil
 	}
 
 	return true, messageMethod, refundValue, nil


### PR DESCRIPTION
Small change to ensure we return false for any methods we don't support to stop sending zero fil messages.