### PR TITLE
mock sealer: Simulate randomness sideeffects

### DIFF
--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -491,6 +491,7 @@ func (m mockVerif) VerifySeal(svi proof2.SealVerifyInfo) (bool, error) {
 }
 
 func (m mockVerif) VerifyWinningPoSt(ctx context.Context, info proof2.WinningPoStVerifyInfo) (bool, error) {
+	info.Randomness[31] &= 0x3f
 	return true, nil
 }
 

--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -325,6 +325,8 @@ func (mgr *SectorMgr) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorI
 }
 
 func generateFakePoStProof(sectorInfo []proof2.SectorInfo, randomness abi.PoStRandomness) []byte {
+	randomness[31] &= 0x3f
+
 	hasher := sha256.New()
 	_, _ = hasher.Write(randomness)
 	for _, info := range sectorInfo {


### PR DESCRIPTION
Ideally we would change the ffiwrapper to not have sideeffects, but we need to make sure that we don't use this randomness anywhere after it's modified by the ffi calls.

This at least makes the mock and ffiwrapper do the same thing