### PR TITLE
cmd sectors commitIDs len debug

### DIFF
--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -210,7 +210,7 @@ var sectorsListCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		commitedIDs := make(map[abi.SectorNumber]struct{}, len(activeSet))
+		commitedIDs := make(map[abi.SectorNumber]struct{}, len(sset))
 		for _, info := range sset {
 			commitedIDs[info.SectorNumber] = struct{}{}
 		}


### PR DESCRIPTION
activeSet should be sset
https://github.com/filecoin-project/lotus/blob/3ec25cbece63d929a8ea06b3572e429393e47f54/cmd/lotus-storage-miner/sectors.go#L213-L215