### PR TITLE
fix deleteFromRemote func: Add call timeout period to prevent blocking

### DIFF
--- a/extern/sector-storage/stores/remote.go
+++ b/extern/sector-storage/stores/remote.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
 	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
@@ -370,7 +371,11 @@ func (r *Remote) deleteFromRemote(ctx context.Context, url string) error {
 	req.Header = r.auth
 	req = req.WithContext(ctx)
 
-	resp, err := http.DefaultClient.Do(req)
+	// Add call timeout period to prevent blocking
+	client := http.DefaultClient
+	client.Timeout = 60 * time.Second // 60 s, should be enough
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return xerrors.Errorf("do request: %w", err)
 	}


### PR DESCRIPTION
If the same sector is sealed on two machines Woker A and B, 
and the sector file on Worker A no longer exists (reason: manual deletion or cleaning), 
at this time, after rescheduling, the correctly sealed B Woker is in Execution to the FIN state will be stuck.

// worker log
2021-09-21T08:43:03.877Z	INFO	stores	stores/local.go:725	Remove	{"info.ID": "461a997d-0721-4828-80f8-dc74af95520e", "sid": 38281}
2021-09-21T08:43:03.877Z	INFO	stores	stores/local.go:725	Remove	{"info.ID": "628f663c-620d-4861-8855-16f7362d7fb9", "sid": 38281}
2021-09-21T08:43:03.877Z	INFO	stores	stores/local.go:834	remove /data/filecoin/lotus-worker/unsealed/s-t01260725-38281
2021-09-21T08:43:03.878Z	INFO	stores	stores/remote.go:335	Delete http://10.1.17.160:3456/remote/unsealed/s-t01260725-38281

The log information is output by the code below:

```
func (r *Remote) Remove(ctx context.Context, sid abi.SectorID, typ storiface.SectorFileType, force bool) error {
	// ...

	if err := r.local.Remove(ctx, sid, typ, force); err != nil {
		return xerrors.Errorf("remove from local: %w", err)
	}
	
	si, err := r.index.StorageFindSector(ctx, sid, typ, 0, false)
	// ...
	for _, info := range si
		for _, url := range info.URLs
			r.deleteFromRemote(ctx, url)

	// ...
}


func (st *Local) Remove(ctx context.Context, sid abi.SectorID, typ storiface.SectorFileType, force bool) error {
	// ...

	si, err := st.index.StorageFindSector(ctx, sid, typ, 0, false)
	if err != nil {
		return xerrors.Errorf("finding existing sector %d(t:%d) failed: %w", sid, typ, err)
	}

	// ...

	for _, info := range si {
		// ...

		log.Infow("Remove", "info.ID", info.ID, "sid", sid.Number)  // here

		// ...
	}

	return nil
}
```

and, http://10.1.17.160:3456 is Worker A, Execute to `stores/remote.go:335 Delete http://10.1.17.160:3456/remote/unsealed/s-t01260725-38281`, it will get stuck. so there should be a timeout in the deleteFromRemote function.
