### PR TITLE
Use 55th percentile instead of median for gas-price

### DIFF
--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -93,13 +93,15 @@ type gasMeta struct {
 	limit int64
 }
 
+// finds 55th percntile instead of median to put negative pressure on gas price
 func medianGasPremium(prices []gasMeta, blocks int) abi.TokenAmount {
 	sort.Slice(prices, func(i, j int) bool {
 		// sort desc by price
 		return prices[i].price.GreaterThan(prices[j].price)
 	})
 
-	at := build.BlockGasTarget * int64(blocks) / 2
+	at := build.BlockGasTarget * int64(blocks) / 2        // 50th
+	at += build.BlockGasTarget * int64(blocks) / (2 * 20) // move 5% further
 	prev1, prev2 := big.Zero(), big.Zero()
 	for _, price := range prices {
 		prev1, prev2 = price.price, prev1


### PR DESCRIPTION
The aim is to put some negative pressure on gas-premium instead of
maintining status quo.

55th percentile instead of median should not make much difference for
block inclusion timing.

Still thinking about it a bit, don't merge yet.