### PR TITLE
Return total power when GetPowerRaw doesn't find miner claim

### DIFF
--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -103,8 +103,7 @@ func GetPowerRaw(ctx context.Context, sm *StateManager, st cid.Cid, maddr addres
 		var found bool
 		mpow, found, err = pas.MinerPower(maddr)
 		if err != nil || !found {
-			// TODO: return an error when not found?
-			return power.Claim{}, power.Claim{}, false, err
+			return power.Claim{}, tpow, false, err
 		}
 
 		minpow, err = pas.MinerNominalPowerMeetsConsensusMinimum(maddr)


### PR DESCRIPTION
This is correcter, and means we don't clumsily fail on commands like `lotus state power <maddr>` when `maddr` isn't found in claims.