### PR TITLE
Commit and Precommit batcher cannot share a getSectorDeadline method

### DIFF
--- a/build/params_nerpanet.go
+++ b/build/params_nerpanet.go
@@ -41,7 +41,7 @@ const UpgradeOrangeHeight = 300
 
 const UpgradeTrustHeight = 600
 const UpgradeNorwegianHeight = 201000
-const UpgradeActorsV4Height = 203000
+const UpgradeTurboHeight = 203000
 const UpgradeHyperdriveHeight = 999999999
 
 func init() {

--- a/extern/storage-sealing/commit_batch.go
+++ b/extern/storage-sealing/commit_batch.go
@@ -456,17 +456,17 @@ func (b *CommitBatcher) Stop(ctx context.Context) error {
 	}
 }
 
+// TODO: If this returned epochs, it would make testing much easier
 func (b *CommitBatcher) getCommitCutoff(si SectorInfo) (time.Time, error) {
 	tok, curEpoch, err := b.api.ChainHead(b.mctx)
 	if err != nil {
-		log.Errorf("getting chain head: %s", err)
-		return time.Now(), nil
+		return time.Now(), xerrors.Errorf("getting chain head: %s", err)
 	}
 
 	nv, err := b.api.StateNetworkVersion(b.mctx, tok)
 	if err != nil {
 		log.Errorf("getting network version: %s", err)
-		return time.Now(), err
+		return time.Now(), xerrors.Errorf("getting network version: %s", err)
 	}
 
 	pci, err := b.api.StateSectorPreCommitInfo(b.mctx, b.maddr, si.SectorNumber, tok)

--- a/extern/storage-sealing/precommit_batch.go
+++ b/extern/storage-sealing/precommit_batch.go
@@ -334,6 +334,7 @@ func (b *PreCommitBatcher) Stop(ctx context.Context) error {
 	}
 }
 
+// TODO: If this returned epochs, it would make testing much easier
 func getPreCommitCutoff(curEpoch abi.ChainEpoch, si SectorInfo) time.Time {
 	cutoffEpoch := si.TicketEpoch + policy.MaxPreCommitRandomnessLookback
 	for _, p := range si.Pieces {


### PR DESCRIPTION
Fixes #6412 

Two commits:

- Rename "deadlines" as requested by @jennijuju to avoid confusion with window post deadlines
- Split the `getSectorCutoff` methods between precommit and commit batchers