### PR TITLE
Optimize miner info & sectors list loading

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -43,6 +43,12 @@ type StorageMiner interface {
 	// List all staged sectors
 	SectorsList(context.Context) ([]abi.SectorNumber, error)
 
+	// Get summary info of sectors
+	SectorsSummary(ctx context.Context) (map[SectorState]int, error)
+
+	// List sectors in particular states
+	SectorsListInStates(context.Context, []SectorState) ([]abi.SectorNumber, error)
+
 	SectorsRefs(context.Context) (map[string][]SealedRef, error)
 
 	// SectorStartSealing can be called on sectors in Empty or WaitDeals states

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -301,6 +301,8 @@ type StorageMinerStruct struct {
 
 		SectorsStatus                 func(ctx context.Context, sid abi.SectorNumber, showOnChainInfo bool) (api.SectorInfo, error) `perm:"read"`
 		SectorsList                   func(context.Context) ([]abi.SectorNumber, error)                                             `perm:"read"`
+		SectorsListInStates           func(context.Context, []api.SectorState) ([]abi.SectorNumber, error)                          `perm:"read"`
+		SectorsSummary                func(ctx context.Context) (map[api.SectorState]int, error)                                    `perm:"read"`
 		SectorsRefs                   func(context.Context) (map[string][]api.SealedRef, error)                                     `perm:"read"`
 		SectorStartSealing            func(context.Context, abi.SectorNumber) error                                                 `perm:"write"`
 		SectorSetSealDelay            func(context.Context, time.Duration) error                                                    `perm:"write"`
@@ -1247,6 +1249,14 @@ func (c *StorageMinerStruct) SectorsStatus(ctx context.Context, sid abi.SectorNu
 // List all staged sectors
 func (c *StorageMinerStruct) SectorsList(ctx context.Context) ([]abi.SectorNumber, error) {
 	return c.Internal.SectorsList(ctx)
+}
+
+func (c *StorageMinerStruct) SectorsListInStates(ctx context.Context, states []api.SectorState) ([]abi.SectorNumber, error) {
+	return c.Internal.SectorsListInStates(ctx, states)
+}
+
+func (c *StorageMinerStruct) SectorsSummary(ctx context.Context) (map[api.SectorState]int, error) {
+	return c.Internal.SectorsSummary(ctx)
 }
 
 func (c *StorageMinerStruct) SectorsRefs(ctx context.Context) (map[string][]api.SealedRef, error) {

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -327,22 +327,18 @@ func init() {
 }
 
 func sectorsInfo(ctx context.Context, napi api.StorageMiner) error {
-	sectors, err := napi.SectorsList(ctx)
+	summary, err := napi.SectorsSummary(ctx)
 	if err != nil {
 		return err
 	}
 
-	buckets := map[sealing.SectorState]int{
-		"Total": len(sectors),
+	buckets := make(map[sealing.SectorState]int)
+	var total int
+	for s, c := range summary {
+		buckets[sealing.SectorState(s)] = c
+		total += c
 	}
-	for _, s := range sectors {
-		st, err := napi.SectorsStatus(ctx, s, false)
-		if err != nil {
-			return err
-		}
-
-		buckets[sealing.SectorState(st.State)]++
-	}
+	buckets["Total"] = total
 
 	var sorted []stateMeta
 	for state, i := range buckets {


### PR DESCRIPTION
1. Fix https://github.com/filecoin-project/lotus/issues/4002
2. add flag '--states' to filter result of sectors list

```
$ lotus-miner sectors list --states PreCommit2,Committing
ID   State       OnChain  Active  Expiration  Deals
708  Committing  NO       NO      n/a         CC
726  PreCommit2  NO       NO      n/a         CC
763  PreCommit2  NO       NO      n/a         CC
771  Committing  NO       NO      n/a         CC
772  Committing  NO       NO      n/a         CC
780  PreCommit2  NO       NO      n/a         CC
792  PreCommit2  NO       NO      n/a         CC
793  PreCommit2  NO       NO      n/a         CC
794  PreCommit2  NO       NO      n/a         CC
```