### PR TITLE
PreCommitPolicy: Don't try to align expirations on proving period boundaries

### DIFF
--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -38,7 +38,7 @@ func init() {
 
 var Methods = builtin{{.latestVersion}}.MethodsMiner
 
-// Unchanged between v0, v2, v3, and v4 actors
+// Unchanged between v0, v2, v3, v4, and v5 actors
 var WPoStProvingPeriod = miner0.WPoStProvingPeriod
 var WPoStPeriodDeadlines = miner0.WPoStPeriodDeadlines
 var WPoStChallengeWindow = miner0.WPoStChallengeWindow

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -61,7 +61,7 @@ func init() {
 
 var Methods = builtin5.MethodsMiner
 
-// Unchanged between v0, v2, v3, and v4 actors
+// Unchanged between v0, v2, v3, v4, and v5 actors
 var WPoStProvingPeriod = miner0.WPoStProvingPeriod
 var WPoStPeriodDeadlines = miner0.WPoStPeriodDeadlines
 var WPoStChallengeWindow = miner0.WPoStChallengeWindow

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -305,6 +305,10 @@ func GetMaxSectorExpirationExtension() abi.ChainEpoch {
 	return miner5.MaxSectorExpirationExtension
 }
 
+func GetMinSectorExpiration() abi.ChainEpoch {
+	return miner5.MinSectorExpiration
+}
+
 func GetMaxPoStPartitions(nv network.Version, p abi.RegisteredPoStProof) (int, error) {
 	sectorsPerPart, err := builtin5.PoStProofWindowPoStPartitionSectors(p)
 	if err != nil {

--- a/chain/actors/policy/policy.go.template
+++ b/chain/actors/policy/policy.go.template
@@ -196,6 +196,10 @@ func GetMaxSectorExpirationExtension() abi.ChainEpoch {
 	return miner{{.latestVersion}}.MaxSectorExpirationExtension
 }
 
+func GetMinSectorExpiration() abi.ChainEpoch {
+	return miner{{.latestVersion}}.MinSectorExpiration
+}
+
 func GetMaxPoStPartitions(nv network.Version, p abi.RegisteredPoStProof) (int, error) {
 	sectorsPerPart, err := builtin{{.latestVersion}}.PoStProofWindowPoStPartitionSectors(p)
 	if err != nil {

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -179,12 +179,11 @@ func (m *Miner) Run(ctx context.Context) error {
 		adaptedAPI = NewSealingAPIAdapter(m.api)
 
 		// Instantiate a precommit policy.
-		cfg             = sealing.GetSealingConfigFunc(m.getSealConfig)
-		provingBoundary = md.PeriodStart % md.WPoStProvingPeriod
-		provingBuffer   = md.WPoStProvingPeriod * 2
+		cfg           = sealing.GetSealingConfigFunc(m.getSealConfig)
+		provingBuffer = md.WPoStProvingPeriod * 2
 
 		// TODO: Maybe we update this policy after actor upgrades?
-		pcp = sealing.NewBasicPreCommitPolicy(adaptedAPI, cfg, provingBoundary, provingBuffer)
+		pcp = sealing.NewBasicPreCommitPolicy(adaptedAPI, cfg, provingBuffer)
 
 		// address selector.
 		as = func(ctx context.Context, mi miner.MinerInfo, use api.AddrUse, goodFunds, minFunds abi.TokenAmount) (address.Address, abi.TokenAmount, error) {


### PR DESCRIPTION
After a thorough examination of actors code, the PreCommitPolicy trying to align expirations on proving period boundaries is entirely unnecessary (and not even doing what it thinks it should be doing). Removing this also fixes #6065.

Also included in this PR is a check that the proposed PCP expiration isn't at risk of being invalidly small as a result of the PC message taking too long to land on chain. "At risk" is currently defined as "within 24 hours", though this should probably be a config setting.