### PR TITLE
testplans: lotus-soup: use default WPoStChallengeWindow

### DIFF
--- a/testplans/Makefile
+++ b/testplans/Makefile
@@ -6,18 +6,18 @@ download-proofs:
 	go run github.com/filecoin-project/go-paramfetch/paramfetch 2048 ./docker-images/proof-parameters.json
 
 build-images:
-	docker build -t "iptestground/oni-buildbase:v14-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
-	docker build -t "iptestground/oni-runtime:v9" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
-	docker build -t "iptestground/oni-runtime:v9-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
+	docker build -t "iptestground/oni-buildbase:v15-lotus" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
+	docker build -t "iptestground/oni-runtime:v10" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
+	docker build -t "iptestground/oni-runtime:v10-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
 
 push-images:
-	docker push iptestground/oni-buildbase:v14-lotus
-	docker push iptestground/oni-runtime:v9
-	docker push iptestground/oni-runtime:v9-debug
+	docker push iptestground/oni-buildbase:v15-lotus
+	docker push iptestground/oni-runtime:v10
+	docker push iptestground/oni-runtime:v10-debug
 
 pull-images:
-	docker pull iptestground/oni-buildbase:v14-lotus
-	docker pull iptestground/oni-runtime:v9
-	docker pull iptestground/oni-runtime:v9-debug
+	docker pull iptestground/oni-buildbase:v15-lotus
+	docker pull iptestground/oni-runtime:v10
+	docker pull iptestground/oni-runtime:v10-debug
 
 .PHONY: download-proofs build-images push-images pull-images

--- a/testplans/docker-images/Dockerfile.oni-buildbase
+++ b/testplans/docker-images/Dockerfile.oni-buildbase
@@ -4,7 +4,7 @@ FROM golang:${GO_VERSION}-buster
 
 RUN apt-get update && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev jq gcc git pkg-config bzr libhwloc-dev
 
-ARG FILECOIN_FFI_COMMIT=d82899449741ce190e950a3582ebe33806f018a9
+ARG FILECOIN_FFI_COMMIT=8b97bd8230b77bd32f4f27e4766a6d8a03b4e801
 ARG FFI_DIR=/extern/filecoin-ffi
 
 RUN mkdir -p ${FFI_DIR} \

--- a/testplans/docker-images/Dockerfile.oni-runtime-debug
+++ b/testplans/docker-images/Dockerfile.oni-runtime-debug
@@ -12,7 +12,7 @@ RUN go get github.com/filecoin-project/go-paramfetch/paramfetch@master
 COPY /proof-parameters.json /
 RUN paramfetch 8388608 /proof-parameters.json
 
-ARG LOTUS_COMMIT=7e25a811c3d80ea3e007a54aa1da089985110c2c
+ARG LOTUS_COMMIT=b8deee048eaf850113e8626a73f64b17ba69a9f6
 
 ## for debug purposes
 RUN apt update && apt install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config libhwloc-dev curl && git clone https://github.com/filecoin-project/lotus.git && cd lotus/ && git checkout ${LOTUS_COMMIT} && make clean && make all && make install

--- a/testplans/lotus-soup/init.go
+++ b/testplans/lotus-soup/init.go
@@ -42,7 +42,7 @@ func init() {
 	// deadline when the challenge is available.
 	//
 	// This will auto-scale the proving period.
-	policy.SetWPoStChallengeWindow(abi.ChainEpoch(5))
+	// policy.SetWPoStChallengeWindow(abi.ChainEpoch(5)) // commented-out until we enable PoSt faults tests
 
 	// Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn
 	// used to ensure it is not predictable by miner.

--- a/testplans/lotus-soup/manifest.toml
+++ b/testplans/lotus-soup/manifest.toml
@@ -9,8 +9,8 @@ enabled = true
 
 [builders."docker:go"]
 enabled = true
-build_base_image = "iptestground/oni-buildbase:v14-lotus"
-runtime_image = "iptestground/oni-runtime:v9-debug"
+build_base_image = "iptestground/oni-buildbase:v15-lotus"
+runtime_image = "iptestground/oni-runtime:v10-debug"
 
 [runners."local:exec"]
 enabled = true


### PR DESCRIPTION
This PR is:
1. Updating `lotus-soup` initialisation to not scale down the `WPoStChallengeWindow` - this results in preseal sectors in the bootstrapper node to fail the minimum deal duration validation (see https://github.com/filecoin-project/lotus/pull/6379). Given that we don't test PoSt faults at the moment, we don't really need to scale this window down at this stage. As soon as we introduce tests for faults, we will need to decide how to speed up the tests - either by using a fake clock, or by reducing these windows.

2. Updating the base and runtime docker images, that include the latest `filecoin-ffi` lib.

---

Tests are passing at: https://ci.testground.ipfs.team/tasks#taskID_c2uu7gt5p7ae493pkipg