### PR TITLE
scale up sector expiration to avoid sector expire in batch-pre-commit waitting

### DIFF
--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -274,7 +274,7 @@ func (m *Sealing) preCommitParams(ctx statemachine.Context, sector SectorInfo) (
 
 	msd := policy.GetMaxProveCommitDuration(actors.VersionForNetwork(nv), sector.SectorType)
 
-	if minExpiration := height + msd + miner.MinSectorExpiration + 10; expiration < minExpiration {
+	if minExpiration := sector.TicketEpoch + policy.MaxPreCommitRandomnessLookback + msd + miner.MinSectorExpiration; expiration < minExpiration {
 		expiration = minExpiration
 	}
 	// TODO: enforce a reasonable _maximum_ sector lifetime?


### PR DESCRIPTION
Here, 10 epoch is no longer satisfied because it mostly will sleep more than 10 epochs in batch submit pre-commit, so I suggested it should scale up to the longest time that pre-commit ticket expired at