### PR TITLE
set buildtype in nerpa and butterfly

### DIFF
--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -47,6 +47,8 @@ func init() {
 	SetAddressNetwork(address.Testnet)
 
 	Devnet = true
+
+	BuildType = BuildButterflynet
 }
 
 const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)

--- a/build/params_nerpanet.go
+++ b/build/params_nerpanet.go
@@ -67,6 +67,8 @@ func init() {
 	//miner.WPoStChallengeLookback = abi.ChainEpoch(2)
 
 	Devnet = false
+
+	BuildType = BuildNerpanet
 }
 
 const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)

--- a/build/version.go
+++ b/build/version.go
@@ -6,12 +6,14 @@ var CurrentCommit string
 var BuildType int
 
 const (
-	BuildDefault    = 0
-	BuildMainnet    = 0x1
-	Build2k         = 0x2
-	BuildDebug      = 0x3
-	BuildCalibnet   = 0x4
-	BuildInteropnet = 0x5
+	BuildDefault      = 0
+	BuildMainnet      = 0x1
+	Build2k           = 0x2
+	BuildDebug        = 0x3
+	BuildCalibnet     = 0x4
+	BuildInteropnet   = 0x5
+	BuildNerpanet     = 0x6
+	BuildButterflynet = 0x7
 )
 
 func buildType() string {
@@ -28,6 +30,10 @@ func buildType() string {
 		return "+calibnet"
 	case BuildInteropnet:
 		return "+interopnet"
+	case BuildNerpanet:
+		return "+nerpanet"
+	case BuildButterflynet:
+		return "+butterflynet"
 	default:
 		return "+huh?"
 	}


### PR DESCRIPTION
Add "Build Type" to nerpanet and butterfly.

I am not sure if these were intentionally left out. If they were, we can just close this.

The impetus of this PR is to allow people doing tests on nerpanet to be able to see what network they are on by running `lotus version`

This includes all the networks in our docs https://network.filecoin.io/