### PR TITLE
fix testground payment channel tests: use 1 miner

### DIFF
--- a/testplans/lotus-soup/_compositions/paych-stress-k8s.toml
+++ b/testplans/lotus-soup/_compositions/paych-stress-k8s.toml
@@ -5,7 +5,7 @@
 [global]
   plan = "lotus-soup"
   case = "paych-stress"
-  total_instances = 5   # 2 clients + 2 miners + 1 bootstrapper
+  total_instances = 4   # 2 clients + 1 miners + 1 bootstrapper
   builder = "docker:go"
   runner = "cluster:k8s"
 
@@ -23,7 +23,7 @@
 
 [global.run.test_params]
   clients = "2"
-  miners = "2"
+  miners = "1"
   genesis_timestamp_offset = "0"
   balance = "100"    ## be careful, this is in FIL.
   sectors = "10"
@@ -44,7 +44,7 @@
 
 [[groups]]
   id = "miners"
-  instances = { count = 2 }
+  instances = { count = 1 }
   [groups.run.test_params]
     role = "miner"
   [groups.resources]


### PR DESCRIPTION
This PR is updating the configuration for the payment channel tests - in order to start only 1 miner, and not a network of 2 miners.

---

This is a work-around to https://github.com/filecoin-project/lotus/issues/6127 so that we get stable Testground tests as part of the Lotus release cycle. Once the underlying issue is fixed, we can fix this composition to start a larger network.