### PR TITLE
Add error codes to worker return 

### DIFF
--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -311,17 +311,17 @@ type StorageMinerStruct struct {
 		WorkerStats   func(context.Context) (map[uuid.UUID]storiface.WorkerStats, error) `perm:"admin"`
 		WorkerJobs    func(context.Context) (map[uuid.UUID][]storiface.WorkerJob, error) `perm:"admin"`
 
-		ReturnAddPiece        func(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err string) error          `perm:"admin" retry:"true"`
-		ReturnSealPreCommit1  func(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err string) error `perm:"admin" retry:"true"`
-		ReturnSealPreCommit2  func(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err string) error `perm:"admin" retry:"true"`
-		ReturnSealCommit1     func(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err string) error    `perm:"admin" retry:"true"`
-		ReturnSealCommit2     func(ctx context.Context, callID storiface.CallID, proof storage.Proof, err string) error       `perm:"admin" retry:"true"`
-		ReturnFinalizeSector  func(ctx context.Context, callID storiface.CallID, err string) error                            `perm:"admin" retry:"true"`
-		ReturnReleaseUnsealed func(ctx context.Context, callID storiface.CallID, err string) error                            `perm:"admin" retry:"true"`
-		ReturnMoveStorage     func(ctx context.Context, callID storiface.CallID, err string) error                            `perm:"admin" retry:"true"`
-		ReturnUnsealPiece     func(ctx context.Context, callID storiface.CallID, err string) error                            `perm:"admin" retry:"true"`
-		ReturnReadPiece       func(ctx context.Context, callID storiface.CallID, ok bool, err string) error                   `perm:"admin" retry:"true"`
-		ReturnFetch           func(ctx context.Context, callID storiface.CallID, err string) error                            `perm:"admin" retry:"true"`
+		ReturnAddPiece        func(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err *storiface.CallError) error          `perm:"admin" retry:"true"`
+		ReturnSealPreCommit1  func(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err *storiface.CallError) error `perm:"admin" retry:"true"`
+		ReturnSealPreCommit2  func(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err *storiface.CallError) error `perm:"admin" retry:"true"`
+		ReturnSealCommit1     func(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err *storiface.CallError) error    `perm:"admin" retry:"true"`
+		ReturnSealCommit2     func(ctx context.Context, callID storiface.CallID, proof storage.Proof, err *storiface.CallError) error       `perm:"admin" retry:"true"`
+		ReturnFinalizeSector  func(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error                            `perm:"admin" retry:"true"`
+		ReturnReleaseUnsealed func(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error                            `perm:"admin" retry:"true"`
+		ReturnMoveStorage     func(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error                            `perm:"admin" retry:"true"`
+		ReturnUnsealPiece     func(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error                            `perm:"admin" retry:"true"`
+		ReturnReadPiece       func(ctx context.Context, callID storiface.CallID, ok bool, err *storiface.CallError) error                   `perm:"admin" retry:"true"`
+		ReturnFetch           func(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error                            `perm:"admin" retry:"true"`
 
 		SealingSchedDiag func(context.Context, bool) (interface{}, error)       `perm:"admin"`
 		SealingAbort     func(ctx context.Context, call storiface.CallID) error `perm:"admin"`
@@ -1271,47 +1271,47 @@ func (c *StorageMinerStruct) WorkerJobs(ctx context.Context) (map[uuid.UUID][]st
 	return c.Internal.WorkerJobs(ctx)
 }
 
-func (c *StorageMinerStruct) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err string) error {
+func (c *StorageMinerStruct) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err *storiface.CallError) error {
 	return c.Internal.ReturnAddPiece(ctx, callID, pi, err)
 }
 
-func (c *StorageMinerStruct) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err string) error {
+func (c *StorageMinerStruct) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err *storiface.CallError) error {
 	return c.Internal.ReturnSealPreCommit1(ctx, callID, p1o, err)
 }
 
-func (c *StorageMinerStruct) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err string) error {
+func (c *StorageMinerStruct) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err *storiface.CallError) error {
 	return c.Internal.ReturnSealPreCommit2(ctx, callID, sealed, err)
 }
 
-func (c *StorageMinerStruct) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err string) error {
+func (c *StorageMinerStruct) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err *storiface.CallError) error {
 	return c.Internal.ReturnSealCommit1(ctx, callID, out, err)
 }
 
-func (c *StorageMinerStruct) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err string) error {
+func (c *StorageMinerStruct) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err *storiface.CallError) error {
 	return c.Internal.ReturnSealCommit2(ctx, callID, proof, err)
 }
 
-func (c *StorageMinerStruct) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err string) error {
+func (c *StorageMinerStruct) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return c.Internal.ReturnFinalizeSector(ctx, callID, err)
 }
 
