### PR TITLE
add explicit error msg if repo dir does not exist

### DIFF
--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -2,6 +2,7 @@ package cliutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -140,6 +141,15 @@ func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
 		r, err := repo.NewFS(p)
 		if err != nil {
 			return APIInfo{}, xerrors.Errorf("could not open repo at path: %s; %w", p, err)
+		}
+
+		exists, err := r.Exists()
+		if err != nil {
+			return APIInfo{}, xerrors.Errorf("repo.Exists returned an error: %w", err)
+		}
+
+		if !exists {
+			return APIInfo{}, errors.New("repo directory does not exist. Make sure your configuration is correct")
 		}
 
 		ma, err := r.APIEndpoint()


### PR DESCRIPTION
This PR is adding an explicit error in case someone tries to run CLI pointed at incorrect repo location. We had a lot of confusion with this yesterday, given that miners are now running multiple miner instances on one host.

```
# node not started
➜  lotus git:(nonsense/better-error-on-wrong-repo-location) ./lotus-miner info
ERROR: could not get API info: could not get api endpoint: API not running (no endpoint)

# repo directory wrong / configuration problem
➜  lotus git:(nonsense/better-error-on-wrong-repo-location) LOTUS_MINER_PATH=~/smthwrong ./lotus-miner info
ERROR: could not get API info: repo directory does not exist. Make sure your configuration is correct.
```