### PR TITLE
fix: return true when deadlines changed

### DIFF
--- a/chain/actors/builtin/miner/diff_deadlines.go
+++ b/chain/actors/builtin/miner/diff_deadlines.go
@@ -7,9 +7,9 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 )
 
-type DeadlinesDiff map[uint64]*DeadlineDiff
+type DeadlinesDiff map[uint64]DeadlineDiff
 
-func DiffDeadlines(pre, cur State) (*DeadlinesDiff, error) {
+func DiffDeadlines(pre, cur State) (DeadlinesDiff, error) {
 	changed, err := pre.DeadlinesChanged(cur)
 	if err != nil {
 		return nil, err
@@ -18,11 +18,7 @@ func DiffDeadlines(pre, cur State) (*DeadlinesDiff, error) {
 		return nil, nil
 	}
 
-	numDl, err := pre.NumDeadlines()
-	if err != nil {
-		return nil, err
-	}
-	dlDiff := make(DeadlinesDiff, numDl)
+	dlDiff := make(DeadlinesDiff)
 	if err := pre.ForEachDeadline(func(idx uint64, preDl Deadline) error {
 		curDl, err := cur.LoadDeadline(idx)
 		if err != nil {
@@ -39,12 +35,12 @@ func DiffDeadlines(pre, cur State) (*DeadlinesDiff, error) {
 	}); err != nil {
 		return nil, err
 	}
-	return &dlDiff, nil
+	return dlDiff, nil
 }
 
 type DeadlineDiff map[uint64]*PartitionDiff
 
-func DiffDeadline(pre, cur Deadline) (*DeadlineDiff, error) {
+func DiffDeadline(pre, cur Deadline) (DeadlineDiff, error) {
 	changed, err := pre.PartitionsChanged(cur)
 	if err != nil {
 		return nil, err
@@ -104,7 +100,7 @@ func DiffDeadline(pre, cur Deadline) (*DeadlineDiff, error) {
 		return nil, err
 	}
 
-	return &partDiff, nil
+	return partDiff, nil
 }
 
 type PartitionDiff struct {

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -370,7 +370,7 @@ func (d *deadline0) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return d.Deadline.Partitions.Equals(other0.Deadline.Partitions), nil
+	return !d.Deadline.Partitions.Equals(other0.Deadline.Partitions), nil
 }
 
 func (d *deadline0) PostSubmissions() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -274,7 +274,7 @@ func (s *state0) DeadlinesChanged(other State) (bool, error) {
 		return true, nil
 	}
 
-	return s.State.Deadlines.Equals(other0.Deadlines), nil
+	return !s.State.Deadlines.Equals(other0.Deadlines), nil
 }
 
 func (s *state0) Info() (MinerInfo, error) {

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -369,7 +369,7 @@ func (d *deadline2) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return d.Deadline.Partitions.Equals(other2.Deadline.Partitions), nil
+	return !d.Deadline.Partitions.Equals(other2.Deadline.Partitions), nil
 }
 
 func (d *deadline2) PostSubmissions() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -273,7 +273,7 @@ func (s *state2) DeadlinesChanged(other State) (bool, error) {
 		return true, nil
 	}
 
-	return s.State.Deadlines.Equals(other2.Deadlines), nil
+	return !s.State.Deadlines.Equals(other2.Deadlines), nil
 }
 
 func (s *state2) Info() (MinerInfo, error) {


### PR DESCRIPTION
The method name `DeadlinesChanged` suggests it will return true when the deadlines have changed when in fact it returns false. This PR addresses this by having the methods return true when the deadlines have changed. The method `DeadlinesChnaged` is called in chainwatch and in `DiffDeadlines`. Neither of these methods are called in lotus.

A similar issue exists for `PartitionsChanged` as well that has been addressed here.