### PR TITLE
network version logic wrong!!!

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -1462,7 +1462,7 @@ func (sm *StateManager) GetNtwkVersion(ctx context.Context, height abi.ChainEpoc
 	// The epochs here are the _last_ epoch for every version, or -1 if the
 	// version is disabled.
 	for _, spec := range sm.networkVersions {
-		if height <= spec.atOrBelow {
+		if height < spec.atOrBelow {
 			return spec.networkVersion
 		}
 	}


### PR DESCRIPTION
v0 10000
v1 20000
v2 30000
when height=20000
version should be v2 

type Upgrade struct {
	Height    abi.ChainEpoch
	Network   network.Version
	Expensive bool
	Migration UpgradeFunc
}

updates := []Upgrade{{
		Height:    10000,
		Network:   v1,
		Migration: nil,
	}, {
		Height:    20000,
		Network:   v2,
		Migration: nil,
	}, ... ...
https://github.com/filecoin-project/lotus/blob/8232cc8415a36bdc46942afa8c6759a36adcdcdb/chain/stmgr/forks.go#L58-L90