### PR TITLE
Fix repo close typed nil issue

### DIFF
--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -287,7 +287,7 @@ func (fsr *fsLockedRepo) Close() error {
 	}
 
 	// type assertion will return ok=false if fsr.bs is nil altogether.
-	if c, ok := fsr.bs.(io.Closer); ok && c != nil {
+	if c, ok := fsr.bs.(io.Closer); ok && fsr.bs != nil {
 		if err := c.Close(); err != nil {
 			return xerrors.Errorf("could not close blockstore: %w", err)
 		}


### PR DESCRIPTION
Manifests when while trying to run import-chain, the Blockstore fails to
open.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1004a42]goroutine 1 [running]:
github.com/filecoin-project/lotus/lib/blockstore/badger.(*Blockstore).Close(0x0, 0x0, 0x0)
	/root/go/src/github.com/lotus/lib/blockstore/badger/blockstore.go:129 +0x42
github.com/ipfs/go-ipfs-blockstore.(*idstore).Close(0xc0019eb380, 0x331bb60, 0xc0019eb380)
	/root/go/pkg/mod/github.com/ipfs/go-ipfs-blockstore@v1.0.3/idstore.go:120 +0x62
github.com/filecoin-project/lotus/node/repo.(*fsLockedRepo).Close(0xc000d9c0b0, 0x20, 0x2e100c0)
	/root/go/src/github.com/lotus/node/repo/fsrepo.go:291 +0x2a2
main.ImportChain(0x32f6bc0, 0xc0004fffa0, 0x7ffcc6f436cb, 0x64, 0x1, 0x32c9a60, 0xc0023e00c0)
	/root/go/src/github.com/lotus/cmd/lotus/daemon.go:410 +0x2f0
main.glob..func3(0xc0004f7000, 0x0, 0x0)
	/root/go/src/github.com/lotus/cmd/lotus/daemon.go:230 +0x8c8
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000093b00, 0xc0004f6b40, 0x0, 0x0)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:432 +0x9bf
github.com/urfave/cli/v2.(*Command).startApp(0x593c1c0, 0xc0004f6b40, 0x2e7e8e9, 0x7ffcc6f436b2)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:279 +0x6bb
github.com/urfave/cli/v2.(*Command).Run(0x593c1c0, 0xc0004f6b40, 0x0, 0x0)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:94 +0x9cd
github.com/urfave/cli/v2.(*App).RunContext(0xc000093980, 0x33052c0, 0xc0000be000, 0xc0000d2000, 0x4, 0x4, 0x0, 0x0)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x81f
github.com/urfave/cli/v2.(*App).Run(...)
	/root/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
github.com/filecoin-project/lotus/cli.RunApp(0xc000093980)
	/root/go/src/github.com/lotus/cli/helper.go:35 +0x7c
main.main()
	/root/go/src/github.com/lotus/cmd/lotus/main.go:74 +0x645
```