### PR TITLE
rm go-multistore dependency.

### DIFF
--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-filestore"
@@ -90,7 +89,6 @@ func init() {
 	addExample(pid)
 	addExample(&pid)
 
-	multistoreIDExample := multistore.StoreID(50)
 	storeIDExample := imports.ID(50)
 
 	addExample(bitfield.NewFromSet([]uint64{5}))
@@ -124,8 +122,6 @@ func init() {
 	addExample(datatransfer.Ongoing)
 	addExample(storeIDExample)
 	addExample(&storeIDExample)
-	addExample(multistoreIDExample)
-	addExample(&multistoreIDExample)
 	addExample(retrievalmarket.ClientEventDealAccepted)
 	addExample(retrievalmarket.DealStatusNew)
 	addExample(network.ReachabilityPublic)

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
 	github.com/filecoin-project/go-fil-markets v1.9.0
 	github.com/filecoin-project/go-jsonrpc v0.1.4-0.20210217175800-45ea43ac2bec
-	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20210614165157-25a6c7769498
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210810190654-139e0e79e69e


### PR DESCRIPTION
Farewell! Following the adoption of the dagstore, this library has been decommissioned from the Lotus codebase.