### PR TITLE
fix(gas): when estimating GasLimit only apply priors up to the nonce

### DIFF
--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -229,6 +229,9 @@ func gasEstimateGasLimit(
 	pending, ts := mpool.PendingFor(fromA)
 	priorMsgs := make([]types.ChainMsg, 0, len(pending))
 	for _, m := range pending {
+		if m.Message.Nonce == msg.Nonce {
+			break
+		}
 		priorMsgs = append(priorMsgs, m)
 	}
 


### PR DESCRIPTION
The bug is applying all messages from given From address are priors
before appling the message that we are estimating.

If user tries replacing message in the middle with gas limit estimation
then message sequence is off and user will either get an execution error
or gas mis-esimation.

Resolves #5402

Tests will come in in another PR