### PR TITLE
extern/storage: add ability to ignore worker resources when scheduling.

### DIFF
--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -96,6 +96,10 @@ type SealerConfig struct {
 	AllowPreCommit2 bool
 	AllowCommit     bool
 	AllowUnseal     bool
+
+	// IgnoreResourceFiltering instructs the system to ignore available
+	// resources when assigning tasks to the local worker.
+	IgnoreResourceFiltering bool
 }
 
 type StorageAuth http.Header

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -18,7 +18,12 @@ import (
 type WorkerInfo struct {
 	Hostname string
 
-	Resources WorkerResources
+	// IgnoreResources indicates whether the worker's available resources should
+	// be used ignored (true) or used (false) for the purposes of scheduling and
+	// task assignment. Only supported on local workers. Used for testing.
+	// Default should be false (zero value, i.e. resources taken into account).
+	IgnoreResources bool
+	Resources       WorkerResources
 }
 
 type WorkerResources struct {

--- a/itests/kit/node_builder.go
+++ b/itests/kit/node_builder.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/lotus/node/config"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -126,6 +127,12 @@ func CreateTestStorageNode(ctx context.Context, t *testing.T, waddr address.Addr
 
 		node.Override(new(v1api.FullNode), tnd),
 		node.Override(new(*lotusminer.Miner), lotusminer.NewTestMiner(mineBlock, act)),
+
+		node.Override(new(*sectorstorage.SealerConfig), func() *sectorstorage.SealerConfig {
+			scfg := config.DefaultStorageMiner()
+			scfg.Storage.IgnoreResourceFiltering = true
+			return &scfg.Storage
+		}),
 
 		opts,
 	)
@@ -532,6 +539,11 @@ func mockMinerBuilderOpts(t *testing.T, fullOpts []FullNodeOpts, storage []Stora
 			node.Override(new(sectorstorage.SectorManager), node.From(new(*mock.SectorMgr))),
 			node.Override(new(sectorstorage.Unsealer), node.From(new(*mock.SectorMgr))),
 			node.Override(new(sectorstorage.PieceProvider), node.From(new(*mock.SectorMgr))),
+			node.Override(new(*sectorstorage.SealerConfig), func() *sectorstorage.SealerConfig {
+				scfg := config.DefaultStorageMiner()
+				scfg.Storage.IgnoreResourceFiltering = true
+				return &scfg.Storage
+			}),
 
 			node.Override(new(ffiwrapper.Verifier), mock.MockVerifier),
 			node.Override(new(ffiwrapper.Prover), mock.MockProver),


### PR DESCRIPTION
This deflakes tests on some platforms. In some cases, the dev/test workstation may be overcommitted and swapping, and the memory available check performed during scheduling may fail. On macOS this reports a MemoryReserved larger than MemoryPhysical, and Lotus fails to schedule the task.

This introduces a worker configuration option to instruct the scheduler to ignore resources when scheduling tasks. It is intended to be used only in testing.