### PR TITLE
Use the correct lookback for the worker key when creating blocks

### DIFF
--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -27,7 +27,17 @@ func MinerCreateBlock(ctx context.Context, sm *stmgr.StateManager, w api.WalletA
 		return nil, xerrors.Errorf("failed to load tipset state: %w", err)
 	}
 
-	worker, err := stmgr.GetMinerWorkerRaw(ctx, sm, st, bt.Miner)
+	lbts, err := stmgr.GetLookbackTipSetForRound(ctx, sm, pts, bt.Epoch)
+	if err != nil {
+		return nil, xerrors.Errorf("getting lookback miner actor state: %w", err)
+	}
+
+	lbst, _, err := sm.TipSetState(ctx, lbts)
+	if err != nil {
+		return nil, err
+	}
+
+	worker, err := stmgr.GetMinerWorkerRaw(ctx, sm, lbst, bt.Miner)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get miner worker: %w", err)
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -467,17 +467,12 @@ func (m *Miner) computeTicket(ctx context.Context, brand *types.BeaconEntry, bas
 		buf.Write(base.TipSet.MinTicket().VRFProof)
 	}
 
-	worker, err := m.api.StateAccountKey(ctx, mbi.WorkerKey, types.EmptyTSK)
-	if err != nil {
-		return nil, err
-	}
-
 	input, err := store.DrawRandomness(brand.Data, crypto.DomainSeparationTag_TicketProduction, round-build.TicketRandomnessLookback, buf.Bytes())
 	if err != nil {
 		return nil, err
 	}
 
-	vrfOut, err := gen.ComputeVRF(ctx, m.api.WalletSign, worker, input)
+	vrfOut, err := gen.ComputeVRF(ctx, m.api.WalletSign, mbi.WorkerKey, input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, we'd use the _current_ worker key when signing blocks and computing the VRF. Now, we use the worker key from the correct lookback epoch. This now matches the behavior on the validation side.

Required for (and tested by) https://github.com/filecoin-project/lotus/pull/4513.