### PR TITLE
Fix race in paych manager when req context is cancelled

### DIFF
--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -36,8 +36,6 @@ type fundsReq struct {
 	lk sync.Mutex
 	// merge parent, if this req is part of a merge
 	merge *mergedFundsReq
-	// whether the req's context has been cancelled
-	active bool
 }
 
 func newFundsReq(ctx context.Context, amt types.BigInt) *fundsReq {
@@ -46,7 +44,6 @@ func newFundsReq(ctx context.Context, amt types.BigInt) *fundsReq {
 		ctx:     ctx,
 		promise: promise,
 		amt:     amt,
-		active:  true,
 	}
 }
 
@@ -61,25 +58,18 @@ func (r *fundsReq) onComplete(res *paychFundsRes) {
 // cancel is called when the req's context is cancelled
 func (r *fundsReq) cancel() {
 	r.lk.Lock()
-
-	r.active = false
-	m := r.merge
-
-	r.lk.Unlock()
+	defer r.lk.Unlock()
 
 	// If there's a merge parent, tell the merge parent to check if it has any
 	// active reqs left
-	if m != nil {
-		m.checkActive()
+	if r.merge != nil {
+		r.merge.checkActive()
 	}
 }
 
 // isActive indicates whether the req's context has been cancelled
 func (r *fundsReq) isActive() bool {
-	r.lk.Lock()
-	defer r.lk.Unlock()
-
-	return r.active
+	return r.ctx.Err() == nil
 }
 
 // setMergeParent sets the merge that this req is part of


### PR DESCRIPTION
This doesn't cause a problem in practice but did cause some test flakiness

Fixes https://github.com/filecoin-project/lotus/issues/4800