### PR TITLE
Chainxchg write response timeout

### DIFF
--- a/chain/exchange/server.go
+++ b/chain/exchange/server.go
@@ -56,7 +56,11 @@ func (s *server) HandleStream(stream inet.Stream) {
 	}
 
 	_ = stream.SetDeadline(time.Now().Add(WriteResDeadline))
-	if err := cborutil.WriteCborRPC(stream, resp); err != nil {
+	buffered := bufio.NewWriter(stream)
+	if err = cborutil.WriteCborRPC(buffered, resp); err == nil {
+		err = buffered.Flush()
+	}
+	if err != nil {
 		_ = stream.SetDeadline(time.Time{})
 		log.Warnw("failed to write back response for handle stream",
 			"err", err, "peer", stream.Conn().RemotePeer())


### PR DESCRIPTION
**Description**
Chainxchg is slow. Requests with depth >3 are timed out (60 seconds by default). High CPU usage on server side.
We profiled chainxchg methods and found a bottleneck.

**Problem**
From profiling we found that the longest operation is response writing.
Response is marshalled by `MarshalCBOR` directly to network stream.
`MarshalCBOR` makes a lot of small writes with average size of 1 byte (because it writes each CBOR header separately).
Each of these writes is treated like network packet.
Each packet is encrypted and wrapped by underlying security and multiplexing protocols, which adds overhead to packet size.
A lot of small writes with large overhead are causing timeouts.

**Solution**
Buffered writes.
With this patch we could make requests with larger depth (e.g. 100) without timing out.
Would be good to have this patch applied on mainnet nodes.