### PR TITLE
check for deal start epoch on SectorAddPieceToAny

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -207,6 +207,12 @@
   # env var: LOTUS_DEALMAKING_SIMULTANEOUSTRANSFERS
   #SimultaneousTransfers = 20
 
+  # Minimum start epoch buffer to give time for sealing of sector with deal.
+  #
+  # type: uint64
+  # env var: LOTUS_DEALMAKING_STARTEPOCHSEALINGBUFFER
+  #StartEpochSealingBuffer = 480
+
   # A command used for fine-grained evaluation of storage deals
   # see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-fine-grained-storage-and-retrieval-deal-acceptance for more details
   #

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -274,6 +274,16 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		return api.SectorOffset{}, xerrors.Errorf("getting proposal CID: %w", err)
 	}
 
+	_, head, err := m.Api.ChainHead(ctx)
+	if err != nil {
+		return api.SectorOffset{}, xerrors.Errorf("couldnt get chain head: %w", err)
+	}
+	if head > deal.DealProposal.StartEpoch {
+		return api.SectorOffset{}, xerrors.Errorf(
+			"cannot add piece for deal with piece CID %s: current epoch %d has passed deal proposal start epoch %d",
+			deal.DealProposal.PieceCID, head, deal.DealProposal.StartEpoch)
+	}
+
 	m.inputLk.Lock()
 	if _, exist := m.pendingPieces[proposalCID(deal)]; exist {
 		m.inputLk.Unlock()

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -274,11 +274,16 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		return api.SectorOffset{}, xerrors.Errorf("getting proposal CID: %w", err)
 	}
 
+	cfg, err := m.getConfig()
+	if err != nil {
+		return api.SectorOffset{}, xerrors.Errorf("getting config: %w", err)
+	}
+
 	_, head, err := m.Api.ChainHead(ctx)
 	if err != nil {
 		return api.SectorOffset{}, xerrors.Errorf("couldnt get chain head: %w", err)
 	}
-	if head > deal.DealProposal.StartEpoch {
+	if head+cfg.StartEpochSealingBuffer > deal.DealProposal.StartEpoch {
 		return api.SectorOffset{}, xerrors.Errorf(
 			"cannot add piece for deal with piece CID %s: current epoch %d has passed deal proposal start epoch %d",
 			deal.DealProposal.PieceCID, head, deal.DealProposal.StartEpoch)

--- a/extern/storage-sealing/sealiface/config.go
+++ b/extern/storage-sealing/sealiface/config.go
@@ -22,6 +22,8 @@ type Config struct {
 
 	CommittedCapacitySectorLifetime time.Duration
 
+	StartEpochSealingBuffer abi.ChainEpoch
+
 	AlwaysKeepUnsealedCopy bool
 
 	FinalizeEarly bool

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -199,8 +199,9 @@ func ConfigStorageMiner(c interface{}) Option {
 				Override(new(dtypes.RetrievalDealFilter), modules.RetrievalDealFilter(dealfilter.CliRetrievalDealFilter(cfg.Dealmaking.RetrievalFilter))),
 			),
 			Override(new(*storageadapter.DealPublisher), storageadapter.NewDealPublisher(&cfg.Fees, storageadapter.PublishMsgConfig{
-				Period:         time.Duration(cfg.Dealmaking.PublishMsgPeriod),
-				MaxDealsPerMsg: cfg.Dealmaking.MaxDealsPerPublishMsg,
+				Period:                  time.Duration(cfg.Dealmaking.PublishMsgPeriod),
+				MaxDealsPerMsg:          cfg.Dealmaking.MaxDealsPerPublishMsg,
+				StartEpochSealingBuffer: cfg.Dealmaking.StartEpochSealingBuffer,
 			})),
 			Override(new(storagemarket.StorageProviderNode), storageadapter.NewProviderNodeAdapter(&cfg.Fees, &cfg.Dealmaking)),
 		),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -148,6 +148,8 @@ func DefaultStorageMiner() *StorageMiner {
 
 			SimultaneousTransfers: DefaultSimultaneousTransfers,
 
+			StartEpochSealingBuffer: 480, // 480 epochs buffer == 4 hours from adding deal to sector to sector being sealed
+
 			RetrievalPricing: &RetrievalPricing{
 				Strategy: RetrievalPricingDefaultMode,
 				Default: &RetrievalPricingDefault{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -266,6 +266,12 @@ passed to the sealing node by the markets service. 0 is unlimited.`,
 			Comment: `The maximum number of parallel online data transfers (storage+retrieval)`,
 		},
 		{
+			Name: "StartEpochSealingBuffer",
+			Type: "uint64",
+
+			Comment: `Minimum start epoch buffer to give time for sealing of sector with deal.`,
+		},
+		{
 			Name: "Filter",
 			Type: "string",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -131,6 +131,8 @@ type DealmakingConfig struct {
 	MaxStagingDealsBytes int64
 	// The maximum number of parallel online data transfers (storage+retrieval)
 	SimultaneousTransfers uint64
+	// Minimum start epoch buffer to give time for sealing of sector with deal.
+	StartEpochSealingBuffer uint64
 
 	// A command used for fine-grained evaluation of storage deals
 	// see https://docs.filecoin.io/mine/lotus/miner-configuration/#using-filters-for-fine-grained-storage-and-retrieval-deal-acceptance for more details

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -932,6 +932,8 @@ func ToSealingConfig(cfg *config.StorageMiner) sealiface.Config {
 		TerminateBatchMax:  cfg.Sealing.TerminateBatchMax,
 		TerminateBatchMin:  cfg.Sealing.TerminateBatchMin,
 		TerminateBatchWait: time.Duration(cfg.Sealing.TerminateBatchWait),
+
+		StartEpochSealingBuffer: abi.ChainEpoch(cfg.Dealmaking.StartEpochSealingBuffer),
 	}
 }
 


### PR DESCRIPTION
Should fix: https://github.com/filecoin-project/lotus/issues/5137

---

This PR is:
1. Adding a check for deal start epoch in `SectorAddPieceToAny`.
2. Adding an epoch buffer `StartEpochSealingBuffer` to both `SectorAddPieceToAny`, as well as to `validateDeal` prior to sending a `PublishStorageDeals` message, to account for some time necessary to seal a sector.

At the moment I have added `StartEpochSealingBuffer` to be 480 by default == which is 4 hours, and I think this is reasonable. I am not sure if there are miners out there that go from `PublishStorageDeals` to a sealed sector faster than 4 hours...