### PR TITLE
add missing build constraint to statfs_unix.go

### DIFF
--- a/extern/sector-storage/fsutil/statfs_unix.go
+++ b/extern/sector-storage/fsutil/statfs_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package fsutil
 
 import (


### PR DESCRIPTION
https://github.com/filecoin-shipyard/js-lotus-client-schema/pull/19/checks?check_run_id=3926539129 is failing because the `_unix.go` file is also built on Windows.