### PR TITLE
fix handleSubmitPreCommitBatch() preCommitParams error

### DIFF
--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -360,7 +360,7 @@ func (m *Sealing) handleSubmitPreCommitBatch(ctx statemachine.Context, sector Se
 
 	params, deposit, _, err := m.preCommitParams(ctx, sector)
 	if params == nil || err != nil {
-		return ctx.Send(SectorChainPreCommitFailed{xerrors.Errorf("preCommitParams: %w", err)})
+		return err
 	}
 
 	res, err := m.precommiter.AddPreCommit(ctx.Context(), sector, deposit, params)


### PR DESCRIPTION
preCommitParams() will send event ， and two events will be sent.