### PR TITLE
Splitstore: Implement cold object reification

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -96,7 +96,7 @@ type Blockstore struct {
 	viewers sync.WaitGroup
 
 	moveMx    sync.RWMutex
-	moveCond  *sync.Cond
+	moveCond  sync.Cond
 	moveState int
 	rlock     int
 
@@ -135,7 +135,7 @@ func Open(opts Options) (*Blockstore, error) {
 		bs.prefixLen = len(bs.prefix)
 	}
 
-	bs.moveCond = sync.NewCond(&bs.moveMx)
+	bs.moveCond.L = &bs.moveMx
 
 	return bs, nil
 }

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -182,7 +182,7 @@ func (b *Blockstore) isOpen() bool {
 	return b.state == stateOpen
 }
 
-// lockDB/unlockDB implement a recursive lock contigent on move state
+// lockDB/unlockDB implement a recursive lock contingent on move state
 func (b *Blockstore) lockDB() {
 	b.moveMx.Lock()
 	defer b.moveMx.Unlock()

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -475,6 +475,32 @@ func (b *Blockstore) CollectGarbage(options map[interface{}]interface{}) error {
 	}
 	defer b.viewers.Done()
 
+	var movingGC bool
+	movingGCOpt, ok := options[blockstore.BlockstoreMovingGC]
+	if ok {
+		movingGC, ok = movingGCOpt.(bool)
+		if !ok {
+			return fmt.Errorf("incorrect type for moving gc option; expected bool but got %T", movingGCOpt)
+		}
+	}
+
+	if !movingGC {
+		return b.onlineGC()
+	}
+
+	var movingGCPath string
+	movingGCPathOpt, ok := options[blockstore.BlockstoreMovingGCPath]
+	if ok {
+		movingGCPath, ok = movingGCPathOpt.(string)
+		if !ok {
+			return fmt.Errorf("incorrect type for moving gc path option; expected string but got %T", movingGCPathOpt)
+		}
+	}
+
+	return b.moveTo(movingGCPath)
+}
+
+func (b *Blockstore) onlineGC() error {
 	b.lockDB()
 	defer b.unlockDB()
 

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -915,3 +915,9 @@ func (b *Blockstore) StorageKey(dst []byte, cid cid.Cid) []byte {
 	}
 	return dst[:reqsize]
 }
+
+// this method is added for lotus-shed needs
+// WARNING: THIS IS COMPLETELY UNSAFE; DONT USE THIS IN PRODUCTION CODE
+func (b *Blockstore) DB() *badger.DB {
+	return b.db
+}

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -276,6 +276,8 @@ func (b *Blockstore) MoveTo(path string, filter func(cid.Cid) bool) error {
 		}
 	}()
 
+	log.Infof("moving blockstore from %s to %s", b.opts.Dir, path)
+
 	opts := b.opts
 	opts.Dir = path
 	opts.ValueDir = path
