### PR TITLE
itests: remove cid equality comparison

### DIFF
--- a/itests/deals_max_staging_deals_test.go
+++ b/itests/deals_max_staging_deals_test.go
@@ -33,13 +33,11 @@ func TestMaxStagingDeals(t *testing.T) {
 	list, err := client.ClientListImports(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
-	require.Equal(t, res.Root, *list[0].Root)
 
 	res2, _ := client.CreateImportFile(ctx, 0, 4096)
 	list, err = client.ClientListImports(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 2)
-	require.Equal(t, res2.Root, *list[1].Root)
 
 	// first deal stays in staging area, and is not yet passed to the sealing subsystem
 	dp := dh.DefaultStartDealParams()


### PR DESCRIPTION
Fixes flaky test introduced in https://github.com/filecoin-project/lotus/pull/7276

In-memory repo is using the MapDatastore, which doesn't return sorted CIDs list for imported files into Filecoin, hence we got a flaky test for the second comparison for the second deal.

I am removing the CID comparison here altogether, as this is somewhat independent from what this test is testing.