### PR TITLE
ignore the repo exists checking for we only need the api/token files

### DIFF
--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -2,7 +2,6 @@ package cliutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -141,15 +140,6 @@ func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
 		r, err := repo.NewFS(p)
 		if err != nil {
 			return APIInfo{}, xerrors.Errorf("could not open repo at path: %s; %w", p, err)
-		}
-
-		exists, err := r.Exists()
-		if err != nil {
-			return APIInfo{}, xerrors.Errorf("repo.Exists returned an error: %w", err)
-		}
-
-		if !exists {
-			return APIInfo{}, errors.New("repo directory does not exist. Make sure your configuration is correct")
 		}
 
 		ma, err := r.APIEndpoint()


### PR DESCRIPTION
why need the repo exists checking ?

this checking will cuz some problems for the cli api get with repo flags.
![webwxgetmsgimg](https://user-images.githubusercontent.com/7111577/136979407-a1369869-d8a1-464d-9692-cf63a7fe4f9e.jpeg)


before this we only need the api/token files, and with this checking we also have to copy the datastore/keystore directory to all the workers for ONLY to pass the checking ...

the repo.Exists() does not really means the repo exists.