### PR TITLE
add SealProof in SectorBuilder

### DIFF
--- a/markets/retrievaladapter/provider.go
+++ b/markets/retrievaladapter/provider.go
@@ -54,7 +54,7 @@ func (rpn *retrievalProviderNode) GetMinerWorkerAddress(ctx context.Context, min
 
 func (rpn *retrievalProviderNode) UnsealSector(ctx context.Context, sectorID abi.SectorNumber, offset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (io.ReadCloser, error) {
 	log.Debugf("get sector %d, offset %d, length %d", sectorID, offset, length)
-	si, err := rpn.sectorsStatus(ctx, sectorID, true)
+	si, err := rpn.sectorsStatus(ctx, sectorID, false)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/miner_sealing.go
+++ b/storage/miner_sealing.go
@@ -134,7 +134,7 @@ func (m *Miner) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showOnC
 		LastErr: info.LastErr,
 		Log:     log,
 		// on chain info
-		SealProof:          0,
+		SealProof:          info.SectorType,
 		Activation:         0,
 		Expiration:         0,
 		DealWeight:         big.Zero(),


### PR DESCRIPTION
This PR is fixing a bug introduced in https://github.com/filecoin-project/lotus/pull/6356

---

As part of MRA, we modified `UnsealSector` to use `SectorBuilder.SectorsStatus` API (RPC from `markets` node to `sealing/proving` node), instead of a local call `rpn.miner.GetSectorInfo(sectorID)`

Given that we always call `sectorsStatus` with `onChainInfo == true`, we currently get an error for all sectors that are not yet on-chain (i.e. currently in PreCommit1 phase for example).

This results in a regression - a failure of all retrievals for deals on sectors that are not yet on chain.

---

With this PR, I am modifying the call to `sectorsStatus` to not use on-chain data, but also making sure that `SealProof` is initialised correctly based on data from the local store, and not just to 0.