### PR TITLE
lotus-shed splitstore clear command

### DIFF
--- a/blockstore/splitstore/README.md
+++ b/blockstore/splitstore/README.md
@@ -119,6 +119,7 @@ TBD -- see [#6577](https://github.com/filecoin-project/lotus/issues/6577)
   It can also optionally compact/gc the coldstore after the copy (with the `--gc-coldstore` flag)
   and automatically rewrite the lotus config to disable splitstore (with the `--rewrite-config` flag).
   Note: the node *must be stopped* before running this command.
+- `clear` -- clears a splitstore installation for restart from snapshot.
 - `check` -- asynchronously runs a basic healthcheck on the splitstore.
   The results are appended to `<lotus-repo>/datastore/splitstore/check.txt`.
 - `info` -- prints some basic information about the splitstore.

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -128,6 +128,10 @@ var splitstoreClearCmd = &cli.Command{
 			Name:  "repo",
 			Value: "~/.lotus",
 		},
+		&cli.BoolFlag{
+			Name:  "keys-only",
+			Usage: "only delete splitstore keys",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		r, err := repo.NewFS(cctx.String("repo"))
@@ -163,10 +167,12 @@ var splitstoreClearCmd = &cli.Command{
 			return xerrors.Errorf("splitstore is not enabled")
 		}
 
-		fmt.Println("clearing splitstore directory...")
-		err = clearSplitstoreDir(lr)
-		if err != nil {
-			return xerrors.Errorf("error clearing splitstore directory: %w", err)
+		if !cctx.Bool("keys-only") {
+			fmt.Println("clearing splitstore directory...")
+			err = clearSplitstoreDir(lr)
+			if err != nil {
+				return xerrors.Errorf("error clearing splitstore directory: %w", err)
+			}
 		}
 
 		fmt.Println("deleting splitstore keys from metadata datastore...")

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -93,10 +93,16 @@ var splitstoreRollbackCmd = &cli.Command{
 			return xerrors.Errorf("error copying hotstore to coldstore: %w", err)
 		}
 
+		fmt.Println("clearing splitstore directory...")
+		err = clearSplitstoreDir(lr)
+		if err != nil {
+			return xerrors.Errorf("error clearing splitstore directory: %w", err)
+		}
+
 		fmt.Println("deleting splitstore directory...")
 		err = deleteSplitstoreDir(lr)
 		if err != nil {
-			return xerrors.Errorf("error deleting splitstore directory: %w", err)
+			log.Warnf("error deleting splitstore directory: %s", err)
 		}
 
 		fmt.Println("deleting splitstore keys from metadata datastore...")


### PR DESCRIPTION
This is very useful when the splitstore/chain is linked in volatile storage and the user wants to restart from a new snapshot.