### PR TITLE
repro backup restore error

### DIFF
--- a/cmd/lotus-miner/init_restore_test.go
+++ b/cmd/lotus-miner/init_restore_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/lib/backupds"
+	"golang.org/x/xerrors"
+)
+
+func TestRestore(t *testing.T) {
+	require.NoError(t, runBackup())
+}
+
+func runBackup() error {
+	bf := "/tmp/backup.cbor"
+
+	f, err := os.Open(bf)
+	if err != nil {
+		return xerrors.Errorf("opening backup file: %w", err)
+	}
+	defer f.Close() // nolint:errcheck
+
+	dstore := ds.NewMapDatastore()
+	err = backupds.RestoreInto(f, dstore)
+
+	if err != nil {
+		return xerrors.Errorf("restoring metadata: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
On a local devnet:
- start a miner and daemon process
- create a backup of the datastore:
  `./lotus-miner backup /tmp/backup.cbor`
- restore the backup into a new markets repo (see https://docs.filecoin.io/mine/lotus/split-markets-miners/#splitting-the-lotus-miner-monolith)

The resulting error is
```
 7.68 KiB / 13.71 KiB [==================================================================>---------------------------------------------------]  56.01% 6.04 MiB/s 0s
ERROR: restoring metadata: reading backup: unmarshaling log entry: cbor input should be of type array
```

This is an example backup file generated through the above process:
[backup.cbor.zip](https://github.com/filecoin-project/lotus/files/6925148/backup.cbor.zip)

To repro unzip the above file, put it at /tmp/backup.cbor and run TestRestore (included in this PR)