### PR TITLE
sealing: Check piece CIDs after AddPiece

### DIFF
--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-commp-utils/zerocomm"
 	"github.com/filecoin-project/go-padreader"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-statemachine"
@@ -187,6 +188,8 @@ func (m *Sealing) handleAddPiece(ctx statemachine.Context, sector SectorInfo) er
 		offset += padLength.Unpadded()
 
 		for _, p := range pads {
+			expectCid := zerocomm.ZeroPieceCommitment(p.Unpadded())
+
 			ppi, err := m.sealer.AddPiece(sectorstorage.WithPriority(ctx.Context(), DealSectorPriority),
 				m.minerSector(sector.SectorType, sector.SectorNumber),
 				pieceSizes,
@@ -194,6 +197,11 @@ func (m *Sealing) handleAddPiece(ctx statemachine.Context, sector SectorInfo) er
 				NewNullReader(p.Unpadded()))
 			if err != nil {
 				err = xerrors.Errorf("writing padding piece: %w", err)
+				deal.accepted(sector.SectorNumber, offset, err)
+				return ctx.Send(SectorAddPieceFailed{err})
+			}
+			if !ppi.PieceCID.Equals(expectCid) {
+				err = xerrors.Errorf("got unexpected padding piece CID: expected:%s, got:%s", expectCid, ppi.PieceCID)
 				deal.accepted(sector.SectorNumber, offset, err)
 				return ctx.Send(SectorAddPieceFailed{err})
 			}
@@ -211,6 +219,11 @@ func (m *Sealing) handleAddPiece(ctx statemachine.Context, sector SectorInfo) er
 			deal.data)
 		if err != nil {
 			err = xerrors.Errorf("writing piece: %w", err)
+			deal.accepted(sector.SectorNumber, offset, err)
+			return ctx.Send(SectorAddPieceFailed{err})
+		}
+		if !ppi.PieceCID.Equals(deal.deal.DealProposal.PieceCID) {
+			err = xerrors.Errorf("got unexpected piece CID: expected:%s, got:%s", deal.deal.DealProposal.PieceCID, ppi.PieceCID)
 			deal.accepted(sector.SectorNumber, offset, err)
 			return ctx.Send(SectorAddPieceFailed{err})
 		}

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-commp-utils/zerocomm"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
@@ -88,9 +89,14 @@ func (m *Sealing) padSector(ctx context.Context, sectorID storage.SectorRef, exi
 
 	out := make([]abi.PieceInfo, len(sizes))
 	for i, size := range sizes {
+		expectCid := zerocomm.ZeroPieceCommitment(size)
+
 		ppi, err := m.sealer.AddPiece(ctx, sectorID, existingPieceSizes, size, NewNullReader(size))
 		if err != nil {
 			return nil, xerrors.Errorf("add piece: %w", err)
+		}
+		if !expectCid.Equals(expectCid) {
+			return nil, xerrors.Errorf("got unexpected padding piece CID: expected:%s, got:%s", expectCid, ppi.PieceCID)
 		}
 
 		existingPieceSizes = append(existingPieceSizes, size)


### PR DESCRIPTION
Non-worker-api-breaking alternative to https://github.com/filecoin-project/lotus/pull/7175

The difference here is that after adding a bad piece ta a sector, it will be market as 'allocated' in the sector file, but that's actually fine as we allow overwriting allocated parts of sectors - the only thing we need to do to recover from this is to not add the bad piece to the `sector.Pieces` array, and the subsequent AddPiece calls will overwrite the bad data with good data