### PR TITLE
Default AggregateCommits to false

### DIFF
--- a/node/config/def.go
+++ b/node/config/def.go
@@ -328,7 +328,7 @@ func DefaultStorageMiner() *StorageMiner {
 			PreCommitBatchWait:  Duration(24 * time.Hour),           // this should be less than 31.5 hours, which is the expiration of a precommit ticket
 			PreCommitBatchSlack: Duration(3 * time.Hour),            // time buffer for forceful batch submission before sectors/deals in batch would start expiring, higher value will lower the chances for message fail due to expiration
 
-			AggregateCommits: true,
+			AggregateCommits: false,
 			MinCommitBatch:   miner5.MinAggregatedSectors, // per FIP13, we must have at least four proofs to aggregate, where 4 is the cross over point where aggregation wins out on single provecommit gas costs
 			MaxCommitBatch:   miner5.MaxAggregatedSectors, // maximum 819 sectors, this is the maximum aggregation per FIP13
 			CommitBatchWait:  Duration(24 * time.Hour),    // this can be up to 30 days


### PR DESCRIPTION
https://filecoinproject.slack.com/archives/CPFTWMY7N/p1625205022475600
Many small miners are unaware of AggregateCommits may waste their money when basefee is low. It might be better that people choose to aggregate instead of aggregate by defaut. 

Currently, on [filscout](https://filscout.com/en/gas/gas), 99% of the gas burn are from ProveCommitAggregate, which is a bit of a waste given basefee at 100 aFil.

<img src="https://user-images.githubusercontent.com/1591330/124231023-54aed300-db42-11eb-8080-743b0a77d388.png" alt="alt text" width="600">