### PR TITLE
make `lotus-miner net` commands hit markets subsystem.

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -58,7 +58,6 @@ var GetMarketsAPI = cliutil.GetMarketsAPI
 var GetWorkerAPI = cliutil.GetWorkerAPI
 
 var CommonCommands = []*cli.Command{
-	// NetCmd: no longer a common command, since lotus-miner nodes without a markets subsystem no longer run a libp2p node
 	AuthCmd,
 	LogCmd,
 	WaitApiCmd,

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -58,7 +58,7 @@ var GetMarketsAPI = cliutil.GetMarketsAPI
 var GetWorkerAPI = cliutil.GetWorkerAPI
 
 var CommonCommands = []*cli.Command{
-	NetCmd,
+	// NetCmd: no longer a common command, since lotus-miner nodes without a markets subsystem no longer run a libp2p node
 	AuthCmd,
 	LogCmd,
 	WaitApiCmd,

--- a/cmd/lotus-miner/main.go
+++ b/cmd/lotus-miner/main.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	cliutil "github.com/filecoin-project/lotus/cli/util"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/lotus/lib/lotuslog"
 	"github.com/filecoin-project/lotus/lib/tracing"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -78,6 +79,20 @@ func main() {
 		}
 	}
 
+	// adapt the Net* commands to always hit the node running the markets
+	// subsystem, as that is the only one that runs a libp2p node.
+	netCmd := *lcli.NetCmd // make a copy.
+	prev := netCmd.Before
+	netCmd.Before = func(c *cli.Context) error {
+		if prev != nil {
+			if err := prev(c); err != nil {
+				return err
+			}
+		}
+		c.App.Metadata["repoType"] = repo.Markets
+		return nil
+	}
+
 	app := &cli.App{
 		Name:                 "lotus-miner",
 		Usage:                "Filecoin decentralized storage network miner",
@@ -120,7 +135,7 @@ func main() {
 			},
 			cliutil.FlagVeryVerbose,
 		},
-		Commands: append(local, lcli.CommonCommands...),
+		Commands: append(local, append(lcli.CommonCommands, &netCmd)...),
 		Before: func(c *cli.Context) error {
 			// this command is explicitly called on markets, inform
 			// common commands by overriding the repoType.


### PR DESCRIPTION
The libp2p host on the miner is now only started where the markets subsystem runs. This PR makes `lotus-miner net` commands hit the node where the markets subsystem is running.

Honestly, `Net` no longer belongs in the `Common` commands, nor should the endpoint be resolved through `GetCommonAPI`/`GetAPI`, but there is some larger untangling to do to tidy this up, and it's associated with pre-existing tech debt.

Choosing not to do it now, as there are other decisions to make first with regards to providing the optimal UX experience for miners, now and as we introduce more miner services.

---

Testing: unfortunately we don't have a decent framework/suite for CLI testing. All itests hit the JSON-RPC API or the native API. So I can't add a test for this. Instead, I performed manual testing and all looks good.