### PR TITLE
Add message CID to InvocResult

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -734,6 +734,7 @@ type RetrievalOrder struct {
 }
 
 type InvocResult struct {
+	MsgCid         cid.Cid
 	Msg            *types.Message
 	MsgRct         *types.MessageReceipt
 	ExecutionTrace types.ExecutionTrace

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -113,6 +113,7 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 	}
 
 	return &api.InvocResult{
+		MsgCid:         msg.Cid(),
 		Msg:            msg,
 		MsgRct:         &ret.MessageReceipt,
 		ExecutionTrace: ret.ExecutionTrace,
@@ -228,6 +229,7 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 	}
 
 	return &api.InvocResult{
+		MsgCid:         msg.Cid(),
 		Msg:            msg,
 		MsgRct:         &ret.MessageReceipt,
 		ExecutionTrace: ret.ExecutionTrace,

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -200,6 +200,7 @@ func (sm *StateManager) TipSetState(ctx context.Context, ts *types.TipSet) (st c
 func traceFunc(trace *[]*api.InvocResult) func(mcid cid.Cid, msg *types.Message, ret *vm.ApplyRet) error {
 	return func(mcid cid.Cid, msg *types.Message, ret *vm.ApplyRet) error {
 		ir := &api.InvocResult{
+			MsgCid:         mcid,
 			Msg:            msg,
 			MsgRct:         &ret.MessageReceipt,
 			ExecutionTrace: ret.ExecutionTrace,

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -3059,6 +3059,9 @@ Inputs:
 Response:
 ```json
 {
+  "MsgCid": {
+    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+  },
   "Msg": {
     "Version": 42,
     "To": "f01234",
@@ -4079,6 +4082,9 @@ Inputs:
 Response:
 ```json
 {
+  "MsgCid": {
+    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+  },
   "Msg": {
     "Version": 42,
     "To": "f01234",

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -362,6 +362,7 @@ func (a *StateAPI) StateReplay(ctx context.Context, tsk types.TipSetKey, mc cid.
 	}
 
 	return &api.InvocResult{
+		MsgCid:         mc,
 		Msg:            m,
 		MsgRct:         &r.MessageReceipt,
 		ExecutionTrace: r.ExecutionTrace,


### PR DESCRIPTION
The new `InvocResult .MsgCid` is the canonical Msg CID (includes the siggy for secp messages), which may be different than what's returned by `InvocResult.Msg.Cid()`. 