### PR TITLE
Add optional mined block list to miner info

### DIFF
--- a/chain/actors/builtin/reward/reward.go
+++ b/chain/actors/builtin/reward/reward.go
@@ -123,7 +123,7 @@ type State interface {
 	cbor.Marshaler
 
 	ThisEpochBaselinePower() (abi.StoragePower, error)
-	ThisEpochReward() (abi.TokenAmount, error)
+	ThisEpochReward() (abi.StoragePower, error)
 	ThisEpochRewardSmoothed() (builtin.FilterEstimate, error)
 
 	EffectiveBaselinePower() (abi.StoragePower, error)

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -430,6 +430,7 @@ COMMANDS:
 
 OPTIONS:
    --hide-sectors-info  hide sectors info (default: false)
+   --blocks value       Log of produced <blocks> newest blocks and rewards(Miner Fee excluded) (default: 0)
    --help, -h           show help (default: false)
    --version, -v        print the version (default: false)
    


### PR DESCRIPTION
This is https://github.com/filecoin-project/lotus/pull/5290 with conflicts resolved, and with some tweaks (mostly added a  progress indicator which is useful for miners who only mine a block or two per month, where this gets a little slow (2-3 min per month))