### PR TITLE
Optimize VM Blockstore

### DIFF
--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -36,6 +36,7 @@ import (
 	"github.com/filecoin-project/lotus/lib/blockstore"
 	bstore "github.com/filecoin-project/lotus/lib/blockstore"
 	"github.com/filecoin-project/lotus/lib/bufbstore"
+	"github.com/filecoin-project/lotus/lib/cachebs"
 )
 
 var log = logging.Logger("vm")
@@ -182,7 +183,8 @@ type VMOpts struct {
 }
 
 func NewVM(ctx context.Context, opts *VMOpts) (*VM, error) {
-	buf := bufbstore.NewBufferedBstore(opts.Bstore)
+	bstore := cachebs.NewReadCacheBS(opts.Bstore)
+	buf := bufbstore.NewBufferedBstore(bstore)
 	cst := cbor.NewCborStore(buf)
 	state, err := state.LoadStateTree(cst, opts.StateBase)
 	if err != nil {

--- a/lib/cachebs/cachebs.go
+++ b/lib/cachebs/cachebs.go
@@ -19,7 +19,7 @@ type CacheBS struct {
 	bs    bstore.Blockstore
 }
 
-func NewBufferedBstore(base bstore.Blockstore, size int) bstore.Blockstore {
+func NewCacheBS(base bstore.Blockstore, size int) bstore.Blockstore {
 	c, err := lru.NewARC(size)
 	if err != nil {
 		panic(err)

--- a/lib/cachebs/readcachebs.go
+++ b/lib/cachebs/readcachebs.go
@@ -1,0 +1,91 @@
+package cachebs
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lotus/lib/blockstore"
+	bstore "github.com/filecoin-project/lotus/lib/blockstore"
+	block "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+)
+
+type ReadCacheBS struct {
+	cache bstore.MemStore
+	bs    bstore.Blockstore
+}
+
+func NewReadCacheBS(base bstore.Blockstore) bstore.Blockstore {
+	cache := bstore.NewTemporary()
+	// Wrap this in an ID blockstore to avoid caching blocks inlined into
+	// CIDs.
+	return bstore.WrapIDStore(&ReadCacheBS{
+		cache: cache,
+		bs:    base,
+	})
+}
+
+var _ (bstore.Blockstore) = &CacheBS{}
+
+func (bs *ReadCacheBS) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return bs.bs.AllKeysChan(ctx)
+}
+
+func (bs *ReadCacheBS) DeleteBlock(c cid.Cid) error {
+	_ = bs.cache.DeleteBlock(c)
+
+	return bs.bs.DeleteBlock(c)
+}
+
+func (bs *ReadCacheBS) Get(c cid.Cid) (block.Block, error) {
+	b, err := bs.cache.Get(c)
+	if err == blockstore.ErrNotFound {
+		b, err = bs.bs.Get(c)
+		if err != nil {
+			return nil, err
+		}
+		_ = bs.cache.Put(b)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (bs *ReadCacheBS) GetSize(c cid.Cid) (int, error) {
+	size, err := bs.cache.GetSize(c)
+	if err == blockstore.ErrNotFound {
+		size, err = bs.bs.GetSize(c)
+	}
+	return size, err
+}
+
+func (bs *ReadCacheBS) Put(blk block.Block) error {
+	if has, err := bs.cache.Has(blk.Cid()); err == nil && has {
+		return nil
+	}
+	_ = bs.cache.Put(blk)
+	return bs.bs.Put(blk)
+}
+
+func (bs *ReadCacheBS) Has(c cid.Cid) (bool, error) {
+	if has, err := bs.cache.Has(c); err == nil && has {
+		return true, nil
+	}
+	return bs.bs.Has(c)
+}
+
+func (bs *ReadCacheBS) HashOnRead(hor bool) {
+	bs.bs.HashOnRead(hor)
+}
+
+func (bs *ReadCacheBS) PutMany(blks []block.Block) error {
+	newBlks := make([]block.Block, 0, len(blks))
+	for _, blk := range blks {
+		if has, err := bs.cache.Has(blk.Cid()); err == nil && has {
+			continue
+		}
+		newBlks = append(newBlks, blk)
+	}
+	_ = bs.cache.PutMany(newBlks)
+	return bs.bs.PutMany(newBlks)
+}


### PR DESCRIPTION
This patch:

1. Uses a specialized in-memory blockstore instead of an in-memory datastore (wrapped in a blockstore). This won't save us _much_, but should save a tiny bit of overhead converting datastore keys, allocating block objects, etc.
2. Introduces a "read" cache which caches all reads.
3. Uses the read cache in the VM. In theory, this should be fine as the VM is ephemeral and we cache all _writes_ anyways.

I have not yet benchmarked these changes. 1 is totally safe but a tiny win, 3 could be a win, or slow things down.