### PR TITLE
Bite the bullet and hard-disable sync for chainstore

### DIFF
--- a/node/repo/blockstore_opts.go
+++ b/node/repo/blockstore_opts.go
@@ -11,6 +11,12 @@ func BadgerBlockstoreOptions(domain BlockstoreDomain, path string, readonly bool
 
 	opts := badgerbs.DefaultOptions(path)
 
+	// FIXME - to be revisited after tiered store work
+	// By default badger is exceptionally fsync()-happy
+	// It is less safe to run this way, but chain-loss is hardly a catastrophic event
+	// at present
+	opts.SyncWrites = false
+
 	// Due to legacy usage of blockstore.Blockstore, over a datastore, all
 	// blocks are prefixed with this namespace. In the future, this can go away,
 	// in order to shorten keys, but it'll require a migration.


### PR DESCRIPTION
Given the current "state-of-the-chain" requiring folk to keep their chainstore safe is rather futile. Let's just disable sync for now.

Latest exhibit of this: https://github.com/filecoin-project/lotus/issues/3263#issue-684587473
Original: https://github.com/filecoin-project/lotus/issues/3263#issue-684587473
