### PR TITLE
consider storiface.PathStorage when calculating storage requirements

### DIFF
--- a/extern/sector-storage/stores/index.go
+++ b/extern/sector-storage/stores/index.go
@@ -3,6 +3,7 @@ package stores
 import (
 	"context"
 	"errors"
+	"math"
 	"net/url"
 	gopath "path"
 	"sort"
@@ -383,7 +384,14 @@ func (i *Index) StorageBestAlloc(ctx context.Context, allocate storiface.SectorF
 
 	var candidates []storageEntry
 
-	spaceReq, err := allocate.SealSpaceUse(ssize)
+	var err error
+	spaceReq := uint64(math.MaxUint64)
+	switch pathType {
+	case storiface.PathSealing:
+		spaceReq, err = allocate.SealSpaceUse(ssize)
+	case storiface.PathStorage:
+		spaceReq, err = allocate.StoreSpaceUse(ssize)
+	}
 	if err != nil {
 		return nil, xerrors.Errorf("estimating required space: %w", err)
 	}

--- a/extern/sector-storage/stores/index.go
+++ b/extern/sector-storage/stores/index.go
@@ -3,7 +3,7 @@ package stores
 import (
 	"context"
 	"errors"
-	"math"
+	"fmt"
 	"net/url"
 	gopath "path"
 	"sort"
@@ -385,12 +385,14 @@ func (i *Index) StorageBestAlloc(ctx context.Context, allocate storiface.SectorF
 	var candidates []storageEntry
 
 	var err error
-	spaceReq := uint64(math.MaxUint64)
+	var spaceReq uint64
 	switch pathType {
 	case storiface.PathSealing:
 		spaceReq, err = allocate.SealSpaceUse(ssize)
 	case storiface.PathStorage:
 		spaceReq, err = allocate.StoreSpaceUse(ssize)
+	default:
+		panic(fmt.Sprintf("unexpected pathType: %s", pathType))
 	}
 	if err != nil {
 		return nil, xerrors.Errorf("estimating required space: %w", err)

--- a/extern/sector-storage/storiface/filetype.go
+++ b/extern/sector-storage/storiface/filetype.go
@@ -73,6 +73,24 @@ func (t SectorFileType) SealSpaceUse(ssize abi.SectorSize) (uint64, error) {
 	return need, nil
 }
 
+func (t SectorFileType) StoreSpaceUse(ssize abi.SectorSize) (uint64, error) {
+	var need uint64
+	for _, pathType := range PathTypes {
+		if !t.Has(pathType) {
+			continue
+		}
+
+		oh, ok := FsOverheadFinalized[pathType]
+		if !ok {
+			return 0, xerrors.Errorf("no finalized overhead info for %s", pathType)
+		}
+
+		need += uint64(oh) * uint64(ssize) / FSOverheadDen
+	}
+
+	return need, nil
+}
+
 func (t SectorFileType) All() [FileTypes]bool {
 	var out [FileTypes]bool
 


### PR DESCRIPTION
Addresses: https://github.com/filecoin-project/lotus/issues/6182

When a sector gets to the `FinalizeSector` state, currently Lotus tries to acquire ~500GB of storage on the location for storage, while it needs much less for the sector.

This code was proposed by @moremorefun (Thank you!!) and I think it is solving the issue.