### PR TITLE
fix: escape periods to match actual periods in version 

### DIFF
--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -16,7 +16,7 @@ function validate_lotus_version_matches_tag(){
   # get version
   lotus_raw_version=`${lotus_path} --version`
   # grep for version string
-  lotus_actual_version=`echo ${lotus_raw_version} | grep -oE '[0-9]+.[0-9]+.[0-9]+'`
+  lotus_actual_version=`echo ${lotus_raw_version} | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 
   # trim leading 'v'
   tag=${2#v}


### PR DESCRIPTION
Noticed the CI check delivered in https://github.com/filecoin-project/lotus/pull/7331 had [a bug](https://app.circleci.com/pipelines/github/filecoin-project/lotus/17357/workflows/841481df-6e0c-497f-ad75-4015c9d81126/jobs/271837). This is the fix.