### PR TITLE
lotus-soup compositions to test deals with different versions

### DIFF
--- a/testplans/Makefile
+++ b/testplans/Makefile
@@ -6,17 +6,17 @@ download-proofs:
 	go run github.com/filecoin-project/go-paramfetch/paramfetch 2048 ./docker-images/proof-parameters.json
 
 build-images:
-	docker build -t "iptestground/oni-buildbase:v13-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
+	docker build -t "iptestground/oni-buildbase:v14-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
 	docker build -t "iptestground/oni-runtime:v7" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
 	docker build -t "iptestground/oni-runtime:v8-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
 
 push-images:
-	docker push iptestground/oni-buildbase:v13-lotus
+	docker push iptestground/oni-buildbase:v14-lotus
 	docker push iptestground/oni-runtime:v7
 	docker push iptestground/oni-runtime:v8-debug
 
 pull-images:
-	docker pull iptestground/oni-buildbase:v13-lotus
+	docker pull iptestground/oni-buildbase:v14-lotus
 	docker pull iptestground/oni-runtime:v7
 	docker pull iptestground/oni-runtime:v8-debug
 

--- a/testplans/docker-images/Dockerfile.oni-buildbase
+++ b/testplans/docker-images/Dockerfile.oni-buildbase
@@ -4,7 +4,7 @@ FROM golang:${GO_VERSION}-buster
 
 RUN apt-get update && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev jq gcc git pkg-config bzr libhwloc-dev
 
-ARG FILECOIN_FFI_COMMIT=62f89f108a6a8fe9ad6ed52fb7ffbf8594d7ae5c
+ARG FILECOIN_FFI_COMMIT=b6e0b35fb49ed0fedb6a6a473b222e3b8a7d7f17
 ARG FFI_DIR=/extern/filecoin-ffi
 
 RUN mkdir -p ${FFI_DIR} \

--- a/testplans/lotus-soup/_compositions/baseline-docker-1-1-client-master-to-minerv1.4.2
+++ b/testplans/lotus-soup/_compositions/baseline-docker-1-1-client-master-to-minerv1.4.2
@@ -1,0 +1,63 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-e2e"
+  total_instances = 3
+  builder = "docker:go"
+  runner = "local:docker"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
+
+[global.run.test_params]
+  clients = "1"
+  miners = "1"
+  genesis_timestamp_offset = "0"
+  balance = "20000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
+  sectors = "10"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "v1.4.2"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+
+[[groups]]
+  id = "clients"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "7046e2721a528ee8984febca01fc35d1f923008d"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"

--- a/testplans/lotus-soup/_compositions/baseline-docker-1-1-clientv1.4.2-to-miner-master.toml
+++ b/testplans/lotus-soup/_compositions/baseline-docker-1-1-clientv1.4.2-to-miner-master.toml
@@ -1,0 +1,63 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-e2e"
+  total_instances = 3
+  builder = "docker:go"
+  runner = "local:docker"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
+
+[global.run.test_params]
+  clients = "1"
+  miners = "1"
+  genesis_timestamp_offset = "0"
+  balance = "20000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
+  sectors = "10"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "7046e2721a528ee8984febca01fc35d1f923008d"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+
+[[groups]]
+  id = "clients"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "v1.4.2"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"

--- a/testplans/lotus-soup/_compositions/baseline-k8s-1-1-client-current-to-miner-v1.4.2.toml
+++ b/testplans/lotus-soup/_compositions/baseline-k8s-1-1-client-current-to-miner-v1.4.2.toml
@@ -1,0 +1,75 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-e2e"
+  total_instances = 3
+  builder = "docker:go"
+  runner = "cluster:k8s"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  push_registry=true
+  go_proxy_mode="remote"
+  go_proxy_url="http://localhost:8081"
+  registry_type="aws"
+
+[global.run.test_params]
+  clients = "1"
+  miners = "1"
+  genesis_timestamp_offset = "0"
+  balance = "20000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
+  sectors = "10"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.resources]
+    memory = "512Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.resources]
+    memory = "4096Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "v1.4.2"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+
+[[groups]]
+  id = "clients"
+  [groups.resources]
+    memory = "1024Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "7046e2721a528ee8984febca01fc35d1f923008d"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"

--- a/testplans/lotus-soup/_compositions/baseline-k8s-1-1-client-v1.4.2-to-miner-current.toml
+++ b/testplans/lotus-soup/_compositions/baseline-k8s-1-1-client-v1.4.2-to-miner-current.toml
@@ -1,0 +1,75 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-e2e"
+  total_instances = 3
+  builder = "docker:go"
+  runner = "cluster:k8s"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  push_registry=true
+  go_proxy_mode="remote"
+  go_proxy_url="http://localhost:8081"
+  registry_type="aws"
+
+[global.run.test_params]
+  clients = "1"
+  miners = "1"
+  genesis_timestamp_offset = "0"
+  balance = "20000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
+  sectors = "10"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.resources]
+    memory = "512Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.resources]
+    memory = "4096Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "7046e2721a528ee8984febca01fc35d1f923008d"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+
+[[groups]]
+  id = "clients"
+  [groups.resources]
+    memory = "1024Mi"
+    cpu = "1000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build]
+    dependencies = [
+      { module = "github.com/filecoin-project/lotus", version = "v1.4.2"},
+    ]
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"

--- a/testplans/lotus-soup/init.go
+++ b/testplans/lotus-soup/init.go
@@ -22,6 +22,9 @@ func init() {
 	_ = log.SetLogLevel("stats", "WARN")
 	_ = log.SetLogLevel("dht/RtRefreshManager", "ERROR") // noisy
 	_ = log.SetLogLevel("bitswap", "ERROR")              // noisy
+	_ = log.SetLogLevel("badgerbs", "INFO")              // noisy
+	_ = log.SetLogLevel("basichost", "INFO")             // noisy
+	_ = log.SetLogLevel("chain", "WARN")                 // noisy
 
 	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 

--- a/testplans/lotus-soup/manifest.toml
+++ b/testplans/lotus-soup/manifest.toml
@@ -9,7 +9,7 @@ enabled = true
 
 [builders."docker:go"]
 enabled = true
-build_base_image = "iptestground/oni-buildbase:v13-lotus"
+build_base_image = "iptestground/oni-buildbase:v14-lotus"
 runtime_image = "iptestground/oni-runtime:v8-debug"
 
 [runners."local:exec"]


### PR DESCRIPTION
Compositions to run deals end to end testground tests with the following versions of lotus:
- client https://github.com/filecoin-project/lotus/pull/5635 <-> miner v1.4.2: [Results](https://ci.testground.ipfs.team/logs?task_id=c0pt1cd5p7a6tfhj1b7g)
- client v1.4.2 <-> miner https://github.com/filecoin-project/lotus/pull/5635: [Results](https://ci.testground.ipfs.team/logs?task_id=c0psr9t5p7a6tfhj1b70)