### PR TITLE
Add a LOTUS_DISABLE_V3_ACTOR_MIGRATION envvar

### DIFF
--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -8,6 +8,7 @@
 package build
 
 import (
+	"math"
 	"os"
 
 	"github.com/filecoin-project/go-address"
@@ -53,13 +54,17 @@ const UpgradeOrangeHeight = 336458
 const UpgradeClausHeight = 343200
 
 // 2021-03-04T00:00:30Z
-const UpgradeActorsV3Height = 550321
+var UpgradeActorsV3Height = abi.ChainEpoch(550321)
 
 func init() {
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(10 << 40))
 
 	if os.Getenv("LOTUS_USE_TEST_ADDRESSES") != "1" {
 		SetAddressNetwork(address.Mainnet)
+	}
+
+	if os.Getenv("LOTUS_DISABLE_V3_ACTOR_MIGRATION") == "1" {
+		UpgradeActorsV3Height = math.MaxInt64
 	}
 
 	Devnet = false


### PR DESCRIPTION
Just a safety measure in case the v3 migration goes bad. The remediation will be to set `LOTUS_DISABLE_V3_ACTOR_MIGRATION = 1` and (potentially) set head back.

Fixes #5451