### PR TITLE
Set Calico epoch

### DIFF
--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -38,9 +38,8 @@ const UpgradeLiftoffHeight = 148888
 
 const UpgradeKumquatHeight = 170000
 
-// TODO: Height??
-const UpgradeCalicoHeight = 999999
-const UpgradePersianHeight = UpgradeCalicoHeight + (builtin2.EpochsInDay * 2)
+const UpgradeCalicoHeight = 265200
+const UpgradePersianHeight = UpgradeCalicoHeight + (builtin2.EpochsInHour * 60)
 
 func init() {
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(10 << 40))


### PR DESCRIPTION
Should go into `release/v1.2.0`. First upgrade epoch is midnight UTC between the 24th and 25th (4 PM PST, and 8 AM China). Second upgrade is 60 hours after first upgrade.