### PR TITLE
Use build.BlockDelaySecs for deal start buffer

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -474,7 +474,7 @@ func BasicDealFilter(user dtypes.DealFilter) func(onlineOk dtypes.ConsiderOnline
 
 			// Reject if it's more than 7 days in the future
 			// TODO: read from cfg
-			maxStartEpoch := earliest + abi.ChainEpoch(7*builtin.EpochsInDay)
+			maxStartEpoch := earliest + abi.ChainEpoch(7*builtin.SecondsInDay/build.BlockDelaySecs)
 			if deal.Proposal.StartEpoch > maxStartEpoch {
 				return false, fmt.Sprintf("deal start epoch is too far in the future: %s > %s", deal.Proposal.StartEpoch, maxStartEpoch), nil
 			}


### PR DESCRIPTION
# Goals

Allow deals to be made with interactive deal flow in local devnet (w/ 4sec block time)

# Implementation

Instead of constant from spec-actors which uses hardcoded epoch time, use one that factors in
possibility of different block time across builds