### PR TITLE
Rewire itest's StartDeal to take the full API struct

### DIFF
--- a/itests/batch_deal_test.go
+++ b/itests/batch_deal_test.go
@@ -90,7 +90,11 @@ func TestBatchDealInput(t *testing.T) {
 				res, _, _, err := kit.CreateImportFile(ctx, client, rseed, piece)
 				require.NoError(t, err)
 
-				deal := dh.StartDeal(ctx, res.Root, false, dealStartEpoch)
+				dp := dh.DefaultStartDealParams()
+				dp.Data.Root = res.Root
+				dp.DealStartEpoch = dealStartEpoch
+
+				deal := dh.StartDeal(ctx, dp)
 				dh.WaitDealSealed(ctx, deal, false, true, checkNoPadding)
 			}
 

--- a/itests/deals_power_test.go
+++ b/itests/deals_power_test.go
@@ -50,7 +50,9 @@ func TestFirstDealEnablesMining(t *testing.T) {
 	}()
 
 	// now perform the deal.
-	deal := dh.StartDeal(ctx, ref.Root, false, 0)
+	dp := dh.DefaultStartDealParams()
+	dp.Data.Root = ref.Root
+	deal := dh.StartDeal(ctx, dp)
 
 	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 	time.Sleep(time.Second)

--- a/itests/deals_publish_test.go
+++ b/itests/deals_publish_test.go
@@ -69,7 +69,10 @@ func TestPublishDealsBatching(t *testing.T) {
 		upds, err := client.ClientGetDealUpdates(ctx)
 		require.NoError(t, err)
 
-		dh.StartDeal(ctx, res.Root, false, startEpoch)
+		dp := dh.DefaultStartDealParams()
+		dp.Data.Root = res.Root
+		dp.DealStartEpoch = startEpoch
+		dh.StartDeal(ctx, dp)
 
 		// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 		time.Sleep(time.Second)

--- a/itests/kit/deals.go
+++ b/itests/kit/deals.go
@@ -88,7 +88,11 @@ func (dh *DealHarness) MakeOnlineDeal(ctx context.Context, params MakeFullDealPa
 		dh.t.Logf("deal-making continuing; current height is %d", ts.Height())
 	}
 
-	deal = dh.StartDeal(ctx, res.Root, params.FastRet, params.StartEpoch)
+	dp := dh.DefaultStartDealParams()
+	dp.Data.Root = res.Root
+	dp.DealStartEpoch = params.StartEpoch
+	dp.FastRetrieval = params.FastRet
+	deal = dh.StartDeal(ctx, dp)
 
 	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
 	time.Sleep(time.Second)
@@ -97,29 +101,28 @@ func (dh *DealHarness) MakeOnlineDeal(ctx context.Context, params MakeFullDealPa
 	return deal, res, path
 }
 
-// StartDeal starts a storage deal between the client and the miner.
-func (dh *DealHarness) StartDeal(ctx context.Context, fcid cid.Cid, fastRet bool, startEpoch abi.ChainEpoch) *cid.Cid {
-	maddr, err := dh.main.ActorAddress(ctx)
-	require.NoError(dh.t, err)
-
-	addr, err := dh.client.WalletDefaultAddress(ctx)
-	require.NoError(dh.t, err)
-
-	deal, err := dh.client.ClientStartDeal(ctx, &api.StartDealParams{
-		Data: &storagemarket.DataRef{
-			TransferType: storagemarket.TTGraphsync,
-			Root:         fcid,
-		},
-		Wallet:            addr,
-		Miner:             maddr,
+func (dh *DealHarness) DefaultStartDealParams() api.StartDealParams {
+	dp := api.StartDealParams{
+		Data:              &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync},
 		EpochPrice:        types.NewInt(1000000),
-		DealStartEpoch:    startEpoch,
 		MinBlocksDuration: uint64(build.MinDealDuration),
-		FastRetrieval:     fastRet,
-	})
+	}
+
+	var err error
+	dp.Miner, err = dh.main.ActorAddress(context.Background())
 	require.NoError(dh.t, err)
 
-	return deal
+	dp.Wallet, err = dh.client.WalletDefaultAddress(context.Background())
+	require.NoError(dh.t, err)
+
+	return dp
+}
+
+// StartDeal starts a storage deal between the client and the miner.
+func (dh *DealHarness) StartDeal(ctx context.Context, dealParams api.StartDealParams) *cid.Cid {
+	dealProposalCid, err := dh.client.ClientStartDeal(ctx, &dealParams)
+	require.NoError(dh.t, err)
+	return dealProposalCid
 }
 
 // WaitDealSealed waits until the deal is sealed.


### PR DESCRIPTION
This allows one to use the harness for much more versatile deal conditions