### PR TITLE
make IPFS online mode configurable

### DIFF
--- a/lib/ipfsbstore/ipfsbstore.go
+++ b/lib/ipfsbstore/ipfsbstore.go
@@ -25,12 +25,12 @@ type IpfsBstore struct {
 	api iface.CoreAPI
 }
 
-func NewIpfsBstore(ctx context.Context) (*IpfsBstore, error) {
+func NewIpfsBstore(ctx context.Context, onlineMode bool) (*IpfsBstore, error) {
 	localApi, err := httpapi.NewLocalApi()
 	if err != nil {
 		return nil, xerrors.Errorf("getting local ipfs api: %w", err)
 	}
-	api, err := localApi.WithOptions(options.Api.Offline(true))
+	api, err := localApi.WithOptions(options.Api.Offline(!onlineMode))
 	if err != nil {
 		return nil, xerrors.Errorf("setting offline mode: %s", err)
 	}
@@ -41,12 +41,12 @@ func NewIpfsBstore(ctx context.Context) (*IpfsBstore, error) {
 	}, nil
 }
 
-func NewRemoteIpfsBstore(ctx context.Context, maddr multiaddr.Multiaddr) (*IpfsBstore, error) {
+func NewRemoteIpfsBstore(ctx context.Context, maddr multiaddr.Multiaddr, onlineMode bool) (*IpfsBstore, error) {
 	httpApi, err := httpapi.NewApi(maddr)
 	if err != nil {
 		return nil, xerrors.Errorf("setting remote ipfs api: %w", err)
 	}
-	api, err := httpApi.WithOptions(options.Api.Offline(true))
+	api, err := httpApi.WithOptions(options.Api.Offline(!onlineMode))
 	if err != nil {
 		return nil, xerrors.Errorf("applying offline mode: %s", err)
 	}

--- a/node/builder.go
+++ b/node/builder.go
@@ -452,7 +452,7 @@ func ConfigFullNode(c interface{}) Option {
 	return Options(
 		ConfigCommon(&cfg.Common),
 		If(cfg.Client.UseIpfs,
-			Override(new(dtypes.ClientBlockstore), modules.IpfsClientBlockstore(ipfsMaddr)),
+			Override(new(dtypes.ClientBlockstore), modules.IpfsClientBlockstore(ipfsMaddr, cfg.Client.IpfsOnlineMode)),
 			If(cfg.Client.IpfsUseForRetrieval,
 				Override(new(dtypes.ClientRetrievalStoreManager), modules.ClientBlockstoreRetrievalStoreManager),
 			),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -105,6 +105,7 @@ type Metrics struct {
 
 type Client struct {
 	UseIpfs             bool
+	IpfsOnlineMode      bool
 	IpfsMAddr           string
 	IpfsUseForRetrieval bool
 }

--- a/node/modules/ipfsclient.go
+++ b/node/modules/ipfsclient.go
@@ -16,7 +16,7 @@ import (
 // If ipfsMaddr is empty, a local IPFS node is assumed considering IPFS_PATH configuration.
 // If ipfsMaddr is not empty, it will connect to the remote IPFS node with the provided multiaddress.
 // The flag useForRetrieval indicates if the IPFS node will also be used for storing retrieving deals.
-func IpfsClientBlockstore(ipfsMaddr string) func(helpers.MetricsCtx, fx.Lifecycle, dtypes.ClientImportMgr) (dtypes.ClientBlockstore, error) {
+func IpfsClientBlockstore(ipfsMaddr string, onlineMode bool) func(helpers.MetricsCtx, fx.Lifecycle, dtypes.ClientImportMgr) (dtypes.ClientBlockstore, error) {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, localStore dtypes.ClientImportMgr) (dtypes.ClientBlockstore, error) {
 		var err error
 		var ipfsbs blockstore.Blockstore
@@ -26,9 +26,9 @@ func IpfsClientBlockstore(ipfsMaddr string) func(helpers.MetricsCtx, fx.Lifecycl
 			if err != nil {
 				return nil, xerrors.Errorf("parsing ipfs multiaddr: %w", err)
 			}
-			ipfsbs, err = ipfsbstore.NewRemoteIpfsBstore(helpers.LifecycleCtx(mctx, lc), ma)
+			ipfsbs, err = ipfsbstore.NewRemoteIpfsBstore(helpers.LifecycleCtx(mctx, lc), ma, onlineMode)
 		} else {
-			ipfsbs, err = ipfsbstore.NewIpfsBstore(helpers.LifecycleCtx(mctx, lc))
+			ipfsbs, err = ipfsbstore.NewIpfsBstore(helpers.LifecycleCtx(mctx, lc), onlineMode)
 		}
 		if err != nil {
 			return nil, xerrors.Errorf("constructing ipfs blockstore: %w", err)


### PR DESCRIPTION
We have a particular deployment in which the IPFS node connected to Lotus should discover data using other IPFS nodes connected in the same network.

Make the offline mode in the underlying blockstore configurable, keeping the offline default value being the same as before.

Correct configuration for this:
```
...
[Client]
UseIpfs = true
IpfsOnlineMode = true
...
```