### PR TITLE
feat(ci): include version/cli checks in tagged releases 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
       - run: sudo apt-get install npm
       - run:
           command: make buildall
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - store_artifacts:
           path: lotus
       - store_artifacts:
@@ -383,6 +386,9 @@ jobs:
       - run:
           command: make build
           no_output_timeout: 30m
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - store_artifacts:
           path: lotus
       - store_artifacts:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -92,6 +92,9 @@ jobs:
       - run: sudo apt-get install npm
       - run:
           command: make buildall
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - store_artifacts:
           path: lotus
       - store_artifacts:
@@ -383,6 +386,9 @@ jobs:
       - run:
           command: make build
           no_output_timeout: 30m
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - store_artifacts:
           path: lotus
       - store_artifacts:

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -ex
+
+# Validate lotus version matches the current tag
+# $1 - lotus path to execute
+# $2 - lotus git tag for this release
+function validate_lotus_version_matches_tag(){
+  # sanity checks
+  if [[ $# != 2 ]]; then
+    echo "expected 2 args for validate_lotus_version, got ${$#}"
+    exit 100
+  fi
+
+  # extract version from `lotus --version` response
+  lotus_path=$1
+  # get version
+  lotus_raw_version=`${lotus_path} --version`
+  # grep for version string
+  lotus_actual_version=`echo ${lotus_raw_version} | grep -oE '[0-9]+.[0-9]+.[0-9]+'`
+
+  # trim leading 'v'
+  tag=${2#v}
+  # trim possible -rc[0-9]
+  expected_version=${tag%-*}
+
+  # check the versions are consistent
+  if [[ ${expected_version} != ${lotus_actual_version} ]]; then
+    echo "lotus version does not match build tag"
+    exit 101
+  fi
+}
+
+_lotus_path=$1
+
+if [[ ! -z "${CIRCLE_TAG}" ]]; then
+  validate_lotus_version_matches_tag "${_lotus_path}" "${CIRCLE_TAG}"
+else
+  echo "No CI tag found. Skipping version check."
+fi


### PR DESCRIPTION
part of #6319 

Validates the CLI responds to `lotus --version` and compares that to the tag to ensure they are consistent (or fail).
Applied to `build-all` and `build-macos`.

A fix PR was opened against `release/v1.11.3` at https://github.com/filecoin-project/lotus/pull/7331. Do not merge both.