### PR TITLE
api: Document StateSearchMsg replaced message behavior

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -403,6 +403,20 @@ type FullNode interface {
 	// StateSectorPartition finds deadline/partition with the specified sector
 	StateSectorPartition(ctx context.Context, maddr address.Address, sectorNumber abi.SectorNumber, tok types.TipSetKey) (*miner.SectorLocation, error)
 	// StateSearchMsg searches for a message in the chain, and returns its receipt and the tipset where it was executed
+	//
+	// NOTE: If a replacing message is found on chain, this method will return
+	// a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+	// CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+	// result of the execution of the replacing message.
+	//
+	// If the caller wants to ensure that exactly the requested message was executed,
+	// they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+	// Without this check both the requested and original message may appear as
+	// successfully executed on-chain, which may look like a double-spend.
+	//
+	// A replacing message is a message with a different CID, any of Gas values, and
+	// different signature, but with all other parameters matching (source/destination,
+	// nonce, params, etc.)
 	StateSearchMsg(context.Context, cid.Cid) (*MsgLookup, error)
 	// StateSearchMsgLimited looks back up to limit epochs in the chain for a message, and returns its receipt and the tipset where it was executed
 	//

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -404,13 +404,55 @@ type FullNode interface {
 	// StateSearchMsg searches for a message in the chain, and returns its receipt and the tipset where it was executed
 	StateSearchMsg(context.Context, cid.Cid) (*MsgLookup, error)
 	// StateSearchMsgLimited looks back up to limit epochs in the chain for a message, and returns its receipt and the tipset where it was executed
+	//
+	// NOTE: If a replacing message is found on chain, this method will return
+	// a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+	// CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+	// result of the execution of the replacing message.
+	//
+	// If the caller wants to ensure that exactly the requested message was executed,
+	// they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+	// Without this check both the requested and original message may appear as
+	// successfully executed on-chain, which may look like a double-spend.
+	//
+	// A replacing message is a message with a different CID, any of Gas values, and
+	// different signature, but with all other parameters matching (source/destination,
+	// nonce, params, etc.)
 	StateSearchMsgLimited(ctx context.Context, msg cid.Cid, limit abi.ChainEpoch) (*MsgLookup, error)
 	// StateWaitMsg looks back in the chain for a message. If not found, it blocks until the
 	// message arrives on chain, and gets to the indicated confidence depth.
+	//
+	// NOTE: If a replacing message is found on chain, this method will return
+	// a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+	// CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+	// result of the execution of the replacing message.
+	//
+	// If the caller wants to ensure that exactly the requested message was executed,
+	// they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+	// Without this check both the requested and original message may appear as
+	// successfully executed on-chain, which may look like a double-spend.
+	//
+	// A replacing message is a message with a different CID, any of Gas values, and
+	// different signature, but with all other parameters matching (source/destination,
+	// nonce, params, etc.)
 	StateWaitMsg(ctx context.Context, cid cid.Cid, confidence uint64) (*MsgLookup, error)
 	// StateWaitMsgLimited looks back up to limit epochs in the chain for a message.
 	// If not found, it blocks until the message arrives on chain, and gets to the
 	// indicated confidence depth.
+	//
+	// NOTE: If a replacing message is found on chain, this method will return
+	// a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+	// CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+	// result of the execution of the replacing message.
+	//
+	// If the caller wants to ensure that exactly the requested message was executed,
+	// they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+	// Without this check both the requested and original message may appear as
+	// successfully executed on-chain, which may look like a double-spend.
+	//
+	// A replacing message is a message with a different CID, any of Gas values, and
+	// different signature, but with all other parameters matching (source/destination,
+	// nonce, params, etc.)
 	StateWaitMsgLimited(ctx context.Context, cid cid.Cid, confidence uint64, limit abi.ChainEpoch) (*MsgLookup, error)
 	// StateListMiners returns the addresses of every miner that has claimed power in the Power Actor
 	StateListMiners(context.Context, types.TipSetKey) ([]address.Address, error)
@@ -431,7 +473,15 @@ type FullNode interface {
 	// StateChangedActors returns all the actors whose states change between the two given state CIDs
 	// TODO: Should this take tipset keys instead?
 	StateChangedActors(context.Context, cid.Cid, cid.Cid) (map[string]types.Actor, error)
-	// StateGetReceipt returns the message receipt for the given message
+	// StateGetReceipt returns the message receipt for the given message or for a
+	// matching gas-repriced replacing message
+	//
+	// NOTE: If the requested message was replaced, this method will return the receipt
+	// for the replacing message - if the caller needs the receipt for exactly the
+	// requested message, use StateSearchMsg().Receipt, and check that MsgLookup.Message
+	// is matching the requseted CID
+	//
+	// DEPRECATED: Use StateSearchMsg, this method won't be supported in v1 API
 	StateGetReceipt(context.Context, cid.Cid, types.TipSetKey) (*types.MessageReceipt, error)
 	// StateMinerSectorCount returns the number of sectors in a miner's sector set and proving set
 	StateMinerSectorCount(context.Context, address.Address, types.TipSetKey) (MinerSectors, error)

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -3686,7 +3686,13 @@ Response:
 ```
 
 ### StateGetReceipt
-StateGetReceipt returns the message receipt for the given message
+StateGetReceipt returns the message receipt for the given message or for a
+matching gas-repriced replacing message
+
+NOTE: If the requested message was replaced, this method will return the receipt
+for the replacing message - if the caller needs the receipt for exactly the
+requested message, use StateSearchMsg().Receipt, and check that MsgLookup.Message
+is matching the requseted CID
 
 
 Perms: read
@@ -4583,6 +4589,20 @@ Response:
 ### StateSearchMsgLimited
 StateSearchMsgLimited looks back up to limit epochs in the chain for a message, and returns its receipt and the tipset where it was executed
 
+NOTE: If a replacing message is found on chain, this method will return
+a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+result of the execution of the replacing message.
+
+If the caller wants to ensure that exactly the requested message was executed,
+they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+Without this check both the requested and original message may appear as
+successfully executed on-chain, which may look like a double-spend.
+
+A replacing message is a message with a different CID, any of Gas values, and
+different signature, but with all other parameters matching (source/destination,
+nonce, params, etc.)
+
 
 Perms: read
 
@@ -4877,6 +4897,20 @@ Response: `"0"`
 StateWaitMsg looks back in the chain for a message. If not found, it blocks until the
 message arrives on chain, and gets to the indicated confidence depth.
 
+NOTE: If a replacing message is found on chain, this method will return
+a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+result of the execution of the replacing message.
+
+If the caller wants to ensure that exactly the requested message was executed,
+they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+Without this check both the requested and original message may appear as
+successfully executed on-chain, which may look like a double-spend.
+
+A replacing message is a message with a different CID, any of Gas values, and
+different signature, but with all other parameters matching (source/destination,
+nonce, params, etc.)
+
 
 Perms: read
 
@@ -4918,6 +4952,20 @@ Response:
 StateWaitMsgLimited looks back up to limit epochs in the chain for a message.
 If not found, it blocks until the message arrives on chain, and gets to the
 indicated confidence depth.
+
+NOTE: If a replacing message is found on chain, this method will return
+a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+result of the execution of the replacing message.
+
+If the caller wants to ensure that exactly the requested message was executed,
+they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+Without this check both the requested and original message may appear as
+successfully executed on-chain, which may look like a double-spend.
+
+A replacing message is a message with a different CID, any of Gas values, and
+different signature, but with all other parameters matching (source/destination,
+nonce, params, etc.)
 
 
 Perms: read

--- a/documentation/en/api-methods.md
+++ b/documentation/en/api-methods.md
@@ -3695,6 +3695,8 @@ for the replacing message - if the caller needs the receipt for exactly the
 requested message, use StateSearchMsg().Receipt, and check that MsgLookup.Message
 is matching the requseted CID
 
+DEPRECATED: Use StateSearchMsg, this method won't be supported in v1 API
+
 
 Perms: read
 
@@ -4550,6 +4552,20 @@ Response:
 
 ### StateSearchMsg
 StateSearchMsg searches for a message in the chain, and returns its receipt and the tipset where it was executed
+
+NOTE: If a replacing message is found on chain, this method will return
+a MsgLookup for the replacing message - the MsgLookup.Message will be a different
+CID than the one provided in the 'cid' param, MsgLookup.Receipt will contain the
+result of the execution of the replacing message.
+
+If the caller wants to ensure that exactly the requested message was executed,
+they MUST check that MsgLookup.Message is equal to the provided 'cid'.
+Without this check both the requested and original message may appear as
+successfully executed on-chain, which may look like a double-spend.
+
+A replacing message is a message with a different CID, any of Gas values, and
+different signature, but with all other parameters matching (source/destination,
+nonce, params, etc.)
 
 
 Perms: read


### PR DESCRIPTION
This is a fairly sharp edge which we should fix in the v1 API, but for now it should at least get better docs