### PR TITLE
delete bench policy

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -175,7 +175,7 @@ var sealBenchCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		policy.AddSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1)
+		policy.AddSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1, abi.RegisteredSealProof_StackedDrg8MiBV1, abi.RegisteredSealProof_StackedDrg512MiBV1)
 
 		if c.Bool("no-gpu") {
 			err := os.Setenv("BELLMAN_NO_GPU", "1")

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -32,7 +32,6 @@ import (
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
-	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/genesis"
 )
@@ -175,8 +174,6 @@ var sealBenchCmd = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		policy.AddSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1, abi.RegisteredSealProof_StackedDrg8MiBV1, abi.RegisteredSealProof_StackedDrg512MiBV1)
-
 		if c.Bool("no-gpu") {
 			err := os.Setenv("BELLMAN_NO_GPU", "1")
 			if err != nil {


### PR DESCRIPTION
originally add abi.RegisteredSealProof_StackedDrg8MiBV1, abi.RegisteredSealProof_StackedDrg512MiBV1
delete policy  test ok. 

2020-11-21T10:07:25.223+0800	INFO	lotus-bench	lotus-bench/main.go:511	[0] Writing piece into sector...
2020-11-21T10:07:25.227+0800	INFO	lotus-bench	lotus-bench/main.go:511	[1] Writing piece into sector...
2020-11-21T10:07:25.238+0800	INFO	lotus-bench	lotus-bench/main.go:511	[2] Writing piece into sector...
2020-11-21T10:07:25.241+0800	INFO	lotus-bench	lotus-bench/main.go:511	[3] Writing piece into sector...
2020-11-21T10:07:25.251+0800	INFO	lotus-bench	lotus-bench/main.go:511	[4] Writing piece into sector...
2020-11-21T10:07:25.253+0800	INFO	lotus-bench	lotus-bench/main.go:511	[5] Writing piece into sector...
2020-11-21T10:07:25.256+0800	INFO	lotus-bench	lotus-bench/main.go:547	[4] Running replication(1)...
2020-11-21T10:07:25.258+0800	INFO	lotus-bench	lotus-bench/main.go:547	[0] Running replication(1)...
2020-11-21T10:07:25.258+0800	INFO	lotus-bench	lotus-bench/main.go:547	[2] Running replication(1)...
2020-11-21T10:07:25.262+0800	INFO	lotus-bench	lotus-bench/main.go:558	[4] Running replication(2)...
2020-11-21T10:07:25.304+0800	INFO	lotus-bench	lotus-bench/main.go:558	[0] Running replication(2)...
2020-11-21T10:07:25.304+0800	INFO	lotus-bench	lotus-bench/main.go:580	[4] Generating PoRep for sector (1)
2020-11-21T10:07:25.312+0800	INFO	lotus-bench	lotus-bench/main.go:558	[2] Running replication(2)...
2020-11-21T10:07:25.314+0800	INFO	lotus-bench	lotus-bench/main.go:588	[4] Generating PoRep for sector (2)
2020-11-21T10:08:17.519+0800	INFO	lotus-bench	lotus-bench/main.go:580	[0] Generating PoRep for sector (1)
2020-11-21T10:08:17.524+0800	INFO	lotus-bench	lotus-bench/main.go:642	[4] Unsealing sector
2020-11-21T10:08:17.527+0800	INFO	lotus-bench	lotus-bench/main.go:547	[5] Running replication(1)...
2020-11-21T10:08:17.530+0800	INFO	lotus-bench	lotus-bench/main.go:558	[5] Running replication(2)...
2020-11-21T10:08:17.534+0800	INFO	lotus-bench	lotus-bench/main.go:588	[0] Generating PoRep for sector (2)
2020-11-21T10:09:12.103+0800	INFO	lotus-bench	lotus-bench/main.go:580	[2] Generating PoRep for sector (1)
2020-11-21T10:09:12.109+0800	INFO	lotus-bench	lotus-bench/main.go:642	[0] Unsealing sector
2020-11-21T10:09:12.113+0800	INFO	lotus-bench	lotus-bench/main.go:547	[1] Running replication(1)...
2020-11-21T10:09:12.114+0800	INFO	lotus-bench	lotus-bench/main.go:588	[2] Generating PoRep for sector (2)
2020-11-21T10:09:12.116+0800	INFO	lotus-bench	lotus-bench/main.go:558	[1] Running replication(2)...
2020-11-21T10:10:08.032+0800	INFO	lotus-bench	lotus-bench/main.go:580	[5] Generating PoRep for sector (1)
2020-11-21T10:10:08.038+0800	INFO	lotus-bench	lotus-bench/main.go:642	[2] Unsealing sector
2020-11-21T10:10:08.040+0800	INFO	lotus-bench	lotus-bench/main.go:547	[3] Running replication(1)...
2020-11-21T10:10:08.043+0800	INFO	lotus-bench	lotus-bench/main.go:558	[3] Running replication(2)...
2020-11-21T10:10:08.045+0800	INFO	lotus-bench	lotus-bench/main.go:588	[5] Generating PoRep for sector (2)
2020-11-21T10:11:04.136+0800	INFO	lotus-bench	lotus-bench/main.go:580	[1] Generating PoRep for sector (1)
2020-11-21T10:11:04.140+0800	INFO	lotus-bench	lotus-bench/main.go:642	[5] Unsealing sector
2020-11-21T10:11:04.150+0800	INFO	lotus-bench	lotus-bench/main.go:588	[1] Generating PoRep for sector (2)
2020-11-21T10:11:59.553+0800	INFO	lotus-bench	lotus-bench/main.go:580	[3] Generating PoRep for sector (1)
2020-11-21T10:11:59.558+0800	INFO	lotus-bench	lotus-bench/main.go:642	[1] Unsealing sector
2020-11-21T10:11:59.567+0800	INFO	lotus-bench	lotus-bench/main.go:588	[3] Generating PoRep for sector (2)
2020-11-21T10:12:54.959+0800	INFO	lotus-bench	lotus-bench/main.go:642	[3] Unsealing sector
2020-11-21T10:12:54.961+0800	INFO	lotus-bench	lotus-bench/main.go:320	generating winning post candidates
2020-11-21T10:12:54.961+0800	INFO	lotus-bench	lotus-bench/main.go:338	computing winning post snark (cold)
2020-11-21T10:13:01.141+0800	INFO	lotus-bench	lotus-bench/main.go:346	computing winning post snark (hot)
2020-11-21T10:13:06.997+0800	INFO	lotus-bench	lotus-bench/main.go:386	computing window post snark (cold)
2020-11-21T10:13:11.567+0800	INFO	lotus-bench	lotus-bench/main.go:394	computing window post snark (hot)
----
results (v28) SectorSize:(2048), SectorNumber:(6)
seal: addPiece: 32.589691ms (368.2 KiB/s)
seal: preCommit phase 1: 35.123933ms (341.6 KiB/s)
seal: preCommit phase 2: 77.637058ms (154.6 KiB/s)
seal: commit phase 1: 74.854102ms (160.3 KiB/s)
seal: commit phase 2: 5m29.575984093s (37 B/s)
seal: verify: 29.21613ms
unseal: 15.563784ms  (771 KiB/s)

generate candidates: 88.937µs (131.8 MiB/s)
compute winning post proof (cold): 6.179655103s
compute winning post proof (hot): 5.633799629s
verify winning post proof (cold): 217.527573ms
verify winning post proof (hot): 5.007412ms

compute window post proof (cold): 4.570157433s
compute window post proof (hot): 4.626428438s
verify window post proof (cold): 49.432654ms
verify window post proof (hot): 6.340983ms