### PR TITLE
remove job to install jq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,11 +368,6 @@ jobs:
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run:
-          name: Install jq
-          command: |
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output /usr/local/bin/jq
-            chmod +x /usr/local/bin/jq
-      - run:
           name: Install hwloc
           command: |
             mkdir ~/hwloc

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -368,11 +368,6 @@ jobs:
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run:
-          name: Install jq
-          command: |
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output /usr/local/bin/jq
-            chmod +x /usr/local/bin/jq
-      - run:
           name: Install hwloc
           command: |
             mkdir ~/hwloc


### PR DESCRIPTION
jq is already installed now in either a newer version of CircleCI's MacOS VMs or in a previous CI step.
I ran a failing macos job with ssh enabled, and inspected '/usr/local/bin' and found found the following output

lrwxr-xr-x    1 distiller  admin    23 Jun 22 14:50 jq -> ../Cellar/jq/1.6/bin/jq

the existing symlink causes the 'Install jq' job to fail.
removing this job should resolve the issue