### PR TITLE
fix full node painc

### DIFF
--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -604,7 +604,7 @@ func (a *API) clientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 			finish(xerrors.Errorf("cannot make retrieval deal for null total"))
 			return
 		}
-		
+
 		if order.Size == 0 {
 			finish(xerrors.Errorf("cannot make retrieval deal for zero bytes"))
 			return

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -600,6 +600,11 @@ func (a *API) clientRetrieve(ctx context.Context, order api.RetrievalOrder, ref 
 			}
 		}
 
+		if order.Total.Int == nil {
+			finish(xerrors.Errorf("cannot make retrieval deal for null total"))
+			return
+		}
+		
 		if order.Size == 0 {
 			finish(xerrors.Errorf("cannot make retrieval deal for zero bytes"))
 			return


### PR DESCRIPTION
fix: full node painc  when calling  RPC  Filecoin.ClientRetrieve without the order.Total specified.


request:
```json
{
	"jsonrpc": "2.0",
	"method": "Filecoin.ClientRetrieve",
	"params": [
        {
            "Root":{"/":"bafk2bzacecjclkq7dnfr2hcwqvrkvtbwmbx2zh7ygsixlmbh7hbkxm74x7a5m"},
            "Miner":"t01000",
            "Client":"t3wefnh7256b65hya4xnaskm63zqjkhjjtv3ty5nixtu7iv445eiwrtwsv4lyc2opawwabg2daq54omvcbixzq",
            "Size": 1024
        },
        {
            "Path":"/tmp/123.txt",
            "IsCAR":false
        }
        ],
	"id": 3
}
```

![image](https://user-images.githubusercontent.com/43715382/115837582-545fd080-a44b-11eb-8cba-673da5d504da.png)


