### PR TITLE
fix(sync): enforce ForkLengthThreshold for synced chain

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1449,7 +1449,7 @@ func (syncer *Syncer) syncFork(ctx context.Context, incoming *types.TipSet, know
 		return nil, ErrForkCheckpoint
 	}
 
-	// TODO: Does this mean we always ask for ForkLengthThreshold blocks from the network, even if we just need, like, 2?
+	// TODO: Does this mean we always ask for ForkLengthThreshold blocks from the network, even if we just need, like, 2? Yes.
 	// Would it not be better to ask in smaller chunks, given that an ~ForkLengthThreshold is very rare?
 	tips, err := syncer.Exchange.GetBlocks(ctx, incoming.Parents(), int(build.ForkLengthThreshold))
 	if err != nil {
@@ -1460,6 +1460,10 @@ func (syncer *Syncer) syncFork(ctx context.Context, incoming *types.TipSet, know
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load next local tipset: %w", err)
 	}
+	// Track the fork length on our side of the synced chain to enforce
+	// `ForkLengthThreshold`. Initialized to 1 because we already walked back
+	// one tipset from `known` (our synced head).
+	forkLengthInHead := 1
 
 	for cur := 0; cur < len(tips); {
 		if nts.Height() == 0 {
@@ -1476,6 +1480,13 @@ func (syncer *Syncer) syncFork(ctx context.Context, incoming *types.TipSet, know
 		if nts.Height() < tips[cur].Height() {
 			cur++
 		} else {
+			// Walk back one block in our synced chain to try to meet the fork's
+			// height.
+			forkLengthInHead++
+			if forkLengthInHead > int(build.ForkLengthThreshold) {
+				return nil, ErrForkTooLong
+			}
+
 			// We will be forking away from nts, check that it isn't checkpointed
 			if nts.Key() == chkpt {
 				return nil, ErrForkCheckpoint


### PR DESCRIPTION
In `syncFork`, we currently only apply `ForkLengthThreshold` to the tipsets being fetched for the forked chain (by means of `GetBlocks`, if we walk back the fork chain without finding a common ancestor `syncFork` will fail). We do not apply the threshold for our synced chain, that is, the tipsets that would be "walked back" if the fork is selected as our new head.

This fix introduces a variable (`forkLengthInHead`) to track the tipsets walked back from our synced head to find the common ancestor with the fork. Before we allowed to freely walk back our chain (`nts.Parents()`) to match the next tipset height in the fork chain being traversed (to perform the common ancestor check).

We left the previous check in place for the fork chain (in the `GetBlocks` call) to minimize changes at this time, so we will now enforce the threshold on both sides of the fork. It should be later revisited what do we mean exactly by *fork length* (a term presently missing in the spec).

In theory this is a protocol breaking change but in practice forks in the chain are orders of magnitude smaller than the current limit of 900 enforced here.