### PR TITLE
refactor: share code between CLI tests

### DIFF
--- a/cli/test/client.go
+++ b/cli/test/client.go
@@ -25,8 +25,8 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	defer cancel()
 
 	// Create mock CLI
-	mockCLI := newMockCLI(t, cmds)
-	clientCLI := mockCLI.client(clientNode.ListenAddr)
+	mockCLI := NewMockCLI(t, cmds)
+	clientCLI := mockCLI.Client(clientNode.ListenAddr)
 
 	// Get the miner address
 	addrs, err := clientNode.StateListMiners(ctx, types.EmptyTSK)
@@ -40,7 +40,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	cmd := []string{
 		"client", "query-ask", minerAddr.String(),
 	}
-	out := clientCLI.runCmd(cmd)
+	out := clientCLI.RunCmd(cmd)
 	require.Regexp(t, regexp.MustCompile("Ask:"), out)
 
 	// Create a deal (non-interactive)
@@ -53,7 +53,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	cmd = []string{
 		"client", "deal", dataCid.String(), minerAddr.String(), price, duration,
 	}
-	out = clientCLI.runCmd(cmd)
+	out = clientCLI.RunCmd(cmd)
 	fmt.Println("client deal", out)
 
 	// Create a deal (interactive)
@@ -77,7 +77,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 		"no",
 		"yes",
 	}
-	out = clientCLI.runInteractiveCmd(cmd, interactiveCmds)
+	out = clientCLI.RunInteractiveCmd(cmd, interactiveCmds)
 	fmt.Println("client deal:\n", out)
 
 	// Wait for provider to start sealing deal
@@ -85,7 +85,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	for dealStatus != "StorageDealSealing" {
 		// client list-deals
 		cmd = []string{"client", "list-deals"}
-		out = clientCLI.runCmd(cmd)
+		out = clientCLI.RunCmd(cmd)
 		fmt.Println("list-deals:\n", out)
 
 		lines := strings.Split(out, "\n")
@@ -109,7 +109,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	cmd = []string{
 		"client", "retrieve", dataCid.String(), path,
 	}
-	out = clientCLI.runCmd(cmd)
+	out = clientCLI.RunCmd(cmd)
 	fmt.Println("retrieve:\n", out)
 	require.Regexp(t, regexp.MustCompile("Success"), out)
 }

--- a/cli/test/client.go
+++ b/cli/test/client.go
@@ -37,10 +37,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	fmt.Println("Miner:", minerAddr)
 
 	// client query-ask <miner addr>
-	cmd := []string{
-		"client", "query-ask", minerAddr.String(),
-	}
-	out := clientCLI.RunCmd(cmd)
+	out := clientCLI.RunCmd("client", "query-ask", minerAddr.String())
 	require.Regexp(t, regexp.MustCompile("Ask:"), out)
 
 	// Create a deal (non-interactive)
@@ -50,10 +47,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	dataCid := res.Root
 	price := "1000000attofil"
 	duration := fmt.Sprintf("%d", build.MinDealDuration)
-	cmd = []string{
-		"client", "deal", dataCid.String(), minerAddr.String(), price, duration,
-	}
-	out = clientCLI.RunCmd(cmd)
+	out = clientCLI.RunCmd("client", "deal", dataCid.String(), minerAddr.String(), price, duration)
 	fmt.Println("client deal", out)
 
 	// Create a deal (interactive)
@@ -67,9 +61,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	require.NoError(t, err)
 	dataCid2 := res.Root
 	duration = fmt.Sprintf("%d", build.MinDealDuration/builtin.EpochsInDay)
