### PR TITLE
[WIP] use the correct context when starting services

### DIFF
--- a/api/test/paych.go
+++ b/api/test/paych.go
@@ -27,7 +27,8 @@ import (
 )
 
 func TestPaymentChannels(t *testing.T, b APIBuilder, blocktime time.Duration) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	n, sn := b(t, TwoFull, OneMiner)
 
 	paymentCreator := n[0]

--- a/cli/paych_test.go
+++ b/cli/paych_test.go
@@ -40,7 +40,8 @@ func TestPaymentChannels(t *testing.T) {
 	clitest.QuietMiningLogs()
 
 	blocktime := 5 * time.Millisecond
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	nodes, addrs := clitest.StartTwoNodesOneMiner(ctx, t, blocktime)
 	paymentCreator := nodes[0]
 	paymentReceiver := nodes[1]
@@ -92,7 +93,8 @@ func TestPaymentChannelStatus(t *testing.T) {
 	clitest.QuietMiningLogs()
 
 	blocktime := 5 * time.Millisecond
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	nodes, addrs := clitest.StartTwoNodesOneMiner(ctx, t, blocktime)
 	paymentCreator := nodes[0]
 	creatorAddr := addrs[0]
@@ -171,7 +173,8 @@ func TestPaymentChannelVouchers(t *testing.T) {
 	clitest.QuietMiningLogs()
 
 	blocktime := 5 * time.Millisecond
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	nodes, addrs := clitest.StartTwoNodesOneMiner(ctx, t, blocktime)
 	paymentCreator := nodes[0]
 	paymentReceiver := nodes[1]
@@ -303,7 +306,8 @@ func TestPaymentChannelVoucherCreateShortfall(t *testing.T) {
 	clitest.QuietMiningLogs()
 
 	blocktime := 5 * time.Millisecond
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	nodes, addrs := clitest.StartTwoNodesOneMiner(ctx, t, blocktime)
 	paymentCreator := nodes[0]
 	creatorAddr := addrs[0]

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -188,14 +188,16 @@ func HandleIncomingMessages(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub
 	waitForSync(stmgr, pubsubMsgsSyncEpochs, subscribe)
 }
 
-func NewLocalDiscovery(lc fx.Lifecycle, ds dtypes.MetadataDS) (*discoveryimpl.Local, error) {
+func NewLocalDiscovery(mctx helpers.MetricsCtx, lc fx.Lifecycle, ds dtypes.MetadataDS) (*discoveryimpl.Local, error) {
 	local, err := discoveryimpl.NewLocal(namespace.Wrap(ds, datastore.NewKey("/deals/local")))
 	if err != nil {
 		return nil, err
 	}
+
+	ctx := helpers.LifecycleCtx(mctx, lc)
 	local.OnReady(marketevents.ReadyLogger("discovery"))
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(context.Context) error {
 			return local.Start(ctx)
 		},
 	})

--- a/paychmgr/settler/settler.go
+++ b/paychmgr/settler/settler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/impl/full"
 	payapi "github.com/filecoin-project/lotus/node/impl/paych"
+	"github.com/filecoin-project/lotus/node/modules/helpers"
 )
 
 var log = logging.Logger("payment-channel-settler")
@@ -50,9 +51,10 @@ type paymentChannelSettler struct {
 
 // SettlePaymentChannels checks the chain for events related to payment channels settling and
 // submits any vouchers for inbound channels tracked for this node
-func SettlePaymentChannels(lc fx.Lifecycle, api API) error {
+func SettlePaymentChannels(mctx helpers.MetricsCtx, lc fx.Lifecycle, api API) error {
+	ctx := helpers.LifecycleCtx(mctx, lc)
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
+		OnStart: func(context.Context) error {
 			pcs := newPaymentChannelSettler(ctx, &api)
 			ev := events.NewEvents(ctx, &api)
 			return ev.Called(pcs.check, pcs.messageHandler, pcs.revertHandler, int(build.MessageConfidence+1), events.NoTimeout, pcs.matcher)


### PR DESCRIPTION
The lifecycle context survives the entire time, the start context may (well, should) be canceled after starting.