### PR TITLE
manual deployment triggers

### DIFF
--- a/.github/workflows/trigger-devnet-reset.yaml
+++ b/.github/workflows/trigger-devnet-reset.yaml
@@ -1,0 +1,38 @@
+---
+name: trigger-devnet-reset
+on:
+  workflow_dispatch:
+    inputs:
+      override_tag:
+        description: "lotus tag"
+      lotus_install_network:
+        description: "network to build lotus tools"
+        default: "butterflynet"
+      lotus_deploy_network:
+        description: "network to find ansible host"
+        default: "butterfly.fildev.network"
+      slack_channel:
+        description: "the slack channel where notifications are sent"
+        default: "netops-circleci-test"
+      circle_branch:
+        description: "circleci branch (used for testing new lotus-infra deploy code)"
+        default: master
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: ${{ github.event.inputs.circle_branch }}
+          payload: |
+            {
+              "api_workflow_requested": "lotus-devnet-ansible-reset",
+              "override_tag": "${{ github.event.inputs.override_tag }}",
+              "lotus_install_network": "${{ github.event.inputs.lotus_install_network }}",
+              "lotus_deploy_network": "${{ github.event.inputs.lotus_deploy_network }}",
+              "slack_channel": "${{ github.event.inputs.slack_channel }}"
+            }

--- a/.github/workflows/trigger-devnet-reset.yaml
+++ b/.github/workflows/trigger-devnet-reset.yaml
@@ -13,7 +13,7 @@ on:
         default: "butterfly.fildev.network"
       slack_channel:
         description: "the slack channel where notifications are sent"
-        default: "netops-circleci-test"
+        default: "fil-infra-alerts"
       circle_branch:
         description: "circleci branch (used for testing new lotus-infra deploy code)"
         default: master

--- a/.github/workflows/trigger-devnet-upgrade.yaml
+++ b/.github/workflows/trigger-devnet-upgrade.yaml
@@ -10,7 +10,7 @@ on:
         default: "butterfly.fildev.network"
       slack_channel:
         description: "the slack channel where notifications are sent"
-        default: "netops-circleci-test"
+        default: "fil-infra-alerts"
       circle_branch:
         description: "circleci branch (used for testing new lotus-infra deploy code)"
         default: master

--- a/.github/workflows/trigger-devnet-upgrade.yaml
+++ b/.github/workflows/trigger-devnet-upgrade.yaml
@@ -1,0 +1,34 @@
+---
+name: trigger-devnet-upgrade
+on:
+  workflow_dispatch:
+    inputs:
+      override_tag:
+        description: "lotus tag"
+      lotus_deploy_network:
+        description: "network to find ansible host"
+        default: "butterfly.fildev.network"
+      slack_channel:
+        description: "the slack channel where notifications are sent"
+        default: "netops-circleci-test"
+      circle_branch:
+        description: "circleci branch (used for testing new lotus-infra deploy code)"
+        default: master
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: ${{ github.event.inputs.circle_branch }}
+          payload: |
+            {
+              "api_workflow_requested": "lotus-devnet-ansible-upgrade",
+              "override_tag": "${{ github.event.inputs.override_tag }}",
+              "lotus_deploy_network": "${{ github.event.inputs.lotus_deploy_network }}",
+              "slack_channel": "${{ github.event.inputs.slack_channel }}"
+            }

--- a/.github/workflows/trigger-helm-deploy.yaml
+++ b/.github/workflows/trigger-helm-deploy.yaml
@@ -2,6 +2,7 @@
 name: trigger-helm-deploy
 on:
   workflow_dispatch:
+    # Warn: workflow_dispatch events take a maximum of 10 inputs
     inputs:
       circle_context:
         description: "CI context for aws credentials"
@@ -30,12 +31,6 @@ on:
         description: "helm chart image.repository"
       override_tag:
         description: "helm chart image.tag"
-      slack_channel:
-        description: "the slack channel where notifications are sent"
-        default: "netops-circleci-test"
-      circle_branch:
-        description: "circleci branch (used for testing new lotus-infra deploy code)"
-        default: master
 
 jobs:
   trigger-circleci:
@@ -46,7 +41,7 @@ jobs:
         with:
           user-token: ${{ secrets.CIRCLE_TOKEN }}
           project-slug: filecoin-project/lotus-infra
-          branch: ${{ github.event.inputs.circle_branch }}
+          branch: master
           payload: |
             {
               "api_workflow_requested": "helm-deploy",
@@ -60,5 +55,5 @@ jobs:
               "helm_append": "${{ github.event.inputs.helm_append }}",
               "override_repository": "${{ github.event.inputs.override_repository }}",
               "override_tag": "${{ github.event.inputs.override_tag }}",
-              "slack_channel": "${{ github.event.inputs.slack_channel }}"
+              "slack_channel": "netops-circleci-test"
             }

