### PR TITLE
Refactor Sync tests

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -716,6 +716,7 @@ func (cs *ChainStore) GetHeaviestTipSet() *types.TipSet {
 	return cs.heaviest
 }
 
+// FIXME: What is the tracker? There is no reference in this function. Define it.
 func (cs *ChainStore) AddToTipSetTracker(b *types.BlockHeader) error {
 	cs.tstLk.Lock()
 	defer cs.tstLk.Unlock()

--- a/node/builder.go
+++ b/node/builder.go
@@ -149,6 +149,11 @@ const (
 
 	SetApiEndpointKey
 
+	// FIXME: Testing a way to manually start a subsystem, probably should
+	//  happen outside of the Settings configuration that seems too coupled
+	//  with an entires node.
+	RunSync
+
 	_nInvokes // keep this last
 )
 
@@ -576,6 +581,25 @@ func Lite(enable bool) FullOption {
 		s.Lite = enable
 		return nil
 	}
+}
+
+func Full() FullOption {
+	return func(s *Settings) error {
+		s.nodeType = repo.FullNode
+		return nil
+	}
+}
+
+func BuildAPI(api interface{}) Option {
+	// FIXME: Actually check that this is one of the sub-structures in
+	//  `impl.FullNodeAPI{}`. This was the closest (suboptimal) solution
+	//  to avoid needing a separate functions for each of the APIs.
+	return Options(
+		func(s *Settings) error {
+			s.invokes[ExtractApiKey] = fx.Populate(api)
+			return nil
+		},
+	)
 }
 
 func FullAPI(out *api.FullNode, fopts ...FullOption) Option {

--- a/node/builder.go
+++ b/node/builder.go
@@ -334,10 +334,15 @@ func Online() Option {
 		// Full node
 		ApplyIf(isFullNode,
 			Override(new(messagesigner.MpoolNonceAPI), From(new(*messagepool.MessagePool))),
+			// Who provides the ChainModule? Is `fx` populating it
+			//  with `ChainStore`, and if so where/when? The From will change
+			//  it to a function taking the struct as an argument which will
+			//  populate as part of the dependency injection.
 			Override(new(full.ChainModuleAPI), From(new(full.ChainModule))),
 			Override(new(full.GasModuleAPI), From(new(full.GasModule))),
 			Override(new(full.MpoolModuleAPI), From(new(full.MpoolModule))),
 			Override(new(full.StateModuleAPI), From(new(full.StateModule))),
+			// FIXME: This one doesn't need the From, it's not an `fx.In` struct.
 			Override(new(stmgr.StateManagerAPI), From(new(*stmgr.StateManager))),
 
 			Override(RunHelloKey, modules.RunHello),

--- a/node/options.go
+++ b/node/options.go
@@ -60,7 +60,7 @@ func Override(typ, constructor interface{}) Option {
 		}
 		ctor := as(constructor, typ)
 		rt := reflect.TypeOf(typ).Elem()
-
+		// We index `modules` with the type `typ` points to.
 		s.modules[rt] = fx.Provide(ctor)
 		return nil
 	}
@@ -85,7 +85,12 @@ func Unset(typ interface{}) Option {
 }
 
 // From(*T) -> func(t T) T {return t}
+// The return type T will be overwritten in Override. The input is normally
+// an `fx.In` structure that the DI system will populate.
+// FIXME: Why do we need this if we already implicitly call `as` in `Override()`?
+//  Can't we move this logic there?
 func From(typ interface{}) interface{} {
+	// FIXME: Validate input before unwrapping with Elem(), we usually expect a pointer.
 	rt := []reflect.Type{reflect.TypeOf(typ).Elem()}
 	ft := reflect.FuncOf(rt, rt, false)
 	return reflect.MakeFunc(ft, func(args []reflect.Value) (results []reflect.Value) {
@@ -104,6 +109,13 @@ func From(typ interface{}) interface{} {
 // Note 2: when making changes here, make sure this method stays at
 // 100% coverage. This makes it less likely it will be terribly broken
 func as(in interface{}, as interface{}) interface{} {
+	// `as` is assumed to be a pointer in this case (`new()` -> `*Type).
+
+	// FIXME: Do we actually need to call this every time? We should at least
+	//  put a check here to see if types already match and do nothing.
+
+	// FIXME: VERY CONFUSING. Renaming the `as` with the `out` prefix will
+	//  be misleading when manipulating the rest of the outputs.
 	outType := reflect.TypeOf(as)
 
 	if outType.Kind() != reflect.Ptr {
@@ -111,44 +123,80 @@ func as(in interface{}, as interface{}) interface{} {
 	}
 
 	if reflect.TypeOf(in).Kind() != reflect.Func {
+		// FIXME: This should absorb the From case, distinguishing if we want a pointer
+		//  or not. From() unwraps the pointer, this case doesn't.
 		ctype := reflect.FuncOf(nil, []reflect.Type{outType.Elem()}, false)
 
+		// Wrap the `in` in a function that returns it with type `as`.
 		return reflect.MakeFunc(ctype, func(args []reflect.Value) (results []reflect.Value) {
+			// First dereference the pointer, `Type.Elem()`. (Empty value pointer.)
 			out := reflect.New(outType.Elem())
+			// Then take the value pointed to, `Value.Elem()`. Set it to the input
+			// function. So it's a pointer to a non-function? (Normally the value
+			// that has been provided.)
+			// FIXME: Check if settable.
 			out.Elem().Set(reflect.ValueOf(in))
 
 			return []reflect.Value{out.Elem()}
 		}).Interface()
 	}
 
+	// `in` is a function, take its signature type, its inputs/outputs:
 	inType := reflect.TypeOf(in)
-
 	ins := make([]reflect.Type, inType.NumIn())
 	outs := make([]reflect.Type, inType.NumOut())
-
 	for i := range ins {
 		ins[i] = inType.In(i)
 	}
+	// FIXME: What are we assuming here by extracting the element of the first
+	//  return value? That it's a pointer? Yes, it is the `as` argument.
+	// We will overwrite the first return value with the `as` type.
 	outs[0] = outType.Elem()
 	for i := range outs[1:] {
 		outs[i+1] = inType.Out(i + 1)
+		// FIXME: Change names, `inType.Out()` is confusing.
 	}
-
+	// The extracted types of the functions in/outs are use to reconstruct
+	// the function type.
+	// FIXME: What is the difference between ctype and the original inType
+	//  from which it was constructed? Only the first return type.
 	ctype := reflect.FuncOf(ins, outs, false)
 
+	// Make a function with the constructed type calling the original in function
+	// changing then the return type of the first element.
+	// FIXME: Complete description.
 	return reflect.MakeFunc(ctype, func(args []reflect.Value) (results []reflect.Value) {
 		outs := reflect.ValueOf(in).Call(args)
 
+		// We replace the first return value (leaving the rest of the `outs` as is).
+		// FIXME: Again calling `Elem()` on the type "de-referencing" it.
 		out := reflect.New(outType.Elem())
+		// Using `out` as an intermediary for the assignment to the real return
+		// values in `outs`.
+		// If the original return value and the new (`as`) one are compatible
+		// just change it.
 		if outs[0].Type().AssignableTo(outType.Elem()) {
 			// Out: Iface = In: *Struct; Out: Iface = In: OtherIface
 			out.Elem().Set(outs[0])
 		} else {
+			// FIXME: Expand on this case.
 			// Out: Iface = &(In: Struct)
 			t := reflect.New(outs[0].Type())
+			// FIXME: If we assume this is a pointer explicitly check it.
 			t.Elem().Set(outs[0])
 			out.Elem().Set(t)
+			// FIXME: How do we know the type of the function return is compatible
+			//  with the new type `as`? We already know `AssignableTo` is false.
+			//  How are these two lines different from the other if case above
+			//  `out.Elem().Set(outs[0])`?
+			// The difference is the `t.Elem()` indirection. We don't assign
+			//  outs[0] but something pointing to outs[0]. The fact the pointer
+			//  is also of type `outs[0].Type()` seems confusing and it may also
+			//  depend on other assumptions.
 		}
+		// FIXME: Explain why can't we just assign to outs[0] directly. (Because
+		//  we seem to be covering two different cases in the `if`, this final
+		//  assignment could have been absorbed there.)
 		outs[0] = out.Elem()
 
 		return outs


### PR DESCRIPTION
This PR is the central point of information and placeholder for WIP notes on an effort to refactor some parts of the sync test logic and more clearly expose the validations taking place.

With no clear plan at the moment the basic intuition is to more clearly decouple between:
* storing
* fetching
* validating
* retransmitting

much of which is now under the umbrella of the Sync API.

Need to review flaky test https://github.com/filecoin-project/lotus/issues/4829 after refactoring.

https://github.com/filecoin-project/lotus/pull/5328: streamline sync  top-level calls to reflect states. This helps moving validations in `syncMessagesAndCheckState` closer to the surface to start giving them an entity of their own.

https://github.com/filecoin-project/lotus/issues/5370

https://github.com/filecoin-project/lotus/issues/4624