### PR TITLE
Hack to handle old network versions from old apis

### DIFF
--- a/chain/actors/version.go
+++ b/chain/actors/version.go
@@ -22,6 +22,10 @@ const (
 
 // Converts a network version into an actors adt version.
 func VersionForNetwork(version network.Version) Version {
+	// Handle previous api version (1 - 13)
+	if version > network.Version0 && version < network.Version1 {
+		version = version * network.Version1 // assumes (1) even spacing between integer network numbers and (2) network.Version0 == 0
+	}
 	switch version {
 	case network.Version0, network.Version1, network.Version2, network.Version3:
 		return Version0


### PR DESCRIPTION
I don't know if this is a good idea but it should work and will make things work out when new code reads from old api calls.  

@whyrusleeping hit the panic in the wild reading from the old api.