### PR TITLE
fix: always check if StateSearchMessage returns nil

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -446,6 +446,9 @@ var StateExecTraceCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
+		if lookup == nil {
+			return fmt.Errorf("failed to find message: %s", mcid)
+		}
 
 		ts, err := capi.ChainGetTipSet(ctx, lookup.TipSet)
 		if err != nil {
@@ -1489,6 +1492,10 @@ var StateSearchMsgCmd = &cli.Command{
 		mw, err := api.StateSearchMsg(ctx, msg)
 		if err != nil {
 			return err
+		}
+
+		if mw == nil {
+			return fmt.Errorf("failed to find message: %s", msg)
 		}
 
 		m, err := api.ChainGetMessage(ctx, msg)

--- a/cmd/tvx/extract_message.go
+++ b/cmd/tvx/extract_message.go
@@ -337,6 +337,9 @@ func resolveFromChain(ctx context.Context, api v0api.FullNode, mcid cid.Cid, blo
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to locate message: %w", err)
 		}
+		if msgInfo == nil {
+			return nil, nil, nil, fmt.Errorf("failed to locate message: not found")
+		}
 
 		log.Printf("located message at tipset %s (height: %d) with exit code: %s", msgInfo.TipSet, msgInfo.Height, msgInfo.Receipt.ExitCode)
 

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -121,6 +121,7 @@ func (ts *apiSuite) testSearchMsg(t *testing.T) {
 
 	searchRes, err := full.StateSearchMsg(ctx, types.EmptyTSK, sm.Cid(), lapi.LookbackNoLimit, true)
 	require.NoError(t, err)
+	require.NotNil(t, searchRes)
 
 	require.Equalf(t, res.TipSet, searchRes.TipSet, "search ts: %s, different from wait ts: %s", searchRes.TipSet, res.TipSet)
 }


### PR DESCRIPTION
It returns nil on "not found".

Fixes the cases not covered in: https://github.com/filecoin-project/lotus/pull/6787