### PR TITLE
update filecoin-ffi in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/go-sysinfo v1.3.0
 	github.com/fatih/color v1.9.0
-	github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200716204036-cddc56607e1d
+	github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f
 	github.com/filecoin-project/go-address v0.0.4
 	github.com/filecoin-project/go-amt-ipld/v2 v2.1.1-0.20201006184820-924ee87a1349 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.1


### PR DESCRIPTION
Currently, the go.mod has an old version of this dependency. 
For this repo isn't a problem since it has a `replace` directive, but for *any* client `go mod tidy` fails.

Minimal way to reproduce the problem now:
```main.go
package main

import (
        "context"
        "github.com/filecoin-project/lotus/api/apistruct"
)

func main() {
        var api apistruct.FullNodeStruct
        _ = api
  }
```

Run `go mod tidy`:
```
go: finding module for package github.com/filecoin-project/specs-actors/actors/abi
github.com/jsign/lotusclientest imports
        github.com/filecoin-project/lotus/api/apistruct imports
        github.com/filecoin-project/go-fil-markets/storagemarket tested by
        github.com/filecoin-project/go-fil-markets/storagemarket.test imports
        github.com/filecoin-project/go-fil-markets/pieceio imports
        github.com/filecoin-project/filecoin-ffi imports
        github.com/filecoin-project/specs-actors/actors/abi: module github.com/filecoin-project/specs-actors@latest found (v0.9.13), but does not contain package github.com/filecoin-project/specs-actors/actors/abi
```
Generated go.mod:
```
module github.com/jsign/lotusclientest

go 1.15

require (
        github.com/filecoin-project/lotus v1.1.2
)
```

In Poweragte I work around this with a `replace`, but other users might not have a clue of how to fix it. Also, if anyone else is using Powergate as a lib they should also `replace` in their go.mod since `replaces` doesn't bubble up modules, which is a bigger problem.

This PR fixes this problem.