### PR TITLE
Raise client MaxFee default

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -205,7 +205,7 @@ func defCommon() Common {
 
 }
 
-var DefaultDefaultMaxFee = types.MustParseFIL("0.007")
+var DefaultDefaultMaxFee = types.MustParseFIL("0.07")
 var DefaultSimultaneousTransfers = uint64(20)
 
 // DefaultFullNode returns the default config


### PR DESCRIPTION
The original value is too conservative for the current state of mainnet
Resolves (temporarily) #5543