### PR TITLE
sync: log a message when there aren't enough peers

### DIFF
--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -59,4 +59,5 @@ const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)
 
 const PropagationDelaySecs = uint64(6)
 
+// BootstrapPeerThreshold is the minimum number peers we need to track for a sync worker to start
 const BootstrapPeerThreshold = 4

--- a/chain/sync_manager.go
+++ b/chain/sync_manager.go
@@ -203,6 +203,7 @@ func (sm *syncManager) handlePeerHead(head peerHead) {
 
 		// not yet; do we have enough peers?
 		if len(sm.heads) < BootstrapPeerThreshold {
+			log.Debugw("not tracking enough peers to start sync worker", "have", len(sm.heads), "need", BootstrapPeerThreshold)
 			// not enough peers; track it and wait
 			return
 		}


### PR DESCRIPTION
This is really annoying to hit and have no information when `lotus sync status` just returns nothing. Ideally a message should be printed when this command is ran and there aren't enough peers. But at least a debug message will make it possible to track down for people.

```
$ lotus lotus sync status
sync status:
```