### PR TITLE
Add a terminate sectors command to lotus-shed

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -56,6 +57,13 @@ func main() {
 				EnvVars: []string{"LOTUS_PATH"},
 				Hidden:  true,
 				Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
+			},
+			&cli.StringFlag{
+				Name:    "miner-repo",
+				Aliases: []string{"storagerepo"},
+				EnvVars: []string{"LOTUS_MINER_PATH", "LOTUS_STORAGE_PATH"},
+				Value:   "~/.lotusminer", // TODO: Consider XDG_DATA_HOME
+				Usage:   fmt.Sprintf("Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON"),
 			},
 			&cli.StringFlag{
 				Name:  "log-level",

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -42,6 +42,7 @@ func main() {
 		stateTreePruneCmd,
 		datastoreCmd,
 		ledgerCmd,
+		sectorsCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"golang.org/x/xerrors"
+	"strconv"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	miner0 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	"github.com/urfave/cli/v2"
+)
+
+var sectorsCmd = &cli.Command{
+	Name:  "sectors",
+	Usage: "Tools for interacting with sectors",
+	Flags: []cli.Flag{},
+	Subcommands: []*cli.Command{
+		terminateSectorCmd,
+	},
+}
+
+var terminateSectorCmd = &cli.Command{
+	Name:      "terminate",
+	Usage:     "Forcefully terminate a sector (WARNING: This means losing power and pay a one-time termination penalty(including collateral) for the terminated sector)",
+	ArgsUsage: "[sectorNum1 sectorNum2 ...]",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "really-do-it",
+			Usage: "pass this flag if you know what you are doing",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Len() < 1 {
+			return fmt.Errorf("at least one sector must be specified")
+		}
+
+		if !cctx.Bool("really-do-it") {
+			return fmt.Errorf("this is a command for advanced users, only use it if you are sure of what you are doing")
+		}
+
+		nodeApi, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		api, acloser, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer acloser()
+
+		ctx := lcli.ReqContext(cctx)
+
+		maddr, err := api.ActorAddress(ctx)
+		if err != nil {
+			return err
+		}
+
+		mi, err := nodeApi.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		terminationDeclarationParams := []miner0.TerminationDeclaration{}
+
+		for _, sn := range cctx.Args().Slice() {
+			sectorNum, err := strconv.ParseUint(sn, 10, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse sector number: %w", err)
+			}
+
+			sectorbit := bitfield.New()
+			sectorbit.Set(sectorNum)
+
+			loca, err := nodeApi.StateSectorPartition(ctx, maddr, abi.SectorNumber(sectorNum), types.EmptyTSK)
+			if err != nil {
+				return fmt.Errorf("get state sector partition %s", err)
+			}
+
+			para := miner0.TerminationDeclaration{
+				Deadline:  loca.Deadline,
+				Partition: loca.Partition,
+				Sectors:   sectorbit,
+			}
+
+			terminationDeclarationParams = append(terminationDeclarationParams, para)
+		}
+
+		terminateSectorParams := &miner0.TerminateSectorsParams{
+			Terminations: terminationDeclarationParams,
+		}
+
+		sp, err := actors.SerializeParams(terminateSectorParams)
+		if err != nil {
+			return xerrors.Errorf("serializing params: %w", err)
+		}
+
+		smsg, err := nodeApi.MpoolPushMessage(ctx, &types.Message{
+			From:   mi.Owner,
+			To:     maddr,
+			Method: builtin.MethodsMiner.TerminateSectors,
+
+			Value:  big.Zero(),
+			Params: sp,
+		}, nil)
+		if err != nil {
+			return xerrors.Errorf("mpool push message: %w", err)
+		}
+
+		fmt.Println("Message CID:", smsg.Cid())
+
+		return nil
+	},
+}


### PR DESCRIPTION
 Add terminate sectors based on 1475's #4433 implementation in lotus-shed:
-  Moving the cmd to lotus-shed so that miners can use this right away without waiting for fsm changes.
- Note: this should only be used when the miner is 100% sure that they want to terminate the sector on chain and they will be lose the power and pay a big one-time termination penalty for the sectors.
- Only live sectors can be terminated.
- To use, run `./lotus-shed sectors terminate --really-do-it=true sectorNum1 sectorNum2`.
- A message will be sent and after the message is landed on chain, miner can run `lotus-miner sectors status --on-chain-info <terminated sector number>`, and check Expiration Info at the bottom. Both `OnTime` and `Early` are 0 indicates the sector is terminated.