### PR TITLE
Modify vesting schedule post-calico

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -72,13 +72,17 @@ type StateManager struct {
 	// ErrExpensiveFork.
 	expensiveUpgrades map[abi.ChainEpoch]struct{}
 
-	stCache              map[string][]cid.Cid
-	compWait             map[string]chan struct{}
-	stlk                 sync.Mutex
-	genesisMsigLk        sync.Mutex
-	newVM                func(context.Context, *vm.VMOpts) (*vm.VM, error)
-	preIgnitionGenInfos  *genesisInfo
-	postIgnitionGenInfos *genesisInfo
+	stCache             map[string][]cid.Cid
+	compWait            map[string]chan struct{}
+	stlk                sync.Mutex
+	genesisMsigLk       sync.Mutex
+	newVM               func(context.Context, *vm.VMOpts) (*vm.VM, error)
+	preIgnitionVesting  []msig0.State
+	postIgnitionVesting []msig0.State
+	postCalicoVesting   []msig0.State
+
+	genesisPledge      abi.TokenAmount
+	genesisMarketFunds abi.TokenAmount
 }
 
 func NewStateManager(cs *store.ChainStore) *StateManager {
@@ -889,23 +893,8 @@ func (sm *StateManager) SetVMConstructor(nvm func(context.Context, *vm.VMOpts) (
 	sm.newVM = nvm
 }
 
-type genesisInfo struct {
-	genesisMsigs []msig0.State
-	// info about the Accounts in the genesis state
-	genesisActors      []genesisActor
-	genesisPledge      abi.TokenAmount
-	genesisMarketFunds abi.TokenAmount
-}
-
-type genesisActor struct {
-	addr    address.Address
-	initBal abi.TokenAmount
-}
-
-// sets up information about the actors in the genesis state
-func (sm *StateManager) setupGenesisActors(ctx context.Context) error {
-
-	gi := genesisInfo{}
+// sets up information about the vesting schedule
+func (sm *StateManager) setupGenesisVestingSchedule(ctx context.Context) error {
 
 	gb, err := sm.cs.GetGenesis()
 	if err != nil {
@@ -928,127 +917,18 @@ func (sm *StateManager) setupGenesisActors(ctx context.Context) error {
 		return xerrors.Errorf("loading state tree: %w", err)
 	}
 
-	gi.genesisMarketFunds, err = getFilMarketLocked(ctx, sTree)
+	gmf, err := getFilMarketLocked(ctx, sTree)
 	if err != nil {
 		return xerrors.Errorf("setting up genesis market funds: %w", err)
 	}
 
-	gi.genesisPledge, err = getFilPowerLocked(ctx, sTree)
+	gp, err := getFilPowerLocked(ctx, sTree)
 	if err != nil {
 		return xerrors.Errorf("setting up genesis pledge: %w", err)
 	}
 
-	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
-	err = sTree.ForEach(func(kaddr address.Address, act *types.Actor) error {
-		if builtin.IsMultisigActor(act.Code) {
-			s, err := multisig.Load(sm.cs.Store(ctx), act)
-			if err != nil {
-				return err
-			}
-
-			se, err := s.StartEpoch()
-			if err != nil {
-				return err
-			}
-
-			if se != 0 {
-				return xerrors.New("genesis multisig doesn't start vesting at epoch 0!")
-			}
-
-			ud, err := s.UnlockDuration()
-			if err != nil {
-				return err
-			}
-
-			ib, err := s.InitialBalance()
-			if err != nil {
-				return err
-			}
-
-			ot, f := totalsByEpoch[ud]
-			if f {
-				totalsByEpoch[ud] = big.Add(ot, ib)
-			} else {
-				totalsByEpoch[ud] = ib
-			}
-
-		} else if builtin.IsAccountActor(act.Code) {
-			// should exclude burnt funds actor and "remainder account actor"
-			// should only ever be "faucet" accounts in testnets
-			if kaddr == builtin.BurntFundsActorAddr {
-				return nil
-			}
-
-			kid, err := sTree.LookupID(kaddr)
-			if err != nil {
-				return xerrors.Errorf("resolving address: %w", err)
-			}
-
-			gi.genesisActors = append(gi.genesisActors, genesisActor{
-				addr:    kid,
-				initBal: act.Balance,
-			})
-		}
-		return nil
-	})
-
-	if err != nil {
-		return xerrors.Errorf("error setting up genesis infos: %w", err)
-	}
-
-	// TODO: use network upgrade abstractions or always start at actors v0?
-	gi.genesisMsigs = make([]msig0.State, 0, len(totalsByEpoch))
-	for k, v := range totalsByEpoch {
-		ns := msig0.State{
-			InitialBalance: v,
-			UnlockDuration: k,
-			PendingTxns:    cid.Undef,
-		}
-		gi.genesisMsigs = append(gi.genesisMsigs, ns)
-	}
-
-	sm.preIgnitionGenInfos = &gi
-
-	return nil
-}
-
-// sets up information about the actors in the genesis state
-// For testnet we use a hardcoded set of multisig states, instead of what's actually in the genesis multisigs
-// We also do not consider ANY account actors (including the faucet)
-func (sm *StateManager) setupPreIgnitionGenesisActorsTestnet(ctx context.Context) error {
-
-	gi := genesisInfo{}
-
-	gb, err := sm.cs.GetGenesis()
-	if err != nil {
-		return xerrors.Errorf("getting genesis block: %w", err)
-	}
-
-	gts, err := types.NewTipSet([]*types.BlockHeader{gb})
-	if err != nil {
-		return xerrors.Errorf("getting genesis tipset: %w", err)
-	}
-
-	st, _, err := sm.TipSetState(ctx, gts)
-	if err != nil {
-		return xerrors.Errorf("getting genesis tipset state: %w", err)
-	}
-
-	cst := cbor.NewCborStore(sm.cs.Blockstore())
-	sTree, err := state.LoadStateTree(cst, st)
-	if err != nil {
-		return xerrors.Errorf("loading state tree: %w", err)
-	}
-
-	gi.genesisMarketFunds, err = getFilMarketLocked(ctx, sTree)
-	if err != nil {
-		return xerrors.Errorf("setting up genesis market funds: %w", err)
-	}
-
-	gi.genesisPledge, err = getFilPowerLocked(ctx, sTree)
-	if err != nil {
-		return xerrors.Errorf("setting up genesis pledge: %w", err)
-	}
+	sm.genesisMarketFunds = gmf
+	sm.genesisPledge = gp
 
 	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
 
@@ -1074,58 +954,21 @@ func (sm *StateManager) setupPreIgnitionGenesisActorsTestnet(ctx context.Context
 	totalsByEpoch[sixYears] = big.NewInt(100_000_000)
 	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(300_000_000))
 
-	gi.genesisMsigs = make([]msig0.State, 0, len(totalsByEpoch))
+	sm.preIgnitionVesting = make([]msig0.State, 0, len(totalsByEpoch))
 	for k, v := range totalsByEpoch {
 		ns := msig0.State{
 			InitialBalance: v,
 			UnlockDuration: k,
 			PendingTxns:    cid.Undef,
 		}
-		gi.genesisMsigs = append(gi.genesisMsigs, ns)
+		sm.preIgnitionVesting = append(sm.preIgnitionVesting, ns)
 	}
-
-	sm.preIgnitionGenInfos = &gi
 
 	return nil
 }
 
-// sets up information about the actors in the genesis state, post the ignition fork
-func (sm *StateManager) setupPostIgnitionGenesisActors(ctx context.Context) error {
-
-	gi := genesisInfo{}
-
-	gb, err := sm.cs.GetGenesis()
-	if err != nil {
-		return xerrors.Errorf("getting genesis block: %w", err)
-	}
-
-	gts, err := types.NewTipSet([]*types.BlockHeader{gb})
-	if err != nil {
-		return xerrors.Errorf("getting genesis tipset: %w", err)
-	}
-
-	st, _, err := sm.TipSetState(ctx, gts)
-	if err != nil {
-		return xerrors.Errorf("getting genesis tipset state: %w", err)
-	}
-
-	cst := cbor.NewCborStore(sm.cs.Blockstore())
-	sTree, err := state.LoadStateTree(cst, st)
-	if err != nil {
-		return xerrors.Errorf("loading state tree: %w", err)
-	}
-
-	// Unnecessary, should be removed
-	gi.genesisMarketFunds, err = getFilMarketLocked(ctx, sTree)
-	if err != nil {
-		return xerrors.Errorf("setting up genesis market funds: %w", err)
-	}
-
-	// Unnecessary, should be removed
-	gi.genesisPledge, err = getFilPowerLocked(ctx, sTree)
-	if err != nil {
-		return xerrors.Errorf("setting up genesis pledge: %w", err)
-	}
+// sets up information about the vesting schedule post the ignition upgrade
+func (sm *StateManager) setupPostIgnitionVesting(ctx context.Context) error {
 
 	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
 
@@ -1151,7 +994,7 @@ func (sm *StateManager) setupPostIgnitionGenesisActors(ctx context.Context) erro
 	totalsByEpoch[sixYears] = big.NewInt(100_000_000)
 	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(300_000_000))
 
-	gi.genesisMsigs = make([]msig0.State, 0, len(totalsByEpoch))
+	sm.postIgnitionVesting = make([]msig0.State, 0, len(totalsByEpoch))
 	for k, v := range totalsByEpoch {
 		ns := msig0.State{
 			// In the pre-ignition logic, we incorrectly set this value in Fil, not attoFil, an off-by-10^18 error
@@ -1161,10 +1004,56 @@ func (sm *StateManager) setupPostIgnitionGenesisActors(ctx context.Context) erro
 			// In the pre-ignition logic, the start epoch was 0. This changes in the fork logic of the Ignition upgrade itself.
 			StartEpoch: build.UpgradeLiftoffHeight,
 		}
-		gi.genesisMsigs = append(gi.genesisMsigs, ns)
+		sm.postIgnitionVesting = append(sm.postIgnitionVesting, ns)
 	}
 
-	sm.postIgnitionGenInfos = &gi
+	return nil
+}
+
+// sets up information about the vesting schedule post the calico upgrade
+func (sm *StateManager) setupPostCalicoVesting(ctx context.Context) error {
+
+	totalsByEpoch := make(map[abi.ChainEpoch]abi.TokenAmount)
+
+	// 0 days
+	zeroDays := abi.ChainEpoch(0)
+	totalsByEpoch[zeroDays] = big.NewInt(10_632_000)
+
+	// 6 months
+	sixMonths := abi.ChainEpoch(183 * builtin.EpochsInDay)
+	totalsByEpoch[sixMonths] = big.NewInt(19_015_887)
+	totalsByEpoch[sixMonths] = big.Add(totalsByEpoch[sixMonths], big.NewInt(32_787_700))
+
+	// 1 year
+	oneYear := abi.ChainEpoch(365 * builtin.EpochsInDay)
+	totalsByEpoch[oneYear] = big.NewInt(22_421_712)
+	totalsByEpoch[oneYear] = big.Add(totalsByEpoch[oneYear], big.NewInt(9_400_000))
+
+	// 2 years
+	twoYears := abi.ChainEpoch(2 * 365 * builtin.EpochsInDay)
+	totalsByEpoch[twoYears] = big.NewInt(7_223_364)
+
+	// 3 years
+	threeYears := abi.ChainEpoch(3 * 365 * builtin.EpochsInDay)
+	totalsByEpoch[threeYears] = big.NewInt(87_637_883)
+	totalsByEpoch[threeYears] = big.Add(totalsByEpoch[threeYears], big.NewInt(898_958))
+
+	// 6 years
+	sixYears := abi.ChainEpoch(6 * 365 * builtin.EpochsInDay)
+	totalsByEpoch[sixYears] = big.NewInt(100_000_000)
+	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(300_000_000))
+	totalsByEpoch[sixYears] = big.Add(totalsByEpoch[sixYears], big.NewInt(9_805_053))
+
+	sm.postCalicoVesting = make([]msig0.State, 0, len(totalsByEpoch))
+	for k, v := range totalsByEpoch {
+		ns := msig0.State{
+			InitialBalance: big.Mul(v, big.NewInt(int64(build.FilecoinPrecision))),
+			UnlockDuration: k,
+			PendingTxns:    cid.Undef,
+			StartEpoch:     build.UpgradeLiftoffHeight,
+		}
+		sm.postCalicoVesting = append(sm.postCalicoVesting, ns)
+	}
 
 	return nil
 }
@@ -1175,12 +1064,19 @@ func (sm *StateManager) setupPostIgnitionGenesisActors(ctx context.Context) erro
 func (sm *StateManager) GetFilVested(ctx context.Context, height abi.ChainEpoch, st *state.StateTree) (abi.TokenAmount, error) {
 	vf := big.Zero()
 	if height <= build.UpgradeIgnitionHeight {
-		for _, v := range sm.preIgnitionGenInfos.genesisMsigs {
+		for _, v := range sm.preIgnitionVesting {
 			au := big.Sub(v.InitialBalance, v.AmountLocked(height))
 			vf = big.Add(vf, au)
 		}
+	} else if height <= build.UpgradeCalicoHeight {
+		for _, v := range sm.postIgnitionVesting {
+			// In the pre-ignition logic, we simply called AmountLocked(height), assuming startEpoch was 0.
+			// The start epoch changed in the Ignition upgrade.
+			au := big.Sub(v.InitialBalance, v.AmountLocked(height-v.StartEpoch))
+			vf = big.Add(vf, au)
+		}
 	} else {
-		for _, v := range sm.postIgnitionGenInfos.genesisMsigs {
+		for _, v := range sm.postCalicoVesting {
 			// In the pre-ignition logic, we simply called AmountLocked(height), assuming startEpoch was 0.
 			// The start epoch changed in the Ignition upgrade.
 			au := big.Sub(v.InitialBalance, v.AmountLocked(height-v.StartEpoch))
@@ -1188,26 +1084,12 @@ func (sm *StateManager) GetFilVested(ctx context.Context, height abi.ChainEpoch,
 		}
 	}
 
-	// there should not be any such accounts in testnet (and also none in mainnet?)
-	// continue to use preIgnitionGenInfos, nothing changed at the Ignition epoch
-	for _, v := range sm.preIgnitionGenInfos.genesisActors {
-		act, err := st.GetActor(v.addr)
-		if err != nil {
-			return big.Zero(), xerrors.Errorf("failed to get actor: %w", err)
-		}
-
-		diff := big.Sub(v.initBal, act.Balance)
-		if diff.GreaterThan(big.Zero()) {
-			vf = big.Add(vf, diff)
-		}
-	}
-
 	// After UpgradeActorsV2Height these funds are accounted for in GetFilReserveDisbursed
 	if height <= build.UpgradeActorsV2Height {
 		// continue to use preIgnitionGenInfos, nothing changed at the Ignition epoch
-		vf = big.Add(vf, sm.preIgnitionGenInfos.genesisPledge)
+		vf = big.Add(vf, sm.genesisPledge)
 		// continue to use preIgnitionGenInfos, nothing changed at the Ignition epoch
-		vf = big.Add(vf, sm.preIgnitionGenInfos.genesisMarketFunds)
+		vf = big.Add(vf, sm.genesisMarketFunds)
 	}
 
 	return vf, nil
@@ -1301,16 +1183,22 @@ func (sm *StateManager) GetVMCirculatingSupply(ctx context.Context, height abi.C
 func (sm *StateManager) GetVMCirculatingSupplyDetailed(ctx context.Context, height abi.ChainEpoch, st *state.StateTree) (api.CirculatingSupply, error) {
 	sm.genesisMsigLk.Lock()
 	defer sm.genesisMsigLk.Unlock()
-	if sm.preIgnitionGenInfos == nil {
-		err := sm.setupPreIgnitionGenesisActorsTestnet(ctx)
+	if sm.preIgnitionVesting == nil || sm.genesisPledge.IsZero() || sm.genesisMarketFunds.IsZero() {
+		err := sm.setupGenesisVestingSchedule(ctx)
 		if err != nil {
-			return api.CirculatingSupply{}, xerrors.Errorf("failed to setup pre-ignition genesis information: %w", err)
+			return api.CirculatingSupply{}, xerrors.Errorf("failed to setup pre-ignition vesting schedule: %w", err)
 		}
 	}
-	if sm.postIgnitionGenInfos == nil {
-		err := sm.setupPostIgnitionGenesisActors(ctx)
+	if sm.postIgnitionVesting == nil {
+		err := sm.setupPostIgnitionVesting(ctx)
 		if err != nil {
-			return api.CirculatingSupply{}, xerrors.Errorf("failed to setup post-ignition genesis information: %w", err)
+			return api.CirculatingSupply{}, xerrors.Errorf("failed to setup post-ignition vesting schedule: %w", err)
+		}
+	}
+	if sm.postCalicoVesting == nil {
+		err := sm.setupPostCalicoVesting(ctx)
+		if err != nil {
+			return api.CirculatingSupply{}, xerrors.Errorf("failed to setup post-calico vesting schedule: %w", err)
 		}
 	}
 


### PR DESCRIPTION
There was an accounting mistake in the vesting table. It was reported but not fixed because of timeline and fixing it earlier will mean a spike in collateral for miners. This PR upgrades the vesting table to more closely match the actual multisig vesting.

Fixes #4660 