### PR TITLE
ipfsbstore: Fix has for non-existing blocks

### DIFF
--- a/lib/ipfsbstore/ipfsbstore.go
+++ b/lib/ipfsbstore/ipfsbstore.go
@@ -21,7 +21,7 @@ import (
 )
 
 type IpfsBstore struct {
-	ctx context.Context
+	ctx             context.Context
 	api, offlineAPI iface.CoreAPI
 }
 
@@ -43,8 +43,8 @@ func NewIpfsBstore(ctx context.Context, onlineMode bool) (*IpfsBstore, error) {
 	}
 
 	return &IpfsBstore{
-		ctx: ctx,
-		api: api,
+		ctx:        ctx,
+		api:        api,
 		offlineAPI: offlineAPI,
 	}, nil
 }
@@ -67,8 +67,8 @@ func NewRemoteIpfsBstore(ctx context.Context, maddr multiaddr.Multiaddr, onlineM
 	}
 
 	return &IpfsBstore{
-		ctx: ctx,
-		api: api,
+		ctx:        ctx,
+		api:        api,
 		offlineAPI: offlineAPI,
 	}, nil
 }


### PR DESCRIPTION
Fixes #5361

Discovered this when doing something unrelated on top of this blockstore

Basically the implementation of `blockstore.Has` would call `block/stat` on the ipfs node - doing that in online mode will obviously try to fetch that node from the network. This then compounds with the default blockservice implementation, which calls `Has` before calling `Put`, which is basically guaranteed to hang in online mode when trying to retrieve data into ipfs which can't be fetched from the ipfs network (also means that data would be fetched from ipfs first before being retrieved from filecoin..)