### PR TITLE
Util for miners to extend all v1 sectors

### DIFF
--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -50,6 +50,7 @@ var FaultDeclarationCutoff = miner0.FaultDeclarationCutoff
 const MinSectorExpiration = miner0.MinSectorExpiration
 
 // Not used / checked in v0
+// TODO: Abstract over network versions
 var DeclarationsMax = miner2.DeclarationsMax
 var AddressedSectorsMax = miner2.AddressedSectorsMax
 

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -132,7 +132,7 @@ func DealProviderCollateralBounds(
 	case actors.Version3:
 		return market3.DealProviderCollateralBounds(size, verified, rawBytePower, qaPower, baselinePower, circulatingFil)
 	default:
-		panic("unsupported network version")
+		panic("unsupported actors version")
 	}
 }
 
@@ -190,4 +190,39 @@ func GetDefaultSectorSize() abi.SectorSize {
 	})
 
 	return szs[0]
+}
+
+func GetSectorMaxLifetime(proof abi.RegisteredSealProof, nwVer network.Version) abi.ChainEpoch {
+	if nwVer <= network.Version10 {
+		return builtin3.SealProofPoliciesV0[proof].SectorMaxLifetime
+	}
+
+	return builtin3.SealProofPoliciesV11[proof].SectorMaxLifetime
+}
+
+func GetAddressedSectorsMax(nwVer network.Version) int {
+	switch actors.VersionForNetwork(nwVer) {
+	case actors.Version0:
+		return miner0.AddressedSectorsMax
+	case actors.Version2:
+		return miner2.AddressedSectorsMax
+	case actors.Version3:
+		return miner3.AddressedSectorsMax
+	default:
+		panic("unsupported network version")
+	}
+}
+
+func GetDeclarationsMax(nwVer network.Version) int {
+	switch actors.VersionForNetwork(nwVer) {
+	case actors.Version0:
+		// TODO: Should we instead panic here since the concept doesn't exist yet?
+		return miner0.AddressedPartitionsMax
+	case actors.Version2:
+		return miner2.DeclarationsMax
+	case actors.Version3:
+		return miner3.DeclarationsMax
+	default:
+		panic("unsupported network version")
+	}
 }

--- a/cmd/lotus-storage-miner/info.go
+++ b/cmd/lotus-storage-miner/info.go
@@ -90,7 +90,7 @@ func infoCmdAct(cctx *cli.Context) error {
 
 	fmt.Println()
 
-	maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
+	maddr, err := getActorAddress(ctx, cctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/lotus-storage-miner/main.go
+++ b/cmd/lotus-storage-miner/main.go
@@ -106,14 +106,20 @@ func main() {
 	lcli.RunApp(app)
 }
 
-func getActorAddress(ctx context.Context, nodeAPI api.StorageMiner, overrideMaddr string) (maddr address.Address, err error) {
-	if overrideMaddr != "" {
-		maddr, err = address.NewFromString(overrideMaddr)
+func getActorAddress(ctx context.Context, cctx *cli.Context) (maddr address.Address, err error) {
+	if cctx.IsSet("actor") {
+		maddr, err = address.NewFromString(cctx.String("actor"))
 		if err != nil {
 			return maddr, err
 		}
 		return
 	}
+
+	nodeAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+	if err != nil {
+		return address.Undef, err
+	}
+	defer closer()
 
 	maddr, err = nodeAPI.ActorAddress(ctx)
 	if err != nil {

--- a/cmd/lotus-storage-miner/proving.go
+++ b/cmd/lotus-storage-miner/proving.go
@@ -38,12 +38,6 @@ var provingFaultsCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		color.NoColor = !cctx.Bool("color")
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -54,7 +48,7 @@ var provingFaultsCmd = &cli.Command{
 
 		stor := store.ActorStore(ctx, blockstore.NewAPIBlockstore(api))
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
 			return err
 		}
@@ -98,12 +92,6 @@ var provingInfoCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		color.NoColor = !cctx.Bool("color")
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -112,7 +100,7 @@ var provingInfoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
 			return err
 		}
@@ -211,12 +199,6 @@ var provingDeadlinesCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		color.NoColor = !cctx.Bool("color")
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -225,7 +207,7 @@ var provingDeadlinesCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
 			return err
 		}
@@ -301,12 +283,6 @@ var provingDeadlineInfoCmd = &cli.Command{
 			return xerrors.Errorf("could not parse deadline index: %w", err)
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -315,7 +291,7 @@ var provingDeadlineInfoCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := getActorAddress(ctx, nodeApi, cctx.String("actor"))
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -434,11 +434,6 @@ var sectorsExtendCmd = &cli.Command{
 		&cli.StringFlag{},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
 
 		api, nCloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
@@ -447,9 +442,10 @@ var sectorsExtendCmd = &cli.Command{
 		defer nCloser()
 
 		ctx := lcli.ReqContext(cctx)
-		maddr, err := nodeApi.ActorAddress(ctx)
+
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
-			return xerrors.Errorf("getting miner actor address: %w", err)
+			return err
 		}
 
 		var params []miner0.ExtendSectorExpirationParams
@@ -512,7 +508,6 @@ var sectorsExtendCmd = &cli.Command{
 					}
 				}
 
-				// TODO: Count added sectors, if it exceeds 10k, split messages
 				p := &miner0.ExtendSectorExpirationParams{}
 				scount := 0
 				for l, exts := range sectors {
@@ -578,8 +573,8 @@ var sectorsExtendCmd = &cli.Command{
 			return xerrors.Errorf("getting miner info: %w", err)
 		}
 
-		for _, p := range params {
-			sp, aerr := actors.SerializeParams(&p)
+		for i := range params {
+			sp, aerr := actors.SerializeParams(&params[i])
 			if aerr != nil {
 				return xerrors.Errorf("serializing params: %w", err)
 			}
@@ -836,12 +831,6 @@ var sectorsCapacityCollateralCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 
-		mApi, mCloser, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer mCloser()
-
 		nApi, nCloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -850,7 +839,7 @@ var sectorsCapacityCollateralCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := mApi.ActorAddress(ctx)
+		maddr, err := getActorAddress(ctx, cctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Run `lotus-miner sectors extend --v1-sectors`. 

- The `tolerance` flag can be passed to indicate what durations aren't "worth" extending. It defaults to one week, which means that sectors whose current lifetime's are within one week of the maximum possible lifetime will not be extended.
- The `expiration-cutoff` flag can be passed to skip sectors whose expiration is past a certain point from the current head. It defaults to infinity (no cutoff), but if, say, `28800` was specified, then only sectors expiring in the next 10 days would be extended (2880 epochs in 1 day).



- [x] Tested manually on butterfly (kinda)
- [x] Should be tested on a large mainnet miner