### PR TITLE
Add election run-dummy command

### DIFF
--- a/cmd/lotus-shed/election.go
+++ b/cmd/lotus-shed/election.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
+	"math/rand"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
@@ -30,7 +31,7 @@ var electionRunDummy = &cli.Command{
 		},
 		&cli.Uint64Flag{
 			Name:  "seed",
-			Value: 4,
+			Value: 0,
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -46,7 +47,11 @@ var electionRunDummy = &cli.Command{
 
 		ep := &types.ElectionProof{}
 		ep.VRFProof = make([]byte, 32)
-		binary.BigEndian.PutUint64(ep.VRFProof, cctx.Uint64("seed"))
+		seed := cctx.Uint64("seed")
+		if seed == 0 {
+			seed = rand.Uint64()
+		}
+		binary.BigEndian.PutUint64(ep.VRFProof, seed)
 
 		i := uint64(0)
 		for {

--- a/cmd/lotus-shed/election.go
+++ b/cmd/lotus-shed/election.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+)
+
+var electionCmd = &cli.Command{
+	Name:  "election",
+	Usage: "commands related to leader election",
+	Subcommands: []*cli.Command{
+		electionRunDummy,
+	},
+}
+
+var electionRunDummy = &cli.Command{
+	Name:  "run-dummy",
+	Usage: "runs dummy elections with given power",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name: "network-power",
+		},
+		&cli.StringFlag{
+			Name: "miner-power",
+		},
+		&cli.Uint64Flag{
+			Name:  "seed",
+			Value: 4,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lcli.ReqContext(cctx)
+		minerPow, err := types.BigFromString(cctx.String("miner-power"))
+		if err != nil {
+			return xerrors.Errorf("decoding miner-power: %w", err)
+		}
+		networkPow, err := types.BigFromString(cctx.String("network-power"))
+		if err != nil {
+			return xerrors.Errorf("decoding miner-power: %w", err)
+		}
+
+		ep := &types.ElectionProof{}
+		ep.VRFProof = make([]byte, 32)
+		binary.BigEndian.PutUint64(ep.VRFProof, cctx.Uint64("seed"))
+
+		i := uint64(0)
+		for {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			binary.BigEndian.PutUint64(ep.VRFProof[8:], i)
+			j := ep.ComputeWinCount(minerPow, networkPow)
+			_, err := fmt.Printf("%t, %d\n", j != 0, j)
+			if err != nil {
+				return err
+			}
+			i++
+		}
+	},
+}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -46,6 +46,7 @@ func main() {
 		ledgerCmd,
 		sectorsCmd,
 		msgCmd,
+		electionCmd,
 	}
 
 	app := &cli.App{


### PR DESCRIPTION
```bash
> source scripts/dev/runAPI.bash
> runAPI MinerGetBaseInfo '["t02388", 163405, [{"/": "'"$(./lotus chain head | head -1)"'"}]]' | jq .
{
  "jsonrpc": "2.0",
  "result": {
    "MinerPower": "14156212207616",
    "NetworkPower": "681826195678953472",
    "Sectors": [
      {
        "SealProof": 3,
        "SectorNumber": 179,
        "SealedCID": {
          "/": "bagboea4b5abcas5opeafvoqljrxfwnfbo5amnyhg6cwzyt37rch5z4not3stserq"
        }
      }
    ],
    "WorkerKey": "f3rutut57upcbuzyq6si2xajhvr7d4u7exd7knqop4t6w3bpl57uqpdnfs72t2tyaz7vivwdvyc3bzvq2i37ma",
    "SectorSize": 34359738368,
    "PrevBeaconEntry": {
      "Round": 259249,
      "Data": "hQ687JZRrGV4U6QMrzac7I3evTOGnXAIY3bZagH4TLZI00+3KkclftPDtVoPbyEvFAwV474o/0G+EzoSnHf4I6Uh+uLupLBH0QVB5VdlHf0RyaBO8iYPHlNF5Hrmr0+6"
    },
    "BeaconEntries": null,
    "EligibleForMining": true
  },
  "id": 2
}
# take MinerPower and Network Power and run what is below with these numbers to simulate a day of mining
> ./lotus-shed election run-dummy  --miner-power 14156212207616 --network-power 681826195678953472 | head -2880 | grep true | wc -l
0
```
