### PR TITLE
introduce MaxStagingDealsBytes - reject new deals if our staging deals area is full

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,6 +821,11 @@ workflows:
           target: "./itests/deals_concurrent_test.go"
       
       - test:
+          name: test-itest-deals_max_staging_deals
+          suite: itest-deals_max_staging_deals
+          target: "./itests/deals_max_staging_deals_test.go"
+      
+      - test:
           name: test-itest-deals_offline
           suite: itest-deals_offline
           target: "./itests/deals_offline_test.go"

--- a/itests/deals_max_staging_deals_test.go
+++ b/itests/deals_max_staging_deals_test.go
@@ -1,0 +1,65 @@
+package itests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/itests/kit"
+)
+
+func TestMaxStagingDeals(t *testing.T) {
+	ctx := context.Background()
+
+	// enable 512MiB proofs so we can conduct larger transfers.
+	kit.EnableLargeSectors(t)
+	kit.QuietMiningLogs()
+
+	client, miner, ens := kit.EnsembleMinimal(t,
+		kit.MockProofs(),
+		kit.WithMaxStagingDealsBytes(8192), // max 8KB staging deals
+		kit.SectorSize(512<<20),            // 512MiB sectors.
+	)
+	ens.InterconnectAll().BeginMining(200 * time.Millisecond)
+
+	dh := kit.NewDealHarness(t, client, miner, miner)
+
+	client.WaitTillChain(ctx, kit.HeightAtLeast(5))
+
+	res, _ := client.CreateImportFile(ctx, 0, 8192) // 8KB file
+	list, err := client.ClientListImports(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, res.Root, *list[0].Root)
+
+	res2, _ := client.CreateImportFile(ctx, 0, 4096)
+	list, err = client.ClientListImports(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	require.Equal(t, res2.Root, *list[1].Root)
+
+	// first deal stays in staging area, and is not yet passed to the sealing subsystem
+	dp := dh.DefaultStartDealParams()
+	dp.Data.Root = res.Root
+	dp.FastRetrieval = true
+	dp.EpochPrice = abi.NewTokenAmount(62500000) // minimum asking price.
+	deal := dh.StartDeal(ctx, dp)
+
+	time.Sleep(1 * time.Second)
+
+	// expecting second deal to fail since staging area is full
+	dp.Data.Root = res2.Root
+	dp.FastRetrieval = true
+	dp.EpochPrice = abi.NewTokenAmount(62500000) // minimum asking price.
+	deal2 := dh.StartDeal(ctx, dp)
+
+	_ = deal
+
+	err = dh.ExpectDealFailure(ctx, deal2, "cannot accept deal as miner is overloaded at the moment")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -453,6 +453,7 @@ func (n *Ensemble) Start() *Ensemble {
 		cfg.Subsystems.EnableMining = m.options.subsystems.Has(SMining)
 		cfg.Subsystems.EnableSealing = m.options.subsystems.Has(SSealing)
 		cfg.Subsystems.EnableSectorStorage = m.options.subsystems.Has(SSectorStorage)
+		cfg.Dealmaking.MaxStagingDealsBytes = m.options.maxStagingDealsBytes
 
 		if m.options.mainMiner != nil {
 			token, err := m.options.mainMiner.FullNode.AuthNew(ctx, api.AllPermissions)

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -27,11 +27,12 @@ type nodeOpts struct {
 	ownerKey      *wallet.Key
 	extraNodeOpts []node.Option
 
-	subsystems    MinerSubsystem
-	mainMiner     *TestMiner
-	disableLibp2p bool
-	optBuilders   []OptBuilder
-	sectorSize    abi.SectorSize
+	subsystems           MinerSubsystem
+	mainMiner            *TestMiner
+	disableLibp2p        bool
+	optBuilders          []OptBuilder
+	sectorSize           abi.SectorSize
+	maxStagingDealsBytes int64
 }
 
 // DefaultNodeOpts are the default options that will be applied to test nodes.
@@ -64,6 +65,13 @@ func WithSubsystems(systems ...MinerSubsystem) NodeOpt {
 		for _, s := range systems {
 			opts.subsystems = opts.subsystems.Add(s)
 		}
+		return nil
+	}
+}
+
+func WithMaxStagingDealsBytes(size int64) NodeOpt {
+	return func(opts *nodeOpts) error {
+		opts.maxStagingDealsBytes = size
 		return nil
 	}
 }

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -165,7 +165,7 @@ func ConfigStorageMiner(c interface{}) Option {
 			// Markets (storage)
 			Override(new(dtypes.ProviderDataTransfer), modules.NewProviderDAGServiceDataTransfer),
 			Override(new(*storedask.StoredAsk), modules.NewStorageAsk),
-			Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(nil)),
+			Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(cfg.Dealmaking, nil)),
 			Override(new(storagemarket.StorageProvider), modules.StorageProvider),
 			Override(new(*storageadapter.DealPublisher), storageadapter.NewDealPublisher(nil, storageadapter.PublishMsgConfig{})),
 			Override(HandleMigrateProviderFundsKey, modules.HandleMigrateProviderFunds),
@@ -192,7 +192,7 @@ func ConfigStorageMiner(c interface{}) Option {
 			Override(new(dtypes.GetMaxDealStartDelayFunc), modules.NewGetMaxDealStartDelayFunc),
 
 			If(cfg.Dealmaking.Filter != "",
-				Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(dealfilter.CliStorageDealFilter(cfg.Dealmaking.Filter))),
+				Override(new(dtypes.StorageDealFilter), modules.BasicDealFilter(cfg.Dealmaking, dealfilter.CliStorageDealFilter(cfg.Dealmaking.Filter))),
 			),
 
 			If(cfg.Dealmaking.RetrievalFilter != "",

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -253,6 +253,13 @@ message`,
 as a multiplier of the minimum collateral bound`,
 		},
 		{
+			Name: "MaxStagingDealsGiB",
+			Type: "int64",
+
+			Comment: `The maximum size of staging deals not yet passed to the sealing node,
+that the markets service can accept`,
+		},
+		{
 			Name: "SimultaneousTransfers",
 			Type: "uint64",
 

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -257,7 +257,7 @@ as a multiplier of the minimum collateral bound`,
 			Type: "int64",
 
 			Comment: `The maximum allowed disk usage size in bytes of staging deals not yet
-passed to the sealing node by the markets service`,
+passed to the sealing node by the markets service. 0 is unlimited.`,
 		},
 		{
 			Name: "SimultaneousTransfers",

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -253,11 +253,11 @@ message`,
 as a multiplier of the minimum collateral bound`,
 		},
 		{
-			Name: "MaxStagingDealsGiB",
+			Name: "MaxStagingDealsBytes",
 			Type: "int64",
 
-			Comment: `The maximum size of staging deals not yet passed to the sealing node,
-that the markets service can accept`,
+			Comment: `The maximum allowed disk usage size in bytes of staging deals not yet
+passed to the sealing node by the markets service`,
 		},
 		{
 			Name: "SimultaneousTransfers",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -126,9 +126,9 @@ type DealmakingConfig struct {
 	// The maximum collateral that the provider will put up against a deal,
 	// as a multiplier of the minimum collateral bound
 	MaxProviderCollateralMultiplier uint64
-	// The maximum size of staging deals not yet passed to the sealing node,
-	// that the markets service can accept
-	MaxStagingDealsGiB int64
+	// The maximum allowed disk usage size in bytes of staging deals not yet
+	// passed to the sealing node by the markets service
+	MaxStagingDealsBytes int64
 	// The maximum number of parallel online data transfers (storage+retrieval)
 	SimultaneousTransfers uint64
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -127,7 +127,7 @@ type DealmakingConfig struct {
 	// as a multiplier of the minimum collateral bound
 	MaxProviderCollateralMultiplier uint64
 	// The maximum allowed disk usage size in bytes of staging deals not yet
-	// passed to the sealing node by the markets service
+	// passed to the sealing node by the markets service. 0 is unlimited.
 	MaxStagingDealsBytes int64
 	// The maximum number of parallel online data transfers (storage+retrieval)
 	SimultaneousTransfers uint64

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -126,7 +126,9 @@ type DealmakingConfig struct {
 	// The maximum collateral that the provider will put up against a deal,
 	// as a multiplier of the minimum collateral bound
 	MaxProviderCollateralMultiplier uint64
-
+	// The maximum size of staging deals not yet passed to the sealing node,
+	// that the markets service can accept
+	MaxStagingDealsGiB int64
 	// The maximum number of parallel online data transfers (storage+retrieval)
 	SimultaneousTransfers uint64
 

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -542,9 +542,8 @@ func BasicDealFilter(cfg config.DealmakingConfig, user dtypes.StorageDealFilter)
 				return false, "miner error", err
 			}
 
-			diskUsageGiB := diskUsageBytes / 1024 / 1024 / 1024
-			if cfg.MaxStagingDealsGiB != 0 && diskUsageGiB >= cfg.MaxStagingDealsGiB {
-				log.Errorw("proposed deal rejected because there are too many deals in the staging area at the moment", "MaxStagingDealsGiB", cfg.MaxStagingDealsGiB, "DiskUsageGiB", diskUsageGiB)
+			if cfg.MaxStagingDealsBytes != 0 && diskUsageBytes >= cfg.MaxStagingDealsBytes {
+				log.Errorw("proposed deal rejected because there are too many deals in the staging area at the moment", "MaxStagingDealsBytes", cfg.MaxStagingDealsBytes, "DiskUsageBytes", diskUsageBytes)
 				return false, "cannot accept deal as miner is overloaded at the moment - there are too many staging deals being processed", nil
 			}
 


### PR DESCRIPTION
This PR is introducing a `MaxStagingDealsBytes` config - if the markets repository `deals-staging` directory gets too large, the markets node can now be configured to reject new incoming deals.

A stopgap for https://github.com/filecoin-project/lotus/issues/7241

---

TODO:
- [x] add a test as part of the `itests` suite (this PR has already been tested on a devnet)