### PR TITLE
Fix bootstrapper profile setting

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -313,10 +313,11 @@ var DaemonCmd = &cli.Command{
 		stop, err := node.New(ctx,
 			node.FullAPI(&api, node.Lite(isLite)),
 
-			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
-			node.Override(new(dtypes.ShutdownChan), shutdownChan),
 			node.Online(),
 			node.Repo(r),
+
+			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
+			node.Override(new(dtypes.ShutdownChan), shutdownChan),
 
 			genesis,
 			liteModeDeps,


### PR DESCRIPTION
node.Online()->LibP2P would override it again, setting it to false - https://github.com/filecoin-project/lotus/blob/master/node/builder.go#L194