### PR TITLE
Use version0 when pre-sealing

### DIFF
--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/filecoin-project/go-state-types/network"
+
 	"github.com/docker/go-units"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/mitchellh/go-homedir"
@@ -127,7 +129,7 @@ var preSealCmd = &cli.Command{
 		}
 		sectorSize := abi.SectorSize(sectorSizeInt)
 
-		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, build.NewestNetworkVersion)
+		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, network.Version0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We don't currently have any way to start a network with a later version, so pre-sealing should just use version0. I think. Maybe make this configable?