### PR TITLE
lotus-gateway: add check command

### DIFF
--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -8,13 +8,17 @@ import (
 	"os"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/gateway"
+	"github.com/gorilla/mux"
+	logging "github.com/ipfs/go-log/v2"
 	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-jsonrpc"
 
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/client"
@@ -23,15 +27,9 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
-	"github.com/filecoin-project/lotus/cli/util"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
 	"github.com/filecoin-project/lotus/metrics"
-
-	logging "github.com/ipfs/go-log/v2"
-	"go.opencensus.io/stats/view"
-
-	"github.com/gorilla/mux"
-	"github.com/urfave/cli/v2"
 )
 
 var log = logging.Logger("gateway")

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -13,11 +14,16 @@ import (
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/tag"
 
+	"github.com/filecoin-project/go-address"
+
 	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/client"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
 	"github.com/filecoin-project/lotus/metrics"
 
@@ -35,6 +41,7 @@ func main() {
 
 	local := []*cli.Command{
 		runCmd,
+		checkCmd,
 	}
 
 	app := &cli.App{
@@ -54,9 +61,58 @@ func main() {
 	app.Setup()
 
 	if err := app.Run(os.Args); err != nil {
-		log.Warnf("%+v", err)
+		log.Errorf("%+v", err)
+		os.Exit(1)
 		return
 	}
+}
+
+var checkCmd = &cli.Command{
+	Name:      "check",
+	Usage:     "performs a simple check to verify that a connection can be made to a gateway",
+	ArgsUsage: "[apiInfo]",
+	Description: `Any valid value for FULLNODE_API_INFO is a valid argument to the check command.
+
+   Examples
+   - ws://127.0.0.1:2346
+   - http://127.0.0.1:2346
+   - /ip4/127.0.0.1/tcp/2346`,
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		ctx := lcli.ReqContext(cctx)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ainfo := cliutil.ParseApiInfo(cctx.Args().First())
+
+		darg, err := ainfo.DialArgs("v1")
+		if err != nil {
+			return err
+		}
+
+		api, closer, err := client.NewFullNodeRPCV1(ctx, darg, nil)
+		if err != nil {
+			return err
+		}
+
+		defer closer()
+
+		addr, err := address.NewIDAddress(100)
+		if err != nil {
+			return err
+		}
+
+		laddr, err := api.StateLookupID(ctx, addr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		if laddr != addr {
+			return fmt.Errorf("looked up addresses does not match returned address, %s != %s", addr, laddr)
+		}
+
+		return nil
+	},
 }
 
 var runCmd = &cli.Command{


### PR DESCRIPTION
The check command provides a quick way to try out different transports and verify that a connection can be made to a running gateway.