### PR TITLE
upgrade `lotus-soup` testplans and reduce deals concurrency to a single miner

### DIFF
--- a/testplans/Makefile
+++ b/testplans/Makefile
@@ -6,18 +6,18 @@ download-proofs:
 	go run github.com/filecoin-project/go-paramfetch/paramfetch 2048 ./docker-images/proof-parameters.json
 
 build-images:
-	docker build -t "iptestground/oni-buildbase:v13-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
-	docker build -t "iptestground/oni-runtime:v7" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
-	docker build -t "iptestground/oni-runtime:v8-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
+	docker build -t "iptestground/oni-buildbase:v14-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
+	docker build -t "iptestground/oni-runtime:v9" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
+	docker build -t "iptestground/oni-runtime:v9-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
 
 push-images:
-	docker push iptestground/oni-buildbase:v13-lotus
-	docker push iptestground/oni-runtime:v7
-	docker push iptestground/oni-runtime:v8-debug
+	docker push iptestground/oni-buildbase:v14-lotus
+	docker push iptestground/oni-runtime:v9
+	docker push iptestground/oni-runtime:v9-debug
 
 pull-images:
-	docker pull iptestground/oni-buildbase:v13-lotus
-	docker pull iptestground/oni-runtime:v7
-	docker pull iptestground/oni-runtime:v8-debug
+	docker pull iptestground/oni-buildbase:v14-lotus
+	docker pull iptestground/oni-runtime:v9
+	docker pull iptestground/oni-runtime:v9-debug
 
 .PHONY: download-proofs build-images push-images pull-images

--- a/testplans/docker-images/Dockerfile.oni-buildbase
+++ b/testplans/docker-images/Dockerfile.oni-buildbase
@@ -1,10 +1,10 @@
-ARG GO_VERSION=1.15.6
+ARG GO_VERSION=1.16.3
 
 FROM golang:${GO_VERSION}-buster
 
 RUN apt-get update && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev jq gcc git pkg-config bzr libhwloc-dev
 
-ARG FILECOIN_FFI_COMMIT=62f89f108a6a8fe9ad6ed52fb7ffbf8594d7ae5c
+ARG FILECOIN_FFI_COMMIT=d82899449741ce190e950a3582ebe33806f018a9
 ARG FFI_DIR=/extern/filecoin-ffi
 
 RUN mkdir -p ${FFI_DIR} \

--- a/testplans/docker-images/Dockerfile.oni-runtime
+++ b/testplans/docker-images/Dockerfile.oni-runtime
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.15.6
+ARG GO_VERSION=1.16.3
 
 FROM golang:${GO_VERSION}-buster as downloader
 
@@ -8,7 +8,7 @@ FROM golang:${GO_VERSION}-buster as downloader
 ## 3. Trigger the download.
 ## Output will be in /var/tmp/filecoin-proof-parameters.
 
-RUN go get github.com/filecoin-project/go-paramfetch/paramfetch
+RUN go get github.com/filecoin-project/go-paramfetch/paramfetch@master
 COPY /proof-parameters.json /
 RUN paramfetch 8388608 /proof-parameters.json
 

--- a/testplans/docker-images/Dockerfile.oni-runtime-debug
+++ b/testplans/docker-images/Dockerfile.oni-runtime-debug
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.15.6
+ARG GO_VERSION=1.16.3
 
 FROM golang:${GO_VERSION}-buster as downloader
 
@@ -8,11 +8,11 @@ FROM golang:${GO_VERSION}-buster as downloader
 ## 3. Trigger the download.
 ## Output will be in /var/tmp/filecoin-proof-parameters.
 
-RUN go get github.com/filecoin-project/go-paramfetch/paramfetch
+RUN go get github.com/filecoin-project/go-paramfetch/paramfetch@master
 COPY /proof-parameters.json /
 RUN paramfetch 8388608 /proof-parameters.json
 
-ARG LOTUS_COMMIT=b4ad2e5e93dc710d985eb9cf3ee04142efb47bf0
+ARG LOTUS_COMMIT=7e25a811c3d80ea3e007a54aa1da089985110c2c
 
 ## for debug purposes
 RUN apt update && apt install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config libhwloc-dev curl && git clone https://github.com/filecoin-project/lotus.git && cd lotus/ && git checkout ${LOTUS_COMMIT} && make clean && make all && make install

--- a/testplans/lotus-soup/_compositions/baseline-k8s-3-1.toml
+++ b/testplans/lotus-soup/_compositions/baseline-k8s-3-1.toml
@@ -45,7 +45,7 @@
 [[groups]]
   id = "miners"
   [groups.resources]
-    memory = "4096Mi"
+    memory = "8192Mi"
     cpu = "1000m"
   [groups.instances]
     count = 1

--- a/testplans/lotus-soup/deals_e2e.go
+++ b/testplans/lotus-soup/deals_e2e.go
@@ -75,7 +75,9 @@ func dealsE2E(t *testkit.TestEnvironment) error {
 	// give some time to the miner, otherwise, we get errors like:
 	// deal errored deal failed: (State=26) error calling node: publishing deal: GasEstimateMessageGas
 	// error: estimating gas used: message execution failed: exit 19, reason: failed to lock balance: failed to lock client funds: not enough balance to lock for addr t0102: escrow balance 0 < locked 0 + required 640297000 (RetCode=19)
-	time.Sleep(50 * time.Second)
+	time.Sleep(40 * time.Second)
+
+	time.Sleep(time.Duration(t.GlobalSeq) * 5 * time.Second)
 
 	// generate 1600 bytes of random data
 	data := make([]byte, 5000000)

--- a/testplans/lotus-soup/init.go
+++ b/testplans/lotus-soup/init.go
@@ -22,6 +22,12 @@ func init() {
 	_ = log.SetLogLevel("stats", "WARN")
 	_ = log.SetLogLevel("dht/RtRefreshManager", "ERROR") // noisy
 	_ = log.SetLogLevel("bitswap", "ERROR")              // noisy
+	_ = log.SetLogLevel("badgerbs", "ERROR")             // noisy
+	_ = log.SetLogLevel("sub", "ERROR")                  // noisy
+	_ = log.SetLogLevel("pubsub", "ERROR")               // noisy
+	_ = log.SetLogLevel("chain", "ERROR")                // noisy
+	_ = log.SetLogLevel("chainstore", "ERROR")           // noisy
+	_ = log.SetLogLevel("basichost", "ERROR")            // noisy
 
 	_ = os.Setenv("BELLMAN_NO_GPU", "1")
 

--- a/testplans/lotus-soup/manifest.toml
+++ b/testplans/lotus-soup/manifest.toml
@@ -9,8 +9,8 @@ enabled = true
 
 [builders."docker:go"]
 enabled = true
-build_base_image = "iptestground/oni-buildbase:v13-lotus"
-runtime_image = "iptestground/oni-runtime:v8-debug"
+build_base_image = "iptestground/oni-buildbase:v14-lotus"
+runtime_image = "iptestground/oni-runtime:v9-debug"
 
 [runners."local:exec"]
 enabled = true


### PR DESCRIPTION
This PR is bumping up Go to 1.16.3 for all docker images used in Testground test plans.

It is also reduce concurrency for deals towards a single miner, until we fix the underlying issues with deals being blocked in `StorageDealAwaitingPreCommit` stage.

<img width="835" alt="Screenshot 2021-04-28 at 14 03 35" src="https://user-images.githubusercontent.com/50459/116400613-8c3f8d00-a82a-11eb-8f24-d3f59f0d57d5.png">