### PR TITLE
Revert "Merge pull request #7187 from filecoin-project/test/disable-broken-testground"

### DIFF
--- a/.github/workflows/testground-on-push.yml
+++ b/.github/workflows/testground-on-push.yml
@@ -10,11 +10,10 @@ jobs:
     strategy:
       matrix:
         include:
-          # Currently broken.
-          #- backend_addr: ci.testground.ipfs.team
-          #  backend_proto: https
-          #  plan_directory: testplans/lotus-soup
-          #  composition_file: testplans/lotus-soup/_compositions/baseline-k8s-3-1.toml
+          - backend_addr: ci.testground.ipfs.team
+            backend_proto: https
+            plan_directory: testplans/lotus-soup
+            composition_file: testplans/lotus-soup/_compositions/baseline-k8s-3-1.toml
           - backend_addr: ci.testground.ipfs.team
             backend_proto: https
             plan_directory: testplans/lotus-soup


### PR DESCRIPTION
This reverts commit a9826dce27a37718c990d8d7f5c081c5b64f60d0, reversing
changes made to 8bcd917c12d6a741942c467f04f0184e510714a1.

Unfortunately, the underlying issue looks like it might still be load related so I've disabled the entire workflow through the GitHub UI. We might as well re-enable this test while we're at it, it won't run till we re-enable the workflow.