### PR TITLE
fix window post rand check

### DIFF
--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -589,7 +589,7 @@ func (s *WindowPoStScheduler) runPost(ctx context.Context, di dline.Info, ts *ty
 				return nil, err
 			}
 
-			postOut, ps, err := s.prover.GenerateWindowPoSt(ctx, abi.ActorID(mid), sinfos, abi.PoStRandomness(rand))
+			postOut, ps, err := s.prover.GenerateWindowPoSt(ctx, abi.ActorID(mid), sinfos, append(abi.PoStRandomness{}, rand...))
 			elapsed := time.Since(tsStart)
 
 			log.Infow("computing window post", "batch", batchIdx, "elapsed", elapsed)


### PR DESCRIPTION
GenerateWindowPoSt func will modifies the value of rand (randomness[31] &= 0x3f), this will result in false in the bytes.Equal(checkRand, rand)