### PR TITLE
Update Dockerfile.lotus

### DIFF
--- a/Dockerfile.lotus
+++ b/Dockerfile.lotus
@@ -53,8 +53,9 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libnuma.so.1   /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libhwloc.so.5  /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libOpenCL.so.1 /lib/
 
-RUN useradd -r -u 532 -U fc
-
+RUN useradd -r -u 532 -U fc \
+ && mkdir -p /etc/OpenCL/vendors \
+ && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
 
 ###
 FROM base AS lotus


### PR DESCRIPTION
fix docker can't find gpus

```
docker run -it --rm --gpus=all filecoin/lotus-all-in-one /bin/bash
$ apt-get update && apt install clinfo
$ clinfo -l

Platform #0: NVIDIA CUDA
 `-- Device #0: GeForce RTX 3080
Platform #1: Clover

```