### PR TITLE
Test multicore SDR support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ jobs:
       deadline-test:
         type: string
         default: "0"
+      proofs-log-test:
+        type: string
+        default: "0"
       test-suite-name:
         type: string
         default: unit
@@ -167,6 +170,7 @@ jobs:
           environment:
             LOTUS_TEST_WINDOW_POST: << parameters.winpost-test >>
             LOTUS_TEST_DEADLINE_TOGGLING: << parameters.deadline-test >>
+            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
             SKIP_CONFORMANCE: "1"
           command: |
             mkdir -p /tmp/test-reports/<< parameters.test-suite-name >>
@@ -211,6 +215,8 @@ jobs:
   test-deadline-toggling:
     <<: *test
   test-terminate:
+    <<: *test
+  check-proofs-multicore-sdr:
     <<: *test
   test-conformance:
     description: |
@@ -815,6 +821,12 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - check-proofs-multicore-sdr:
+          codecov-upload: true
+          go-test-flags: "-run=TestMulticoreSDR"
+          test-suite-name: multicore-sdr-check
+          packages: "./extern/sector-storage/ffiwrapper"
+          proofs-log-test: "1"
       - test-conformance:
           test-suite-name: conformance
           packages: "./conformance"

--- a/extern/sector-storage/ffiwrapper/sealer_test.go
+++ b/extern/sector-storage/ffiwrapper/sealer_test.go
@@ -882,11 +882,11 @@ func setupLogger(t *testing.T) *bytes.Buffer {
 }
 
 func TestMulticoreSDR(t *testing.T) {
-	rustLogger := setupLogger(t)
-
 	if os.Getenv("TEST_RUSTPROOFS_LOGS") != "1" {
 		t.Skip("skipping test without TEST_RUSTPROOFS_LOGS=1")
 	}
+
+	rustLogger := setupLogger(t)
 
 	getGrothParamFileAndVerifyingKeys(sectorSize)
 

--- a/extern/sector-storage/ffiwrapper/sealer_test.go
+++ b/extern/sector-storage/ffiwrapper/sealer_test.go
@@ -883,8 +883,8 @@ func TestAddPiece512MPadded(t *testing.T) {
 }
 
 func TestMulticoreSDR(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
+	if os.Getenv("TEST_RUSTPROOFS_LOGS") != "1" {
+		t.Skip("skipping test without TEST_RUSTPROOFS_LOGS=1")
 	}
 
 	getGrothParamFileAndVerifyingKeys(sectorSize)


### PR DESCRIPTION
This test works when run individually, but broken when it runs with any other tests as proofs expect the call to FilInitLogFd to be the very first proofs call.

Probably acceptable to work around by just running this test individually in a separate step on Circle