### PR TITLE
Ensure msig inspect cli works with lotus-lite

### DIFF
--- a/api/api_gateway.go
+++ b/api/api_gateway.go
@@ -10,9 +10,11 @@ import (
 )
 
 type GatewayAPI interface {
+	ChainHasObj(context.Context, cid.Cid) (bool, error)
 	ChainHead(ctx context.Context) (*types.TipSet, error)
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
+	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 	GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
 	MpoolPush(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
 	MsigGetAvailableBalance(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -371,9 +371,11 @@ type WorkerStruct struct {
 type GatewayStruct struct {
 	Internal struct {
 		// TODO: does the gateway need perms?
+		ChainHasObj             func(context.Context, cid.Cid) (bool, error)
 		ChainGetTipSet          func(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 		ChainGetTipSetByHeight  func(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
 		ChainHead               func(ctx context.Context) (*types.TipSet, error)
+		ChainReadObj            func(context.Context, cid.Cid) ([]byte, error)
 		GasEstimateMessageGas   func(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error)
 		MpoolPush               func(ctx context.Context, sm *types.SignedMessage) (cid.Cid, error)
 		MsigGetAvailableBalance func(ctx context.Context, addr address.Address, tsk types.TipSetKey) (types.BigInt, error)
@@ -1432,6 +1434,10 @@ func (w *WorkerStruct) Closing(ctx context.Context) (<-chan struct{}, error) {
 	return w.Internal.Closing(ctx)
 }
 
+func (g GatewayStruct) ChainHasObj(ctx context.Context, c cid.Cid) (bool, error) {
+	return g.Internal.ChainHasObj(ctx, c)
+}
+
 func (g GatewayStruct) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	return g.Internal.ChainHead(ctx)
 }
@@ -1442,6 +1448,10 @@ func (g GatewayStruct) ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) 
 
 func (g GatewayStruct) ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error) {
 	return g.Internal.ChainGetTipSetByHeight(ctx, h, tsk)
+}
+
+func (g GatewayStruct) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
+	return g.Internal.ChainReadObj(ctx, c)
 }
 
 func (g GatewayStruct) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error) {

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -677,7 +677,7 @@ var msigAddProposeCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Println("sent add proposal in message: ", msgCid)
+		fmt.Fprintln(cctx.App.Writer, "sent add proposal in message: ", msgCid)
 
 		wait, err := api.StateWaitMsg(ctx, msgCid, build.MessageConfidence)
 		if err != nil {

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -153,7 +152,7 @@ var msigCreateCmd = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode != 0 {
-			fmt.Println("actor creation failed!")
+			fmt.Fprintln(cctx.App.Writer, "actor creation failed!")
 			return err
 		}
 
@@ -163,7 +162,7 @@ var msigCreateCmd = &cli.Command{
 		if err := execreturn.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
 			return err
 		}
-		fmt.Println("Created new multisig: ", execreturn.IDAddress, execreturn.RobustAddress)
+		fmt.Fprintln(cctx.App.Writer, "Created new multisig: ", execreturn.IDAddress, execreturn.RobustAddress)
 
 		// TODO: maybe register this somewhere
 		return nil
@@ -227,25 +226,25 @@ var msigInspectCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("Balance: %s\n", types.FIL(act.Balance))
-		fmt.Printf("Spendable: %s\n", types.FIL(types.BigSub(act.Balance, locked)))
+		fmt.Fprintf(cctx.App.Writer, "Balance: %s\n", types.FIL(act.Balance))
+		fmt.Fprintf(cctx.App.Writer, "Spendable: %s\n", types.FIL(types.BigSub(act.Balance, locked)))
 
 		if cctx.Bool("vesting") {
 			ib, err := mstate.InitialBalance()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("InitialBalance: %s\n", types.FIL(ib))
+			fmt.Fprintf(cctx.App.Writer, "InitialBalance: %s\n", types.FIL(ib))
 			se, err := mstate.StartEpoch()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("StartEpoch: %d\n", se)
+			fmt.Fprintf(cctx.App.Writer, "StartEpoch: %d\n", se)
 			ud, err := mstate.UnlockDuration()
 			if err != nil {
 				return err
 			}
-			fmt.Printf("UnlockDuration: %d\n", ud)
+			fmt.Fprintf(cctx.App.Writer, "UnlockDuration: %d\n", ud)
 		}
 
 		signers, err := mstate.Signers()
@@ -256,10 +255,10 @@ var msigInspectCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Threshold: %d / %d\n", threshold, len(signers))
-		fmt.Println("Signers:")
+		fmt.Fprintf(cctx.App.Writer, "Threshold: %d / %d\n", threshold, len(signers))
+		fmt.Fprintln(cctx.App.Writer, "Signers:")
 		for _, s := range signers {
-			fmt.Printf("\t%s\n", s)
+			fmt.Fprintf(cctx.App.Writer, "\t%s\n", s)
 		}
 
 		pending := make(map[int64]multisig.Transaction)
@@ -271,7 +270,7 @@ var msigInspectCmd = &cli.Command{
 		}
 
 		decParams := cctx.Bool("decode-params")
-		fmt.Println("Transactions: ", len(pending))
+		fmt.Fprintln(cctx.App.Writer, "Transactions: ", len(pending))
 		if len(pending) > 0 {
 			var txids []int64
 			for txid := range pending {
@@ -281,7 +280,7 @@ var msigInspectCmd = &cli.Command{
 				return txids[i] < txids[j]
 			})
 
-			w := tabwriter.NewWriter(os.Stdout, 8, 4, 2, ' ', 0)
+			w := tabwriter.NewWriter(cctx.App.Writer, 8, 4, 2, ' ', 0)
 			fmt.Fprintf(w, "ID\tState\tApprovals\tTo\tValue\tMethod\tParams\n")
 			for _, txid := range txids {
 				tx := pending[txid]

--- a/cli/multisig_test.go
+++ b/cli/multisig_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api/test"
+	clitest "github.com/filecoin-project/lotus/cli/test"
+	builder "github.com/filecoin-project/lotus/node/test"
+)
+
+// TestMultisig does a basic test to exercise the multisig CLI
+// commands
+func TestMultisig(t *testing.T) {
+	_ = os.Setenv("BELLMAN_NO_GPU", "1")
+
+	blocktime := 5 * time.Millisecond
+	ctx := context.Background()
+	nodes, _ := startNodes(ctx, t, blocktime)
+	clientNode := nodes[0]
+	clitest.RunMultisigTest(t, Commands, clientNode)
+}
+
+func startNodes(ctx context.Context, t *testing.T, blocktime time.Duration) ([]test.TestNode, []address.Address) {
+	n, sn := builder.RPCMockSbBuilder(t, test.OneFull, test.OneMiner)
+
+	full := n[0]
+	miner := sn[0]
+
+	// Get everyone connected
+	addrs, err := full.NetAddrsListen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := miner.NetConnect(ctx, addrs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start mining blocks
+	bm := test.NewBlockMiner(ctx, t, miner, blocktime)
+	bm.MineBlocks()
+
+	// Get the creator's address
+	creatorAddr, err := full.WalletDefaultAddress(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock CLI
+	return n, []address.Address{creatorAddr}
+}

--- a/cli/paych_test.go
+++ b/cli/paych_test.go
@@ -437,6 +437,7 @@ type mockCLI struct {
 	out  *bytes.Buffer
 }
 
+// TODO: refactor to use the methods in cli/test/mockcli.go
 func newMockCLI(t *testing.T) *mockCLI {
 	// Create a CLI App with an --api-url flag so that we can specify which node
 	// the command should be executed against

--- a/cli/test/mockcli.go
+++ b/cli/test/mockcli.go
@@ -1,0 +1,124 @@
+package test
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	lcli "github.com/urfave/cli/v2"
+)
+
+type mockCLI struct {
+	t    *testing.T
+	cmds []*lcli.Command
+	cctx *lcli.Context
+	out  *bytes.Buffer
+}
+
+func newMockCLI(t *testing.T, cmds []*lcli.Command) *mockCLI {
+	// Create a CLI App with an --api-url flag so that we can specify which node
+	// the command should be executed against
+	app := &lcli.App{
+		Flags: []lcli.Flag{
+			&lcli.StringFlag{
+				Name:   "api-url",
+				Hidden: true,
+			},
+		},
+		Commands: cmds,
+	}
+
+	var out bytes.Buffer
+	app.Writer = &out
+	app.Setup()
+
+	cctx := lcli.NewContext(app, &flag.FlagSet{}, nil)
+	return &mockCLI{t: t, cmds: cmds, cctx: cctx, out: &out}
+}
+
+func (c *mockCLI) client(addr multiaddr.Multiaddr) *mockCLIClient {
+	return &mockCLIClient{t: c.t, cmds: c.cmds, addr: addr, cctx: c.cctx, out: c.out}
+}
+
+// mockCLIClient runs commands against a particular node
+type mockCLIClient struct {
+	t    *testing.T
+	cmds []*lcli.Command
+	addr multiaddr.Multiaddr
+	cctx *lcli.Context
+	out  *bytes.Buffer
+}
+
+func (c *mockCLIClient) run(cmd []string, params []string, args []string) string {
+	// Add parameter --api-url=<node api listener address>
+	apiFlag := "--api-url=" + c.addr.String()
+	params = append([]string{apiFlag}, params...)
+
+	err := c.cctx.App.Run(append(append(cmd, params...), args...))
+	require.NoError(c.t, err)
+
+	// Get the output
+	str := strings.TrimSpace(c.out.String())
+	c.out.Reset()
+	return str
+}
+
+func (c *mockCLIClient) runCmd(input []string) string {
+	cmd := c.cmdByNameSub(input[0], input[1])
+	out, err := c.runCmdRaw(cmd, input[2:])
+	require.NoError(c.t, err)
+
+	return out
+}
+
+func (c *mockCLIClient) cmdByNameSub(name string, sub string) *lcli.Command {
+	for _, c := range c.cmds {
+		if c.Name == name {
+			for _, s := range c.Subcommands {
+				if s.Name == sub {
+					return s
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *mockCLIClient) runCmdRaw(cmd *lcli.Command, input []string) (string, error) {
+	// prepend --api-url=<node api listener address>
+	apiFlag := "--api-url=" + c.addr.String()
+	input = append([]string{apiFlag}, input...)
+
+	fs := c.flagSet(cmd)
+	err := fs.Parse(input)
+	require.NoError(c.t, err)
+
+	err = cmd.Action(lcli.NewContext(c.cctx.App, fs, c.cctx))
+
+	// Get the output
+	str := strings.TrimSpace(c.out.String())
+	c.out.Reset()
+	return str, err
+}
+
+func (c *mockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
+	// Apply app level flags (so we can process --api-url flag)
+	fs := &flag.FlagSet{}
+	for _, f := range c.cctx.App.Flags {
+		err := f.Apply(fs)
+		if err != nil {
+			c.t.Fatal(err)
+		}
+	}
+	// Apply command level flags
+	for _, f := range cmd.Flags {
+		err := f.Apply(fs)
+		if err != nil {
+			c.t.Fatal(err)
+		}
+	}
+	return fs
+}

--- a/cli/test/multisig.go
+++ b/cli/test/multisig.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api/test"
+	"github.com/filecoin-project/lotus/chain/types"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
+	lcli "github.com/urfave/cli/v2"
+)
+
+func QuietMiningLogs() {
+	logging.SetLogLevel("miner", "ERROR")
+	logging.SetLogLevel("chainstore", "ERROR")
+	logging.SetLogLevel("chain", "ERROR")
+	logging.SetLogLevel("sub", "ERROR")
+	logging.SetLogLevel("storageminer", "ERROR")
+}
+
+func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode) {
+	ctx := context.Background()
+
+	// Create mock CLI
+	mockCLI := newMockCLI(t, cmds)
+	clientCLI := mockCLI.client(clientNode.ListenAddr)
+
+	// Create some wallets on the node to use for testing multisig
+	var walletAddrs []address.Address
+	for i := 0; i < 4; i++ {
+		addr, err := clientNode.WalletNew(ctx, types.KTSecp256k1)
+		require.NoError(t, err)
+
+		walletAddrs = append(walletAddrs, addr)
+
+		test.SendFunds(ctx, t, clientNode, addr, types.NewInt(1e15))
+	}
+
+	// Create an msig with three of the addresses and threshold of two sigs
+	// msig create --required=2 --duration=50 --value=1000attofil <addr1> <addr2> <addr3>
+	amtAtto := types.NewInt(1000)
+	threshold := 2
+	paramDuration := "--duration=50"
+	paramRequired := fmt.Sprintf("--required=%d", threshold)
+	paramValue := fmt.Sprintf("--value=%dattofil", amtAtto)
+	cmd := []string{
+		"msig", "create",
+		paramRequired,
+		paramDuration,
+		paramValue,
+		walletAddrs[0].String(),
+		walletAddrs[1].String(),
+		walletAddrs[2].String(),
+	}
+	out := clientCLI.runCmd(cmd)
+	fmt.Println(out)
+
+	// Extract msig robust address from output
+	expCreateOutPrefix := "Created new multisig:"
+	require.Regexp(t, regexp.MustCompile(expCreateOutPrefix), out)
+	parts := strings.Split(strings.TrimSpace(strings.Replace(out, expCreateOutPrefix, "", -1)), " ")
+	require.Len(t, parts, 2)
+	msigRobustAddr := parts[1]
+	fmt.Println("msig robust address:", msigRobustAddr)
+
+	// msig inspect <msig>
+	cmd = []string{"msig", "inspect", msigRobustAddr}
+	out = clientCLI.runCmd(cmd)
+	fmt.Println(out)
+
+	require.Regexp(t, regexp.MustCompile("Balance: 0.000000000000001 FIL"), out)
+}

--- a/cmd/lotus-gateway/api_test.go
+++ b/cmd/lotus-gateway/api_test.go
@@ -109,6 +109,10 @@ type mockGatewayDepsAPI struct {
 	tipsets []*types.TipSet
 }
 
+func (m *mockGatewayDepsAPI) ChainHasObj(context.Context, cid.Cid) (bool, error) {
+	panic("implement me")
+}
+
 func (m *mockGatewayDepsAPI) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	m.lk.RLock()
 	defer m.lk.RUnlock()
@@ -156,6 +160,10 @@ func (m *mockGatewayDepsAPI) ChainGetTipSetByHeight(ctx context.Context, h abi.C
 	defer m.lk.Unlock()
 
 	return m.tipsets[h], nil
+}
+
+func (m *mockGatewayDepsAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {
+	panic("implement me")
 }
 
 func (m *mockGatewayDepsAPI) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, tsk types.TipSetKey) (*types.Message, error) {

--- a/cmd/lotus-gateway/api_test.go
+++ b/cmd/lotus-gateway/api_test.go
@@ -88,7 +88,7 @@ func TestGatewayAPIChainGetTipSetByHeight(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockGatewayDepsAPI{}
-			a := &GatewayAPI{api: mock}
+			a := NewGatewayAPI(mock)
 
 			// Create tipsets from genesis up to tskh and return the highest
 			ts := mock.createTipSets(tt.args.tskh, tt.args.genesisTS)

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -76,7 +76,7 @@ var runCmd = &cli.Command{
 		log.Info("Setting up API endpoint at " + address)
 
 		rpcServer := jsonrpc.NewServer()
-		rpcServer.Register("Filecoin", &GatewayAPI{api: api})
+		rpcServer.Register("Filecoin", NewGatewayAPI(api))
 
 		mux.Handle("/rpc/v0", rpcServer)
 		mux.PathPrefix("/").Handler(http.DefaultServeMux)

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -40,9 +40,11 @@ import (
 var log = logging.Logger("fullnode")
 
 type ChainModuleAPI interface {
+	ChainHasObj(context.Context, cid.Cid) (bool, error)
 	ChainHead(context.Context) (*types.TipSet, error)
 	ChainGetTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
+	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 }
 
 // ChainModule provides a default implementation of ChainModuleAPI.
@@ -206,8 +208,8 @@ func (m *ChainModule) ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpo
 	return m.Chain.GetTipsetByHeight(ctx, h, ts, true)
 }
 
-func (a *ChainAPI) ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error) {
-	blk, err := a.Chain.Blockstore().Get(obj)
+func (m *ChainModule) ChainReadObj(ctx context.Context, obj cid.Cid) ([]byte, error) {
+	blk, err := m.Chain.Blockstore().Get(obj)
 	if err != nil {
 		return nil, xerrors.Errorf("blockstore get: %w", err)
 	}
@@ -219,8 +221,8 @@ func (a *ChainAPI) ChainDeleteObj(ctx context.Context, obj cid.Cid) error {
 	return a.Chain.Blockstore().DeleteBlock(obj)
 }
 
-func (a *ChainAPI) ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error) {
-	return a.Chain.Blockstore().Has(obj)
+func (m *ChainModule) ChainHasObj(ctx context.Context, obj cid.Cid) (bool, error) {
+	return m.Chain.Blockstore().Has(obj)
 }
 
 func (a *ChainAPI) ChainStatObj(ctx context.Context, obj cid.Cid, base cid.Cid) (api.ObjStat, error) {


### PR DESCRIPTION
This PR
- Creates a basic CLI test for msig create & msig inspect
- Adds hooks to run the test
  - from CLI with a regular node
  - from api-gateway with lite node -> gateway -> full node

Now that the framework is in place, it should be easy to add other CLI commands to the basic msig CLI test to ensure they run in regular and lite mode.