### PR TITLE
fix(ci): Updates to lotus CI build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
     resource_class: 2xlarge
   ubuntu:
     docker:
-      - image: ubuntu:19.10
+      - image: ubuntu:20.04
 
 commands:
   install-deps:

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -29,13 +29,20 @@ RELEASE_ID=`echo "${RELEASE_RESPONSE}" | jq '.id'`
 if [ "${RELEASE_ID}" = "null" ]; then
   echo "creating release"
 
+  COND_CREATE_DISCUSSION=""
+  PRERELEASE=true
+  if [[ ${CIRCLE_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    COND_CREATE_DISCUSSION="\"discussion_category_name\": \"announcement\","
+    PRERELEASE=false
+  fi
+
   RELEASE_DATA="{
     \"tag_name\": \"${CIRCLE_TAG}\",
     \"target_commitish\": \"${CIRCLE_SHA1}\",
-    \"discussion_category_name\": \"announcement\",
+    ${COND_CREATE_DISCUSSION}
     \"name\": \"${CIRCLE_TAG}\",
     \"body\": \"\",
-    \"prerelease\": false
+    \"prerelease\": ${PRERELEASE}
   }"
 
   # create it if it doesn't exist yet

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -32,6 +32,7 @@ if [ "${RELEASE_ID}" = "null" ]; then
   RELEASE_DATA="{
     \"tag_name\": \"${CIRCLE_TAG}\",
     \"target_commitish\": \"${CIRCLE_SHA1}\",
+    \"discussion_category_name\": \"announcement\",
     \"name\": \"${CIRCLE_TAG}\",
     \"body\": \"\",
     \"prerelease\": false
@@ -51,8 +52,9 @@ else
 fi
 
 RELEASE_UPLOAD_URL=`echo "${RELEASE_RESPONSE}" | jq -r '.upload_url' | cut -d'{' -f1`
+echo "Preparing to send artifacts to ${RELEASE_UPLOAD_URL}"
 
-bundles=(
+artifacts=(
   "lotus_${CIRCLE_TAG}_linux-amd64.tar.gz"
   "lotus_${CIRCLE_TAG}_linux-amd64.tar.gz.cid"
   "lotus_${CIRCLE_TAG}_linux-amd64.tar.gz.sha512"
@@ -60,9 +62,10 @@ bundles=(
   "lotus_${CIRCLE_TAG}_darwin-amd64.tar.gz.cid"
   "lotus_${CIRCLE_TAG}_darwin-amd64.tar.gz.sha512"
 )
-for RELEASE_FILE in "${bundles[@]}"
+
+for RELEASE_FILE in "${artifacts[@]}"
 do
-  echo "Uploading release bundle: ${RELEASE_FILE}"
+  echo "Uploading ${RELEASE_FILE}..."
   curl \
     --request POST \
     --header "Authorization: token ${GITHUB_TOKEN}" \
@@ -70,7 +73,7 @@ do
     --data-binary "@${RELEASE_FILE}" \
     "$RELEASE_UPLOAD_URL?name=$(basename "${RELEASE_FILE}")"
 
-  echo "Release bundle uploaded: ${RELEASE_FILE}"
+  echo "Uploaded ${RELEASE_FILE}"
 done
 
 popd


### PR DESCRIPTION
- updates build environment to latest Ubuntu LTS (20.04).
- creates discussion in "announcements" category when tag doesn't contain `-rc[0-9]+$`
- only marks tags which do have `-rc[0-9]+$` as pre-release releases
- includes more output in build during release posting for future troubleshooting

Contributions toward #6030 