### PR TITLE
avoid use mp.cfg directly to avoid race

### DIFF
--- a/chain/messagepool/config.go
+++ b/chain/messagepool/config.go
@@ -48,9 +48,13 @@ func saveConfig(cfg *types.MpoolConfig, ds dtypes.MetadataDS) error {
 }
 
 func (mp *MessagePool) GetConfig() *types.MpoolConfig {
-	mp.cfgLk.Lock()
-	defer mp.cfgLk.Unlock()
-	return mp.cfg.Clone()
+	return mp.getConfig().Clone()
+}
+
+func (mp *MessagePool) getConfig() *types.MpoolConfig {
+	mp.cfgLk.RLock()
+	defer mp.cfgLk.RUnlock()
+	return mp.cfg
 }
 
 func validateConfg(cfg *types.MpoolConfig) error {

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -133,7 +133,7 @@ type MessagePool struct {
 	curTsLk sync.Mutex // DO NOT LOCK INSIDE lk
 	curTs   *types.TipSet
 
-	cfgLk sync.Mutex
+	cfgLk sync.RWMutex
 	cfg   *types.MpoolConfig
 
 	api Provider
@@ -781,7 +781,7 @@ func (mp *MessagePool) addLocked(m *types.SignedMessage, strict, untrusted bool)
 
 	if incr {
 		mp.currentSize++
-		if mp.currentSize > mp.cfg.SizeLimitHigh {
+		if mp.currentSize > mp.getConfig().SizeLimitHigh {
 			// send signal to prune messages if it hasnt already been sent
 			select {
 			case mp.pruneTrigger <- struct{}{}:

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -532,14 +532,14 @@ func (mp *MessagePool) selectPriorityMessages(pending map[address.Address]map[ui
 			log.Infow("select priority messages done", "took", dt)
 		}
 	}()
-
-	result := make([]*types.SignedMessage, 0, mp.cfg.SizeLimitLow)
+	mpCfg := mp.getConfig()
+	result := make([]*types.SignedMessage, 0, mpCfg.SizeLimitLow)
 	gasLimit := int64(build.BlockGasLimit)
 	minGas := int64(gasguess.MinGas)
 
 	// 1. Get priority actor chains
 	var chains []*msgChain
-	priority := mp.cfg.PriorityAddrs
+	priority := mpCfg.PriorityAddrs
 	for _, actor := range priority {
 		mset, ok := pending[actor]
 		if ok {


### PR DESCRIPTION
Since there exists a way to modify the value of mpool.cfg, it will cause a data race and create some unexpected cases.  Lock it with an RWMutex is good