### PR TITLE
Shed: Add a util to find miner based on peerid

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -59,6 +59,7 @@ func main() {
 		signaturesCmd,
 		actorCmd,
 		minerTypesCmd,
+		minerPeeridCmd,
 		minerMultisigsCmd,
 		splitstoreCmd,
 		fr32Cmd,

--- a/cmd/lotus-shed/miner-peerid.go
+++ b/cmd/lotus-shed/miner-peerid.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
+
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/state"
+	"github.com/filecoin-project/lotus/chain/store"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/filecoin-project/specs-actors/v4/actors/util/adt"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+)
+
+var minerPeeridCmd = &cli.Command{
+	Name:  "miner-peerid",
+	Usage: "Scrape state to find a miner based on peerid", Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := context.TODO()
+
+		if cctx.NArg() != 2 {
+			return fmt.Errorf("must pass peer id and state root")
+		}
+
+		pid, err := peer.Decode(cctx.Args().Get(0))
+		if err != nil {
+			return fmt.Errorf("failed to parse input as a peerId: %w", err)
+		}
+
+		sroot, err := cid.Decode(cctx.Args().Get(1))
+		if err != nil {
+			return fmt.Errorf("failed to parse state root: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		tree, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		err = tree.ForEach(func(addr address.Address, act *types.Actor) error {
+			if act.Code == builtin5.StorageMinerActorCodeID {
+				ms, err := miner.Load(store, act)
+				if err != nil {
+					return err
+				}
+
+				mi, err := ms.Info()
+				if err != nil {
+					return err
+				}
+
+				if mi.PeerId != nil && *mi.PeerId == pid {
+					fmt.Println(addr)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return xerrors.Errorf("failed to loop over actors: %w", err)
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
For @dkkapur 

Usage: `lotus-shed miner-peerid <peerId> <stateRoot>`