### PR TITLE
add support of share storage and disable allowfetch for precommit2

### DIFF
--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -3,6 +3,7 @@ package sectorstorage
 import (
 	"context"
 	"fmt"
+	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"math/rand"
 	"sort"
 	"sync"
@@ -80,6 +81,11 @@ type workerHandle struct {
 	w Worker
 
 	info storiface.WorkerInfo
+
+	acceptTasks map[sealtasks.TaskType]struct{}
+
+	path []stores.StoragePath
+
 
 	preparing *activeResources
 	active    *activeResources

--- a/extern/sector-storage/selector_task.go
+++ b/extern/sector-storage/selector_task.go
@@ -3,8 +3,6 @@ package sectorstorage
 import (
 	"context"
 
-	"golang.org/x/xerrors"
-
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/extern/sector-storage/sealtasks"
@@ -20,24 +18,16 @@ func newTaskSelector() *taskSelector {
 }
 
 func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredSealProof, whnd *workerHandle) (bool, error) {
-	tasks, err := whnd.w.TaskTypes(ctx)
-	if err != nil {
-		return false, xerrors.Errorf("getting supported worker task types: %w", err)
-	}
+	tasks := whnd.acceptTasks
 	_, supported := tasks[task]
 
 	return supported, nil
 }
 
 func (s *taskSelector) Cmp(ctx context.Context, _ sealtasks.TaskType, a, b *workerHandle) (bool, error) {
-	atasks, err := a.w.TaskTypes(ctx)
-	if err != nil {
-		return false, xerrors.Errorf("getting supported worker task types: %w", err)
-	}
-	btasks, err := b.w.TaskTypes(ctx)
-	if err != nil {
-		return false, xerrors.Errorf("getting supported worker task types: %w", err)
-	}
+	atasks := a.acceptTasks
+	btasks := b.acceptTasks
+
 	if len(atasks) != len(btasks) {
 		return len(atasks) < len(btasks), nil // prefer workers which can do less
 	}

--- a/extern/sector-storage/stores/interface.go
+++ b/extern/sector-storage/stores/interface.go
@@ -12,6 +12,8 @@ type PathType string
 const (
 	PathStorage PathType = "storage"
 	PathSealing PathType = "sealing"
+	PathNone PathType = "none"
+
 )
 
 type AcquireMode string


### PR DESCRIPTION
This PR enables share storage (such as NFS or Ceph) between miner and remote workers,  so that in Finalize phase worker can move sectors data files (cache/sealed/unsealed) into share storage instead of transferring data to miner, thus improves the throughoutput of the whole distributed mining system.