### PR TITLE
GetCurrentDealInfo err: handle correctly err case

### DIFF
--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -392,6 +392,7 @@ func (m *Sealing) HandleRecoverDealIDs(ctx Context, sector SectorInfo) error {
 		res, err := m.DealInfo.GetCurrentDealInfo(ctx.Context(), tok, dp, *p.DealInfo.PublishCid)
 		if err != nil {
 			failed[i] = xerrors.Errorf("getting current deal info for piece %d: %w", i, err)
+			continue
 		}
 
 		if res.MarketDeal.Proposal.PieceCID != p.Piece.PieceCID {

--- a/extern/storage-sealing/states_failed_test.go
+++ b/extern/storage-sealing/states_failed_test.go
@@ -3,6 +3,7 @@ package sealing_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,6 +20,64 @@ import (
 	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
 	"github.com/filecoin-project/lotus/extern/storage-sealing/mocks"
 )
+
+func TestStateRecoverDealIDsErredDealInfo(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	api := mocks.NewMockSealingAPI(mockCtrl)
+
+	fakeSealing := &sealing.Sealing{
+		Api:      api,
+		DealInfo: &sealing.CurrentDealInfoManager{CDAPI: api},
+	}
+
+	sctx := mocks.NewMockContext(mockCtrl)
+	sctx.EXPECT().Context().AnyTimes().Return(ctx)
+
+	api.EXPECT().ChainHead(ctx).Times(1).Return(nil, abi.ChainEpoch(10), nil)
+
+	var dealId abi.DealID = 12
+	dealProposal := market.DealProposal{
+		PieceCID: idCid("newPieceCID"),
+	}
+
+	api.EXPECT().StateMarketStorageDealProposal(ctx, dealId, nil).Return(dealProposal, nil)
+
+	pc := idCid("publishCID")
+
+	// expect GetCurrentDealInfo
+	{
+		api.EXPECT().StateSearchMsg(ctx, pc).Return(&sealing.MsgLookup{
+			Receipt: sealing.MessageReceipt{
+				ExitCode: exitcode.Ok,
+				Return: cborRet(&market.PublishStorageDealsReturn{
+					IDs: []abi.DealID{dealId},
+				}),
+			},
+		}, nil)
+		api.EXPECT().StateMarketStorageDeal(ctx, dealId, nil).Return(nil, errors.New("deal may not have completed sealing or slashed"))
+	}
+
+	sctx.EXPECT().Send(sealing.SectorRemove{}).Return(nil)
+
+	err := fakeSealing.HandleRecoverDealIDs(sctx, sealing.SectorInfo{
+		Pieces: []sealing.Piece{
+			{
+				DealInfo: &api2.PieceDealInfo{
+					DealID:     dealId,
+					PublishCid: &pc,
+				},
+				Piece: abi.PieceInfo{
+					PieceCID: idCid("oldPieceCID"),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}
 
 func TestStateRecoverDealIDs(t *testing.T) {
 	mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/lotus/issues/7345

---

When `GetCurrentDealInfo` returns an error, such as:

```
		return nil, xerrors.Errorf(
			"deal %d not found "+
				"- deal may not have completed sealing before deal proposal "+
				"start epoch, or deal may have been slashed",
			dealID)
```

we should just note that we can't recover that deal, mark it as failed, and later remove the sector.

At the moment when `GetCurrentDealInfo` returns an error, we continue below the if-condition check for err and we throw a nil pointer exception and crash.