### PR TITLE
fix: StateManager.Replay

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -255,7 +255,7 @@ func (sm *StateManager) Replay(ctx context.Context, ts *types.TipSet, mcid cid.C
 		}
 		return nil
 	})
-	if err != nil && err != errHaltExecution {
+	if err != nil && !xerrors.Is(err, errHaltExecution) {
 		return nil, nil, xerrors.Errorf("unexpected error during execution: %w", err)
 	}
 


### PR DESCRIPTION
in the `statemanager.replay` method, 
after get the msg(specified by 'mcid' param) execution result,
the callback function returns an 'errHaltExecution' to break  out the loop in `computeTipSetState`
but some times `computeTipsetstate`  warps the `errHaltExecution` with `xerrors`
that would cause following expression:

(err != errHaltExecution)  to be `true` .

which  causes `StateManager.Replay` returns an error with following message: 

`unexpected error during execution: callback failed on reward message: halt`
