### PR TITLE
fix: add check manual-stateless-deal with interactive deal making

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -356,9 +356,9 @@ The minimum value is 518400 (6 months).`,
 		&CidBaseFlag,
 	},
 	Action: func(cctx *cli.Context) error {
-		
+
 		expectedArgsMsg := "expected 4 args: dataCid, miner, price, duration"
-		
+
 		if !cctx.Args().Present() {
 			if cctx.Bool("manual-stateless-deal") {
 				return xerrors.New("--manual-stateless-deal can not be combined with interactive deal mode: you must specify the " + expectedArgsMsg)


### PR DESCRIPTION
add check manual-stateless-deal with interactive deal making as --manual-stateless-deal can not be combined with interactive deal mode.