### PR TITLE
rollout on release

### DIFF
--- a/.github/workflows/rollout-on-release.yaml
+++ b/.github/workflows/rollout-on-release.yaml
@@ -1,0 +1,27 @@
+---
+
+name: rollout on release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: trigger deploy
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: ${{ github.event.inputs.circle_branch }}
+          payload: |
+            {
+              "override_tag": "${{ steps.get_version.VERSION }}",
+              "slack_channel": "fil-infra-alerts"
+            }


### PR DESCRIPTION
This is an automaticly-executed trigger of the "rollout" workflow. It should be have the same as the trigger-lotus-rollout job, except this one will be executed when a release is created.

See here for the manual deployment.

see https://github.com/filecoin-project/lotus/pull/6263 for the manual trigger for this workflow.

