### PR TITLE
Implement pre-migration framework

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -465,7 +465,12 @@ func (cg *ChainGen) NextTipSetFromMinersWithMessages(base *types.TipSet, miners 
 		}
 	}
 
-	return store.NewFullTipSet(blks), nil
+	fts := store.NewFullTipSet(blks)
+	if err := cg.cs.PutTipSet(context.TODO(), fts.TipSet()); err != nil {
+		return nil, err
+	}
+
+	return fts, nil
 }
 
 func (cg *ChainGen) makeBlock(parents *types.TipSet, m address.Address, vrfticket *types.Ticket,

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -14,7 +14,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/google/uuid"
-	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
@@ -85,19 +84,6 @@ type ChainGen struct {
 	lr repo.LockedRepo
 }
 
-type mybs struct {
-	blockstore.Blockstore
-}
-
-func (m mybs) Get(c cid.Cid) (block.Block, error) {
-	b, err := m.Blockstore.Get(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
-}
-
 var rootkeyMultisig = genesis.MultisigMeta{
 	Signers:         []address.Address{remAccTestKey},
 	Threshold:       1,
@@ -151,8 +137,6 @@ func NewGeneratorWithSectors(numSectors int) (*ChainGen, error) {
 			}
 		}
 	}()
-
-	bs = mybs{bs}
 
 	ks, err := lr.KeyStore()
 	if err != nil {

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -292,7 +292,7 @@ func (sm *StateManager) preMigrationWorker(ctx context.Context) {
 						// migration to use the cache may assume that
 						// certain blocks exist, even if they don't.
 						tmpCache := cache.Clone()
-						err := migrationFunc(preCtx, sm, cache, ts.ParentState(), ts.Height(), ts)
+						err := migrationFunc(preCtx, sm, tmpCache, ts.ParentState(), ts.Height(), ts)
 						if err != nil {
 							log.Errorw("failed to run pre-migration",
 								"error", err)

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"sort"
+	"sync"
 
 	"github.com/filecoin-project/go-state-types/rt"
 
@@ -243,6 +244,8 @@ func (sm *StateManager) hasExpensiveFork(ctx context.Context, height abi.ChainEp
 }
 
 func (sm *StateManager) preMigrationWorker(ctx context.Context) {
+	defer close(sm.shutdown)
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -251,6 +254,9 @@ func (sm *StateManager) preMigrationWorker(ctx context.Context) {
 		notAfter abi.ChainEpoch
 		run      func(ts *types.TipSet)
 	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
 
 	// Turn each pre-migration into an operation in a schedule.
 	var schedule []op
@@ -270,7 +276,9 @@ func (sm *StateManager) preMigrationWorker(ctx context.Context) {
 
 				// TODO: are these values correct?
 				run: func(ts *types.TipSet) {
+					wg.Add(1)
 					go func() {
+						defer wg.Done()
 						err := migrationFunc(preCtx, sm, cache, ts.ParentState(), ts.Height(), ts)
 						if err != nil {
 							log.Errorw("failed to run pre-migration",

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -191,14 +191,20 @@ func DefaultUpgradeSchedule() UpgradeSchedule {
 }
 
 func (us UpgradeSchedule) Validate() error {
-	// Make sure we're not trying to upgrade to version 0.
+	// Make sure each upgrade is valid.
 	for _, u := range us {
 		if u.Network <= 0 {
 			return xerrors.Errorf("cannot upgrade to version <= 0: %d", u.Network)
 		}
+
+		for _, m := range u.PreUpgrades {
+			if m.When <= m.NotAfter {
+				return xerrors.Errorf("pre-migration cannot end before it starts: %d <= %d", m.When, m.NotAfter)
+			}
+		}
 	}
 
-	// Make sure all the upgrades make sense.
+	// Make sure the upgrade order makes sense.
 	for i := 1; i < len(us); i++ {
 		prev := &us[i-1]
 		curr := &us[i]

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -848,7 +848,7 @@ func UpgradeActorsV3(ctx context.Context, sm *StateManager, cache MigrationCache
 	config := nv10.Config{MaxWorkers: 1}
 	newRoot, err := upgradeActorsV3Common(ctx, sm, cache, root, epoch, ts, config)
 	if err != nil {
-		return cid.Undef, xerrors.Errorf("failed to persist new state root: %w", err)
+		return cid.Undef, xerrors.Errorf("migrating actors v3 state: %w", err)
 	}
 
 	// perform some basic sanity checks to make sure everything still works.

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -207,7 +207,7 @@ func (us UpgradeSchedule) Validate() error {
 			}
 		}
 		if !sort.SliceIsSorted(u.PreMigrations, func(i, j int) bool {
-			return u.PreMigrations[i].When < u.PreMigrations[j].When
+			return u.PreMigrations[i].When > u.PreMigrations[j].When //nolint:scopelint,gosec
 		}) {
 			return xerrors.Errorf("pre-migrations must be sorted by start epoch")
 		}

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -199,9 +199,17 @@ func (us UpgradeSchedule) Validate() error {
 		}
 
 		for _, m := range u.PreMigrations {
+			if m.When < 0 || m.NotAfter < 0 {
+				return xerrors.Errorf("pre-migration must specify non-negative epochs")
+			}
 			if m.When <= m.NotAfter {
 				return xerrors.Errorf("pre-migration cannot end before it starts: %d <= %d", m.When, m.NotAfter)
 			}
+		}
+		if !sort.SliceIsSorted(u.PreMigrations, func(i, j int) bool {
+			return u.PreMigrations[i].When < u.PreMigrations[j].When
+		}) {
+			return xerrors.Errorf("pre-migrations must be sorted by start epoch")
 		}
 	}
 

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -122,7 +122,7 @@ func TestForkHeightTriggers(t *testing.T) {
 		cg.ChainStore(), UpgradeSchedule{{
 			Network: 1,
 			Height:  testForkHeight,
-			Migration: func(ctx context.Context, sm *StateManager, cb ExecCallback,
+			Migration: func(ctx context.Context, sm *StateManager, cache MigrationCache, cb ExecCallback,
 				root cid.Cid, height abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
 				cst := ipldcbor.NewCborStore(sm.ChainStore().Blockstore())
 
@@ -252,7 +252,7 @@ func TestForkRefuseCall(t *testing.T) {
 			Network:   1,
 			Expensive: true,
 			Height:    testForkHeight,
-			Migration: func(ctx context.Context, sm *StateManager, cb ExecCallback,
+			Migration: func(ctx context.Context, sm *StateManager, cache MigrationCache, cb ExecCallback,
 				root cid.Cid, height abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
 				return root, nil
 			}}})

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -414,15 +414,6 @@ func TestForkPreMigration(t *testing.T) {
 					return fmt.Errorf("failed")
 				},
 			}, {
-				When: 10,
-				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
-					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
-
-					checkCache(t, cache)
-
-					return nil
-				},
-			}, {
 				When:     15,
 				NotAfter: 5,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
@@ -430,6 +421,15 @@ func TestForkPreMigration(t *testing.T) {
 
 					<-ctx.Done()
 					close(wasCanceled)
+
+					return nil
+				},
+			}, {
+				When: 10,
+				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
+					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
+
+					checkCache(t, cache)
 
 					return nil
 				},

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -377,7 +377,7 @@ func TestForkPreMigration(t *testing.T) {
 				return root, nil
 			},
 			PreMigrations: []PreMigration{{
-				When: 20,
+				StartWithin: 20,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
 					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
 					wait20.Done()
@@ -389,7 +389,7 @@ func TestForkPreMigration(t *testing.T) {
 					return nil
 				},
 			}, {
-				When: 20,
+				StartWithin: 20,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
 					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
 					wait20.Done()
@@ -401,7 +401,7 @@ func TestForkPreMigration(t *testing.T) {
 					return nil
 				},
 			}, {
-				When: 20,
+				StartWithin: 20,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
 					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
 					wait20.Done()
@@ -414,8 +414,8 @@ func TestForkPreMigration(t *testing.T) {
 					return fmt.Errorf("failed")
 				},
 			}, {
-				When:     15,
-				NotAfter: 5,
+				StartWithin: 15,
+				StopWithin:  5,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
 					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
 
@@ -425,7 +425,7 @@ func TestForkPreMigration(t *testing.T) {
 					return nil
 				},
 			}, {
-				When: 10,
+				StartWithin: 10,
 				PreMigration: func(ctx context.Context, _ *StateManager, cache MigrationCache,
 					_ cid.Cid, _ abi.ChainEpoch, _ *types.TipSet) error {
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -64,8 +64,8 @@ type versionSpec struct {
 }
 
 type migration struct {
-	upgrade       UpgradeFunc
-	preMigrations []PreUpgrade
+	upgrade       MigrationFunc
+	preMigrations []PreMigration
 	cache         MigrationCache
 }
 
@@ -121,10 +121,10 @@ func NewStateManagerWithUpgradeSchedule(cs *store.ChainStore, us UpgradeSchedule
 		// If we have any upgrades, process them and create a version
 		// schedule.
 		for _, upgrade := range us {
-			if upgrade.Migration != nil || upgrade.PreUpgrades != nil {
+			if upgrade.Migration != nil || upgrade.PreMigrations != nil {
 				migration := &migration{
 					upgrade:       upgrade.Migration,
-					preMigrations: upgrade.PreUpgrades,
+					preMigrations: upgrade.PreMigrations,
 					cache:         nv10.NewMemMigrationCache(),
 				}
 				stateMigrations[upgrade.Height] = migration

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -66,7 +66,7 @@ type versionSpec struct {
 type migration struct {
 	upgrade       MigrationFunc
 	preMigrations []PreMigration
-	cache         MigrationCache
+	cache         *nv10.MemMigrationCache
 }
 
 type StateManager struct {

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -166,7 +166,7 @@ func cidsToKey(cids []cid.Cid) string {
 // Start starts the state manager's optional background processes. At the moment, this schedules
 // pre-migration functions to run ahead of network upgrades.
 //
-// This is method is not safe to invoke from multiple threads or concurrently with Stop.
+// This method is not safe to invoke from multiple threads or concurrently with Stop.
 func (sm *StateManager) Start(context.Context) error {
 	var ctx context.Context
 	ctx, sm.cancel = context.WithCancel(context.Background())
@@ -177,7 +177,7 @@ func (sm *StateManager) Start(context.Context) error {
 
 // Stop starts the state manager's background processes.
 //
-// This is method is not safe to invoke concurrently with Start.
+// This method is not safe to invoke concurrently with Start.
 func (sm *StateManager) Stop(ctx context.Context) error {
 	if sm.cancel != nil {
 		sm.cancel()

--- a/node/builder.go
+++ b/node/builder.go
@@ -269,7 +269,7 @@ func Online() Option {
 			Override(new(vm.SyscallBuilder), vm.Syscalls),
 			Override(new(*store.ChainStore), modules.ChainStore),
 			Override(new(stmgr.UpgradeSchedule), stmgr.DefaultUpgradeSchedule()),
-			Override(new(*stmgr.StateManager), stmgr.NewStateManagerWithUpgradeSchedule),
+			Override(new(*stmgr.StateManager), modules.StateManager),
 			Override(new(*wallet.LocalWallet), wallet.NewWallet),
 			Override(new(wallet.Default), From(new(*wallet.LocalWallet))),
 			Override(new(api.WalletAPI), From(new(wallet.MultiWallet))),

--- a/node/modules/stmgr.go
+++ b/node/modules/stmgr.go
@@ -1,0 +1,20 @@
+package modules
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/store"
+)
+
+func StateManager(lc fx.Lifecycle, cs *store.ChainStore, us stmgr.UpgradeSchedule) (*stmgr.StateManager, error) {
+	sm, err := stmgr.NewStateManagerWithUpgradeSchedule(cs, us)
+	if err != nil {
+		return nil, err
+	}
+	lc.Append(fx.Hook{
+		OnStart: sm.Start,
+		OnStop:  sm.Stop,
+	})
+	return sm, nil
+}


### PR DESCRIPTION
This PR adds:

1. A PreMigrations slice to every Upgrade. This can be filled with functions that should be executed
   some number of epochs before the upgrade happens.
2. A MigrationCache that's passed to both the final Migration function, and any PreMigration functions.
3. An _optional_ Start/Stop method on the StateManager that starts/stops the pre-migration scheduler.

Finally, this PR wires up pre-migrations for the actors V3 upgrade.

fixes #5415 

TODO:

* [x] Tests.
* [ ] Consider extracting into a new service. I really don't like shoving this into the state manager along with everything else, but the state manager _is_ responsible for upgrades.
* [x] Merge https://github.com/filecoin-project/specs-actors/pull/1368