### PR TITLE
 Correct the config comment for SimultaneousTransfers, where it only applies to retrieval deals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This is a **highly recommended** release of Lotus that have many bug fixes, impr
 
 ## Highlights
 - Miner SimultaneousTransfers config ([filecoin-project/lotus#6612](https://github.com/filecoin-project/lotus/pull/6612))
-  - Set `SimultaneousTransfers` in lotus miner config to configure the maximum number of parallel online data transfers, including both storage and retrieval deals.
+  - Set `SimultaneousTransfers` in lotus miner config to configure the maximum number of parallel online data transfers for retrieval deals.
+    > Note: This Changelog is updated after lotus v1.11.0 was released, and originally it was stated that
+    *Set `SimultaneousTransfers` in lotus miner config to configure the maximum number of parallel online data
+    transfers, including *both* storage and retrieval deals.* while it only applies for retrieval deals.
 - Dynamic Retrieval pricing ([filecoin-project/lotus#6175](https://github.com/filecoin-project/lotus/pull/6175))
   - Customize your retrieval ask price, see a quick tutorial [here](https://github.com/filecoin-project/lotus/discussions/6780).
 - Robust message management  ([filecoin-project/lotus#5822](https://github.com/filecoin-project/lotus/pull/5822))

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -95,8 +95,7 @@ your node if metadata log is disabled`,
 			Name: "SimultaneousTransfers",
 			Type: "uint64",
 
-			Comment: `The maximum number of simultaneous data transfers between the client
-and storage providers`,
+			Comment: `The maximum number of simultaneous data transfers between the storage provider and retrieval client`,
 		},
 	},
 	"Common": []DocField{
@@ -207,7 +206,7 @@ as a multiplier of the minimum collateral bound`,
 			Name: "SimultaneousTransfers",
 			Type: "uint64",
 
-			Comment: `The maximum number of parallel online data transfers (storage+retrieval)`,
+			Comment: `The maximum number of parallel online data transfers for retrieval deals`,
 		},
 		{
 			Name: "Filter",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -92,7 +92,7 @@ type DealmakingConfig struct {
 	// as a multiplier of the minimum collateral bound
 	MaxProviderCollateralMultiplier uint64
 
-	// The maximum number of parallel online data transfers (storage+retrieval)
+	// The maximum number of parallel online data transfers for retrieval deals
 	SimultaneousTransfers uint64
 
 	// A command used for fine-grained evaluation of storage deals
@@ -307,8 +307,7 @@ type Client struct {
 	IpfsOnlineMode      bool
 	IpfsMAddr           string
 	IpfsUseForRetrieval bool
-	// The maximum number of simultaneous data transfers between the client
-	// and storage providers
+	// The maximum number of simultaneous data transfers between the storage provider and retrieval client
 	SimultaneousTransfers uint64
 }
 


### PR DESCRIPTION
@hannahhoward has confirmed that Simultaneous transfers in graphsync ONLY affect the responder, and for storage deals the storage provoider is the receiving side so the configuration wont be effective.  