### PR TITLE
Error out deals that are not activated by proposed deal start epoch

### DIFF
--- a/api/test/ccupgrade.go
+++ b/api/test/ccupgrade.go
@@ -89,7 +89,7 @@ func testCCUpgrade(t *testing.T, b APIBuilder, blocktime time.Duration, upgradeH
 		t.Fatal(err)
 	}
 
-	MakeDeal(t, ctx, 6, client, miner, false, false)
+	MakeDeal(t, ctx, 6, client, miner, false, false, 0)
 
 	// Validate upgrade
 

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-cid"
@@ -31,7 +33,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
-func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport, fastRet bool) {
+func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport, fastRet bool, startEpoch abi.ChainEpoch) {
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -60,14 +62,14 @@ func TestDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, carExport
 		}
 	}()
 
-	MakeDeal(t, ctx, 6, client, miner, carExport, fastRet)
+	MakeDeal(t, ctx, 6, client, miner, carExport, fastRet, startEpoch)
 
 	atomic.AddInt64(&mine, -1)
 	fmt.Println("shutting down mining")
 	<-done
 }
 
-func TestDoubleDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
+func TestDoubleDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, startEpoch abi.ChainEpoch) {
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -97,15 +99,15 @@ func TestDoubleDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
 		}
 	}()
 
-	MakeDeal(t, ctx, 6, client, miner, false, false)
-	MakeDeal(t, ctx, 7, client, miner, false, false)
+	MakeDeal(t, ctx, 6, client, miner, false, false, startEpoch)
+	MakeDeal(t, ctx, 7, client, miner, false, false, startEpoch)
 
 	atomic.AddInt64(&mine, -1)
 	fmt.Println("shutting down mining")
 	<-done
 }
 
