### PR TITLE
Configurable storage path storage limit

### DIFF
--- a/cmd/lotus-seal-worker/storage.go
+++ b/cmd/lotus-seal-worker/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli/v2"
@@ -46,6 +47,10 @@ var storageAttachCmd = &cli.Command{
 			Name:  "store",
 			Usage: "(for init) use path for long-term storage",
 		},
+		&cli.StringFlag{
+			Name:  "max-storage",
+			Usage: "(for init) limit storage space for sectors (expensive for very large paths!)",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		nodeApi, closer, err := lcli.GetWorkerAPI(cctx)
@@ -79,11 +84,20 @@ var storageAttachCmd = &cli.Command{
 				return err
 			}
 
+			var maxStor int64
+			if cctx.IsSet("max-storage") {
+				maxStor, err = units.RAMInBytes(cctx.String("max-storage"))
+				if err != nil {
+					return xerrors.Errorf("parsing max-storage: %w", err)
+				}
+			}
+
 			cfg := &stores.LocalStorageMeta{
-				ID:       stores.ID(uuid.New().String()),
-				Weight:   cctx.Uint64("weight"),
-				CanSeal:  cctx.Bool("seal"),
-				CanStore: cctx.Bool("store"),
+				ID:         stores.ID(uuid.New().String()),
+				Weight:     cctx.Uint64("weight"),
+				CanSeal:    cctx.Bool("seal"),
+				CanStore:   cctx.Bool("store"),
+				MaxStorage: uint64(maxStor),
 			}
 
 			if !(cfg.CanStore || cfg.CanSeal) {

--- a/documentation/en/api-methods-miner.md
+++ b/documentation/en/api-methods-miner.md
@@ -1772,13 +1772,17 @@ Inputs:
     "ID": "76f1988b-ef30-4d7e-b3ec-9a627f4ba5a8",
     "URLs": null,
     "Weight": 42,
+    "MaxStorage": 42,
     "CanSeal": true,
     "CanStore": true
   },
   {
     "Capacity": 9,
     "Available": 9,
-    "Reserved": 9
+    "FSAvailable": 9,
+    "Reserved": 9,
+    "Max": 9,
+    "Used": 9
   }
 ]
 ```
@@ -1878,6 +1882,7 @@ Response:
   "ID": "76f1988b-ef30-4d7e-b3ec-9a627f4ba5a8",
   "URLs": null,
   "Weight": 42,
+  "MaxStorage": 42,
   "CanSeal": true,
   "CanStore": true
 }
@@ -1949,7 +1954,10 @@ Inputs:
     "Stat": {
       "Capacity": 9,
       "Available": 9,
-      "Reserved": 9
+      "FSAvailable": 9,
+      "Reserved": 9,
+      "Max": 9,
+      "Used": 9
     },
     "Err": "string value"
   }
@@ -1975,7 +1983,10 @@ Response:
 {
   "Capacity": 9,
   "Available": 9,
-  "Reserved": 9
+  "FSAvailable": 9,
+  "Reserved": 9,
+  "Max": 9,
+  "Used": 9
 }
 ```
 

--- a/extern/sector-storage/fsutil/statfs.go
+++ b/extern/sector-storage/fsutil/statfs.go
@@ -1,7 +1,12 @@
 package fsutil
 
 type FsStat struct {
-	Capacity  int64
-	Available int64 // Available to use for sector storage
-	Reserved  int64
+	Capacity    int64
+	Available   int64 // Available to use for sector storage
+	FSAvailable int64 // Available in the filesystem
+	Reserved    int64
+
+	// non-zero when storage has configured MaxStorage
+	Max  int64
+	Used int64
 }

--- a/extern/sector-storage/fsutil/statfs_unix.go
+++ b/extern/sector-storage/fsutil/statfs_unix.go
@@ -15,7 +15,9 @@ func Statfs(path string) (FsStat, error) {
 	// force int64 to handle platform specific differences
 	//nolint:unconvert
 	return FsStat{
-		Capacity:  int64(stat.Blocks) * int64(stat.Bsize),
-		Available: int64(stat.Bavail) * int64(stat.Bsize),
+		Capacity: int64(stat.Blocks) * int64(stat.Bsize),
+
+		Available:   int64(stat.Bavail) * int64(stat.Bsize),
+		FSAvailable: int64(stat.Bavail) * int64(stat.Bsize),
 	}, nil
 }

