### PR TITLE
restore filters for the build-macos job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -962,7 +962,14 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-lotus-soup
-      - build-macos
+      - build-macos:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-appimage:
           filters:
             branches:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -812,7 +812,14 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-lotus-soup
-      - build-macos
+      - build-macos:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-appimage:
           filters:
             branches:


### PR DESCRIPTION
This is to enable macos builds on releases.

see the previous failure: https://app.circleci.com/pipelines/github/filecoin-project/lotus/17616/workflows/db669049-9e62-4d4d-809f-d4b021de0284