### PR TITLE
fix: use a consistent tipset in commands

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -723,12 +723,6 @@ var ChainGetCmd = &cli.Command{
 				return err
 			}
 
-			if ts == nil {
-				ts, err = api.ChainHead(ctx)
-				if err != nil {
-					return err
-				}
-			}
 			p = "/ipfs/" + ts.ParentState().String() + p
 			if cctx.Bool("verbose") {
 				fmt.Println(p)

--- a/cli/state.go
+++ b/cli/state.go
@@ -180,10 +180,13 @@ func ParseTipSetString(ts string) ([]cid.Cid, error) {
 	return cids, nil
 }
 
+// LoadTipSet gets the tipset from the context, or the head from the API.
+//
+// It always gets the head from the API so commands use a consistent tipset even if time pases.
 func LoadTipSet(ctx context.Context, cctx *cli.Context, api v0api.FullNode) (*types.TipSet, error) {
 	tss := cctx.String("tipset")
 	if tss == "" {
-		return nil, nil
+		return api.ChainHead(ctx)
 	}
 
 	return ParseTipSetRef(ctx, api, tss)
@@ -850,14 +853,6 @@ var StateListMessagesCmd = &cli.Command{
 			return err
 		}
 
-		if ts == nil {
-			head, err := api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
-			ts = head
-		}
-
 		windowSize := abi.ChainEpoch(100)
 
 		cur := ts
@@ -957,13 +952,6 @@ var StateComputeStateCmd = &cli.Command{
 		}
 
 		h := abi.ChainEpoch(cctx.Uint64("vm-height"))
-		if ts == nil {
-			head, err := api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
-			ts = head
-		}
 		if h == 0 {
 			h = ts.Height()
 		}
@@ -1763,13 +1751,6 @@ var StateSectorCmd = &cli.Command{
 		ts, err := LoadTipSet(ctx, cctx, api)
 		if err != nil {
 			return err
-		}
-
-		if ts == nil {
-			ts, err = api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
 		}
 
 		maddr, err := address.NewFromString(cctx.Args().Get(0))

--- a/cmd/lotus-shed/frozen-miners.go
+++ b/cmd/lotus-shed/frozen-miners.go
@@ -35,12 +35,6 @@ var frozenMinersCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if ts == nil {
-			ts, err = api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
-		}
 
 		queryEpoch := ts.Height()
 

--- a/cmd/lotus-shed/postfind.go
+++ b/cmd/lotus-shed/postfind.go
@@ -49,12 +49,6 @@ var postFindCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if startTs == nil {
-			startTs, err = api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
-		}
 		stopEpoch := startTs.Height() - abi.ChainEpoch(c.Int("lookback"))
 		if verbose {
 			fmt.Printf("Collecting messages between %d and %d\n", startTs.Height(), stopEpoch)

--- a/cmd/lotus-shed/stateroot-stats.go
+++ b/cmd/lotus-shed/stateroot-stats.go
@@ -56,13 +56,6 @@ var staterootDiffsCmd = &cli.Command{
 			return err
 		}
 
-		if ts == nil {
-			ts, err = api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
-		}
-
 		fn := func(ts *types.TipSet) (cid.Cid, []cid.Cid) {
 			blk := ts.Blocks()[0]
 			strt := blk.ParentStateRoot
@@ -132,13 +125,6 @@ var staterootStatCmd = &cli.Command{
 		ts, err := lcli.LoadTipSet(ctx, cctx, api)
 		if err != nil {
 			return err
-		}
-
-		if ts == nil {
-			ts, err = api.ChainHead(ctx)
-			if err != nil {
-				return err
-			}
 		}
 
 		var addrs []address.Address


### PR DESCRIPTION
It's very easy to write an incorrect command that operates over different heads by using the "empty" tipset. This change makes the `LoadTipSet` command helper get the latest head from the lotus daemon if its unset.

The cost is an extra call to get the head. That should be trivial in most cases.