### PR TITLE
Check liveness of sectors when processing termination batches

### DIFF
--- a/extern/storage-sealing/terminate_batch.go
+++ b/extern/storage-sealing/terminate_batch.go
@@ -143,6 +143,18 @@ func (b *TerminateBatcher) processBatch(notif, after bool) (*cid.Cid, error) {
 			continue
 		}
 
+		ps, err := b.api.StateMinerPartitions(b.mctx, b.maddr, loc.Deadline, nil)
+		if err != nil {
+			log.Warnw("TerminateBatcher: getting miner partitions", "deadline", loc.Deadline, "partition", loc.Partition, "error", err)
+			continue
+		}
+
+		toTerminate, err = bitfield.IntersectBitField(ps[loc.Partition].LiveSectors, toTerminate)
+		if err != nil {
+			log.Warnw("TerminateBatcher: intersecting liveSectors and toTerminate bitfields", "deadline", loc.Deadline, "partition", loc.Partition, "error", err)
+			continue
+		}
+
 		if total+n > uint64(miner.AddressedSectorsMax) {
 			n = uint64(miner.AddressedSectorsMax) - total
 


### PR DESCRIPTION
`lzusaga` somehow ran into this problem on Slack: https://filecoinproject.slack.com/archives/CPFTWMY7N/p1615315583105100.

I'm not entirely sure how this happened, since the liveness check [here](https://github.com/filecoin-project/lotus/blob/32885e1129178582fbf75711b249f5b8d99663c3/extern/storage-sealing/states_proving.go#L48-L65) should be preventing putting such sectors into the termination queue. Maybe that liveness check isn't 100% correct? I'm not sure.

But, regardless, re-checking liveness and removing out any not-live sectors should be a fine thing to do?