### PR TITLE
Introduce the LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC envvar

### DIFF
--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -327,6 +327,21 @@ func (fsr *fsLockedRepo) Blockstore(ctx context.Context, domain BlockstoreDomain
 			return
 		}
 
+		//
+		// Tri-state environment variable LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC
+		// - unset == the default (currently fsync enabled)
+		// - set with a false-y value == fsync enabled no matter what a future default is
+		// - set with any other value == fsync is disabled ignored defaults (recommended for day-to-day use)
+		//
+		if nosyncBs, nosyncBsSet := os.LookupEnv("LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC"); nosyncBsSet {
+			nosyncBs = strings.ToLower(nosyncBs)
+			if nosyncBs == "" || nosyncBs == "0" || nosyncBs == "false" || nosyncBs == "no" {
+				opts.SyncWrites = true
+			} else {
+				opts.SyncWrites = false
+			}
+		}
+
 		bs, err := badgerbs.Open(opts)
 		if err != nil {
 			fsr.bsErr = err


### PR DESCRIPTION
This is a redux of https://github.com/filecoin-project/lotus/pull/5050

Allows the user to control the opts.SyncWrites option of BadgerDs, with the tri-state environment variable `LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC`

- unset == the default (currently fsync enabled)
- set with a false-y value ( `""`, `"0"`, `"no"`, `"false"` ) == fsync enabled no matter what a future default is
- set with any other value == fsync is disabled ignored defaults (recommended for day-to-day use)

Applying this brought @whyrusleeping's average chain validation times from "impossible to sync" ( > 30s ) down to 1~3s/tipset

