### PR TITLE
add `lotus-miner storage-deals list --format=json` with transfers

### DIFF
--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -401,10 +401,6 @@ var dealsListCmd = &cli.Command{
 			Name:  "watch",
 			Usage: "watch deal updates in real-time, rather than a one time list",
 		},
-		&cli.BoolFlag{
-			Name:  "with-transfers",
-			Usage: "include information about transfers together with deals",
-		},
 	},
 	Action: func(cctx *cli.Context) error {
 		switch cctx.String("format") {

--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -974,7 +974,10 @@ func listDealsWithJSON(cctx *cli.Context) error {
 			}
 		}
 
-		w.Encode(val)
+		err := w.Encode(val)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -390,7 +390,7 @@ var dealsListCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "format",
-			Usage: "output format of data, `json` and `table` are supported",
+			Usage: "output format of data, supported: table, json",
 			Value: "table",
 		},
 		&cli.BoolFlag{

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -658,9 +658,10 @@ USAGE:
    lotus-miner storage-deals list [command options] [arguments...]
 
 OPTIONS:
-   --verbose, -v  (default: false)
-   --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   --help, -h     show help (default: false)
+   --format value  output format of data, supported: table, json (default: "table")
+   --verbose, -v   (default: false)
+   --watch         watch deal updates in real-time, rather than a one time list (default: false)
+   --help, -h      show help (default: false)
    
 ```
 


### PR DESCRIPTION
This PR is updating the `lotus-miner storage-deals list` cmd to print out storage deals together with their respective transfers, for easier debugging - only when using `--format=json`. At the moment fetching storage deals and transfers is done via two separate commands and somewhat cumbersome to use given the tab-delimited tables.

`--format=json` prints out results in line-delimited JSON, which I think is much easier to read than the `table` approach we use in many commands, because:

1. Field type is right next to every value (given that we generally have 100s-1000s of deals):
```
{"datetime":"2021-09-10T00:57:41+03:00","verified-deal":true,"proposal-cid":"bafyreif5yiywi6njej3nz2uwrj6yo2dnrc7mnokk3qhhfc6m46efpurmay","deal-id":0,"deal-status":"StorageDealTransferring","client":"f3vnq2cmwig3qjisnx5hobxvsd4drn4f54xfxnv4tciw6vnjdsf5xipgafreprh5riwmgtcirpcdmi3urbg36a","piece-size":"16GiB","price":"0 FIL","duration-epochs":1494720,"transfer-id":1631214107052231430,"transfer-status":"Ongoing","transferred-data":"0B"}
```

2. Searching and formatting is very easy with `grep` and `jq`:
```
$ LOTUS_MARKETS_PATH=~/markets-repo-location ./lotus-miner storage-deals --format=json | grep 7vsgutuiem | jq
{
  "datetime": "2021-09-10T11:36:48+03:00",
  "verified-deal": true,
  "proposal-cid": "bafyreie2e66s3ztkdrfoqxm7hrch5d75i3nbrtp6jnsdcyrr7vsgutuiem",
  "deal-id": 0,
  "deal-status": "StorageDealTransferring",
  "client": "f3vnq2cmwig3qjisnx5hobxvsd4drn4f54xfxnv4tciw6vnjdsf5xipgafreprh5riwmgtcirpcdmi3urbg36a",
  "piece-size": "8GiB",
  "price": "0 FIL",
  "duration-epochs": 1494720,
  "transfer-id": 1631214107052231700,
  "transfer-status": "Ongoing",
  "transferred-data": "0B"
}
```