### PR TITLE
Truncate genesis file before generating

### DIFF
--- a/node/modules/testing/genesis.go
+++ b/node/modules/testing/genesis.go
@@ -81,7 +81,7 @@ func MakeGenesis(outFile, genesisTemplate string) func(bs dtypes.ChainBlockstore
 
 			fmt.Printf("GENESIS MINER ADDRESS: t0%d\n", genesis2.MinerStart)
 
-			f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
When running the daemon for a devnet it generates a genesis file.
But if there is already a genesis file from a previous run the new genesis file is corrupted, preventing restarts.
This PR truncates the genesis file before generation.