### PR TITLE
Update sched_worker.go

### DIFF
--- a/extern/sector-storage/sched_worker.go
+++ b/extern/sector-storage/sched_worker.go
@@ -341,9 +341,7 @@ func (sw *schedWorker) processAssignedWindows() {
 	worker := sw.worker
 
 	// process windows in order
-	widx := 0
-	for len(worker.activeWindows) > widx {
-		firstWindow := worker.activeWindows[widx]
+	for widx, window := range worker.activeWindows {
 
 		// process tasks within a window, preferring tasks at lower indexes
 		tidx := 0


### PR DESCRIPTION
fixed ap, c1 and fin not to be processed in time

We want to handle all tasks that can todo in all windows, not the first window. The "break assignLoop" will return, not loop.