### PR TITLE
chore(ci): Enable build on RC tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,7 +751,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - test-conformance:
           test-suite-name: conformance
           packages: "./conformance"
@@ -772,28 +772,28 @@ workflows:
           filters:
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-ntwk-calibration:
           requires:
             - test-short
           filters:
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-ntwk-butterfly:
           requires:
             - test-short
           filters:
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-ntwk-nerpa:
           requires:
             - test-short
           filters:
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-lotus-soup
       - build-macos:
           requires:
@@ -804,7 +804,7 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
           requires:
             - build-all
@@ -815,7 +815,7 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-and-push-image:
           dockerfile: Dockerfile.lotus
           path: .
@@ -830,7 +830,7 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish-packer-calibrationnet:
           requires:
             - build-ntwk-calibration
@@ -840,7 +840,7 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish-packer-butterflynet:
           requires:
             - build-ntwk-butterfly
@@ -850,7 +850,7 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish-packer-nerpanet:
           requires:
             - build-ntwk-nerpa
@@ -860,4 +860,4 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/


### PR DESCRIPTION
Enables test, build, publish for all OS and network targets for release candidate tags in CI.

Re: #6030