--- a/extern/sector-storage/fsutil/statfs_windows.go
+++ b/extern/sector-storage/fsutil/statfs_windows.go
@@ -22,7 +22,8 @@ func Statfs(volumePath string) (FsStat, error) {
 		uintptr(unsafe.Pointer(&availBytes)))
 
 	return FsStat{
-		Capacity:  totalBytes,
-		Available: availBytes,
+		Capacity:    totalBytes,
+		Available:   availBytes,
+		FSAvailable: availBytes,
 	}, nil
 }

--- a/extern/sector-storage/sched_test.go
+++ b/extern/sector-storage/sched_test.go
@@ -154,9 +154,10 @@ func addTestWorker(t *testing.T, sched *scheduler, index *stores.Index, name str
 			CanSeal:  path.CanSeal,
 			CanStore: path.CanStore,
 		}, fsutil.FsStat{
-			Capacity:  1 << 40,
-			Available: 1 << 40,
-			Reserved:  3,
+			Capacity:    1 << 40,
+			Available:   1 << 40,
+			FSAvailable: 1 << 40,
+			Reserved:    3,
 		})
 		require.NoError(t, err)
 	}

--- a/extern/sector-storage/stores/index.go
+++ b/extern/sector-storage/stores/index.go
@@ -26,9 +26,10 @@ var SkippedHeartbeatThresh = HeartbeatInterval * 5
 type ID string
 
 type StorageInfo struct {
-	ID     ID
-	URLs   []string // TODO: Support non-http transports
-	Weight uint64
+	ID         ID
+	URLs       []string // TODO: Support non-http transports
+	Weight     uint64
+	MaxStorage uint64
 
 	CanSeal  bool
 	CanStore bool
@@ -156,6 +157,7 @@ func (i *Index) StorageAttach(ctx context.Context, si StorageInfo, st fsutil.FsS
 		}
 
 		i.stores[si.ID].info.Weight = si.Weight
+		i.stores[si.ID].info.MaxStorage = si.MaxStorage
 		i.stores[si.ID].info.CanSeal = si.CanSeal
 		i.stores[si.ID].info.CanStore = si.CanStore
 

--- a/extern/sector-storage/stores/local_test.go
+++ b/extern/sector-storage/stores/local_test.go
@@ -36,8 +36,9 @@ func (t *TestingLocalStorage) SetStorage(f func(*StorageConfig)) error {
 
 func (t *TestingLocalStorage) Stat(path string) (fsutil.FsStat, error) {
 	return fsutil.FsStat{
-		Capacity:  pathSize,
-		Available: pathSize,
+		Capacity:    pathSize,
+		Available:   pathSize,
+		FSAvailable: pathSize,
 	}, nil
 }
 


### PR DESCRIPTION
This adds a new `MaxStorage` field to sectorstore.json files, which allows setting maximum number of bytes to use in a storage path.

TODO:
- [x] Test on a miner
- [x] Add max-storage param to storage-attach commands

```
$ lotus-miner storage list
09b4f94d-b548-4382-92d1-551676289e3e:
        [###################################               ] 38.92 TiB/54.57 TiB 71%
        Unsealed: 180; Sealed: 867; Caches: 867; Reserved: 0 B
        Weight: 10; Use: Store
        Local: /data/1/store
        URL: http://[...]:2345/remote

92da064d-c2ee-4be1-802f-adbbabf1a06b:
        [#####################################             ] 1.367 TiB/1.818 TiB 75% (filesystem)
        [####################                              ] 64 GiB/153.6 GiB 41% (limit)
        Unsealed: 2; Sealed: 0; Caches: 0; Reserved: 0 B
        Weight: 10; Use: Seal 
        Local: /data/nvme/store
        URL: http://[...]:2345/remote

```