### PR TITLE
Update sealing.go

### DIFF
--- a/cmd/lotus-storage-miner/sealing.go
+++ b/cmd/lotus-storage-miner/sealing.go
@@ -85,8 +85,12 @@ var sealingWorkersCmd = &cli.Command{
 
 			var barCols = uint64(64)
 			cpuBars := int(stat.CpuUse * barCols / stat.Info.Resources.CPUs)
-			cpuBar := strings.Repeat("|", cpuBars) + strings.Repeat(" ", int(barCols)-cpuBars)
-
+			cpuBar := ""
+			if int(barCols)-cpuBars >= 0 {
+				cpuBar = strings.Repeat("|", cpuBars) + strings.Repeat(" ", int(barCols)-cpuBars)
+			} else {
+				cpuBar = strings.Repeat("|", cpuBars) + strings.Repeat(" ", 0)
+			}
 			fmt.Printf("\tCPU:  [%s] %d/%d core(s) in use\n",
 				color.GreenString(cpuBar), stat.CpuUse, stat.Info.Resources.CPUs)
 


### PR DESCRIPTION
Consider the case where the int(barCols)-cpuBars is negative,solve  negative Repeat count bug 


panic: strings: negative Repeat count
goroutine 1 [running]:
strings.Repeat(0x2e33731, 0x1, 0xffffffffffffffd8, 0x0, 0x0)
	/usr/local/go/src/strings/strings.go:529 +0x5e5
main.glob..func46(0xc0006628c0, 0x0, 0x0)
	/mnt/filecoin-lvm/labs/labs/lotus/cmd/lotus-storage-miner/sealing.go:97 +0x9ea
github.com/urfave/cli/v2.(*Command).Run(0x58c65e0, 0xc0006627c0, 0x0, 0x0)
	/mnt/filecoin-lvm/labs/labs/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4ed
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000524480, 0xc0006625c0, 0x0, 0x0)
	/mnt/filecoin-lvm/labs/labs/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:427 +0xa9f