### PR TITLE
Add healthz endpoint

### DIFF
--- a/node/rpc.go
+++ b/node/rpc.go
@@ -99,7 +99,11 @@ func FullNodeHandler(a v1api.FullNode, permissioned bool, opts ...jsonrpc.Server
 		m.HandleFunc("/rest/v0/import", handleImportFunc)
 	}
 
+	// status
+	m.HandleFunc("/healthz", handleAPIStatus(a.(*impl.FullNodeAPI)))
+
 	// debugging
+
 	m.Handle("/debug/metrics", metrics.Exporter())
 	m.Handle("/debug/pprof-set/block", handleFractionOpt("BlockProfileRate", runtime.SetBlockProfileRate))
 	m.Handle("/debug/pprof-set/mutex", handleFractionOpt("MutexProfileFraction", func(x int) {
@@ -140,6 +144,17 @@ func MinerHandler(a api.StorageMiner, permissioned bool) (http.Handler, error) {
 		Next:   m.ServeHTTP,
 	}
 	return ah, nil
+}
+
+func handleAPIStatus(a *impl.FullNodeAPI) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := make(map[string]string)
+		resp["API"] = "OK"
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+
+	}
 }
 
 func handleImport(a *impl.FullNodeAPI) func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Why

To solve https://github.com/filecoin-project/lotus/issues/6455

Add a basic `http` endpoint `/healthz` to expose binary status of several components:
- API
- Sync
- Peer

## What

- Add `/healthz` endpoint
- Get `NodeStatus` thanks to `NodeStatus` api. This is added thanks to https://github.com/filecoin-project/lotus/pull/5767

## Impelmentation

A few consideration:
- The endpoint will be used by basic liveness probe like Kubernetes or AWS Route53 Health or other similar services. Thus it should be extremely simple, with explicit status code, indicated by either 200 or 500, with a JSON string `OK` or `unhealthy`. Anything more complex than that would potentially make its usage difficult. Moreover, from monitoring point of view, this kind of liveness endpoint should be extremely simple, and thus, reliable.
- Calling this API should be light-weight, as this endpoint is pinged very often.
- For each component, one single endpoint with param should be used. As merging multiple status in one endpoint may complicate usage by rudimentary liveness probe tools.
 
Thus, the endpoint would have:

1.  `/healthz`: Responses are
- Status 500 : 
```json

{
  "component": "api",
  "status": "unhealthy"
}
```
  -  Status 200 :
```json
{
  "component": "api",
  "status": "OK"
}
```

2.  `/healthz?syncstatus=true` : Responses are
- Status 500: 
```json
{
  "component": "sync",
  "status": "unhealthy"
}
```
- Status 200: 
```json
{
  "component": "sync",
  "status": "OK"
}
```

3. `/healthz?peerstatus=true`:

- Status 500: 
```json
{
  "component": "peer",
  "status": "unhealthy"
}
```
- Status 200: 
```json
{
  "component": "peer",
  "status": "OK"
}
```

