### PR TITLE
miner: Control address config for (pre)commits

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -201,6 +201,14 @@ func (st *SealSeed) Equals(ost *SealSeed) bool {
 
 type SectorState string
 
+type AddrUse int
+
+const (
+	PreCommitAddr AddrUse = iota
+	CommitAddr
+	PoStAddr
+)
+
 type AddressConfig struct {
 	PreCommitControl []address.Address
 	CommitControl    []address.Address

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -5,21 +5,22 @@ import (
 	"context"
 	"time"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/specs-storage/storage"
+
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
-	"github.com/filecoin-project/specs-storage/storage"
 )
 
 // StorageMiner is a low-level interface to the Filecoin network storage miner node
@@ -29,6 +30,7 @@ type StorageMiner interface {
 	ActorAddress(context.Context) (address.Address, error)
 
 	ActorSectorSize(context.Context, address.Address) (abi.SectorSize, error)
+	ActorAddressConfig(ctx context.Context) (AddressConfig, error)
 
 	MiningBase(context.Context) (*types.TipSet, error)
 
@@ -198,3 +200,8 @@ func (st *SealSeed) Equals(ost *SealSeed) bool {
 }
 
 type SectorState string
+
+type AddressConfig struct {
+	PreCommitControl []address.Address
+	CommitControl    []address.Address
+}

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -279,6 +279,7 @@ type StorageMinerStruct struct {
 	Internal struct {
 		ActorAddress    func(context.Context) (address.Address, error)                 `perm:"read"`
 		ActorSectorSize func(context.Context, address.Address) (abi.SectorSize, error) `perm:"read"`
+		ActorAddressConfig func(ctx context.Context) (api.AddressConfig, error)`perm:"read"`
 
 		MiningBase func(context.Context) (*types.TipSet, error) `perm:"read"`
 
@@ -1228,6 +1229,10 @@ func (c *StorageMinerStruct) MiningBase(ctx context.Context) (*types.TipSet, err
 
 func (c *StorageMinerStruct) ActorSectorSize(ctx context.Context, addr address.Address) (abi.SectorSize, error) {
 	return c.Internal.ActorSectorSize(ctx, addr)
+}
+
+func (c *StorageMinerStruct) ActorAddressConfig(ctx context.Context) (api.AddressConfig, error) {
+	return c.Internal.ActorAddressConfig(ctx)
 }
 
 func (c *StorageMinerStruct) PledgeSector(ctx context.Context) error {

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -277,9 +277,9 @@ type StorageMinerStruct struct {
 	CommonStruct
 
 	Internal struct {
-		ActorAddress    func(context.Context) (address.Address, error)                 `perm:"read"`
-		ActorSectorSize func(context.Context, address.Address) (abi.SectorSize, error) `perm:"read"`
-		ActorAddressConfig func(ctx context.Context) (api.AddressConfig, error)`perm:"read"`
+		ActorAddress       func(context.Context) (address.Address, error)                 `perm:"read"`
+		ActorSectorSize    func(context.Context, address.Address) (abi.SectorSize, error) `perm:"read"`
+		ActorAddressConfig func(ctx context.Context) (api.AddressConfig, error)           `perm:"read"`
 
 		MiningBase func(context.Context) (*types.TipSet, error) `perm:"read"`
 

--- a/cmd/lotus-storage-miner/actor.go
+++ b/cmd/lotus-storage-miner/actor.go
@@ -27,7 +27,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
-	"github.com/filecoin-project/lotus/storage"
 )
 
 var actorCmd = &cli.Command{
@@ -414,9 +413,37 @@ var actorControlList = &cli.Command{
 			tablewriter.Col("balance"),
 		)
 
-		postAddr, _, err := storage.AddressFor(ctx, api, mi, storage.PoStAddr, types.FromFil(1), types.FromFil(1))
+		ac, err := nodeApi.ActorAddressConfig(ctx)
 		if err != nil {
-			return xerrors.Errorf("getting address for post: %w", err)
+			return err
+		}
+
+		commit := map[address.Address]struct{}{}
+		precommit := map[address.Address]struct{}{}
+		post := map[address.Address]struct{}{}
+
+		for _, ca := range mi.ControlAddresses {
+			post[ca] = struct{}{}
+		}
+
+		for _, ca := range ac.PreCommitControl {
+			ca, err := api.StateLookupID(ctx, ca, types.EmptyTSK)
+			if err != nil {
+				return err
+			}
+
+			delete(post, ca)
+			precommit[ca] = struct{}{}
+		}
+
+		for _, ca := range ac.CommitControl {
+			ca, err := api.StateLookupID(ctx, ca, types.EmptyTSK)
+			if err != nil {
+				return err
+			}
+
+			delete(post, ca)
+			commit[ca] = struct{}{}
 		}
 
 		printKey := func(name string, a address.Address) {
@@ -451,8 +478,14 @@ var actorControlList = &cli.Command{
 			if a == mi.Worker {
 				uses = append(uses, color.YellowString("other"))
 			}
-			if a == postAddr {
+			if _, ok := post[a]; ok {
 				uses = append(uses, color.GreenString("post"))
+			}
+			if _, ok := precommit[a]; ok {
+				uses = append(uses, color.CyanString("precommit"))
+			}
+			if _, ok := commit[a]; ok {
+				uses = append(uses, color.BlueString("commit"))
 			}
 
 			tw.Write(map[string]interface{}{

--- a/documentation/en/api-methods-miner.md
+++ b/documentation/en/api-methods-miner.md
@@ -6,6 +6,7 @@
   * [Version](#Version)
 * [Actor](#Actor)
   * [ActorAddress](#ActorAddress)
+  * [ActorAddressConfig](#ActorAddressConfig)
   * [ActorSectorSize](#ActorSectorSize)
 * [Auth](#Auth)
   * [AuthNew](#AuthNew)
@@ -174,6 +175,21 @@ Perms: read
 Inputs: `null`
 
 Response: `"f01234"`
+
+### ActorAddressConfig
+There are not yet any comments for this method.
+
+Perms: read
+
+Inputs: `null`
+
+Response:
+```json
+{
+  "PreCommitControl": null,
+  "CommitControl": null
+}
+```
 
 ### ActorSectorSize
 There are not yet any comments for this method.

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -271,7 +271,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 
 	from, _, err := m.addrSel(ctx.Context(), mi, api.PreCommitAddr, goodFunds, deposit)
 	if err != nil {
-		return ctx.Send(SectorChainPreCommitFailed{xerrors.Errorf("no good address to send precommit message from", err)})
+		return ctx.Send(SectorChainPreCommitFailed{xerrors.Errorf("no good address to send precommit message from: %w", err)})
 	}
 
 	log.Infof("submitting precommit for sector %d (deposit: %s): ", sector.SectorNumber, deposit)
@@ -461,7 +461,7 @@ func (m *Sealing) handleSubmitCommit(ctx statemachine.Context, sector SectorInfo
 
 	from, _, err := m.addrSel(ctx.Context(), mi, api.PreCommitAddr, goodFunds, collateral)
 	if err != nil {
-		return ctx.Send(SectorCommitFailed{xerrors.Errorf("no good address to send commit message from", err)})
+		return ctx.Send(SectorCommitFailed{xerrors.Errorf("no good address to send commit message from: %w", err)})
 	}
 
 	// TODO: check seed / ticket / deals are up to date

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -459,7 +459,7 @@ func (m *Sealing) handleSubmitCommit(ctx statemachine.Context, sector SectorInfo
 
 	goodFunds := big.Add(collateral, m.feeCfg.MaxCommitGasFee)
 
-	from, _, err := m.addrSel(ctx.Context(), mi, api.PreCommitAddr, goodFunds, collateral)
+	from, _, err := m.addrSel(ctx.Context(), mi, api.CommitAddr, goodFunds, collateral)
 	if err != nil {
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("no good address to send commit message from: %w", err)})
 	}

--- a/node/builder.go
+++ b/node/builder.go
@@ -357,6 +357,7 @@ func Online() Option {
 
 			Override(new(*sectorblocks.SectorBlocks), sectorblocks.NewSectorBlocks),
 			Override(new(*storage.Miner), modules.StorageMiner(config.DefaultStorageMiner().Fees)),
+			Override(new(*storage.AddressSelector), modules.AddressSelector(nil)),
 			Override(new(dtypes.NetworkName), modules.StorageNetworkName),
 
 			Override(new(dtypes.StagingMultiDstore), modules.StagingMultiDatastore),
@@ -511,6 +512,7 @@ func ConfigStorageMiner(c interface{}) Option {
 		Override(new(storagemarket.StorageProviderNode), storageadapter.NewProviderNodeAdapter(&cfg.Fees)),
 
 		Override(new(sectorstorage.SealerConfig), cfg.Storage),
+		Override(new(*storage.AddressSelector), modules.AddressSelector(&cfg.Addresses)),
 		Override(new(*storage.Miner), modules.StorageMiner(cfg.Fees)),
 	)
 }

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -211,6 +211,11 @@ func DefaultStorageMiner() *StorageMiner {
 			MaxPublishDealsFee:     types.MustParseFIL("0.05"),
 			MaxMarketBalanceAddFee: types.MustParseFIL("0.007"),
 		},
+
+		Addresses: MinerAddressConfig{
+			PreCommitControl: []string{},
+			CommitControl:    []string{},
+		},
 	}
 	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"
 	cfg.Common.API.RemoteListenAddress = "127.0.0.1:2345"

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -36,6 +36,7 @@ type StorageMiner struct {
 	Sealing    SealingConfig
 	Storage    sectorstorage.SealerConfig
 	Fees       MinerFeeConfig
+	Addresses  MinerAddressConfig
 }
 
 type DealmakingConfig struct {
@@ -69,6 +70,11 @@ type MinerFeeConfig struct {
 	MaxWindowPoStGasFee    types.FIL
 	MaxPublishDealsFee     types.FIL
 	MaxMarketBalanceAddFee types.FIL
+}
+
+type MinerAddressConfig struct {
+	PreCommitControl []string
+	CommitControl    []string
 }
 
 // API contains configs for API endpoint

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -574,7 +574,6 @@ func (sm *StorageMinerAPI) CheckProvable(ctx context.Context, pp abi.RegisteredP
 	return out, nil
 }
 
-
 func (sm *StorageMinerAPI) ActorAddressConfig(ctx context.Context) (api.AddressConfig, error) {
 	return sm.AddrSel.AddressConfig, nil
 }

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -57,6 +57,7 @@ type StorageMinerAPI struct {
 	storiface.WorkerReturn
 	DataTransfer dtypes.ProviderDataTransfer
 	Host         host.Host
+	AddrSel      *storage.AddressSelector
 
 	DS dtypes.MetadataDS
 
@@ -571,6 +572,11 @@ func (sm *StorageMinerAPI) CheckProvable(ctx context.Context, pp abi.RegisteredP
 	}
 
 	return out, nil
+}
+
+
+func (sm *StorageMinerAPI) ActorAddressConfig(ctx context.Context) (api.AddressConfig, error) {
+	return sm.AddrSel.AddressConfig, nil
 }
 
 var _ api.StorageMiner = &StorageMinerAPI{}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -145,6 +145,35 @@ func SectorIDCounter(ds dtypes.MetadataDS) sealing.SectorIDCounter {
 	return &sidsc{sc}
 }
 
+func AddressSelector(addrConf *config.MinerAddressConfig) func() (*storage.AddressSelector, error) {
+	return func() (*storage.AddressSelector, error) {
+		as := &storage.AddressSelector{}
+		if addrConf == nil {
+			return as, nil
+		}
+
+		for _, s := range addrConf.PreCommitControl {
+			addr, err := address.NewFromString(s)
+			if err != nil {
+				return nil, xerrors.Errorf("parsing precommit control address: %w", err)
+			}
+
+			as.PreCommitControl = append(as.PreCommitControl, addr)
+		}
+
+		for _, s := range addrConf.CommitControl {
+			addr, err := address.NewFromString(s)
+			if err != nil {
+				return nil, xerrors.Errorf("parsing commit control address: %w", err)
+			}
+
+			as.CommitControl = append(as.CommitControl, addr)
+		}
+
+		return as, nil
+	}
+}
+
 type StorageMinerParams struct {
 	fx.In
 
@@ -158,6 +187,7 @@ type StorageMinerParams struct {
 	Verifier           ffiwrapper.Verifier
 	GetSealingConfigFn dtypes.GetSealingConfigFunc
 	Journal            journal.Journal
+	AddrSel            *storage.AddressSelector
 }
 
 func StorageMiner(fc config.MinerFeeConfig) func(params StorageMinerParams) (*storage.Miner, error) {
@@ -173,6 +203,7 @@ func StorageMiner(fc config.MinerFeeConfig) func(params StorageMinerParams) (*st
 			verif  = params.Verifier
 			gsd    = params.GetSealingConfigFn
 			j      = params.Journal
+			as     = params.AddrSel
 		)
 
 		maddr, err := minerAddrFromDS(ds)
@@ -182,7 +213,7 @@ func StorageMiner(fc config.MinerFeeConfig) func(params StorageMinerParams) (*st
 
 		ctx := helpers.LifecycleCtx(mctx, lc)
 
-		fps, err := storage.NewWindowedPoStScheduler(api, fc, sealer, sealer, j, maddr)
+		fps, err := storage.NewWindowedPoStScheduler(api, fc, as, sealer, sealer, j, maddr)
 		if err != nil {
 			return nil, err
 		}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -218,7 +218,7 @@ func StorageMiner(fc config.MinerFeeConfig) func(params StorageMinerParams) (*st
 			return nil, err
 		}
 
-		sm, err := storage.NewMiner(api, maddr, h, ds, sealer, sc, verif, gsd, fc, j)
+		sm, err := storage.NewMiner(api, maddr, h, ds, sealer, sc, verif, gsd, fc, j, as)
 		if err != nil {
 			return nil, err
 		}

--- a/storage/addresses.go
+++ b/storage/addresses.go
@@ -11,14 +11,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-type AddrUse int
-
-const (
-	PreCommitAddr AddrUse = iota
-	CommitAddr
-	PoStAddr
-)
-
 type addrSelectApi interface {
 	WalletBalance(context.Context, address.Address) (types.BigInt, error)
 	WalletHas(context.Context, address.Address) (bool, error)
@@ -31,12 +23,12 @@ type AddressSelector struct {
 	api.AddressConfig
 }
 
-func (as *AddressSelector) AddressFor(ctx context.Context, a addrSelectApi, mi miner.MinerInfo, use AddrUse, goodFunds, minFunds abi.TokenAmount) (address.Address, abi.TokenAmount, error) {
+func (as *AddressSelector) AddressFor(ctx context.Context, a addrSelectApi, mi miner.MinerInfo, use api.AddrUse, goodFunds, minFunds abi.TokenAmount) (address.Address, abi.TokenAmount, error) {
 	var addrs []address.Address
 	switch use {
-	case PreCommitAddr:
+	case api.PreCommitAddr:
 		addrs = append(addrs, as.PreCommitControl...)
-	case CommitAddr:
+	case api.CommitAddr:
 		addrs = append(addrs, as.CommitControl...)
 	default:
 		defaultCtl := map[address.Address]struct{}{}

--- a/storage/addresses.go
+++ b/storage/addresses.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 )
@@ -26,8 +28,7 @@ type addrSelectApi interface {
 }
 
 type AddressSelector struct {
-	PreCommitControl []address.Address
-	CommitControl    []address.Address
+	api.AddressConfig
 }
 
 func (as *AddressSelector) AddressFor(ctx context.Context, a addrSelectApi, mi miner.MinerInfo, use AddrUse, goodFunds, minFunds abi.TokenAmount) (address.Address, abi.TokenAmount, error) {
@@ -77,10 +78,12 @@ func pickAddress(ctx context.Context, a addrSelectApi, mi miner.MinerInfo, goodF
 	}
 
 	for _, addr := range addrs {
-		addr, err := a.StateLookupID(ctx, addr, types.EmptyTSK)
-		if err != nil {
-			log.Warnw("looking up control address", "address", addr, "error", err)
-			continue
+		if addr.Protocol() != address.ID {
+			addr, err := a.StateLookupID(ctx, addr, types.EmptyTSK)
+			if err != nil {
+				log.Warnw("looking up control address", "address", addr, "error", err)
+				continue
+			}
 		}
 
 		if _, ok := ctl[addr]; !ok {

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -91,6 +91,7 @@ type storageMinerApi interface {
 	StateMinerRecoveries(context.Context, address.Address, types.TipSetKey) (bitfield.BitField, error)
 	StateAccountKey(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
+	StateLookupID(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 
 	MpoolPushMessage(context.Context, *types.Message, *api.MessageSendSpec) (*types.SignedMessage, error)
 

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -41,13 +41,14 @@ import (
 var log = logging.Logger("storageminer")
 
 type Miner struct {
-	api    storageMinerApi
-	feeCfg config.MinerFeeConfig
-	h      host.Host
-	sealer sectorstorage.SectorManager
-	ds     datastore.Batching
-	sc     sealing.SectorIDCounter
-	verif  ffiwrapper.Verifier
+	api     storageMinerApi
+	feeCfg  config.MinerFeeConfig
+	h       host.Host
+	sealer  sectorstorage.SectorManager
+	ds      datastore.Batching
+	sc      sealing.SectorIDCounter
+	verif   ffiwrapper.Verifier
+	addrSel *AddressSelector
 
 	maddr address.Address
 
@@ -114,15 +115,16 @@ type storageMinerApi interface {
 	WalletHas(context.Context, address.Address) (bool, error)
 }
 
-func NewMiner(api storageMinerApi, maddr address.Address, h host.Host, ds datastore.Batching, sealer sectorstorage.SectorManager, sc sealing.SectorIDCounter, verif ffiwrapper.Verifier, gsd dtypes.GetSealingConfigFunc, feeCfg config.MinerFeeConfig, journal journal.Journal) (*Miner, error) {
+func NewMiner(api storageMinerApi, maddr address.Address, h host.Host, ds datastore.Batching, sealer sectorstorage.SectorManager, sc sealing.SectorIDCounter, verif ffiwrapper.Verifier, gsd dtypes.GetSealingConfigFunc, feeCfg config.MinerFeeConfig, journal journal.Journal, as *AddressSelector) (*Miner, error) {
 	m := &Miner{
-		api:    api,
-		feeCfg: feeCfg,
-		h:      h,
-		sealer: sealer,
-		ds:     ds,
-		sc:     sc,
-		verif:  verif,
+		api:     api,
+		feeCfg:  feeCfg,
+		h:       h,
+		sealer:  sealer,
+		ds:      ds,
+		sc:      sc,
+		verif:   verif,
+		addrSel: as,
 
 		maddr:          maddr,
 		getSealConfig:  gsd,
@@ -152,7 +154,12 @@ func (m *Miner) Run(ctx context.Context) error {
 	adaptedAPI := NewSealingAPIAdapter(m.api)
 	// TODO: Maybe we update this policy after actor upgrades?
 	pcp := sealing.NewBasicPreCommitPolicy(adaptedAPI, policy.GetMaxSectorExpirationExtension()-(md.WPoStProvingPeriod*2), md.PeriodStart%md.WPoStProvingPeriod)
-	m.sealing = sealing.New(adaptedAPI, fc, NewEventsAdapter(evts), m.maddr, m.ds, m.sealer, m.sc, m.verif, &pcp, sealing.GetSealingConfigFunc(m.getSealConfig), m.handleSealingNotifications)
+
+	as := func(ctx context.Context, mi miner.MinerInfo, use api.AddrUse, goodFunds, minFunds abi.TokenAmount) (address.Address, abi.TokenAmount, error) {
+		return m.addrSel.AddressFor(ctx, m.api, mi, use, goodFunds, minFunds)
+	}
+
+	m.sealing = sealing.New(adaptedAPI, fc, NewEventsAdapter(evts), m.maddr, m.ds, m.sealer, m.sc, m.verif, &pcp, sealing.GetSealingConfigFunc(m.getSealConfig), m.handleSealingNotifications, as)
 
 	go m.sealing.Run(ctx) //nolint:errcheck // logged intside the function
 

--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -799,7 +799,7 @@ func (s *WindowPoStScheduler) setSender(ctx context.Context, msg *types.Message,
 	goodFunds := big.Add(msg.RequiredFunds(), msg.Value)
 	minFunds := big.Min(big.Add(minGasFeeMsg.RequiredFunds(), minGasFeeMsg.Value), goodFunds)
 
-	pa, avail, err := AddressFor(ctx, s.api, mi, PoStAddr, goodFunds, minFunds)
+	pa, avail, err := s.addrSel.AddressFor(ctx, s.api, mi, PoStAddr, goodFunds, minFunds)
 	if err != nil {
 		log.Errorw("error selecting address for window post", "error", err)
 		return nil

--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -799,7 +799,7 @@ func (s *WindowPoStScheduler) setSender(ctx context.Context, msg *types.Message,
 	goodFunds := big.Add(msg.RequiredFunds(), msg.Value)
 	minFunds := big.Min(big.Add(minGasFeeMsg.RequiredFunds(), minGasFeeMsg.Value), goodFunds)
 
-	pa, avail, err := s.addrSel.AddressFor(ctx, s.api, mi, PoStAddr, goodFunds, minFunds)
+	pa, avail, err := s.addrSel.AddressFor(ctx, s.api, mi, api.PoStAddr, goodFunds, minFunds)
 	if err != nil {
 		log.Errorw("error selecting address for window post", "error", err)
 		return nil

--- a/storage/wdpost_run_test.go
+++ b/storage/wdpost_run_test.go
@@ -180,6 +180,7 @@ func TestWDPostDoPost(t *testing.T) {
 		proofType:    proofType,
 		actor:        postAct,
 		journal:      journal.NilJournal(),
+		addrSel:      &AddressSelector{},
 	}
 
 	di := &dline.Info{

--- a/storage/wdpost_sched.go
+++ b/storage/wdpost_sched.go
@@ -25,6 +25,7 @@ import (
 type WindowPoStScheduler struct {
 	api              storageMinerApi
 	feeCfg           config.MinerFeeConfig
+	addrSel          *AddressSelector
 	prover           storage.Prover
 	faultTracker     sectorstorage.FaultTracker
 	proofType        abi.RegisteredPoStProof
@@ -40,7 +41,7 @@ type WindowPoStScheduler struct {
 	// failLk sync.Mutex
 }
 
-func NewWindowedPoStScheduler(api storageMinerApi, fc config.MinerFeeConfig, sb storage.Prover, ft sectorstorage.FaultTracker, j journal.Journal, actor address.Address) (*WindowPoStScheduler, error) {
+func NewWindowedPoStScheduler(api storageMinerApi, fc config.MinerFeeConfig, as *AddressSelector, sb storage.Prover, ft sectorstorage.FaultTracker, j journal.Journal, actor address.Address) (*WindowPoStScheduler, error) {
 	mi, err := api.StateMinerInfo(context.TODO(), actor, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("getting sector size: %w", err)
@@ -54,6 +55,7 @@ func NewWindowedPoStScheduler(api storageMinerApi, fc config.MinerFeeConfig, sb 
 	return &WindowPoStScheduler{
 		api:              api,
 		feeCfg:           fc,
+		addrSel:          as,
 		prover:           sb,
 		faultTracker:     ft,
 		proofType:        rt,


### PR DESCRIPTION
Works in pond
```
[magik6k@nexus go-lotus]$ ./lotus-miner actor control list
name       ID      key           use        balance                         
owner      t0100   t3qjeopnj...  other      4999939.999818471486715073 FIL  
worker     t0100   t3qjeopnj...  other      4999939.999818471486715073 FIL  
control-0  t01003  t1jmtyeyi...  post       19.999968525034269047 FIL       
control-1  t01002  t1ssrtzxf...  commit     19.999995140976892322 FIL       
control-2  t01001  t1yqcbo2a...  precommit  19.999998703067058983 FIL
```