### PR TITLE
Revert "feat: deals - show data transfer %"

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -938,10 +938,9 @@ type DataSize struct {
 }
 
 type DataCIDSize struct {
-	RawBlockSize uint64
-	PayloadSize  int64
-	PieceSize    abi.PaddedPieceSize
-	PieceCID     cid.Cid
+	PayloadSize int64
+	PieceSize   abi.PaddedPieceSize
+	PieceCID    cid.Cid
 }
 
 type CommPRet struct {

--- a/cli/client.go
+++ b/cli/client.go
@@ -850,9 +850,8 @@ uiLoop:
 						TransferType: storagemarket.TTGraphsync,
 						Root:         data,
 
-						PieceCid:     &ds.PieceCID,
-						PieceSize:    ds.PieceSize.Unpadded(),
-						RawBlockSize: ds.RawBlockSize,
+						PieceCid:  &ds.PieceCID,
+						PieceSize: ds.PieceSize.Unpadded(),
 					},
 					Wallet:            a,
 					Miner:             maddr,
@@ -1568,7 +1567,7 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 
 	if verbose {
 		w := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
-		fmt.Fprintf(w, "Created\tDealCid\tDealId\tProvider\tState\tOn Chain?\tSlashed?\tPieceCID\tSize\tPrice\tDuration\tTransferChannelID\tTransferStatus\tTransfer %%\tVerified\tMessage\n")
+		fmt.Fprintf(w, "Created\tDealCid\tDealId\tProvider\tState\tOn Chain?\tSlashed?\tPieceCID\tSize\tPrice\tDuration\tTransferChannelID\tTransferStatus\tVerified\tMessage\n")
 		for _, d := range deals {
 			onChain := "N"
 			if d.OnChainDealState.SectorStartEpoch != -1 {
@@ -1586,16 +1585,17 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 				transferChannelID = d.LocalDeal.TransferChannelID.String()
 			}
 			transferStatus := ""
-			transferPct := ""
 			if d.LocalDeal.DataTransfer != nil {
 				transferStatus = datatransfer.Statuses[d.LocalDeal.DataTransfer.Status]
-				// Calculate transfer %
-				if d.LocalDeal.DataRef.RawBlockSize > 0 {
-					pct := (100 * d.LocalDeal.DataTransfer.Transferred) / d.LocalDeal.DataRef.RawBlockSize
-					transferPct = fmt.Sprintf("%d%%", pct)
-				}
+				// TODO: Include the transferred percentage once this bug is fixed:
+				// https://github.com/ipfs/go-graphsync/issues/126
+				//fmt.Printf("transferred: %d / size: %d\n", d.LocalDeal.DataTransfer.Transferred, d.LocalDeal.Size)
+				//if d.LocalDeal.Size > 0 {
+				//	pct := (100 * d.LocalDeal.DataTransfer.Transferred) / d.LocalDeal.Size
+				//	transferPct = fmt.Sprintf("%d%%", pct)
+				//}
 			}
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%v\t%s\n",
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%v\t%s\n",
 				d.LocalDeal.CreationTime.Format(time.Stamp),
 				d.LocalDeal.ProposalCid,
 				d.LocalDeal.DealID,
@@ -1609,7 +1609,6 @@ func outputStorageDeals(ctx context.Context, out io.Writer, full lapi.FullNode, 
 				d.LocalDeal.Duration,
 				transferChannelID,
 				transferStatus,
-				transferPct,
 				d.LocalDeal.Verified,
 				d.LocalDeal.Message)
 		}

--- a/cli/test/client.go
+++ b/cli/test/client.go
@@ -69,6 +69,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode test.TestNode)
 		dataCid2.String(),
 		duration,
 		minerAddr.String(),
+		"no",
 		"yes",
 	}
 	out = clientCLI.RunInteractiveCmd(cmd, interactiveCmds)

--- a/documentation/en/api-methods-miner.md
+++ b/documentation/en/api-methods-miner.md
@@ -643,8 +643,7 @@ Response:
       "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
     },
     "PieceCid": null,
