### PR TITLE
Wdpost worker: Reduce challenge confidence to 1 epoch

### DIFF
--- a/storage/wdpost_changehandler.go
+++ b/storage/wdpost_changehandler.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	SubmitConfidence    = 4
-	ChallengeConfidence = 10
+	ChallengeConfidence = 1
 )
 
 type CompleteGeneratePoSTCb func(posts []miner.SubmitWindowedPoStParams, err error)


### PR DESCRIPTION
This confidence was introduced in https://github.com/filecoin-project/lotus/pull/5764 as a stopgap until https://github.com/filecoin-project/lotus/issues/3613 was fixed, which happened in the chocolate upgrade.

It is now strictly unnecessary and the 5 minutes can be spent on PoSt computation. We could kill it entirely, or leave it at 1 epoch.