### PR TITLE
sync branch main with master on updates

### DIFF
--- a/.github/workflows/sync-master-main.yaml
+++ b/.github/workflows/sync-master-main.yaml
@@ -1,0 +1,14 @@
+name: sync-master-main
+on:
+  push:
+    branches:
+      - master
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: update remote branch main
+        run: |
+          # overrides the remote branch (origin:github) `main`
+          git push origin --force master:main


### PR DESCRIPTION
This will forcefully update the branch `main` to the git ref that triggered the workflow. This will keep the branch `main` in sync with the branch `master` at all times.

This requires that workflows have write permissions (which I believe they already do).

![image](https://user-images.githubusercontent.com/165274/134239984-1ded72cb-0c0a-470b-a8a5-52f1c5389ec6.png)


---
_address the first item in #7356_