### PR TITLE
fix: make sure atomic 64bit fields are 64bit aligned

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -84,10 +84,10 @@ const (
 // operation calls after Close() has returned, but it may not happen for
 // operations in progress. Those are likely to fail with a different error.
 type Blockstore struct {
-	DB *badger.DB
-
-	// state is guarded by atomic.
+	// state is accessed atomically
 	state int64
+
+	DB *badger.DB
 
 	prefixing bool
 	prefix    []byte


### PR DESCRIPTION
Otherwise, this won't work on 32bit ARM.

See https://golang.org/pkg/sync/atomic/#pkg-note-BUG