### PR TITLE
Splitstore: Some small fixes

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -180,7 +180,7 @@ func (b *Blockstore) CollectGarbage() error {
 	}
 
 	for err == nil {
-		err = b.db.RunValueLogGC(0.125)
+		err = b.DB.RunValueLogGC(0.125)
 	}
 
 	if err == badger.ErrNoRewrite {

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -35,6 +35,27 @@ type BlockstoreIterator interface {
 	ForEachKey(func(cid.Cid) error) error
 }
 
+// BlockstoreMover is a trait for movable blockstores
+type BlockstoreMover interface {
+	// Moves the blockstore to path, and creates a symlink from the current path
+	// to the new path; the old blockstore is deleted.
+	// If path is empty, then a new path adjacent to the current path is created
+	// automatically.
+	// If the filter function is not nil, then the move filters and moves only
+	// objects whose cid satisfyn the filter.
+	//
+	// The blockstore must accept new writes during the move and ensure that these
+	// are persisted to the new blockstore; if a failure occurs aboring the move,
+	// then they must be peristed to the old blockstore.
+	// In short, the blockstore must not lose data from new writes during the move.
+	MoveTo(path string, filter func(cid.Cid) bool) error
+}
+
+// BlockstoreGC is a trait for blockstores that support online garbage collection
+type BlockstoreGC interface {
+	CollectGarbage() error
+}
+
 // WrapIDStore wraps the underlying blockstore in an "identity" blockstore.
 // The ID store filters out all puts for blocks with CIDs using the "identity"
 // hash function. It also extracts inlined blocks from CIDs using the identity

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -35,22 +35,6 @@ type BlockstoreIterator interface {
 	ForEachKey(func(cid.Cid) error) error
 }
 
-// BlockstoreMover is a trait for movable blockstores
-type BlockstoreMover interface {
-	// Moves the blockstore to path, and creates a symlink from the current path
-	// to the new path; the old blockstore is deleted.
-	// If path is empty, then a new path adjacent to the current path is created
-	// automatically.
-	// If the filter function is not nil, then the move filters and moves only
-	// objects whose cid satisfyn the filter.
-	//
-	// The blockstore must accept new writes during the move and ensure that these
-	// are persisted to the new blockstore; if a failure occurs aboring the move,
-	// then they must be peristed to the old blockstore.
-	// In short, the blockstore must not lose data from new writes during the move.
-	MoveTo(path string, filter func(cid.Cid) bool) error
-}
-
 // BlockstoreGC is a trait for blockstores that support online garbage collection
 type BlockstoreGC interface {
 	CollectGarbage() error

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -1439,8 +1439,7 @@ func (s *SplitStore) has(c cid.Cid) (bool, error) {
 
 func (s *SplitStore) checkClosing() error {
 	if atomic.LoadInt32(&s.closing) == 1 {
-		log.Info("splitstore is closing; aborting compaction")
-		return xerrors.Errorf("compaction aborted")
+		return xerrors.Errorf("splitstore is closing")
 	}
 
 	return nil

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -1697,30 +1697,6 @@ func (s *SplitStore) waitForMissingRefs(markSet MarkSet) {
 	}
 }
 
-func (s *SplitStore) gcHotstore() {
-	if compact, ok := s.hot.(interface{ Compact() error }); ok {
-		log.Infof("compacting hotstore")
-		startCompact := time.Now()
-		err := compact.Compact()
-		if err != nil {
-			log.Warnf("error compacting hotstore: %s", err)
-			return
-		}
-		log.Infow("hotstore compaction done", "took", time.Since(startCompact))
-	}
-
-	if gc, ok := s.hot.(interface{ CollectGarbage() error }); ok {
-		log.Infof("garbage collecting hotstore")
-		startGC := time.Now()
-		err := gc.CollectGarbage()
-		if err != nil {
-			log.Warnf("error garbage collecting hotstore: %s", err)
-			return
-		}
-		log.Infow("hotstore garbage collection done", "took", time.Since(startGC))
-	}
-}
-
 func (s *SplitStore) setBaseEpoch(epoch abi.ChainEpoch) error {
 	s.baseEpoch = epoch
 	return s.ds.Put(baseEpochKey, epochToBytes(epoch))

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -742,7 +742,7 @@ func (s *SplitStore) trackTxnRefMany(cids []cid.Cid) {
 					quiet = true
 					log.Warnf("error checking markset: %s", err)
 				}
-				continue
+				// track it anyways
 			}
 
 			if mark {

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -678,7 +678,7 @@ func (s *SplitStore) viewDone() {
 
 	s.txnViews--
 	if s.txnViews == 0 && s.txnViewsWaiting {
-		s.txnViewsCond.Signal()
+		s.txnViewsCond.Broadcast()
 	}
 }
 

--- a/blockstore/splitstore/splitstore_gc.go
+++ b/blockstore/splitstore/splitstore_gc.go
@@ -5,39 +5,12 @@ import (
 	"time"
 
 	bstore "github.com/filecoin-project/lotus/blockstore"
-	cid "github.com/ipfs/go-cid"
 )
 
 func (s *SplitStore) gcHotstore() {
-	// we only perform moving gc every 20 compactions (about once a week) as it can take a while
-	if s.compactionIndex%20 == 0 {
-		if err := s.gcBlockstoreMoving(s.hot, "", nil); err != nil {
-			log.Warnf("error moving hotstore: %s", err)
-			// fallthrough to online gc
-		} else {
-			return
-		}
-	}
-
 	if err := s.gcBlockstoreOnline(s.hot); err != nil {
 		log.Warnf("error garbage collecting hostore: %s", err)
 	}
-}
-
-func (s *SplitStore) gcBlockstoreMoving(b bstore.Blockstore, path string, filter func(cid.Cid) bool) error {
-	if mover, ok := b.(bstore.BlockstoreMover); ok {
-		log.Info("moving blockstore")
-		startMove := time.Now()
-
-		if err := mover.MoveTo(path, filter); err != nil {
-			return err
-		}
-
-		log.Infow("moving hotstore done", "took", time.Since(startMove))
-		return nil
-	}
-
-	return fmt.Errorf("blockstore doesn't support moving: %T", b)
 }
 
 func (s *SplitStore) gcBlockstoreOnline(b bstore.Blockstore) error {

--- a/blockstore/splitstore/splitstore_gc.go
+++ b/blockstore/splitstore/splitstore_gc.go
@@ -1,0 +1,39 @@
+package splitstore
+
+import (
+	"time"
+
+	bstore "github.com/filecoin-project/lotus/blockstore"
+)
+
+func (s *SplitStore) gcHotstore() {
+	// check if the hotstore is movable; if so, move it.
+	if mover, ok := s.hot.(bstore.BlockstoreMover); ok {
+		log.Info("moving hotstore")
+		startMove := time.Now()
+		err := mover.MoveTo("", nil)
+		if err != nil {
+			log.Warnf("error moving hotstore: %s", err)
+			return
+		}
+
+		log.Infof("moving hotstore done", "took", time.Since(startMove))
+		return
+	}
+
+	// check if the hotstore supports online GC; if so, GC it.
+	if gc, ok := s.hot.(bstore.BlockstoreGC); ok {
+		log.Info("garbage collecting hotstore")
+		startGC := time.Now()
+		err := gc.CollectGarbage()
+		if err != nil {
+			log.Warnf("error garbage collecting hotstore: %s", err)
+			return
+		}
+
+		log.Infof("garbage collecting hotstore done", "took", time.Since(startGC))
+		return
+	}
+
+	return
+}

--- a/blockstore/splitstore/splitstore_gc.go
+++ b/blockstore/splitstore/splitstore_gc.go
@@ -7,6 +7,11 @@ import (
 )
 
 func (s *SplitStore) gcHotstore() {
+	// we only perform moving gc every 10 compactions as it can take a while
+	if s.compactionIndex%10 != 0 {
+		goto online_gc
+	}
+
 	// check if the hotstore is movable; if so, move it.
 	if mover, ok := s.hot.(bstore.BlockstoreMover); ok {
 		log.Info("moving hotstore")
@@ -14,13 +19,15 @@ func (s *SplitStore) gcHotstore() {
 		err := mover.MoveTo("", nil)
 		if err != nil {
 			log.Warnf("error moving hotstore: %s", err)
-			return
+			// try online gc
+			goto online_gc
 		}
 
-		log.Infof("moving hotstore done", "took", time.Since(startMove))
+		log.Infow("moving hotstore done", "took", time.Since(startMove))
 		return
 	}
 
+online_gc:
 	// check if the hotstore supports online GC; if so, GC it.
 	if gc, ok := s.hot.(bstore.BlockstoreGC); ok {
 		log.Info("garbage collecting hotstore")


### PR DESCRIPTION
Cherry-picked from #6728 

- Fixes a couple of inconsistencies identified post merge
- Introduces BlockstoreGC and BlockstoreMover interfaces in preparation for moving GC in #6728
- Adds a compactionIndex state variable to use as decision for moving gc (where applicable) and also a warmup indicator for splitstore v0 upgrades.
