### PR TITLE
introduce message prototypes

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -488,15 +488,15 @@ type FullNode interface {
 	// MsigCreate creates a multisig wallet
 	// It takes the following params: <required number of senders>, <approving addresses>, <unlock duration>
 	//<initial balance>, <sender address of the create msg>, <gas price>
-	MsigCreate(context.Context, uint64, []address.Address, abi.ChainEpoch, types.BigInt, address.Address, types.BigInt) (cid.Cid, error) //INVERT
+	MsigCreate(context.Context, uint64, []address.Address, abi.ChainEpoch, types.BigInt, address.Address, types.BigInt) (*MessagePrototype, error) //INVERT
 	// MsigPropose proposes a multisig message
 	// It takes the following params: <multisig address>, <recipient address>, <value to transfer>,
 	// <sender address of the propose msg>, <method to call in the proposed message>, <params to include in the proposed message>
-	MsigPropose(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) //INVERT
+	MsigPropose(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (*MessagePrototype, error) //INVERT
 
 	// MsigApprove approves a previously-proposed multisig message by transaction ID
 	// It takes the following params: <multisig address>, <proposed transaction ID> <signer address>
-	MsigApprove(context.Context, address.Address, uint64, address.Address) (cid.Cid, error) //INVERT
+	MsigApprove(context.Context, address.Address, uint64, address.Address) (*MessagePrototype, error) //INVERT
 
 	// MsigApproveTxnHash approves a previously-proposed multisig message, specified
 	// using both transaction ID and a hash of the parameters used in the
@@ -504,43 +504,43 @@ type FullNode interface {
 	// exactly the transaction you think you are.
 	// It takes the following params: <multisig address>, <proposed message ID>, <proposer address>, <recipient address>, <value to transfer>,
 	// <sender address of the approve msg>, <method to call in the proposed message>, <params to include in the proposed message>
-	MsigApproveTxnHash(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) //INVERT
+	MsigApproveTxnHash(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (*MessagePrototype, error) //INVERT
 
 	// MsigCancel cancels a previously-proposed multisig message
 	// It takes the following params: <multisig address>, <proposed transaction ID>, <recipient address>, <value to transfer>,
 	// <sender address of the cancel msg>, <method to call in the proposed message>, <params to include in the proposed message>
-	MsigCancel(context.Context, address.Address, uint64, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) //INVERT
+	MsigCancel(context.Context, address.Address, uint64, address.Address, types.BigInt, address.Address, uint64, []byte) (*MessagePrototype, error) //INVERT
 	// MsigAddPropose proposes adding a signer in the multisig
 	// It takes the following params: <multisig address>, <sender address of the propose msg>,
 	// <new signer>, <whether the number of required signers should be increased>
-	MsigAddPropose(context.Context, address.Address, address.Address, address.Address, bool) (cid.Cid, error) //INVERT
+	MsigAddPropose(context.Context, address.Address, address.Address, address.Address, bool) (*MessagePrototype, error) //INVERT
 	// MsigAddApprove approves a previously proposed AddSigner message
 	// It takes the following params: <multisig address>, <sender address of the approve msg>, <proposed message ID>,
 	// <proposer address>, <new signer>, <whether the number of required signers should be increased>
-	MsigAddApprove(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, bool) (cid.Cid, error) //INVERT
+	MsigAddApprove(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, bool) (*MessagePrototype, error) //INVERT
 	// MsigAddCancel cancels a previously proposed AddSigner message
 	// It takes the following params: <multisig address>, <sender address of the cancel msg>, <proposed message ID>,
 	// <new signer>, <whether the number of required signers should be increased>
-	MsigAddCancel(context.Context, address.Address, address.Address, uint64, address.Address, bool) (cid.Cid, error) //INVERT
+	MsigAddCancel(context.Context, address.Address, address.Address, uint64, address.Address, bool) (*MessagePrototype, error) //INVERT
 	// MsigSwapPropose proposes swapping 2 signers in the multisig
 	// It takes the following params: <multisig address>, <sender address of the propose msg>,
 	// <old signer>, <new signer>
-	MsigSwapPropose(context.Context, address.Address, address.Address, address.Address, address.Address) (cid.Cid, error) //INVERT
+	MsigSwapPropose(context.Context, address.Address, address.Address, address.Address, address.Address) (*MessagePrototype, error) //INVERT
 	// MsigSwapApprove approves a previously proposed SwapSigner
 	// It takes the following params: <multisig address>, <sender address of the approve msg>, <proposed message ID>,
 	// <proposer address>, <old signer>, <new signer>
-	MsigSwapApprove(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, address.Address) (cid.Cid, error) //INVERT
+	MsigSwapApprove(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, address.Address) (*MessagePrototype, error) //INVERT
 	// MsigSwapCancel cancels a previously proposed SwapSigner message
 	// It takes the following params: <multisig address>, <sender address of the cancel msg>, <proposed message ID>,
 	// <old signer>, <new signer>
-	MsigSwapCancel(context.Context, address.Address, address.Address, uint64, address.Address, address.Address) (cid.Cid, error) //INVERT
+	MsigSwapCancel(context.Context, address.Address, address.Address, uint64, address.Address, address.Address) (*MessagePrototype, error) //INVERT
 
 	// MsigRemoveSigner proposes the removal of a signer from the multisig.
 	// It accepts the multisig to make the change on, the proposer address to
 	// send the message from, the address to be removed, and a boolean
 	// indicating whether or not the signing threshold should be lowered by one
 	// along with the address removal.
-	MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (cid.Cid, error) //INVERT
+	MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (*MessagePrototype, error) //INVERT
 
 	// MarketAddBalance adds funds to the market actor
 	MarketAddBalance(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error) //INVERT

--- a/api/apistruct/struct.go
+++ b/api/apistruct/struct.go
@@ -233,22 +233,22 @@ type FullNodeStruct struct {
 		StateVMCirculatingSupplyInternal   func(context.Context, types.TipSetKey) (api.CirculatingSupply, error)                                               `perm:"read"`
 		StateNetworkVersion                func(context.Context, types.TipSetKey) (stnetwork.Version, error)                                                   `perm:"read"`
 
-		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)                                                                    `perm:"read"`
-		MsigGetVestingSchedule  func(context.Context, address.Address, types.TipSetKey) (api.MsigVesting, error)                                                                 `perm:"read"`
-		MsigGetVested           func(context.Context, address.Address, types.TipSetKey, types.TipSetKey) (types.BigInt, error)                                                   `perm:"read"`
-		MsigGetPending          func(context.Context, address.Address, types.TipSetKey) ([]*api.MsigTransaction, error)                                                          `perm:"read"`
-		MsigCreate              func(context.Context, uint64, []address.Address, abi.ChainEpoch, types.BigInt, address.Address, types.BigInt) (cid.Cid, error)                   `perm:"sign"`
-		MsigPropose             func(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)                          `perm:"sign"`
-		MsigApprove             func(context.Context, address.Address, uint64, address.Address) (cid.Cid, error)                                                                 `perm:"sign"`
-		MsigApproveTxnHash      func(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error) `perm:"sign"`
-		MsigCancel              func(context.Context, address.Address, uint64, address.Address, types.BigInt, address.Address, uint64, []byte) (cid.Cid, error)                  `perm:"sign"`
-		MsigAddPropose          func(context.Context, address.Address, address.Address, address.Address, bool) (cid.Cid, error)                                                  `perm:"sign"`
-		MsigAddApprove          func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, bool) (cid.Cid, error)                         `perm:"sign"`
-		MsigAddCancel           func(context.Context, address.Address, address.Address, uint64, address.Address, bool) (cid.Cid, error)                                          `perm:"sign"`
-		MsigSwapPropose         func(context.Context, address.Address, address.Address, address.Address, address.Address) (cid.Cid, error)                                       `perm:"sign"`
-		MsigSwapApprove         func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, address.Address) (cid.Cid, error)              `perm:"sign"`
-		MsigSwapCancel          func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address) (cid.Cid, error)                               `perm:"sign"`
-		MsigRemoveSigner        func(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (cid.Cid, error)              `perm:"sign"`
+		MsigGetAvailableBalance func(context.Context, address.Address, types.TipSetKey) (types.BigInt, error)                                                                                  `perm:"read"`
+		MsigGetVestingSchedule  func(context.Context, address.Address, types.TipSetKey) (api.MsigVesting, error)                                                                               `perm:"read"`
+		MsigGetVested           func(context.Context, address.Address, types.TipSetKey, types.TipSetKey) (types.BigInt, error)                                                                 `perm:"read"`
+		MsigGetPending          func(context.Context, address.Address, types.TipSetKey) ([]*api.MsigTransaction, error)                                                                        `perm:"read"`
+		MsigCreate              func(context.Context, uint64, []address.Address, abi.ChainEpoch, types.BigInt, address.Address, types.BigInt) (*api.MessagePrototype, error)                   `perm:"sign"`
+		MsigPropose             func(context.Context, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (*api.MessagePrototype, error)                          `perm:"sign"`
+		MsigApprove             func(context.Context, address.Address, uint64, address.Address) (*api.MessagePrototype, error)                                                                 `perm:"sign"`
+		MsigApproveTxnHash      func(context.Context, address.Address, uint64, address.Address, address.Address, types.BigInt, address.Address, uint64, []byte) (*api.MessagePrototype, error) `perm:"sign"`
+		MsigCancel              func(context.Context, address.Address, uint64, address.Address, types.BigInt, address.Address, uint64, []byte) (*api.MessagePrototype, error)                  `perm:"sign"`
+		MsigAddPropose          func(context.Context, address.Address, address.Address, address.Address, bool) (*api.MessagePrototype, error)                                                  `perm:"sign"`
+		MsigAddApprove          func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, bool) (*api.MessagePrototype, error)                         `perm:"sign"`
+		MsigAddCancel           func(context.Context, address.Address, address.Address, uint64, address.Address, bool) (*api.MessagePrototype, error)                                          `perm:"sign"`
+		MsigSwapPropose         func(context.Context, address.Address, address.Address, address.Address, address.Address) (*api.MessagePrototype, error)                                       `perm:"sign"`
+		MsigSwapApprove         func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address, address.Address) (*api.MessagePrototype, error)              `perm:"sign"`
+		MsigSwapCancel          func(context.Context, address.Address, address.Address, uint64, address.Address, address.Address) (*api.MessagePrototype, error)                               `perm:"sign"`
+		MsigRemoveSigner        func(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (*api.MessagePrototype, error)              `perm:"sign"`
 
 		MarketAddBalance   func(ctx context.Context, wallet, addr address.Address, amt types.BigInt) (cid.Cid, error)                 `perm:"sign"`
 		MarketGetReserved  func(ctx context.Context, addr address.Address) (types.BigInt, error)                                      `perm:"sign"`
@@ -1141,51 +1141,51 @@ func (c *FullNodeStruct) MsigGetPending(ctx context.Context, a address.Address, 
 	return c.Internal.MsigGetPending(ctx, a, tsk)
 }
 
-func (c *FullNodeStruct) MsigCreate(ctx context.Context, req uint64, addrs []address.Address, duration abi.ChainEpoch, val types.BigInt, src address.Address, gp types.BigInt) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigCreate(ctx context.Context, req uint64, addrs []address.Address, duration abi.ChainEpoch, val types.BigInt, src address.Address, gp types.BigInt) (*api.MessagePrototype, error) {
 	return c.Internal.MsigCreate(ctx, req, addrs, duration, val, src, gp)
 }
 
-func (c *FullNodeStruct) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	return c.Internal.MsigPropose(ctx, msig, to, amt, src, method, params)
 }
 
-func (c *FullNodeStruct) MsigApprove(ctx context.Context, msig address.Address, txID uint64, signer address.Address) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigApprove(ctx context.Context, msig address.Address, txID uint64, signer address.Address) (*api.MessagePrototype, error) {
 	return c.Internal.MsigApprove(ctx, msig, txID, signer)
 }
 
-func (c *FullNodeStruct) MsigApproveTxnHash(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigApproveTxnHash(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	return c.Internal.MsigApproveTxnHash(ctx, msig, txID, proposer, to, amt, src, method, params)
 }
 
-func (c *FullNodeStruct) MsigCancel(ctx context.Context, msig address.Address, txID uint64, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigCancel(ctx context.Context, msig address.Address, txID uint64, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	return c.Internal.MsigCancel(ctx, msig, txID, to, amt, src, method, params)
 }
 
-func (c *FullNodeStruct) MsigAddPropose(ctx context.Context, msig address.Address, src address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigAddPropose(ctx context.Context, msig address.Address, src address.Address, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	return c.Internal.MsigAddPropose(ctx, msig, src, newAdd, inc)
 }
 
-func (c *FullNodeStruct) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	return c.Internal.MsigAddApprove(ctx, msig, src, txID, proposer, newAdd, inc)
 }
 
-func (c *FullNodeStruct) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	return c.Internal.MsigAddCancel(ctx, msig, src, txID, newAdd, inc)
 }
 
-func (c *FullNodeStruct) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	return c.Internal.MsigSwapPropose(ctx, msig, src, oldAdd, newAdd)
 }
 
-func (c *FullNodeStruct) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	return c.Internal.MsigSwapApprove(ctx, msig, src, txID, proposer, oldAdd, newAdd)
 }
 
