### PR TITLE
Fix helptext

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -308,8 +308,8 @@ var clientDealCmd = &cli.Command{
 	Description: `Make a deal with a miner.
 dataCid comes from running 'lotus client import'.
 miner is the address of the miner you wish to make a deal with.
-price is measured in FIL/GB/Epoch. Miners usually don't accept a bid
-lower than their advertised ask. You can check a miners listed price
+price is measured in FIL/Epoch. Miners usually don't accept a bid
+lower than their advertised ask (which is in FIL/GiB/epoch). You can check a miners listed price
 with 'lotus client query-ask <miner address>'.
 duration is how long the miner should store the data for, in blocks.
 The minimum value is 518400 (6 months).`,

--- a/cli/client.go
+++ b/cli/client.go
@@ -309,7 +309,7 @@ var clientDealCmd = &cli.Command{
 dataCid comes from running 'lotus client import'.
 miner is the address of the miner you wish to make a deal with.
 price is measured in FIL/Epoch. Miners usually don't accept a bid
-lower than their advertised ask (which is in FIL/GiB/epoch). You can check a miners listed price
+lower than their advertised ask (which is in FIL/GiB/Epoch). You can check a miners listed price
 with 'lotus client query-ask <miner address>'.
 duration is how long the miner should store the data for, in blocks.
 The minimum value is 518400 (6 months).`,

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -559,7 +559,7 @@ DESCRIPTION:
 dataCid comes from running 'lotus client import'.
 miner is the address of the miner you wish to make a deal with.
 price is measured in FIL/Epoch. Miners usually don't accept a bid
-lower than their advertised ask (which is in FIL/GiB/epoch). You can check a miners listed price
+lower than their advertised ask (which is in FIL/GiB/Epoch). You can check a miners listed price
 with 'lotus client query-ask <miner address>'.
 duration is how long the miner should store the data for, in blocks.
 The minimum value is 518400 (6 months).

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -558,8 +558,8 @@ DESCRIPTION:
    Make a deal with a miner.
 dataCid comes from running 'lotus client import'.
 miner is the address of the miner you wish to make a deal with.
-price is measured in FIL/GB/Epoch. Miners usually don't accept a bid
-lower than their advertised ask. You can check a miners listed price
+price is measured in FIL/Epoch. Miners usually don't accept a bid
+lower than their advertised ask (which is in FIL/GiB/epoch). You can check a miners listed price
 with 'lotus client query-ask <miner address>'.
 duration is how long the miner should store the data for, in blocks.
 The minimum value is 518400 (6 months).


### PR DESCRIPTION
I'm pretty sure this is correct based on current markets. The helptext was introduced in a PR accompanied by a markets change (https://github.com/filecoin-project/go-fil-markets/pull/491), but that change was then reverted for breaking backwards compatibility.