### PR TITLE
just return storedask.NewStoredAsk to reduce unuseful code

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -431,15 +431,8 @@ func NewStorageAsk(ctx helpers.MetricsCtx, fapi lapi.FullNode, ds dtypes.Metadat
 	if err != nil {
 		return nil, err
 	}
-	storedAsk, err := storedask.NewStoredAsk(namespace.Wrap(providerDs, datastore.NewKey("/storage-ask")), datastore.NewKey("latest"), spn, address.Address(minerAddress),
+	return storedask.NewStoredAsk(namespace.Wrap(providerDs, datastore.NewKey("/storage-ask")), datastore.NewKey("latest"), spn, address.Address(minerAddress),
 		storagemarket.MaxPieceSize(abi.PaddedPieceSize(mi.SectorSize)))
-	if err != nil {
-		return nil, err
-	}
-	if err != nil {
-		return storedAsk, err
-	}
-	return storedAsk, nil
 }
 
 func BasicDealFilter(user dtypes.StorageDealFilter) func(onlineOk dtypes.ConsiderOnlineStorageDealsConfigFunc,


### PR DESCRIPTION
the code in `NewStorageAsk` seems to be unuseful, remove to keep the code clean. btw the second  `err != nil` always be true, there is no need to judge this condition.