### PR TITLE
Reduce noise from 'peer has different genesis' messages

### DIFF
--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -77,7 +77,7 @@ func (hs *Service) HandleStream(s inet.Stream) {
 		"hash", hmsg.GenesisHash)
 
 	if hmsg.GenesisHash != hs.syncer.Genesis.Cids()[0] {
-		log.Warnf("other peer has different genesis! (%s)", hmsg.GenesisHash)
+		log.Debugf("other peer has different genesis! (%s)", hmsg.GenesisHash)
 		_ = s.Conn().Close()
 		return
 	}


### PR DESCRIPTION
After the unification of all networks behind a build-tag, the amount of these
warnings has risen sharply. Reduce it to a debug-level, since it isn't actionable
to an operator.