-    "PieceSize": 1024,
-    "RawBlockSize": 42
+    "PieceSize": 1024
   },
   "AvailableForRetrieval": true,
   "DealID": 5432,

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -930,7 +930,6 @@ Inputs:
 Response:
 ```json
 {
-  "RawBlockSize": 42,
   "PayloadSize": 9,
   "PieceSize": 1032,
   "PieceCID": {
@@ -1029,8 +1028,7 @@ Response:
       "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
     },
     "PieceCid": null,
-    "PieceSize": 1024,
-    "RawBlockSize": 42
+    "PieceSize": 1024
   },
   "PieceCID": {
     "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
@@ -1100,8 +1098,7 @@ Response:
       "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
     },
     "PieceCid": null,
-    "PieceSize": 1024,
-    "RawBlockSize": 42
+    "PieceSize": 1024
   },
   "PieceCID": {
     "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
@@ -1419,8 +1416,7 @@ Inputs:
         "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
       },
       "PieceCid": null,
-      "PieceSize": 1024,
-      "RawBlockSize": 42
+      "PieceSize": 1024
     },
     "Wallet": "f01234",
     "Miner": "f01234",

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-data-transfer v1.2.7
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a
-	github.com/filecoin-project/go-fil-markets v1.1.8
+	github.com/filecoin-project/go-fil-markets v1.1.7
 	github.com/filecoin-project/go-jsonrpc v0.1.2
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go
 github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a h1:hyJ+pUm/4U4RdEZBlg6k8Ma4rDiuvqyGpoICXAxwsTg=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-markets v1.0.5-0.20201113164554-c5eba40d5335/go.mod h1:AJySOJC00JRWEZzRG2KsfUnqEf5ITXxeX09BE9N4f9c=
-github.com/filecoin-project/go-fil-markets v1.1.8 h1:rnb+9Did4sClxTUHDpzmf9WmTzL1wQsBSsUb9RQa4Rg=
-github.com/filecoin-project/go-fil-markets v1.1.8/go.mod h1:6oTRaAsHnCqhi3mpZqdvnWIzH6QzHQc4dbhJrI9/BfQ=
+github.com/filecoin-project/go-fil-markets v1.1.7 h1:7yy7alIDWzUxljxZhGmG3+wvaU4Ty5QDMbPmdZeaIJ8=
+github.com/filecoin-project/go-fil-markets v1.1.7/go.mod h1:6oTRaAsHnCqhi3mpZqdvnWIzH6QzHQc4dbhJrI9/BfQ=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -755,13 +755,7 @@ func (a *API) ClientDealPieceCID(ctx context.Context, root cid.Cid) (api.DataCID
 	w := &writer.Writer{}
 	bw := bufio.NewWriterSize(w, int(writer.CommPBuf))
 
-	// Calculate the raw block size so we can figure out the transfer percentage
-	// (the raw block size is the denominator)
-	var rawBlockSize uint64
-	err := car.WriteCarWithWalker(ctx, dag, []cid.Cid{root}, w, func(nd ipld.Node) ([]*ipld.Link, error) {
-		rawBlockSize += uint64(len(nd.RawData()))
-		return nd.Links(), nil
-	})
+	err := car.WriteCar(ctx, dag, []cid.Cid{root}, w)
 	if err != nil {
 		return api.DataCIDSize{}, err
 	}
@@ -771,12 +765,7 @@ func (a *API) ClientDealPieceCID(ctx context.Context, root cid.Cid) (api.DataCID
 	}
 
 	dataCIDSize, err := w.Sum()
-	return api.DataCIDSize{
-		RawBlockSize: rawBlockSize,
-		PayloadSize:  dataCIDSize.PayloadSize,
-		PieceSize:    dataCIDSize.PieceSize,
-		PieceCID:     dataCIDSize.PieceCID,
-	}, err
+	return api.DataCIDSize(dataCIDSize), err
 }
 
 func (a *API) ClientGenCar(ctx context.Context, ref api.FileRef, outputPath string) error {


### PR DESCRIPTION
This reverts commit b6c9ddccfff30a47b3cb1d29f1d99b7a29dd01b4
PR: https://github.com/filecoin-project/lotus/pull/5553

Adding the `RawBlockSize` field to the `DataRef` created a backwards-incompatibile unmarshalling issue: https://github.com/filecoin-project/lotus/issues/5601