### PR TITLE
Allow 8MB sectors in devnet

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -44,7 +44,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 }
 
 func init() {
-	policy.SetSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1)
+	policy.SetSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1, abi.RegisteredSealProof_StackedDrg8MiBV1)
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(2048))
 	policy.SetMinVerifiedDealSize(abi.NewStoragePower(256))
 	policy.SetPreCommitChallengeDelay(abi.ChainEpoch(10))


### PR DESCRIPTION
This allows us to run a local devnet with 8MB sectors:
```
make debug && rm -rf ~/.devLotus && export LOTUS_PATH=~/.devLotus && rm -rf localnet.json &&  ./lotus-seed genesis new localnet.json  && ./lotus-seed pre-seal --sector-size 8388608 --num-sectors 2 && ./lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json && clear && ./lotus daemon --lotus-make-genesis=dev.gen --genesis-template=localnet.json --bootstrap=false
```

```
rm -rf ~/.lotusminer && export LOTUS_PATH=~/.devLotus && ./lotus wallet import ~/.genesis-sectors/pre-seal-t01000.key && ./lotus-miner init --genesis-miner --actor=t01000 --sector-size=8388608 --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync && ./lotus-miner run --nosync
```