### PR TITLE
Fix: dont crash on startup if funds migration fails

### DIFF
--- a/node/modules/client.go
+++ b/node/modules/client.go
@@ -55,16 +55,20 @@ func HandleMigrateClientFunds(lc fx.Lifecycle, ds dtypes.MetadataDS, wallet full
 				if xerrors.Is(err, datastore.ErrNotFound) {
 					return nil
 				}
-				return err
+				log.Errorf("client funds migration - getting datastore value: %w", err)
+				return nil
 			}
 
 			var value abi.TokenAmount
 			if err = value.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
-				return err
+				log.Errorf("client funds migration - unmarshalling datastore value: %w", err)
+				return nil
 			}
 			_, err = fundMgr.Reserve(ctx, addr, addr, value)
 			if err != nil {
-				return err
+				log.Errorf("client funds migration - reserving funds (wallet %s, addr %s, funds %d): %w",
+					addr, addr, value, err)
+				return nil
 			}
 
 			return ds.Delete(datastore.NewKey("/marketfunds/client"))

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -263,17 +263,21 @@ func HandleMigrateProviderFunds(lc fx.Lifecycle, ds dtypes.MetadataDS, node api.
 			}
 			ts, err := node.ChainHead(ctx)
 			if err != nil {
-				return err
+				log.Errorf("provider funds migration - getting chain head: %w", err)
+				return nil
 			}
 
 			mi, err := node.StateMinerInfo(ctx, address.Address(minerAddress), ts.Key())
 			if err != nil {
-				return err
+				log.Errorf("provider funds migration - getting miner info %s: %w", minerAddress, err)
+				return nil
 			}
 
 			_, err = node.MarketReserveFunds(ctx, mi.Worker, address.Address(minerAddress), value)
 			if err != nil {
-				return err
+				log.Errorf("provider funds migration - reserving funds (wallet %s, addr %s, funds %d): %w",
+					mi.Worker, minerAddress, value, err)
+				return nil
 			}
 
 			return ds.Delete(datastore.NewKey("/marketfunds/provider"))


### PR DESCRIPTION
Don't crash on startup if funds migration fails.

I'm not 100% sure this is what we want to do. It may cause some in-progress deals to fail, but is probably better than crashing.

_Edit: The correct solution here is probably for the migration to subtract the amount of completed / failed deals from the reserved amount_