### PR TITLE
oh, snap!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,10 @@ gen: type-gen method-gen docsgen api-gen
 	@echo ">>> IF YOU'VE MODIFIED THE CLI, REMEMBER TO ALSO MAKE docsgen-cli"
 .PHONY: gen
 
+snap: lotus lotus-miner lotus-worker
+	snapcraft
+	# snapcraft upload ./lotus_*.snap
+
 # separate from gen because it needs binaries
 docsgen-cli: lotus lotus-miner lotus-worker
 	python ./scripts/generate-lotus-cli.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: lotus
+base: core20
+version: '1.8.0'
+summary: filecoin daemon/client
+description: |
+  Filecoin is a peer-to-peer network that stores files on the internet
+  with built-in economic incentives to ensure files are stored reliably over time
+grade: devel
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  libs:
+    plugin: dump
+    source: ./
+    organize:
+      'lotus' : bin/
+      'lotus-*' : bin/
+    stage-packages:
+      - ocl-icd-libopencl1
+      - libhwloc15
+apps:
+  lotus:
+    command: bin/lotus
+  lotus-miner:
+    command: bin/lotus-miner
+  lotus-worker:
+    command: bin/lotus-worker

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: lotus
-base: core20
+base: core18
 version: '1.8.0'
 summary: filecoin daemon/client
 description: |
@@ -17,7 +17,8 @@ parts:
       'lotus-*' : bin/
     stage-packages:
       - ocl-icd-libopencl1
-      - libhwloc15
+      - libhwloc1
+      - libgcc1
 apps:
   lotus:
     command: bin/lotus


### PR DESCRIPTION
This adds a very basic snapcraft build.

It would be possible to *build* and *package* all within snapcraft, however to avoid dealing with snapcraft plugins this would require you to build natively and simply copies the binaries into the snap.

Could be a viable solution for https://github.com/filecoin-project/lotus/issues/6030 and to help people get up-and-running more quickly.


When reviewing, keep in mind that the version of hwloc you have installed may not be the same as the version running in, for example, the golang docker container. Ubuntu users running 18.04 have a different version than those running 20.20. This could add a complication during review as native builds may link incorrectly in the snap.

I chose to use `core18` as a base with the knowledge that the golang:1.15.X docker containers have libhwloc1, not libhowloc15, available, and this is frequently the way binaries are built. However, I could be easily convinced to use `core20` and updated libs instead if anyone has this preference.

building the snap: 
```
make snap
```

after some time, you are given a snap file you can install.
```
sudo snap install --devmode ./lotus_1.8.0_amd64.snap
2021-05-06T23:21:41Z INFO Waiting for automatic snapd restart...
lotus 1.8.0 installed
```

proof that lotus is contained:
```
$ which lotus
/snap/bin/lotus
$ lotus daemon 
2021-05-06T23:23:32.443Z        INFO    main    lotus/daemon.go:214     lotus repo: /home/vagrant/snap/lotus/x1/.lotus
2021-05-06T23:23:32.443Z        INFO    repo    repo/fsrepo.go:122      Initializing repo at '/home/vagrant/snap/lotus/x1/.lotus'
2021-05-06T23:23:32.452Z        INFO    build   go-paramfetch@v0.0.2-0.20200701152213-3e0f0afdc261/paramfetch.go:173     Fetching /var/tmp/filecoin-proof-parameters/v28-stacked-proof-of-replication-merkletree-poseidon_hasher-8-0-0-sha256_hasher-ecd683648512ab1765faa2a5f14bab48f676e633467f0aa8aad4b55dcb0652bb.vk from https://proofs.filecoin.io/ipfs/
2021-05-06T23:23:32.452Z        INFO    build   go-paramfetch@v0.0.2-0.20200701152213-3e0f0afdc261/paramfetch.go:191     GET https://proofs.filecoin.io/ipfs/QmYCuipFyvVW1GojdMrjK1JnMobXtT4zRCZs1CGxjizs99
...
---

$ ls ~/snap/lotus/current/.lotus/
config.toml  datastore  data-transfer  heapprof  journal  keystore  kvlog  token

```

Of course, this snap would then be made available for everyone to use through the snap store, which could be pushed with CI by someone during releases.