### PR TITLE
chore: add available options for perm on error

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -90,7 +90,7 @@ var authApiInfoToken = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if !cctx.IsSet("perm") {
-			return xerrors.New("--perm flag not set")
+			return xerrors.New("--perm flag not set, use with one of: read, write, sign, admin")
 		}
 
 		perm := cctx.String("perm")


### PR DESCRIPTION
This PR adds more information on the auth CLI error. My flow to use the auth command was:

```sh
$ lotus auth
NAME:
   lotus auth - Manage RPC permissions

USAGE:
   lotus auth command [command options] [arguments...]

COMMANDS:
   create-token  Create token
   api-info      Get token with API info required to connect to this node
   help, h       Shows a list of commands or help for one command

OPTIONS:
   --help, -h     show help (default: false)
   --version, -v  print the version (default: false)

$ lotus auth api-info
ERROR: --perm flag not set
```

This PR suggests the enhancement of the error to: 

```sh
$ lotus auth api-info
ERROR: --perm flag not set, use with one of: read, write, sign, admin
```

We can also use `lotus auth api-info --help`, but I think that creates some confusion as commandOptions seem optional. This helps the user to be able to just act instead of trying to figure out what the problem is.

---

I would also like to discuss the usage of the read token. It is not mandatory for the client, are there thoughts about having it required? Otherwise, we could remove the `read` option as it is quite useless at this moment.

We could iterate on:

```
lotus auth create-token --write
lotus auth create-token --sign
lotus auth create-token --admin
lotus auth api-info
```

The `api-info` would return all the available tokens for each type of permissions. Let me know your thoughts and I can update this PR or create a follow up