### PR TITLE
Better CLI for wallet market withdraw and client info

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -517,6 +517,8 @@ type FullNode interface {
 
 	// MarketAddBalance adds funds to the market actor
 	MarketAddBalance(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)
+	// MarketGetReserved gets the amount of funds that are currently reserved for the address
+	MarketGetReserved(ctx context.Context, addr address.Address) (types.BigInt, error)
 	// MarketReserveFunds reserves funds for a deal
 	MarketReserveFunds(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error)
 	// MarketReleaseFunds releases funds reserved by MarketReserveFunds

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -244,10 +244,11 @@ type FullNodeStruct struct {
 		MsigSwapCancel          func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address) (cid.Cid, error)                               `perm:"sign"`
 		MsigRemoveSigner        func(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (cid.Cid, error)              `perm:"sign"`
 
+		MarketAddBalance   func(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)                 `perm:"sign"`
+		MarketGetReserved  func(ctx context.Context, addr address.Address) (types.BigInt, error)                                      `perm:"sign"`
 		MarketReserveFunds func(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error) `perm:"sign"`
 		MarketReleaseFunds func(ctx context.Context, addr address.Address, amt types.BigInt) error                                    `perm:"sign"`
 		MarketWithdraw     func(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)                 `perm:"sign"`
-		MarketAddBalance   func(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)                 `perm:"sign"`
 
 		PaychGet                    func(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)           `perm:"sign"`
 		PaychGetWaitReady           func(context.Context, cid.Cid) (address.Address, error)                                                   `perm:"sign"`
@@ -1151,6 +1152,10 @@ func (c *FullNodeStruct) MsigRemoveSigner(ctx context.Context, msig address.Addr
 
 func (c *FullNodeStruct) MarketAddBalance(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error) {
 	return c.Internal.MarketAddBalance(ctx, wallet, addr, amt)
+}
+
+func (c *FullNodeStruct) MarketGetReserved(ctx context.Context, addr address.Address) (types.BigInt, error) {
+	return c.Internal.MarketGetReserved(ctx, addr)
 }
 
 func (c *FullNodeStruct) MarketReserveFunds(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error) {

--- a/cli/client.go
+++ b/cli/client.go
@@ -1770,10 +1770,22 @@ var clientInfoCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("Client Market Info:\n")
+		reserved, err := api.MarketGetReserved(ctx, addr)
+		if err != nil {
+			return err
+		}
 
-		fmt.Printf("Locked Funds:\t%s\n", types.FIL(balance.Locked))
-		fmt.Printf("Escrowed Funds:\t%s\n", types.FIL(balance.Escrow))
+		avail := big.Sub(big.Sub(balance.Escrow, balance.Locked), reserved)
+		if avail.LessThan(big.Zero()) {
+			avail = big.Zero()
+		}
+
+		fmt.Printf("Client Market Balance for address %s:\n", addr)
+
+		fmt.Printf("  Escrowed Funds:        %s\n", types.FIL(balance.Escrow))
+		fmt.Printf("  Locked Funds:          %s\n", types.FIL(balance.Locked))
+		fmt.Printf("  Reserved Funds:        %s\n", types.FIL(reserved))
+		fmt.Printf("  Available to Withdraw: %s\n", types.FIL(avail))
 
 		return nil
 	},

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -69,6 +69,7 @@
   * [LogSetLevel](#LogSetLevel)
 * [Market](#Market)
   * [MarketAddBalance](#MarketAddBalance)
+  * [MarketGetReserved](#MarketGetReserved)
   * [MarketReleaseFunds](#MarketReleaseFunds)
   * [MarketReserveFunds](#MarketReserveFunds)
   * [MarketWithdraw](#MarketWithdraw)
@@ -1675,6 +1676,21 @@ Response:
   "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
 }
 ```
+
+### MarketGetReserved
+MarketGetReserved gets the amount of funds that are currently reserved for the address
+
+
+Perms: sign
+
+Inputs:
+```json
+[
+  "f01234"
+]
+```
+
+Response: `"0"`
 
 ### MarketReleaseFunds
 MarketReleaseFunds releases funds reserved by MarketReserveFunds

--- a/node/impl/market/market.go
+++ b/node/impl/market/market.go
@@ -42,6 +42,10 @@ func (a *MarketAPI) MarketAddBalance(ctx context.Context, wallet, addr address.A
 	return smsg.Cid(), nil
 }
 
+func (a *MarketAPI) MarketGetReserved(ctx context.Context, addr address.Address) (types.BigInt, error) {
+	return a.FMgr.GetReserved(addr), nil
+}
+
 func (a *MarketAPI) MarketReserveFunds(ctx context.Context, wallet address.Address, addr address.Address, amt types.BigInt) (cid.Cid, error) {
 	return a.FMgr.Reserve(ctx, wallet, addr, amt)
 }


### PR DESCRIPTION
Depends on https://github.com/filecoin-project/lotus/pull/5300

1. Take into account reserved funds when checking if a withdrawal can go through
  FundManager already takes reserved funds into account. This just allows us to provide a nicer error message.
```
$ ./lotus wallet market withdraw 0.1
ERROR: can't withdraw more funds than available; requested: 0.1 FIL; available (0.028390768721594256 FIL) = escrow (0.030402437533428 FIL) - locked (0.001609365784995864 FIL) - reserved (0.00040230302683788 FIL)
```


2. Change `wallet market withdraw` parameter name
  It was `--from`, which was confusing. Change it to `--wallet`.
```
$ ./lotus wallet market withdraw --help
NAME:
   lotus wallet market withdraw - Withdraw funds from the Storage Market Actor

USAGE:
   lotus wallet market withdraw [command options] [amount (FIL) optional, otherwise will withdraw max available]

OPTIONS:
   --wallet value, -w value   Specify address to withdraw funds to, otherwise it will use the default wallet address
   --address value, -a value  Market address to withdraw from (account or miner actor address, defaults to --wallet address)
   --help, -h                 show help (default: false)```
```


3. Include reserved and available amounts in `client info`:
```
Client Market Balance for address t3q6lax2ki2af5tixlv6mx3gfggykjmitozj5n4y5azyebtpgbgwftl6eh6r3z4dwv6kba3huhhuloogmzrkoq:
  Escrowed Funds:        0.030402437533428 FIL
  Locked Funds:          0.001609365784995864 FIL
  Reserved Funds:        0.00040230302683788 FIL
  Available to Withdraw: 0.028390768721594256 FIL
```
