### PR TITLE
ClientFindData: always fetch peer id from chain

### DIFF
--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -436,7 +436,19 @@ func (a *API) ClientFindData(ctx context.Context, root cid.Cid, piece *cid.Cid) 
 		if piece != nil && !piece.Equals(*p.PieceCID) {
 			continue
 		}
-		out = append(out, a.makeRetrievalQuery(ctx, p, root, piece, rm.QueryParams{}))
+
+		// do not rely on local data with respect to peer id
+		// fetch an up-to-date miner peer id from chain
+		mi, err := a.StateMinerInfo(ctx, p.Address, types.EmptyTSK)
+		if err != nil {
+			return nil, err
+		}
+		pp := rm.RetrievalPeer{
+			Address: p.Address,
+			ID:      *mi.PeerId,
+		}
+
+		out = append(out, a.makeRetrievalQuery(ctx, pp, root, piece, rm.QueryParams{}))
 	}
 
 	return out, nil


### PR DESCRIPTION
This PR is fixing `ClientFindData` when data about peers in the local store of a node is out-dated.

---

If a client makes a deal with a miner, it keeps the miner's peer id in a local store. In the future if the miner changes its peer id, and the client tries to retrieve the content (datacid), `ClientFindData` would still be trying to reach the miner on its old peer id, ultimately failing.

This is manifested with `Failed to find file` error in the CLI:

```
➜  lotus git:(master) lotus client retrieve $datacid /tmp/file1234
Failed to find file
```