### PR TITLE
storagefsm: Fix double unlock with ready WaitDeals sectors

### DIFF
--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -93,7 +93,6 @@ func (m *Sealing) maybeStartSealing(ctx statemachine.Context, sector SectorInfo,
 	if sector.CreationTime != 0 {
 		cfg, err := m.getConfig()
 		if err != nil {
-			m.inputLk.Unlock()
 			return false, xerrors.Errorf("getting storage config: %w", err)
 		}
 
@@ -101,7 +100,6 @@ func (m *Sealing) maybeStartSealing(ctx statemachine.Context, sector SectorInfo,
 		sealTime := time.Unix(sector.CreationTime, 0).Add(cfg.WaitDealsDelay)
 
 		if now.After(sealTime) {
-			m.inputLk.Unlock()
 			log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "wait-timeout")
 			return true, ctx.Send(SectorStartPacking{})
 		}


### PR DESCRIPTION
We would double-unlock the `inputLk` when the miner had a sector in WaitDeals state become ready for sealing while the node wasn't running

Somehow those unlocks got left there when this was refactored, and would cause double unlock with the unlock here -> https://github.com/filecoin-project/lotus/blob/master/extern/storage-sealing/input.go#L33

Looked at other usages of this lock, and it seems like we don't have more cases of this

(manually reproduced and verified the fix on my node)