### PR TITLE
localstorage: Demote reservation stat error to debug

### DIFF
--- a/extern/sector-storage/stores/local.go
+++ b/extern/sector-storage/stores/local.go
@@ -114,7 +114,7 @@ func (p *path) stat(ls LocalStorage) (fsutil.FsStat, error) {
 				used, err = ls.DiskUsage(p)
 			}
 			if err != nil {
-				log.Errorf("getting disk usage of '%s': %+v", p.sectorPath(id, fileType), err)
+				log.Debugf("getting disk usage of '%s': %+v", p.sectorPath(id, fileType), err)
 				continue
 			}
 


### PR DESCRIPTION
This can be a bit spammy, and can happen normally, for example when finalizing the sector:
* We'll reserve space for the sealed sector and cache, 
* We'll start fetching sealed data
* Cache will not start to be fetched until we fetch the sealed sector file
* Since that takes a while, we'll spam this error when periodically checking storage health / getting disk usage when scheduling tasks