-func (c *FullNodeStruct) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	return c.Internal.MsigSwapCancel(ctx, msig, src, txID, oldAdd, newAdd)
 }
 
-func (c *FullNodeStruct) MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (cid.Cid, error) {
+func (c *FullNodeStruct) MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (*api.MessagePrototype, error) {
 	return c.Internal.MsigRemoveSigner(ctx, msig, proposer, toRemove, decrease)
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/filecoin-project/lotus/chain/types"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
@@ -167,4 +169,9 @@ type CheckStatus struct {
 type MessageCheckStatus struct {
 	Cid cid.Cid
 	CheckStatus
+}
+
+type MessagePrototype struct {
+	Message    types.Message
+	ValidNonce bool
 }

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -95,11 +95,13 @@ var msigCreateCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("multisigs must have at least one signer"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		var addrs []address.Address
@@ -146,10 +148,17 @@ var msigCreateCmd = &cli.Command{
 
 		gp := types.NewInt(1)
 
-		msgCid, err := api.MsigCreate(ctx, required, addrs, d, intVal, sendAddr, gp)
+		proto, err := api.MsigCreate(ctx, required, addrs, d, intVal, sendAddr, gp)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, msgCid, uint64(cctx.Int("confidence")))
@@ -364,11 +373,13 @@ var msigProposeCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must either pass three or five arguments"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -426,10 +437,17 @@ var msigProposeCmd = &cli.Command{
 			return fmt.Errorf("actor %s is not a multisig actor", msig)
 		}
 
-		msgCid, err := api.MsigPropose(ctx, msig, dest, types.BigInt(value), from, method, params)
+		proto, err := api.MsigPropose(ctx, msig, dest, types.BigInt(value), from, method, params)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("send proposal in message: ", msgCid)
 
@@ -481,11 +499,13 @@ var msigApproveCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("usage: msig approve <msig addr> <message ID> <proposer address> <desination> <value> [ <method> <params> ]"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -515,10 +535,17 @@ var msigApproveCmd = &cli.Command{
 
 		var msgCid cid.Cid
 		if cctx.Args().Len() == 2 {
-			msgCid, err = api.MsigApprove(ctx, msig, txid, from)
+			proto, err := api.MsigApprove(ctx, msig, txid, from)
 			if err != nil {
 				return err
 			}
+
+			sm, _, err := srv.PublishMessage(ctx, proto, false)
+			if err != nil {
+				return err
+			}
+
+			msgCid = sm.Cid()
 		} else {
 			proposer, err := address.NewFromString(cctx.Args().Get(2))
 			if err != nil {
@@ -558,10 +585,17 @@ var msigApproveCmd = &cli.Command{
 				params = p
 			}
 
-			msgCid, err = api.MsigApproveTxnHash(ctx, msig, txid, proposer, dest, types.BigInt(value), from, method, params)
+			proto, err := api.MsigApproveTxnHash(ctx, msig, txid, proposer, dest, types.BigInt(value), from, method, params)
 			if err != nil {
 				return err
 			}
+
+			sm, _, err := srv.PublishMessage(ctx, proto, false)
+			if err != nil {
+				return err
+			}
+
+			msgCid = sm.Cid()
 		}
 
 		fmt.Println("sent approval in message: ", msgCid)
@@ -598,11 +632,13 @@ var msigRemoveProposeCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -630,10 +666,17 @@ var msigRemoveProposeCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigRemoveSigner(ctx, msig, from, addr, cctx.Bool("decrease-threshold"))
+		proto, err := api.MsigRemoveSigner(ctx, msig, from, addr, cctx.Bool("decrease-threshold"))
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent remove proposal in message: ", msgCid)
 
@@ -676,11 +719,13 @@ var msigAddProposeCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -708,10 +753,17 @@ var msigAddProposeCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigAddPropose(ctx, msig, from, addr, cctx.Bool("increase-threshold"))
+		proto, err := api.MsigAddPropose(ctx, msig, from, addr, cctx.Bool("increase-threshold"))
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Fprintln(cctx.App.Writer, "sent add proposal in message: ", msgCid)
 
@@ -743,11 +795,13 @@ var msigAddApproveCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, new signer address, whether to increase threshold"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -790,10 +844,17 @@ var msigAddApproveCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigAddApprove(ctx, msig, from, txid, prop, newAdd, inc)
+		proto, err := api.MsigAddApprove(ctx, msig, from, txid, prop, newAdd, inc)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent add approval in message: ", msgCid)
 
@@ -825,11 +886,13 @@ var msigAddCancelCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, new signer address, whether to increase threshold"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -867,10 +930,17 @@ var msigAddCancelCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigAddCancel(ctx, msig, from, txid, newAdd, inc)
+		proto, err := api.MsigAddCancel(ctx, msig, from, txid, newAdd, inc)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent add cancellation in message: ", msgCid)
 
@@ -902,11 +972,13 @@ var msigSwapProposeCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, old signer address, new signer address"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -939,10 +1011,17 @@ var msigSwapProposeCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigSwapPropose(ctx, msig, from, oldAdd, newAdd)
+		proto, err := api.MsigSwapPropose(ctx, msig, from, oldAdd, newAdd)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent swap proposal in message: ", msgCid)
 
@@ -974,11 +1053,13 @@ var msigSwapApproveCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, old signer address, new signer address"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1021,10 +1102,17 @@ var msigSwapApproveCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigSwapApprove(ctx, msig, from, txid, prop, oldAdd, newAdd)
+		proto, err := api.MsigSwapApprove(ctx, msig, from, txid, prop, oldAdd, newAdd)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent swap approval in message: ", msgCid)
 
@@ -1056,11 +1144,13 @@ var msigSwapCancelCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, old signer address, new signer address"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1098,10 +1188,17 @@ var msigSwapCancelCmd = &cli.Command{
 			from = defaddr
 		}
 
-		msgCid, err := api.MsigSwapCancel(ctx, msig, from, txid, oldAdd, newAdd)
+		proto, err := api.MsigSwapCancel(ctx, msig, from, txid, oldAdd, newAdd)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent swap cancellation in message: ", msgCid)
 
@@ -1133,11 +1230,13 @@ var msigLockProposeCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, start epoch, unlock duration, and amount"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1185,10 +1284,17 @@ var msigLockProposeCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigPropose(ctx, msig, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
+		proto, err := api.MsigPropose(ctx, msig, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent lock proposal in message: ", msgCid)
 
@@ -1220,11 +1326,13 @@ var msigLockApproveCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, tx id, start epoch, unlock duration, and amount"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1282,10 +1390,17 @@ var msigLockApproveCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigApproveTxnHash(ctx, msig, txid, prop, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
+		proto, err := api.MsigApproveTxnHash(ctx, msig, txid, prop, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent lock approval in message: ", msgCid)
 
@@ -1317,11 +1432,13 @@ var msigLockCancelCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, tx id, start epoch, unlock duration, and amount"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1374,10 +1491,17 @@ var msigLockCancelCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigCancel(ctx, msig, txid, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
+		proto, err := api.MsigCancel(ctx, msig, txid, msig, big.Zero(), from, uint64(multisig.Methods.LockBalance), params)
 		if err != nil {
 			return err
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent lock cancellation in message: ", msgCid)
 
@@ -1471,11 +1595,13 @@ var msigProposeThresholdCmd = &cli.Command{
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and new threshold value"))
 		}
 
-		api, closer, err := GetFullNodeAPI(cctx)
+		srv, err := GetFullNodeServices(cctx)
 		if err != nil {
 			return err
 		}
-		defer closer()
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
 		ctx := ReqContext(cctx)
 
 		msig, err := address.NewFromString(cctx.Args().Get(0))
@@ -1511,10 +1637,17 @@ var msigProposeThresholdCmd = &cli.Command{
 			return actErr
 		}
 
-		msgCid, err := api.MsigPropose(ctx, msig, msig, types.NewInt(0), from, uint64(multisig.Methods.ChangeNumApprovalsThreshold), params)
+		proto, err := api.MsigPropose(ctx, msig, msig, types.NewInt(0), from, uint64(multisig.Methods.ChangeNumApprovalsThreshold), params)
 		if err != nil {
 			return fmt.Errorf("failed to propose change of threshold: %w", err)
 		}
+
+		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		if err != nil {
+			return err
+		}
+
+		msgCid := sm.Cid()
 
 		fmt.Println("sent change threshold proposal in message: ", msgCid)
 

--- a/cli/send.go
+++ b/cli/send.go
@@ -147,7 +147,7 @@ var sendCmd = &cli.Command{
 		}
 		msg, checks, err := srv.PublishMessage(ctx, proto, cctx.Bool("force"))
 		if xerrors.Is(err, ErrCheckFailed) {
-			proto, err = resolveChecks(ctx, srv, cctx.App.Writer, proto, checks, true)
+			proto, err := resolveChecks(ctx, srv, cctx.App.Writer, proto, checks, true)
 			if err != nil {
 				return xerrors.Errorf("from UI: %w", err)
 			}

--- a/cli/services.go
+++ b/cli/services.go
@@ -22,22 +22,24 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -destination=servicesmock_test.go -package=cli -self_package github.com/filecoin-project/lotus/cli . ServicesAPI
 
 type ServicesAPI interface {
+	FullNodeAPI() api.FullNode
+
 	GetBaseFee(ctx context.Context) (abi.TokenAmount, error)
 
 	// MessageForSend creates a prototype of a message based on SendParams
-	MessageForSend(ctx context.Context, params SendParams) (*types.Message, error)
+	MessageForSend(ctx context.Context, params SendParams) (*api.MessagePrototype, error)
 
 	// DecodeTypedParamsFromJSON takes in information needed to identify a method and converts JSON
 	// parameters to bytes of their CBOR encoding
 	DecodeTypedParamsFromJSON(ctx context.Context, to address.Address, method abi.MethodNum, paramstr string) ([]byte, error)
 
-	RunChecksForPrototype(ctx context.Context, prototype *types.Message) ([][]api.MessageCheckStatus, error)
+	RunChecksForPrototype(ctx context.Context, prototype *api.MessagePrototype) ([][]api.MessageCheckStatus, error)
 
 	// PublishMessage takes in a message prototype and publishes it
 	// before publishing the message, it runs checks on the node, message and mpool to verify that
 	// message is valid and won't be stuck.
 	// if `force` is true, it skips the checks
-	PublishMessage(ctx context.Context, prototype *types.Message, interactive bool) (*types.SignedMessage, [][]api.MessageCheckStatus, error)
+	PublishMessage(ctx context.Context, prototype *api.MessagePrototype, interactive bool) (*types.SignedMessage, [][]api.MessageCheckStatus, error)
 
 	// Close ends the session of services and disconnects from RPC, using Services after Close is called
 	// most likely will result in an error
@@ -48,6 +50,10 @@ type ServicesAPI interface {
 type ServicesImpl struct {
 	api    api.FullNode
 	closer jsonrpc.ClientCloser
+}
+
+func (s *ServicesImpl) FullNodeAPI() api.FullNode {
+	return s.api
 }
 
 func (s *ServicesImpl) Close() error {
@@ -102,15 +108,24 @@ type CheckInfo struct {
 
 var ErrCheckFailed = fmt.Errorf("check has failed")
 
-func (s *ServicesImpl) RunChecksForPrototype(ctx context.Context, prototype *types.Message) ([][]api.MessageCheckStatus, error) {
+func (s *ServicesImpl) RunChecksForPrototype(ctx context.Context, prototype *api.MessagePrototype) ([][]api.MessageCheckStatus, error) {
+	if !prototype.ValidNonce {
+		nonce, err := s.api.MpoolGetNonce(ctx, prototype.Message.From)
+		if err != nil {
+			return nil, xerrors.Errorf("mpool get nonce: %w", err)
+		}
+		prototype.Message.Nonce = nonce
+		prototype.ValidNonce = true
+	}
+
 	var outChecks [][]api.MessageCheckStatus
-	checks, err := s.api.MpoolCheckMessages(ctx, []*types.Message{prototype})
+	checks, err := s.api.MpoolCheckMessages(ctx, []*types.Message{&prototype.Message})
 	if err != nil {
 		return nil, xerrors.Errorf("message check: %w", err)
 	}
 	outChecks = append(outChecks, checks...)
 
-	checks, err = s.api.MpoolCheckPendingMessages(ctx, prototype.From)
+	checks, err = s.api.MpoolCheckPendingMessages(ctx, prototype.Message.From)
 	if err != nil {
 		return nil, xerrors.Errorf("pending mpool check: %w", err)
 	}
@@ -123,13 +138,13 @@ func (s *ServicesImpl) RunChecksForPrototype(ctx context.Context, prototype *typ
 // Errors with ErrCheckFailed if any of the checks fail
 // First group of checks is related to the message prototype
 func (s *ServicesImpl) PublishMessage(ctx context.Context,
-	prototype *types.Message, force bool) (*types.SignedMessage, [][]api.MessageCheckStatus, error) {
+	prototype *api.MessagePrototype, force bool) (*types.SignedMessage, [][]api.MessageCheckStatus, error) {
 
-	gasedMsg, err := s.api.GasEstimateMessageGas(ctx, prototype, nil, types.EmptyTSK)
+	gasedMsg, err := s.api.GasEstimateMessageGas(ctx, &prototype.Message, nil, types.EmptyTSK)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("estimating gas: %w", err)
 	}
-	*prototype = *gasedMsg
+	prototype.Message = *gasedMsg
 
 	if !force {
 		checks, err := s.RunChecksForPrototype(ctx, prototype)
@@ -141,9 +156,8 @@ func (s *ServicesImpl) PublishMessage(ctx context.Context,
 		}
 	}
 
-	//TODO: message prototype needs to have "IsNonceSet"
-	if prototype.Nonce != 0 {
-		sm, err := s.api.WalletSignMessage(ctx, prototype.From, prototype)
+	if prototype.ValidNonce {
+		sm, err := s.api.WalletSignMessage(ctx, prototype.Message.From, &prototype.Message)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -155,7 +169,7 @@ func (s *ServicesImpl) PublishMessage(ctx context.Context,
 		return sm, nil, nil
 	}
 
-	sm, err := s.api.MpoolPushMessage(ctx, prototype, nil)
+	sm, err := s.api.MpoolPushMessage(ctx, &prototype.Message, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -177,7 +191,7 @@ type SendParams struct {
 	Params []byte
 }
 
-func (s *ServicesImpl) MessageForSend(ctx context.Context, params SendParams) (*types.Message, error) {
+func (s *ServicesImpl) MessageForSend(ctx context.Context, params SendParams) (*api.MessagePrototype, error) {
 	if params.From == address.Undef {
 		defaddr, err := s.api.WalletDefaultAddress(ctx)
 		if err != nil {
@@ -186,7 +200,7 @@ func (s *ServicesImpl) MessageForSend(ctx context.Context, params SendParams) (*
 		params.From = defaddr
 	}
 
-	msg := &types.Message{
+	msg := types.Message{
 		From:  params.From,
 		To:    params.To,
 		Value: params.Val,
@@ -210,9 +224,15 @@ func (s *ServicesImpl) MessageForSend(ctx context.Context, params SendParams) (*
 	} else {
 		msg.GasLimit = 0
 	}
+	validNonce := false
 	if params.Nonce != nil {
 		msg.Nonce = *params.Nonce
+		validNonce = true
 	}
 
-	return msg, nil
+	prototype := &api.MessagePrototype{
+		Message:    msg,
+		ValidNonce: validNonce,
+	}
+	return prototype, nil
 }

--- a/node/impl/full/multisig.go
+++ b/node/impl/full/multisig.go
@@ -14,7 +14,6 @@ import (
 
 	multisig2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
-	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 )
@@ -37,134 +36,129 @@ func (a *MsigAPI) messageBuilder(ctx context.Context, from address.Address) (mul
 
 // TODO: remove gp (gasPrice) from arguments
 // TODO: Add "vesting start" to arguments.
-func (a *MsigAPI) MsigCreate(ctx context.Context, req uint64, addrs []address.Address, duration abi.ChainEpoch, val types.BigInt, src address.Address, gp types.BigInt) (cid.Cid, error) {
+func (a *MsigAPI) MsigCreate(ctx context.Context, req uint64, addrs []address.Address, duration abi.ChainEpoch, val types.BigInt, src address.Address, gp types.BigInt) (*api.MessagePrototype, error) {
 
 	mb, err := a.messageBuilder(ctx, src)
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
 	msg, err := mb.Create(addrs, req, 0, duration, val)
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
-	// send the message out to the network
-	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg, nil)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	return smsg.Cid(), nil
+	return &api.MessagePrototype{
+		Message:    *msg,
+		ValidNonce: false,
+	}, nil
 }
 
-func (a *MsigAPI) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (a *MsigAPI) MsigPropose(ctx context.Context, msig address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 
 	mb, err := a.messageBuilder(ctx, src)
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
 	msg, err := mb.Propose(msig, to, amt, abi.MethodNum(method), params)
 	if err != nil {
-		return cid.Undef, xerrors.Errorf("failed to create proposal: %w", err)
+		return nil, xerrors.Errorf("failed to create proposal: %w", err)
 	}
 
-	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg, nil)
-	if err != nil {
-		return cid.Undef, xerrors.Errorf("failed to push message: %w", err)
-	}
-
-	return smsg.Cid(), nil
+	return &api.MessagePrototype{
+		Message:    *msg,
+		ValidNonce: false,
+	}, nil
 }
 
-func (a *MsigAPI) MsigAddPropose(ctx context.Context, msig address.Address, src address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (a *MsigAPI) MsigAddPropose(ctx context.Context, msig address.Address, src address.Address, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	enc, actErr := serializeAddParams(newAdd, inc)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
-func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (a *MsigAPI) MsigAddApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	enc, actErr := serializeAddParams(newAdd, inc)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigApproveTxnHash(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
-func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (cid.Cid, error) {
+func (a *MsigAPI) MsigAddCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, newAdd address.Address, inc bool) (*api.MessagePrototype, error) {
 	enc, actErr := serializeAddParams(newAdd, inc)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(multisig.Methods.AddSigner), enc)
 }
 
-func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (a *MsigAPI) MsigSwapPropose(ctx context.Context, msig address.Address, src address.Address, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	enc, actErr := serializeSwapParams(oldAdd, newAdd)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigPropose(ctx, msig, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
-func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (a *MsigAPI) MsigSwapApprove(ctx context.Context, msig address.Address, src address.Address, txID uint64, proposer address.Address, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	enc, actErr := serializeSwapParams(oldAdd, newAdd)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigApproveTxnHash(ctx, msig, txID, proposer, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
-func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (cid.Cid, error) {
+func (a *MsigAPI) MsigSwapCancel(ctx context.Context, msig address.Address, src address.Address, txID uint64, oldAdd address.Address, newAdd address.Address) (*api.MessagePrototype, error) {
 	enc, actErr := serializeSwapParams(oldAdd, newAdd)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigCancel(ctx, msig, txID, msig, big.Zero(), src, uint64(multisig.Methods.SwapSigner), enc)
 }
 
-func (a *MsigAPI) MsigApprove(ctx context.Context, msig address.Address, txID uint64, src address.Address) (cid.Cid, error) {
+func (a *MsigAPI) MsigApprove(ctx context.Context, msig address.Address, txID uint64, src address.Address) (*api.MessagePrototype, error) {
 	return a.msigApproveOrCancelSimple(ctx, api.MsigApprove, msig, txID, src)
 }
 
-func (a *MsigAPI) MsigApproveTxnHash(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (a *MsigAPI) MsigApproveTxnHash(ctx context.Context, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	return a.msigApproveOrCancelTxnHash(ctx, api.MsigApprove, msig, txID, proposer, to, amt, src, method, params)
 }
 
-func (a *MsigAPI) MsigCancel(ctx context.Context, msig address.Address, txID uint64, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (a *MsigAPI) MsigCancel(ctx context.Context, msig address.Address, txID uint64, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	return a.msigApproveOrCancelTxnHash(ctx, api.MsigCancel, msig, txID, src, to, amt, src, method, params)
 }
 
-func (a *MsigAPI) MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (cid.Cid, error) {
+func (a *MsigAPI) MsigRemoveSigner(ctx context.Context, msig address.Address, proposer address.Address, toRemove address.Address, decrease bool) (*api.MessagePrototype, error) {
 	enc, actErr := serializeRemoveParams(toRemove, decrease)
 	if actErr != nil {
-		return cid.Undef, actErr
+		return nil, actErr
 	}
 
 	return a.MsigPropose(ctx, msig, msig, types.NewInt(0), proposer, uint64(multisig.Methods.RemoveSigner), enc)
 }
 
-func (a *MsigAPI) msigApproveOrCancelSimple(ctx context.Context, operation api.MsigProposeResponse, msig address.Address, txID uint64, src address.Address) (cid.Cid, error) {
+func (a *MsigAPI) msigApproveOrCancelSimple(ctx context.Context, operation api.MsigProposeResponse, msig address.Address, txID uint64, src address.Address) (*api.MessagePrototype, error) {
 	if msig == address.Undef {
-		return cid.Undef, xerrors.Errorf("must provide multisig address")
+		return nil, xerrors.Errorf("must provide multisig address")
 	}
 
 	if src == address.Undef {
-		return cid.Undef, xerrors.Errorf("must provide source address")
+		return nil, xerrors.Errorf("must provide source address")
 	}
 
 	mb, err := a.messageBuilder(ctx, src)
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
 	var msg *types.Message
@@ -174,34 +168,31 @@ func (a *MsigAPI) msigApproveOrCancelSimple(ctx context.Context, operation api.M
 	case api.MsigCancel:
 		msg, err = mb.Cancel(msig, txID, nil)
 	default:
-		return cid.Undef, xerrors.Errorf("Invalid operation for msigApproveOrCancel")
+		return nil, xerrors.Errorf("Invalid operation for msigApproveOrCancel")
 	}
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
-	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg, nil)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	return smsg.Cid(), nil
-
+	return &api.MessagePrototype{
+		Message:    *msg,
+		ValidNonce: false,
+	}, nil
 }
 
-func (a *MsigAPI) msigApproveOrCancelTxnHash(ctx context.Context, operation api.MsigProposeResponse, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
+func (a *MsigAPI) msigApproveOrCancelTxnHash(ctx context.Context, operation api.MsigProposeResponse, msig address.Address, txID uint64, proposer address.Address, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (*api.MessagePrototype, error) {
 	if msig == address.Undef {
-		return cid.Undef, xerrors.Errorf("must provide multisig address")
+		return nil, xerrors.Errorf("must provide multisig address")
 	}
 
 	if src == address.Undef {
-		return cid.Undef, xerrors.Errorf("must provide source address")
+		return nil, xerrors.Errorf("must provide source address")
 	}
 
 	if proposer.Protocol() != address.ID {
 		proposerID, err := a.StateAPI.StateLookupID(ctx, proposer, types.EmptyTSK)
 		if err != nil {
-			return cid.Undef, err
+			return nil, err
 		}
 		proposer = proposerID
 	}
@@ -216,7 +207,7 @@ func (a *MsigAPI) msigApproveOrCancelTxnHash(ctx context.Context, operation api.
 
 	mb, err := a.messageBuilder(ctx, src)
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
 	var msg *types.Message
@@ -226,18 +217,16 @@ func (a *MsigAPI) msigApproveOrCancelTxnHash(ctx context.Context, operation api.
 	case api.MsigCancel:
 		msg, err = mb.Cancel(msig, txID, &p)
 	default:
-		return cid.Undef, xerrors.Errorf("Invalid operation for msigApproveOrCancel")
+		return nil, xerrors.Errorf("Invalid operation for msigApproveOrCancel")
 	}
 	if err != nil {
-		return cid.Undef, err
+		return nil, err
 	}
 
-	smsg, err := a.MpoolAPI.MpoolPushMessage(ctx, msg, nil)
-	if err != nil {
-		return cid.Undef, err
-	}
-
-	return smsg.Cid(), nil
+	return &api.MessagePrototype{
+		Message:    *msg,
+		ValidNonce: false,
+	}, nil
 }
 
 func serializeAddParams(new address.Address, inc bool) ([]byte, error) {


### PR DESCRIPTION
This introduces message prototypes to applicable API endpoints, which
allows us to invert control of message sending and give the user a
chance to intervene with an interactive ui.