### PR TITLE
Fix TestUnpadReader on Go 1.16

### DIFF
--- a/extern/sector-storage/fr32/readers_test.go
+++ b/extern/sector-storage/fr32/readers_test.go
@@ -1,6 +1,7 @@
 package fr32_test
 
 import (
+	"bufio"
 	"bytes"
 	"io/ioutil"
 	"testing"
@@ -25,7 +26,8 @@ func TestUnpadReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readered, err := ioutil.ReadAll(r)
+	// using bufio reader to make sure reads are big enough for the padreader - it can't handle small reads right now
+	readered, err := ioutil.ReadAll(bufio.NewReaderSize(r, 512))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
UnpadReader can't deal with small reads right now, and `ioutil.ReadAll` in Go 1.16 starts with some tiny reads