### PR TITLE
list-asks: add --output-format & omit progress if !stdout

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1221,8 +1221,8 @@ var clientListAsksCmd = &cli.Command{
 		}
 		pfmt := "%s: min:%s max:%s price:%s/GiB/Epoch verifiedPrice:%s/GiB/Epoch ping:%s\n"
 		if cctx.String("output-format") == "csv" {
-			fmt.Printf("Miner, Min, Max, Price, VerifiedPrice, Ping\n")
-			pfmt = "%s, %s, %s, %s, %s, %s\n"
+			fmt.Printf("Miner,Min,Max,Price,VerifiedPrice,Ping\n")
+			pfmt = "%s,%s,%s,%s,%s,%s\n"
 		}
 
 		for _, a := range asks {


### PR DESCRIPTION
1. Detect if stdout, and if not, omit all the progress reporting up the top so your redirected output isn't a mess
2. Add an `--output-format` to allow switching to a nice CSV format (JSON could be added too) that can be more easily machine-manipulated

`lotus client list-asks  --output-format csv > asks.csv`

yields:

```
Miner,Min,Max,Price,VerifiedPrice,Ping
f0134516,256 B,32 GiB,0 FIL,0.00000000005 FIL,421.694105ms
f02529,256 B,32 GiB,0 FIL,0 FIL,182.920096ms
f0116445,256 B,32 GiB,0 FIL,0.00000000005 FIL,426.349591ms
f0148143,1 MiB,32 GiB,0 FIL,0 FIL,181.059489ms
f02613,256 B,32 GiB,0 FIL,0 FIL,181.039067ms
f0116436,256 B,32 GiB,0 FIL,0.00000000005 FIL,444.814418ms
f023982,256 B,32 GiB,0 FIL,0 FIL,183.604611ms
f0134518,256 B,32 GiB,0 FIL,0.00000000005 FIL,372.644666ms
f019002,1 GiB,32 GiB,0 FIL,0 FIL,181.331792ms
f063869,256 B,32 GiB,0 FIL,0.00000000005 FIL,611.692555ms
f03249,56 KiB,32 GiB,0 FIL,0 FIL,388.112484ms
```