### PR TITLE
Get retrieval pricing input should not error out on a deal state fetch

### DIFF
--- a/markets/retrievaladapter/provider.go
+++ b/markets/retrievaladapter/provider.go
@@ -135,10 +135,13 @@ func (rpn *retrievalProviderNode) GetRetrievalPricingInput(ctx context.Context, 
 	}
 	tsk := head.Key()
 
+	var lastErr error
+
 	for _, dealID := range storageDeals {
 		ds, err := rpn.full.StateMarketStorageDeal(ctx, dealID, tsk)
 		if err != nil {
 			log.Warnf("failed to look up deal %d on chain: err=%w", dealID, err)
+			lastErr = err
 			continue
 		}
 		if ds.Proposal.VerifiedDeal {
@@ -159,7 +162,11 @@ func (rpn *retrievalProviderNode) GetRetrievalPricingInput(ctx context.Context, 
 	// Note: The piece size can never actually be zero. We only use it to here
 	// to assert that we didn't find a matching piece.
 	if resp.PieceSize == 0 {
-		return resp, xerrors.New("failed to find matching piece")
+		if lastErr == nil {
+			return resp, xerrors.New("failed to find matching piece")
+		} else {
+			return resp, xerrors.Errorf("failed to fetch storage deal state: %w", err)
+		}
 	}
 
 	return resp, nil

--- a/markets/retrievaladapter/provider.go
+++ b/markets/retrievaladapter/provider.go
@@ -138,7 +138,8 @@ func (rpn *retrievalProviderNode) GetRetrievalPricingInput(ctx context.Context, 
 	for _, dealID := range storageDeals {
 		ds, err := rpn.full.StateMarketStorageDeal(ctx, dealID, tsk)
 		if err != nil {
-			return resp, xerrors.Errorf("failed to look up deal %d on chain: err=%w", dealID, err)
+			log.Warnf("failed to look up deal %d on chain: err=%w", dealID, err)
+			continue
 		}
 		if ds.Proposal.VerifiedDeal {
 			resp.VerifiedDeal = true

--- a/markets/retrievaladapter/provider_test.go
+++ b/markets/retrievaladapter/provider_test.go
@@ -66,6 +66,31 @@ func TestGetPricingInput(t *testing.T) {
 			expectedErrorStr: "failed to find matching piece",
 		},
 
+		"error when fails to fetch deal state": {
+			fFnc: func(n *mocks.MockFullNode) {
+				out1 := &api.MarketDeal{
+					Proposal: market.DealProposal{
+						PieceCID:  pcid,
+						PieceSize: paddedSize,
+					},
+				}
+				out2 := &api.MarketDeal{
+					Proposal: market.DealProposal{
+						PieceCID:     testnet.GenerateCids(1)[0],
+						VerifiedDeal: true,
+					},
+				}
+
+				n.EXPECT().ChainHead(gomock.Any()).Return(tsk, nil).Times(1)
+				gomock.InOrder(
+					n.EXPECT().StateMarketStorageDeal(gomock.Any(), deals[0], key).Return(out1, xerrors.New("error 1")),
+					n.EXPECT().StateMarketStorageDeal(gomock.Any(), deals[1], key).Return(out2, xerrors.New("error 2")),
+				)
+
+			},
+			expectedErrorStr: "failed to fetch storage deal state",
+		},
+
 		"verified is true even if one deal is verified and we get the correct piecesize": {
 			fFnc: func(n *mocks.MockFullNode) {
 				out1 := &api.MarketDeal{


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/6678.

We iterate over all storage deals for a payload to see if we have a verified storage deal with the required PieceCID to fetch the input for the retrieval pricing function. This PR introduces a fix so we don't error out in we fail to look up a deal state and just continue iterating over the other deals.