### PR TITLE
tvx extract: make it work with secp messages.

### DIFF
--- a/cmd/tvx/extract.go
+++ b/cmd/tvx/extract.go
@@ -73,7 +73,7 @@ var extractCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:        "exec-block",
-			Usage:       "optionally, the block CID of a block where this message was executed, to aovid",
+			Usage:       "optionally, the block CID of a block where this message was executed, to avoid expensive chain scanning",
 			Destination: &extractFlags.block,
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Unfortunately `ChainGetMessage` returns a `*types.Message`, which in the case of secp messages is lacking the signature. The signature is part of the input to calculate the CID on secp messages. Therefore, calling `.Cid()` on the result of `ChainGetMessage` for this kind of message will result in an incorrect CID.

tvx was relying on that call to return the correct CID. Since this is not the case (and this is a footgun that needs to be corrected, ideally together with the `*types.{,Signed}Message` duality mess), I'm replacing the comparison.

---

cc @austinabell 