### PR TITLE
sealing: Fix restartSectors race

### DIFF
--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -514,6 +514,8 @@ func planCommitting(events []statemachine.Event, state *SectorInfo) (uint64, err
 }
 
 func (m *Sealing) restartSectors(ctx context.Context) error {
+	defer m.startupWait.Done()
+
 	trackedSectors, err := m.ListSectors()
 	if err != nil {
 		log.Errorf("loading sector list: %+v", err)
@@ -531,6 +533,7 @@ func (m *Sealing) restartSectors(ctx context.Context) error {
 }
 
 func (m *Sealing) ForceSectorState(ctx context.Context, id abi.SectorNumber, state SectorState) error {
+	m.startupWait.Wait()
 	return m.sectors.Send(id, SectorForceState{state})
 }
 

--- a/extern/storage-sealing/garbage.go
+++ b/extern/storage-sealing/garbage.go
@@ -9,6 +9,8 @@ import (
 )
 
 func (m *Sealing) PledgeSector(ctx context.Context) (storage.SectorRef, error) {
+	m.startupWait.Wait()
+
 	m.inputLk.Lock()
 	defer m.inputLk.Unlock()
 

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -376,6 +376,8 @@ func (m *Sealing) updateInput(ctx context.Context, sp abi.RegisteredSealProof) e
 }
 
 func (m *Sealing) tryCreateDealSector(ctx context.Context, sp abi.RegisteredSealProof) error {
+	m.startupWait.Wait()
+
 	cfg, err := m.getConfig()
 	if err != nil {
 		return xerrors.Errorf("getting storage config: %w", err)
@@ -422,6 +424,8 @@ func (m *Sealing) createSector(ctx context.Context, cfg sealiface.Config, sp abi
 }
 
 func (m *Sealing) StartPacking(sid abi.SectorNumber) error {
+	m.startupWait.Wait()
+
 	return m.sectors.Send(uint64(sid), SectorStartPacking{})
 }
 


### PR DESCRIPTION
This caused TestDeadlineToggling (and likely other tests which pledged a bunch of sectors just after startup) to hang.

What happened was that before `Sealing.restartSectors` would run, some other place would start pledging a new sector, which would result in `restartSectors` sending a `SectorRestart` event, which would cause us to execute the sectors state planer twice, which then would result in the state planner getting duplicate events in wrong states.