### PR TITLE
wrap gateway api

### DIFF
--- a/api/v0api/v1_wrapper.go
+++ b/api/v0api/v1_wrapper.go
@@ -19,6 +19,10 @@ type WrapperV1Full struct {
 	v1api.FullNode
 }
 
+type WrapperV1Gateway struct {
+	v1api.Gateway
+}
+
 func (w *WrapperV1Full) StateSearchMsg(ctx context.Context, msg cid.Cid) (*api.MsgLookup, error) {
 	return w.FullNode.StateSearchMsg(ctx, types.EmptyTSK, msg, api.LookbackNoLimit, true)
 }

--- a/api/v1api/latest.go
+++ b/api/v1api/latest.go
@@ -7,6 +7,9 @@ import (
 type FullNode = api.FullNode
 type FullNodeStruct = api.FullNodeStruct
 
+type Gateway = api.Gateway
+type GatewayStruct = api.GatewayStruct
+
 func PermissionedFullAPI(a FullNode) FullNode {
 	return api.PermissionedFullAPI(a)
 }

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api/client"
+	"github.com/filecoin-project/lotus/api/v0api"
+	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
@@ -162,6 +164,10 @@ var runCmd = &cli.Command{
 		}
 
 		log.Info("setting up API endpoint at " + address)
+		ma := metrics.MetricedGatewayAPI(NewGatewayAPI(api))
+
+		serveRpc("/rpc/v1", ma)
+		serveRpc("/rpc/v0", lapi.Wrap(new(v1api.GatewayStruct), new(v0api.WrapperV1Gateway), ma))
 
 		addr, err := net.ResolveTCPAddr("tcp", address)
 		if err != nil {


### PR DESCRIPTION
This fixes a bug in which the gateway rpc api registered all the jsonrpc method for the FullNode and causes the gateway to hit nil pointer errors when one of those methods was called.