### PR TITLE
Import secp sigs in paych tests

### DIFF
--- a/paychmgr/paych_test.go
+++ b/paychmgr/paych_test.go
@@ -23,6 +23,7 @@ import (
 	paychmock "github.com/filecoin-project/lotus/chain/actors/builtin/paych/mock"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/sigs"
+	_ "github.com/filecoin-project/lotus/lib/sigs/secp"
 )
 
 func TestCheckVoucherValid(t *testing.T) {


### PR DESCRIPTION
When running those tests directly, secp sigs wouldn't be imported, and some of the paych tests would fail