### PR TITLE
fix: wait-api should use GetAPI to acquire binary specific API

### DIFF
--- a/cli/wait.go
+++ b/cli/wait.go
@@ -12,7 +12,7 @@ var WaitApiCmd = &cli.Command{
 	Usage: "Wait for lotus api to come online",
 	Action: func(cctx *cli.Context) error {
 		for i := 0; i < 30; i++ {
-			api, closer, err := GetFullNodeAPI(cctx)
+			api, closer, err := GetAPI(cctx)
 			if err != nil {
 				fmt.Printf("Not online yet... (%s)\n", err)
 				time.Sleep(time.Second)


### PR DESCRIPTION
Fixes #6244