### PR TITLE
fix FileSize to return correct disk usage recursively

### DIFF
--- a/extern/sector-storage/fsutil/filesize_unix.go
+++ b/extern/sector-storage/fsutil/filesize_unix.go
@@ -21,7 +21,10 @@ func FileSize(path string) (SizeInfo, error) {
 			return err
 		}
 		if !info.IsDir() {
-			stat := info.Sys().(*syscall.Stat_t)
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				return xerrors.New("FileInfo.Sys of wrong type")
+			}
 
 			// NOTE: stat.Blocks is in 512B blocks, NOT in stat.Blksize		return SizeInfo{size}, nil
 			//  See https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html

--- a/extern/sector-storage/fsutil/filesize_unix.go
+++ b/extern/sector-storage/fsutil/filesize_unix.go
@@ -3,6 +3,7 @@ package fsutil
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"golang.org/x/xerrors"
 )
@@ -12,6 +13,7 @@ type SizeInfo struct {
 }
 
 // FileSize returns bytes used by a file or directory on disk
+// NOTE: We care about the allocated bytes, not file or directory size
 func FileSize(path string) (SizeInfo, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
@@ -19,7 +21,11 @@ func FileSize(path string) (SizeInfo, error) {
 			return err
 		}
 		if !info.IsDir() {
-			size += info.Size()
+			stat := info.Sys().(*syscall.Stat_t)
+
+			// NOTE: stat.Blocks is in 512B blocks, NOT in stat.Blksize		return SizeInfo{size}, nil
+			//  See https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html
+			size += int64(stat.Blocks) * 512 // nolint NOTE: int64 cast is needed on osx
 		}
 		return err
 	})

--- a/extern/sector-storage/fsutil/filesize_unix.go
+++ b/extern/sector-storage/fsutil/filesize_unix.go
@@ -2,7 +2,7 @@ package fsutil
 
 import (
 	"os"
-	"syscall"
+	"path/filepath"
 
 	"golang.org/x/xerrors"
 )
@@ -11,19 +11,24 @@ type SizeInfo struct {
 	OnDisk int64
 }
 
-// FileSize returns bytes used by a file on disk
+// FileSize returns bytes used by a file or directory on disk
 func FileSize(path string) (SizeInfo, error) {
-	var stat syscall.Stat_t
-	if err := syscall.Stat(path, &stat); err != nil {
-		if err == syscall.ENOENT {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
 			return SizeInfo{}, os.ErrNotExist
 		}
-		return SizeInfo{}, xerrors.Errorf("stat: %w", err)
+		return SizeInfo{}, xerrors.Errorf("filepath.Walk err: %w", err)
 	}
 
-	// NOTE: stat.Blocks is in 512B blocks, NOT in stat.Blksize
-	//  See https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html
-	return SizeInfo{
-		int64(stat.Blocks) * 512, // nolint NOTE: int64 cast is needed on osx
-	}, nil
+	return SizeInfo{size}, nil
 }


### PR DESCRIPTION
At the moment `FileSize` is not recursive and doesn't calculate correctly the disk usage of various paths.

This PR is fixing it, by recursively walking the path and adding together all file sizes.

---

Ultimately this is fixing a bug in the `stores` package, where we iterate over all storage reservations and then check how much disk space is used per sector:

```
	for id, ft := range p.reservations {
		for _, fileType := range storiface.PathTypes {
			if fileType&ft == 0 {
				continue
			}

			sp := p.sectorPath(id, fileType)
			used, err := ls.DiskUsage(sp)
```

`sp` in this case has the form of `./cache/s-t0127896-36` which is actually a directory with many `.dat` files, and not a single file.

---

TODO:
- [x] test with `lotus-miner`