-func (c *StorageMinerStruct) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err string) error {
+func (c *StorageMinerStruct) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return c.Internal.ReturnReleaseUnsealed(ctx, callID, err)
 }
 
-func (c *StorageMinerStruct) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err string) error {
+func (c *StorageMinerStruct) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return c.Internal.ReturnMoveStorage(ctx, callID, err)
 }
 
-func (c *StorageMinerStruct) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err string) error {
+func (c *StorageMinerStruct) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return c.Internal.ReturnUnsealPiece(ctx, callID, err)
 }
 
-func (c *StorageMinerStruct) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err string) error {
+func (c *StorageMinerStruct) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err *storiface.CallError) error {
 	return c.Internal.ReturnReadPiece(ctx, callID, ok, err)
 }
 
-func (c *StorageMinerStruct) ReturnFetch(ctx context.Context, callID storiface.CallID, err string) error {
+func (c *StorageMinerStruct) ReturnFetch(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return c.Internal.ReturnFetch(ctx, callID, err)
 }
 

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -233,6 +233,7 @@ func init() {
 			CpuUse:     0,
 		},
 	})
+	addExample(storiface.ErrorCode(0))
 
 	// worker specific
 	addExample(storiface.AcquireMove)

--- a/documentation/en/api-methods-miner.md
+++ b/documentation/en/api-methods-miner.md
@@ -987,7 +987,10 @@ Inputs:
       "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
     }
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1008,7 +1011,10 @@ Inputs:
     },
     "ID": "07070707-0707-0707-0707-070707070707"
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1029,7 +1035,10 @@ Inputs:
     },
     "ID": "07070707-0707-0707-0707-070707070707"
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1050,7 +1059,10 @@ Inputs:
     },
     "ID": "07070707-0707-0707-0707-070707070707"
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1072,7 +1084,10 @@ Inputs:
     "ID": "07070707-0707-0707-0707-070707070707"
   },
   true,
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1093,7 +1108,10 @@ Inputs:
     },
     "ID": "07070707-0707-0707-0707-070707070707"
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1115,7 +1133,10 @@ Inputs:
     "ID": "07070707-0707-0707-0707-070707070707"
   },
   null,
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1137,7 +1158,10 @@ Inputs:
     "ID": "07070707-0707-0707-0707-070707070707"
   },
   null,
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1159,7 +1183,10 @@ Inputs:
     "ID": "07070707-0707-0707-0707-070707070707"
   },
   null,
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1188,7 +1215,10 @@ Inputs:
       "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
     }
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 
@@ -1209,7 +1239,10 @@ Inputs:
     },
     "ID": "07070707-0707-0707-0707-070707070707"
   },