--- a/.github/workflows/trigger-helm-deploy.yaml
+++ b/.github/workflows/trigger-helm-deploy.yaml
@@ -1,0 +1,48 @@
+---
+name: trigger-helm-deploy
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "kubernetes namespace"
+      release:
+        description: "helm release"
+      chart:
+        description: "the helm chart"
+      chart_version:
+        description: "the helm chart version"
+      helm_append:
+        description: "append this to the end of the helm command (i.e to add more -set's)"
+      override_repository:
+        description: "helm chart image.repository"
+      override_tag:
+        description: "helm chart image.tag"
+      slack_channel:
+        description: "the slack channel where notifications are sent"
+        default: "netops-circleci-test"
+      circle_branch:
+        description: "circleci branch (used for testing new lotus-infra deploy code)"
+        default: master
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: ${{ github.event.inputs.circle_branch }}
+          payload: |
+            {
+              "api_workflow_requested": "helm-deploy",
+              "namespace": "${{ github.event.inputs.namespace }}",
+              "release": "${{ github.event.inputs.release }}",
+              "chart": "${{ github.event.inputs.chart }}",
+              "chart_version": "${{ github.event.inputs.chart_version }}",
+              "helm_append": "${{ github.event.inputs.helm_append }}",
+              "override_repository": "${{ github.event.inputs.override_repository }}",
+              "override_tag": "${{ github.event.inputs.override_tag }}",
+              "slack_channel": "${{ github.event.inputs.slack_channel }}"
+            }

--- a/.github/workflows/trigger-helm-deploy.yaml
+++ b/.github/workflows/trigger-helm-deploy.yaml
@@ -3,14 +3,27 @@ name: trigger-helm-deploy
 on:
   workflow_dispatch:
     inputs:
+      circle_context:
+        description: "CI context for aws credentials"
+        default: "sentinel-staging-deploy"
+      kubernetes_cluster:
+        description: "kubernetes cluster"
+        default: "mainnet-us-east-2-dev-eks"
+      aws_region:
+        description: "aws region"
+        default: "us-east-2"
       namespace:
         description: "kubernetes namespace"
+        default: "ntwk-butterfly-fullnode"
       release:
         description: "helm release"
+        default: "fullnode-0"
       chart:
         description: "the helm chart"
+        default: "filecoin/lotus-fullnode"
       chart_version:
         description: "the helm chart version"
+        default: "0.3.2"
       helm_append:
         description: "append this to the end of the helm command (i.e to add more -set's)"
       override_repository:
@@ -19,7 +32,7 @@ on:
         description: "helm chart image.tag"
       slack_channel:
         description: "the slack channel where notifications are sent"
-        default: "fil-infra-alerts"
+        default: "netops-circleci-test"
       circle_branch:
         description: "circleci branch (used for testing new lotus-infra deploy code)"
         default: master
@@ -37,6 +50,9 @@ jobs:
           payload: |
             {
               "api_workflow_requested": "helm-deploy",
+              "circle_context": "${{ github.event.inputs.circle_context }}",
+              "kubernetes_cluster": "${{ github.event.inputs.kubernetes_cluster }}",
+              "aws_region": "${{ github.event.inputs.aws_region }}",
               "namespace": "${{ github.event.inputs.namespace }}",
               "release": "${{ github.event.inputs.release }}",
               "chart": "${{ github.event.inputs.chart }}",

--- a/.github/workflows/trigger-helm-deploy.yaml
+++ b/.github/workflows/trigger-helm-deploy.yaml
@@ -19,7 +19,7 @@ on:
         description: "helm chart image.tag"
       slack_channel:
         description: "the slack channel where notifications are sent"
-        default: "netops-circleci-test"
+        default: "fil-infra-alerts"
       circle_branch:
         description: "circleci branch (used for testing new lotus-infra deploy code)"
         default: master

--- a/.github/workflows/trigger-lotus-rollout.yaml
+++ b/.github/workflows/trigger-lotus-rollout.yaml
@@ -1,0 +1,29 @@
+---
+name: trigger-lotus-rollout
+on:
+  workflow_dispatch:
+    inputs:
+      override_tag:
+        description: "lotus tag"
+      slack_channel:
+        description: "the slack channel where notifications are sent"
+        default: "netops-circleci-test"
+      circle_branch:
+        description: "circleci branch (used for testing new lotus-infra deploy code)"
+        default: master
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: ${{ github.event.inputs.circle_branch }}
+          payload: |
+            {
+              "override_tag": "${{ github.event.inputs.override_tag }}",
+              "slack_channel": "${{ github.event.inputs.slack_channel }}"
+            }

--- a/.github/workflows/trigger-lotus-rollout.yaml
+++ b/.github/workflows/trigger-lotus-rollout.yaml
@@ -7,7 +7,7 @@ on:
         description: "lotus tag"
       slack_channel:
         description: "the slack channel where notifications are sent"
-        default: "netops-circleci-test"
+        default: "fil-infra-alerts"
       circle_branch:
         description: "circleci branch (used for testing new lotus-infra deploy code)"
         default: master


### PR DESCRIPTION
This creates a UI in the github actions interface to handle deployments.


1. helm-deploy can be used to deploy kubernetes deployments. For example, the lotus-gateway can be deployed this way.
2. devnet-upgrade upgrades the binaries of a devnet without doing a network reset.
3. devnet-reset upgrades devnet binaries and also resets the network
4. lotus-rollout is a combination of helm deploy and reset which is intended to be executed as part of the release pipeline. 


These github actions are triggered manually. Each of these actions trigger messages in chat and the progress can be followed as described in https://docs.google.com/document/d/1tEw6_y42VVpAdrevsNXV16k0Oxh2TlmV4ywfi6pn-rw/edit


Here is what the github action looks like when starting it manually:


![action](https://user-images.githubusercontent.com/8444698/118348795-7fe15280-b501-11eb-88e7-58a1f79d9e63.png)

I'll submit a separate for automaticly starting actions like this during release.