### PR TITLE
Introduce a high-level node builder API

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -278,11 +278,11 @@ var DaemonCmd = &cli.Command{
 		}
 
 		builder := node.Builder{
-			IsLite: isLite,
+			IsLite:         isLite,
 			IsBootstrapper: isBootstrapper,
-			IsBootstrap: cctx.Bool("bootstrap"),
-			ShutdownChan: shutdownChan,
-			Repo: r,
+			IsBootstrap:    cctx.Bool("bootstrap"),
+			ShutdownChan:   shutdownChan,
+			Repo:           r,
 		}
 		if cctx.IsSet("api") {
 			builder.ApiAddress = "/ip4/127.0.0.1/tcp/" + cctx.String("api")

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -277,13 +277,13 @@ var DaemonCmd = &cli.Command{
 			log.Warnf("unable to inject prometheus ipfs/go-metrics exporter; some metrics will be unavailable; err: %s", err)
 		}
 
-		builder := node.Builder{
+		builder := (&node.Builder{
 			IsLite:         isLite,
 			IsBootstrapper: isBootstrapper,
 			IsBootstrap:    cctx.Bool("bootstrap"),
 			ShutdownChan:   shutdownChan,
-			Repo:           r,
-		}
+		}).WithRepo(r)
+
 		if cctx.IsSet("api") {
 			builder.ApiAddress = "/ip4/127.0.0.1/tcp/" + cctx.String("api")
 		}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -277,7 +277,7 @@ var DaemonCmd = &cli.Command{
 			log.Warnf("unable to inject prometheus ipfs/go-metrics exporter; some metrics will be unavailable; err: %s", err)
 		}
 
-		builder := (&node.Builder{
+		buildConfig := (&node.Config{
 			IsLite:         isLite,
 			IsBootstrapper: isBootstrapper,
 			IsBootstrap:    cctx.Bool("bootstrap"),
@@ -285,11 +285,11 @@ var DaemonCmd = &cli.Command{
 		}).WithRepo(r)
 
 		if cctx.IsSet("api") {
-			builder.ApiAddress = "/ip4/127.0.0.1/tcp/" + cctx.String("api")
+			buildConfig.ApiAddress = "/ip4/127.0.0.1/tcp/" + cctx.String("api")
 		}
 		// FIXME: Try to process the more complex `Override()` calls like `genesis` and
 		//  `liteModeDeps` also as `Builder` options.
-		api, stop, err := builder.BuildFullNode(ctx, genesis, liteModeDeps)
+		api, stop, err := node.BuildFullNode(ctx, buildConfig, genesis, liteModeDeps)
 		if err != nil {
 			return xerrors.Errorf("initializing node: %w", err)
 		}

--- a/node/builder.go
+++ b/node/builder.go
@@ -662,12 +662,12 @@ type Builder struct {
 	// FIXME: Consider making configuration options private and exposing functions
 	//  to set them. For now it doesn't seem worth it as they are mostly constants
 	//  that we don't process (maybe the ShutdownChan/Repo are the exception).
-	IsLite bool
+	IsLite         bool
 	IsBootstrapper dtypes.Bootstrapper // FIXME: Check why this isn't just a bool.
-	IsBootstrap bool
-	ApiAddress string
-	ShutdownChan chan struct{}
-	Repo repo.Repo
+	IsBootstrap    bool
+	ApiAddress     string
+	ShutdownChan   chan struct{}
+	Repo           repo.Repo
 
 	// FIXME: Add Mock network and Test().
 
@@ -686,7 +686,7 @@ type Builder struct {
 func (b *Builder) BuildFullNode(ctx context.Context, userOptions ...Option) (api.FullNode, StopFunc, error) {
 	var api api.FullNode
 
-	opts := []Option {
+	opts := []Option{
 		FullAPI(&api, Lite(b.IsLite)),
 
 		// FIXME: Do we need to set these before Repo()/Online()?


### PR DESCRIPTION
Introduce a `node.Builder` intermediary that encapsulates the `Override()` logic needed to instantiate a node through `node.New()` providing a new `BuildFullNode()` API. The most common configuration options are now part of the `Builder` logic while `BuildFullNode()` still accepts user-provided `Option`s to enable advanced configurations.

This is a compromise between decoupling the `Override()` logic from the consumer and still offer some flexibility. If anything this can be seen as just a way to reduce boilerplate code (like the ubiquitous `Online()`/`Repo()` options) letting the user specify directly the value they want to configure and not have to embed it in the corresponding `Override()` call.

Currently as a draft, the new API is applied only in the `daemon` command. Once better refined it will be propagated to other consumers outside the `node` package before converting it to a ready-for-review PR. I'm open to changes in the `Builder`/`BuildFullNode()` API; the only real objective here is to minimize `Override()` calls.

Closes https://github.com/filecoin-project/lotus/issues/5370.