### PR TITLE
call string.Repeat always with positive int

### DIFF
--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -101,17 +101,27 @@ var sealingWorkersCmd = &cli.Command{
 
 			ramBarsRes := int(stat.Info.Resources.MemReserved * barCols / stat.Info.Resources.MemPhysical)
 			ramBarsUsed := int(stat.MemUsedMin * barCols / stat.Info.Resources.MemPhysical)
-			ramBar := color.YellowString(strings.Repeat("|", ramBarsRes)) +
-				color.GreenString(strings.Repeat("|", ramBarsUsed)) +
-				strings.Repeat(" ", int(barCols)-ramBarsUsed-ramBarsRes)
+			ramRepeatSpace := int(barCols) - (ramBarsUsed + ramBarsRes)
+			var ramBar string
+			if ramRepeatSpace < 0 {
+				ramRepeatSpace = 0
+				ramBar = color.RedString(strings.Repeat("|", ramBarsRes)) +
+					color.GreenString(strings.Repeat("|", ramBarsUsed)) +
+					strings.Repeat(" ", ramRepeatSpace)
+			} else {
+				ramBar = color.YellowString(strings.Repeat("|", ramBarsRes)) +
+					color.GreenString(strings.Repeat("|", ramBarsUsed)) +
+					strings.Repeat(" ", ramRepeatSpace)
+			}
 
 			vmem := stat.Info.Resources.MemPhysical + stat.Info.Resources.MemSwap
 
 			vmemBarsRes := int(stat.Info.Resources.MemReserved * barCols / vmem)
 			vmemBarsUsed := int(stat.MemUsedMax * barCols / vmem)
+			vmemRepeatSpace := int(barCols) - (vmemBarsUsed + vmemBarsRes)
 			vmemBar := color.YellowString(strings.Repeat("|", vmemBarsRes)) +
 				color.GreenString(strings.Repeat("|", vmemBarsUsed)) +
-				strings.Repeat(" ", int(barCols)-vmemBarsUsed-vmemBarsRes)
+				strings.Repeat(" ", vmemRepeatSpace)
 
 			fmt.Printf("\tRAM:  [%s] %d%% %s/%s\n", ramBar,
 				(stat.Info.Resources.MemReserved+stat.MemUsedMin)*100/stat.Info.Resources.MemPhysical,

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -102,24 +102,30 @@ var sealingWorkersCmd = &cli.Command{
 			ramBarsRes := int(stat.Info.Resources.MemReserved * barCols / stat.Info.Resources.MemPhysical)
 			ramBarsUsed := int(stat.MemUsedMin * barCols / stat.Info.Resources.MemPhysical)
 			ramRepeatSpace := int(barCols) - (ramBarsUsed + ramBarsRes)
-			var ramBar string
+
+			colorFunc := color.YellowString
 			if ramRepeatSpace < 0 {
 				ramRepeatSpace = 0
-				ramBar = color.RedString(strings.Repeat("|", ramBarsRes)) +
-					color.GreenString(strings.Repeat("|", ramBarsUsed)) +
-					strings.Repeat(" ", ramRepeatSpace)
-			} else {
-				ramBar = color.YellowString(strings.Repeat("|", ramBarsRes)) +
-					color.GreenString(strings.Repeat("|", ramBarsUsed)) +
-					strings.Repeat(" ", ramRepeatSpace)
+				colorFunc = color.RedString
 			}
+
+			ramBar := colorFunc(strings.Repeat("|", ramBarsRes)) +
+				color.GreenString(strings.Repeat("|", ramBarsUsed)) +
+				strings.Repeat(" ", ramRepeatSpace)
 
 			vmem := stat.Info.Resources.MemPhysical + stat.Info.Resources.MemSwap
 
 			vmemBarsRes := int(stat.Info.Resources.MemReserved * barCols / vmem)
 			vmemBarsUsed := int(stat.MemUsedMax * barCols / vmem)
 			vmemRepeatSpace := int(barCols) - (vmemBarsUsed + vmemBarsRes)
-			vmemBar := color.YellowString(strings.Repeat("|", vmemBarsRes)) +
+
+			colorFunc = color.YellowString
+			if vmemRepeatSpace < 0 {
+				vmemRepeatSpace = 0
+				colorFunc = color.RedString
+			}
+
+			vmemBar := colorFunc(strings.Repeat("|", vmemBarsRes)) +
 				color.GreenString(strings.Repeat("|", vmemBarsUsed)) +
 				strings.Repeat(" ", vmemRepeatSpace)
 


### PR DESCRIPTION
We have a report for a panic at:

```
panic: strings: negative Repeat count

goroutine 1 [running]:
strings.Repeat(0x37e2a10, 0x1, 0xffffffffffffffdf, 0x0, 0x0)
	/usr/local/go/src/strings/strings.go:529 +0x5e5
main.glob..func55(0xc000a51bc0, 0x0, 0x0)
	/home/reiers/lotus/cmd/lotus-miner/sealing.go:103 +0xa08
github.com/urfave/cli/v2.(*Command).Run(0x4c210a0, 0xc000a51ac0, 0x0, 0x0)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4dd
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000702f00, 0xc000a518c0, 0x0, 0x0)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:427 +0xa49
github.com/urfave/cli/v2.(*Command).startApp(0x4c21520, 0xc000a518c0, 0x7ffe9a138055, 0x7)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:279 +0x6bb
github.com/urfave/cli/v2.(*Command).Run(0x4c21520, 0xc000a518c0, 0x0, 0x0)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:94 +0x9cd
github.com/urfave/cli/v2.(*App).RunContext(0xc000702d80, 0x3863c10, 0xc000052948, 0xc00004e180, 0x3, 0x3, 0x0, 0x0)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
	/home/reiers/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
github.com/filecoin-project/lotus/cli.RunApp(0xc000702d80)
	/home/reiers/lotus/cli/helper.go:35 +0x7c
main.main()
	/home/reiers/lotus/cmd/lotus-miner/main.go:138 +0xd59
```

on tag `m1.3.4`

---

Apparently `int(barCols)-ramBarsUsed-ramBarsRes` somehow gets negative (calling it `ramRepeatSpace` now).

This PR is making sure `ramRepeatSpace` is set to 0, in case it is negative, and changes the colour of the string from yellow to red in this case.