### PR TITLE
Custom filters for retrieval deals

### DIFF
--- a/markets/dealfilter/cli.go
+++ b/markets/dealfilter/cli.go
@@ -6,35 +6,57 @@ import (
 	"encoding/json"
 	"os/exec"
 
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
-func CliDealFilter(cmd string) dtypes.DealFilter {
-	// TODO: run some checks on the cmd string
-
+func CliStorageDealFilter(cmd string) dtypes.StorageDealFilter {
 	return func(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error) {
-		j, err := json.MarshalIndent(deal, "", "  ")
-		if err != nil {
-			return false, "", err
+		d := struct {
+			storagemarket.MinerDeal
+			DealType string
+		}{
+			MinerDeal: deal,
+			DealType:  "storage",
 		}
+		return runDealFilter(ctx, cmd, d)
+	}
+}
 
-		var out bytes.Buffer
-
-		c := exec.Command("sh", "-c", cmd)
-		c.Stdin = bytes.NewReader(j)
-		c.Stdout = &out
-		c.Stderr = &out
-
-		switch err := c.Run().(type) {
-		case nil:
-			return true, "", nil
-		case *exec.ExitError:
-			return false, out.String(), nil
-		default:
-			return false, "filter cmd run error", err
+func CliRetrievalDealFilter(cmd string) dtypes.RetrievalDealFilter {
+	return func(ctx context.Context, deal retrievalmarket.ProviderDealState) (bool, string, error) {
+		d := struct {
+			retrievalmarket.ProviderDealState
+			DealType string
+		}{
+			ProviderDealState: deal,
+			DealType:          "retrieval",
 		}
+		return runDealFilter(ctx, cmd, d)
+	}
+}
 
+func runDealFilter(ctx context.Context, cmd string, deal interface{}) (bool, string, error) {
+	j, err := json.MarshalIndent(deal, "", "  ")
+	if err != nil {
+		return false, "", err
+	}
+
+	var out bytes.Buffer
+
+	c := exec.Command("sh", "-c", cmd)
+	c.Stdin = bytes.NewReader(j)
+	c.Stdout = &out
+	c.Stderr = &out
+
+	switch err := c.Run().(type) {
+	case nil:
+		return true, "", nil
+	case *exec.ExitError:
+		return false, out.String(), nil
+	default:
+		return false, "filter cmd run error", err
 	}
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -486,7 +486,10 @@ func ConfigStorageMiner(c interface{}) Option {
 
 		If(cfg.Dealmaking.Filter != "",
 			Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(dealfilter.CliStorageDealFilter(cfg.Dealmaking.Filter))),
-			Override(new(dtypes.RetrievalDealFilter), modules.RetrievalDealFilter(dealfilter.CliRetrievalDealFilter(cfg.Dealmaking.Filter))),
+		),
+
+		If(cfg.Dealmaking.RetrievalFilter != "",
+			Override(new(dtypes.RetrievalDealFilter), modules.RetrievalDealFilter(dealfilter.CliRetrievalDealFilter(cfg.Dealmaking.RetrievalFilter))),
 		),
 
 		Override(new(storagemarket.StorageProviderNode), storageadapter.NewProviderNodeAdapter(&cfg.Fees)),

--- a/node/builder.go
+++ b/node/builder.go
@@ -354,7 +354,8 @@ func Online() Option {
 			Override(new(dtypes.ProviderDataTransfer), modules.NewProviderDAGServiceDataTransfer),
 			Override(new(dtypes.ProviderPieceStore), modules.NewProviderPieceStore),
 			Override(new(*storedask.StoredAsk), modules.NewStorageAsk),
-			Override(new(dtypes.DealFilter), modules.BasicDealFilter(nil)),
+			Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(nil)),
+			Override(new(dtypes.RetrievalDealFilter), modules.RetrievalDealFilter(nil)),
 			Override(new(modules.ProviderDealFunds), modules.NewProviderDealFunds),
 			Override(new(storagemarket.StorageProvider), modules.StorageProvider),
 			Override(new(storagemarket.StorageProviderNode), storageadapter.NewProviderNodeAdapter(nil)),
@@ -484,7 +485,8 @@ func ConfigStorageMiner(c interface{}) Option {
 		ConfigCommon(&cfg.Common),
 
 		If(cfg.Dealmaking.Filter != "",
-			Override(new(dtypes.DealFilter), modules.BasicDealFilter(dealfilter.CliDealFilter(cfg.Dealmaking.Filter))),
+			Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(dealfilter.CliStorageDealFilter(cfg.Dealmaking.Filter))),
+			Override(new(dtypes.RetrievalDealFilter), modules.RetrievalDealFilter(dealfilter.CliRetrievalDealFilter(cfg.Dealmaking.Filter))),
 		),
 
 		Override(new(storagemarket.StorageProviderNode), storageadapter.NewProviderNodeAdapter(&cfg.Fees)),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -45,7 +45,8 @@ type DealmakingConfig struct {
 	PieceCidBlocklist             []cid.Cid
 	ExpectedSealDuration          Duration
 
-	Filter string
+	Filter          string
+	RetrievalFilter string
 }
 
 type SealingConfig struct {

--- a/node/modules/dtypes/miner.go
+++ b/node/modules/dtypes/miner.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-state-types/abi"
 
@@ -71,4 +72,5 @@ type SetExpectedSealDurationFunc func(time.Duration) error
 // too determine how long sealing is expected to take
 type GetExpectedSealDurationFunc func() (time.Duration, error)
 
-type DealFilter func(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error)
+type StorageDealFilter func(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error)
+type RetrievalDealFilter func(ctx context.Context, deal retrievalmarket.ProviderDealState) (bool, string, error)


### PR DESCRIPTION
## Problem
We would like to have custom user filters for retrieval deals, like we have for storage deals.

## Solution
If a custom filter is set in `Dealmaking.Filter`, use it when deciding on both retrieval deals and storage deals.  The JSON passed to the custom filter will be augmented with `"DealType": <"storage" | "retrieval">` so that the custom filter can distinguish between the two types of deals.

Resolves #4195 