### PR TITLE
Add two utils to Lotus-shed

### DIFF
--- a/cmd/lotus-shed/base64.go
+++ b/cmd/lotus-shed/base64.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/go-address"
+
+	"github.com/urfave/cli/v2"
+)
+
+var base64Cmd = &cli.Command{
+	Name:        "base64",
+	Description: "multiformats base64",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "decodeAddr",
+			Value: false,
+			Usage: "Decode a base64 addr",
+		},
+		&cli.BoolFlag{
+			Name:  "decodeBig",
+			Value: false,
+			Usage: "Decode a base64 big",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		var input io.Reader
+
+		if cctx.Args().Len() == 0 {
+			input = os.Stdin
+		} else {
+			input = strings.NewReader(cctx.Args().First())
+		}
+
+		bytes, err := ioutil.ReadAll(input)
+		if err != nil {
+			return nil
+		}
+
+		decoded, err := base64.RawStdEncoding.DecodeString(strings.TrimSpace(string(bytes)))
+		if err != nil {
+			return err
+		}
+
+		if cctx.Bool("decodeAddr") {
+			addr, err := address.NewFromBytes(decoded)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(addr)
+
+			return nil
+		}
+
+		if cctx.Bool("decodeBig") {
+			var val abi.TokenAmount
+			err = val.UnmarshalBinary(decoded)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(val)
+		}
+
+		return nil
+	},
+}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -53,6 +53,7 @@ func main() {
 		rpcCmd,
 		cidCmd,
 		blockmsgidCmd,
+		signaturesCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -16,6 +16,7 @@ func main() {
 	logging.SetLogLevel("*", "INFO")
 
 	local := []*cli.Command{
+		base64Cmd,
 		base32Cmd,
 		base16Cmd,
 		bitFieldCmd,

--- a/cmd/lotus-shed/signatures.go
+++ b/cmd/lotus-shed/signatures.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/lotus/lib/sigs"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+)
+
+var signaturesCmd = &cli.Command{
+	Name:  "signatures",
+	Usage: "tools involving signatures",
+	Subcommands: []*cli.Command{
+		sigsVerifyVoteCmd,
+	},
+}
+
+var sigsVerifyVoteCmd = &cli.Command{
+	Name:        "verify-vote",
+	Description: "can be used to verify signed votes being submitted for FILPolls",
+	Usage:       "<FIPnumber> <signingAddress> <signature>",
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 3 {
+			return xerrors.Errorf("usage: verify-vote <FIPnumber> <signingAddress> <signature>")
+		}
+
+		fip, err := strconv.ParseInt(cctx.Args().First(), 10, 64)
+		if err != nil {
+			return xerrors.Errorf("couldn't parse FIP number: %w", err)
+		}
+
+		addr, err := address.NewFromString(cctx.Args().Get(1))
+		if err != nil {
+			return xerrors.Errorf("couldn't parse signing address: %w", err)
+		}
+
+		sigBytes, err := hex.DecodeString(cctx.Args().Get(2))
+		if err != nil {
+			return xerrors.Errorf("couldn't parse sig: %w", err)
+		}
+
+		var sig crypto.Signature
+		if err := sig.UnmarshalBinary(sigBytes); err != nil {
+			return xerrors.Errorf("couldn't unmarshal sig: %w", err)
+		}
+
+		switch fip {
+		case 14:
+			approve := []byte("7 - Approve")
+
+			if sigs.Verify(&sig, addr, approve) == nil {
+				fmt.Println("valid vote for approving FIP-0014")
+				return nil
+			}
+
+			reject := []byte("7 - Reject")
+			if sigs.Verify(&sig, addr, reject) == nil {
+				fmt.Println("valid vote for rejecting FIP-0014")
+				return nil
+			}
+
+			return xerrors.Errorf("invalid vote for FIP-0014!")
+		default:
+			return xerrors.Errorf("unrecognized FIP number")
+		}
+	},
+}


### PR DESCRIPTION
- The first is to help with base64 inputs
- The second can be used to validate signed votes for FILPolls, so that users can be confident that they have not been tricked into signing something other than a ballot. To use it for the FIP-0014 poll, run 
```
lotus-shed signatures verify-vote 14 <signingAddress> <signature (hex string)>
```

Example:
```
lotus-shed signatures verify-vote 14 f1vstk2dncjlimtmbcmu7tjxwekaurhvvma3joqea 01c109f5c39d6792e991a6f8d74f081f98850bdcdb1c0432608e9d30dcaeaf030a5e9c7101bb12ffa7a4c0b311308462763b928edc7828d6563e1e2b8562aa3d8b00
valid vote for rejecting FIP-0014
```