### PR TITLE
Avoid having the same message CID show up in execution traces

### DIFF
--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -312,11 +312,13 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 				available = st.GetAvailableBalance(act.Balance)
 			}
 
-			transfers = append(transfers, transfer{
-				From: addr,
-				To:   builtin.ReserveAddress,
-				Amt:  available,
-			})
+			if !available.IsZero() {
+				transfers = append(transfers, transfer{
+					From: addr,
+					To:   builtin.ReserveAddress,
+					Amt:  available,
+				})
+			}
 		}
 		return nil
 	})

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -168,7 +168,7 @@ func (sm *StateManager) hasExpensiveFork(ctx context.Context, height abi.ChainEp
 	return ok
 }
 
-func doTransfer(cb ExecCallback, tree types.StateTree, from, to address.Address, amt abi.TokenAmount) error {
+func doTransfer(tree types.StateTree, from, to address.Address, amt abi.TokenAmount, cb func(trace types.ExecutionTrace)) error {
 	fromAct, err := tree.GetActor(from)
 	if err != nil {
 		return xerrors.Errorf("failed to get 'from' actor for transfer: %w", err)
@@ -201,7 +201,6 @@ func doTransfer(cb ExecCallback, tree types.StateTree, from, to address.Address,
 			From:  from,
 			To:    to,
 			Value: amt,
-			Nonce: math.MaxUint64,
 		}
 		fakeRct := &types.MessageReceipt{
 			ExitCode: 0,
@@ -209,22 +208,14 @@ func doTransfer(cb ExecCallback, tree types.StateTree, from, to address.Address,
 			GasUsed:  0,
 		}
 
-		if err := cb(fakeMsg.Cid(), fakeMsg, &vm.ApplyRet{
-			MessageReceipt: *fakeRct,
-			ActorErr:       nil,
-			ExecutionTrace: types.ExecutionTrace{
-				Msg:        fakeMsg,
-				MsgRct:     fakeRct,
-				Error:      "",
-				Duration:   0,
-				GasCharges: nil,
-				Subcalls:   nil,
-			},
-			Duration: 0,
-			GasCosts: vm.ZeroGasOutputs(),
-		}); err != nil {
-			return xerrors.Errorf("recording transfer: %w", err)
-		}
+		cb(types.ExecutionTrace{
+			Msg:        fakeMsg,
+			MsgRct:     fakeRct,
+			Error:      "",
+			Duration:   0,
+			GasCharges: nil,
+			Subcalls:   nil,
+		})
 	}
 
 	return nil
@@ -277,6 +268,10 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 	}
 
 	var transfers []transfer
+	subcalls := make([]types.ExecutionTrace, 0)
+	transferCb := func(trace types.ExecutionTrace) {
+		subcalls = append(subcalls, trace)
+	}
 
 	// Take all excess funds away, put them into the reserve account
 	err = tree.ForEach(func(addr address.Address, act *types.Actor) error {
@@ -328,7 +323,7 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 
 	// Execute transfers from previous step
 	for _, t := range transfers {
-		if err := doTransfer(cb, tree, t.From, t.To, t.Amt); err != nil {
+		if err := doTransfer(tree, t.From, t.To, t.Amt, transferCb); err != nil {
 			return cid.Undef, xerrors.Errorf("transfer %s %s->%s failed: %w", t.Amt, t.From, t.To, err)
 		}
 	}
@@ -431,7 +426,7 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 	}
 
 	for _, t := range transfersBack {
-		if err := doTransfer(cb, tree, t.From, t.To, t.Amt); err != nil {
+		if err := doTransfer(tree, t.From, t.To, t.Amt, transferCb); err != nil {
 			return cid.Undef, xerrors.Errorf("transfer %s %s->%s failed: %w", t.Amt, t.From, t.To, err)
 		}
 	}
@@ -441,7 +436,7 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to load burnt funds actor: %w", err)
 	}
-	if err := doTransfer(cb, tree, builtin0.BurntFundsActorAddr, builtin.ReserveAddress, burntAct.Balance); err != nil {
+	if err := doTransfer(tree, builtin0.BurntFundsActorAddr, builtin.ReserveAddress, burntAct.Balance, transferCb); err != nil {
 		return cid.Undef, xerrors.Errorf("failed to unburn funds: %w", err)
 	}
 
@@ -457,7 +452,7 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 	}
 
 	difference := types.BigSub(DesiredReimbursementBalance, reimb.Balance)
-	if err := doTransfer(cb, tree, builtin.ReserveAddress, reimbAddr, difference); err != nil {
+	if err := doTransfer(tree, builtin.ReserveAddress, reimbAddr, difference, transferCb); err != nil {
 		return cid.Undef, xerrors.Errorf("failed to top up reimbursement account: %w", err)
 	}
 
@@ -474,6 +469,39 @@ func UpgradeFaucetBurnRecovery(ctx context.Context, sm *StateManager, cb ExecCal
 	exp := types.FromFil(build.FilBase)
 	if !exp.Equals(total) {
 		return cid.Undef, xerrors.Errorf("resultant state tree account balance was not correct: %s", total)
+	}
+
+	if cb != nil {
+		// record the transfer in execution traces
+
+		fakeMsg := &types.Message{
+			From:  builtin.SystemActorAddr,
+			To:    builtin.SystemActorAddr,
+			Value: big.Zero(),
+			Nonce: uint64(epoch),
+		}
+		fakeRct := &types.MessageReceipt{
+			ExitCode: 0,
+			Return:   nil,
+			GasUsed:  0,
+		}
+
+		if err := cb(fakeMsg.Cid(), fakeMsg, &vm.ApplyRet{
+			MessageReceipt: *fakeRct,
+			ActorErr:       nil,
+			ExecutionTrace: types.ExecutionTrace{
+				Msg:        fakeMsg,
+				MsgRct:     fakeRct,
+				Error:      "",
+				Duration:   0,
+				GasCharges: nil,
+				Subcalls:   subcalls,
+			},
+			Duration: 0,
+			GasCosts: vm.ZeroGasOutputs(),
+		}); err != nil {
+			return cid.Undef, xerrors.Errorf("recording transfers: %w", err)
+		}
 	}
 
 	return tree.Flush(ctx)
@@ -516,12 +544,12 @@ func UpgradeIgnition(ctx context.Context, sm *StateManager, cb ExecCallback, roo
 		return cid.Undef, xerrors.Errorf("resetting genesis msig start epochs: %w", err)
 	}
 
-	err = splitGenesisMultisig(ctx, cb, split1, store, tree, 50)
+	err = splitGenesisMultisig(ctx, cb, split1, store, tree, 50, epoch)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("splitting first msig: %w", err)
 	}
 
-	err = splitGenesisMultisig(ctx, cb, split2, store, tree, 50)
+	err = splitGenesisMultisig(ctx, cb, split2, store, tree, 50, epoch)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("splitting second msig: %w", err)
 	}
@@ -647,7 +675,7 @@ func setNetworkName(ctx context.Context, store adt.Store, tree *state.StateTree,
 	return nil
 }
 
-func splitGenesisMultisig(ctx context.Context, cb ExecCallback, addr address.Address, store adt0.Store, tree *state.StateTree, portions uint64) error {
+func splitGenesisMultisig(ctx context.Context, cb ExecCallback, addr address.Address, store adt0.Store, tree *state.StateTree, portions uint64, epoch abi.ChainEpoch) error {
 	if portions < 1 {
 		return xerrors.Errorf("cannot split into 0 portions")
 	}
@@ -716,6 +744,11 @@ func splitGenesisMultisig(ctx context.Context, cb ExecCallback, addr address.Add
 	}
 
 	i := uint64(0)
+	subcalls := make([]types.ExecutionTrace, 0, portions)
+	transferCb := func(trace types.ExecutionTrace) {
+		subcalls = append(subcalls, trace)
+	}
+
 	for i < portions {
 		keyAddr, err := makeKeyAddr(addr, i)
 		if err != nil {
@@ -732,11 +765,44 @@ func splitGenesisMultisig(ctx context.Context, cb ExecCallback, addr address.Add
 			return xerrors.Errorf("setting new msig actor state: %w", err)
 		}
 
-		if err := doTransfer(cb, tree, addr, idAddr, newIbal); err != nil {
+		if err := doTransfer(tree, addr, idAddr, newIbal, transferCb); err != nil {
 			return xerrors.Errorf("transferring split msig balance: %w", err)
 		}
 
 		i++
+	}
+
+	if cb != nil {
+		// record the transfer in execution traces
+
+		fakeMsg := &types.Message{
+			From:  builtin.SystemActorAddr,
+			To:    addr,
+			Value: big.Zero(),
+			Nonce: uint64(epoch),
+		}
+		fakeRct := &types.MessageReceipt{
+			ExitCode: 0,
+			Return:   nil,
+			GasUsed:  0,
+		}
+
+		if err := cb(fakeMsg.Cid(), fakeMsg, &vm.ApplyRet{
+			MessageReceipt: *fakeRct,
+			ActorErr:       nil,
+			ExecutionTrace: types.ExecutionTrace{
+				Msg:        fakeMsg,
+				MsgRct:     fakeRct,
+				Error:      "",
+				Duration:   0,
+				GasCharges: nil,
+				Subcalls:   subcalls,
+			},
+			Duration: 0,
+			GasCosts: vm.ZeroGasOutputs(),
+		}); err != nil {
+			return xerrors.Errorf("recording transfers: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The relevant changes are:
- Don't `doTransfer` 0 FIL in `UpgradeFaucetBurnRecovery`
- Use currHeight as the nonce for implicit messages (not consensus-critical, since it doesn't live on chain, and is never observed by actors)
- Don't use the same nonce for every `doTransfer` 

**Someone should compute-state 41281 before merging this (i don't have the relevant state tree).**