### PR TITLE
Implement scaffolding for sentinel integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,3 +331,11 @@ docsgen:
 
 print-%:
 	@echo $*=$($*)
+
+# Sentinel build mode
+lotus-sentinel: $(BUILD_DEPS)
+	rm -f lotus
+	go build $(GOFLAGS) -ldflags="-X=github.com/filecoin-project/lotus/build.SentinelMode=true" -o lotus ./cmd/lotus
+	go run github.com/GeertJohan/go.rice/rice append --exec lotus -i ./build
+
+.PHONY: lotus

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -35,6 +35,7 @@ import (
 // FullNode API is a low-level interface to the Filecoin network full node
 type FullNode interface {
 	Common
+	Sentinel
 
 	// MethodGroup: Chain
 	// The Chain method group contains methods for interacting with the

--- a/api/api_sentinel.go
+++ b/api/api_sentinel.go
@@ -7,6 +7,6 @@ import (
 type Sentinel interface {
 	// MethodGroup: Sentinel
 
-	// WatchStart start a watch against the chain
+	// SentinelWatchStart start a watch against the chain
 	SentinelWatchStart(context.Context) error
 }

--- a/api/api_sentinel.go
+++ b/api/api_sentinel.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"context"
+)
+
+type Sentinel interface {
+	// MethodGroup: Sentinel
+
+	// WatchStart start a watch against the chain
+	WatchStart(context.Context) error
+}

--- a/api/api_sentinel.go
+++ b/api/api_sentinel.go
@@ -8,5 +8,5 @@ type Sentinel interface {
 	// MethodGroup: Sentinel
 
 	// WatchStart start a watch against the chain
-	WatchStart(context.Context) error
+	SentinelWatchStart(context.Context) error
 }

--- a/api/apistruct/permissioned.go
+++ b/api/apistruct/permissioned.go
@@ -28,6 +28,7 @@ func PermissionedFullAPI(a api.FullNode) api.FullNode {
 	var out FullNodeStruct
 	auth.PermissionedProxy(AllPermissions, DefaultPerms, a, &out.Internal)
 	auth.PermissionedProxy(AllPermissions, DefaultPerms, a, &out.CommonStruct.Internal)
+	auth.PermissionedProxy(AllPermissions, DefaultPerms, a, &out.SentinelStruct.Internal)
 	return &out
 }
 

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -1861,7 +1861,7 @@ func (c *WalletStruct) WalletDelete(ctx context.Context, addr address.Address) e
 	return c.Internal.WalletDelete(ctx, addr)
 }
 
-func (s *SentinelStruct) WatchStart(ctx context.Context) error {
+func (s *SentinelStruct) SentinelWatchStart(ctx context.Context) error {
 	return s.Internal.WatchStart(ctx)
 }
 

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -473,7 +473,7 @@ type WalletStruct struct {
 
 type SentinelStruct struct {
 	Internal struct {
-		WatchStart func(ctx context.Context) error `perm:"admin"`
+		SentinelWatchStart func(ctx context.Context) error `perm:"admin"`
 	}
 }
 
@@ -1862,7 +1862,7 @@ func (c *WalletStruct) WalletDelete(ctx context.Context, addr address.Address) e
 }
 
 func (s *SentinelStruct) SentinelWatchStart(ctx context.Context) error {
-	return s.Internal.WatchStart(ctx)
+	return s.Internal.SentinelWatchStart(ctx)
 }
 
 var _ api.Common = &CommonStruct{}

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -79,6 +79,7 @@ type CommonStruct struct {
 // FullNodeStruct implements API passing calls to user-provided function values.
 type FullNodeStruct struct {
 	CommonStruct
+	SentinelStruct
 
 	Internal struct {
 		ChainNotify                   func(context.Context) (<-chan []*api.HeadChange, error)                                                            `perm:"read"`
@@ -467,6 +468,12 @@ type WalletStruct struct {
 		WalletExport func(context.Context, address.Address) (*types.KeyInfo, error)                         `perm:"admin"`
 		WalletImport func(context.Context, *types.KeyInfo) (address.Address, error)                         `perm:"admin"`
 		WalletDelete func(context.Context, address.Address) error                                           `perm:"write"`
+	}
+}
+
+type SentinelStruct struct {
+	Internal struct {
+		WatchStart func(ctx context.Context) error `perm:"admin"`
 	}
 }
 
@@ -1854,9 +1861,14 @@ func (c *WalletStruct) WalletDelete(ctx context.Context, addr address.Address) e
 	return c.Internal.WalletDelete(ctx, addr)
 }
 
+func (s *SentinelStruct) WatchStart(ctx context.Context) error {
+	return s.Internal.WatchStart(ctx)
+}
+
 var _ api.Common = &CommonStruct{}
 var _ api.FullNode = &FullNodeStruct{}
 var _ api.StorageMiner = &StorageMinerStruct{}
 var _ api.WorkerAPI = &WorkerStruct{}
 var _ api.GatewayAPI = &GatewayStruct{}
 var _ api.WalletAPI = &WalletStruct{}
+var _ api.Sentinel = &SentinelStruct{}

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -79,7 +79,7 @@ type CommonStruct struct {
 // FullNodeStruct implements API passing calls to user-provided function values.
 type FullNodeStruct struct {
 	CommonStruct
-	SentinelStruct
+	SentinelStruct `optional:"true"`
 
 	Internal struct {
 		ChainNotify                   func(context.Context) (<-chan []*api.HeadChange, error)                                                            `perm:"read"`

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -33,6 +33,7 @@ func NewFullNodeRPC(ctx context.Context, addr string, requestHeader http.Header)
 	closer, err := jsonrpc.NewMergeClient(ctx, addr, "Filecoin",
 		[]interface{}{
 			&res.CommonStruct.Internal,
+			&res.SentinelStruct.Internal,
 			&res.Internal,
 		}, requestHeader)
 

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -405,13 +405,14 @@ func main() {
 	groups := make(map[string]*MethodGroup)
 
 	var t reflect.Type
-	var permStruct, commonPermStruct reflect.Type
+	var permStruct, commonPermStruct, sentinelPermStruct reflect.Type
 
 	switch os.Args[2] {
 	case "FullNode":
 		t = reflect.TypeOf(new(struct{ api.FullNode })).Elem()
 		permStruct = reflect.TypeOf(apistruct.FullNodeStruct{}.Internal)
 		commonPermStruct = reflect.TypeOf(apistruct.CommonStruct{}.Internal)
+		sentinelPermStruct = reflect.TypeOf(apistruct.SentinelStruct{}.Internal)
 	case "StorageMiner":
 		t = reflect.TypeOf(new(struct{ api.StorageMiner })).Elem()
 		permStruct = reflect.TypeOf(apistruct.StorageMinerStruct{}.Internal)
@@ -499,7 +500,10 @@ func main() {
 			if !ok {
 				meth, ok = commonPermStruct.FieldByName(m.Name)
 				if !ok {
-					panic("no perms for method: " + m.Name)
+					meth, ok = sentinelPermStruct.FieldByName(m.Name)
+					if !ok {
+						panic("no perms for method: " + m.Name)
+					}
 				}
 			}
 

--- a/build/sentinel.go
+++ b/build/sentinel.go
@@ -1,0 +1,3 @@
+package build
+
+var SentinelMode string = "false"

--- a/chain/events/events.go
+++ b/chain/events/events.go
@@ -55,11 +55,15 @@ type Events struct {
 
 	heightEvents
 	*hcEvents
+
+	observers []TipSetObserver
 }
 
 func NewEvents(ctx context.Context, api eventAPI) *Events {
-	gcConfidence := 2 * build.ForkLengthThreshold
+	return NewEventsWithConfidence(ctx, api, 2*build.ForkLengthThreshold)
+}
 
+func NewEventsWithConfidence(ctx context.Context, api eventAPI, gcConfidence abi.ChainEpoch) *Events {
 	tsc := newTSCache(gcConfidence, api)
 
 	e := &Events{
@@ -77,8 +81,9 @@ func NewEvents(ctx context.Context, api eventAPI) *Events {
 			htHeights:        map[abi.ChainEpoch][]uint64{},
 		},
 
-		hcEvents: newHCEvents(ctx, api, tsc, uint64(gcConfidence)),
-		ready:    make(chan struct{}),
+		hcEvents:  newHCEvents(ctx, api, tsc, uint64(gcConfidence)),
+		ready:     make(chan struct{}),
+		observers: []TipSetObserver{},
 	}
 
 	go e.listenHeadChanges(ctx)
@@ -90,6 +95,7 @@ func NewEvents(ctx context.Context, api eventAPI) *Events {
 	}
 
 	return e
+
 }
 
 func (e *Events) listenHeadChanges(ctx context.Context) {
@@ -164,7 +170,7 @@ func (e *Events) listenHeadChangesOnce(ctx context.Context) error {
 			}
 		}
 
-		if err := e.headChange(rev, app); err != nil {
+		if err := e.headChange(ctx, rev, app); err != nil {
 			log.Warnf("headChange failed: %s", err)
 		}
 
@@ -177,7 +183,7 @@ func (e *Events) listenHeadChangesOnce(ctx context.Context) error {
 	return nil
 }
 
-func (e *Events) headChange(rev, app []*types.TipSet) error {
+func (e *Events) headChange(ctx context.Context, rev, app []*types.TipSet) error {
 	if len(app) == 0 {
 		return xerrors.New("events.headChange expected at least one applied tipset")
 	}
@@ -189,5 +195,40 @@ func (e *Events) headChange(rev, app []*types.TipSet) error {
 		return err
 	}
 
+	if err := e.observeChanges(ctx, rev, app); err != nil {
+		return err
+	}
+
 	return e.processHeadChangeEvent(rev, app)
+}
+
+// A TipSetObserver receives notifications of tipsets
+type TipSetObserver interface {
+	Apply(ctx context.Context, ts *types.TipSet) error
+	Revert(ctx context.Context, ts *types.TipSet) error
+}
+
+// TODO: add a confidence level so we can have observers with difference levels of confidence
+func (e *Events) Observe(obs TipSetObserver) error {
+	e.lk.Lock()
+	defer e.lk.Unlock()
+	e.observers = append(e.observers, obs)
+	return nil
+}
+
+// observeChanges expects caller to hold e.lk
+func (e *Events) observeChanges(ctx context.Context, rev, app []*types.TipSet) error {
+	for _, ts := range rev {
+		for _, o := range e.observers {
+			_ = o.Revert(ctx, ts)
+		}
+	}
+
+	for _, ts := range app {
+		for _, o := range e.observers {
+			_ = o.Apply(ctx, ts)
+		}
+	}
+
+	return nil
 }

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -319,6 +319,7 @@ var Commands = []*cli.Command{
 	WithCategory("developer", fetchParamCmd),
 	WithCategory("network", netCmd),
 	WithCategory("network", syncCmd),
+	WithCategory("sentinel", sentinelCmd),
 	pprofCmd,
 	VersionCmd,
 }

--- a/cli/sentinel.go
+++ b/cli/sentinel.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var sentinelCmd = &cli.Command{
+	Name:  "sentinel",
+	Usage: "Interact with the sentinel module",
+	Subcommands: []*cli.Command{
+		sentinelStartWatchCmd,
+	},
+}
+
+var sentinelStartWatchCmd = &cli.Command{
+	Name:  "watch",
+	Usage: "start a watch against the chain",
+	Flags: []cli.Flag{
+		&cli.Int64Flag{
+			Name: "confidence",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		apic, closer, err := GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := ReqContext(cctx)
+
+		//confidence := abi.ChainEpoch(cctx.Int64("confidence"))
+
+		if err := apic.WatchStart(ctx); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cli/sentinel.go
+++ b/cli/sentinel.go
@@ -30,7 +30,7 @@ var sentinelStartWatchCmd = &cli.Command{
 
 		//confidence := abi.ChainEpoch(cctx.Int64("confidence"))
 
-		if err := apic.WatchStart(ctx); err != nil {
+		if err := apic.SentinelWatchStart(ctx); err != nil {
 			return err
 		}
 

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 
 	paramfetch "github.com/filecoin-project/go-paramfetch"
@@ -127,10 +128,6 @@ var DaemonCmd = &cli.Command{
 			Name:   "lite",
 			Usage:  "start lotus in lite mode",
 			Hidden: true,
-		},
-		&cli.BoolFlag{
-			Name:  "sentinel",
-			Usage: "start lotus in sentinel mode.",
 		},
 		&cli.StringFlag{
 			Name:  "pprof",
@@ -517,7 +514,10 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 
 func getDaemonMode(cctx *cli.Context) (daemonMode, error) {
 	isLite := cctx.Bool("lite")
-	isSentinel := cctx.Bool("sentinel")
+	isSentinel, err := strconv.ParseBool(build.SentinelMode)
+	if err != nil {
+		return modeUnknown, err
+	}
 
 	switch {
 	case !isLite && !isSentinel:

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -140,6 +140,8 @@
   * [PaychVoucherCreate](#PaychVoucherCreate)
   * [PaychVoucherList](#PaychVoucherList)
   * [PaychVoucherSubmit](#PaychVoucherSubmit)
+* [Sentinel](#Sentinel)
+  * [SentinelWatchStart](#SentinelWatchStart)
 * [State](#State)
   * [StateAccountKey](#StateAccountKey)
   * [StateAllMinerFaults](#StateAllMinerFaults)
@@ -3309,6 +3311,18 @@ Response:
   "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
 }
 ```
+
+## Sentinel
+
+
+### SentinelWatchStart
+
+
+Perms: admin
+
+Inputs: `null`
+
+Response: `{}`
 
 ## State
 The State methods are used to query, inspect, and interact with chain state.

--- a/go.sum
+++ b/go.sum
@@ -1402,6 +1402,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/metrics/proxy.go
+++ b/metrics/proxy.go
@@ -21,6 +21,7 @@ func MetricedFullAPI(a api.FullNode) api.FullNode {
 	var out apistruct.FullNodeStruct
 	proxy(a, &out.Internal)
 	proxy(a, &out.CommonStruct.Internal)
+	proxy(a, &out.SentinelStruct.Internal)
 	return &out
 }
 

--- a/node/builder.go
+++ b/node/builder.go
@@ -357,9 +357,6 @@ var ChainNode = Options(
 		Override(HandleIncomingMessagesKey, modules.HandleIncomingMessages),
 		Override(HandleIncomingBlocksKey, modules.HandleIncomingBlocks),
 	),
-
-	// Sentinel API is unavailable by default
-	Override(new(api.Sentinel), From(new(sentinel.SentinelUnavailable))),
 )
 
 var MinerNode = Options(

--- a/node/impl/full.go
+++ b/node/impl/full.go
@@ -29,7 +29,7 @@ type FullNodeAPI struct {
 	full.WalletAPI
 	full.SyncAPI
 	full.BeaconAPI
-	api.Sentinel
+	api.Sentinel `optional:"true"`
 
 	DS dtypes.MetadataDS
 }

--- a/node/impl/full.go
+++ b/node/impl/full.go
@@ -29,6 +29,7 @@ type FullNodeAPI struct {
 	full.WalletAPI
 	full.SyncAPI
 	full.BeaconAPI
+	api.Sentinel
 
 	DS dtypes.MetadataDS
 }

--- a/node/impl/sentinel/sentinel.go
+++ b/node/impl/sentinel/sentinel.go
@@ -20,7 +20,7 @@ type SentinelAPI struct {
 	Events *events.Events
 }
 
-func (m *SentinelAPI) WatchStart(ctx context.Context) error {
+func (m *SentinelAPI) SentinelWatchStart(ctx context.Context) error {
 	log.Info("starting sentinel watch")
 	return m.Events.Observe(&sentinel.LoggingTipSetObserver{})
 }

--- a/node/impl/sentinel/sentinel.go
+++ b/node/impl/sentinel/sentinel.go
@@ -5,7 +5,6 @@ import (
 
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/events"
@@ -24,15 +23,6 @@ type SentinelAPI struct {
 func (m *SentinelAPI) WatchStart(ctx context.Context) error {
 	log.Info("starting sentinel watch")
 	return m.Events.Observe(&sentinel.LoggingTipSetObserver{})
-}
-
-// SentinelUnavailable is an implementation of the sentinel api that returns an unavailable error for every request.
-type SentinelUnavailable struct {
-	fx.In
-}
-
-func (SentinelUnavailable) WatchStart(ctx context.Context) error {
-	return xerrors.Errorf("sentinel unavailable")
 }
 
 var _ api.Sentinel = &SentinelAPI{}

--- a/node/impl/sentinel/sentinel.go
+++ b/node/impl/sentinel/sentinel.go
@@ -1,0 +1,38 @@
+package sentinel
+
+import (
+	"context"
+
+	logging "github.com/ipfs/go-log/v2"
+	"go.uber.org/fx"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/events"
+	"github.com/filecoin-project/lotus/sentinel"
+)
+
+var log = logging.Logger("sentinel-module")
+
+// SentinelAPI is an implementation of the sentinel api that logs each tipset as its applied and reverted.
+type SentinelAPI struct {
+	fx.In
+
+	Events *events.Events
+}
+
+func (m *SentinelAPI) WatchStart(ctx context.Context) error {
+	log.Info("starting sentinel watch")
+	return m.Events.Observe(&sentinel.LoggingTipSetObserver{})
+}
+
+// SentinelUnavailable is an implementation of the sentinel api that returns an unavailable error for every request.
+type SentinelUnavailable struct {
+	fx.In
+}
+
+func (SentinelUnavailable) WatchStart(ctx context.Context) error {
+	return xerrors.Errorf("sentinel unavailable")
+}
+
+var _ api.Sentinel = &SentinelAPI{}

--- a/node/modules/sentinel.go
+++ b/node/modules/sentinel.go
@@ -1,0 +1,21 @@
+package modules
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/filecoin-project/lotus/chain/events"
+	"github.com/filecoin-project/lotus/node/impl/full"
+	"github.com/filecoin-project/lotus/node/modules/helpers"
+)
+
+func NewEvents(mctx helpers.MetricsCtx, lc fx.Lifecycle, chainAPI full.ChainModuleAPI, stateAPI full.StateModuleAPI) *events.Events {
+	api := struct {
+		full.ChainModuleAPI
+		full.StateModuleAPI
+	}{
+		ChainModuleAPI: chainAPI,
+		StateModuleAPI: stateAPI,
+	}
+
+	return events.NewEventsWithConfidence(mctx, api, 10)
+}

--- a/sentinel/observer.go
+++ b/sentinel/observer.go
@@ -1,0 +1,27 @@
+package sentinel
+
+import (
+	"context"
+
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/filecoin-project/lotus/chain/events"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var log = logging.Logger("sentinel-observer")
+
+var _ events.TipSetObserver = (*LoggingTipSetObserver)(nil)
+
+type LoggingTipSetObserver struct {
+}
+
+func (o *LoggingTipSetObserver) Apply(ctx context.Context, ts *types.TipSet) error {
+	log.Infof("TipSetObserver.Apply(%q)", ts.Key())
+	return nil
+}
+
+func (o *LoggingTipSetObserver) Revert(ctx context.Context, ts *types.TipSet) error {
+	log.Infof("TipSetObserver.Revert(%q)", ts.Key())
+	return nil
+}


### PR DESCRIPTION
### What
- add sentinel module scaffolding and API
  - allows lotus to be started in sentinel mode and start a watch that logs
tipsets as they are received. closes https://github.com/filecoin-project/sentinel/issues/179
  - Define Sentinel API and embed it in FullNodeAPI.
- add ldflag to build lotus in "SentinelMode" with make command `lotus-sentinel`.

### TODO
- [x] Figure out how to make docs-check green.
  - currently fails `panic: no perms for method: WatchStart` but WatchStart has perms admin