### PR TITLE
Don't overwrite previously-configured maxPieceSize for a persisted ask

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -398,8 +398,6 @@ func NewStorageAsk(ctx helpers.MetricsCtx, fapi lapi.FullNode, ds dtypes.Metadat
 	if err != nil {
 		return nil, err
 	}
-	a := storedAsk.GetAsk().Ask
-	err = storedAsk.SetAsk(a.Price, a.VerifiedPrice, a.Expiry-a.Timestamp)
 	if err != nil {
 		return storedAsk, err
 	}


### PR DESCRIPTION
## Problem
When constructing a new stored ask, the `MaxPieceSize` was not properly preserved.

## Solution
There was leftover code that was inadvertently overwriting the provided `MaxPieceSize` with the default.

Related: https://github.com/filecoin-project/go-fil-markets/pull/438

Resolves #4440, #4458 