### PR TITLE
Expose ClientDealSize via CLI

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -84,6 +84,7 @@ var clientCmd = &cli.Command{
 		WithCategory("data", clientImportCmd),
 		WithCategory("data", clientDropCmd),
 		WithCategory("data", clientLocalCmd),
+		WithCategory("data", clientStat),
 		WithCategory("retrieval", clientFindCmd),
 		WithCategory("retrieval", clientRetrieveCmd),
 		WithCategory("util", clientCommPCmd),
@@ -1634,6 +1635,39 @@ var clientInfoCmd = &cli.Command{
 
 		fmt.Printf("Locked Funds:\t%s\n", types.FIL(balance.Locked))
 		fmt.Printf("Escrowed Funds:\t%s\n", types.FIL(balance.Escrow))
+
+		return nil
+	},
+}
+
+var clientStat = &cli.Command{
+	Name:      "stat",
+	Usage:     "Print information about a locally stored file (piece size, etc)",
+	ArgsUsage: "<cid>",
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := ReqContext(cctx)
+
+		if !cctx.Args().Present() || cctx.NArg() != 1 {
+			return fmt.Errorf("must specify cid of data")
+		}
+
+		dataCid, err := cid.Parse(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("parsing data cid: %w", err)
+		}
+
+		ds, err := api.ClientDealSize(ctx, dataCid)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Piece Size  : %v\n", ds.PieceSize)
+		fmt.Printf("Payload Size: %v\n", ds.PayloadSize)
 
 		return nil
 	},


### PR DESCRIPTION
## Summary
While `ClientDealSize` is exposed via the JSON API, there are some users using the CLI that need this information to create deals (without using interactive deal creation).

```
NAME:
   lotus client deal-size - Calculate size of deal piece

USAGE:
   lotus client deal-size [command options] <cid>
```

### Example output
```
./lotus client deal-size bafykbzaceclbis4au7xmwecpf6k2hy4uv4lpdfkm5tsn2syacn4snm2hzpdnk 
Deal sizes for data cid ...m2hzpdnk
  Piece Size: 134217728
Payload Size: 101920082
```