### PR TITLE
Remove log line when tracing is not configured

### DIFF
--- a/lib/tracing/setup.go
+++ b/lib/tracing/setup.go
@@ -56,7 +56,6 @@ func jaegerOptsFromEnv(opts *jaeger.Options) bool {
 		log.Infof("jaeger traces will be sent to agent %s", opts.AgentEndpoint)
 		return true
 	}
-	log.Infof("jaeger tracing is not configured.")
 	return false
 }
 


### PR DESCRIPTION
This line was printed for commands where it was not relevant. This way, logs about tracing will only appear when they are enabled.