### PR TITLE
Hackily fix Drand fetching around null blocks

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1299,7 +1299,8 @@ func (cs *ChainStore) GetBeaconRandomness(ctx context.Context, blks []cid.Cid, p
 		searchHeight = 0
 	}
 
-	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, true)
+	// This is........awful?
+	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, searchHeight > build.UpgradeHyperdriveHeight)
 	if err != nil {
 		return nil, err
 	}
@@ -1333,7 +1334,8 @@ func (cs *ChainStore) GetChainRandomness(ctx context.Context, blks []cid.Cid, pe
 		searchHeight = 0
 	}
 
-	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, true)
+	// This is........awful?
+	randTs, err := cs.GetTipsetByHeight(ctx, searchHeight, ts, searchHeight > build.UpgradeHyperdriveHeight)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is the no-effort fix to the critical portion of #3613. I really don't want to take this route, though, chainstore really shouldn't be reasoning about upgrade heights.

See #6240 for the better fix. 