### PR TITLE
Do not fail wallet delete because of pre-existing trashed key

### DIFF
--- a/chain/wallet/wallet.go
+++ b/chain/wallet/wallet.go
@@ -283,6 +283,10 @@ func (w *LocalWallet) WalletDelete(ctx context.Context, addr address.Address) er
 	w.lk.Lock()
 	defer w.lk.Unlock()
 
+	if err := w.keystore.Delete(KTrashPrefix + k.Address.String()); err != nil && !xerrors.Is(err, types.ErrKeyInfoNotFound) {
+		return xerrors.Errorf("failed to purge trashed key %s: %w", addr, err)
+	}
+
 	if err := w.keystore.Put(KTrashPrefix+k.Address.String(), k.KeyInfo); err != nil {
 		return xerrors.Errorf("failed to mark key %s as trashed: %w", addr, err)
 	}


### PR DESCRIPTION
Fixes issue #4283

Try deleting 'trash-f3*' key before backing up to-be-deleted wallet key. Ignore ErrKeyInfoNotFound.