### PR TITLE
fix get sector bug

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1759,6 +1759,9 @@ var stateSectorCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
+		if si == nil {
+			return xerrors.Errorf("sector %d for miner %s not found", sid, maddr)
+		}
 
 		fmt.Println("SectorNumber: ", si.SectorNumber)
 		fmt.Println("SealProof: ", si.SealProof)


### PR DESCRIPTION
This PR aims to fix a panic bug when check nonexistent sectors with the following command:

`lotus state sector [miner address] [sector number]`
