### PR TITLE
Strict major minor version checking on v0 and v1 apis

### DIFF
--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -236,19 +236,7 @@ func GetFullNodeAPI(ctx *cli.Context) (v0api.FullNode, jsonrpc.ClientCloser, err
 		_, _ = fmt.Fprintln(ctx.App.Writer, "using full node API v0 endpoint:", addr)
 	}
 
-	v0API, closer, err := client.NewFullNodeRPCV0(ctx.Context, addr, headers)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v, err := v0API.Version(ctx.Context)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !v.APIVersion.EqMajorMinor(api.FullAPIVersion0) {
-		return nil, nil, xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", api.FullAPIVersion0, v.APIVersion)
-	}
-	return v0API, closer, nil
+	return client.NewFullNodeRPCV0(ctx.Context, addr, headers)
 }
 
 func GetFullNodeAPIV1(ctx *cli.Context) (v1api.FullNode, jsonrpc.ClientCloser, error) {

--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -236,7 +236,19 @@ func GetFullNodeAPI(ctx *cli.Context) (v0api.FullNode, jsonrpc.ClientCloser, err
 		_, _ = fmt.Fprintln(ctx.App.Writer, "using full node API v0 endpoint:", addr)
 	}
 
-	return client.NewFullNodeRPCV0(ctx.Context, addr, headers)
+	v0API, closer, err := client.NewFullNodeRPCV0(ctx.Context, addr, headers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, err := v0API.Version(ctx.Context)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !v.APIVersion.EqMajorMinor(api.FullAPIVersion0) {
+		return nil, nil, xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", api.FullAPIVersion0, v.APIVersion)
+	}
+	return v0API, closer, nil
 }
 
 func GetFullNodeAPIV1(ctx *cli.Context) (v1api.FullNode, jsonrpc.ClientCloser, error) {
@@ -253,7 +265,19 @@ func GetFullNodeAPIV1(ctx *cli.Context) (v1api.FullNode, jsonrpc.ClientCloser, e
 		_, _ = fmt.Fprintln(ctx.App.Writer, "using full node API v1 endpoint:", addr)
 	}
 
-	return client.NewFullNodeRPCV1(ctx.Context, addr, headers)
+	v1API, closer, err := client.NewFullNodeRPCV1(ctx.Context, addr, headers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, err := v1API.Version(ctx.Context)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !v.APIVersion.EqMajorMinor(api.FullAPIVersion1) {
+		return nil, nil, xerrors.Errorf("Remote API version didn't match (expected %s, remote %s)", api.FullAPIVersion1, v.APIVersion)
+	}
+	return v1API, closer, nil
 }
 
 type GetStorageMinerOptions struct {

--- a/itests/kit/client.go
+++ b/itests/kit/client.go
@@ -26,7 +26,7 @@ func RunClientTest(t *testing.T, cmds []*lcli.Command, clientNode *TestFullNode)
 	defer cancel()
 
 	// Create mock CLI
-	mockCLI := NewMockCLI(ctx, t, cmds)
+	mockCLI := NewMockCLI(ctx, t, cmds, api.NodeFull)
 	clientCLI := mockCLI.Client(clientNode.ListenAddr)
 
 	// Get the Miner address

--- a/itests/kit/mockcli.go
+++ b/itests/kit/mockcli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	lcli "github.com/urfave/cli/v2"
@@ -19,7 +20,7 @@ type MockCLI struct {
 	out  *bytes.Buffer
 }
 
-func NewMockCLI(ctx context.Context, t *testing.T, cmds []*lcli.Command) *MockCLI {
+func NewMockCLI(ctx context.Context, t *testing.T, cmds []*lcli.Command, nodeType api.NodeType) *MockCLI {
 	// Create a CLI App with an --api-url flag so that we can specify which node
 	// the command should be executed against
 	app := &lcli.App{
@@ -31,6 +32,8 @@ func NewMockCLI(ctx context.Context, t *testing.T, cmds []*lcli.Command) *MockCL
 		},
 		Commands: cmds,
 	}
+	// Set node type
+	api.RunningNodeType = nodeType
 
 	var out bytes.Buffer
 	app.Writer = &out

--- a/itests/multisig/suite.go
+++ b/itests/multisig/suite.go
@@ -18,10 +18,8 @@ import (
 func RunMultisigTests(t *testing.T, client *kit.TestFullNode) {
 	// Create mock CLI
 	ctx := context.Background()
-	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
+	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands, api.NodeFull)
 	clientCLI := mockCLI.Client(client.ListenAddr)
-	// msig tests run against a full node
-	api.RunningNodeType = api.NodeFull
 
 	// Create some wallets on the node to use for testing multisig
 	var walletAddrs []address.Address

--- a/itests/multisig/suite.go
+++ b/itests/multisig/suite.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/itests/kit"
@@ -19,6 +20,8 @@ func RunMultisigTests(t *testing.T, client *kit.TestFullNode) {
 	ctx := context.Background()
 	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
 	clientCLI := mockCLI.Client(client.ListenAddr)
+	// msig tests run against a full node
+	api.RunningNodeType = api.NodeFull
 
 	// Create some wallets on the node to use for testing multisig
 	var walletAddrs []address.Address

--- a/itests/paych_cli_test.go
+++ b/itests/paych_cli_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/itests/kit"
 
@@ -42,7 +43,7 @@ func TestPaymentChannelsBasic(t *testing.T) {
 	creatorAddr, receiverAddr := startPaychCreatorReceiverMiner(ctx, t, &paymentCreator, &paymentReceiver, blocktime)
 
 	// Create mock CLI
-	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
+	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands, api.NodeFull)
 	creatorCLI := mockCLI.Client(paymentCreator.ListenAddr)
 	receiverCLI := mockCLI.Client(paymentReceiver.ListenAddr)
 
@@ -98,7 +99,7 @@ func TestPaymentChannelStatus(t *testing.T) {
 	creatorAddr, receiverAddr := startPaychCreatorReceiverMiner(ctx, t, &paymentCreator, &paymentReceiver, blocktime)
 
 	// Create mock CLI
-	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
+	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands, api.NodeFull)
 	creatorCLI := mockCLI.Client(paymentCreator.ListenAddr)
 
 	// creator: paych status-by-from-to <creator> <receiver>
@@ -178,7 +179,7 @@ func TestPaymentChannelVouchers(t *testing.T) {
 	creatorAddr, receiverAddr := startPaychCreatorReceiverMiner(ctx, t, &paymentCreator, &paymentReceiver, blocktime)
 
 	// Create mock CLI
-	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
+	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands, api.NodeFull)
 	creatorCLI := mockCLI.Client(paymentCreator.ListenAddr)
 	receiverCLI := mockCLI.Client(paymentReceiver.ListenAddr)
 
@@ -310,7 +311,7 @@ func TestPaymentChannelVoucherCreateShortfall(t *testing.T) {
 	creatorAddr, receiverAddr := startPaychCreatorReceiverMiner(ctx, t, &paymentCreator, &paymentReceiver, blocktime)
 
 	// Create mock CLI
-	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands)
+	mockCLI := kit.NewMockCLI(ctx, t, cli.Commands, api.NodeFull)
 	creatorCLI := mockCLI.Client(paymentCreator.ListenAddr)
 
 	// creator: paych add-funds <creator> <receiver> <amount>


### PR DESCRIPTION
Related to #7012 #7020 I've been thinking that a step in the right direction is to enforce that new nodes are talking to the same API version both v0 and v1.  This won't help the problem of needing to support backwards compatibility for the v0 api for older coder versions but it will prevent nodes from this point onwards from getting too far and erroring in confusing ways when attempting to work against different api versions.

I put this up (1) to see if it breaks CI in interesting ways (2) to get the opinion of @filecoin-project/lotus-maintainers @whyrusleeping and @raulk.