### PR TITLE
storage: Track worker hostnames with work

### DIFF
--- a/cmd/lotus-storage-miner/sealing.go
+++ b/cmd/lotus-storage-miner/sealing.go
@@ -187,10 +187,12 @@ var sealingJobsCmd = &cli.Command{
 
 		for _, l := range lines {
 			state := "running"
-			if l.RunWait > 0 {
+			switch {
+			case l.RunWait > 0:
 				state = fmt.Sprintf("assigned(%d)", l.RunWait-1)
-			}
-			if l.RunWait == -1 {
+			case l.RunWait == -2:
+				state = "returned"
+			case l.RunWait == -1:
 				state = "ret-wait"
 			}
 			dur := "n/a"

--- a/cmd/lotus-storage-miner/sealing.go
+++ b/cmd/lotus-storage-miner/sealing.go
@@ -198,11 +198,16 @@ var sealingJobsCmd = &cli.Command{
 				dur = time.Now().Sub(l.Start).Truncate(time.Millisecond * 100).String()
 			}
 
+			hostname, ok := workerHostnames[l.wid]
+			if !ok {
+				hostname = l.Hostname
+			}
+
 			_, _ = fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
 				hex.EncodeToString(l.ID.ID[10:]),
 				l.Sector.Number,
 				hex.EncodeToString(l.wid[5:]),
-				workerHostnames[l.wid],
+				hostname,
 				l.Task.Short(),
 				state,
 				dur)

--- a/cmd/lotus-storage-miner/sealing.go
+++ b/cmd/lotus-storage-miner/sealing.go
@@ -190,9 +190,11 @@ var sealingJobsCmd = &cli.Command{
 			switch {
 			case l.RunWait > 0:
 				state = fmt.Sprintf("assigned(%d)", l.RunWait-1)
-			case l.RunWait == -2:
+			case l.RunWait == storiface.RWRetDone:
+				state = "ret-done"
+			case l.RunWait == storiface.RWReturned:
 				state = "returned"
-			case l.RunWait == -1:
+			case l.RunWait == storiface.RWRetWait:
 				state = "ret-wait"
 			}
 			dur := "n/a"

--- a/extern/sector-storage/cbor_gen.go
+++ b/extern/sector-storage/cbor_gen.go
@@ -199,7 +199,7 @@ func (t *WorkState) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{164}); err != nil {
+	if _, err := w.Write([]byte{166}); err != nil {
 		return err
 	}
 
@@ -282,6 +282,51 @@ func (t *WorkState) MarshalCBOR(w io.Writer) error {
 	if _, err := io.WriteString(w, string(t.WorkError)); err != nil {
 		return err
 	}
+
+	// t.WorkerHostname (string) (string)
+	if len("WorkerHostname") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"WorkerHostname\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("WorkerHostname"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("WorkerHostname")); err != nil {
+		return err
+	}
+
+	if len(t.WorkerHostname) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.WorkerHostname was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.WorkerHostname))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.WorkerHostname)); err != nil {
+		return err
+	}
+
+	// t.StartTime (int64) (int64)
+	if len("StartTime") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"StartTime\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StartTime"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("StartTime")); err != nil {
+		return err
+	}
+
+	if t.StartTime >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.StartTime)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.StartTime-1)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -359,6 +404,43 @@ func (t *WorkState) UnmarshalCBOR(r io.Reader) error {
 				}
 
 				t.WorkError = string(sval)
