### PR TITLE
Feat/api no dep build

### DIFF
--- a/api/api_common.go
+++ b/api/api_common.go
@@ -11,8 +11,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
-
-	"github.com/filecoin-project/lotus/build"
 )
 
 type Common interface {
@@ -57,7 +55,7 @@ type Common interface {
 	ID(context.Context) (peer.ID, error)
 
 	// Version provides information about API provider
-	Version(context.Context) (Version, error)
+	Version(context.Context) (APIVersion, error)
 
 	LogList(context.Context) ([]string, error)
 	LogSetLevel(context.Context, string, string) error
@@ -71,15 +69,15 @@ type Common interface {
 	Closing(context.Context) (<-chan struct{}, error)
 }
 
-// Version provides various build-time information
-type Version struct {
+// APIVersion provides various build-time information
+type APIVersion struct {
 	Version string
 
 	// APIVersion is a binary encoded semver version of the remote implementing
 	// this api
 	//
 	// See APIVersion in build/version.go
-	APIVersion build.Version
+	APIVersion Version
 
 	// TODO: git commit / os / genesis cid?
 
@@ -87,7 +85,7 @@ type Version struct {
 	BlockDelay uint64
 }
 
-func (v Version) String() string {
+func (v APIVersion) String() string {
 	return fmt.Sprintf("%s+api%s", v.Version, v.APIVersion.String())
 }
 

--- a/api/api_worker.go
+++ b/api/api_worker.go
@@ -9,12 +9,10 @@ import (
 	"github.com/filecoin-project/lotus/extern/sector-storage/sealtasks"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
-
-	"github.com/filecoin-project/lotus/build"
 )
 
 type WorkerAPI interface {
-	Version(context.Context) (build.Version, error)
+	Version(context.Context) (Version, error)
 	// TODO: Info() (name, ...) ?
 
 	TaskTypes(context.Context) (map[sealtasks.TaskType]struct{}, error) // TaskType -> Weight

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -33,7 +33,6 @@ import (
 	"github.com/filecoin-project/specs-storage/storage"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -64,8 +63,8 @@ type CommonStruct struct {
 		NetBlockRemove              func(ctx context.Context, acl api.NetBlockList) error            `perm:"admin"`
 		NetBlockList                func(ctx context.Context) (api.NetBlockList, error)              `perm:"read"`
 
-		ID      func(context.Context) (peer.ID, error)     `perm:"read"`
-		Version func(context.Context) (api.Version, error) `perm:"read"`
+		ID      func(context.Context) (peer.ID, error)        `perm:"read"`
+		Version func(context.Context) (api.APIVersion, error) `perm:"read"`
 
 		LogList     func(context.Context) ([]string, error)     `perm:"write"`
 		LogSetLevel func(context.Context, string, string) error `perm:"write"`
@@ -389,7 +388,7 @@ type WorkerStruct struct {
 	Internal struct {
 		// TODO: lower perms
 
-		Version func(context.Context) (build.Version, error) `perm:"admin"`
+		Version func(context.Context) (api.Version, error) `perm:"admin"`
 
 		TaskTypes func(context.Context) (map[sealtasks.TaskType]struct{}, error) `perm:"admin"`
 		Paths     func(context.Context) ([]stores.StoragePath, error)            `perm:"admin"`
@@ -546,7 +545,7 @@ func (c *CommonStruct) ID(ctx context.Context) (peer.ID, error) {
 }
 
 // Version implements API.Version
-func (c *CommonStruct) Version(ctx context.Context) (api.Version, error) {
+func (c *CommonStruct) Version(ctx context.Context) (api.APIVersion, error) {
 	return c.Internal.Version(ctx)
 }
 
@@ -1610,7 +1609,7 @@ func (c *StorageMinerStruct) CheckProvable(ctx context.Context, pp abi.Registere
 
 // WorkerStruct
 
-func (w *WorkerStruct) Version(ctx context.Context) (build.Version, error) {
+func (w *WorkerStruct) Version(ctx context.Context) (api.Version, error) {
 	return w.Internal.Version(ctx)
 }
 

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -113,7 +113,7 @@ func init() {
 	addExample(network.Connected)
 	addExample(dtypes.NetworkName("lotus"))
 	addExample(api.SyncStateStage(1))
-	addExample(build.FullAPIVersion)
+	addExample(api.FullAPIVersion)
 	addExample(api.PCHInbound)
 	addExample(time.Minute)
 	addExample(datatransfer.TransferID(3))

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -6,6 +6,8 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	address "github.com/filecoin-project/go-address"
 	bitfield "github.com/filecoin-project/go-bitfield"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -31,7 +33,6 @@ import (
 	network0 "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
-	reflect "reflect"
 )
 
 // MockFullNode is a mock of FullNode interface
@@ -2764,10 +2765,10 @@ func (mr *MockFullNodeMockRecorder) SyncValidateTipset(arg0, arg1 interface{}) *
 }
 
 // Version mocks base method
-func (m *MockFullNode) Version(arg0 context.Context) (api.Version, error) {
+func (m *MockFullNode) Version(arg0 context.Context) (api.APIVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version", arg0)
-	ret0, _ := ret[0].(api.Version)
+	ret0, _ := ret[0].(api.APIVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -6,8 +6,6 @@ package mocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	address "github.com/filecoin-project/go-address"
 	bitfield "github.com/filecoin-project/go-bitfield"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -33,6 +31,7 @@ import (
 	network0 "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
+	reflect "reflect"
 )
 
 // MockFullNode is a mock of FullNode interface

--- a/api/test/test.go
+++ b/api/test/test.go
@@ -155,13 +155,13 @@ var MineNext = miner.MineReq{
 }
 
 func (ts *testSuite) testVersion(t *testing.T) {
-	build.RunningNodeType = build.NodeFull
+	api.RunningNodeType = api.NodeFull
 
 	ctx := context.Background()
 	apis, _ := ts.makeNodes(t, OneFull, OneMiner)
-	api := apis[0]
+	napi := apis[0]
 
-	v, err := api.Version(ctx)
+	v, err := napi.Version(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/version.go
+++ b/api/version.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"fmt"
+
+	xerrors "golang.org/x/xerrors"
+)
+
+type Version uint32
+
+func newVer(major, minor, patch uint8) Version {
+	return Version(uint32(major)<<16 | uint32(minor)<<8 | uint32(patch))
+}
+
+// Ints returns (major, minor, patch) versions
+func (ve Version) Ints() (uint32, uint32, uint32) {
+	v := uint32(ve)
+	return (v & majorOnlyMask) >> 16, (v & minorOnlyMask) >> 8, v & patchOnlyMask
+}
+
+func (ve Version) String() string {
+	vmj, vmi, vp := ve.Ints()
+	return fmt.Sprintf("%d.%d.%d", vmj, vmi, vp)
+}
+
+func (ve Version) EqMajorMinor(v2 Version) bool {
+	return ve&minorMask == v2&minorMask
+}
+
+type NodeType int
+
+const (
+	NodeUnknown NodeType = iota
+
+	NodeFull
+	NodeMiner
+	NodeWorker
+)
+
+var RunningNodeType NodeType
+
+func VersionForType(nodeType NodeType) (Version, error) {
+	switch nodeType {
+	case NodeFull:
+		return FullAPIVersion, nil
+	case NodeMiner:
+		return MinerAPIVersion, nil
+	case NodeWorker:
+		return WorkerAPIVersion, nil
+	default:
+		return Version(0), xerrors.Errorf("unknown node type %d", nodeType)
+	}
+}
+
+// semver versions of the rpc api exposed
+var (
+	FullAPIVersion   = newVer(1, 1, 0)
+	MinerAPIVersion  = newVer(1, 0, 1)
+	WorkerAPIVersion = newVer(1, 0, 0)
+)
+
+//nolint:varcheck,deadcode
+const (
+	majorMask = 0xff0000
+	minorMask = 0xffff00
+	patchMask = 0xffffff
+
+	majorOnlyMask = 0xff0000
+	minorOnlyMask = 0x00ff00
+	patchOnlyMask = 0x0000ff
+)

--- a/build/version.go
+++ b/build/version.go
@@ -1,11 +1,5 @@
 package build
 
-import (
-	"fmt"
-
-	"golang.org/x/xerrors"
-)
-
 var CurrentCommit string
 var BuildType int
 
@@ -40,67 +34,3 @@ const BuildVersion = "1.5.0"
 func UserVersion() string {
 	return BuildVersion + buildType() + CurrentCommit
 }
-
-type Version uint32
-
-func newVer(major, minor, patch uint8) Version {
-	return Version(uint32(major)<<16 | uint32(minor)<<8 | uint32(patch))
-}
-
-// Ints returns (major, minor, patch) versions
-func (ve Version) Ints() (uint32, uint32, uint32) {
-	v := uint32(ve)
-	return (v & majorOnlyMask) >> 16, (v & minorOnlyMask) >> 8, v & patchOnlyMask
-}
-
-func (ve Version) String() string {
-	vmj, vmi, vp := ve.Ints()
-	return fmt.Sprintf("%d.%d.%d", vmj, vmi, vp)
-}
-
-func (ve Version) EqMajorMinor(v2 Version) bool {
-	return ve&minorMask == v2&minorMask
-}
-
-type NodeType int
-
-const (
-	NodeUnknown NodeType = iota
-
-	NodeFull
-	NodeMiner
-	NodeWorker
-)
-
-var RunningNodeType NodeType
-
-func VersionForType(nodeType NodeType) (Version, error) {
-	switch nodeType {
-	case NodeFull:
-		return FullAPIVersion, nil
-	case NodeMiner:
-		return MinerAPIVersion, nil
-	case NodeWorker:
-		return WorkerAPIVersion, nil
-	default:
-		return Version(0), xerrors.Errorf("unknown node type %d", nodeType)
-	}
-}
-
-// semver versions of the rpc api exposed
-var (
-	FullAPIVersion   = newVer(1, 1, 0)
-	MinerAPIVersion  = newVer(1, 0, 1)
-	WorkerAPIVersion = newVer(1, 0, 0)
-)
-
-//nolint:varcheck,deadcode
-const (
-	majorMask = 0xff0000
-	minorMask = 0xffff00
-	patchMask = 0xffffff
-
-	majorOnlyMask = 0xff0000
-	minorOnlyMask = 0x00ff00
-	patchOnlyMask = 0x0000ff
-)

--- a/cmd/lotus-gateway/api.go
+++ b/cmd/lotus-gateway/api.go
@@ -34,7 +34,7 @@ var (
 // gatewayDepsAPI defines the API methods that the GatewayAPI depends on
 // (to make it easy to mock for tests)
 type gatewayDepsAPI interface {
-	Version(context.Context) (api.Version, error)
+	Version(context.Context) (api.APIVersion, error)
 	ChainGetBlockMessages(context.Context, cid.Cid) (*api.BlockMessages, error)
 	ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error)
 	ChainGetNode(ctx context.Context, p string) (*api.IpldObject, error)
@@ -130,7 +130,7 @@ func (a *GatewayAPI) checkTimestamp(at time.Time) error {
 	return nil
 }
 
-func (a *GatewayAPI) Version(ctx context.Context) (api.Version, error) {
+func (a *GatewayAPI) Version(ctx context.Context) (api.APIVersion, error) {
 	return a.api.Version(ctx)
 }
 

--- a/cmd/lotus-seal-worker/main.go
+++ b/cmd/lotus-seal-worker/main.go
@@ -50,7 +50,7 @@ const FlagWorkerRepo = "worker-repo"
 const FlagWorkerRepoDeprecation = "workerrepo"
 
 func main() {
-	build.RunningNodeType = build.NodeWorker
+	api.RunningNodeType = api.NodeWorker
 
 	lotuslog.SetupLogLevels()
 
@@ -211,8 +211,8 @@ var runCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if v.APIVersion != build.MinerAPIVersion {
-			return xerrors.Errorf("lotus-miner API version doesn't match: expected: %s", api.Version{APIVersion: build.MinerAPIVersion})
+		if v.APIVersion != api.MinerAPIVersion {
+			return xerrors.Errorf("lotus-miner API version doesn't match: expected: %s", api.APIVersion{APIVersion: api.MinerAPIVersion})
 		}
 		log.Infof("Remote version %s", v)
 

--- a/cmd/lotus-seal-worker/rpc.go
+++ b/cmd/lotus-seal-worker/rpc.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/api"
 	sectorstorage "github.com/filecoin-project/lotus/extern/sector-storage"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
@@ -23,8 +23,8 @@ type worker struct {
 	disabled int64
 }
 
-func (w *worker) Version(context.Context) (build.Version, error) {
-	return build.WorkerAPIVersion, nil
+func (w *worker) Version(context.Context) (api.Version, error) {
+	return api.WorkerAPIVersion, nil
 }
 
 func (w *worker) StorageAddLocal(ctx context.Context, path string) error {

--- a/cmd/lotus-shed/consensus.go
+++ b/cmd/lotus-shed/consensus.go
@@ -36,7 +36,7 @@ type consensusItem struct {
 	targetTipset  *types.TipSet
 	headTipset    *types.TipSet
 	peerID        peer.ID
-	version       api.Version
+	version       api.APIVersion
 	api           api.FullNode
 }
 

--- a/cmd/lotus-storage-miner/actor_test.go
+++ b/cmd/lotus-storage-miner/actor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/test"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -70,7 +71,7 @@ func TestWorkerKeyChange(t *testing.T) {
 			"testnode-storage": sn[0],
 		}
 		app.Writer = output
-		build.RunningNodeType = build.NodeMiner
+		api.RunningNodeType = api.NodeMiner
 
 		fs := flag.NewFlagSet("", flag.ContinueOnError)
 		for _, f := range cmd.Flags {

--- a/cmd/lotus-storage-miner/allinfo_test.go
+++ b/cmd/lotus-storage-miner/allinfo_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/test"
-	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -55,7 +55,7 @@ func TestMinerAllInfo(t *testing.T) {
 			"testnode-full":    n[0],
 			"testnode-storage": sn[0],
 		}
-		build.RunningNodeType = build.NodeMiner
+		api.RunningNodeType = api.NodeMiner
 
 		cctx := cli.NewContext(app, flag.NewFlagSet("", flag.ContinueOnError), nil)
 

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	cliutil "github.com/filecoin-project/lotus/cli/util"
-
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-datastore"

--- a/cmd/lotus-storage-miner/init.go
+++ b/cmd/lotus-storage-miner/init.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	cliutil "github.com/filecoin-project/lotus/cli/util"
+
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-datastore"
@@ -186,8 +188,8 @@ var initCmd = &cli.Command{
 			return err
 		}
 
-		if !v.APIVersion.EqMajorMinor(build.FullAPIVersion) {
-			return xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", build.FullAPIVersion, v.APIVersion)
+		if !v.APIVersion.EqMajorMinor(lapi.FullAPIVersion) {
+			return xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", lapi.FullAPIVersion, v.APIVersion)
 		}
 
 		log.Info("Initializing repo")

--- a/cmd/lotus-storage-miner/init_restore.go
+++ b/cmd/lotus-storage-miner/init_restore.go
@@ -18,9 +18,11 @@ import (
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/go-state-types/big"
 
+	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/lib/backupds"
 	"github.com/filecoin-project/lotus/node/config"
@@ -68,8 +70,8 @@ var initRestoreCmd = &cli.Command{
 			return err
 		}
 
-		if !v.APIVersion.EqMajorMinor(build.FullAPIVersion) {
-			return xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", build.FullAPIVersion, v.APIVersion)
+		if !v.APIVersion.EqMajorMinor(lapi.FullAPIVersion) {
+			return xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", lapi.FullAPIVersion, v.APIVersion)
 		}
 
 		if !cctx.Bool("nosync") {

--- a/cmd/lotus-storage-miner/init_restore.go
+++ b/cmd/lotus-storage-miner/init_restore.go
@@ -22,7 +22,6 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
-	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/extern/sector-storage/stores"
 	"github.com/filecoin-project/lotus/lib/backupds"
 	"github.com/filecoin-project/lotus/node/config"

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -26,7 +26,7 @@ const FlagMinerRepo = "miner-repo"
 const FlagMinerRepoDeprecation = "storagerepo"
 
 func main() {
-	build.RunningNodeType = build.NodeMiner
+	api.RunningNodeType = api.NodeMiner
 
 	lotuslog.SetupLogLevels()
 

--- a/cmd/lotus-storage-miner/run.go
+++ b/cmd/lotus-storage-miner/run.go
@@ -9,8 +9,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	cliutil "github.com/filecoin-project/lotus/cli/util"
-
 	mux "github.com/gorilla/mux"
 	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"

--- a/cmd/lotus-storage-miner/run.go
+++ b/cmd/lotus-storage-miner/run.go
@@ -9,6 +9,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	cliutil "github.com/filecoin-project/lotus/cli/util"
+
 	mux "github.com/gorilla/mux"
 	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
@@ -95,8 +97,8 @@ var runCmd = &cli.Command{
 			}
 		}
 
-		if v.APIVersion != build.FullAPIVersion {
-			return xerrors.Errorf("lotus-daemon API version doesn't match: expected: %s", api.Version{APIVersion: build.FullAPIVersion})
+		if v.APIVersion != api.FullAPIVersion {
+			return xerrors.Errorf("lotus-daemon API version doesn't match: expected: %s", api.APIVersion{APIVersion: api.FullAPIVersion})
 		}
 
 		log.Info("Checking full node sync status")

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.opencensus.io/trace"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
@@ -16,7 +17,7 @@ import (
 var AdvanceBlockCmd *cli.Command
 
 func main() {
-	build.RunningNodeType = build.NodeFull
+	api.RunningNodeType = api.NodeFull
 
 	lotuslog.SetupLogLevels()
 

--- a/cmd/tvx/simulate.go
+++ b/cmd/tvx/simulate.go
@@ -154,7 +154,7 @@ func runSimulateCmd(_ *cli.Context) error {
 	version, err := FullAPI.Version(ctx)
 	if err != nil {
 		log.Printf("failed to get node version: %s; falling back to unknown", err)
-		version = api.Version{}
+		version = api.APIVersion{}
 	}
 
 	nv, err := FullAPI.StateNetworkVersion(ctx, ts.Key())

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -179,13 +179,13 @@ func (a *CommonAPI) ID(context.Context) (peer.ID, error) {
 	return a.Host.ID(), nil
 }
 
-func (a *CommonAPI) Version(context.Context) (api.Version, error) {
-	v, err := build.VersionForType(build.RunningNodeType)
+func (a *CommonAPI) Version(context.Context) (api.APIVersion, error) {
+	v, err := api.VersionForType(api.RunningNodeType)
 	if err != nil {
-		return api.Version{}, err
+		return api.APIVersion{}, err
 	}
 
-	return api.Version{
+	return api.APIVersion{
 		Version:    build.UserVersion(),
 		APIVersion: v,
 


### PR DESCRIPTION
This removes the api packages dependency on the build package, which transitively removes its dependency on the chain/actors/policy package which depends on every single version of the specs actors, which is a fairly bad time for people who just want to use the lotus api.

further extractions coming as my quest to have a very lightweight api package continues.