### PR TITLE
Reduce lotus-miner startup spam

### DIFF
--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -575,7 +575,6 @@ func (m *Manager) FinalizeSector(ctx context.Context, sector storage.SectorRef, 
 }
 
 func (m *Manager) ReleaseUnsealed(ctx context.Context, sector storage.SectorRef, safeToFree []storage.Range) error {
-	log.Warnw("ReleaseUnsealed todo")
 	return nil
 }
 

--- a/extern/storage-sealing/states_proving.go
+++ b/extern/storage-sealing/states_proving.go
@@ -129,7 +129,6 @@ func (m *Sealing) handleRemoving(ctx statemachine.Context, sector SectorInfo) er
 
 func (m *Sealing) handleProvingSector(ctx statemachine.Context, sector SectorInfo) error {
 	// TODO: track sector health / expiration
-	log.Infof("Proving sector %d", sector.SectorNumber)
 
 	cfg, err := m.getConfig()
 	if err != nil {


### PR DESCRIPTION
Those 2 logs would be printed on each lotus-miner startup for each sector, which even for not-so-big miners means tens of thousands of rather useless log lines on every restart