-func MakeDeal(t *testing.T, ctx context.Context, rseed int, client api.FullNode, miner TestStorageNode, carExport, fastRet bool) {
+func MakeDeal(t *testing.T, ctx context.Context, rseed int, client api.FullNode, miner TestStorageNode, carExport, fastRet bool, startEpoch abi.ChainEpoch) {
 	res, data, err := CreateClientFile(ctx, client, rseed)
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +116,7 @@ func MakeDeal(t *testing.T, ctx context.Context, rseed int, client api.FullNode,
 	fcid := res.Root
 	fmt.Println("FILE CID: ", fcid)
 
-	deal := startDeal(t, ctx, miner, client, fcid, fastRet)
+	deal := startDeal(t, ctx, miner, client, fcid, fastRet, startEpoch)
 
 	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 	time.Sleep(time.Second)
@@ -149,7 +151,7 @@ func CreateClientFile(ctx context.Context, client api.FullNode, rseed int) (*api
 	return res, data, nil
 }
 
-func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration) {
+func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, startEpoch abi.ChainEpoch) {
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -189,7 +191,7 @@ func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Durati
 
 	fmt.Println("FILE CID: ", fcid)
 
-	deal := startDeal(t, ctx, miner, client, fcid, true)
+	deal := startDeal(t, ctx, miner, client, fcid, true, startEpoch)
 
 	waitDealPublished(t, ctx, miner, deal)
 	fmt.Println("deal published, retrieving")
@@ -203,7 +205,7 @@ func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Durati
 	<-done
 }
 
-func TestSenondDealRetrieval(t *testing.T, b APIBuilder, blocktime time.Duration) {
+func TestSecondDealRetrieval(t *testing.T, b APIBuilder, blocktime time.Duration) {
 
 	ctx := context.Background()
 	n, sn := b(t, OneFull, OneMiner)
@@ -252,13 +254,13 @@ func TestSenondDealRetrieval(t *testing.T, b APIBuilder, blocktime time.Duration
 			t.Fatal(err)
 		}
 
-		deal1 := startDeal(t, ctx, miner, client, fcid1, true)
+		deal1 := startDeal(t, ctx, miner, client, fcid1, true, 0)
 
 		// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 		time.Sleep(time.Second)
 		waitDealSealed(t, ctx, miner, client, deal1, true)
 
-		deal2 := startDeal(t, ctx, miner, client, fcid2, true)
+		deal2 := startDeal(t, ctx, miner, client, fcid2, true, 0)
 
 		time.Sleep(time.Second)
 		waitDealSealed(t, ctx, miner, client, deal2, false)
@@ -278,7 +280,7 @@ func TestSenondDealRetrieval(t *testing.T, b APIBuilder, blocktime time.Duration
 	<-done
 }
 
-func startDeal(t *testing.T, ctx context.Context, miner TestStorageNode, client api.FullNode, fcid cid.Cid, fastRet bool) *cid.Cid {
+func startDeal(t *testing.T, ctx context.Context, miner TestStorageNode, client api.FullNode, fcid cid.Cid, fastRet bool, startEpoch abi.ChainEpoch) *cid.Cid {
 	maddr, err := miner.ActorAddress(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -296,6 +298,7 @@ func startDeal(t *testing.T, ctx context.Context, miner TestStorageNode, client 
 		Wallet:            addr,
 		Miner:             maddr,
 		EpochPrice:        types.NewInt(1000000),
+		DealStartEpoch:    startEpoch,
 		MinBlocksDuration: uint64(build.MinDealDuration),
 		FastRetrieval:     fastRet,
 	})

--- a/api/test/mining.go
+++ b/api/test/mining.go
@@ -186,7 +186,7 @@ func TestDealMining(t *testing.T, b APIBuilder, blocktime time.Duration, carExpo
 		}
 	}()
 
-	deal := startDeal(t, ctx, provider, client, fcid, false)
+	deal := startDeal(t, ctx, provider, client, fcid, false, 0)
 
 	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 	time.Sleep(time.Second)

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -300,7 +300,11 @@ func GetStorageDeal(ctx context.Context, sm *StateManager, dealID abi.DealID, ts
 	if err != nil {
 		return nil, err
 	} else if !found {
-		return nil, xerrors.Errorf("deal %d not found", dealID)
+		return nil, xerrors.Errorf(
+			"deal %d not found "+
+				"- deal may not have completed sealing before deal proposal "+
+				"start epoch, or deal may have been slashed",
+			dealID)
 	}
 
 	states, err := state.States()

--- a/cli/test/client.go
+++ b/cli/test/client.go
@@ -43,13 +43,14 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 	require.Regexp(t, regexp.MustCompile("Ask:"), out)
 
 	// Create a deal (non-interactive)
-	// client deal <cid> <miner addr> 1000000attofil <duration>
+	// client deal --start-epoch=<start epoch> <cid> <miner addr> 1000000attofil <duration>
 	res, _, err := test.CreateClientFile(ctx, clientNode, 1)
 	require.NoError(t, err)
+	startEpoch := fmt.Sprintf("--start-epoch=%d", 2<<12)
 	dataCid := res.Root
 	price := "1000000attofil"
 	duration := fmt.Sprintf("%d", build.MinDealDuration)
-	out = clientCLI.RunCmd("client", "deal", dataCid.String(), minerAddr.String(), price, duration)
+	out = clientCLI.RunCmd("client", "deal", startEpoch, dataCid.String(), minerAddr.String(), price, duration)
 	fmt.Println("client deal", out)
 
 	// Create a deal (interactive)

--- a/cmd/lotus-gateway/endtoend_test.go
+++ b/cmd/lotus-gateway/endtoend_test.go
@@ -171,7 +171,11 @@ func TestDealFlow(t *testing.T) {
 	nodes := startNodesWithFunds(ctx, t, blocktime, maxLookbackCap, maxStateWaitLookbackLimit)
 	defer nodes.closer()
 
-	test.MakeDeal(t, ctx, 6, nodes.lite, nodes.miner, false, false)
+	// For these tests where the block time is artificially short, just use
+	// a deal start epoch that is guaranteed to be far enough in the future
+	// so that the deal starts sealing in time
+	dealStartEpoch := abi.ChainEpoch(2 << 12)
+	test.MakeDeal(t, ctx, 6, nodes.lite, nodes.miner, false, false, dealStartEpoch)
 }
 
 func TestCLIDealFlow(t *testing.T) {

--- a/cmd/lotus-storage-miner/allinfo_test.go
+++ b/cmd/lotus-storage-miner/allinfo_test.go
@@ -70,7 +70,7 @@ func TestMinerAllInfo(t *testing.T) {
 		return n, sn
 	}
 
-	test.TestDealFlow(t, bp, time.Second, false, false)
+	test.TestDealFlow(t, bp, time.Second, false, false, 0)
 
 	t.Run("post-info-all", run)
 }

--- a/markets/storageadapter/ondealsectorcommitted.go
+++ b/markets/storageadapter/ondealsectorcommitted.go
@@ -71,7 +71,7 @@ func OnDealSectorPreCommitted(ctx context.Context, api getCurrentDealInfoAPI, ev
 		// If the deal hasn't been activated by the proposed start epoch, the
 		// deal will timeout (when msg == nil it means the timeout epoch was reached)
 		if msg == nil {
-			err := xerrors.Errorf("deal %d was not activated by proposed deal start epoch %d", dealID, proposal.StartEpoch)
+			err = xerrors.Errorf("deal %d was not activated by proposed deal start epoch %d", dealID, proposal.StartEpoch)
 			return false, err
 		}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -38,17 +38,24 @@ func TestAPIDealFlow(t *testing.T) {
 	logging.SetLogLevel("sub", "ERROR")
 	logging.SetLogLevel("storageminer", "ERROR")
 
+	blockTime := 10 * time.Millisecond
+
+	// For these tests where the block time is artificially short, just use
+	// a deal start epoch that is guaranteed to be far enough in the future
+	// so that the deal starts sealing in time
+	dealStartEpoch := abi.ChainEpoch(2 << 12)
+
 	t.Run("TestDealFlow", func(t *testing.T) {
-		test.TestDealFlow(t, builder.MockSbBuilder, 10*time.Millisecond, false, false)
+		test.TestDealFlow(t, builder.MockSbBuilder, blockTime, false, false, dealStartEpoch)
 	})
 	t.Run("WithExportedCAR", func(t *testing.T) {
-		test.TestDealFlow(t, builder.MockSbBuilder, 10*time.Millisecond, true, false)
+		test.TestDealFlow(t, builder.MockSbBuilder, blockTime, true, false, dealStartEpoch)
 	})
 	t.Run("TestDoubleDealFlow", func(t *testing.T) {
-		test.TestDoubleDealFlow(t, builder.MockSbBuilder, 10*time.Millisecond)
+		test.TestDoubleDealFlow(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
 	})
 	t.Run("TestFastRetrievalDealFlow", func(t *testing.T) {
-		test.TestFastRetrievalDealFlow(t, builder.MockSbBuilder, 10*time.Millisecond)
+		test.TestFastRetrievalDealFlow(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
 	})
 }
 
@@ -71,15 +78,15 @@ func TestAPIDealFlowReal(t *testing.T) {
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		test.TestDealFlow(t, builder.Builder, time.Second, false, false)
+		test.TestDealFlow(t, builder.Builder, time.Second, false, false, 0)
 	})
 
 	t.Run("fast-retrieval", func(t *testing.T) {
-		test.TestDealFlow(t, builder.Builder, time.Second, false, true)
+		test.TestDealFlow(t, builder.Builder, time.Second, false, true, 0)
 	})
 
 	t.Run("retrieval-second", func(t *testing.T) {
-		test.TestSenondDealRetrieval(t, builder.Builder, time.Second)
+		test.TestSecondDealRetrieval(t, builder.Builder, time.Second)
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/lotus/issues/4990

When a deal is terminated by the miner, the client can get stuck in `StorageDealSealing`.

This PR adds functionality to the functions that wait for pre-commit and prove-commit such that they will callback with an error if the chain reaches the proposed start epoch for the deal without the deal being activated.

Fixes https://github.com/filecoin-project/lotus/issues/4977

Provides a better error message for when the deal is not found.
Old: "deal 12345 not found"
New: "deal 12345 not found - deal may not have completed sealing before deal proposal start epoch, or deal may have been slashed"