### PR TITLE
fix: use the parent state when listing actors

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -854,10 +854,7 @@ func (sm *StateManager) ListAllActors(ctx context.Context, ts *types.TipSet) ([]
 	if ts == nil {
 		ts = sm.cs.GetHeaviestTipSet()
 	}
-	st, _, err := sm.TipSetState(ctx, ts)
-	if err != nil {
-		return nil, err
-	}
+	st := ts.ParentState()
 
 	stateTree, err := sm.StateTree(st)
 	if err != nil {


### PR DESCRIPTION
To be consistent with other commands. Otherwise, two API calls with the same tipset can return inconsistent results.