### PR TITLE
explicitly check miner address protocol

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -676,6 +676,10 @@ func blockSanityChecks(h *types.BlockHeader) error {
 		return xerrors.Errorf("block had nil bls aggregate signature")
 	}
 
+	if h.Miner.Protocol() != address.ID {
+		return xerrors.Errorf("block had non-ID miner address")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is implicitly checked when verifying the miner signature, but explicitly checking it here makes it clear that this is a protocol requirement, and reduces the chances that it will be accidentally "refactored out".

cc @wadeAlexC