### PR TITLE
storagefsm: Fix unsealedInfoMap.lk init race

### DIFF
--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -409,8 +409,9 @@ func (m *Sealing) restartSectors(ctx context.Context) error {
 		return err
 	}
 
-	m.unsealedInfoMap.lk.Lock()
+	// m.unsealedInfoMap.lk.Lock() taken early in .New to prevent races
 	defer m.unsealedInfoMap.lk.Unlock()
+
 	for _, sector := range trackedSectors {
 		if err := m.sectors.Send(uint64(sector.SectorNumber), SectorRestart{}); err != nil {
 			log.Errorf("restarting sector %d: %+v", sector.SectorNumber, err)

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -145,6 +145,8 @@ func New(api SealingAPI, fc FeeConfig, events Events, maddr address.Address, ds 
 
 	s.sectors = statemachine.New(namespace.Wrap(ds, datastore.NewKey(SectorStorePrefix)), s, SectorInfo{})
 
+	s.unsealedInfoMap.lk.Lock() // released after initialized in .Run()
+
 	return s
 }
 


### PR DESCRIPTION
This:
```
goroutine 38357 [semacquire, 17 minutes]:
sync.runtime_SemacquireMutex(0xc01089f264, 0xc0001b9700, 0x1)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc01089f260)
	/usr/local/go/src/sync/mutex.go:138 +0x105
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
github.com/filecoin-project/lotus/extern/storage-sealing.(*Sealing).restartSectors(0xc01089f1d0, 0x32c6520, 0xc01279c700, 0x0, 0x0)
	/opt/lotus/extern/storage-sealing/fsm.go:412 +0x8ea
github.com/filecoin-project/lotus/extern/storage-sealing.(*Sealing).Run(0xc01089f1d0, 0x32c6520, 0xc01279c700, 0xc012312990, 0xc01278f814)
	/opt/lotus/extern/storage-sealing/sealing.go:152 +0x5a
created by github.com/filecoin-project/lotus/storage.(*Miner).Run
	/opt/lotus/storage/miner.go:164 +0x589
```
Could happen when there were a bunch of deals pending on restart, and the market sent them to storage-fsm before it started initializing, leading to a deadlock