### PR TITLE
fix race in paych manager add funds

### DIFF
--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -663,6 +663,7 @@ func TestPaychGetMergeAddFunds(t *testing.T) {
 		defer addFundsSent.Done()
 
 		// Request add funds - should block until create channel has completed
+		var err error
 		addFundsCh1, addFundsMcid1, err = mgr.GetPaych(ctx, from, to, addFundsAmt1)
 		require.NoError(t, err)
 	}()
@@ -671,6 +672,7 @@ func TestPaychGetMergeAddFunds(t *testing.T) {
 		defer addFundsSent.Done()
 
 		// Request add funds again - should merge with waiting add funds request
+		var err error
 		addFundsCh2, addFundsMcid2, err = mgr.GetPaych(ctx, from, to, addFundsAmt2)
 		require.NoError(t, err)
 	}()
@@ -766,6 +768,7 @@ func TestPaychGetMergeAddFundsCtxCancelOne(t *testing.T) {
 		defer addFundsSent.Done()
 
 		// Request add funds again - should merge with waiting add funds request
+		var err error
 		addFundsCh2, addFundsMcid2, err = mgr.GetPaych(ctx, from, to, addFundsAmt2)
 		require.NoError(t, err)
 	}()
@@ -861,7 +864,6 @@ func TestPaychGetMergeAddFundsCtxCancelAll(t *testing.T) {
 
 		// Request add funds again - should merge with waiting add funds request
 		_, _, addFundsErr2 = mgr.GetPaych(addFundsCtx2, from, to, big.NewInt(3))
-		require.NoError(t, err)
 	}()
 	// Wait for add funds requests to be queued up
 	waitForQueueSize(t, mgr, from, to, 2)
@@ -950,6 +952,7 @@ func TestPaychAvailableFunds(t *testing.T) {
 		defer addFundsSent.Done()
 
 		// Request add funds - should block until create channel has completed
+		var err error
 		_, addFundsMcid, err = mgr.GetPaych(ctx, from, to, addFundsAmt)
 		require.NoError(t, err)
 	}()

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -101,10 +101,13 @@ type mergedFundsReq struct {
 
 func newMergedFundsReq(reqs []*fundsReq) *mergedFundsReq {
 	ctx, cancel := context.WithCancel(context.Background())
+
+	rqs := make([]*fundsReq, len(reqs))
+	copy(rqs, reqs)
 	m := &mergedFundsReq{
 		ctx:    ctx,
 		cancel: cancel,
-		reqs:   reqs,
+		reqs:   rqs,
 	}
 
 	for _, r := range m.reqs {
@@ -201,7 +204,7 @@ func (ca *channelAccessor) processQueue(channelID string) (*api.ChannelAvailable
 	// Merge all pending requests into one.
 	// For example if there are pending requests for 3, 2, 4 then
 	// amt = 3 + 2 + 4 = 9
-	merged := newMergedFundsReq(ca.fundsReqQueue[:])
+	merged := newMergedFundsReq(ca.fundsReqQueue)
 	amt := merged.sum()
 	if amt.IsZero() {
 		// Note: The amount can be zero if requests are cancelled as we're


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/lotus/issues/4585

This PR fixes a race in payment channel manager, when a payment request gets cancelled at the same time as a new request is being processed. I believe it also fixes a flaky test: TestPaychGetMergeAddFundsCtxCancelAll