### PR TITLE
ci: increase miner codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,7 +25,7 @@ coverage:
           - "paychmgr"
       miner: 
         target: auto
-        threshold: 0.5%
+        threshold: 1%
         informational: false       
         paths: 
           - "miner"


### PR DESCRIPTION
Unfortunately, the tests are non-deterministic enough to vary by more than 0.5 (up to 0.75%). This change allows up to 1% variance in code coverage, but only for miner tests.