-  "string value"
+  {
+    "Code": 0,
+    "Message": "string value"
+  }
 ]
 ```
 

--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -617,47 +617,47 @@ func (m *Manager) Remove(ctx context.Context, sector storage.SectorRef) error {
 	return err
 }
 
-func (m *Manager) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err string) error {
+func (m *Manager) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err *storiface.CallError) error {
 	return m.returnResult(callID, pi, err)
 }
 
-func (m *Manager) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err string) error {
+func (m *Manager) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err *storiface.CallError) error {
 	return m.returnResult(callID, p1o, err)
 }
 
-func (m *Manager) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err string) error {
+func (m *Manager) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err *storiface.CallError) error {
 	return m.returnResult(callID, sealed, err)
 }
 
-func (m *Manager) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err string) error {
+func (m *Manager) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err *storiface.CallError) error {
 	return m.returnResult(callID, out, err)
 }
 
-func (m *Manager) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err string) error {
+func (m *Manager) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err *storiface.CallError) error {
 	return m.returnResult(callID, proof, err)
 }
 
-func (m *Manager) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err string) error {
+func (m *Manager) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return m.returnResult(callID, nil, err)
 }
 
-func (m *Manager) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err string) error {
+func (m *Manager) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return m.returnResult(callID, nil, err)
 }
 
-func (m *Manager) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err string) error {
+func (m *Manager) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return m.returnResult(callID, nil, err)
 }
 
-func (m *Manager) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err string) error {
+func (m *Manager) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return m.returnResult(callID, nil, err)
 }
 
-func (m *Manager) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err string) error {
+func (m *Manager) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err *storiface.CallError) error {
 	return m.returnResult(callID, ok, err)
 }
 
-func (m *Manager) ReturnFetch(ctx context.Context, callID storiface.CallID, err string) error {
+func (m *Manager) ReturnFetch(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	return m.returnResult(callID, nil, err)
 }
 

--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -418,47 +418,47 @@ func (mgr *SectorMgr) CheckProvable(ctx context.Context, pp abi.RegisteredPoStPr
 	return bad, nil
 }
 
-func (mgr *SectorMgr) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err string) error {
+func (mgr *SectorMgr) ReturnAddPiece(ctx context.Context, callID storiface.CallID, pi abi.PieceInfo, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err string) error {
+func (mgr *SectorMgr) ReturnSealPreCommit1(ctx context.Context, callID storiface.CallID, p1o storage.PreCommit1Out, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err string) error {
+func (mgr *SectorMgr) ReturnSealPreCommit2(ctx context.Context, callID storiface.CallID, sealed storage.SectorCids, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err string) error {
+func (mgr *SectorMgr) ReturnSealCommit1(ctx context.Context, callID storiface.CallID, out storage.Commit1Out, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err string) error {
+func (mgr *SectorMgr) ReturnSealCommit2(ctx context.Context, callID storiface.CallID, proof storage.Proof, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err string) error {
+func (mgr *SectorMgr) ReturnFinalizeSector(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err string) error {
+func (mgr *SectorMgr) ReturnReleaseUnsealed(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err string) error {
+func (mgr *SectorMgr) ReturnMoveStorage(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err string) error {
+func (mgr *SectorMgr) ReturnUnsealPiece(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err string) error {
+func (mgr *SectorMgr) ReturnReadPiece(ctx context.Context, callID storiface.CallID, ok bool, err *storiface.CallError) error {
 	panic("not supported")
 }
 
-func (mgr *SectorMgr) ReturnFetch(ctx context.Context, callID storiface.CallID, err string) error {
+func (mgr *SectorMgr) ReturnFetch(ctx context.Context, callID storiface.CallID, err *storiface.CallError) error {
 	panic("not supported")
 }
 

--- a/extern/sector-storage/stores/local.go
+++ b/extern/sector-storage/stores/local.go
@@ -361,7 +361,7 @@ func (st *Local) Reserve(ctx context.Context, sid storage.SectorRef, ft storifac
 		overhead := int64(overheadTab[fileType]) * int64(ssize) / storiface.FSOverheadDen
 
 		if stat.Available < overhead {
-			return nil, xerrors.Errorf("can't reserve %d bytes in '%s' (id:%s), only %d available", overhead, p.local, id, stat.Available)
+			return nil, storiface.Err(storiface.ErrTempAllocateSpace, xerrors.Errorf("can't reserve %d bytes in '%s' (id:%s), only %d available", overhead, p.local, id, stat.Available))
 		}
 
 		p.reserved += overhead

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -2,6 +2,7 @@ package storiface
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -104,22 +105,29 @@ const (
 )
 
 type CallError struct {
-	Code ErrorCode
-	Sub  error
+	Code    ErrorCode
+	Message string
+	sub     error
 }
 
 func (c *CallError) Error() string {
-	return fmt.Sprintf("storage call error %d: %s", c.Code, c.Sub.Error())
+	return fmt.Sprintf("storage call error %d: %s", c.Code, c.Message)
 }
 
 func (c *CallError) Unwrap() error {
-	return c.Sub
+	if c.sub != nil {
+		return c.sub
+	}
+
+	return errors.New(c.Message)
 }
 
 func Err(code ErrorCode, sub error) *CallError {
 	return &CallError{
-		Code: code,
-		Sub:  sub,
+		Code:    code,
+		Message: sub.Error(),
+
+		sub: sub,
 	}
 }
 

--- a/extern/sector-storage/testworker_test.go
+++ b/extern/sector-storage/testworker_test.go
@@ -61,7 +61,7 @@ func (t *testWorker) asyncCall(sector storage.SectorRef, work func(ci storiface.
 func (t *testWorker) AddPiece(ctx context.Context, sector storage.SectorRef, pieceSizes []abi.UnpaddedPieceSize, newPieceSize abi.UnpaddedPieceSize, pieceData storage.Data) (storiface.CallID, error) {
 	return t.asyncCall(sector, func(ci storiface.CallID) {
 		p, err := t.mockSeal.AddPiece(ctx, sector, pieceSizes, newPieceSize, pieceData)
-		if err := t.ret.ReturnAddPiece(ctx, ci, p, errstr(err)); err != nil {
+		if err := t.ret.ReturnAddPiece(ctx, ci, p, toCallError(err)); err != nil {
 			log.Error(err)
 		}
 	})
@@ -79,7 +79,7 @@ func (t *testWorker) SealPreCommit1(ctx context.Context, sector storage.SectorRe
 		defer t.pc1lk.Unlock()
 
 		p1o, err := t.mockSeal.SealPreCommit1(ctx, sector, ticket, pieces)
-		if err := t.ret.ReturnSealPreCommit1(ctx, ci, p1o, errstr(err)); err != nil {
+		if err := t.ret.ReturnSealPreCommit1(ctx, ci, p1o, toCallError(err)); err != nil {
 			log.Error(err)
 		}
 	})
@@ -87,7 +87,7 @@ func (t *testWorker) SealPreCommit1(ctx context.Context, sector storage.SectorRe
 
 func (t *testWorker) Fetch(ctx context.Context, sector storage.SectorRef, fileType storiface.SectorFileType, ptype storiface.PathType, am storiface.AcquireMode) (storiface.CallID, error) {
 	return t.asyncCall(sector, func(ci storiface.CallID) {
-		if err := t.ret.ReturnFetch(ctx, ci, ""); err != nil {
+		if err := t.ret.ReturnFetch(ctx, ci, nil); err != nil {
 			log.Error(err)
 		}
 	})

--- a/extern/sector-storage/worker_local.go
+++ b/extern/sector-storage/worker_local.go
@@ -90,10 +90,7 @@ func newLocalWorker(executor ExecutorFunc, wcfg WorkerConfig, store stores.Store
 
 	go func() {
 		for _, call := range unfinished {
-			err := &storiface.CallError{
-				Sub:  xerrors.New("worker restarted"),
-				Code: storiface.ErrTempWorkerRestart,
-			}
+			err := storiface.Err(storiface.ErrTempWorkerRestart, xerrors.New("worker restarted"))
 
 			// TODO: Handle restarting PC1 once support is merged
 
@@ -261,10 +258,7 @@ func (l *LocalWorker) asyncCall(ctx context.Context, sector storage.SectorRef, r
 func toCallError(err error) *storiface.CallError {
 	var serr *storiface.CallError
 	if err != nil && !xerrors.As(err, &serr) {
-		serr = &storiface.CallError{
-			Sub:  err,
-			Code: storiface.ErrUnknown,
-		}
+		serr = storiface.Err(storiface.ErrUnknown, err)
 	}
 
 	return serr


### PR DESCRIPTION
We're bumping API versions in 1.2.0 already, so getting this in now is nice because we can avoid breaking worker APIs again

This is part 1 of 2 of handling things like failing to allocate storage more gracefully. Part 2 will be handling those errors at the scheduler level, just returning tasks which got Temp errors to the scheduler instead of failing them
