### PR TITLE
add "expected duration" label to inspect-deals output

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -2347,7 +2347,7 @@ func renderDeal(di *lapi.DealInfo) {
 	}
 
 	for _, stg := range di.DealStages.Stages {
-		msg := fmt.Sprintf("%s %s: %s (%s)", color.BlueString("Stage:"), color.BlueString(strings.TrimPrefix(stg.Name, "StorageDeal")), stg.Description, color.GreenString(stg.ExpectedDuration))
+		msg := fmt.Sprintf("%s %s: %s (expected duration: %s)", color.BlueString("Stage:"), color.BlueString(strings.TrimPrefix(stg.Name, "StorageDeal")), stg.Description, color.GreenString(stg.ExpectedDuration))
 		if stg.UpdatedTime.Time().IsZero() {
 			msg = color.YellowString(msg)
 		}


### PR DESCRIPTION
This is a one-line change that adds an "expected duration" label to the `lotus client inspect-deal` command output, since there was some confusion about what the times referred to in our user testing. The confusion was based on the output showing states that had already passed, so we though it might be "time elapsed" instead of an estimate.