### PR TITLE
fix bug in MpoolPending message exclusion

### DIFF
--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -84,9 +84,10 @@ func (a *MpoolAPI) MpoolPending(ctx context.Context, tsk types.TipSetKey) ([]*ty
 			if mpts.Equals(ts) {
 				return pending, nil
 			}
-			// different blocks in tipsets
 
-			have, err := a.Mpool.MessagesForBlocks(ts.Blocks())
+			// different blocks in tipsets of the same height
+			// we exclude messages that have been included in blocks in the mpool tipset
+			have, err := a.Mpool.MessagesForBlocks(mpts.Blocks())
 			if err != nil {
 				return nil, xerrors.Errorf("getting messages for base ts: %w", err)
 			}


### PR DESCRIPTION
This was discovered while reviewing the mysterious pr #4462; the intent of the code is to exclude messages that have already been included in blocks at the same height. Unfortunately, the code used `ts` instead of `mpts` rendering it effectively a noop.

This fixes the bug and adds a comment.

Note: the bug is not correctness critical, as selection is more intelleigent at picking pending messages.

Closes #4462.