### PR TITLE
add fauxrep2 sector sealing

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -264,6 +264,7 @@ var sealBenchCmd = &cli.Command{
 		var sealTimings []SealingResult
 		var extendedSealedSectors []saproof7.ExtendedSectorInfo
 		var sealedSectors []saproof7.SectorInfo
+		var bo BenchResults
 
 		if robench == "" {
 			var err error
@@ -276,12 +277,21 @@ var sealBenchCmd = &cli.Command{
 			if err != nil {
 				return xerrors.Errorf("failed to run seals: %w", err)
 			}
+
 			for _, s := range extendedSealedSectors {
 				sealedSectors = append(sealedSectors, proof.SectorInfo{
 					SealedCID:    s.SealedCID,
 					SectorNumber: s.SectorNumber,
 					SealProof:    s.SealProof,
 				})
+			}
+
+			bo.SectorSize = sectorSize
+			bo.SectorNumber = sectorNumber
+			bo.SealingResults = sealTimings
+
+			if err := bo.SumSealingTime(); err != nil {
+				return err
 			}
 		} else {
 			// TODO: implement sbfs.List() and use that for all cases (preexisting sectorbuilder or not)
@@ -318,15 +328,6 @@ var sealBenchCmd = &cli.Command{
 					SealProof:    s.ProofType,
 				})
 			}
-		}
-
-		bo := BenchResults{
-			SectorSize:     sectorSize,
-			SectorNumber:   sectorNumber,
-			SealingResults: sealTimings,
-		}
-		if err := bo.SumSealingTime(); err != nil {
-			return err
 		}
 
 		var challenge [32]byte

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -99,6 +99,11 @@ var preSealCmd = &cli.Command{
 			Usage: "specify network version",
 			Value: uint(build.NewestNetworkVersion),
 		},
+		&cli.StringFlag{
+			Name:  "pre-aux",
+			Value: "",
+			Usage: "path to previously generated p_aux file",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		sdir := c.String("sector-dir")
@@ -144,12 +149,21 @@ var preSealCmd = &cli.Command{
 			return err
 		}
 
-		gm, key, err := seed.PreSeal(maddr, spt, abi.SectorNumber(c.Uint64("sector-offset")), c.Int("num-sectors"), sbroot, []byte(c.String("ticket-preimage")), k, c.Bool("fake-sectors"))
-		if err != nil {
-			return err
+		if c.IsSet("pre-aux") {
+			gm, key, err := seed.PreSealFauxRep2(maddr, spt, abi.SectorNumber(c.Uint64("sector-offset")), c.Int("num-sectors"), sbroot, []byte(c.String("ticket-preimage")), k, c.String("pre-aux"))
+			if err != nil {
+				return err
+			}
+			return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
+		} else {
+			gm, key, err := seed.PreSeal(maddr, spt, abi.SectorNumber(c.Uint64("sector-offset")), c.Int("num-sectors"), sbroot, []byte(c.String("ticket-preimage")), k, c.Bool("fake-sectors"))
+			if err != nil {
+				return err
+			}
+			return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
 		}
 
-		return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
+		return nil
 	},
 }
 

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -154,16 +154,16 @@ var preSealCmd = &cli.Command{
 			if err != nil {
 				return err
 			}
-			return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
-		} else {
-			gm, key, err := seed.PreSeal(maddr, spt, abi.SectorNumber(c.Uint64("sector-offset")), c.Int("num-sectors"), sbroot, []byte(c.String("ticket-preimage")), k, c.Bool("fake-sectors"))
-			if err != nil {
-				return err
-			}
+
 			return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
 		}
 
-		return nil
+		gm, key, err := seed.PreSeal(maddr, spt, abi.SectorNumber(c.Uint64("sector-offset")), c.Int("num-sectors"), sbroot, []byte(c.String("ticket-preimage")), k, c.Bool("fake-sectors"))
+		if err != nil {
+			return err
+		}
+
+		return seed.WriteGenesisMiner(maddr, sbroot, gm, key)
 	},
 }
 


### PR DESCRIPTION
fauxrep2 is a faster way to generate sectors for network genesis setup by reusing data from a previously generated sector.

```
$ lotus-seed --sector-dir=/storage/seeding/fake-32GiB-sectors pre-seal --fake-sectors --sector-size 32GiB --network-version 12
$ lotus-seed --sector-dir=/storage/seeding/faux2-32GiB-sectors pre-seal --sector-size 32GiB --network-version 12 --pre-aux /storage/seeding/fake-32GiB-sectors/cache/s-t01000-0/p_aux --num-sectors 1024
```

This will generate 1024 sectors which can reuse the tree data from the previous 32GiB fake sector. File system shaping is required after this step (eg copying / linking the tree data files into each sector, generating zero block sectors, etc).

See https://github.com/filecoin-project/rust-fil-proofs/pull/1218 for more information.