### PR TITLE
conformance: support multiple protocol versions.

### DIFF
--- a/cmd/tvx/codenames.go
+++ b/cmd/tvx/codenames.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/build"
+)
+
+// ProtocolCodenames is a table that summarises the protocol codenames that
+// will be set on extracted vectors, depending on the original execution height.
+//
+// Implementers rely on these names to filter the vectors they can run through
+// their implementations, based on their support level
+var ProtocolCodenames = []struct {
+	firstEpoch abi.ChainEpoch
+	name       string
+}{
+	{0, "genesis"},
+	// TODO there is some off-by-one trickery in GetNtwkVersion. Not sure if the
+	//  protocol version really kicks in at the designated height, or at the
+	//  following epoch.
+	{build.UpgradeBreezeHeight + 1, "breeze"},
+	{build.UpgradeSmokeHeight + 1, "smoke"},
+	{build.UpgradeIgnitionHeight + 1, "ignition"},
+	{build.UpgradeRefuelHeight + 1, "refuel"},
+	{build.UpgradeActorsV2Height + 1, "actorsv2"},
+	{build.UpgradeTapeHeight + 1, "tape"},
+	{build.UpgradeLiftoffHeight + 1, "liftoff"},
+}
+
+// GetProtocolCodename gets the protocol codename associated with a height.
+func GetProtocolCodename(height abi.ChainEpoch) string {
+	for i, v := range ProtocolCodenames {
+		if height < v.firstEpoch {
+			// found the cutoff, return previous.
+			return ProtocolCodenames[i-1].name
+		}
+	}
+	return ProtocolCodenames[len(ProtocolCodenames)-1].name
+}

--- a/cmd/tvx/codenames.go
+++ b/cmd/tvx/codenames.go
@@ -16,9 +16,6 @@ var ProtocolCodenames = []struct {
 	name       string
 }{
 	{0, "genesis"},
-	// TODO there is some off-by-one trickery in GetNtwkVersion. Not sure if the
-	//  protocol version really kicks in at the designated height, or at the
-	//  following epoch.
 	{build.UpgradeBreezeHeight + 1, "breeze"},
 	{build.UpgradeSmokeHeight + 1, "smoke"},
 	{build.UpgradeIgnitionHeight + 1, "ignition"},

--- a/cmd/tvx/codenames_test.go
+++ b/cmd/tvx/codenames_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"math"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/build"
+)
+
+func TestProtocolCodenames(t *testing.T) {
+	if height := abi.ChainEpoch(100); GetProtocolCodename(height) != "genesis" {
+		t.Fatal("expected genesis codename")
+	}
+
+	if height := abi.ChainEpoch(build.UpgradeBreezeHeight + 1); GetProtocolCodename(height) != "breeze" {
+		t.Fatal("expected breeze codename")
+	}
+
+	if height := abi.ChainEpoch(build.UpgradeActorsV2Height + 1); GetProtocolCodename(height) != "actorsv2" {
+		t.Fatal("expected actorsv2 codename")
+	}
+
+	if height := abi.ChainEpoch(math.MaxInt64); GetProtocolCodename(height) != ProtocolCodenames[len(ProtocolCodenames)-1].name {
+		t.Fatal("expected last codename")
+	}
+}

--- a/cmd/tvx/codenames_test.go
+++ b/cmd/tvx/codenames_test.go
@@ -18,7 +18,7 @@ func TestProtocolCodenames(t *testing.T) {
 		t.Fatal("expected breeze codename")
 	}
 
