### PR TITLE
ClientRetrieve stops on cancel

### DIFF
--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -680,6 +680,8 @@ func readSubscribeEvents(ctx context.Context, dealID retrievalmarket.DealID, sub
 			return nil
 		case rm.DealStatusRejected:
 			return xerrors.Errorf("Retrieval Proposal Rejected: %s", state.Message)
+		case rm.DealStatusCancelled:
+			return xerrors.Errorf("Retrieval was cancelled externally: %s", state.Message)
 		case
 			rm.DealStatusDealNotFound,
 			rm.DealStatusErrored:


### PR DESCRIPTION
# Goals

fix #6738

# Implementation

Check for deal status cancelled when inspecting deal events in ClientRetrieve and ClientRetrieveWithEvents, and close channel when that happens.