### PR TITLE
Improve splitstore warmup

### DIFF
--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -24,6 +24,7 @@ import (
 func init() {
 	CompactionThreshold = 5
 	CompactionBoundary = 2
+	WarmupBoundary = 0
 	logging.SetLogLevel("splitstore", "DEBUG")
 }
 

--- a/blockstore/splitstore/splitstore_warmup.go
+++ b/blockstore/splitstore/splitstore_warmup.go
@@ -9,6 +9,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	bstore "github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -49,8 +50,11 @@ func (s *SplitStore) warmup(curTs *types.TipSet) error {
 // and headers all the way up to genesis.
 // objects are written in batches so as to minimize overhead.
 func (s *SplitStore) doWarmup(curTs *types.TipSet) error {
+	var boundaryEpoch abi.ChainEpoch
 	epoch := curTs.Height()
-	boundaryEpoch := epoch - WarmupBoundary
+	if WarmupBoundary < epoch {
+		boundaryEpoch = epoch - WarmupBoundary
+	}
 	batchHot := make([]blocks.Block, 0, batchSize)
 	count := int64(0)
 	xcount := int64(0)

--- a/blockstore/splitstore/splitstore_warmup.go
+++ b/blockstore/splitstore/splitstore_warmup.go
@@ -76,7 +76,7 @@ func (s *SplitStore) doWarmup(curTs *types.TipSet) error {
 			if err != nil {
 				if err == bstore.ErrNotFound {
 					missing++
-					return nil
+					return errStopWalk
 				}
 				return err
 			}


### PR DESCRIPTION
While testing the `check` command in #6811 it was observed (to my great surprise) that my discard node actually has some cold references, dating back to the original snapshot.
So it appears that the warmup is not capturing all references that it should.

This improves the situation by traversing a full finality worth of state during warmup.