### PR TITLE
Build more binaries by default when a devnet tag is active

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,20 +63,23 @@ CLEAN+=build/.update-modules
 deps: $(BUILD_DEPS)
 .PHONY: deps
 
+build-devnets: build lotus-seed lotus-shed lotus-wallet lotus-gateway
+.PHONY: build-devnets
+
 debug: GOFLAGS+=-tags=debug
-debug: lotus lotus-miner lotus-worker lotus-seed
+debug: build-devnets
 
 2k: GOFLAGS+=-tags=2k
-2k: lotus lotus-miner lotus-worker lotus-seed
+2k: build-devnets
 
 calibnet: GOFLAGS+=-tags=calibnet
-calibnet: lotus lotus-miner lotus-worker lotus-seed
+calibnet: build-devnets
 
 nerpanet: GOFLAGS+=-tags=nerpanet
-nerpanet: lotus lotus-miner lotus-worker lotus-seed
+nerpanet: build-devnets
 
 butterflynet: GOFLAGS+=-tags=butterflynet
-butterflynet: lotus lotus-miner lotus-worker lotus-seed
+butterflynet: build-devnets
 
 lotus: $(BUILD_DEPS)
 	rm -f lotus


### PR DESCRIPTION
@arajasek without doing this I need to manually build shed, which is super annoying