### PR TITLE
remove jaeger envvars

### DIFF
--- a/Dockerfile.lotus
+++ b/Dockerfile.lotus
@@ -66,8 +66,6 @@ COPY scripts/docker-lotus-entrypoint.sh /
 
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV LOTUS_PATH /var/lib/lotus
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 ENV DOCKER_LOTUS_IMPORT_SNAPSHOT https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
 ENV DOCKER_LOTUS_IMPORT_WALLET ""
 
@@ -92,8 +90,6 @@ MAINTAINER Lotus Development Team
 COPY --from=builder /opt/filecoin/lotus-wallet /usr/local/bin/
 
 ENV WALLET_PATH /var/lib/lotus-wallet
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 
 RUN mkdir /var/lib/lotus-wallet
 RUN chown fc: /var/lib/lotus-wallet
@@ -114,8 +110,6 @@ MAINTAINER Lotus Development Team
 
 COPY --from=builder /opt/filecoin/lotus-gateway /usr/local/bin/
 
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 ENV FULLNODE_API_INFO /ip4/127.0.0.1/tcp/1234/http
 
 USER fc
@@ -137,8 +131,6 @@ COPY scripts/docker-lotus-miner-entrypoint.sh /
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV FULLNODE_API_INFO /ip4/127.0.0.1/tcp/1234/http
 ENV LOTUS_MINER_PATH /var/lib/lotus-miner
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 ENV DOCKER_LOTUS_MINER_INIT true
 
 RUN mkdir /var/lib/lotus-miner /var/tmp/filecoin-proof-parameters
@@ -165,8 +157,6 @@ COPY --from=builder /opt/filecoin/lotus-worker /usr/local/bin/
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV MINER_API_INFO /ip4/127.0.0.1/tcp/2345/http
 ENV LOTUS_WORKER_PATH /var/lib/lotus-worker
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 
 RUN mkdir /var/lib/lotus-worker
 RUN chown fc: /var/lib/lotus-worker
@@ -187,8 +177,6 @@ from base as lotus-all-in-one
 
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV FULLNODE_API_INFO /ip4/127.0.0.1/tcp/1234/http
-ENV LOTUS_JAEGER_AGENT_HOST 127.0.0.1
-ENV LOTUS_JAEGER_AGENT_PORT 6831
 ENV LOTUS_MINER_PATH /var/lib/lotus-miner
 ENV LOTUS_PATH /var/lib/lotus
 ENV LOTUS_WORKER_PATH /var/lib/lotus-worker


### PR DESCRIPTION
This was causing excessive logging when jaeger wasn't available.

When it is available, you can add these env vars on your own, but usually best to leave them unset.

fixes: https://github.com/filecoin-project/lotus/issues/7502