-	if height := abi.ChainEpoch(build.UpgradeActorsV2Height + 1); GetProtocolCodename(height) != "actorsv2" {
+	if height := build.UpgradeActorsV2Height + 1; GetProtocolCodename(height) != "actorsv2" {
 		t.Fatal("expected actorsv2 codename")
 	}
 

--- a/cmd/tvx/exec.go
+++ b/cmd/tvx/exec.go
@@ -76,7 +76,7 @@ func executeTestVector(tv schema.TestVector) error {
 	for _, v := range tv.Pre.Variants {
 		r := new(conformance.LogReporter)
 
-		switch class := tv.Class; class {
+		switch class, v := tv.Class, v; class {
 		case "message":
 			conformance.ExecuteMessageVector(r, &tv, &v)
 		case "tipset":

--- a/cmd/tvx/exec.go
+++ b/cmd/tvx/exec.go
@@ -72,20 +72,24 @@ func runExecLotus(_ *cli.Context) error {
 
 func executeTestVector(tv schema.TestVector) error {
 	log.Println("executing test vector:", tv.Meta.ID)
-	r := new(conformance.LogReporter)
-	switch class := tv.Class; class {
-	case "message":
-		conformance.ExecuteMessageVector(r, &tv)
-	case "tipset":
-		conformance.ExecuteTipsetVector(r, &tv)
-	default:
-		return fmt.Errorf("test vector class %s not supported", class)
-	}
 
-	if r.Failed() {
-		log.Println(color.HiRedString("❌ test vector failed"))
-	} else {
-		log.Println(color.GreenString("✅ test vector succeeded"))
+	for _, v := range tv.Pre.Variants {
+		r := new(conformance.LogReporter)
+
+		switch class := tv.Class; class {
+		case "message":
+			conformance.ExecuteMessageVector(r, &tv, &v)
+		case "tipset":
+			conformance.ExecuteTipsetVector(r, &tv, &v)
+		default:
+			return fmt.Errorf("test vector class %s not supported", class)
+		}
+
+		if r.Failed() {
+			log.Println(color.HiRedString("❌ test vector failed for variant %s", v.ID))
+		} else {
+			log.Println(color.GreenString("✅ test vector succeeded for variant %s", v.ID))
+		}
 	}
 
 	return nil

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -82,7 +82,7 @@ type ExecuteTipsetResult struct {
 // This method returns the the receipts root, the poststate root, and the VM
 // message results. The latter _include_ implicit messages, such as cron ticks
 // and reward withdrawal per miner.
-func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, preroot cid.Cid, parentEpoch abi.ChainEpoch, tipset *schema.Tipset) (*ExecuteTipsetResult, error) {
+func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, preroot cid.Cid, parentEpoch abi.ChainEpoch, tipset *schema.Tipset, execEpoch abi.ChainEpoch) (*ExecuteTipsetResult, error) {
 	var (
 		syscalls = vm.Syscalls(ffiwrapper.ProofVerifier)
 		vmRand   = NewFixedRand()
@@ -121,11 +121,10 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, preroot
 		messages []*types.Message
 		results  []*vm.ApplyRet
 
-		epoch   = abi.ChainEpoch(tipset.Epoch)
 		basefee = abi.NewTokenAmount(tipset.BaseFee.Int64())
 	)
 
-	postcid, receiptsroot, err := sm.ApplyBlocks(context.Background(), parentEpoch, preroot, blocks, epoch, vmRand, func(_ cid.Cid, msg *types.Message, ret *vm.ApplyRet) error {
+	postcid, receiptsroot, err := sm.ApplyBlocks(context.Background(), parentEpoch, preroot, blocks, execEpoch, vmRand, func(_ cid.Cid, msg *types.Message, ret *vm.ApplyRet) error {
 		messages = append(messages, msg)
 		results = append(results, ret)
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/filecoin-project/specs-actors/v2 v2.1.0
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
-	github.com/filecoin-project/test-vectors/schema v0.0.4
+	github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/filecoin-project/specs-actors v0.9.12
 	github.com/filecoin-project/specs-actors/v2 v2.1.0
 	github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796
-	github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71
+	github.com/filecoin-project/test-vectors/schema v0.0.5
 	github.com/gbrlsnchs/jwt/v3 v3.0.0-beta.1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/filecoin-project/specs-actors/v2 v2.1.0 h1:ocEuGz8DG2cUWw32c/tvF8D6xT
 github.com/filecoin-project/specs-actors/v2 v2.1.0/go.mod h1:E7fAX4CZkDVQvDNRCxfq+hc3nx56KcCKyuZf0hlQJ20=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
-github.com/filecoin-project/test-vectors/schema v0.0.4 h1:QTRd0gb/NP4ZOTM7Dib5U3xE1/ToGDKnYLfxkC3t/m8=
-github.com/filecoin-project/test-vectors/schema v0.0.4/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
+github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71 h1:qnleaW7X8Gi2e3QtqPMFdqVn/DUaNI5tCnq7wNVMnio=
+github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/filecoin-project/specs-actors/v2 v2.1.0 h1:ocEuGz8DG2cUWw32c/tvF8D6xT
 github.com/filecoin-project/specs-actors/v2 v2.1.0/go.mod h1:E7fAX4CZkDVQvDNRCxfq+hc3nx56KcCKyuZf0hlQJ20=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
-github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71 h1:qnleaW7X8Gi2e3QtqPMFdqVn/DUaNI5tCnq7wNVMnio=
-github.com/filecoin-project/test-vectors/schema v0.0.5-0.20201014133607-1352e6bb4e71/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
+github.com/filecoin-project/test-vectors/schema v0.0.5 h1:w3zHQhzM4pYxJDl21avXjOKBLF8egrvwUwjpT8TquDg=
+github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=


### PR DESCRIPTION
This PR introduces support for running multi-variant vectors. Each variant targets a unique protocol version.

See https://github.com/filecoin-project/test-vectors/pull/178 and https://github.com/filecoin-project/test-vectors/issues/177 for more info on design and rationale.

The entire corpus has been regenerated, and the test-vectors submodule has been updated to point to master.

The tvx tool has been adapted to produce and parse the new version of the schema.