### PR TITLE
polish(adt_diff): optimize adt diff array and map logic

### DIFF
--- a/chain/actors/adt/diff_adt.go
+++ b/chain/actors/adt/diff_adt.go
@@ -27,6 +27,18 @@ type AdtArrayDiff interface {
 // - All values that exist in preArr and in curArr are passed to AdtArrayDiff.Modify()
 //  - It is the responsibility of AdtArrayDiff.Modify() to determine if the values it was passed have been modified.
 func DiffAdtArray(preArr, curArr Array, out AdtArrayDiff) error {
+	preRoot, err := preArr.Root()
+	if err != nil {
+		return err
+	}
+	curRoot, err := curArr.Root()
+	if err != nil {
+		return err
+	}
+	if curRoot.Equals(preRoot) {
+		return nil
+	}
+
 	notNew := make(map[int64]struct{}, curArr.Length())
 	prevVal := new(typegen.Deferred)
 	if err := preArr.ForEach(prevVal, func(i int64) error {
@@ -80,6 +92,18 @@ type AdtMapDiff interface {
 }
 
 func DiffAdtMap(preMap, curMap Map, out AdtMapDiff) error {
+	preRoot, err := preMap.Root()
+	if err != nil {
+		return err
+	}
+	curRoot, err := curMap.Root()
+	if err != nil {
+		return err
+	}
+	if curRoot.Equals(preRoot) {
+		return nil
+	}
+
 	notNew := make(map[string]struct{})
 	prevVal := new(typegen.Deferred)
 	if err := preMap.ForEach(prevVal, func(key string) error {


### PR DESCRIPTION
- only walk the map/array if they have different root CID's

This will fail CI since calling `Root` on a hamt or amt node will cause a write to occur on the underlying blockstore. The blockstore used by all lotus tests is read-only, and thus this operation always fails.