### PR TITLE
separate tracing environment variables

### DIFF
--- a/documentation/en/jaeger-tracing.md
+++ b/documentation/en/jaeger-tracing.md
@@ -12,7 +12,20 @@ Currently it is set up to use Jaeger, though other tracing backends should be fa
 
 To easily run and view tracing locally, first, install jaeger. The easiest way to do this is to [download the binaries](https://www.jaegertracing.io/download/) and then run the `jaeger-all-in-one` binary. This will start up jaeger, listen for spans on `localhost:6831`, and expose a web UI for viewing traces on `http://localhost:16686/`.
 
-Now, to start sending traces from Lotus to Jaeger, set the environment variable `LOTUS_JAEGER` to `localhost:6831`, and start the `lotus daemon`.
+Now, to start sending traces from Lotus to Jaeger, set the environment variable and start the daemon.
+
+```bash
+export LOTUS_JAEGER_AGENT_ENDPOINT=127.0.0.1:6831
+lotus daemon
+```
+
+Alternatively, the agent endpoint can also be configured by a pair of environemnt variables to provide the host and port. The following snipit is functionally equivilent to the previous.
+
+```bash
+export LOTUS_JAEGER_AGENT_HOST=127.0.0.1
+export LOTUS_JAEGER_AGENT_PORT=6831
+lotus daemon
+```
 
 Now, to view any generated traces, open up `http://localhost:16686/` in your browser.
 

--- a/lib/tracing/setup.go
+++ b/lib/tracing/setup.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"os"
+	"strings"
 
 	"contrib.go.opencensus.io/exporter/jaeger"
 	logging "github.com/ipfs/go-log/v2"
@@ -10,17 +11,61 @@ import (
 
 var log = logging.Logger("tracing")
 
-func SetupJaegerTracing(serviceName string) *jaeger.Exporter {
+const (
+	// environment variable names
+	envCollectorEndpoint = "LOTUS_JAEGER_COLLECTOR_ENDPOINT"
+	envAgentEndpoint     = "LOTUS_JAEGER_AGENT_ENDPOINT"
+	envAgentHost         = "LOTUS_JAEGER_AGENT_HOST"
+	envAgentPort         = "LOTUS_JAEGER_AGENT_PORT"
+	envUsername          = "LOTUS_JAEGER_USERNAME"
+	envPassword          = "LOTUS_JAEGER_PASSWORD"
+)
 
-	if _, ok := os.LookupEnv("LOTUS_JAEGER"); !ok {
+// When sending directly to the collector, agent options are ignored.
+// The collector endpoint is an HTTP or HTTPs URL.
+// The agent endpoint is a thrift/udp protocol given like "hostname:port"
+// or separate host and port environment variables.
+func jaegerOptsFromEnv(opts *jaeger.Options) bool {
+	var e string
+	var ok bool
+	if e, ok = os.LookupEnv(envUsername); ok {
+		if p, ok := os.LookupEnv(envPassword); ok {
+			opts.Username = e
+			opts.Password = p
+		} else {
+			log.Warn("jaeger username supplied with no password. authentication will not be used.")
+		}
+	}
+	if e, ok = os.LookupEnv(envCollectorEndpoint); ok {
+		opts.CollectorEndpoint = e
+		log.Infof("jaeger tracess will send to collector %s", e)
+		return true
+	}
+	if e, ok = os.LookupEnv(envAgentEndpoint); ok {
+		log.Infof("jaeger traces will be sent to agent %s", e)
+		opts.AgentEndpoint = e
+		return true
+	}
+	if e, ok = os.LookupEnv(envAgentHost); ok {
+		if p, ok := os.LookupEnv(envAgentPort); ok {
+			opts.AgentEndpoint = strings.Join([]string{e, p}, ":")
+		} else {
+			opts.AgentEndpoint = strings.Join([]string{e, "6831"}, ":")
+		}
+		log.Infof("jaeger traces will be sent to agent %s", opts.AgentEndpoint)
+		return true
+	}
+	log.Infof("jaeger tracing is not configured.")
+	return false
+}
+
+func SetupJaegerTracing(serviceName string) *jaeger.Exporter {
+	opts := jaeger.Options{}
+	if !jaegerOptsFromEnv(&opts) {
 		return nil
 	}
-	agentEndpointURI := os.Getenv("LOTUS_JAEGER")
-
-	je, err := jaeger.NewExporter(jaeger.Options{
-		AgentEndpoint: agentEndpointURI,
-		ServiceName:   serviceName,
-	})
+	opts.ServiceName = serviceName
+	je, err := jaeger.NewExporter(opts)
 	if err != nil {
 		log.Errorw("Failed to create the Jaeger exporter", "error", err)
 		return nil

--- a/lib/tracing/setup.go
+++ b/lib/tracing/setup.go
@@ -17,19 +17,20 @@ const (
 	envAgentEndpoint     = "LOTUS_JAEGER_AGENT_ENDPOINT"
 	envAgentHost         = "LOTUS_JAEGER_AGENT_HOST"
 	envAgentPort         = "LOTUS_JAEGER_AGENT_PORT"
-	envUsername          = "LOTUS_JAEGER_USERNAME"
-	envPassword          = "LOTUS_JAEGER_PASSWORD"
+	envJaegerUser        = "LOTUS_JAEGER_USERNAME"
+	envJaegerCred        = "LOTUS_JAEGER_PASSWORD"
 )
 
 // When sending directly to the collector, agent options are ignored.
 // The collector endpoint is an HTTP or HTTPs URL.
-// The agent endpoint is a thrift/udp protocol given like "hostname:port"
-// or separate host and port environment variables.
+// The agent endpoint is a thrift/udp protocol and should be given
+// as a string like "hostname:port". The agent can also be configured
+// with separate host and port variables.
 func jaegerOptsFromEnv(opts *jaeger.Options) bool {
 	var e string
 	var ok bool
-	if e, ok = os.LookupEnv(envUsername); ok {
-		if p, ok := os.LookupEnv(envPassword); ok {
+	if e, ok = os.LookupEnv(envJaegerUser); ok {
+		if p, ok := os.LookupEnv(envJaegerCred); ok {
 			opts.Username = e
 			opts.Password = p
 		} else {
@@ -67,7 +68,7 @@ func SetupJaegerTracing(serviceName string) *jaeger.Exporter {
 	opts.ServiceName = serviceName
 	je, err := jaeger.NewExporter(opts)
 	if err != nil {
-		log.Errorw("Failed to create the Jaeger exporter", "error", err)
+		log.Errorw("failed to create the jaeger exporter", "error", err)
 		return nil
 	}
 


### PR DESCRIPTION
The reason for this PR is to make it easier to setup metrics in kubernetes environments.

in kubernetes, the IP address of the agent is not known until the pod starts, after which it can be made available as an environment variable. By that time, it is too late to append the port number.  When the agent endpoint is read in with a single environment variable, the best you can do is combine the host and port numbers as a bash script prior to starting lotus.

With this PR, the agent host and port can be read in with two environment variables without any bash shenanigans. 

Also, I added environment variables to support jaeger authentication, or sending directly to the collector.