### PR TITLE
splitstore: compact hotstore prior to garbage collection

### DIFF
--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -805,9 +805,8 @@ func (s *SplitStore) gcHotstore() {
 		if err != nil {
 			log.Warnf("error compacting hotstore: %s", err)
 			return
-		} else {
-			log.Infow("hotstore compaction done", "took", time.Since(startCompact))
 		}
+		log.Infow("hotstore compaction done", "took", time.Since(startCompact))
 	}
 
 	if gc, ok := s.hot.(interface{ CollectGarbage() error }); ok {
@@ -816,9 +815,9 @@ func (s *SplitStore) gcHotstore() {
 		err := gc.CollectGarbage()
 		if err != nil {
 			log.Warnf("error garbage collecting hotstore: %s", err)
-		} else {
-			log.Infow("garbage collection done", "took", time.Since(startGC))
+			return
 		}
+		log.Infow("hotstore garbage collection done", "took", time.Since(startGC))
 	}
 }
 

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -798,6 +798,18 @@ func (s *SplitStore) purgeTracking(cids []cid.Cid) error {
 }
 
 func (s *SplitStore) gcHotstore() {
+	if compact, ok := s.hot.(interface{ Compact() error }); ok {
+		log.Infof("compacting hotstore")
+		startCompact := time.Now()
+		err := compact.Compact()
+		if err != nil {
+			log.Warnf("error compacting hotstore: %s", err)
+			return
+		} else {
+			log.Infow("hotstore compaction done", "took", time.Since(startCompact))
+		}
+	}
+
 	if gc, ok := s.hot.(interface{ CollectGarbage() error }); ok {
 		log.Infof("garbage collecting hotstore")
 		startGC := time.Now()


### PR DESCRIPTION
Makes garbage collection more efficient at reclaiming space.

In one of the nodes, there was a performance effect for an interval of 1-2min, where block validation time jumped up to 30s. Note that this node had been running compaction every 15min for a while, so there was a lot of garbage sst files.

The other two test nodes showed no ill effect in block validation time.

All 3 nodes reclaimed some 10G of space thanks to the compaction.