### PR TITLE
improve get api error messages

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -123,7 +123,7 @@ var AuthApiInfoToken = &cli.Command{
 
 		ainfo, err := GetAPIInfo(cctx, t)
 		if err != nil {
-			return xerrors.Errorf("could not get API info: %w", err)
+			return xerrors.Errorf("could not get API info for %s: %w", t, err)
 		}
 
 		// TODO: Log in audit log when it is implemented

--- a/cli/pprof.go
+++ b/cli/pprof.go
@@ -34,7 +34,7 @@ var PprofGoroutines = &cli.Command{
 		}
 		ainfo, err := GetAPIInfo(cctx, t)
 		if err != nil {
-			return xerrors.Errorf("could not get API info: %w", err)
+			return xerrors.Errorf("could not get API info for %s: %w", t, err)
 		}
 		addr, err := ainfo.Host()
 		if err != nil {

--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -181,7 +181,7 @@ func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
 func GetRawAPI(ctx *cli.Context, t repo.RepoType, version string) (string, http.Header, error) {
 	ainfo, err := GetAPIInfo(ctx, t)
 	if err != nil {
-		return "", nil, xerrors.Errorf("could not get API info: %w", err)
+		return "", nil, xerrors.Errorf("could not get API info for %s: %w", t, err)
 	}
 
 	addr, err := ainfo.DialArgs(version)


### PR DESCRIPTION
This PR is adding the RepoType for the node we are trying to get endpoint to.

This is helpful because with MRA and https://github.com/filecoin-project/lotus/pull/6936 we now have some CLI commands (such as `lotus-miner info`) needing to connect to 3 different API endpoints, and it'd be easier to know which connection out of the 3 cannot be established.

Related: https://github.com/filecoin-project/lotus/issues/7072