### PR TITLE
Update chain list with correct help instructions

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -536,7 +536,7 @@ var ChainListCmd = &cli.Command{
 	Aliases: []string{"love"},
 	Usage:   "View a segment of the chain",
 	Flags: []cli.Flag{
-		&cli.Uint64Flag{Name: "height"},
+		&cli.Uint64Flag{Name: "height", DefaultText: "current head"},
 		&cli.IntFlag{Name: "count", Value: 30},
 		&cli.StringFlag{
 			Name:  "format",


### PR DESCRIPTION
Fixes #6293, changes the help text from (Default: 0) to (Default: current head)