### PR TITLE
fix ticket expiration check

### DIFF
--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -151,7 +151,7 @@ func (m *Sealing) getTicket(ctx statemachine.Context, sector SectorInfo) (abi.Se
 	}
 
 	if allocated { // allocated is true, sector precommitted but expired, will SectorCommitFailed or SectorRemove
-		return nil, 0, allocated, xerrors.Errorf("Sector %s precommitted but expired", sector.SectorNumber)
+		return nil, 0, allocated, xerrors.Errorf("sector %s precommitted but expired", sector.SectorNumber)
 	}
 
 	rand, err := m.api.ChainGetRandomnessFromTickets(ctx.Context(), tok, crypto.DomainSeparationTag_SealRandomness, ticketEpoch, buf.Bytes())

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -150,7 +150,7 @@ func (m *Sealing) getTicket(ctx statemachine.Context, sector SectorInfo) (abi.Se
 		}
 	}
 
-	if allocated { // allocated is true, sector precommitted but expired, will SectorCommitFailed or SectorRemove
+	if pci == nil && allocated { // allocated is true, sector precommitted but expired, will SectorCommitFailed or SectorRemove
 		return nil, 0, allocated, xerrors.Errorf("sector %s precommitted but expired", sector.SectorNumber)
 	}
 


### PR DESCRIPTION
fix ticket expiration check, otherwise it may cause a large number of loops to retry GetTicket when retrying PreCommit1；

Because there may be C1 and C2 execution failures, and after they retries more than a certain number of times,  will cause PreCommit1 to be re-executed, and now it is the submission period of 30, so it will cause an endless loop of repeated execution of GetTicket.