### PR TITLE
storagefsm: Trigger input processing when below limits

### DIFF
--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -23,9 +23,11 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/types"
 	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
+	"github.com/filecoin-project/lotus/extern/storage-sealing/sealiface"
 	"github.com/filecoin-project/lotus/markets/storageadapter"
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/impl"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
 	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
@@ -181,6 +183,71 @@ func TestPublishDealsBatching(t *testing.T, b APIBuilder, blocktime time.Duratio
 		require.Fail(t, "Expected 3rd deal to be published once publish period elapsed")
 	case <-done: // Success
 	}
+}
+
+func TestBatchDealInput(t *testing.T, b APIBuilder, blocktime time.Duration, startEpoch abi.ChainEpoch) {
+	publishPeriod := 10 * time.Second
+	maxDealsPerMsg := uint64(4)
+
+	// Set max deals per publish deals message to maxDealsPerMsg
+	minerDef := []StorageMiner{{
+		Full: 0,
+		Opts: node.Options(
+			node.Override(
+				new(*storageadapter.DealPublisher),
+				storageadapter.NewDealPublisher(nil, storageadapter.PublishMsgConfig{
+					Period:         publishPeriod,
+					MaxDealsPerMsg: maxDealsPerMsg,
+				})),
+			node.Override(new(dtypes.GetSealingConfigFunc), func() (dtypes.GetSealingConfigFunc, error) {
+				return func() (sealiface.Config, error) {
+					return sealiface.Config{
+						MaxWaitDealsSectors:       1,
+						MaxSealingSectors:         2,
+						MaxSealingSectorsForDeals: 3,
+						AlwaysKeepUnsealedCopy:    true,
+					}, nil
+				}, nil
+			}),
+		),
+		Preseal: PresealGenesis,
+	}}
+
+	// Create a connect client and miner node
+	n, sn := b(t, OneFull, minerDef)
+	client := n[0].FullNode.(*impl.FullNodeAPI)
+	miner := sn[0]
+	s := connectAndStartMining(t, b, blocktime, client, miner)
+	defer s.blockMiner.Stop()
+
+	// Starts a deal and waits until it's published
+	runDealTillSeal := func(rseed int) {
+		res, _, err := CreateClientFile(s.ctx, s.client, rseed)
+		require.NoError(t, err)
+
+		dc := startDeal(t, s.ctx, s.miner, s.client, res.Root, false, startEpoch)
+		waitDealSealed(t, s.ctx, s.miner, s.client, dc, false)
+	}
+
+	// Run maxDealsPerMsg+1 deals in parallel
+	done := make(chan struct{}, maxDealsPerMsg+1)
+	for rseed := 1; rseed <= int(maxDealsPerMsg+1); rseed++ {
+		rseed := rseed
+		go func() {
+			runDealTillSeal(rseed)
+			done <- struct{}{}
+		}()
+	}
+
+	// Wait for maxDealsPerMsg of the deals to be published
+	for i := 0; i < int(maxDealsPerMsg); i++ {
+		<-done
+	}
+
+	sl, err := sn[0].SectorsList(s.ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(sl), 4)
+	require.LessOrEqual(t, len(sl), 5)
 }
 
 func TestFastRetrievalDealFlow(t *testing.T, b APIBuilder, blocktime time.Duration, startEpoch abi.ChainEpoch) {

--- a/api/test/deals.go
+++ b/api/test/deals.go
@@ -203,8 +203,8 @@ func TestBatchDealInput(t *testing.T, b APIBuilder, blocktime time.Duration, sta
 				return func() (sealiface.Config, error) {
 					return sealiface.Config{
 						MaxWaitDealsSectors:       1,
-						MaxSealingSectors:         2,
-						MaxSealingSectorsForDeals: 3,
+						MaxSealingSectors:         1,
+						MaxSealingSectorsForDeals: 2,
 						AlwaysKeepUnsealedCopy:    true,
 					}, nil
 				}, nil

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -412,7 +412,7 @@ func (m *Sealing) onUpdateSector(ctx context.Context, state *SectorInfo) error {
 	// trigger more input processing when we've dipped below max sealing limits
 	if shouldUpdateInput {
 		go func() {
-			m.inputLk.Unlock()
+			m.inputLk.Lock()
 			defer m.inputLk.Unlock()
 
 			if err := m.updateInput(ctx, sp); err != nil {

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -394,6 +394,10 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 }
 
 func (m *Sealing) onUpdateSector(ctx context.Context, state *SectorInfo) error {
+	if m.getConfig == nil {
+		return nil // tests
+	}
+
 	cfg, err := m.getConfig()
 	if err != nil {
 		return xerrors.Errorf("getting config: %w", err)

--- a/extern/storage-sealing/garbage.go
+++ b/extern/storage-sealing/garbage.go
@@ -38,6 +38,9 @@ func (m *Sealing) PledgeSector(ctx context.Context) (storage.SectorRef, error) {
 		return storage.SectorRef{}, xerrors.Errorf("notifying sealer of the new sector: %w", err)
 	}
 
+	// update stats early, fsm planner would do that async
+	m.stats.updateSector(cfg, m.minerSectorID(sid), UndefinedSectorState)
+
 	log.Infof("Creating CC sector %d", sid)
 	return sectorID, m.sectors.Send(uint64(sid), SectorStartCC{
 		ID:         sid,

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -400,6 +400,9 @@ func (m *Sealing) tryCreateDealSector(ctx context.Context, sp abi.RegisteredSeal
 		return xerrors.Errorf("initializing sector: %w", err)
 	}
 
+	// update stats early, fsm planner would do that async
+	m.stats.updateSector(cfg, m.minerSectorID(sid), UndefinedSectorState)
+
 	log.Infow("Creating sector", "number", sid, "type", "deal", "proofType", sp)
 	return m.sectors.Send(uint64(sid), SectorStart{
 		ID:         sid,

--- a/extern/storage-sealing/stats.go
+++ b/extern/storage-sealing/stats.go
@@ -45,6 +45,8 @@ func (ss *SectorStats) updateSector(cfg sealiface.Config, id abi.SectorID, st Se
 	sealing := ss.curSealingLocked()
 	staging := ss.curStagingLocked()
 
+	log.Debugw("sector stats", "sealing", sealing, "staging", staging)
+
 	if cfg.MaxSealingSectorsForDeals > 0 && // max sealing deal sector limit set
 		preSealing >= cfg.MaxSealingSectorsForDeals && // we were over limit
 		sealing < cfg.MaxSealingSectorsForDeals { // and we're below the limit now

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -58,6 +58,9 @@ func TestAPIDealFlow(t *testing.T) {
 	t.Run("TestPublishDealsBatching", func(t *testing.T) {
 		test.TestPublishDealsBatching(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
 	})
+	t.Run("TestBatchDealInput", func(t *testing.T) {
+		test.TestBatchDealInput(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
+	})
 }
 
 func TestAPIDealFlowReal(t *testing.T) {


### PR DESCRIPTION
Currently when a miner starts processing more deals in parallel than the configured sealing limits, we wouldn't start processing more deals after the first batch of sectors got sealed.

This should fix that case