### PR TITLE
refactor Sync top level functions

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -840,7 +840,6 @@ type SyncStateStage int
 const (
 	StageIdle = SyncStateStage(iota)
 	StageHeaders
-	StagePersistHeaders
 	StageMessages
 	StageSyncComplete
 	StageSyncErrored
@@ -851,8 +850,6 @@ func (v SyncStateStage) String() string {
 	switch v {
 	case StageHeaders:
 		return "header sync"
-	case StagePersistHeaders:
-		return "persisting headers"
 	case StageMessages:
 		return "message sync"
 	case StageSyncComplete:

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -837,9 +837,13 @@ type SyncState struct {
 
 type SyncStateStage int
 
+// FIXME: Review names. Tipset instead of headers. Describe the action
+//  not the object (fetch and validate instead of headers and messages).
 const (
 	StageIdle = SyncStateStage(iota)
+	// Fetch tipsets.
 	StageHeaders
+	// Validate blocks in tipsets (and messages in those blocks).
 	StageMessages
 	StageSyncComplete
 	StageSyncErrored

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -605,6 +605,11 @@ func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
 
 	ss.SetStage(api.StageMessages)
 
+	// FIXME: `StageFetchingMessages` is buried inside this function (in
+	//  `iterFullTipsets`). We should extract it out and probably request
+	//  *both* block headers and messages together through the corresponding
+	//  chain exchange interface. We can do very little validation without the
+	//  messages so it shouldn't have much impact.
 	if err := syncer.syncMessagesAndCheckState(ctx, subChain); err != nil {
 		span.AddAttributes(trace.StringAttribute("col_error", err.Error()))
 		span.SetStatus(trace.Status{

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1693,7 +1693,7 @@ func persistMessages(ctx context.Context, bs bstore.Blockstore, bst *exchange.Co
 //     else we must drop part of our chain to connect to the peer's head
 //     (referred to as "forking").
 //
-//	2. StagePersistHeaders: now that we've collected the missing headers,
+//     Now that we've collected the missing headers,
 //     augmented by those on the other side of a fork, we persist them to the
 //     BlockStore.
 //
@@ -1718,8 +1718,6 @@ func (syncer *Syncer) collectChain(ctx context.Context, ts *types.TipSet, hts *t
 		log.Errorf("collectChain headers[0] should be equal to sync target. Its not: %s != %s", headers[0].Cids(), ts.Cids())
 	}
 
-	ss.SetStage(api.StagePersistHeaders)
-
 	toPersist := make([]*types.BlockHeader, 0, len(headers)*int(build.BlocksPerEpoch))
 	for _, ts := range headers {
 		toPersist = append(toPersist, ts.Blocks()...)
@@ -1733,6 +1731,7 @@ func (syncer *Syncer) collectChain(ctx context.Context, ts *types.TipSet, hts *t
 
 	ss.SetStage(api.StageMessages)
 
+	// FIXME: Take out to parent function, this is more than just collecting.
 	if err := syncer.syncMessagesAndCheckState(ctx, headers); err != nil {
 		err = xerrors.Errorf("collectChain syncMessages: %w", err)
 		ss.Error(err)


### PR DESCRIPTION
Homogenize `Sync()` calls to better reflect the different states.

Remove `StagePersistHeaders`, absorbed by `StageHeaders` now (the first being local is of low complexity, execution time and possibilities of error compared to the second).

Extract `syncMessagesAndCheckState` out of `collectChain()` and into the main `Sync()` call flow.