### PR TITLE
Bump API versions to 1.0.0

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -83,9 +83,9 @@ func VersionForType(nodeType NodeType) (Version, error) {
 
 // semver versions of the rpc api exposed
 var (
-	FullAPIVersion   = newVer(0, 17, 0)
-	MinerAPIVersion  = newVer(0, 18, 0)
-	WorkerAPIVersion = newVer(0, 17, 0)
+	FullAPIVersion   = newVer(1, 0, 0)
+	MinerAPIVersion  = newVer(1, 0, 0)
+	WorkerAPIVersion = newVer(1, 0, 0)
 )
 
 //nolint:varcheck,deadcode

--- a/documentation/en/api-methods-miner.md
+++ b/documentation/en/api-methods-miner.md
@@ -153,7 +153,7 @@ Response:
 ```json
 {
   "Version": "string value",
-  "APIVersion": 4352,
+  "APIVersion": 65536,
   "BlockDelay": 42
 }
 ```

--- a/documentation/en/api-methods-worker.md
+++ b/documentation/en/api-methods-worker.md
@@ -144,7 +144,7 @@ Perms: admin
 
 Inputs: `null`
 
-Response: `4352`
+Response: `65536`
 
 ## Add
 

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -246,7 +246,7 @@ Response:
 ```json
 {
   "Version": "string value",
-  "APIVersion": 4352,
+  "APIVersion": 65536,
   "BlockDelay": 42
 }
 ```


### PR DESCRIPTION
I assume this is safe to do, if there's any reason why it isn't close the PR :P

"Fixes" #4738