### PR TITLE
Updates for new blst group check API

### DIFF
--- a/chain/gen/mining.go
+++ b/chain/gen/mining.go
@@ -145,8 +145,8 @@ func aggregateSignatures(sigs []crypto.Signature) (*crypto.Signature, error) {
 		sigsS[i] = sigs[i].Data
 	}
 
-	aggregator := new(bls.AggregateSignature).AggregateCompressed(sigsS)
-	if aggregator == nil {
+	aggregator := new(bls.AggregateSignature)
+	if !aggregator.AggregateCompressed(sigsS, true) {
 		if len(sigs) > 0 {
 			return nil, xerrors.Errorf("bls.Aggregate returned nil with %d signatures", len(sigs))
 		}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1199,8 +1199,8 @@ func (syncer *Syncer) verifyBlsAggregate(ctx context.Context, sig *crypto.Signat
 		return nil
 	}
 
-	valid := new(bls.Signature).AggregateVerifyCompressed(sig.Data, pubks,
-		msgsS, []byte(bls.DST))
+	valid := new(bls.Signature).AggregateVerifyCompressed(sig.Data, true, pubks,
+		true, msgsS, []byte(bls.DST))
 	if !valid {
 		return xerrors.New("bls aggregate signature failed to verify")
 	}

--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -362,6 +362,17 @@ var runCmd = &cli.Command{
 
 		remote := stores.NewRemote(localStore, nodeApi, sminfo.AuthHeader(), cctx.Int("parallel-fetch-limit"))
 
+		fh := &stores.FetchHandler{Local: localStore}
+		remoteHandler := func(w http.ResponseWriter, r *http.Request) {
+			if !auth.HasPerm(r.Context(), nil, apistruct.PermAdmin) {
+				w.WriteHeader(401)
+				_ = json.NewEncoder(w).Encode(struct{ Error string }{"unauthorized: missing admin permission"})
+				return
+			}
+
+			fh.ServeHTTP(w, r)
+		}
+
 		// Create / expose the worker
 
 		wsts := statestore.New(namespace.Wrap(ds, modules.WorkerCallsPrefix))
@@ -385,7 +396,7 @@ var runCmd = &cli.Command{
 
 		mux.Handle("/rpc/v0", rpcServer)
 		mux.Handle("/rpc/streams/v0/push/{uuid}", readerHandler)
-		mux.PathPrefix("/remote").HandlerFunc((&stores.FetchHandler{Local: localStore}).ServeHTTP)
+		mux.PathPrefix("/remote").HandlerFunc(remoteHandler)
 		mux.PathPrefix("/").Handler(http.DefaultServeMux) // pprof
 
 		ah := &auth.Handler{

--- a/lib/sigs/bls/init.go
+++ b/lib/sigs/bls/init.go
@@ -50,7 +50,8 @@ func (blsSigner) Sign(p []byte, msg []byte) ([]byte, error) {
 }
 
 func (blsSigner) Verify(sig []byte, a address.Address, msg []byte) error {
-	if !new(Signature).VerifyCompressed(sig, a.Payload()[:], msg, []byte(DST)) {
+	// Need to allow infinity sig/key up until block X?
+	if !new(Signature).VerifyCompressed(sig, true, a.Payload()[:], true, msg, []byte(DST)) {
 		return fmt.Errorf("bls signature failed to verify")
 	}
 	return nil


### PR DESCRIPTION
Update blst to v0.3.1
Update blst wrappers for the new subgroup check API changes

This change should be coordinated with an update of rust-fil-proofs to avoid using differing versions of blst between the two packages.

Do infinite signatures need to be permitted up to a certain block number? See comment in the code. 