### PR TITLE
Unsubscribe slow chain head subscribers

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -31,7 +31,6 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	block "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
 	dstore "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -642,7 +641,7 @@ func (cs *ChainStore) FlushValidationCache() error {
 	return FlushValidationCache(cs.metadataDs)
 }
 
-func FlushValidationCache(ds datastore.Batching) error {
+func FlushValidationCache(ds dstore.Batching) error {
 	log.Infof("clearing block validation cache...")
 
 	dsWalk, err := ds.Query(query.Query{
@@ -674,7 +673,7 @@ func FlushValidationCache(ds datastore.Batching) error {
 	for _, k := range allKeys {
 		if strings.HasPrefix(k.Key, blockValidationCacheKeyPrefix.String()) {
 			delCnt++
-			batch.Delete(datastore.RawKey(k.Key)) // nolint:errcheck
+			batch.Delete(dstore.RawKey(k.Key)) // nolint:errcheck
 		}
 	}
 

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,7 @@ func runAPITest(t *testing.T, opts ...interface{}) {
 	t.Run("testConnectTwo", ts.testConnectTwo)
 	t.Run("testMining", ts.testMining)
 	t.Run("testMiningReal", ts.testMiningReal)
+	t.Run("testSlowNotify", ts.testSlowNotify)
 	t.Run("testSearchMsg", ts.testSearchMsg)
 	t.Run("testNonGenesisMiner", ts.testNonGenesisMiner)
 }
@@ -167,6 +169,51 @@ func (ts *apiSuite) testMiningReal(t *testing.T) {
 	}()
 
 	ts.testMining(t)
+}
+
+func (ts *apiSuite) testSlowNotify(t *testing.T) {
+	_ = logging.SetLogLevel("rpc", "ERROR")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	full, miner, _ := kit.EnsembleMinimal(t, ts.opts...)
+
+	// Subscribe a bunch of times to make sure we fill up any RPC buffers.
+	var newHeadsChans []<-chan []*lapi.HeadChange
+	for i := 0; i < 100; i++ {
+		newHeads, err := full.ChainNotify(ctx)
+		require.NoError(t, err)
+		newHeadsChans = append(newHeadsChans, newHeads)
+	}
+
+	initHead := (<-newHeadsChans[0])[0]
+	baseHeight := initHead.Val.Height()
+
+	bm := kit.NewBlockMiner(t, miner)
+	bm.MineBlocks(ctx, time.Microsecond)
+
+	full.WaitTillChain(ctx, kit.HeightAtLeast(baseHeight+100))
+
+	// Make sure they were all closed.
+	for _, ch := range newHeadsChans {
+		var ok bool
+		for ok {
+			select {
+			case _, ok = <-ch:
+			default:
+				t.Fatal("expected new heads channel to be closed")
+			}
+		}
+	}
+
+	// Make sure we can resubscribe and everything still works.
+	newHeads, err := full.ChainNotify(ctx)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		_, ok := <-newHeads
+		require.True(t, ok, "notify channel closed")
+	}
 }
 
 func (ts *apiSuite) testNonGenesisMiner(t *testing.T) {

--- a/tools/stats/rpc.go
+++ b/tools/stats/rpc.go
@@ -139,7 +139,10 @@ func GetTips(ctx context.Context, api v0api.FullNode, lastHeight abi.ChainEpoch,
 
 		for {
 			select {
-			case changes := <-notif:
+			case changes, ok := <-notif:
+				if !ok {
+					return
+				}
 				for _, change := range changes {
 					log.Infow("Head event", "height", change.Val.Height(), "type", change.Type)
 


### PR DESCRIPTION
This way, slow readers can just "resubscribe" when they're able to catch up. That way, a single slow leader doesn't block all notifications.

fixes #6883, #6947