### PR TITLE
Gavin fixed the issue5267 which runworker can cause dead lock

### DIFF
--- a/extern/sector-storage/sched_worker.go
+++ b/extern/sector-storage/sched_worker.go
@@ -55,7 +55,7 @@ func (sh *scheduler) runWorker(ctx context.Context, w Worker) error {
 	_, exist := sh.workers[wid]
 	if exist {
 		log.Warnw("duplicated worker added", "id", wid)
-
+               sh.workersLk.Unlock()  //Gavin adding this line and fixed the issue 5267
 		// this is ok, we're already handling this worker in a different goroutine
 		return nil
 	}


### PR DESCRIPTION
The sched_worker.go has the dead lock bug in the fun runWorker().