### PR TITLE
fix: support node instantiation in external packages

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -374,6 +374,13 @@ func WithRepoType(repoType repo.RepoType) func(s *Settings) error {
 	}
 }
 
+func WithEnableLibp2pNode(enable bool) func(s *Settings) error {
+	return func(s *Settings) error {
+		s.enableLibp2pNode = enable
+		return nil
+	}
+}
+
 func WithInvokesKey(i invoke, resApi interface{}) func(s *Settings) error {
 	return func(s *Settings) error {
 		s.invokes[i] = fx.Populate(resApi)

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -51,6 +51,7 @@ type ChainModuleAPI interface {
 	ChainGetTipSetByHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainGetTipSetAfterHeight(ctx context.Context, h abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
+	ChainGetPath(ctx context.Context, from, to types.TipSetKey) ([]*api.HeadChange, error)
 }
 
 var _ ChainModuleAPI = *new(api.FullNode)
@@ -103,6 +104,10 @@ func (a *ChainAPI) ChainGetBlock(ctx context.Context, msg cid.Cid) (*types.Block
 
 func (m *ChainModule) ChainGetTipSet(ctx context.Context, key types.TipSetKey) (*types.TipSet, error) {
 	return m.Chain.LoadTipSet(key)
+}
+
+func (m *ChainModule) ChainGetPath(ctx context.Context, from, to types.TipSetKey) ([]*api.HeadChange, error) {
+	return m.Chain.GetPath(ctx, from, to)
 }
 
 func (m *ChainModule) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error) {


### PR DESCRIPTION
Without these changes [lily](https://github.com/filecoin-project/lily) is unable to use lotus as a library to instantiate a node.