### PR TITLE
lotus-seed command to generate lotus block

### DIFF
--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -330,9 +330,6 @@ var genesisCarCmd = &cli.Command{
 		bstor := blockstore.NewTemporarySync()
 		sbldr := vm.Syscalls(ffiwrapper.ProofVerifier)
 		_, err := testing.MakeGenesis(ofile, c.Args().First())(bstor, sbldr, jrnl)()
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	},
 }

--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
+	"github.com/filecoin-project/lotus/journal"
+	"github.com/filecoin-project/lotus/lib/blockstore"
+	"github.com/filecoin-project/lotus/node/modules/testing"
 	"github.com/google/uuid"
 	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli/v2"
@@ -32,6 +37,7 @@ var genesisCmd = &cli.Command{
 		genesisNewCmd,
 		genesisAddMinerCmd,
 		genesisAddMsigsCmd,
+		genesisCarCmd,
 	},
 }
 
@@ -301,4 +307,32 @@ func parseMultisigCsv(csvf string) ([]GenAccountEntry, error) {
 	}
 
 	return entries, nil
+}
+
+var genesisCarCmd = &cli.Command{
+	Name:        "car",
+	Description: "write genesis car file",
+	ArgsUsage:   "genesis template `FILE`",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "out",
+			Aliases: []string{"o"},
+			Value:   "genesis.car",
+			Usage:   "write output to `FILE`",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		if c.Args().Len() != 1 {
+			return xerrors.Errorf("Please specify a genesis template. (i.e, the one created with `genesis new`)")
+		}
+		ofile := c.String("out")
+		jrnl := journal.NilJournal()
+		bstor := blockstore.NewTemporarySync()
+		sbldr := vm.Syscalls(ffiwrapper.ProofVerifier)
+		_, err := testing.MakeGenesis(ofile, c.Args().First())(bstor, sbldr, jrnl)()
+		if err != nil {
+			return err
+		}
+		return nil
+	},
 }


### PR DESCRIPTION
Currently devnet deployment requires spinning up a full daemon.
This would move the daemon `lotus-make-genesis` logic to lotus-seed
so it can be more easily executed in scripts, etc.