### PR TITLE
Correctly format disputer log

### DIFF
--- a/cli/disputer.go
+++ b/cli/disputer.go
@@ -270,7 +270,7 @@ var disputerStartCmd = &cli.Command{
 				if err != nil {
 					disputeLog.Errorw("failed to dispute post message", "err", err.Error(), "miner", dpmsg.To)
 				} else {
-					disputeLog.Infof("submited dispute", "mcid", m.Cid(), "miner", dpmsg.To)
+					disputeLog.Infow("submited dispute", "mcid", m.Cid(), "miner", dpmsg.To)
 				}
 			}
 


### PR DESCRIPTION
Fixes the format of the log so that we can correctly parse out the data when logging as json.