### PR TITLE
Use FundManager to withdraw funds, add MarketWithdraw API

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -519,6 +519,8 @@ type FullNode interface {
 	MarketReserveFunds(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error)
 	// MarketReleaseFunds releases funds reserved by MarketReserveFunds
 	MarketReleaseFunds(ctx context.Context, addr address.Address, amt types.BigInt) error
+	// MarketWithdraw withdraws unlocked funds from the market actor
+	MarketWithdraw(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)
 
 	// MethodGroup: Paych
 	// The Paych methods are for interacting with and managing payment channels

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -246,6 +246,7 @@ type FullNodeStruct struct {
 
 		MarketReserveFunds func(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error) `perm:"sign"`
 		MarketReleaseFunds func(ctx context.Context, addr address.Address, amt types.BigInt) error                                    `perm:"sign"`
+		MarketWithdraw     func(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)                 `perm:"sign"`
 
 		PaychGet                    func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
 		PaychGetWaitReady           func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
@@ -1147,6 +1148,10 @@ func (c *FullNodeStruct) MarketReserveFunds(ctx context.Context, wallet address.
 
 func (c *FullNodeStruct) MarketReleaseFunds(ctx context.Context, addr address.Address, amt types.BigInt) error {
 	return c.Internal.MarketReleaseFunds(ctx, addr, amt)
+}
+
+func (c *FullNodeStruct) MarketWithdraw(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error) {
+	return c.Internal.MarketWithdraw(ctx, wallet, addr, amt)
 }
 
 func (c *FullNodeStruct) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -16,11 +16,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/specs-actors/actors/builtin/market"
-	"github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
-	"github.com/filecoin-project/lotus/chain/actors"
-	types "github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 )
 
@@ -585,27 +582,13 @@ var walletMarketWithdraw = &cli.Command{
 			return xerrors.Errorf("zero unlocked funds available to withdraw")
 		}
 
-		params, err := actors.SerializeParams(&market.WithdrawBalanceParams{
-			ProviderOrClientAddress: addr,
-			Amount:                  amt,
-		})
-		if err != nil {
-			return xerrors.Errorf("serializing params: %w", err)
-		}
-
 		fmt.Printf("Submitting WithdrawBalance message for amount %s for address %s\n", types.FIL(amt), from.String())
-		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
-			To:     builtin.StorageMarketActorAddr,
-			From:   from,
-			Value:  types.NewInt(0),
-			Method: builtin.MethodsMarket.WithdrawBalance,
-			Params: params,
-		}, nil)
+		smsg, err := api.MarketWithdraw(ctx, from, addr, amt)
 		if err != nil {
-			return xerrors.Errorf("submitting WithdrawBalance message: %w", err)
+			return xerrors.Errorf("fund manager withdraw error: %w", err)
 		}
 
-		fmt.Printf("WithdrawBalance message cid: %s\n", smsg.Cid())
+		fmt.Printf("WithdrawBalance message cid: %s\n", smsg)
 
 		return nil
 	},

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -70,6 +70,7 @@
 * [Market](#Market)
   * [MarketReleaseFunds](#MarketReleaseFunds)
   * [MarketReserveFunds](#MarketReserveFunds)
+  * [MarketWithdraw](#MarketWithdraw)
 * [Miner](#Miner)
   * [MinerCreateBlock](#MinerCreateBlock)
   * [MinerGetBaseInfo](#MinerGetBaseInfo)
@@ -1634,6 +1635,28 @@ Response: `{}`
 
 ### MarketReserveFunds
 MarketReserveFunds reserves funds for a deal
+
+
+Perms: sign
+
+Inputs:
+```json
+[
+  "f01234",
+  "f01234",
+  "0"
+]
+```
+
+Response:
+```json
+{
+  "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+}
+```
+
+### MarketWithdraw
+MarketWithdraw withdraws unlocked funds from the market actor
 
 
 Perms: sign

--- a/node/impl/market/market.go
+++ b/node/impl/market/market.go
@@ -5,10 +5,11 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/market"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/ipfs/go-cid"
 )
 
 type MarketAPI struct {
@@ -23,4 +24,8 @@ func (a *MarketAPI) MarketReserveFunds(ctx context.Context, wallet address.Addre
 
 func (a *MarketAPI) MarketReleaseFunds(ctx context.Context, addr address.Address, amt types.BigInt) error {
 	return a.FMgr.Release(addr, amt)
+}
+
+func (a *MarketAPI) MarketWithdraw(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error) {
+	return a.FMgr.Withdraw(ctx, wallet, addr, amt)
 }


### PR DESCRIPTION
## Summary
Use the [FundManager's Withdraw](https://github.com/filecoin-project/lotus/blob/b13226bc2f8a0233b3beb9bd18ab266547bc29c7/chain/market/fundmanager.go#L128-L130) for the CLI command, `wallet market withdraw`.  This will take into account funds reserved for in-progress deals.  Also expose this FundManager method in the API.

Resolves #5100