### PR TITLE
Exposed Splitstore: protect Has invocations 

### DIFF
--- a/blockstore/splitstore/splitstore_expose.go
+++ b/blockstore/splitstore/splitstore_expose.go
@@ -29,16 +29,7 @@ func (es *exposedSplitStore) DeleteMany(_ []cid.Cid) error {
 }
 
 func (es *exposedSplitStore) Has(c cid.Cid) (bool, error) {
-	if isIdentiyCid(c) {
-		return true, nil
-	}
-
-	has, err := es.s.hot.Has(c)
-	if has || err != nil {
-		return has, err
-	}
-
-	return es.s.cold.Has(c)
+	return es.s.Has(c)
 }
 
 func (es *exposedSplitStore) Get(c cid.Cid) (blocks.Block, error) {


### PR DESCRIPTION
It is conceivable that exposed blockstore users may want to optimize their outbound requests for data by invoking Has on the blockstore.
This protects such invocation so as not to break such optimizations.