### PR TITLE
Refactor deadline toggling test to kit2

### DIFF
--- a/itests/deadlines_test.go
+++ b/itests/deadlines_test.go
@@ -26,7 +26,6 @@ import (
 	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,11 +56,8 @@ func TestDeadlineToggling(t *testing.T) {
 	if os.Getenv("LOTUS_TEST_DEADLINE_TOGGLING") != "1" {
 		t.Skip("this takes a few minutes, set LOTUS_TEST_DEADLINE_TOGGLING=1 to run")
 	}
-	_ = logging.SetLogLevel("miner", "ERROR")
-	_ = logging.SetLogLevel("chainstore", "ERROR")
-	_ = logging.SetLogLevel("chain", "ERROR")
-	_ = logging.SetLogLevel("sub", "ERROR")
-	_ = logging.SetLogLevel("storageminer", "FATAL")
+
+	kit2.QuietMiningLogs()
 
 	const sectorsC, sectorsD, sectorsB = 10, 9, 8
 

--- a/itests/kit2/ensemble_opts.go
+++ b/itests/kit2/ensemble_opts.go
@@ -23,8 +23,8 @@ type ensembleOpts struct {
 }
 
 var DefaultEnsembleOpts = ensembleOpts{
-	pastOffset: 10000000 * time.Second, // time sufficiently in the past to trigger catch-up mining.
-	proofType:  abi.RegisteredSealProof_StackedDrg2KiBV1,
+	pastOffset: 10000000 * time.Second,                     // time sufficiently in the past to trigger catch-up mining.
+	proofType:  abi.RegisteredSealProof_StackedDrg2KiBV1_1, // default _concrete_ proof type for non-genesis miners (notice the _1).
 }
 
 func ProofType(proofType abi.RegisteredSealProof) EnsembleOpt {

--- a/itests/kit2/node_opts.go
+++ b/itests/kit2/node_opts.go
@@ -14,6 +14,8 @@ import (
 // PresealSectors option.
 const DefaultPresealsPerBootstrapMiner = 2
 
+const TestSpt = abi.RegisteredSealProof_StackedDrg2KiBV1_1
+
 // nodeOpts is an options accumulating struct, where functional options are
 // merged into.
 type nodeOpts struct {

--- a/itests/kit2/node_opts_nv.go
+++ b/itests/kit2/node_opts_nv.go
@@ -87,5 +87,4 @@ func SDRUpgradeAt(calico, persian abi.ChainEpoch) node.Option {
 		Network: network.Version8,
 		Height:  persian,
 	}})
-
 }

--- a/itests/kit2/node_opts_nv.go
+++ b/itests/kit2/node_opts_nv.go
@@ -58,10 +58,8 @@ func InstantaneousNetworkVersion(version network.Version) node.Option {
 }
 
 func NetworkUpgradeAt(version network.Version, upgradeHeight abi.ChainEpoch) node.Option {
-	fullSchedule := stmgr.UpgradeSchedule{}
-
 	schedule := stmgr.UpgradeSchedule{}
-	for _, upgrade := range fullSchedule {
+	for _, upgrade := range DefaultTestUpgradeSchedule {
 		if upgrade.Network > version {
 			break
 		}


### PR DESCRIPTION
Fails with
```
2021-06-17T14:56:17.610+0200	WARN	vm	vm/runtime.go:350	Abortf: failed to construct initial miner info: invalid partition sectors: unsupported proof type: 0
```

I'm not sure why because proof type 0 is RegisteredSealProof_StackedDrg2KiBV1, which is registered in the init method:
https://github.com/filecoin-project/lotus/blob/2c30ac394daa1706a1c75fcedeea4df90556dd95/itests/kit2/init.go#L17