+			}
+			// t.WorkerHostname (string) (string)
+		case "WorkerHostname":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.WorkerHostname = string(sval)
+			}
+			// t.StartTime (int64) (int64)
+		case "StartTime":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.StartTime = int64(extraI)
 			}
 
 		default:

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -383,7 +383,7 @@ func (m *Manager) SealPreCommit1(ctx context.Context, sector abi.SectorID, ticke
 	selector := newAllocSelector(m.index, storiface.FTCache|storiface.FTSealed, storiface.PathSealing)
 
 	err = m.sched.Schedule(ctx, sector, sealtasks.TTPreCommit1, selector, m.schedFetch(sector, storiface.FTUnsealed, storiface.PathSealing, storiface.AcquireMove), func(ctx context.Context, w Worker) error {
-		err := m.startWork(ctx, wk)(w.SealPreCommit1(ctx, sector, ticket, pieces))
+		err := m.startWork(ctx, w, wk)(w.SealPreCommit1(ctx, sector, ticket, pieces))
 		if err != nil {
 			return err
 		}
@@ -430,7 +430,7 @@ func (m *Manager) SealPreCommit2(ctx context.Context, sector abi.SectorID, phase
 	selector := newExistingSelector(m.index, sector, storiface.FTCache|storiface.FTSealed, true)
 
 	err = m.sched.Schedule(ctx, sector, sealtasks.TTPreCommit2, selector, m.schedFetch(sector, storiface.FTCache|storiface.FTSealed, storiface.PathSealing, storiface.AcquireMove), func(ctx context.Context, w Worker) error {
-		err := m.startWork(ctx, wk)(w.SealPreCommit2(ctx, sector, phase1Out))
+		err := m.startWork(ctx, w, wk)(w.SealPreCommit2(ctx, sector, phase1Out))
 		if err != nil {
 			return err
 		}
@@ -480,7 +480,7 @@ func (m *Manager) SealCommit1(ctx context.Context, sector abi.SectorID, ticket a
 	selector := newExistingSelector(m.index, sector, storiface.FTCache|storiface.FTSealed, false)
 
 	err = m.sched.Schedule(ctx, sector, sealtasks.TTCommit1, selector, m.schedFetch(sector, storiface.FTCache|storiface.FTSealed, storiface.PathSealing, storiface.AcquireMove), func(ctx context.Context, w Worker) error {
-		err := m.startWork(ctx, wk)(w.SealCommit1(ctx, sector, ticket, seed, pieces, cids))
+		err := m.startWork(ctx, w, wk)(w.SealCommit1(ctx, sector, ticket, seed, pieces, cids))
 		if err != nil {
 			return err
 		}
@@ -520,7 +520,7 @@ func (m *Manager) SealCommit2(ctx context.Context, sector abi.SectorID, phase1Ou
 	selector := newTaskSelector()
 
 	err = m.sched.Schedule(ctx, sector, sealtasks.TTCommit2, selector, schedNop, func(ctx context.Context, w Worker) error {
-		err := m.startWork(ctx, wk)(w.SealCommit2(ctx, sector, phase1Out))
+		err := m.startWork(ctx, w, wk)(w.SealCommit2(ctx, sector, phase1Out))
 		if err != nil {
 			return err
 		}

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -67,12 +67,18 @@ func (m *Manager) WorkerJobs() map[uuid.UUID][]storiface.WorkerJob {
 			continue
 		}
 
+		var ws WorkState
+		if err := m.work.Get(work).Get(&ws); err != nil {
+			log.Errorf("WorkerJobs: get work %s: %+v", work, err)
+		}
+
 		out[uuid.UUID{}] = append(out[uuid.UUID{}], storiface.WorkerJob{
-			ID:      id,
-			Sector:  id.Sector,
-			Task:    work.Method,
-			RunWait: -1,
-			Start:   time.Time{},
+			ID:       id,
+			Sector:   id.Sector,
+			Task:     work.Method,
+			RunWait:  -1,
+			Start:    time.Unix(ws.StartTime, 0),
+			Hostname: ws.WorkerHostname,
 		})
 	}
 

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -72,11 +72,16 @@ func (m *Manager) WorkerJobs() map[uuid.UUID][]storiface.WorkerJob {
 			log.Errorf("WorkerJobs: get work %s: %+v", work, err)
 		}
 
+		wait := -1
+		if _, ok := m.results[work]; ok {
+			wait = -2 // mark as returned instead of ret-wait
+		}
+
 		out[uuid.UUID{}] = append(out[uuid.UUID{}], storiface.WorkerJob{
 			ID:       id,
 			Sector:   id.Sector,
 			Task:     work.Method,
-			RunWait:  -1,
+			RunWait:  wait,
 			Start:    time.Unix(ws.StartTime, 0),
 			Hostname: ws.WorkerHostname,
 		})

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -72,9 +72,12 @@ func (m *Manager) WorkerJobs() map[uuid.UUID][]storiface.WorkerJob {
 			log.Errorf("WorkerJobs: get work %s: %+v", work, err)
 		}
 
-		wait := -1
+		wait := storiface.RWRetWait
 		if _, ok := m.results[work]; ok {
-			wait = -2 // mark as returned instead of ret-wait
+			wait = storiface.RWReturned
+		}
+		if ws.Status == wsDone {
+			wait = storiface.RWRetDone
 		}
 
 		out[uuid.UUID{}] = append(out[uuid.UUID{}], storiface.WorkerJob{

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -41,12 +41,23 @@ type WorkerStats struct {
 	CpuUse     uint64 // nolint
 }
 
+const (
+	RWRetWait  = -1
+	RWReturned = -2
+	RWRetDone  = -3
+)
+
 type WorkerJob struct {
 	ID     CallID
 	Sector abi.SectorID
 	Task   sealtasks.TaskType
 
-	RunWait int // -2 - returned, -1 - ret-wait, 0 - running, 1+ - assigned
+	// 1+ - assigned
+	// 0  - running
+	// -1 - ret-wait
+	// -2 - returned
+	// -3 - ret-done
+	RunWait int
 	Start   time.Time
 
 	Hostname string `json:",omitempty"` // optional, set for ret-wait jobs

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -48,6 +48,8 @@ type WorkerJob struct {
 
 	RunWait int // -1 - ret-wait, 0 - running, 1+ - assigned
 	Start   time.Time
+
+	Hostname string `json:",omitempty"` // optional, set for ret-wait jobs
 }
 
 type CallID struct {

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -46,7 +46,7 @@ type WorkerJob struct {
 	Sector abi.SectorID
 	Task   sealtasks.TaskType
 
-	RunWait int // -1 - ret-wait, 0 - running, 1+ - assigned
+	RunWait int // -2 - returned, -1 - ret-wait, 0 - running, 1+ - assigned
 	Start   time.Time
 
 	Hostname string `json:",omitempty"` // optional, set for ret-wait jobs


### PR DESCRIPTION
This PR adds a bunch of info to work metadata, also fixes one edge-case around returning abandoned tasks (part 1/2 of dealing with the ret-wait issues)

TODO:
- [x] Test on a real node

(part 2 will be an 'abort' command to cleanup ret-wait tasks which can't really be cleaned up automatically, after things like nuking worker directories)