### PR TITLE
separate TestBatchDealInput from TestAPIDealFlow

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -58,9 +58,23 @@ func TestAPIDealFlow(t *testing.T) {
 	t.Run("TestPublishDealsBatching", func(t *testing.T) {
 		test.TestPublishDealsBatching(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
 	})
-	t.Run("TestBatchDealInput", func(t *testing.T) {
-		test.TestBatchDealInput(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
-	})
+}
+
+func TestBatchDealInput(t *testing.T) {
+	logging.SetLogLevel("miner", "ERROR")
+	logging.SetLogLevel("chainstore", "ERROR")
+	logging.SetLogLevel("chain", "ERROR")
+	logging.SetLogLevel("sub", "ERROR")
+	logging.SetLogLevel("storageminer", "ERROR")
+
+	blockTime := 10 * time.Millisecond
+
+	// For these tests where the block time is artificially short, just use
+	// a deal start epoch that is guaranteed to be far enough in the future
+	// so that the deal starts sealing in time
+	dealStartEpoch := abi.ChainEpoch(2 << 12)
+
+	test.TestBatchDealInput(t, builder.MockSbBuilder, blockTime, dealStartEpoch)
 }
 
 func TestAPIDealFlowReal(t *testing.T) {


### PR DESCRIPTION
I ran `TestAPIDealFlow` many times locally, and it seems to consistently pass, or hang on the last sub-test: `TestBatchDealInput`.

There is an open PR (https://github.com/filecoin-project/lotus/pull/6041) that changes `TestBatchDealInput` and updates it, so I suggest we either disable this test for now, or at least separate it from the other sub-tests in `TestAPIDealFlow` that consistently pass.