### PR TITLE
shed: command to list duplicate messages in tipsets (steb)

### DIFF
--- a/cmd/lotus-shed/balances.go
+++ b/cmd/lotus-shed/balances.go
@@ -205,6 +205,9 @@ every day of chain processed.
 		}
 
 		target := abi.ChainEpoch(cctx.Int("start"))
+		if target < 0 || target > head.Height() {
+			return fmt.Errorf("start height must be greater than 0 and less than the end height")
+		}
 		totalEpochs := head.Height() - target
 
 		for target <= head.Height() {


### PR DESCRIPTION
Modification of #5841.

This one:

1. Let's you specify a start/stop height.
2. Prints out ndjson to stdout, and status/errors to stderr.
3. Prints one entry per set of duplicates.
4. Allows filtering messages by method number.
5. Allows configuring the number of threads.

Usage:

```bash
> cd cmd/lotus-shed
> go build
> ./lotus-shed audits duplicate-messages --start=148888 | tee output.ndjson
```

That will walk back to the mainnet epoch and write the results to stdout and output.ndjson.

**TODO**

* [x] Make it possible to _start_ at some height.
* [ ] Make it faster (parallel fetch and/or direct datastore access)?
* [ ] Make the method number filter customizable.
* [x] Add better docs