### PR TITLE
sectors expired: Handle precomitted and unproven sectors correctly

### DIFF
--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -157,6 +157,12 @@ type Partition interface {
 
 	// Active sectors are those that are neither terminated nor faulty nor unproven, i.e. actively contributing power.
 	ActiveSectors() (bitfield.BitField, error)
+
+	// Unproven sectors in this partition. This bitfield will be cleared on
+	// a successful window post (or at the end of the partition's next
+	// deadline). At that time, any still unproven sectors will be added to
+	// the faulty sector bitfield.
+	UnprovenSectors() (bitfield.BitField, error)
 }
 
 type SectorOnChainInfo struct {

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -216,6 +216,12 @@ type Partition interface {
 
 	// Active sectors are those that are neither terminated nor faulty nor unproven, i.e. actively contributing power.
 	ActiveSectors() (bitfield.BitField, error)
+
+	// Unproven sectors in this partition. This bitfield will be cleared on
+	// a successful window post (or at the end of the partition's next
+	// deadline). At that time, any still unproven sectors will be added to
+	// the faulty sector bitfield.
+	UnprovenSectors() (bitfield.BitField, error)
 }
 
 type SectorOnChainInfo struct {

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -549,6 +549,10 @@ func (p *partition{{.v}}) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition{{.v}}) UnprovenSectors() (bitfield.BitField, error) {
+	return {{if (ge .v 2)}}p.Partition.Unproven{{else}}bitfield.New(){{end}}, nil
+}
+
 func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorOnChainInfo {
 {{if (ge .v 2)}}
 	return SectorOnChainInfo{

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -500,6 +500,10 @@ func (p *partition0) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition0) UnprovenSectors() (bitfield.BitField, error) {
+	return bitfield.New(), nil
+}
+
 func fromV0SectorOnChainInfo(v0 miner0.SectorOnChainInfo) SectorOnChainInfo {
 
 	return (SectorOnChainInfo)(v0)

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -530,6 +530,10 @@ func (p *partition2) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition2) UnprovenSectors() (bitfield.BitField, error) {
+	return p.Partition.Unproven, nil
+}
+
 func fromV2SectorOnChainInfo(v2 miner2.SectorOnChainInfo) SectorOnChainInfo {
 
 	return SectorOnChainInfo{

--- a/chain/actors/builtin/miner/v3.go
+++ b/chain/actors/builtin/miner/v3.go
@@ -531,6 +531,10 @@ func (p *partition3) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition3) UnprovenSectors() (bitfield.BitField, error) {
+	return p.Partition.Unproven, nil
+}
+
 func fromV3SectorOnChainInfo(v3 miner3.SectorOnChainInfo) SectorOnChainInfo {
 
 	return SectorOnChainInfo{

--- a/chain/actors/builtin/miner/v4.go
+++ b/chain/actors/builtin/miner/v4.go
@@ -531,6 +531,10 @@ func (p *partition4) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition4) UnprovenSectors() (bitfield.BitField, error) {
+	return p.Partition.Unproven, nil
+}
+
 func fromV4SectorOnChainInfo(v4 miner4.SectorOnChainInfo) SectorOnChainInfo {
 
 	return SectorOnChainInfo{

--- a/chain/actors/builtin/miner/v5.go
+++ b/chain/actors/builtin/miner/v5.go
@@ -531,6 +531,10 @@ func (p *partition5) RecoveringSectors() (bitfield.BitField, error) {
 	return p.Partition.Recoveries, nil
 }
 
+func (p *partition5) UnprovenSectors() (bitfield.BitField, error) {
+	return p.Partition.Unproven, nil
+}
+
 func fromV5SectorOnChainInfo(v5 miner5.SectorOnChainInfo) SectorOnChainInfo {
 
 	return SectorOnChainInfo{

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1628,9 +1628,28 @@ var sectorsExpiredCmd = &cli.Command{
 				}
 
 				toCheck, err = bitfield.SubtractBitField(toCheck, live)
+				if err != nil {
+					return err
+				}
+
+				unproven, err := part.UnprovenSectors()
+				if err != nil {
+					return err
+				}
+
+				toCheck, err = bitfield.SubtractBitField(toCheck, unproven)
+
 				return err
 			})
 		}); err != nil {
+			return err
+		}
+
+		err = mas.ForEachPrecommittedSector(func(pci miner.SectorPreCommitOnChainInfo) error {
+			toCheck.Unset(uint64(pci.Info.SectorNumber))
+			return nil
+		})
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Without this we'd say that sectors which were not PoSt-ed yet were already expired.