### PR TITLE
Fix random test failures

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1396,6 +1396,11 @@ loop:
 	}
 
 	base := blockSet[len(blockSet)-1]
+	if base.Equals(known) {
+		blockSet = blockSet[:len(blockSet)-1]
+		base = blockSet[len(blockSet)-1]
+	}
+
 	if base.IsChildOf(known) {
 		// common case: receiving blocks that are building on top of our best tipset
 		return blockSet, nil

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -280,7 +280,7 @@ minerLoop:
 			m.minedBlockHeights.Add(blkKey, true)
 
 			if err := m.api.SyncSubmitBlock(ctx, b); err != nil {
-				log.Errorf("failed to submit newly mined block: %s", err)
+				log.Errorf("failed to submit newly mined block: %+v", err)
 			}
 		} else {
 			base.NullRounds++


### PR DESCRIPTION
If block 1 was a null block then blockSet would include genesis which
would lead to us trying to load parent of a genesis block.

Resolves #4317