### PR TITLE
Fix the bug of SectorRetryFinalize dead loop after SubmitCommitAggregate while FinalizeEarly is true

### DIFF
--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -388,7 +388,7 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 	case CommitWait:
 		return m.handleCommitWait, processed, nil
 	case CommitFinalize:
-		fallthrough
+		return m.handleCommitFinalizeSector, processed, nil
 	case FinalizeSector:
 		return m.handleFinalizeSector, processed, nil
 


### PR DESCRIPTION
with FinalizeEarly set to true:

Before SubmitCommitAggregate and everything is find and sectors were finalized:

![commit-finalize-02](https://user-images.githubusercontent.com/7111577/124152419-170c6480-dac6-11eb-981c-c49f0e76f44e.png)


Also the data were all downloaded to the final storage server and all the sectors were on state SubmitCommitAggregate:

![commit-aggregate-02](https://user-images.githubusercontent.com/7111577/124152394-11168380-dac6-11eb-9da2-d06687ceedb6.png)



After SubmitCommitAggregate by force publish and the sectors state keep firing the following state changes:
```golang
SubmitCommitAggregate(on.SectorCommitAggregateSent)->CommitWait(on.SectorProving)->FinalizeSector
```
since the sectors were deleted before the SubmitCommitAggregate finalize call and the call to Finalize now will fire SectorFinalizeFailed CUZ of sector not found, it then fire FinalizeFailed and enter the following SectorRetryFinalize dead loop.
```golang
FinalizeSector: planOne(
    on(SectorFinalized{}, Proving),
    on(SectorFinalizeFailed{}, FinalizeFailed),
),
FinalizeFailed: planOne(
    on(SectorRetryFinalize{}, FinalizeSector),
),
```

BUG: **it keeps retrying finalize sectors and the sectors state will always be FinalizedFailed**.


**About this PR:**
1, Add handleCommitFinalizeSector to handler the commit finalize and it keeps retry until the finalize finished.
2, Ignore the finalize failed during handleFinalizeSector if cfg.FinalizeEarly is true since the commit finalize will handle this situation, the second call of finalize will return update the sector state to proving (For FinalizeEarly is set to true and ignore finalize retry).
3, everything as usual if cfg.FinalizeEarly is set to false.


now second calling of finalize failed:
![finalize-failed](https://user-images.githubusercontent.com/7111577/124153531-1cb67a00-dac7-11eb-8688-eec02672dfa6.png)

And all sectors state were updated to Proving:

![state-proving](https://user-images.githubusercontent.com/7111577/124153616-31930d80-dac7-11eb-9cee-860adaa0b624.png)

