### PR TITLE
Implement splitstore cold object reification

### DIFF
--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -60,6 +60,11 @@ type BlockstoreSize interface {
 	Size() (int64, error)
 }
 
+// BlockstoreHotView is a trait for blockstores that support a notion of hot views
+type BlockstoreHotView interface {
+	HotView() Blockstore
+}
+
 // WrapIDStore wraps the underlying blockstore in an "identity" blockstore.
 // The ID store filters out all puts for blocks with CIDs using the "identity"
 // hash function. It also extracts inlined blocks from CIDs using the identity

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -250,7 +250,7 @@ func (s *SplitStore) iHas(cid cid.Cid, reify bool) (bool, error) {
 	}
 
 	has, err = s.cold.Has(cid)
-	if has && err != nil {
+	if has && err == nil {
 		s.reifyColdObject(cid)
 		s.trackTxnRef(cid)
 	}

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -246,7 +246,7 @@ func (s *SplitStore) iHas(cid cid.Cid, reify bool) (has bool, err error) {
 	}
 
 	has, err = s.cold.Has(cid)
-	if has && err == nil && reify {
+	if has && err == nil && reify && s.isWarm() {
 		s.reifyColdObject(cid)
 	}
 
@@ -287,7 +287,7 @@ func (s *SplitStore) iGet(cid cid.Cid, reify bool) (blk blocks.Block, err error)
 		blk, err = s.cold.Get(cid)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
-			if reify {
+			if reify && s.isWarm() {
 				s.reifyColdObject(cid)
 			}
 		}
@@ -332,7 +332,7 @@ func (s *SplitStore) iGetSize(cid cid.Cid, reify bool) (size int, err error) {
 		size, err = s.cold.GetSize(cid)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
-			if reify {
+			if reify && s.isWarm() {
 				s.reifyColdObject(cid)
 			}
 		}
@@ -487,7 +487,7 @@ func (s *SplitStore) iView(cid cid.Cid, reify bool, cb func([]byte) error) error
 		err = s.cold.View(cid, cb)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
-			if reify {
+			if reify && s.isWarm() {
 				s.reifyColdObject(cid)
 			}
 		}

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -252,7 +252,6 @@ func (s *SplitStore) iHas(cid cid.Cid, reify bool) (bool, error) {
 	has, err = s.cold.Has(cid)
 	if has && err == nil {
 		s.reifyColdObject(cid)
-		s.trackTxnRef(cid)
 	}
 
 	return has, err
@@ -292,7 +291,6 @@ func (s *SplitStore) iGet(cid cid.Cid, reify bool) (blocks.Block, error) {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
 			if reify {
 				s.reifyColdObject(cid)
-				s.trackTxnRef(cid)
 			}
 		}
 		return blk, err
@@ -336,7 +334,6 @@ func (s *SplitStore) iGetSize(cid cid.Cid, reify bool) (int, error) {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
 			if reify {
 				s.reifyColdObject(cid)
-				s.trackTxnRef(cid)
 			}
 		}
 		return size, err
@@ -492,7 +489,6 @@ func (s *SplitStore) iView(cid cid.Cid, reify bool, cb func([]byte) error) error
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
 			if reify {
 				s.reifyColdObject(cid)
-				s.trackTxnRef(cid)
 			}
 		}
 		return err

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -148,6 +148,12 @@ type SplitStore struct {
 
 	// registered protectors
 	protectors []func(func(cid.Cid) error) error
+
+	// background cold object reification
+	reifyMx         sync.Mutex
+	reifyCond       sync.Cond
+	reifyPend       map[cid.Cid]struct{}
+	reifyInProgress map[cid.Cid]struct{}
 }
 
 var _ bstore.Blockstore = (*SplitStore)(nil)
@@ -190,6 +196,9 @@ func Open(path string, ds dstore.Datastore, hot, cold bstore.Blockstore, cfg *Co
 	}
 
 	ss.txnViewsCond.L = &ss.txnViewsMx
+	ss.reifyCond.L = &ss.reifyMx
+	ss.reifyPend = make(map[cid.Cid]struct{})
+	ss.reifyInProgress = make(map[cid.Cid]struct{})
 	ss.ctx, ss.cancel = context.WithCancel(context.Background())
 
 	if enableDebugLog {
@@ -214,6 +223,10 @@ func (s *SplitStore) DeleteMany(_ []cid.Cid) error {
 }
 
 func (s *SplitStore) Has(cid cid.Cid) (bool, error) {
+	return s.iHas(cid, false)
+}
+
+func (s *SplitStore) iHas(cid cid.Cid, reify bool) (bool, error) {
 	if isIdentiyCid(cid) {
 		return true, nil
 	}
@@ -232,10 +245,24 @@ func (s *SplitStore) Has(cid cid.Cid) (bool, error) {
 		return true, nil
 	}
 
-	return s.cold.Has(cid)
+	if !reify {
+		return s.cold.Has(cid)
+	}
+
+	has, err = s.cold.Has(cid)
+	if has && err != nil {
+		s.reifyColdObject(cid)
+		s.trackTxnRef(cid)
+	}
+
+	return has, err
 }
 
 func (s *SplitStore) Get(cid cid.Cid) (blocks.Block, error) {
+	return s.iGet(cid, false)
+}
+
+func (s *SplitStore) iGet(cid cid.Cid, reify bool) (blocks.Block, error) {
 	if isIdentiyCid(cid) {
 		data, err := decodeIdentityCid(cid)
 		if err != nil {
@@ -263,7 +290,10 @@ func (s *SplitStore) Get(cid cid.Cid) (blocks.Block, error) {
 		blk, err = s.cold.Get(cid)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
-
+			if reify {
+				s.reifyColdObject(cid)
+				s.trackTxnRef(cid)
+			}
 		}
 		return blk, err
 
@@ -273,6 +303,10 @@ func (s *SplitStore) Get(cid cid.Cid) (blocks.Block, error) {
 }
 
 func (s *SplitStore) GetSize(cid cid.Cid) (int, error) {
+	return s.iGetSize(cid, false)
+}
+
+func (s *SplitStore) iGetSize(cid cid.Cid, reify bool) (int, error) {
 	if isIdentiyCid(cid) {
 		data, err := decodeIdentityCid(cid)
 		if err != nil {
@@ -300,6 +334,10 @@ func (s *SplitStore) GetSize(cid cid.Cid) (int, error) {
 		size, err = s.cold.GetSize(cid)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
+			if reify {
+				s.reifyColdObject(cid)
+				s.trackTxnRef(cid)
+			}
 		}
 		return size, err
 
@@ -418,6 +456,10 @@ func (s *SplitStore) HashOnRead(enabled bool) {
 }
 
 func (s *SplitStore) View(cid cid.Cid, cb func([]byte) error) error {
+	return s.iView(cid, false, cb)
+}
+
+func (s *SplitStore) iView(cid cid.Cid, reify bool, cb func([]byte) error) error {
 	if isIdentiyCid(cid) {
 		data, err := decodeIdentityCid(cid)
 		if err != nil {
@@ -448,6 +490,10 @@ func (s *SplitStore) View(cid cid.Cid, cb func([]byte) error) error {
 		err = s.cold.View(cid, cb)
 		if err == nil {
 			stats.Record(s.ctx, metrics.SplitstoreMiss.M(1))
+			if reify {
+				s.reifyColdObject(cid)
+				s.trackTxnRef(cid)
+			}
 		}
 		return err
 
@@ -539,6 +585,9 @@ func (s *SplitStore) Start(chain ChainAccessor) error {
 		}
 	}
 
+	// spawn the reifier
+	go s.reifyOrchestrator()
+
 	// watch the chain
 	chain.SubscribeHeadChanges(s.HeadChange)
 
@@ -565,6 +614,7 @@ func (s *SplitStore) Close() error {
 		}
 	}
 
+	s.reifyCond.Broadcast()
 	s.cancel()
 	return multierr.Combine(s.markSetEnv.Close(), s.debug.Close())
 }

--- a/blockstore/splitstore/splitstore_hotview.go
+++ b/blockstore/splitstore/splitstore_hotview.go
@@ -1,0 +1,60 @@
+package splitstore
+
+import (
+	"context"
+	"errors"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+
+	bstore "github.com/filecoin-project/lotus/blockstore"
+)
+
+type reifyingSplitStore struct {
+	s *SplitStore
+}
+
+var _ bstore.Blockstore = (*reifyingSplitStore)(nil)
+var _ bstore.BlockstoreHotView = (*SplitStore)(nil)
+
+func (s *SplitStore) HotView() bstore.Blockstore {
+	return &reifyingSplitStore{s: s}
+}
+
+func (rs *reifyingSplitStore) DeleteBlock(_ cid.Cid) error {
+	return errors.New("DeleteBlock: operation not supported")
+}
+
+func (rs *reifyingSplitStore) DeleteMany(_ []cid.Cid) error {
+	return errors.New("DeleteMany: operation not supported")
+}
+
+func (rs *reifyingSplitStore) Has(c cid.Cid) (bool, error) {
+	return rs.s.iHas(c, true)
+}
+
+func (rs *reifyingSplitStore) Get(c cid.Cid) (blocks.Block, error) {
+	return rs.s.iGet(c, true)
+}
+
+func (rs *reifyingSplitStore) GetSize(c cid.Cid) (int, error) {
+	return rs.s.iGetSize(c, true)
+}
+
+func (rs *reifyingSplitStore) Put(blk blocks.Block) error {
+	return rs.s.Put(blk)
+}
+
+func (rs *reifyingSplitStore) PutMany(blks []blocks.Block) error {
+	return rs.s.PutMany(blks)
+}
+
+func (rs *reifyingSplitStore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return rs.s.AllKeysChan(ctx)
+}
+
+func (rs *reifyingSplitStore) HashOnRead(enabled bool) {}
+
+func (rs *reifyingSplitStore) View(c cid.Cid, f func([]byte) error) error {
+	return rs.s.iView(c, true, f)
+}

--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -1,0 +1,135 @@
+package splitstore
+
+import (
+	"runtime"
+	"sync/atomic"
+
+	"golang.org/x/xerrors"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+)
+
+func (s *SplitStore) reifyColdObject(c cid.Cid) {
+	if isUnitaryObject(c) {
+		return
+	}
+
+	s.reifyMx.Lock()
+	defer s.reifyMx.Unlock()
+
+	_, ok := s.reifyInProgress[c]
+	if ok {
+		return
+	}
+
+	s.reifyPend[c] = struct{}{}
+	s.reifyCond.Broadcast()
+}
+
+func (s *SplitStore) reifyOrchestrator() {
+	workers := runtime.NumCPU() / 4
+	if workers < 2 {
+		workers = 2
+	}
+
+	workch := make(chan cid.Cid, workers)
+	defer close(workch)
+
+	for i := 0; i < workers; i++ {
+		go s.reifyWorker(workch)
+	}
+
+	for {
+		s.reifyMx.Lock()
+		for len(s.reifyPend) == 0 && atomic.LoadInt32(&s.closing) == 0 {
+			s.reifyCond.Wait()
+		}
+
+		if atomic.LoadInt32(&s.closing) != 0 {
+			s.reifyMx.Unlock()
+			return
+		}
+
+		reifyPend := s.reifyPend
+		s.reifyPend = make(map[cid.Cid]struct{})
+		for c := range reifyPend {
+			s.reifyInProgress[c] = struct{}{}
+		}
+		s.reifyMx.Unlock()
+
+		for c := range reifyPend {
+			select {
+			case workch <- c:
+			case <-s.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (s *SplitStore) reifyWorker(workch chan cid.Cid) {
+	for c := range workch {
+		s.doReify(c)
+	}
+}
+
+func (s *SplitStore) doReify(c cid.Cid) {
+	defer s.reifyDone(c)
+
+	var toreify []cid.Cid
+	err := s.walkObject(c, cid.NewSet(),
+		func(c cid.Cid) error {
+			if isUnitaryObject(c) {
+				return errStopWalk
+			}
+
+			has, err := s.hot.Has(c)
+			if err != nil {
+				return xerrors.Errorf("error checking hotstore: %w", err)
+			}
+
+			if has {
+				return errStopWalk
+			}
+
+			toreify = append(toreify, c)
+			return nil
+		})
+
+	if err != nil {
+		log.Warnf("error walking cold object for reification (cid: %s): %s", c, err)
+		return
+	}
+
+	if len(toreify) == 0 {
+		return
+	}
+
+	batch := make([]blocks.Block, 0, len(toreify))
+	for _, c := range toreify {
+		blk, err := s.cold.Get(c)
+		if err != nil {
+			log.Warnf("error retrieving cold object for reification (cid: %s): %s", c, err)
+			continue
+		}
+
+		batch = append(batch, blk)
+	}
+
+	if len(batch) == 0 {
+		return
+	}
+
+	err = s.hot.PutMany(batch)
+	if err != nil {
+		log.Warnf("error reifying cold object (cid: %s): %s", c, err)
+	}
+}
+
+func (s *SplitStore) reifyDone(c cid.Cid) {
+	s.reifyMx.Lock()
+	defer s.reifyMx.Unlock()
+
+	delete(s.reifyInProgress, c)
+}

--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -82,7 +82,7 @@ func (s *SplitStore) doReify(c cid.Cid) {
 	s.txnLk.RUnlock()
 
 	var toreify []cid.Cid
-	err := s.walkObject(c, cid.NewSet(),
+	err := s.walkObject(c, tmpVisitor(),
 		func(c cid.Cid) error {
 			if isUnitaryObject(c) {
 				return errStopWalk

--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -77,6 +77,10 @@ func (s *SplitStore) reifyWorker(workch chan cid.Cid) {
 func (s *SplitStore) doReify(c cid.Cid) {
 	defer s.reifyDone(c)
 
+	s.txnLk.RLock()
+	s.trackTxnRef(c)
+	s.txnLk.RUnlock()
+
 	var toreify []cid.Cid
 	err := s.walkObject(c, cid.NewSet(),
 		func(c cid.Cid) error {

--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -128,6 +128,8 @@ func (s *SplitStore) doReify(c cid.Cid) {
 		return
 	}
 
+	log.Debugf("reifying %d objects rooted at %s", len(toreify), c)
+
 	batch := make([]blocks.Block, 0, len(toreify))
 	for _, c := range toreify {
 		blk, err := s.cold.Get(c)

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -263,6 +263,7 @@ func testSplitStoreReification(t *testing.T, f func(blockstore.Blockstore, cid.C
 	}
 	defer ss.Close() //nolint
 
+	ss.warmupEpoch = 1
 	go ss.reifyOrchestrator()
 
 	waitForReification := func() {

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1097,7 +1097,12 @@ func (cs *ChainStore) ChainBlockstore() bstore.Blockstore {
 // stores are both backed by the same physical store, albeit with different
 // caching policies, but in the future they will segregate.
 func (cs *ChainStore) StateBlockstore() bstore.Blockstore {
-	return cs.stateBlockstore
+	bs := cs.stateBlockstore
+	if hotviewer, ok := bs.(bstore.BlockstoreHotView); ok {
+		bs = hotviewer.HotView()
+	}
+
+	return bs
 }
 
 func ActorStore(ctx context.Context, bs bstore.Blockstore) adt.Store {


### PR DESCRIPTION
See #6726 for context.

This implements a specialized view for the splitstore which reifies cold objects on hotstore misses.

~The view is hooked to the VM through the constructor _for now_ but I am not sure that's the right place to do it.~

~One alternative would be to change `Chainstore.StateBlockstore()` to take a hotview parameter, but that would touch too many call sites.~
~But maybe that's the right thing to do, open to discussion about this.~

~Another alternative is to make a `Chainstore.StateBlockstoreHotView()` and call that when we want to use the hotview.~
~We'd have to go through the vm constructor call sites and see whether we want to use it.~

Edit: the hotview is presented through the `StateBlockstore` accessor in `Chainstore`. This ensure that state accesses are reifying. Maybe that's too broad though and we need to introduce and alternate accessor which uses the reifying view, and hunt down callsites to decide what's appropriate.