### PR TITLE
go.mod: remove gocheck indirect dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gotest.tools v2.2.0+incompatible
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
 replace github.com/filecoin-project/lotus => ./

--- a/testplans/lotus-soup/go.mod
+++ b/testplans/lotus-soup/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.1.2
 	github.com/filecoin-project/go-state-types v0.0.0-20210119062722-4adba5aaea71
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/lotus v1.5.0-pre3.0.20210208143915-0afe7325f677
+	github.com/filecoin-project/lotus v1.5.0-pre3.0.20210209125031-811fb44dd0d4
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.4

--- a/testplans/lotus-soup/go.sum
+++ b/testplans/lotus-soup/go.sum
@@ -268,8 +268,6 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go
 github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a h1:hyJ+pUm/4U4RdEZBlg6k8Ma4rDiuvqyGpoICXAxwsTg=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-markets v1.0.5-0.20201113164554-c5eba40d5335/go.mod h1:AJySOJC00JRWEZzRG2KsfUnqEf5ITXxeX09BE9N4f9c=
-github.com/filecoin-project/go-fil-markets v1.1.2 h1:5FVdDmF9GvW6Xllql9OGiJXEZjh/tu590BXSQH2W/vU=
-github.com/filecoin-project/go-fil-markets v1.1.2/go.mod h1:6oTRaAsHnCqhi3mpZqdvnWIzH6QzHQc4dbhJrI9/BfQ=
 github.com/filecoin-project/go-fil-markets v1.1.7 h1:7yy7alIDWzUxljxZhGmG3+wvaU4Ty5QDMbPmdZeaIJ8=
 github.com/filecoin-project/go-fil-markets v1.1.7/go.mod h1:6oTRaAsHnCqhi3mpZqdvnWIzH6QzHQc4dbhJrI9/BfQ=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
@@ -298,10 +296,8 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
-github.com/filecoin-project/lotus v1.5.0-pre3.0.20210129041213-b4ad2e5e93dc h1:sSuevGua2qnMYFbCfmIVY4PrgeiqnO+B+lMvAvjOQJg=
-github.com/filecoin-project/lotus v1.5.0-pre3.0.20210129041213-b4ad2e5e93dc/go.mod h1:z4jbMMD9IFSBsin3xytoe4XphQPaJDrqdnC8AWNIF5w=
-github.com/filecoin-project/lotus v1.5.0-pre3.0.20210208143915-0afe7325f677 h1:q5JrE5JVqwwn8UFN7rBHfG0dJt2EJNbw8DY21dVngvM=
-github.com/filecoin-project/lotus v1.5.0-pre3.0.20210208143915-0afe7325f677/go.mod h1:uFOz8oe+uOQnU+ynrzs5jInUw4tyXsxPui6x3k2DKhM=
+github.com/filecoin-project/lotus v1.5.0-pre3.0.20210209125031-811fb44dd0d4 h1:UEEARrRG5zvno5tTjyRQCc0m5bKnrJ2S4chAOvY1wEs=
+github.com/filecoin-project/lotus v1.5.0-pre3.0.20210209125031-811fb44dd0d4/go.mod h1:uFOz8oe+uOQnU+ynrzs5jInUw4tyXsxPui6x3k2DKhM=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.13 h1:rUEOQouefi9fuVY/2HOroROJlZbOzWYXXeIh41KF2M4=
@@ -310,8 +306,6 @@ github.com/filecoin-project/specs-actors/v2 v2.0.1/go.mod h1:v2NZVYinNIKA9acEMBm
 github.com/filecoin-project/specs-actors/v2 v2.3.2/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
 github.com/filecoin-project/specs-actors/v2 v2.3.4 h1:NZK2oMCcA71wNsUzDBmLQyRMzcCnX9tDGvwZ53G67j8=
 github.com/filecoin-project/specs-actors/v2 v2.3.4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
-github.com/filecoin-project/specs-actors/v3 v3.0.1-0.20210128055125-ab0632b1c8fa h1:J0yyTt9MLDaN0XvzjEAWTCvG6SRVfXc6dVLluvRiOsQ=
-github.com/filecoin-project/specs-actors/v3 v3.0.1-0.20210128055125-ab0632b1c8fa/go.mod h1:NL24TPjJGyU7fh1ztpUyYcoZi3TmRKNEI0huPYmhObA=
 github.com/filecoin-project/specs-actors/v3 v3.0.1-0.20210128235937-57195d8909b1 h1:I6mvbwANIoToUZ37cYmuLyDKbPlAUxWnp0fJOZnlTz4=
 github.com/filecoin-project/specs-actors/v3 v3.0.1-0.20210128235937-57195d8909b1/go.mod h1:NL24TPjJGyU7fh1ztpUyYcoZi3TmRKNEI0huPYmhObA=
 github.com/filecoin-project/specs-storage v0.1.1-0.20201105051918-5188d9774506 h1:Ur/l2+6qN+lQiqjozWWc5p9UDaAMDZKTlDS98oRnlIw=


### PR DESCRIPTION
This PR is removing the `launchpad.net/gocheck v0.0.0-20140225173054-000000000087` indirect dependency in Lotus, added in https://github.com/filecoin-project/lotus/pull/3688

Fetching this dependency requires `bzr`, which requires adding `bzr` to all goproxy containers. It seems like we don't need this dependency in Lotus as it compiles just fine without it, so I'd rather we remove it, than introducing `bzr` everywhere where we need to fetch it.

Related to: https://github.com/filecoin-project/lotus/issues/5548