### PR TITLE
fix: start a new line in print miner-info to avoid ambiguous display

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -128,6 +128,7 @@ var stateMinerInfo = &cli.Command{
 			}
 			fmt.Printf("%s ", a)
 		}
+		fmt.Println()
 		fmt.Printf("Consensus Fault End:\t%d\n", mi.ConsensusFaultElapsed)
 
 		fmt.Printf("SectorSize:\t%s (%d)\n", types.SizeStr(types.NewInt(uint64(mi.SectorSize))), mi.SectorSize)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34792731/100421619-acc0bb00-30c3-11eb-9424-2c8d4fcdfd67.png)
This is miner info now, it really makes us confused.