### PR TITLE
skip unnecessary event check

### DIFF
--- a/chain/events/events_called.go
+++ b/chain/events/events_called.go
@@ -124,6 +124,9 @@ func (e *hcEvents) processHeadChangeEvent(rev, app []*types.TipSet) error {
 	}
 
 	for _, ts := range app {
+		if ts.ParentState().Equals(e.lastTs.ParentState()) {
+			continue
+		}
 		// Check if the head change caused any state changes that we were
 		// waiting for
 		stateChanges := e.watcherEvents.checkStateChanges(e.lastTs, ts)

--- a/chain/events/events_called.go
+++ b/chain/events/events_called.go
@@ -124,7 +124,8 @@ func (e *hcEvents) processHeadChangeEvent(rev, app []*types.TipSet) error {
 	}
 
 	for _, ts := range app {
-		if ts.ParentState().Equals(e.lastTs.ParentState()) {
+
+		if e.lastTs != nil && ts.Height() == e.lastTs.Height() && ts.ParentState().Equals(e.lastTs.ParentState()) {
 			continue
 		}
 		// Check if the head change caused any state changes that we were


### PR DESCRIPTION
Deal state checking currently takes a long time. With an average of 5 blocks per epoch, this can significantly reduce time-consuming. 

As I mentioned in [PR](https://github.com/filecoin-project/lotus/pull/4289) and [slack](https://filecoinproject.slack.com/archives/CP50PPW2X/p1602296605244900). I had to turn off deal reception twice due to the issue.

After this modification, my miner can handle deal state correctly now. But this is still temporary. as number of deals increased, event checking will fail to keep up with the chain again.

additional info:

1.  My miner currently has 59086 deals
![image](https://user-images.githubusercontent.com/16440610/96703340-4e6a3380-13c5-11eb-9e8b-9f877f17b0dd.png)
2. The performance of deal event checking with [PR](https://github.com/filecoin-project/lotus/pull/4289) is below. It's running on a 3970x with nvme driver.
```
events  events/events_called.go:136     checkStateChanges, elapsed: 16231
events  events/events_called.go:136     checkStateChanges, elapsed: 16351
```

