### PR TITLE
async connect to bootstrappers

### DIFF
--- a/lib/peermgr/peermgr.go
+++ b/lib/peermgr/peermgr.go
@@ -196,8 +196,6 @@ func (pmgr *PeerMgr) doExpand(ctx context.Context) {
 			wg.Add(1)
 			go func(bsp peer.AddrInfo) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-				defer cancel()
 				if err := pmgr.h.Connect(ctx, bsp); err != nil {
 					log.Warnf("failed to connect to bootstrap peer: %s", err)
 				}

--- a/lib/peermgr/peermgr.go
+++ b/lib/peermgr/peermgr.go
@@ -191,11 +191,19 @@ func (pmgr *PeerMgr) doExpand(ctx context.Context) {
 		}
 
 		log.Info("connecting to bootstrap peers")
+		wg := sync.WaitGroup{}
 		for _, bsp := range pmgr.bootstrappers {
-			if err := pmgr.h.Connect(ctx, bsp); err != nil {
-				log.Warnf("failed to connect to bootstrap peer: %s", err)
-			}
+			wg.Add(1)
+			go func(bsp peer.AddrInfo) {
+				defer wg.Done()
+				ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+				defer cancel()
+				if err := pmgr.h.Connect(ctx, bsp); err != nil {
+					log.Warnf("failed to connect to bootstrap peer: %s", err)
+				}
+			}(bsp)
 		}
+		wg.Wait()
 		return
 	}
 


### PR DESCRIPTION
If the connection of the first bootstrap peer times out, the others cannot be connected.

![1](https://user-images.githubusercontent.com/7932644/98655320-4aa14f80-237a-11eb-9411-226657ad7554.png)

This can solve this problem and make the connection faster.