-	cmd = []string{
-		"client", "deal",
-	}
+	cmd := []string{"client", "deal"}
 	interactiveCmds := []string{
 		dataCid2.String(),
 		duration,
@@ -84,8 +76,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	dealStatus := ""
 	for dealStatus != "StorageDealSealing" {
 		// client list-deals
-		cmd = []string{"client", "list-deals"}
-		out = clientCLI.RunCmd(cmd)
+		out = clientCLI.RunCmd("client", "list-deals")
 		fmt.Println("list-deals:\n", out)
 
 		lines := strings.Split(out, "\n")
@@ -106,10 +97,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	tmpdir, err := ioutil.TempDir(os.TempDir(), "test-cli-client")
 	require.NoError(t, err)
 	path := filepath.Join(tmpdir, "outfile.dat")
-	cmd = []string{
-		"client", "retrieve", dataCid.String(), path,
-	}
-	out = clientCLI.RunCmd(cmd)
+	out = clientCLI.RunCmd("client", "retrieve", dataCid.String(), path)
 	fmt.Println("retrieve:\n", out)
 	require.Regexp(t, regexp.MustCompile("Success"), out)
 }

--- a/cli/test/mockcli.go
+++ b/cli/test/mockcli.go
@@ -52,22 +52,8 @@ type MockCLIClient struct {
 	out  *bytes.Buffer
 }
 
-func (c *MockCLIClient) run(cmd []string, params []string, args []string) string {
-	// Add parameter --api-url=<node api listener address>
-	apiFlag := "--api-url=" + c.addr.String()
-	params = append([]string{apiFlag}, params...)
-
-	err := c.cctx.App.Run(append(append(cmd, params...), args...))
-	require.NoError(c.t, err)
-
-	// Get the output
-	str := strings.TrimSpace(c.out.String())
-	c.out.Reset()
-	return str
-}
-
-func (c *MockCLIClient) RunCmd(input []string) string {
-	out, err := c.RunCmdRaw(input)
+func (c *MockCLIClient) RunCmd(input ...string) string {
+	out, err := c.RunCmdRaw(input...)
 	require.NoError(c.t, err)
 
 	return out
@@ -102,7 +88,7 @@ func (c *MockCLIClient) findSubcommand(cmd *lcli.Command, input []string) (*lcli
 	return nil, []string{}
 }
 
-func (c *MockCLIClient) RunCmdRaw(input []string) (string, error) {
+func (c *MockCLIClient) RunCmdRaw(input ...string) (string, error) {
 	cmd, input := c.cmdByNameSub(input)
 	if cmd == nil {
 		panic("Could not find command " + input[0] + " " + input[1])
@@ -145,7 +131,7 @@ func (c *MockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
 
 func (c *MockCLIClient) RunInteractiveCmd(cmd []string, interactive []string) string {
 	c.toStdin(strings.Join(interactive, "\n") + "\n")
-	return c.RunCmd(cmd)
+	return c.RunCmd(cmd...)
 }
 
 func (c *MockCLIClient) toStdin(s string) {

--- a/cli/test/mockcli.go
+++ b/cli/test/mockcli.go
@@ -11,14 +11,14 @@ import (
 	lcli "github.com/urfave/cli/v2"
 )
 
-type mockCLI struct {
+type MockCLI struct {
 	t    *testing.T
 	cmds []*lcli.Command
 	cctx *lcli.Context
 	out  *bytes.Buffer
 }
 
-func newMockCLI(t *testing.T, cmds []*lcli.Command) *mockCLI {
+func NewMockCLI(t *testing.T, cmds []*lcli.Command) *MockCLI {
 	// Create a CLI App with an --api-url flag so that we can specify which node
 	// the command should be executed against
 	app := &lcli.App{
@@ -36,15 +36,15 @@ func newMockCLI(t *testing.T, cmds []*lcli.Command) *mockCLI {
 	app.Setup()
 
 	cctx := lcli.NewContext(app, &flag.FlagSet{}, nil)
-	return &mockCLI{t: t, cmds: cmds, cctx: cctx, out: &out}
+	return &MockCLI{t: t, cmds: cmds, cctx: cctx, out: &out}
 }
 
-func (c *mockCLI) client(addr multiaddr.Multiaddr) *mockCLIClient {
-	return &mockCLIClient{t: c.t, cmds: c.cmds, addr: addr, cctx: c.cctx, out: c.out}
+func (c *MockCLI) Client(addr multiaddr.Multiaddr) *MockCLIClient {
+	return &MockCLIClient{t: c.t, cmds: c.cmds, addr: addr, cctx: c.cctx, out: c.out}
 }
 
-// mockCLIClient runs commands against a particular node
-type mockCLIClient struct {
+// MockCLIClient runs commands against a particular node
+type MockCLIClient struct {
 	t    *testing.T
 	cmds []*lcli.Command
 	addr multiaddr.Multiaddr
@@ -52,7 +52,7 @@ type mockCLIClient struct {
 	out  *bytes.Buffer
 }
 
-func (c *mockCLIClient) run(cmd []string, params []string, args []string) string {
+func (c *MockCLIClient) run(cmd []string, params []string, args []string) string {
 	// Add parameter --api-url=<node api listener address>
 	apiFlag := "--api-url=" + c.addr.String()
 	params = append([]string{apiFlag}, params...)
@@ -66,28 +66,48 @@ func (c *mockCLIClient) run(cmd []string, params []string, args []string) string
 	return str
 }
 
-func (c *mockCLIClient) runCmd(input []string) string {
-	cmd := c.cmdByNameSub(input[0], input[1])
-	out, err := c.runCmdRaw(cmd, input[2:])
+func (c *MockCLIClient) RunCmd(input []string) string {
+	out, err := c.RunCmdRaw(input)
 	require.NoError(c.t, err)
 
 	return out
 }
 
-func (c *mockCLIClient) cmdByNameSub(name string, sub string) *lcli.Command {
-	for _, c := range c.cmds {
-		if c.Name == name {
-			for _, s := range c.Subcommands {
-				if s.Name == sub {
-					return s
-				}
-			}
+// Given an input, find the corresponding command or sub-command.
+// eg "paych add-funds"
+func (c *MockCLIClient) cmdByNameSub(input []string) (*lcli.Command, []string) {
+	name := input[0]
+	for _, cmd := range c.cmds {
+		if cmd.Name == name {
+			return c.findSubcommand(cmd, input[1:])
 		}
 	}
-	return nil
+	return nil, []string{}
 }
 
-func (c *mockCLIClient) runCmdRaw(cmd *lcli.Command, input []string) (string, error) {
+func (c *MockCLIClient) findSubcommand(cmd *lcli.Command, input []string) (*lcli.Command, []string) {
+	// If there are no sub-commands, return the current command
+	if len(cmd.Subcommands) == 0 {
+		return cmd, input
+	}
+
+	// Check each sub-command for a match against the name
+	subName := input[0]
+	for _, subCmd := range cmd.Subcommands {
+		if subCmd.Name == subName {
+			// Found a match, recursively search for sub-commands
+			return c.findSubcommand(subCmd, input[1:])
+		}
+	}
+	return nil, []string{}
+}
+
+func (c *MockCLIClient) RunCmdRaw(input []string) (string, error) {
+	cmd, input := c.cmdByNameSub(input)
+	if cmd == nil {
+		panic("Could not find command " + input[0] + " " + input[1])
+	}
+
 	// prepend --api-url=<node api listener address>
 	apiFlag := "--api-url=" + c.addr.String()
 	input = append([]string{apiFlag}, input...)
@@ -104,7 +124,7 @@ func (c *mockCLIClient) runCmdRaw(cmd *lcli.Command, input []string) (string, er
 	return str, err
 }
 
-func (c *mockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
+func (c *MockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
 	// Apply app level flags (so we can process --api-url flag)
 	fs := &flag.FlagSet{}
 	for _, f := range c.cctx.App.Flags {
@@ -123,11 +143,11 @@ func (c *mockCLIClient) flagSet(cmd *lcli.Command) *flag.FlagSet {
 	return fs
 }
 
-func (c *mockCLIClient) runInteractiveCmd(cmd []string, interactive []string) string {
+func (c *MockCLIClient) RunInteractiveCmd(cmd []string, interactive []string) string {
 	c.toStdin(strings.Join(interactive, "\n") + "\n")
-	return c.runCmd(cmd)
+	return c.RunCmd(cmd)
 }
 
-func (c *mockCLIClient) toStdin(s string) {
+func (c *MockCLIClient) toStdin(s string) {
 	c.cctx.App.Metadata["stdin"] = bytes.NewBufferString(s)
 }

--- a/cli/test/multisig.go
+++ b/cli/test/multisig.go
@@ -18,8 +18,8 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 	ctx := context.Background()
 
 	// Create mock CLI
-	mockCLI := newMockCLI(t, cmds)
-	clientCLI := mockCLI.client(clientNode.ListenAddr)
+	mockCLI := NewMockCLI(t, cmds)
+	clientCLI := mockCLI.Client(clientNode.ListenAddr)
 
 	// Create some wallets on the node to use for testing multisig
 	var walletAddrs []address.Address
@@ -48,7 +48,7 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 		walletAddrs[1].String(),
 		walletAddrs[2].String(),
 	}
-	out := clientCLI.runCmd(cmd)
+	out := clientCLI.RunCmd(cmd)
 	fmt.Println(out)
 
 	// Extract msig robust address from output
@@ -68,12 +68,12 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 		msigRobustAddr,
 		walletAddrs[3].String(),
 	}
-	out = clientCLI.runCmd(cmd)
+	out = clientCLI.RunCmd(cmd)
 	fmt.Println(out)
 
 	// msig inspect <msig>
 	cmd = []string{"msig", "inspect", "--vesting", "--decode-params", msigRobustAddr}
-	out = clientCLI.runCmd(cmd)
+	out = clientCLI.RunCmd(cmd)
 	fmt.Println(out)
 
 	// Expect correct balance
@@ -96,6 +96,6 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 		walletAddrs[3].String(),
 		"false",
 	}
-	out = clientCLI.runCmd(cmd)
+	out = clientCLI.RunCmd(cmd)
 	fmt.Println(out)
 }

--- a/cli/test/multisig.go
+++ b/cli/test/multisig.go
@@ -39,7 +39,7 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 	paramDuration := "--duration=50"
 	paramRequired := fmt.Sprintf("--required=%d", threshold)
 	paramValue := fmt.Sprintf("--value=%dattofil", amtAtto)
-	cmd := []string{
+	out := clientCLI.RunCmd(
 		"msig", "create",
 		paramRequired,
 		paramDuration,
@@ -47,8 +47,7 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 		walletAddrs[0].String(),
 		walletAddrs[1].String(),
 		walletAddrs[2].String(),
-	}
-	out := clientCLI.RunCmd(cmd)
+	)
 	fmt.Println(out)
 
 	// Extract msig robust address from output
@@ -62,18 +61,16 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 	// Propose to add a new address to the msig
 	// msig add-propose --from=<addr> <msig> <addr>
 	paramFrom := fmt.Sprintf("--from=%s", walletAddrs[0])
-	cmd = []string{
+	out = clientCLI.RunCmd(
 		"msig", "add-propose",
 		paramFrom,
 		msigRobustAddr,
 		walletAddrs[3].String(),
-	}
-	out = clientCLI.RunCmd(cmd)
+	)
 	fmt.Println(out)
 
 	// msig inspect <msig>
-	cmd = []string{"msig", "inspect", "--vesting", "--decode-params", msigRobustAddr}
-	out = clientCLI.RunCmd(cmd)
+	out = clientCLI.RunCmd("msig", "inspect", "--vesting", "--decode-params", msigRobustAddr)
 	fmt.Println(out)
 
 	// Expect correct balance
@@ -87,7 +84,7 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 	// msig add-approve --from=<addr> <msig> <addr> 0 <addr> false
 	txnID := "0"
 	paramFrom = fmt.Sprintf("--from=%s", walletAddrs[1])
-	cmd = []string{
+	out = clientCLI.RunCmd(
 		"msig", "add-approve",
 		paramFrom,
 		msigRobustAddr,
@@ -95,7 +92,6 @@ func RunMultisigTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNod
 		txnID,
 		walletAddrs[3].String(),
 		"false",
-	}
-	out = clientCLI.RunCmd(cmd)
+	)
 	fmt.Println(out)
 }

--- a/cli/test/net.go
+++ b/cli/test/net.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/types"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api/test"
 	test2 "github.com/filecoin-project/lotus/node/test"
@@ -38,4 +41,47 @@ func StartOneNodeOneMiner(ctx context.Context, t *testing.T, blocktime time.Dura
 
 	// Create mock CLI
 	return full, fullAddr
+}
+
+func StartTwoNodesOneMiner(ctx context.Context, t *testing.T, blocktime time.Duration) ([]test.TestNode, []address.Address) {
+	n, sn := test2.RPCMockSbBuilder(t, test.TwoFull, test.OneMiner)
+
+	fullNode1 := n[0]
+	fullNode2 := n[1]
+	miner := sn[0]
+
+	// Get everyone connected
+	addrs, err := fullNode1.NetAddrsListen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fullNode2.NetConnect(ctx, addrs); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := miner.NetConnect(ctx, addrs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start mining blocks
+	bm := test.NewBlockMiner(ctx, t, miner, blocktime)
+	bm.MineBlocks()
+
+	// Send some funds to register the second node
+	fullNodeAddr2, err := fullNode2.WalletNew(ctx, types.KTSecp256k1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test.SendFunds(ctx, t, fullNode1, fullNodeAddr2, abi.NewTokenAmount(1e18))
+
+	// Get the first node's address
+	fullNodeAddr1, err := fullNode1.WalletDefaultAddress(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock CLI
+	return n, []address.Address{fullNodeAddr1, fullNodeAddr2}
 }


### PR DESCRIPTION
Just takes care of some tech-debt, no changes to non-test code.

This PR removes some duplicate code from the payment channels CLI tests.