### PR TITLE
Revert "Add support for /https, /http, /wss API multiaddresses."

### DIFF
--- a/cli/util/apiinfo.go
+++ b/cli/util/apiinfo.go
@@ -44,22 +44,7 @@ func (a APIInfo) DialArgs() (string, error) {
 			return "", err
 		}
 
-		protocol := "ws"
-
-		// If the user specifies the multiaddress as
-		// /something/tcp/1234/http or/something/tcp/1234/https
-		// or /something/tcp/1234/wss then honor that.
-		for _, p := range []int{
-			multiaddr.P_HTTP,
-			multiaddr.P_HTTPS,
-			multiaddr.P_WSS,
-		} {
-			if _, err := ma.ValueForProtocol(p); err == nil {
-				protocol = multiaddr.ProtocolWithCode(p).Name
-				break
-			}
-		}
-		return protocol + "://" + addr + "/rpc/v0", nil
+		return "ws://" + addr + "/rpc/v0", nil
 	}
 
 	_, err = url.Parse(a.Addr)


### PR DESCRIPTION
Reverts filecoin-project/lotus#4391

This breaks lotus-miner because we set a /http multiaddr as default in the config, and lotus-miner is using some functions which require channel support