@@ -289,6 +291,7 @@ func (b *Blockstore) MoveTo(path string, filter func(cid.Cid) bool) error {
 	b.db2 = db2
 	b.unlockMove(moveStateMoving)
 
+	log.Info("copying blockstore")
 	err = b.doCopy(b.db, b.db2, filter)
 	if err != nil {
 		return fmt.Errorf("error moving badger blockstore to %s: %w", path, err)
@@ -326,6 +329,7 @@ func (b *Blockstore) MoveTo(path string, filter func(cid.Cid) bool) error {
 		b.deleteDB(oldpath)
 	}
 
+	log.Info("moving blockstore done")
 	return nil
 }
 
@@ -428,7 +432,7 @@ func (b *Blockstore) deleteDB(path string) {
 	for {
 		fi, err := os.Lstat(lpath)
 		if err != nil {
-			log.Warnf("error stating %s: %s", path, err)
+			log.Warnf("error stating %s: %s", lpath, err)
 			return
 		}
 
@@ -436,18 +440,24 @@ func (b *Blockstore) deleteDB(path string) {
 			break
 		}
 
-		lpath, err := os.Readlink(lpath)
+		log.Infof("resolving symbolic link %s", lpath)
+		newpath, err := os.Readlink(lpath)
 		if err != nil {
 			log.Warnf("error resolving symbolic link %s: %s", lpath, err)
+			return
 		}
+		log.Infof("resolved symbolic link %s -> %s", lpath, newpath)
+		lpath = newpath
 	}
 
+	log.Infof("removing data directory %s", lpath)
 	if err := os.RemoveAll(lpath); err != nil {
 		log.Warnf("error deleting db at %s: %s", lpath, err)
 		return
 	}
 
 	if path != lpath {
+		log.Infof("removing link %s", path)
 		if err := os.Remove(path); err != nil {
 			log.Warnf("error removing symbolic link %s", err)
 		}

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -423,9 +423,34 @@ func (b *Blockstore) doCopy(from, to *badger.DB, filter func(cid.Cid) bool) erro
 }
 
 func (b *Blockstore) deleteDB(path string) {
-	err := os.RemoveAll(path)
-	if err != nil {
-		log.Warnf("error deleting db at %s: %s", path, err)
+	// follow symbolic links, otherwise the data wil be left behind
+	lpath := path
+	for {
+		fi, err := os.Lstat(lpath)
+		if err != nil {
+			log.Warnf("error stating %s: %s", path, err)
+			return
+		}
+
+		if fi.Mode()&os.ModeSymlink == 0 {
+			break
+		}
+
+		lpath, err := os.Readlink(lpath)
+		if err != nil {
+			log.Warnf("error resolving symbolic link %s: %s", lpath, err)
+		}
+	}
+
+	if err := os.RemoveAll(lpath); err != nil {
+		log.Warnf("error deleting db at %s: %s", lpath, err)
+		return
+	}
+
+	if path != lpath {
+		if err := os.Remove(path); err != nil {
+			log.Warnf("error removing symbolic link %s", err)
+		}
 	}
 }
 

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -469,7 +469,7 @@ func (b *Blockstore) deleteDB(path string) {
 
 // CollectGarbage compacts and runs garbage collection on the value log;
 // implements the BlockstoreGC trait
-func (b *Blockstore) CollectGarbage() error {
+func (b *Blockstore) CollectGarbage(options map[interface{}]interface{}) error {
 	if err := b.access(); err != nil {
 		return err
 	}

--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -408,6 +408,8 @@ func (b *Blockstore) doCopy(from, to *badger.DB, filter func(cid.Cid) bool) erro
 			if err := batch.Flush(); err != nil {
 				return err
 			}
+			// Flush discards the transaction, so we need a new batch
+			batch = to.NewWriteBatch()
 			count = 0
 			putPooled()
 		}

--- a/blockstore/badger/blockstore_test.go
+++ b/blockstore/badger/blockstore_test.go
@@ -154,7 +154,7 @@ func testMove(t *testing.T, optsF func(string) Options) {
 		return nil
 	})
 	g.Go(func() error {
-		return db.MoveTo("", nil)
+		return db.moveTo("")
 	})
 
 	err = g.Wait()

--- a/blockstore/badger/blockstore_test.go
+++ b/blockstore/badger/blockstore_test.go
@@ -1,12 +1,19 @@
 package badgerbs
 
 import (
+	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
-	blocks "github.com/ipfs/go-block-format"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/blockstore"
 )
@@ -88,4 +95,150 @@ func openBlockstore(optsSupplier func(path string) Options) func(tb testing.TB, 
 		tb.Helper()
 		return Open(optsSupplier(path))
 	}
+}
+
+func testMove(t *testing.T, optsF func(string) Options) {
+	basePath, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(basePath, "db")
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(basePath)
+	})
+
+	db, err := Open(optsF(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer db.Close() //nolint
+
+	var have []blocks.Block
+	var deleted []cid.Cid
+
+	// add some blocks
+	for i := 0; i < 10; i++ {
+		blk := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
+		err := db.Put(blk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		have = append(have, blk)
+	}
+
+	// delete some of them
+	for i := 5; i < 10; i++ {
+		c := have[i].Cid()
+		err := db.DeleteBlock(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		deleted = append(deleted, c)
+	}
+	have = have[:5]
+
+	// start a move concurrent with some more puts
+	g := new(errgroup.Group)
+	g.Go(func() error {
+		for i := 10; i < 1000; i++ {
+			blk := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
+			err := db.Put(blk)
+			if err != nil {
+				return err
+			}
+			have = append(have, blk)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		return db.MoveTo("", nil)
+	})
+
+	err = g.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now check that we have all the blocks in have and none in the deleted lists
+	for _, blk := range have {
+		has, err := db.Has(blk.Cid())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !has {
+			t.Fatal("missing block")
+		}
+
+		blk2, err := db.Get(blk.Cid())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(blk.RawData(), blk2.RawData()) {
+			t.Fatal("data mismatch")
+		}
+	}
+
+	for _, c := range deleted {
+		has, err := db.Has(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if has {
+			t.Fatal("resurrected block")
+		}
+	}
+
+	// check the basePath -- it should contain a directory with name db.{timestamp}, soft-linked
+	// to db and nothing else
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("too many entries; expected %d but got %d", 2, len(entries))
+	}
+
+	var haveDB, haveDBLink bool
+	for _, e := range entries {
+		if e.Name() == "db" {
+			if (e.Type() & os.ModeSymlink) == 0 {
+				t.Fatal("found db, but it's not a symlink")
+			}
+			haveDBLink = true
+			continue
+		}
+		if strings.HasPrefix(e.Name(), "db.") {
+			if !e.Type().IsDir() {
+				t.Fatal("found db prefix, but it's not a directory")
+			}
+			haveDB = true
+			continue
+		}
+	}
+
+	if !haveDB {
+		t.Fatal("db directory is missing")
+	}
+	if !haveDBLink {
+		t.Fatal("db link is missing")
+	}
+}
+
+func TestMoveNoPrefix(t *testing.T) {
+	testMove(t, DefaultOptions)
+}
+
+func TestMoveWithPrefix(t *testing.T) {
+	testMove(t, func(path string) Options {
+		opts := DefaultOptions(path)
+		opts.Prefix = "/prefixed/"
+		return opts
+	})
 }

--- a/blockstore/badger/blockstore_test.go
+++ b/blockstore/badger/blockstore_test.go
@@ -154,7 +154,9 @@ func testMove(t *testing.T, optsF func(string) Options) {
 		return nil
 	})
 	g.Go(func() error {
-		return db.moveTo("")
+		return db.CollectGarbage(map[interface{}]interface{}{
+			blockstore.BlockstoreMovingGC: true,
+		})
 	})
 
 	err = g.Wait()

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -37,8 +37,20 @@ type BlockstoreIterator interface {
 
 // BlockstoreGC is a trait for blockstores that support online garbage collection
 type BlockstoreGC interface {
-	CollectGarbage() error
+	CollectGarbage(options map[interface{}]interface{}) error
 }
+
+// garbage collection options
+type blockstoreMovingGCKey struct{}
+type blockstoreMovingGCPath struct{}
+
+// BlockstoreMovingGC is a garbage collection option that instructs the blockstore
+// to use moving GC if supported.
+var BlockstoreMovingGC = blockstoreMovingGCKey{}
+
+// BlockstoreMovingGCPath is a garbage collection option that specifies an optional
+// target path for moving GC.
+var BlockstoreMovingGCPath = blockstoreMovingGCPath{}
 
 // WrapIDStore wraps the underlying blockstore in an "identity" blockstore.
 // The ID store filters out all puts for blocks with CIDs using the "identity"

--- a/blockstore/splitstore/README.md
+++ b/blockstore/splitstore/README.md
@@ -59,6 +59,17 @@ These are options in the `[Chainstore.Splitstore]` section of the configuration:
   nodes beyond 4 finalities, while running with the discard coldstore option.
   It is also useful for miners who accept deals and need to lookback messages beyond
   the 4 finalities, which would otherwise hit the coldstore.
+- `HotStoreMovingGCFrequency` -- specifies how frequenty to garbage collect the hotstore
+  using moving GC.
+  The default value is 20, which uses moving GC every 20 compactions; set to 0 to disable moving
+  GC altogether.
+  Rationale: badger supports online GC, and this is used by default. However it has proven to
+  be ineffective in practice with the hotstore size slowly creeping up. In order to address this,
+  we have added moving GC support in our badger wrapper, which can effectively reclaim all space.
+  The downside is that it takes a bit of time to perform a moving GC (about 40min) and you also
+  need enough space to house the new hotstore while the old one is still live.
+  This option controls how frequently to perform moving GC, with the default of 20 corresponding
+  to about once a week.
 
 
 ## Operation

--- a/blockstore/splitstore/README.md
+++ b/blockstore/splitstore/README.md
@@ -70,7 +70,13 @@ These are options in the `[Chainstore.Splitstore]` section of the configuration:
   need enough space to house the new hotstore while the old one is still live.
   This option controls how frequently to perform moving GC, with the default of 20 corresponding
   to about once a week.
-
+- `ReifyColdObjects` -- specifies the behaviour of the splitstore on hotstore misses.
+  Possible values are:
+  - 0 -- don't reify cold objects (default).
+  - 1 -- reify cold objects when there is a missing View.
+  - 2 -- reify cold objects when there is a missing View or Get access.
+  Note that we distinguish View from Get, as the former is indicative of state computation or chain
+  walk, while the latter is indicative of chain exchange access from peer syncing.
 
 ## Operation
 

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -81,6 +81,13 @@ type Config struct {
 	// - a positive integer indicates the number of finalities, outside the compaction boundary,
 	//   for which messages will be retained in the hotstore.
 	HotStoreMessageRetention uint64
+
+	// HotstoreMovingGCFrequency indicates how frequently to garbage collect the hotstore using
+	// moving GC (if supported by the hotstore).
+	// A value of 0 disables moving GC entirely.
+	// A positive value is the number of compactions before a moving GC is performed;
+	// a value of 1 will perform moving GC in every compaction.
+	HotStoreMovingGCFrequency uint
 }
 
 // ChainAccessor allows the Splitstore to access the chain. It will most likely

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -87,7 +87,7 @@ type Config struct {
 	// A value of 0 disables moving GC entirely.
 	// A positive value is the number of compactions before a moving GC is performed;
 	// a value of 1 will perform moving GC in every compaction.
-	HotStoreMovingGCFrequency uint
+	HotStoreMovingGCFrequency uint64
 }
 
 // ChainAccessor allows the Splitstore to access the chain. It will most likely

--- a/cmd/lotus-shed/pruning.go
+++ b/cmd/lotus-shed/pruning.go
@@ -161,7 +161,7 @@ var stateTreePruneCmd = &cli.Command{
 		if cctx.Bool("only-ds-gc") {
 			fmt.Println("running datastore gc....")
 			for i := 0; i < cctx.Int("gc-count"); i++ {
-				if err := badgbs.DB.RunValueLogGC(DiscardRatio); err != nil {
+				if err := badgbs.DB().RunValueLogGC(DiscardRatio); err != nil {
 					return xerrors.Errorf("datastore GC failed: %w", err)
 				}
 			}
@@ -208,7 +208,7 @@ var stateTreePruneCmd = &cli.Command{
 			return nil
 		}
 
-		b := badgbs.DB.NewWriteBatch()
+		b := badgbs.DB().NewWriteBatch()
 		defer b.Cancel()
 
 		markForRemoval := func(c cid.Cid) error {
@@ -249,7 +249,7 @@ var stateTreePruneCmd = &cli.Command{
 
 		fmt.Println("running datastore gc....")
 		for i := 0; i < cctx.Int("gc-count"); i++ {
-			if err := badgbs.DB.RunValueLogGC(DiscardRatio); err != nil {
+			if err := badgbs.DB().RunValueLogGC(DiscardRatio); err != nil {
 				return xerrors.Errorf("datastore GC failed: %w", err)
 			}
 		}

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -72,6 +72,8 @@ func DefaultFullNode() *FullNode {
 				ColdStoreType: "universal",
 				HotStoreType:  "badger",
 				MarkSetType:   "map",
+
+				HotStoreMovingGCFrequency: 20,
 			},
 		},
 	}

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -717,6 +717,17 @@ the compaction boundary; default is 0.`,
 A value of 0 disables, while a value 1 will do moving GC in every compaction.
 Default is 20 (about once a week).`,
 		},
+		{
+			Name: "ReifyColdObjects",
+			Type: "int",
+
+			Comment: `ReifyColdObjects specifies whether the splitstore should automatically reify cold object
+references into the hotstore.
+It has the following possible values:
+- 0 -- don't reify cold objects (default).
+- 1 -- reify cold objects when there is a missing View.
+- 2 -- reify cold objects when there is a missing View or Get access.`,
+		},
 	},
 	"StorageMiner": []DocField{
 		{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -685,25 +685,37 @@ submitting proofs to the chain individually`,
 			Name: "ColdStoreType",
 			Type: "string",
 
-			Comment: ``,
+			Comment: `ColdStoreType specifies the type of the coldstore.
+It can be "universal" (default) or "discard" for discarding cold blocks.`,
 		},
 		{
 			Name: "HotStoreType",
 			Type: "string",
 
-			Comment: ``,
+			Comment: `HotStoreType specifies the type of the hotstore.
+Only currently supported value is "badger".`,
 		},
 		{
 			Name: "MarkSetType",
 			Type: "string",
 
-			Comment: ``,
+			Comment: `MarkSetType specifies the type of the markset.
+It can be "map" (default) for in memory marking or "badger" for on-disk marking.`,
 		},
 		{
 			Name: "HotStoreMessageRetention",
 			Type: "uint64",
 
-			Comment: ``,
+			Comment: `HotStoreMessageRetention specifies the retention policy for messages, in finalities beyond
+the compaction boundary; default is 0.`,
+		},
+		{
+			Name: "HotStoreMovingGCFrequency",
+			Type: "uint64",
+
+			Comment: `HotStoreMovingGCFrequency specifies how often to perform moving GC on the hotstore.
+A value of 0 disables, while a value 1 will do moving GC in every compaction.
+Default is 20 (about once a week).`,
 		},
 	},
 	"StorageMiner": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -295,6 +295,14 @@ type Splitstore struct {
 	// A value of 0 disables, while a value 1 will do moving GC in every compaction.
 	// Default is 20 (about once a week).
 	HotStoreMovingGCFrequency uint64
+
+	// ReifyColdObjects specifies whether the splitstore should automatically reify cold object
+	// references into the hotstore.
+	// It has the following possible values:
+	// - 0 -- don't reify cold objects (default).
+	// - 1 -- reify cold objects when there is a missing View.
+	// - 2 -- reify cold objects when there is a missing View or Get access.
+	ReifyColdObjects int
 }
 
 // // Full Node

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -282,7 +282,8 @@ type Splitstore struct {
 	HotStoreType  string
 	MarkSetType   string
 
-	HotStoreMessageRetention uint64
+	HotStoreMessageRetention  uint64
+	HotStoreMovingGCFrequency uint64
 }
 
 // // Full Node

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -278,11 +278,22 @@ type Chainstore struct {
 }
 
 type Splitstore struct {
+	// ColdStoreType specifies the type of the coldstore.
+	// It can be "universal" (default) or "discard" for discarding cold blocks.
 	ColdStoreType string
-	HotStoreType  string
-	MarkSetType   string
+	// HotStoreType specifies the type of the hotstore.
+	// Only currently supported value is "badger".
+	HotStoreType string
+	// MarkSetType specifies the type of the markset.
+	// It can be "map" (default) for in memory marking or "badger" for on-disk marking.
+	MarkSetType string
 
-	HotStoreMessageRetention  uint64
+	// HotStoreMessageRetention specifies the retention policy for messages, in finalities beyond
+	// the compaction boundary; default is 0.
+	HotStoreMessageRetention uint64
+	// HotStoreMovingGCFrequency specifies how often to perform moving GC on the hotstore.
+	// A value of 0 disables, while a value 1 will do moving GC in every compaction.
+	// Default is 20 (about once a week).
 	HotStoreMovingGCFrequency uint64
 }
 

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -78,9 +78,10 @@ func SplitBlockstore(cfg *config.Chainstore) func(lc fx.Lifecycle, r repo.Locked
 		}
 
 		cfg := &splitstore.Config{
-			MarkSetType:              cfg.Splitstore.MarkSetType,
-			DiscardColdBlocks:        cfg.Splitstore.ColdStoreType == "discard",
-			HotStoreMessageRetention: cfg.Splitstore.HotStoreMessageRetention,
+			MarkSetType:               cfg.Splitstore.MarkSetType,
+			DiscardColdBlocks:         cfg.Splitstore.ColdStoreType == "discard",
+			HotStoreMessageRetention:  cfg.Splitstore.HotStoreMessageRetention,
+			HotStoreMovingGCFrequency: cfg.Splitstore.HotStoreMovingGCFrequency,
 		}
 		ss, err := splitstore.Open(path, ds, hot, cold, cfg)
 		if err != nil {

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -82,6 +82,7 @@ func SplitBlockstore(cfg *config.Chainstore) func(lc fx.Lifecycle, r repo.Locked
 			DiscardColdBlocks:         cfg.Splitstore.ColdStoreType == "discard",
 			HotStoreMessageRetention:  cfg.Splitstore.HotStoreMessageRetention,
 			HotStoreMovingGCFrequency: cfg.Splitstore.HotStoreMovingGCFrequency,
+			ReifyColdObjects:          cfg.Splitstore.ReifyColdObjects,
 		}
 		ss, err := splitstore.Open(path, ds, hot, cold, cfg)
 		if err != nil {


### PR DESCRIPTION
On top of #6854 
Closes #6726 

This adds configurable cold object reification in the splitstore. We can do that now that #6705 is resolved.

Rationale: It has been observed that the hot range in my discard store still contains some references to the cold store (containing only the original snapshot data), even after rewarming up with #6867; afacit these are objects that get recreated by the VM and occurs-checked with Has, which avoids a write.

This patch adds a policy for cold object reification, with the following options:
- 0/default no cold object reification.
- 1 reification when there is a view.
- 2 reification when there is a view or a get.

The separation of view from get comes from the observation that state computations access objects with view to unmarshal, while chain exchange uses get to transmit over the network. Thus a setting of 1 should be safe; a setting of 2 becomes relevant only when we have gc for the coldstore, but it's there to future proof.