### PR TITLE
Cleanup test initialization and always validate VRFs in tests

### DIFF
--- a/api/test/ccupgrade.go
+++ b/api/test/ccupgrade.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,8 +16,6 @@ import (
 )
 
 func TestCCUpgrade(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
-
 	for _, height := range []abi.ChainEpoch{
 		1,    // before
 		162,  // while sealing

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -16,15 +16,12 @@ import (
 
 	"github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-car"
 
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
-	"github.com/filecoin-project/lotus/miner"
 	dag "github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
 	unixfile "github.com/ipfs/go-unixfs/file"
@@ -34,18 +31,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
-var MineNext = miner.MineReq{
-	InjectNulls: 0,
-	Done:        func(bool, abi.ChainEpoch, error) {},
-}
-
-func init() {
-	logging.SetAllLoggers(logging.LevelInfo)
-	build.InsecurePoStValidation = true
-}
-
 func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport, fastRet bool) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -82,7 +68,6 @@ func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport
 }
 
 func TestDoubleDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -146,7 +131,6 @@ func makeDeal(t *testing.T, ctx context.Context, rseed int, client *impl.FullNod
 }
 
 func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -201,7 +185,6 @@ func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Durati
 }
 
 func TestSenondDealRetrieval(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)

--- a/api/test/mining.go
+++ b/api/test/mining.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -88,8 +87,6 @@ func (ts *testSuite) testMiningReal(t *testing.T) {
 }
 
 func TestDealMining(t *testing.T, b APIBuilder, blocktime time.Duration, carExport bool) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
-
 	// test making a deal with a fresh miner, and see if it starts to mine
 
 	ctx := context.Background()

--- a/api/test/paych.go
+++ b/api/test/paych.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,8 +27,6 @@ import (
 )
 
 func TestPaymentChannels(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	_ = os.Setenv("BELLMAN_NO_GPU", "1")
-
 	ctx := context.Background()
 	n, sn := b(t, TwoFull, OneMiner)
 

--- a/api/test/test.go
+++ b/api/test/test.go
@@ -2,12 +2,15 @@ package test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-multiaddr"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +24,15 @@ import (
 	"github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node"
 )
+
+func init() {
+	logging.SetAllLoggers(logging.LevelInfo)
+	err := os.Setenv("BELLMAN_NO_GPU", "1")
+	if err != nil {
+		panic(fmt.Sprintf("failed to set BELLMAN_NO_GPU env variable: %s", err))
+	}
+	build.InsecurePoStValidation = true
+}
 
 type TestNode struct {
 	api.FullNode
@@ -108,6 +120,11 @@ var FullNodeWithUpgradeAt = func(upgradeHeight abi.ChainEpoch) FullNodeOpts {
 			}})
 		},
 	}
+}
+
+var MineNext = miner.MineReq{
+	InjectNulls: 0,
+	Done:        func(bool, abi.ChainEpoch, error) {},
 }
 
 func (ts *testSuite) testVersion(t *testing.T) {

--- a/api/test/window_post.go
+++ b/api/test/window_post.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -23,13 +22,6 @@ import (
 	bminer "github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node/impl"
 )
-
-func init() {
-	err := os.Setenv("BELLMAN_NO_GPU", "1")
-	if err != nil {
-		panic(fmt.Sprintf("failed to set BELLMAN_NO_GPU env variable: %s", err))
-	}
-}
 
 func TestPledgeSector(t *testing.T, b APIBuilder, blocktime time.Duration, nSectors int) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1731,9 +1731,6 @@ func (syncer *Syncer) collectChain(ctx context.Context, ts *types.TipSet) error 
 }
 
 func VerifyElectionPoStVRF(ctx context.Context, worker address.Address, rand []byte, evrf []byte) error {
-	if build.InsecurePoStValidation {
-		return nil
-	}
 	return gen.VerifyVRF(ctx, worker, rand, evrf)
 }
 


### PR DESCRIPTION
1. Avoid setting global variables multiple times from different tests.
2. Don't skip VRF validation in tests when "insecure post" is enable. VRFs are always calculated, so we might as well test them.