### PR TITLE
Check (pre)commit receipt before other checks in failed states

### DIFF
--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -106,6 +106,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	),
 	PreCommitFailed: planOne(
 		on(SectorRetryPreCommit{}, PreCommitting),
+		on(SectorRetryPreCommitWait{}, PreCommitWait),
 		on(SectorRetryWaitSeed{}, WaitSeed),
 		on(SectorSealPreCommit1Failed{}, SealPreCommit1Failed),
 		on(SectorPreCommitLanded{}, WaitSeed),
@@ -125,6 +126,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 		on(SectorChainPreCommitFailed{}, PreCommitFailed),
 		on(SectorRetryPreCommit{}, PreCommitting),
 		on(SectorRetryCommitWait{}, CommitWait),
+		on(SectorRetrySubmitCommit{}, SubmitCommit),
 		on(SectorDealsExpired{}, DealsExpired),
 		on(SectorInvalidDealIDs{}, RecoverDealIDs),
 		on(SectorTicketExpired{}, Removing),

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -77,6 +77,34 @@ func (m *Sealing) handlePreCommitFailed(ctx statemachine.Context, sector SectorI
 		return nil
 	}
 
+	if sector.PreCommitMessage != nil {
+		mw, err := m.api.StateSearchMsg(ctx.Context(), *sector.PreCommitMessage)
+		if err != nil {
+			// API error
+			if err := failedCooldown(ctx, sector); err != nil {
+				return err
+			}
+
+			return ctx.Send(SectorRetryPreCommitWait{})
+		}
+
+		if mw == nil {
+			// API error in precommit
+			return ctx.Send(SectorRetryPreCommitWait{})
+		}
+
+		switch mw.Receipt.ExitCode {
+		case exitcode.Ok:
+			// API error in PreCommitWait
+			return ctx.Send(SectorRetryPreCommitWait{})
+		case exitcode.SysErrOutOfGas:
+			// API error in PreCommitWait AND gas estimator guessed a wrong number in PreCommit
+			return ctx.Send(SectorRetryPreCommit{})
+		default:
+			// something else went wrong
+		}
+	}
+
 	if err := checkPrecommit(ctx.Context(), m.Address(), sector, tok, height, m.api); err != nil {
 		switch err.(type) {
 		case *ErrApi:
@@ -158,6 +186,34 @@ func (m *Sealing) handleCommitFailed(ctx statemachine.Context, sector SectorInfo
 	if err != nil {
 		log.Errorf("handleCommitting: api error, not proceeding: %+v", err)
 		return nil
+	}
+
+	if sector.CommitMessage != nil {
+		mw, err := m.api.StateSearchMsg(ctx.Context(), *sector.CommitMessage)
+		if err != nil {
+			// API error
+			if err := failedCooldown(ctx, sector); err != nil {
+				return err
+			}
+
+			return ctx.Send(SectorRetryCommitWait{})
+		}
+
+		if mw == nil {
+			// API error in commit
+			return ctx.Send(SectorRetryCommitWait{})
+		}
+
+		switch mw.Receipt.ExitCode {
+		case exitcode.Ok:
+			// API error in CcommitWait
+			return ctx.Send(SectorRetryCommitWait{})
+		case exitcode.SysErrOutOfGas:
+			// API error in CommitWait AND gas estimator guessed a wrong number in SubmitCommit
+			return ctx.Send(SectorRetrySubmitCommit{})
+		default:
+			// something else went wrong
+		}
 	}
 
 	if err := checkPrecommit(ctx.Context(), m.maddr, sector, tok, height, m.api); err != nil {


### PR DESCRIPTION
If we don't do this, we can end up noticing things like deals being expired, and throw the sector away even though the sector got committed just fine