### PR TITLE
Extending sectors: more practical and flexible tools

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -575,14 +575,12 @@ var sectorsRenewCmd = &cli.Command{
 	Usage: "Renew expiring sectors while not exceeding each sector's max life",
 	Flags: []cli.Flag{
 		&cli.Int64Flag{
-			Name:  "lower-cutoff",
-			Usage: "skip sectors whose current expiration is less than <lower-cutoff> epochs from now",
-			Value: 120,
+			Name:  "from",
+			Usage: "only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120",
 		},
 		&cli.Int64Flag{
-			Name:  "upper-cutoff",
-			Usage: "skip sectors whose current expiration is more than <upper-cutoff> epochs from now",
-			Value: 86400,
+			Name:  "to",
+			Usage: "only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 86400",
 		},
 		&cli.StringFlag{
 			Name:  "sector-file",
@@ -742,9 +740,19 @@ var sectorsRenewCmd = &cli.Command{
 				}
 			}
 		} else {
+			from := currEpoch + 120
+			to := currEpoch + 86400
+
+			if cctx.IsSet("from") {
+				from = abi.ChainEpoch(cctx.Int64("from"))
+			}
+
+			if cctx.IsSet("to") {
+				to = abi.ChainEpoch(cctx.Int64("to"))
+			}
+
 			for _, si := range activeSet {
-				if si.Expiration >= currEpoch+abi.ChainEpoch(cctx.Int64("lower-cutoff")) &&
-					si.Expiration <= currEpoch+abi.ChainEpoch(cctx.Int64("upper-cutoff")) {
+				if si.Expiration >= from && si.Expiration <= to {
 					if _, exclude := excludeSet[uint64(si.SectorNumber)]; !exclude {
 						sis = append(sis, si)
 					}

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1376,6 +1376,8 @@ COMMANDS:
    refs               List References to sectors
    update-state       ADVANCED: manually update the state of a sector, this may aid in error recovery
    pledge             store random data in a sector
+   check-expire       Inspect expiring sectors
+   renew              Renew expiring sectors while not exceeding each sector's max life
    extend             Extend sector expiration
    terminate          Terminate sector on-chain then remove (WARNING: This means losing power and collateral for the removed sector)
    remove             Forcefully remove a sector (WARNING: This means losing power and collateral for the removed sector (use 'terminate' for lower penalty))
@@ -1463,6 +1465,42 @@ USAGE:
 
 OPTIONS:
    --help, -h  show help (default: false)
+   
+```
+
+### lotus-miner sectors check-expire
+```
+NAME:
+   lotus-miner sectors check-expire - Inspect expiring sectors
+
+USAGE:
+   lotus-miner sectors check-expire [command options] [arguments...]
+
+OPTIONS:
+   --cutoff value  skip sectors whose current expiration is more than <cutoff> epochs from now, defaults to 60 days (default: 172800)
+   --help, -h      show help (default: false)
+   
+```
+
+### lotus-miner sectors renew
+```
+NAME:
+   lotus-miner sectors renew - Renew expiring sectors while not exceeding each sector's max life
+
+USAGE:
+   lotus-miner sectors renew [command options] [arguments...]
+
+OPTIONS:
+   --from value            only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120 (1 hour) (default: 0)
+   --to value              only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 92160 (32 days) (default: 0)
+   --sector-file value     provide a file containing one sector number in each line, ignoring above selecting criteria
+   --exclude value         optionally provide a file containing excluding sectors
+   --extension value       try to extend selected sectors by this number of epochs, defaults to 540 days (default: 1555200)
+   --new-expiration value  try to extend selected sectors to this epoch, ignoring extension (default: 0)
+   --tolerance value       don't try to extend sectors by fewer than this number of epochs, defaults to 7 days (default: 20160)
+   --max-fee value         use up to this amount of FIL for one message. pass this flag to avoid message congestion. (default: "0")
+   --really-do-it          pass this flag to really renew sectors, otherwise will only print out json representation of parameters (default: false)
+   --help, -h              show help (default: false)
    
 ```
 


### PR DESCRIPTION
New cli tools for managing sectors expiration:

- `check-expire`, facilitates insepection of expiring sectors

- `renew`, a more practical alternative to `extend` with the following features:

    - can automatically extend sectors of all kinds of seal proof, not just v1 ones
 
    - can mannully provide sector numbers in a file
   
    - can choose from 2 extending schemes: a relative extension or an uniform new expiration
   
    - will take care of `SectorMaxLifetime` and `MaxSectorExpirationExtension`
   
    - fast search of sector location
   
    - can specify max-fee to avoid message congestion