### PR TITLE
itests: support larger sector sizes; add large deal test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,6 +811,11 @@ workflows:
           target: "./itests/deadlines_test.go"
       
       - test:
+          name: test-itest-deals_512mb
+          suite: itest-deals_512mb
+          target: "./itests/deals_512mb_test.go"
+      
+      - test:
           name: test-itest-deals_concurrent
           suite: itest-deals_concurrent
           target: "./itests/deals_concurrent_test.go"

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/stretchr/testify/require"
+
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAPI(t *testing.T) {
@@ -186,7 +186,7 @@ func (ts *apiSuite) testNonGenesisMiner(t *testing.T) {
 	var newMiner kit.TestMiner
 	ens.Miner(&newMiner, full,
 		kit.OwnerAddr(full.DefaultKey),
-		kit.ProofType(abi.RegisteredSealProof_StackedDrg2KiBV1_1),
+		kit.SectorSize(2<<10),
 		kit.WithAllSubsystems(),
 	).Start().InterconnectAll()
 

--- a/itests/deals_512mb_test.go
+++ b/itests/deals_512mb_test.go
@@ -15,7 +15,7 @@ func TestStorageDealMissingBlock(t *testing.T) {
 	ctx := context.Background()
 
 	// enable 512MiB proofs so we can conduct larger transfers.
-	kit.EnableLargeSectors()
+	kit.EnableLargeSectors(t)
 	kit.QuietMiningLogs()
 
 	client, miner, ens := kit.EnsembleMinimal(t,

--- a/itests/deals_512mb_test.go
+++ b/itests/deals_512mb_test.go
@@ -1,0 +1,44 @@
+package itests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/itests/kit"
+)
+
+func TestStorageDealMissingBlock(t *testing.T) {
+	ctx := context.Background()
+
+	// enable 512MiB proofs so we can conduct larger transfers.
+	kit.EnableLargeSectors()
+	kit.QuietMiningLogs()
+
+	client, miner, ens := kit.EnsembleMinimal(t,
+		kit.MockProofs(),
+		kit.SectorSize(512<<20), // 512MiB sectors.
+	)
+	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
+
+	dh := kit.NewDealHarness(t, client, miner, miner)
+
+	client.WaitTillChain(ctx, kit.HeightAtLeast(5))
+
+	res, _ := client.CreateImportFile(ctx, 0, 64<<20) // 64MiB file.
+	list, err := client.ClientListImports(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, res.Root, *list[0].Root)
+
+	dp := dh.DefaultStartDealParams()
+	dp.Data.Root = res.Root
+	dp.FastRetrieval = true
+	dp.EpochPrice = abi.NewTokenAmount(62500000) // minimum asking price.
+	deal := dh.StartDeal(ctx, dp)
+
+	dh.WaitDealSealed(ctx, deal, false, false, nil)
+}

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -17,13 +17,6 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/network"
 	"github.com/filecoin-project/go-storedcounter"
-	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
-	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
-	"github.com/ipfs/go-datastore"
-	libp2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/peer"
-	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
@@ -51,6 +44,13 @@ import (
 	testing2 "github.com/filecoin-project/lotus/node/modules/testing"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/lotus/storage/mockstorage"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	power2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/power"
+	"github.com/ipfs/go-datastore"
+	libp2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {

--- a/itests/kit/ensemble_opts.go
+++ b/itests/kit/ensemble_opts.go
@@ -4,8 +4,10 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/stmgr"
+
 	"github.com/filecoin-project/lotus/chain/wallet"
 )
 
@@ -37,6 +39,9 @@ var DefaultEnsembleOpts = ensembleOpts{
 func MockProofs() EnsembleOpt {
 	return func(opts *ensembleOpts) error {
 		opts.mockProofs = true
+		// since we're using mock proofs, we don't need to download
+		// proof parameters
+		build.DisableBuiltinAssets = true
 		return nil
 	}
 }

--- a/itests/kit/init.go
+++ b/itests/kit/init.go
@@ -6,16 +6,16 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	logging "github.com/ipfs/go-log/v2"
+
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
-	logging "github.com/ipfs/go-log/v2"
 )
 
 func init() {
 	_ = logging.SetLogLevel("*", "INFO")
 
 	policy.SetProviderCollateralSupplyTarget(big.Zero(), big.NewInt(1))
-
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(2048))
 	policy.SetSupportedProofTypes(abi.RegisteredSealProof_StackedDrg2KiBV1)
 	policy.SetMinVerifiedDealSize(abi.NewStoragePower(256))

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -3,6 +3,7 @@ package kit
 import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
@@ -30,14 +31,14 @@ type nodeOpts struct {
 	mainMiner     *TestMiner
 	disableLibp2p bool
 	optBuilders   []OptBuilder
-	proofType     abi.RegisteredSealProof
+	sectorSize    abi.SectorSize
 }
 
 // DefaultNodeOpts are the default options that will be applied to test nodes.
 var DefaultNodeOpts = nodeOpts{
-	balance:   big.Mul(big.NewInt(100000000), types.NewInt(build.FilecoinPrecision)),
-	sectors:   DefaultPresealsPerBootstrapMiner,
-	proofType: abi.RegisteredSealProof_StackedDrg2KiBV1_1, // default _concrete_ proof type for non-genesis miners (notice the _1) for new actors versions.
+	balance:    big.Mul(big.NewInt(100000000), types.NewInt(build.FilecoinPrecision)),
+	sectors:    DefaultPresealsPerBootstrapMiner,
+	sectorSize: abi.SectorSize(2 << 10), // 2KiB.
 }
 
 // OptBuilder is used to create an option after some other node is already
@@ -135,11 +136,13 @@ func ConstructorOpts(extra ...node.Option) NodeOpt {
 	}
 }
 
-// ProofType sets the proof type for this node. If you're using new actor
-// versions, this should be a _1 proof type.
-func ProofType(proofType abi.RegisteredSealProof) NodeOpt {
+// SectorSize sets the sector size for this miner. Start() will populate the
+// corresponding proof type depending on the network version (genesis network
+// version if the Ensemble is unstarted, or the current network version
+// if started).
+func SectorSize(sectorSize abi.SectorSize) NodeOpt {
 	return func(opts *nodeOpts) error {
-		opts.proofType = proofType
+		opts.sectorSize = sectorSize
 		return nil
 	}
 }

--- a/itests/kit/sectors.go
+++ b/itests/kit/sectors.go
@@ -1,6 +1,8 @@
 package kit
 
 import (
+	"testing"
+
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -8,9 +10,14 @@ import (
 
 // EnableLargeSectors enables 512MiB sectors. This is useful in combination with
 // mock proofs, for testing larger transfers.
-func EnableLargeSectors() {
+func EnableLargeSectors(t *testing.T) {
 	policy.SetSupportedProofTypes(
 		abi.RegisteredSealProof_StackedDrg2KiBV1,
-		abi.RegisteredSealProof_StackedDrg512MiBV1, // <==
+		abi.RegisteredSealProof_StackedDrg512MiBV1, // <== here
 	)
+	t.Cleanup(func() { // reset when done.
+		policy.SetSupportedProofTypes(
+			abi.RegisteredSealProof_StackedDrg2KiBV1,
+		)
+	})
 }

--- a/itests/kit/sectors.go
+++ b/itests/kit/sectors.go
@@ -1,0 +1,16 @@
+package kit
+
+import (
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/chain/actors/policy"
+)
+
+// EnableLargeSectors enables 512MiB sectors. This is useful in combination with
+// mock proofs, for testing larger transfers.
+func EnableLargeSectors() {
+	policy.SetSupportedProofTypes(
+		abi.RegisteredSealProof_StackedDrg2KiBV1,
+		abi.RegisteredSealProof_StackedDrg512MiBV1, // <==
+	)
+}


### PR DESCRIPTION
Up until now, itests has been limited by the 2KiB sector size. It has been impractical to use larger sizes because we would go download the proof parameters, even if using mock proofs.

This PR:
1. introduces the ability to specify the sector size as a `Miner` `NodeOpt`.
2. introduces sugar to enable large sectors in the policy (concretely 512MiB sectors).
3. adds a test that performs a 64MiB deal.
4. allows us to specify arbitrary sector sizes on genesis (before, we would ignore the relevant NodeOpt).

## Future

Now that we can perform deals with more interesting sizes, we should look into the following:

- performing deals without writing files on disk (constructing a random DAG in memoroy, for example)
- adjusting the test kit to introduce deal size as a first-class parameter -- right now it's not really adjustable.