### PR TITLE
Splitstore optimizations

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -165,6 +165,15 @@ func (b *Blockstore) Compact() error {
 	return b.DB.Flatten(nworkers)
 }
 
+func (b *Blockstore) Size() (int64, error) {
+	if atomic.LoadInt64(&b.state) != stateOpen {
+		return 0, ErrBlockstoreClosed
+	}
+
+	lsm, vlog := b.DB.Size()
+	return lsm + vlog, nil
+}
+
 // View implements blockstore.Viewer, which leverages zero-copy read-only
 // access to values.
 func (b *Blockstore) View(cid cid.Cid, fn func([]byte) error) error {

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -140,7 +140,7 @@ func (b *Blockstore) CollectGarbage() error {
 
 	var err error
 	for err == nil {
-		err = b.DB.RunValueLogGC(0.125)
+		err = b.DB.RunValueLogGC(0.0625)
 	}
 
 	if err == badger.ErrNoRewrite {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -42,7 +42,7 @@ var (
 	// === :: cold (already archived)
 	// ≡≡≡ :: to be archived in this compaction
 	// --- :: hot
-	CompactionThreshold = 5 * build.Finality
+	CompactionThreshold = 3 * build.Finality
 
 	// CompactionCold is the number of epochs that will be archived to the
 	// cold store on compaction. See diagram on CompactionThreshold for a

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -676,20 +676,6 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 	}
 	defer markSet.Close() //nolint:errcheck
 
-	// 0. mark genesis and its state root as reachable
-	log.Info("marking genesis")
-	err = markSet.Mark(s.genesis)
-	if err != nil {
-		return xerrors.Errorf("error marking genesis: %w", err)
-	}
-
-	err = s.walkLinks(s.genesisStateRoot, cid.NewSet(), func(c cid.Cid) error {
-		return markSet.Mark(c)
-	})
-	if err != nil {
-		return xerrors.Errorf("error marking genesis state root: %w", err)
-	}
-
 	// 1. mark reachable objects by walking the chain from the current epoch to the boundary epoch
 	log.Infow("marking reachable blocks", "currentEpoch", currentEpoch, "boundaryEpoch", boundaryEpoch)
 	startMark := time.Now()

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -358,7 +358,7 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 		}
 	}
 
-	s.walkLinks(s.genesisStateRoot, cid.NewSet(), func(c cid.Cid) error {
+	err = s.walkLinks(s.genesisStateRoot, cid.NewSet(), func(c cid.Cid) error {
 		has, err = s.hot.Has(c)
 		if err != nil {
 			return xerrors.Errorf("error checking hotstore for genesis state root: %w", err)
@@ -378,6 +378,9 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 
 		return nil
 	})
+	if err != nil {
+		return xerrors.Errorf("error walking genesis state root links: %w", err)
+	}
 
 	// load base epoch from metadata ds
 	// if none, then use current epoch because it's a fresh start

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -367,12 +367,16 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 		if !has {
 			blk, err := s.cold.Get(c)
 			if err != nil {
-				return xerrors.Errorf("error retrieving genesis state root from coldstore: %w", err)
+				if err == bstore.ErrNotFound {
+					return nil
+				}
+
+				return xerrors.Errorf("error retrieving genesis state linked object from coldstore: %w", err)
 			}
 
 			err = s.hot.Put(blk)
 			if err != nil {
-				return xerrors.Errorf("error putting genesis state root to hotstore: %w", err)
+				return xerrors.Errorf("error putting genesis state linked object to hotstore: %w", err)
 			}
 		}
 

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -537,7 +537,7 @@ func (s *SplitStore) warmup(curTs *types.TipSet) error {
 	count := int64(0)
 	xcount := int64(0)
 	missing := int64(0)
-	err := s.walk(curTs, epoch,
+	err := s.walk(curTs, epoch, false,
 		func(cid cid.Cid) error {
 			count++
 
@@ -649,7 +649,7 @@ func (s *SplitStore) estimateMarkSetSize(curTs *types.TipSet) error {
 	epoch := curTs.Height()
 
 	var count int64
-	err := s.walk(curTs, epoch,
+	err := s.walk(curTs, epoch, false,
 		func(cid cid.Cid) error {
 			count++
 			return nil
@@ -680,6 +680,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 	log.Infow("marking reachable blocks", "currentEpoch", currentEpoch, "boundaryEpoch", boundaryEpoch)
 	startMark := time.Now()
 
+	var inclMsgs bool
 	var markTs *types.TipSet
 	if syncGapEpoch > boundaryEpoch {
 		// There is a sync gap that may have caused writes that are logically after the boundary
@@ -689,6 +690,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 		// In this case we perform a full walk to avoid pathologies with pushing actually hot
 		// objects into the coldstore.
 		markTs = curTs
+		inclMsgs = true
 		log.Infof("sync gap detected at epoch %d; marking from current epoch to boundary epoch", syncGapEpoch)
 	} else {
 		// There is no pathological sync gap, so we can use the much faster single tipset walk at
@@ -701,7 +703,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 	}
 
 	var count int64
-	err = s.walk(markTs, boundaryEpoch,
+	err = s.walk(markTs, boundaryEpoch, inclMsgs,
 		func(cid cid.Cid) error {
 			count++
 			return markSet.Mark(cid)
@@ -823,7 +825,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 	return nil
 }
 
-func (s *SplitStore) walk(ts *types.TipSet, boundary abi.ChainEpoch, f func(cid.Cid) error) error {
+func (s *SplitStore) walk(ts *types.TipSet, boundary abi.ChainEpoch, inclMsgs bool, f func(cid.Cid) error) error {
 	walked := cid.NewSet()
 	toWalk := ts.Cids()
 
@@ -849,6 +851,12 @@ func (s *SplitStore) walk(ts *types.TipSet, boundary abi.ChainEpoch, f func(cid.
 
 		if err := f(c); err != nil {
 			return err
+		}
+
+		if inclMsgs {
+			if err := s.walkLinks(hdr.Messages, walked, f); err != nil {
+				return xerrors.Errorf("error walking state root (cid: %s): %w", hdr.ParentStateRoot, err)
+			}
 		}
 
 		if err := s.walkLinks(hdr.ParentStateRoot, walked, f); err != nil {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -877,12 +877,12 @@ func (s *SplitStore) walkLinks(c cid.Cid, walked *cid.Set, f func(cid.Cid) error
 		return nil
 	}
 
-	if c.Prefix().Codec != cid.DagCBOR {
-		return nil
-	}
-
 	if err := f(c); err != nil {
 		return err
+	}
+
+	if c.Prefix().Codec != cid.DagCBOR {
+		return nil
 	}
 
 	blk, err := s.Get(c)

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -313,7 +313,11 @@ func (s *SplitStore) View(cid cid.Cid, cb func([]byte) error) error {
 	err := s.hot.View(cid, cb)
 	switch err {
 	case bstore.ErrNotFound:
-		return s.cold.View(cid, cb)
+		err = s.cold.View(cid, cb)
+		if err == nil {
+			stats.Record(context.Background(), metrics.SplitstoreMiss.M(1))
+		}
+		return err
 
 	default:
 		return err

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -86,17 +86,6 @@ type Config struct {
 	//
 	// Supported values are: "bloom" (default if omitted), "bolt".
 	MarkSetType string
-	// perform full reachability analysis (expensive) for compaction
-	// You should enable this option if you plan to use the splitstore without a backing coldstore
-	EnableFullCompaction bool
-	// EXPERIMENTAL enable pruning of unreachable objects.
-	// This has not been sufficiently tested yet; only enable if you know what you are doing.
-	// Only applies if you enable full compaction.
-	EnableGC bool
-	// full archival nodes should enable this if EnableFullCompaction is enabled
-	// do NOT enable this if you synced from a snapshot.
-	// Only applies if you enabled full compaction
-	Archival bool
 }
 
 // ChainAccessor allows the Splitstore to access the chain. It will most likely
@@ -113,16 +102,10 @@ type SplitStore struct {
 	critsection int32 // compaction critical section
 	closing     int32 // the split store is closing
 
-	fullCompaction  bool
-	enableGC        bool
-	skipOldMsgs     bool
-	skipMsgReceipts bool
-
 	baseEpoch   abi.ChainEpoch
 	warmupEpoch abi.ChainEpoch
 
 	coldPurgeSize int
-	deadPurgeSize int
 
 	mx    sync.Mutex
 	curTs *types.TipSet
@@ -165,16 +148,7 @@ func Open(path string, ds dstore.Datastore, hot, cold bstore.Blockstore, cfg *Co
 		tracker: tracker,
 		env:     env,
 
-		fullCompaction:  cfg.EnableFullCompaction,
-		enableGC:        cfg.EnableGC,
-		skipOldMsgs:     !(cfg.EnableFullCompaction && cfg.Archival),
-		skipMsgReceipts: !(cfg.EnableFullCompaction && cfg.Archival),
-
 		coldPurgeSize: defaultColdPurgeSize,
-	}
-
-	if cfg.EnableGC {
-		ss.deadPurgeSize = defaultDeadPurgeSize
 	}
 
 	return ss, nil
@@ -460,7 +434,7 @@ func (s *SplitStore) warmup(curTs *types.TipSet) {
 	batchSnoop := make([]cid.Cid, 0, batchSize)
 
 	count := int64(0)
-	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, s.skipOldMsgs, s.skipMsgReceipts,
+	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, true, true,
 		func(cid cid.Cid) error {
 			count++
 
@@ -551,11 +525,7 @@ func (s *SplitStore) compact(curTs *types.TipSet) {
 	}
 
 	start := time.Now()
-	if s.fullCompaction {
-		err = s.compactFull(curTs)
-	} else {
-		err = s.compactSimple(curTs)
-	}
+	err = s.doCompact(curTs)
 	took := time.Since(start).Milliseconds()
 	stats.Record(context.Background(), metrics.SplitstoreCompactionTimeSeconds.M(float64(took)/1e3))
 
@@ -566,7 +536,7 @@ func (s *SplitStore) compact(curTs *types.TipSet) {
 
 func (s *SplitStore) estimateMarkSetSize(curTs *types.TipSet) error {
 	var count int64
-	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, s.skipOldMsgs, s.skipMsgReceipts,
+	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, true, true,
 		func(cid cid.Cid) error {
 			count++
 			return nil
@@ -580,12 +550,12 @@ func (s *SplitStore) estimateMarkSetSize(curTs *types.TipSet) error {
 	return nil
 }
 
-func (s *SplitStore) compactSimple(curTs *types.TipSet) error {
+func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 	coldEpoch := s.baseEpoch + CompactionCold
 	currentEpoch := curTs.Height()
 	boundaryEpoch := currentEpoch - CompactionBoundary
 
-	log.Infow("running simple compaction", "currentEpoch", currentEpoch, "baseEpoch", s.baseEpoch, "coldEpoch", coldEpoch, "boundaryEpoch", boundaryEpoch)
+	log.Infow("running compaction", "currentEpoch", currentEpoch, "baseEpoch", s.baseEpoch, "coldEpoch", coldEpoch, "boundaryEpoch", boundaryEpoch)
 
 	coldSet, err := s.env.Create("cold", s.markSetSize)
 	if err != nil {
@@ -603,7 +573,7 @@ func (s *SplitStore) compactSimple(curTs *types.TipSet) error {
 	}
 
 	var count int64
-	err = s.chain.WalkSnapshot(context.Background(), boundaryTs, 1, s.skipOldMsgs, s.skipMsgReceipts,
+	err = s.chain.WalkSnapshot(context.Background(), boundaryTs, 1, true, true,
 		func(cid cid.Cid) error {
 			count++
 			return coldSet.Mark(cid)
@@ -819,231 +789,6 @@ func (s *SplitStore) gcHotstore() {
 		}
 		log.Infow("hotstore garbage collection done", "took", time.Since(startGC))
 	}
-}
-
-func (s *SplitStore) compactFull(curTs *types.TipSet) error {
-	currentEpoch := curTs.Height()
-	coldEpoch := s.baseEpoch + CompactionCold
-	boundaryEpoch := currentEpoch - CompactionBoundary
-
-	log.Infow("running full compaction", "currentEpoch", currentEpoch, "baseEpoch", s.baseEpoch, "coldEpoch", coldEpoch, "boundaryEpoch", boundaryEpoch)
-
-	// create two mark sets, one for marking the cold finality region
-	// and one for marking the hot region
-	hotSet, err := s.env.Create("hot", s.markSetSize)
-	if err != nil {
-		return xerrors.Errorf("error creating hot mark set: %w", err)
-	}
-	defer hotSet.Close() //nolint:errcheck
-
-	coldSet, err := s.env.Create("cold", s.markSetSize)
-	if err != nil {
-		return xerrors.Errorf("error creating cold mark set: %w", err)
-	}
-	defer coldSet.Close() //nolint:errcheck
-
-	// Phase 1: marking
-	log.Info("marking live blocks")
-	startMark := time.Now()
-
-	// Phase 1a: mark all reachable CIDs in the hot range
-	boundaryTs, err := s.chain.GetTipsetByHeight(context.Background(), boundaryEpoch, curTs, true)
-	if err != nil {
-		return xerrors.Errorf("error getting tipset at boundary epoch: %w", err)
-	}
-
-	count := int64(0)
-	err = s.chain.WalkSnapshot(context.Background(), boundaryTs, boundaryEpoch-coldEpoch, s.skipOldMsgs, s.skipMsgReceipts,
-		func(cid cid.Cid) error {
-			count++
-			return hotSet.Mark(cid)
-		})
-
-	if err != nil {
-		return xerrors.Errorf("error marking hot blocks: %w", err)
-	}
-
-	if count > s.markSetSize {
-		s.markSetSize = count + count>>2 // overestimate a bit
-	}
-
-	// Phase 1b: mark all reachable CIDs in the cold range
-	coldTs, err := s.chain.GetTipsetByHeight(context.Background(), coldEpoch, curTs, true)
-	if err != nil {
-		return xerrors.Errorf("error getting tipset at cold epoch: %w", err)
-	}
-
-	count = 0
-	err = s.chain.WalkSnapshot(context.Background(), coldTs, CompactionCold, s.skipOldMsgs, s.skipMsgReceipts,
-		func(cid cid.Cid) error {
-			count++
-			return coldSet.Mark(cid)
-		})
-
-	if err != nil {
-		return xerrors.Errorf("error marking cold blocks: %w", err)
-	}
-
-	if count > s.markSetSize {
-		s.markSetSize = count + count>>2 // overestimate a bit
-	}
-
-	log.Infow("marking done", "took", time.Since(startMark))
-
-	// Phase 2: sweep cold objects:
-	// - If a cold object is reachable in the hot range, it stays in the hotstore.
-	// - If a cold object is reachable in the cold range, it is moved to the coldstore.
-	// - If a cold object is unreachable, it is deleted if GC is enabled, otherwise moved to the coldstore.
-	log.Info("collecting cold objects")
-	startCollect := time.Now()
-
-	// some stats for logging
-	var hotCnt, coldCnt, deadCnt int
-
-	cold := make([]cid.Cid, 0, s.coldPurgeSize)
-	dead := make([]cid.Cid, 0, s.deadPurgeSize)
-
-	// 2.1 iterate through the tracker and collect cold and dead objects
-	err = s.tracker.ForEach(func(cid cid.Cid, wrEpoch abi.ChainEpoch) error {
-		// is the object stil hot?
-		if wrEpoch > coldEpoch {
-			// yes, stay in the hotstore
-			hotCnt++
-			return nil
-		}
-
-		// the object is cold -- check whether it is reachable in the hot range
-		mark, err := hotSet.Has(cid)
-		if err != nil {
-			return xerrors.Errorf("error checking live mark for %s: %w", cid, err)
-		}
-
-		if mark {
-			// the object is reachable in the hot range, stay in the hotstore
-			hotCnt++
-			return nil
-		}
-
-		// check whether it is reachable in the cold range
-		mark, err = coldSet.Has(cid)
-		if err != nil {
-			return xerrors.Errorf("error checkiing cold set for %s: %w", cid, err)
-		}
-
-		if s.enableGC {
-			if mark {
-				// the object is reachable in the cold range, move it to the cold store
-				cold = append(cold, cid)
-				coldCnt++
-			} else {
-				// the object is dead and will be deleted
-				dead = append(dead, cid)
-				deadCnt++
-			}
-		} else {
-			// if GC is disabled, we move both cold and dead objects to the coldstore
-			cold = append(cold, cid)
-			if mark {
-				coldCnt++
-			} else {
-				deadCnt++
-			}
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return xerrors.Errorf("error collecting cold objects: %w", err)
-	}
-
-	if coldCnt > 0 {
-		s.coldPurgeSize = coldCnt + coldCnt>>2 // overestimate a bit
-	}
-	if deadCnt > 0 {
-		s.deadPurgeSize = deadCnt + deadCnt>>2 // overestimate a bit
-	}
-
-	log.Infow("collection done", "took", time.Since(startCollect))
-	log.Infow("compaction stats", "hot", hotCnt, "cold", coldCnt, "dead", deadCnt)
-	stats.Record(context.Background(), metrics.SplitstoreCompactionHot.M(int64(hotCnt)))
-	stats.Record(context.Background(), metrics.SplitstoreCompactionCold.M(int64(coldCnt)))
-	stats.Record(context.Background(), metrics.SplitstoreCompactionDead.M(int64(deadCnt)))
-
-	// Enter critical section
-	atomic.StoreInt32(&s.critsection, 1)
-	defer atomic.StoreInt32(&s.critsection, 0)
-
-	// check to see if we are closing first; if that's the case just return
-	if atomic.LoadInt32(&s.closing) == 1 {
-		log.Info("splitstore is closing; aborting compaction")
-		return xerrors.Errorf("compaction aborted")
-	}
-
-	// 2.2 copy the cold objects to the coldstore
-	log.Info("moving cold objects to the coldstore")
-	startMove := time.Now()
-	err = s.moveColdBlocks(cold)
-	if err != nil {
-		return xerrors.Errorf("error moving cold blocks: %w", err)
-	}
-	log.Infow("moving done", "took", time.Since(startMove))
-
-	// 2.3 delete cold objects from the hotstore
-	log.Info("purging cold objects from the hotstore")
-	startPurge := time.Now()
-	err = s.purgeBlocks(cold)
-	if err != nil {
-		return xerrors.Errorf("error purging cold blocks: %w", err)
-	}
-	log.Infow("purging cold from hotstore done", "took", time.Since(startPurge))
-
-	// 2.4 remove the tracker tracking for cold objects
-	startPurge = time.Now()
-	log.Info("purging cold objects from tracker")
-	err = s.purgeTracking(cold)
-	if err != nil {
-		return xerrors.Errorf("error purging tracking for cold blocks: %w", err)
-	}
-	log.Infow("purging cold from tracker done", "took", time.Since(startPurge))
-
-	// 3. if we have dead objects, delete them from the hotstore and remove the tracking
-	if len(dead) > 0 {
-		log.Info("deleting dead objects")
-		err = s.purgeBlocks(dead)
-		if err != nil {
-			return xerrors.Errorf("error purging dead blocks: %w", err)
-		}
-
-		// remove the tracker tracking
-		startPurge := time.Now()
-		log.Info("purging dead objects from tracker")
-		err = s.purgeTracking(dead)
-		if err != nil {
-			return xerrors.Errorf("error purging tracking for dead blocks: %w", err)
-		}
-		log.Infow("purging dead from tracker done", "took", time.Since(startPurge))
-	}
-
-	// we are done; do some housekeeping
-	err = s.tracker.Sync()
-	if err != nil {
-		return xerrors.Errorf("error syncing tracker: %w", err)
-	}
-
-	s.gcHotstore()
-
-	err = s.setBaseEpoch(coldEpoch)
-	if err != nil {
-		return xerrors.Errorf("error saving base epoch: %w", err)
-	}
-
-	err = s.ds.Put(markSetSizeKey, int64ToBytes(s.markSetSize))
-	if err != nil {
-		return xerrors.Errorf("error saving mark set size: %w", err)
-	}
-
-	return nil
 }
 
 func (s *SplitStore) setBaseEpoch(epoch abi.ChainEpoch) error {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -52,6 +52,10 @@ var (
 	// CompactionBoundary is the number of epochs from the current epoch at which
 	// we will walk the chain for live objects.
 	CompactionBoundary = 2 * build.Finality
+
+	// SyncGapTime is the time delay from a tipset's min timestamp before we decide
+	// there is a sync gap
+	SyncGapTime = 5 * time.Minute
 )
 
 var (
@@ -63,6 +67,11 @@ var (
 	// On first start, the splitstore will walk the state tree and will copy
 	// all active blocks into the hotstore.
 	warmupEpochKey = dstore.NewKey("/splitstore/warmupEpoch")
+
+	// syncGapEpochKey stores the last epoch where a sync gap was detected.
+	// If there is a sync gap after the boundary epoch, compaction will perform
+	// a slower full walk from the current epoch to the boundary epoch
+	syncGapEpochKey = dstore.NewKey("/splitstore/syncGapEpoch")
 
 	// markSetSizeKey stores the current estimate for the mark set size.
 	// this is first computed at warmup and updated in every compaction
@@ -102,9 +111,10 @@ type SplitStore struct {
 	critsection int32 // compaction critical section
 	closing     int32 // the split store is closing
 
-	baseEpoch   abi.ChainEpoch
-	warmupEpoch abi.ChainEpoch
-	warm        bool
+	baseEpoch    abi.ChainEpoch
+	syncGapEpoch abi.ChainEpoch
+	warmupEpoch  abi.ChainEpoch
+	warm         bool
 
 	coldPurgeSize int
 
@@ -348,6 +358,17 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 		return xerrors.Errorf("error loading warmup epoch: %w", err)
 	}
 
+	// load sync gap epoch from metadata ds
+	bs, err = s.ds.Get(syncGapEpochKey)
+	switch err {
+	case nil:
+		s.syncGapEpoch = bytesToEpoch(bs)
+
+	case dstore.ErrNotFound:
+	default:
+		return xerrors.Errorf("error loading sync gap epoch: %w", err)
+	}
+
 	// load markSetSize from metadata ds
 	// if none, the splitstore will compute it during warmup and update in every compaction
 	bs, err = s.ds.Get(markSetSizeKey)
@@ -388,6 +409,14 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 	s.curTs = curTs
 	s.mx.Unlock()
 
+	timestamp := time.Unix(int64(curTs.MinTimestamp()), 0)
+	if time.Since(timestamp) > SyncGapTime {
+		err := s.setSyncGapEpoch(epoch)
+		if err != nil {
+			log.Warnf("error saving sync gap epoch: %s", err)
+		}
+	}
+
 	if !atomic.CompareAndSwapInt32(&s.compacting, 0, 1) {
 		// we are currently compacting, do nothing and wait for the next head change
 		return nil
@@ -427,7 +456,7 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 			log.Info("compacting splitstore")
 			start := time.Now()
 
-			s.compact(curTs)
+			s.compact(curTs, s.syncGapEpoch)
 
 			log.Infow("compaction done", "took", time.Since(start))
 		}()
@@ -531,7 +560,7 @@ func (s *SplitStore) warmup(curTs *types.TipSet) error {
 }
 
 // Compaction/GC Algorithm
-func (s *SplitStore) compact(curTs *types.TipSet) {
+func (s *SplitStore) compact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch) {
 	var err error
 	if s.markSetSize == 0 {
 		start := time.Now()
@@ -547,7 +576,7 @@ func (s *SplitStore) compact(curTs *types.TipSet) {
 	}
 
 	start := time.Now()
-	err = s.doCompact(curTs)
+	err = s.doCompact(curTs, syncGapEpoch)
 	took := time.Since(start).Milliseconds()
 	stats.Record(context.Background(), metrics.SplitstoreCompactionTimeSeconds.M(float64(took)/1e3))
 
@@ -574,7 +603,7 @@ func (s *SplitStore) estimateMarkSetSize(curTs *types.TipSet) error {
 	return nil
 }
 
-func (s *SplitStore) doCompact(curTs *types.TipSet) error {
+func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch) error {
 	coldEpoch := s.baseEpoch + CompactionCold
 	currentEpoch := curTs.Height()
 	boundaryEpoch := currentEpoch - CompactionBoundary
@@ -591,8 +620,28 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 	log.Infow("marking reachable blocks", "currentEpoch", currentEpoch, "boundaryEpoch", boundaryEpoch)
 	startMark := time.Now()
 
+	var markTs *types.TipSet
+	if syncGapEpoch > boundaryEpoch {
+		// There is a sync gap that may have caused writes that are logically after the boundary
+		// epoch to be written before the respective head change notification and hence be tracked
+		// at the wrong epoch.
+		// This can happen if the node is offline or falls out of sync for an extended period of time.
+		// In this case we perform a full walk to avoid pathologies with pushing actually hot
+		// objects into the coldstore.
+		markTs = curTs
+		log.Info("sync gap detected at epoch %d; marking from current epoch to boundary epoch", syncGapEpoch)
+	} else {
+		// There is no pathological sync gap, so we can use the much faster single tipset walk at
+		// the boundary epoch.
+		boundaryTs, err := s.chain.GetTipsetByHeight(context.Background(), boundaryEpoch, curTs, true)
+		if err != nil {
+			return xerrors.Errorf("error getting tipset at boundary epoch: %w", err)
+		}
+		markTs = boundaryTs
+	}
+
 	var count int64
-	err = s.walk(curTs, boundaryEpoch,
+	err = s.walk(markTs, boundaryEpoch,
 		func(cid cid.Cid) error {
 			count++
 			return markSet.Mark(cid)
@@ -895,8 +944,12 @@ func (s *SplitStore) gcHotstore() {
 
 func (s *SplitStore) setBaseEpoch(epoch abi.ChainEpoch) error {
 	s.baseEpoch = epoch
-	// write to datastore
 	return s.ds.Put(baseEpochKey, epochToBytes(epoch))
+}
+
+func (s *SplitStore) setSyncGapEpoch(epoch abi.ChainEpoch) error {
+	s.syncGapEpoch = epoch
+	return s.ds.Put(syncGapEpochKey, epochToBytes(epoch))
 }
 
 func epochToBytes(epoch abi.ChainEpoch) []byte {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -537,7 +537,7 @@ func (s *SplitStore) warmup(curTs *types.TipSet) error {
 		}
 	}
 
-	log.Infow("warmup stats", "visited", count, "cold", xcount, "missing", missing)
+	log.Infow("warmup stats", "visited", count, "warmed", xcount, "missing", missing)
 
 	if count > s.markSetSize {
 		s.markSetSize = count + count>>2 // overestimate a bit

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -1,6 +1,7 @@
 package splitstore
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 	dstore "github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/go-state-types/abi"
 
@@ -48,7 +50,7 @@ var (
 	CompactionCold = build.Finality
 
 	// CompactionBoundary is the number of epochs from the current epoch at which
-	// we will walk the chain for live objects
+	// we will walk the chain for live objects.
 	CompactionBoundary = 2 * build.Finality
 )
 
@@ -73,7 +75,6 @@ const (
 	batchSize = 16384
 
 	defaultColdPurgeSize = 7_000_000
-	defaultDeadPurgeSize = 1_000_000
 )
 
 type Config struct {
@@ -94,7 +95,6 @@ type ChainAccessor interface {
 	GetTipsetByHeight(context.Context, abi.ChainEpoch, *types.TipSet, bool) (*types.TipSet, error)
 	GetHeaviestTipSet() *types.TipSet
 	SubscribeHeadChanges(change func(revert []*types.TipSet, apply []*types.TipSet) error)
-	WalkSnapshot(context.Context, *types.TipSet, abi.ChainEpoch, bool, bool, func(cid.Cid) error) error
 }
 
 type SplitStore struct {
@@ -104,6 +104,7 @@ type SplitStore struct {
 
 	baseEpoch   abi.ChainEpoch
 	warmupEpoch abi.ChainEpoch
+	warm        bool
 
 	coldPurgeSize int
 
@@ -340,6 +341,7 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 	switch err {
 	case nil:
 		s.warmupEpoch = bytesToEpoch(bs)
+		s.warm = true
 
 	case dstore.ErrNotFound:
 	default:
@@ -391,7 +393,7 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 		return nil
 	}
 
-	if s.warmupEpoch == 0 {
+	if !s.warm {
 		// splitstore needs to warm up
 		go func() {
 			defer atomic.StoreInt32(&s.compacting, 0)
@@ -399,7 +401,17 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 			log.Info("warming up hotstore")
 			start := time.Now()
 
-			s.warmup(curTs)
+			baseTs, err := s.chain.GetTipsetByHeight(context.Background(), s.baseEpoch, curTs, true)
+			if err != nil {
+				log.Errorf("error warming up hotstore: error getting tipset at base epoch: %s", err)
+				return
+			}
+
+			err = s.warmup(baseTs)
+			if err != nil {
+				log.Errorf("error warming up hotstore: %s", err)
+				return
+			}
 
 			log.Infow("warm up done", "took", time.Since(start))
 		}()
@@ -427,14 +439,16 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 	return nil
 }
 
-func (s *SplitStore) warmup(curTs *types.TipSet) {
+func (s *SplitStore) warmup(curTs *types.TipSet) error {
 	epoch := curTs.Height()
 
 	batchHot := make([]blocks.Block, 0, batchSize)
 	batchSnoop := make([]cid.Cid, 0, batchSize)
 
 	count := int64(0)
-	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, true, true,
+	xcount := int64(0)
+	missing := int64(0)
+	err := s.walk(curTs, epoch,
 		func(cid cid.Cid) error {
 			count++
 
@@ -449,8 +463,14 @@ func (s *SplitStore) warmup(curTs *types.TipSet) {
 
 			blk, err := s.cold.Get(cid)
 			if err != nil {
+				if err == bstore.ErrNotFound {
+					missing++
+					return nil
+				}
 				return err
 			}
+
+			xcount++
 
 			batchHot = append(batchHot, blk)
 			batchSnoop = append(batchSnoop, cid)
@@ -473,39 +493,41 @@ func (s *SplitStore) warmup(curTs *types.TipSet) {
 		})
 
 	if err != nil {
-		log.Errorf("error warming up splitstore: %s", err)
-		return
+		return err
 	}
 
 	if len(batchHot) > 0 {
 		err = s.tracker.PutBatch(batchSnoop, epoch)
 		if err != nil {
-			log.Errorf("error warming up splitstore: %s", err)
-			return
+			return err
 		}
 
 		err = s.hot.PutMany(batchHot)
 		if err != nil {
-			log.Errorf("error warming up splitstore: %s", err)
-			return
+			return err
 		}
 	}
+
+	log.Infow("warmup stats", "visited", count, "cold", xcount, "missing", missing)
 
 	if count > s.markSetSize {
 		s.markSetSize = count + count>>2 // overestimate a bit
 	}
 
 	// save the warmup epoch
+	s.warm = true
 	s.warmupEpoch = epoch
 	err = s.ds.Put(warmupEpochKey, epochToBytes(epoch))
 	if err != nil {
-		log.Errorf("error saving warmup epoch: %s", err)
+		log.Warnf("error saving warmup epoch: %s", err)
 	}
 
 	err = s.ds.Put(markSetSizeKey, int64ToBytes(s.markSetSize))
 	if err != nil {
-		log.Errorf("error saving mark set size: %s", err)
+		log.Warnf("error saving mark set size: %s", err)
 	}
+
+	return nil
 }
 
 // Compaction/GC Algorithm
@@ -535,8 +557,10 @@ func (s *SplitStore) compact(curTs *types.TipSet) {
 }
 
 func (s *SplitStore) estimateMarkSetSize(curTs *types.TipSet) error {
+	epoch := curTs.Height()
+
 	var count int64
-	err := s.chain.WalkSnapshot(context.Background(), curTs, 1, true, true,
+	err := s.walk(curTs, epoch,
 		func(cid cid.Cid) error {
 			count++
 			return nil
@@ -573,7 +597,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 	}
 
 	var count int64
-	err = s.chain.WalkSnapshot(context.Background(), boundaryTs, 1, true, true,
+	err = s.walk(boundaryTs, boundaryEpoch,
 		func(cid cid.Cid) error {
 			count++
 			return coldSet.Mark(cid)
@@ -587,7 +611,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 		s.markSetSize = count + count>>2 // overestimate a bit
 	}
 
-	log.Infow("marking done", "took", time.Since(startMark))
+	log.Infow("marking done", "took", time.Since(startMark), "marked", count)
 
 	// 2. move cold unreachable objects to the coldstore
 	log.Info("collecting cold objects")
@@ -693,6 +717,93 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 	}
 
 	return nil
+}
+
+func (s *SplitStore) walk(ts *types.TipSet, boundary abi.ChainEpoch, f func(cid.Cid) error) error {
+	walked := cid.NewSet()
+	toWalk := ts.Cids()
+
+	walkBlock := func(c cid.Cid) error {
+		if !walked.Visit(c) {
+			return nil
+		}
+
+		blk, err := s.Get(c)
+		if err != nil {
+			return xerrors.Errorf("error retrieving block (cid: %s): %w", c, err)
+		}
+
+		var hdr types.BlockHeader
+		if err := hdr.UnmarshalCBOR(bytes.NewBuffer(blk.RawData())); err != nil {
+			return xerrors.Errorf("error unmarshaling block header (cid: %s): %w", c, err)
+		}
+
+		// don't walk under the boundary
+		if hdr.Height < boundary {
+			return nil
+		}
+
+		if err := f(c); err != nil {
+			return err
+		}
+
+		if err := s.walkLinks(hdr.Messages, walked, f); err != nil {
+			return xerrors.Errorf("error walking messages (cid: %s): %w", hdr.Messages, err)
+		}
+
+		if err := s.walkLinks(hdr.ParentStateRoot, walked, f); err != nil {
+			return xerrors.Errorf("error walking state root (cid: %s): %w", hdr.ParentStateRoot, err)
+		}
+
+		toWalk = append(toWalk, hdr.Parents...)
+		return nil
+	}
+
+	for len(toWalk) > 0 {
+		walking := toWalk
+		toWalk = nil
+		for _, c := range walking {
+			if err := walkBlock(c); err != nil {
+				return xerrors.Errorf("error walking block (cid: %s): %w", c, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SplitStore) walkLinks(c cid.Cid, walked *cid.Set, f func(cid.Cid) error) error {
+	if !walked.Visit(c) {
+		return nil
+	}
+
+	if c.Prefix().Codec != cid.DagCBOR {
+		return nil
+	}
+
+	if err := f(c); err != nil {
+		return err
+	}
+
+	blk, err := s.Get(c)
+	if err != nil {
+		return xerrors.Errorf("error retrieving linked block (cid: %s): %w", c, err)
+	}
+
+	var rerr error
+	err = cbg.ScanForLinks(bytes.NewReader(blk.RawData()), func(c cid.Cid) {
+		if rerr != nil {
+			return
+		}
+
+		rerr = s.walkLinks(c, walked, f)
+	})
+
+	if err != nil {
+		return xerrors.Errorf("error scanning links (cid: %s): %w", c, err)
+	}
+
+	return rerr
 }
 
 func (s *SplitStore) moveColdBlocks(cold []cid.Cid) error {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -85,8 +85,8 @@ const (
 
 	defaultColdPurgeSize = 12_000_000
 
-	aggressiveGCThreshold         = 60 << 30      // 60GiB
-	continueAggressiveGCThreshold = (1 << 30) / 2 // 512MiB
+	aggressiveGCThreshold         = 60 << 30  // 60GiB
+	continueAggressiveGCThreshold = 128 << 20 // 128MiB
 )
 
 type Config struct {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -1075,7 +1075,7 @@ func (s *SplitStore) gcHotstore() {
 		reclaimed := size - newSize
 		log.Infof("gc reclaimed %d bytes", reclaimed)
 
-		if reclaimed < continueAggressiveGCThreshold {
+		if reclaimed >= 0 && reclaimed < continueAggressiveGCThreshold {
 			return
 		}
 

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -747,10 +747,6 @@ func (s *SplitStore) walk(ts *types.TipSet, boundary abi.ChainEpoch, f func(cid.
 			return err
 		}
 
-		if err := s.walkLinks(hdr.Messages, walked, f); err != nil {
-			return xerrors.Errorf("error walking messages (cid: %s): %w", hdr.Messages, err)
-		}
-
 		if err := s.walkLinks(hdr.ParentStateRoot, walked, f); err != nil {
 			return xerrors.Errorf("error walking state root (cid: %s): %w", hdr.ParentStateRoot, err)
 		}

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -85,8 +85,8 @@ const (
 
 	defaultColdPurgeSize = 12_000_000
 
-	aggressiveGCThreshold         = 64 << 30 // 64GiB
-	continueAggressiveGCThreshold = 64 << 20 // 64MiB
+	aggressiveGCThreshold         = 128 << 30 // 128GiB
+	continueAggressiveGCThreshold = 64 << 20  // 64MiB
 )
 
 type Config struct {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -632,7 +632,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet, syncGapEpoch abi.ChainEpoch)
 		// In this case we perform a full walk to avoid pathologies with pushing actually hot
 		// objects into the coldstore.
 		markTs = curTs
-		log.Info("sync gap detected at epoch %d; marking from current epoch to boundary epoch", syncGapEpoch)
+		log.Infof("sync gap detected at epoch %d; marking from current epoch to boundary epoch", syncGapEpoch)
 	} else {
 		// There is no pathological sync gap, so we can use the much faster single tipset walk at
 		// the boundary epoch.

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -46,6 +46,7 @@ func testSplitStore(t *testing.T, cfg *Config) {
 	genBlock.Messages = garbage.Cid()
 	genBlock.ParentMessageReceipts = garbage.Cid()
 	genBlock.ParentStateRoot = garbage.Cid()
+	genBlock.Timestamp = uint64(time.Now().Unix())
 
 	genTs := mock.TipSet(genBlock)
 	chain.push(genTs)
@@ -80,6 +81,7 @@ func testSplitStore(t *testing.T, cfg *Config) {
 		blk.Messages = garbage.Cid()
 		blk.ParentMessageReceipts = garbage.Cid()
 		blk.ParentStateRoot = garbage.Cid()
+		blk.Timestamp = uint64(time.Now().Unix())
 
 		sblk, err := blk.ToStorageBlock()
 		if err != nil {

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -132,8 +132,8 @@ func testSplitStore(t *testing.T, cfg *Config) {
 		t.Errorf("expected %d blocks, but got %d", 2, coldCnt)
 	}
 
-	if hotCnt != 5 {
-		t.Errorf("expected %d blocks, but got %d", 5, hotCnt)
+	if hotCnt != 6 {
+		t.Errorf("expected %d blocks, but got %d", 6, hotCnt)
 	}
 
 	// trigger a compaction
@@ -149,8 +149,8 @@ func testSplitStore(t *testing.T, cfg *Config) {
 		t.Errorf("expected %d cold blocks, but got %d", 7, coldCnt)
 	}
 
-	if hotCnt != 4 {
-		t.Errorf("expected %d hot blocks, but got %d", 4, hotCnt)
+	if hotCnt != 6 {
+		t.Errorf("expected %d hot blocks, but got %d", 6, hotCnt)
 	}
 }
 
@@ -160,6 +160,7 @@ func TestSplitStoreSimpleCompaction(t *testing.T) {
 
 type mockChain struct {
 	sync.Mutex
+	genesis  *types.BlockHeader
 	tipsets  []*types.TipSet
 	listener func(revert []*types.TipSet, apply []*types.TipSet) error
 }
@@ -167,6 +168,9 @@ type mockChain struct {
 func (c *mockChain) push(ts *types.TipSet) {
 	c.Lock()
 	c.tipsets = append(c.tipsets, ts)
+	if c.genesis == nil {
+		c.genesis = ts.Blocks()[0]
+	}
 	c.Unlock()
 
 	if c.listener != nil {
@@ -175,6 +179,10 @@ func (c *mockChain) push(ts *types.TipSet) {
 			log.Errorf("mockchain: error dispatching listener: %s", err)
 		}
 	}
+}
+
+func (c *mockChain) GetGenesis() (*types.BlockHeader, error) {
+	return c.genesis, nil
 }
 
 func (c *mockChain) GetTipsetByHeight(_ context.Context, epoch abi.ChainEpoch, _ *types.TipSet, _ bool) (*types.TipSet, error) {

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -140,34 +140,12 @@ func testSplitStore(t *testing.T, cfg *Config) {
 	coldCnt = countBlocks(cold)
 	hotCnt = countBlocks(hot)
 
-	if !cfg.EnableFullCompaction {
-		if coldCnt != 5 {
-			t.Errorf("expected %d cold blocks, but got %d", 5, coldCnt)
-		}
-
-		if hotCnt != 5 {
-			t.Errorf("expected %d hot blocks, but got %d", 5, hotCnt)
-		}
+	if coldCnt != 7 {
+		t.Errorf("expected %d cold blocks, but got %d", 7, coldCnt)
 	}
 
-	if cfg.EnableFullCompaction && !cfg.EnableGC {
-		if coldCnt != 3 {
-			t.Errorf("expected %d cold blocks, but got %d", 3, coldCnt)
-		}
-
-		if hotCnt != 7 {
-			t.Errorf("expected %d hot blocks, but got %d", 7, hotCnt)
-		}
-	}
-
-	if cfg.EnableFullCompaction && cfg.EnableGC {
-		if coldCnt != 2 {
-			t.Errorf("expected %d cold blocks, but got %d", 2, coldCnt)
-		}
-
-		if hotCnt != 7 {
-			t.Errorf("expected %d hot blocks, but got %d", 7, hotCnt)
-		}
+	if hotCnt != 4 {
+		t.Errorf("expected %d hot blocks, but got %d", 4, hotCnt)
 	}
 }
 

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/mock"
 
-	cid "github.com/ipfs/go-cid"
+	blocks "github.com/ipfs/go-block-format"
 	datastore "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log/v2"
@@ -28,15 +28,27 @@ func init() {
 
 func testSplitStore(t *testing.T, cfg *Config) {
 	chain := &mockChain{}
-	// genesis
-	genBlock := mock.MkBlock(nil, 0, 0)
-	genTs := mock.TipSet(genBlock)
-	chain.push(genTs)
 
 	// the myriads of stores
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	hot := blockstore.NewMemorySync()
 	cold := blockstore.NewMemorySync()
+
+	// this is necessary to avoid the garbage mock puts in the blocks
+	garbage := blocks.NewBlock([]byte{1, 2, 3})
+	err := cold.Put(garbage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// genesis
+	genBlock := mock.MkBlock(nil, 0, 0)
+	genBlock.Messages = garbage.Cid()
+	genBlock.ParentMessageReceipts = garbage.Cid()
+	genBlock.ParentStateRoot = garbage.Cid()
+
+	genTs := mock.TipSet(genBlock)
+	chain.push(genTs)
 
 	// put the genesis block to cold store
 	blk, err := genBlock.ToStorageBlock()
@@ -64,6 +76,11 @@ func testSplitStore(t *testing.T, cfg *Config) {
 	// make some tipsets, but not enough to cause compaction
 	mkBlock := func(curTs *types.TipSet, i int) *types.TipSet {
 		blk := mock.MkBlock(curTs, uint64(i), uint64(i))
+
+		blk.Messages = garbage.Cid()
+		blk.ParentMessageReceipts = garbage.Cid()
+		blk.ParentStateRoot = garbage.Cid()
+
 		sblk, err := blk.ToStorageBlock()
 		if err != nil {
 			t.Fatal(err)
@@ -78,18 +95,6 @@ func testSplitStore(t *testing.T, cfg *Config) {
 		return ts
 	}
 
-	mkGarbageBlock := func(curTs *types.TipSet, i int) {
-		blk := mock.MkBlock(curTs, uint64(i), uint64(i))
-		sblk, err := blk.ToStorageBlock()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = ss.Put(sblk)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	waitForCompaction := func() {
 		for atomic.LoadInt32(&ss.compacting) == 1 {
 			time.Sleep(100 * time.Millisecond)
@@ -101,8 +106,6 @@ func testSplitStore(t *testing.T, cfg *Config) {
 		curTs = mkBlock(curTs, i)
 		waitForCompaction()
 	}
-
-	mkGarbageBlock(genTs, 1)
 
 	// count objects in the cold and hot stores
 	ctx, cancel := context.WithCancel(context.Background())
@@ -123,8 +126,8 @@ func testSplitStore(t *testing.T, cfg *Config) {
 	coldCnt := countBlocks(cold)
 	hotCnt := countBlocks(hot)
 
-	if coldCnt != 1 {
-		t.Errorf("expected %d blocks, but got %d", 1, coldCnt)
+	if coldCnt != 2 {
+		t.Errorf("expected %d blocks, but got %d", 2, coldCnt)
 	}
 
 	if hotCnt != 5 {
@@ -151,21 +154,6 @@ func testSplitStore(t *testing.T, cfg *Config) {
 
 func TestSplitStoreSimpleCompaction(t *testing.T) {
 	testSplitStore(t, &Config{TrackingStoreType: "mem"})
-}
-
-func TestSplitStoreFullCompactionWithoutGC(t *testing.T) {
-	testSplitStore(t, &Config{
-		TrackingStoreType:    "mem",
-		EnableFullCompaction: true,
-	})
-}
-
-func TestSplitStoreFullCompactionWithGC(t *testing.T) {
-	testSplitStore(t, &Config{
-		TrackingStoreType:    "mem",
-		EnableFullCompaction: true,
-		EnableGC:             true,
-	})
 }
 
 type mockChain struct {
@@ -196,7 +184,7 @@ func (c *mockChain) GetTipsetByHeight(_ context.Context, epoch abi.ChainEpoch, _
 		return nil, fmt.Errorf("bad epoch %d", epoch)
 	}
 
-	return c.tipsets[iEpoch-1], nil
+	return c.tipsets[iEpoch], nil
 }
 
 func (c *mockChain) GetHeaviestTipSet() *types.TipSet {
@@ -208,26 +196,4 @@ func (c *mockChain) GetHeaviestTipSet() *types.TipSet {
 
 func (c *mockChain) SubscribeHeadChanges(change func(revert []*types.TipSet, apply []*types.TipSet) error) {
 	c.listener = change
-}
-
-func (c *mockChain) WalkSnapshot(_ context.Context, ts *types.TipSet, epochs abi.ChainEpoch, _ bool, _ bool, f func(cid.Cid) error) error {
-	c.Lock()
-	defer c.Unlock()
-
-	start := int(ts.Height()) - 1
-	end := start - int(epochs)
-	if end < 0 {
-		end = -1
-	}
-	for i := start; i > end; i-- {
-		ts := c.tipsets[i]
-		for _, cid := range ts.Cids() {
-			err := f(cid)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }

--- a/blockstore/splitstore/tracking_bolt.go
+++ b/blockstore/splitstore/tracking_bolt.go
@@ -21,7 +21,6 @@ var _ TrackingStore = (*BoltTrackingStore)(nil)
 func OpenBoltTrackingStore(path string) (*BoltTrackingStore, error) {
 	opts := &bolt.Options{
 		Timeout: 1 * time.Second,
-		NoSync:  true,
 	}
 	db, err := bolt.Open(path, 0644, opts)
 	if err != nil {

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -54,6 +54,7 @@ func main() {
 		cidCmd,
 		blockmsgidCmd,
 		signaturesCmd,
+		splitstoreCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -98,12 +98,14 @@ var splitstoreGCCmd = &cli.Command{
 		log.Infof("hotstore size is %d bytes", size)
 		for {
 			// gc more aggressively than CollectGarbage
-			for err == nil {
-				err = bs.DB.RunValueLogGC(0.025)
-			}
+			for i := 0; i < 3; i++ {
+				for err == nil {
+					err = bs.DB.RunValueLogGC(0.025)
+				}
 
-			if err != badger.ErrNoRewrite {
-				return err
+				if err != badger.ErrNoRewrite {
+					return err
+				}
 			}
 
 			err = bs.Compact()

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -97,9 +97,9 @@ var splitstoreGCCmd = &cli.Command{
 
 		log.Infof("hotstore size is %d bytes", size)
 		for {
-			// gc more aggressively than CollectGarbage
-			for i := 0; i < 3; i++ {
+			for i := 0; i < 10; i++ {
 				for err == nil {
+					// gc more aggressively than CollectGarbage
 					err = bs.DB.RunValueLogGC(0.025)
 				}
 

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -99,7 +99,7 @@ var splitstoreGCCmd = &cli.Command{
 		for {
 			// gc more aggressively than CollectGarbage
 			for err == nil {
-				err = bs.DB.RunValueLogGC(0.05)
+				err = bs.DB.RunValueLogGC(0.025)
 			}
 
 			if err != badger.ErrNoRewrite {

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+	logging "github.com/ipfs/go-log"
+	"github.com/urfave/cli/v2"
+
+	badgerbs "github.com/filecoin-project/lotus/blockstore/badger"
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/filecoin-project/lotus/node/repo"
+)
+
+var splitstoreCmd = &cli.Command{
+	Name:        "splitstore",
+	Description: "manage the splitstore directly",
+	Subcommands: []*cli.Command{
+		splitstoreGCCmd,
+	},
+}
+
+var splitstoreGCCmd = &cli.Command{
+	Name:        "gc",
+	Description: "compacts and garbage collects the hotstore; node must be offline",
+	Action: func(cctx *cli.Context) error {
+		logging.SetLogLevel("badger", "ERROR")   // nolint:errcheck
+		logging.SetLogLevel("badgerbs", "ERROR") // nolint:errcheck
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		c, err := lkrepo.Config()
+		if err != nil {
+			return err
+		}
+
+		cfg, ok := c.(*config.FullNode)
+		if !ok {
+			return fmt.Errorf("bad config")
+		}
+
+		if !cfg.Chainstore.EnableSplitstore {
+			return fmt.Errorf("splitstore is not enabled")
+		}
+
+		if cfg.Chainstore.Splitstore.HotStoreType != "badger" {
+			return fmt.Errorf("hotstore is not badger; can't compact")
+		}
+
+		path, err := lkrepo.SplitstorePath()
+		if err != nil {
+			return err
+		}
+
+		path = filepath.Join(path, "hot.badger")
+
+		opts, err := repo.BadgerBlockstoreOptions(repo.HotBlockstore, path, false)
+		if err != nil {
+			return err
+		}
+
+		bs, err := badgerbs.Open(opts)
+		if err != nil {
+			return err
+		}
+
+		defer bs.Close() //nolint:errcheck
+
+		log.Infof("compacting hotstore")
+		startCompact := time.Now()
+		err = bs.Compact()
+		if err != nil {
+			log.Warnf("error compacting hotstore: %s", err)
+			return err
+		}
+		log.Infow("hotstore compaction done", "took", time.Since(startCompact))
+
+		log.Infof("garbage collecting hotstore")
+		startGC := time.Now()
+
+		size, err := bs.Size()
+		if err != nil {
+			return err
+		}
+
+		log.Infof("hotstore size is %d bytes", size)
+		for {
+			// gc more aggressively than CollectGarbage
+			for err == nil {
+				err = bs.DB.RunValueLogGC(0.05)
+			}
+
+			if err != badger.ErrNoRewrite {
+				return err
+			}
+
+			err = bs.Compact()
+			if err != nil {
+				return err
+			}
+
+			newsize, err := bs.Size()
+			if err != nil {
+				return err
+			}
+
+			if newsize < size {
+				log.Infof("reclaimed %d bytes", size-newsize)
+				size = newsize
+				continue
+			}
+
+			break
+		}
+
+		log.Infow("hotstore garbage collection done", "took", time.Since(startGC))
+
+		return nil
+	},
+}

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -145,12 +145,9 @@ type Chainstore struct {
 }
 
 type Splitstore struct {
-	HotStoreType         string
-	TrackingStoreType    string
-	MarkSetType          string
-	EnableFullCompaction bool
-	EnableGC             bool // EXPERIMENTAL
-	Archival             bool
+	HotStoreType      string
+	TrackingStoreType string
+	MarkSetType       string
 }
 
 // // Full Node

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -74,11 +74,8 @@ func SplitBlockstore(cfg *config.Chainstore) func(lc fx.Lifecycle, r repo.Locked
 		}
 
 		cfg := &splitstore.Config{
-			TrackingStoreType:    cfg.Splitstore.TrackingStoreType,
-			MarkSetType:          cfg.Splitstore.MarkSetType,
-			EnableFullCompaction: cfg.Splitstore.EnableFullCompaction,
-			EnableGC:             cfg.Splitstore.EnableGC,
-			Archival:             cfg.Splitstore.Archival,
+			TrackingStoreType: cfg.Splitstore.TrackingStoreType,
+			MarkSetType:       cfg.Splitstore.MarkSetType,
 		}
 		ss, err := splitstore.Open(path, ds, hot, cold, cfg)
 		if err != nil {


### PR DESCRIPTION
This optimizes the splitstore so that
- we get rid of the full compaction option, as it is not exercised or terribly useful. It was written with an eye to gc, but that one is dangerous.
- we use an optimized version of chain walking that doesn't walk the entire chain and only visits state roots; this keeps the hotstore size effectively constant, instead of slowly growing as it the chain grows.
- we mark from the current epoch to the boundary epoch when we detect sync gaps, in order to avoid pathologies if the node stays offline for an extended period of time.
- we reduce the CompactionThreshold to 3 finalities; that means that we retain only 2-3 finalities in the hot range, reducing the size of the hotstore by 40% (50% right after a compaction).

Also adds a lotus-shed command for aggressive offline gc.

See #5789 

The new chain walking warms up the splitstore 3x faster, while it makes marking 4x faster.