### PR TITLE
Ledger signature verification

### DIFF
--- a/cmd/lotus-shed/ledger.go
+++ b/cmd/lotus-shed/ledger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/urfave/cli/v2"
 	ledgerfil "github.com/whyrusleeping/ledger-filecoin-go"
 
@@ -249,7 +250,9 @@ var ledgerSignTestCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("Signature: %x\n", sig.SignatureBytes())
+		sigBytes := append([]byte{byte(crypto.SigTypeSecp256k1)}, sig.SignatureBytes()...)
+
+		fmt.Printf("Signature: %x\n", sigBytes)
 
 		return nil
 	},

--- a/cmd/lotus-shed/ledger.go
+++ b/cmd/lotus-shed/ledger.go
@@ -242,13 +242,14 @@ var ledgerSignTestCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
+		fmt.Printf("Message: %x\n", b.RawData())
 
 		sig, err := fl.SignSECP256K1(p, b.RawData())
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(sig.SignatureBytes())
+		fmt.Printf("Signature: %x\n", sig.SignatureBytes())
 
 		return nil
 	},


### PR DESCRIPTION
Print message and signature including secpk byte to try validating ledger signature with `lotus wallet verify`