### PR TITLE
sector-storage/mock: improve mocked readpiece

### DIFF
--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -347,7 +347,7 @@ func generateFakePoSt(sectorInfo []proof2.SectorInfo, rpt func(abi.RegisteredSea
 }
 
 func (mgr *SectorMgr) ReadPiece(ctx context.Context, w io.Writer, sectorID storage.SectorRef, offset storiface.UnpaddedByteIndex, size abi.UnpaddedPieceSize, randomness abi.SealRandomness, c cid.Cid) error {
-	if len(mgr.sectors[sectorID.ID].pieces) > 1 || offset != 0 {
+	if offset != 0 {
 		panic("implme")
 	}
 


### PR DESCRIPTION
This is an old improvement spotted by @arajasek  when we were trying to figure out the cause of this panic:
```
2020-12-16T10:18:09.309-0300    INFO    markets loggers/loggers.go:25   retrieval event {"name": "ClientEventOpen", "deal ID": "0", "state": "DealStatusNew", "message": ""}
2020-12-16T10:18:09.313-0300    WARN    graphsync_network       network/libp2p_impl.go:65       error setting deadline: set pipe: deadline not supported
2020-12-16T10:18:09.314-0300    INFO    markets loggers/loggers.go:25   retrieval event {"name": "ClientEventDealProposed", "deal ID": "0", "state": "DealStatusWaitForAcceptance", "message": ""}
2020-12-16T10:18:09.315-0300    WARN    graphsync_network       network/libp2p_impl.go:79       error resetting deadline: set pipe: deadline not supported
2020-12-16T10:18:09.318-0300    INFO    markets loggers/loggers.go:30   retrieval event {"name": "ProviderEventOpen", "deal ID": "0", "receiver": "12D3KooWDsnTCj47cRHoBtHcaiiM73dAfqX2FKJr5VpM4heQ6Quz", "state": "DealStatusNew", "message": ""}
2020-12-16T10:18:09.321-0300    INFO    markets loggers/loggers.go:30   retrieval event {"name": "ProviderEventDealAccepted", "deal ID": "0", "receiver": "12D3KooWDsnTCj47cRHoBtHcaiiM73dAfqX2FKJr5VpM4heQ6Quz", "state": "DealStatusUnsealing", "message": ""}
panic: implme

goroutine 12455 [running]:
github.com/filecoin-project/lotus/extern/sector-storage/mock.(*SectorMgr).ReadPiece(0xc0009d8e20, 0x3dd3720, 0xc000124018, 0x3d9b6a0, 0xc00b396258, 0x3e8, 0x3, 0x2, 0x0, 0x7f00000, ...)
        /home/ignacio/go/pkg/mod/github.com/filecoin-project/lotus@v1.3.0-rc1/extern/sector-storage/mock/mock.go:351 +0x350
github.com/filecoin-project/lotus/markets/retrievaladapter.(*retrievalProviderNode).UnsealSector.func1(0xc0093b2000, 0xc000aa9b60, 0x3dd3720, 0xc000124018, 0xc00b396258, 0x3e8, 0x3, 0x2, 0x0, 0x7f00000)
        /home/ignacio/go/pkg/mod/github.com/filecoin-project/lotus@v1.3.0-rc1/markets/retrievaladapter/provider.go:70 +0x1a5
created by github.com/filecoin-project/lotus/markets/retrievaladapter.(*retrievalProviderNode).UnsealSector
        /home/ignacio/go/pkg/mod/github.com/filecoin-project/lotus@v1.3.0-rc1/markets/retrievaladapter/provider.go:65 +0x52b
```
This happens when using 512MiB sectors for the mocked sector-storage. 

The [original PR](https://github.com/filecoin-project/sector-storage/pull/75) for this still exists but was never merged so I'm always doing this patch on every new release for [lotus-devnet](https://github.com/textileio/lotus-devnet/tree/v1.2.2).

cc @arajasek