### PR TITLE
extern/sector-storage: fix GPU usage overwrite bug

### DIFF
--- a/extern/sector-storage/sched_resources.go
+++ b/extern/sector-storage/sched_resources.go
@@ -27,7 +27,9 @@ func (a *activeResources) withResources(id WorkerID, wr storiface.WorkerResource
 }
 
 func (a *activeResources) add(wr storiface.WorkerResources, r Resources) {
-	a.gpuUsed = r.CanGPU
+	if r.CanGPU {
+		a.gpuUsed = true
+	}
 	a.cpuUse += r.Threads(wr.CPUs)
 	a.memUsedMin += r.MinMemory
 	a.memUsedMax += r.MaxMemory


### PR DESCRIPTION
GPU tracking currently is a bit broken on master because each subsequently scheduled task blindly overwrites the flag, irrelevant of what its current value is. E.g.:

- Schedule C2, mark GPU as used
- Schedule PC1, mark GPU as unused (blindly overwrite)
- Schedule C2, mark GPU as used (double usage allocated)

The second C2 should not have been permitted to be allocated onto the same GPU, but since PC1 blindly overwritten the flag, a second C2 becomes schedulable. Repeat until the GPU is overloaded and starts going OOM (PC2 cannot recover from it).

The fix is that tasks should only set the flag if they themselves requested the GPU (and have been granted). If they didn't request the GPU, they should most definitely not set the GPU as unused.

---

Funky caveat: On my system at least, overlapping GPU allocation results in better resource use because I can run multiple PC2 or PC2+C2 on the same GPU. This fix will actually prevent that, but IMHO it's nonetheless necessary because a better GPU scheduling can't be written as long as tasks can exceed the available video RAM and crash.