### PR TITLE
miner: Command to list/remove expired sectors

### DIFF
--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -141,10 +141,21 @@ type Deadline interface {
 }
 
 type Partition interface {
+	// AllSectors returns all sector numbers in this partition, including faulty, unproven, and terminated sectors
 	AllSectors() (bitfield.BitField, error)
+
+	// Subset of sectors detected/declared faulty and not yet recovered (excl. from PoSt).
+	// Faults ∩ Terminated = ∅
 	FaultySectors() (bitfield.BitField, error)
+
+	// Subset of faulty sectors expected to recover on next PoSt
+	// Recoveries ∩ Terminated = ∅
 	RecoveringSectors() (bitfield.BitField, error)
+
+	// Live sectors are those that are not terminated (but may be faulty).
 	LiveSectors() (bitfield.BitField, error)
+
+	// Active sectors are those that are neither terminated nor faulty nor unproven, i.e. actively contributing power.
 	ActiveSectors() (bitfield.BitField, error)
 }
 

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -200,10 +200,21 @@ type Deadline interface {
 }
 
 type Partition interface {
+	// AllSectors returns all sector numbers in this partition, including faulty, unproven, and terminated sectors
 	AllSectors() (bitfield.BitField, error)
+
+	// Subset of sectors detected/declared faulty and not yet recovered (excl. from PoSt).
+	// Faults ∩ Terminated = ∅
 	FaultySectors() (bitfield.BitField, error)
+
+	// Subset of faulty sectors expected to recover on next PoSt
+	// Recoveries ∩ Terminated = ∅
 	RecoveringSectors() (bitfield.BitField, error)
+
+	// Live sectors are those that are not terminated (but may be faulty).
 	LiveSectors() (bitfield.BitField, error)
+
+	// Active sectors are those that are neither terminated nor faulty nor unproven, i.e. actively contributing power.
 	ActiveSectors() (bitfield.BitField, error)
 }
 

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1553,24 +1553,6 @@ var sectorsExpiredCmd = &cli.Command{
 		defer nCloser()
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
-		if err != nil {
-			return xerrors.Errorf("getting actor address: %w", err)
-		}
-
-		// toCheck is a working bitfield which will only contain terminated sectors
-		toCheck := bitfield.New()
-		{
-			sectors, err := nodeApi.SectorsList(ctx)
-			if err != nil {
-				return xerrors.Errorf("getting sector list: %w", err)
-			}
-
-			for _, sector := range sectors {
-				toCheck.Set(uint64(sector))
-			}
-		}
-
 		head, err := fullApi.ChainHead(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting chain head: %w", err)
@@ -1596,6 +1578,24 @@ var sectorsExpiredCmd = &cli.Command{
 		lbts, err := fullApi.ChainGetTipSetByHeight(ctx, lbEpoch, head.Key())
 		if err != nil {
 			return xerrors.Errorf("getting lookback tipset: %w", err)
+		}
+
+		maddr, err := nodeApi.ActorAddress(ctx)
+		if err != nil {
+			return xerrors.Errorf("getting actor address: %w", err)
+		}
+
+		// toCheck is a working bitfield which will only contain terminated sectors
+		toCheck := bitfield.New()
+		{
+			sectors, err := nodeApi.SectorsList(ctx)
+			if err != nil {
+				return xerrors.Errorf("getting sector list: %w", err)
+			}
+
+			for _, sector := range sectors {
+				toCheck.Set(uint64(sector))
+			}
 		}
 
 		mact, err := fullApi.StateGetActor(ctx, maddr, lbts.Key())

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1616,6 +1616,9 @@ var sectorsExpiredCmd = &cli.Command{
 
 		// only allocated sectors can be expired,
 		toCheck, err = bitfield.IntersectBitField(toCheck, *alloc)
+		if err != nil {
+			return xerrors.Errorf("intersecting bitfields: %w", err)
+		}
 
 		if err := mas.ForEachDeadline(func(dlIdx uint64, dl miner.Deadline) error {
 			return dl.ForEachPartition(func(partIdx uint64, part miner.Partition) error {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1472,6 +1472,7 @@ COMMANDS:
    update-state       ADVANCED: manually update the state of a sector, this may aid in error recovery
    pledge             store random data in a sector
    check-expire       Inspect expiring sectors
+   expired            Get or cleanup expired sectors
    renew              Renew expiring sectors while not exceeding each sector's max life
    extend             Extend sector expiration
    terminate          Terminate sector on-chain then remove (WARNING: This means losing power and collateral for the removed sector)
@@ -1574,6 +1575,22 @@ USAGE:
 OPTIONS:
    --cutoff value  skip sectors whose current expiration is more than <cutoff> epochs from now, defaults to 60 days (default: 172800)
    --help, -h      show help (default: false)
+   
+```
+
+### lotus-miner sectors expired
+```
+NAME:
+   lotus-miner sectors expired - Get or cleanup expired sectors
+
+USAGE:
+   lotus-miner sectors expired [command options] [arguments...]
+
+OPTIONS:
+   --show-removed         show removed sectors (default: false)
+   --remove-expired       remove expired sectors (default: false)
+   --expired-epoch value  epoch at which to check sector expirations (default: WinningPoSt lookback epoch)
+   --help, -h             show help (default: false)
    
 ```
 


### PR DESCRIPTION
We should make this automatic at some point, but this is at least a good tool to manage expired sectors

`--show-removed` output:
![2021-08-19-170424_792x730_scrot](https://user-images.githubusercontent.com/3867941/130093463-2cf05709-fd7e-4e27-8cc4-c7e3e532a54a.png)

The 'actually remove things' output:
![2021-08-19-170441_897x1123_scrot](https://user-images.githubusercontent.com/3867941/130093568-9532b40b-5fbf-4c13-95e6-cfb5d96998d6.png)
