### PR TITLE
lotus state call will panic

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1617,7 +1617,7 @@ func parseParamsForMethod(act cid.Cid, method uint64, args []string) ([]byte, er
 		return nil, fmt.Errorf("unknown method %d for actor %s", method, act)
 	}
 
-	paramObj := methodMeta.Params
+	paramObj := methodMeta.Params.Elem()
 	if paramObj.NumField() != len(args) {
 		return nil, fmt.Errorf("not enough arguments given to call that method (expecting %d)", paramObj.NumField())
 	}


### PR DESCRIPTION
when use lotus state call method, in lotus/cli/state.go 1620 line, the paramObj needs struct type not a ptr type,if use a ptr type, the program will panic in line 1621(paramObj.NumField())