### PR TITLE
reorder `transfer` checks so as to ensure sending 2B FIL to yourself fails if you don't have that amount

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,6 +891,11 @@ workflows:
           target: "./itests/sector_terminate_test.go"
       
       - test:
+          name: test-itest-self_sent_txn
+          suite: itest-self_sent_txn
+          target: "./itests/self_sent_txn_test.go"
+      
+      - test:
           name: test-itest-tape
           suite: itest-tape
           target: "./itests/tape_test.go"

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -332,7 +332,7 @@ func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 		}
 
 		// Transfer the executing actor's balance to the beneficiary
-		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance); err != nil {
+		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance, rt.vm.ntwkVersion(rt.ctx, rt.vm.blockHeight)); err != nil {
 			panic(aerrors.Fatalf("failed to transfer balance to beneficiary actor: %s", err))
 		}
 	}

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -332,7 +332,7 @@ func (rt *Runtime) DeleteActor(beneficiary address.Address) {
 		}
 
 		// Transfer the executing actor's balance to the beneficiary
-		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance, rt.vm.ntwkVersion(rt.ctx, rt.vm.blockHeight)); err != nil {
+		if err := rt.vm.transfer(rt.Receiver(), beneficiary, act.Balance, rt.NetworkVersion()); err != nil {
 			panic(aerrors.Fatalf("failed to transfer balance to beneficiary actor: %s", err))
 		}
 	}

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -885,7 +885,6 @@ func (vm *VM) transfer(from, to address.Address, amt types.BigInt, networkVersio
 			return aerrors.Fatalf("transfer failed when retrieving sender actor: %s", err)
 		}
 
-
 		if f.Balance.LessThan(amt) {
 			return aerrors.Newf(exitcode.SysErrInsufficientFunds, "transfer failed, insufficient balance in sender actor: %v", f.Balance)
 		}

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -339,7 +339,7 @@ func (vm *VM) send(ctx context.Context, msg *types.Message, parent *Runtime,
 		defer rt.chargeGasSafe(newGasCharge("OnMethodInvocationDone", 0, 0))
 
 		if types.BigCmp(msg.Value, types.NewInt(0)) != 0 {
-			if err := vm.transfer(msg.From, msg.To, msg.Value); err != nil {
+			if err := vm.transfer(msg.From, msg.To, msg.Value, vm.ntwkVersion(ctx, vm.blockHeight)); err != nil {
 				return nil, aerrors.Wrap(err, "failed to transfer funds")
 			}
 		}
@@ -869,32 +869,70 @@ func (vm *VM) incrementNonce(addr address.Address) error {
 	})
 }
 
-func (vm *VM) transfer(from, to address.Address, amt types.BigInt) aerrors.ActorError {
-	if from == to {
-		return nil
-	}
+func (vm *VM) transfer(from, to address.Address, amt types.BigInt, networkVersion network.Version) aerrors.ActorError {
+	var f *types.Actor
+	var fromID, toID address.Address
+	var err error
+	// switching the order around so that transactions for more than the balance sent to self fail
+	if networkVersion >= network.Version15 {
+		fromID, err = vm.cstate.LookupID(from)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when resolving sender address: %s", err)
+		}
 
-	fromID, err := vm.cstate.LookupID(from)
-	if err != nil {
-		return aerrors.Fatalf("transfer failed when resolving sender address: %s", err)
-	}
+		f, err = vm.cstate.GetActor(fromID)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when retrieving sender actor: %s", err)
+		}
 
-	toID, err := vm.cstate.LookupID(to)
-	if err != nil {
-		return aerrors.Fatalf("transfer failed when resolving receiver address: %s", err)
-	}
 
-	if fromID == toID {
-		return nil
-	}
+		if f.Balance.LessThan(amt) {
+			return aerrors.Newf(exitcode.SysErrInsufficientFunds, "transfer failed, insufficient balance in sender actor: %v", f.Balance)
+		}
 
-	if amt.LessThan(types.NewInt(0)) {
-		return aerrors.Newf(exitcode.SysErrForbidden, "attempted to transfer negative value: %s", amt)
-	}
+		if from == to {
+			return nil
+		}
 
-	f, err := vm.cstate.GetActor(fromID)
-	if err != nil {
-		return aerrors.Fatalf("transfer failed when retrieving sender actor: %s", err)
+		toID, err = vm.cstate.LookupID(to)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when resolving receiver address: %s", err)
+		}
+
+		if fromID == toID {
+			return nil
+		}
+
+		if amt.LessThan(types.NewInt(0)) {
+			return aerrors.Newf(exitcode.SysErrForbidden, "attempted to transfer negative value: %s", amt)
+		}
+	} else {
+		if from == to {
+			return nil
+		}
+
+		fromID, err = vm.cstate.LookupID(from)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when resolving sender address: %s", err)
+		}
+
+		toID, err = vm.cstate.LookupID(to)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when resolving receiver address: %s", err)
+		}
+
+		if fromID == toID {
+			return nil
+		}
+
+		if amt.LessThan(types.NewInt(0)) {
+			return aerrors.Newf(exitcode.SysErrForbidden, "attempted to transfer negative value: %s", amt)
+		}
+
+		f, err = vm.cstate.GetActor(fromID)
+		if err != nil {
+			return aerrors.Fatalf("transfer failed when retrieving sender actor: %s", err)
+		}
 	}
 
 	t, err := vm.cstate.GetActor(toID)
@@ -902,16 +940,16 @@ func (vm *VM) transfer(from, to address.Address, amt types.BigInt) aerrors.Actor
 		return aerrors.Fatalf("transfer failed when retrieving receiver actor: %s", err)
 	}
 
-	if err := deductFunds(f, amt); err != nil {
+	if err = deductFunds(f, amt); err != nil {
 		return aerrors.Newf(exitcode.SysErrInsufficientFunds, "transfer failed when deducting funds (%s): %s", types.FIL(amt), err)
 	}
 	depositFunds(t, amt)
 
-	if err := vm.cstate.SetActor(fromID, f); err != nil {
+	if err = vm.cstate.SetActor(fromID, f); err != nil {
 		return aerrors.Fatalf("transfer failed when setting receiver actor: %s", err)
 	}
 
-	if err := vm.cstate.SetActor(toID, t); err != nil {
+	if err = vm.cstate.SetActor(toID, t); err != nil {
 		return aerrors.Fatalf("transfer failed when setting sender actor: %s", err)
 	}
 

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -874,10 +874,7 @@ func (vm *VM) transfer(from, to address.Address, amt types.BigInt, networkVersio
 	var fromID, toID address.Address
 	var err error
 	// switching the order around so that transactions for more than the balance sent to self fail
-	fmt.Printf("network version! %s\n", networkVersion)
 	if networkVersion >= network.Version15 {
-		fmt.Println("network version high")
-
 		if amt.LessThan(types.NewInt(0)) {
 			return aerrors.Newf(exitcode.SysErrForbidden, "attempted to transfer negative value: %s", amt)
 		}
@@ -911,7 +908,6 @@ func (vm *VM) transfer(from, to address.Address, amt types.BigInt, networkVersio
 			return nil
 		}
 	} else {
-		fmt.Println("network version low")
 		if from == to {
 			return nil
 		}

--- a/itests/self_sent_txn_test.go
+++ b/itests/self_sent_txn_test.go
@@ -1,0 +1,53 @@
+package itests
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-state-types/network"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfSentTxn(t *testing.T) {
+	ctx := context.Background()
+
+	kit.QuietMiningLogs()
+
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.GenesisNetworkVersion(network.Version15))
+	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
+
+	bal, err := client.WalletBalance(ctx, client.DefaultKey.Address)
+	require.NoError(t, err)
+
+	// send self half of account balance
+	msgExactlyBal := &types.Message{
+		From:  client.DefaultKey.Address,
+		To:    client.DefaultKey.Address,
+		Value: big.Div(bal, big.NewInt(2)),
+	}
+	smExactlyBal, err := client.MpoolPushMessage(ctx, msgExactlyBal, nil)
+	require.NoError(t, err)
+	mLookup, err := client.StateWaitMsg(ctx, smExactlyBal.Cid(), 3, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.Equal(t, exitcode.Ok, mLookup.Receipt.ExitCode)
+
+	msgOverBal := &types.Message{
+		From:  client.DefaultKey.Address,
+		To:    client.DefaultKey.Address,
+		Value: big.Mul(big.NewInt(2), bal),
+	}
+	_, err = client.MpoolPushMessage(ctx, msgOverBal, nil)
+	require.Error(t, err)
+	// this is horrifying and a crime... I don't know how else to check it.
+	require.Contains(t, fmt.Sprintf("%v", err), "SysErrInsufficientFunds")
+	//mLookup, err = client.StateWaitMsg(ctx, smOverBal.Cid(), 3, api.LookbackNoLimit, true)
+	//require.NoError(t, err)
+	//require.Equal(t, exitcode.SysErrInsufficientFunds, mLookup.Receipt.ExitCode)
+}

--- a/itests/self_sent_txn_test.go
+++ b/itests/self_sent_txn_test.go
@@ -2,9 +2,10 @@ package itests
 
 import (
 	"context"
-	"github.com/filecoin-project/go-state-types/network"
 	"testing"
 	"time"
+
+	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"

--- a/itests/self_sent_txn_test.go
+++ b/itests/self_sent_txn_test.go
@@ -38,13 +38,13 @@ func TestSelfSentTxn(t *testing.T) {
 	require.Equal(t, exitcode.Ok, mLookup.Receipt.ExitCode)
 
 	msgOverBal := &types.Message{
-		From:  client.DefaultKey.Address,
-		To:    client.DefaultKey.Address,
-		Value: big.Mul(big.NewInt(2), bal),
-		GasLimit: 10000000000,
+		From:       client.DefaultKey.Address,
+		To:         client.DefaultKey.Address,
+		Value:      big.Mul(big.NewInt(2), bal),
+		GasLimit:   10000000000,
 		GasPremium: big.NewInt(10000000000),
-		GasFeeCap: big.NewInt(100000000000),
-		Nonce: 1,
+		GasFeeCap:  big.NewInt(100000000000),
+		Nonce:      1,
 	}
 	smOverBal, err := client.WalletSignMessage(ctx, client.DefaultKey.Address, msgOverBal)
 	require.NoError(t, err)

--- a/itests/self_sent_txn_test.go
+++ b/itests/self_sent_txn_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
+// these tests check that the versioned code in vm.transfer is functioning correctly across versions! 
+// we reordered the checks to make sure that a transaction with too much money in it sent to yourself will fail instead of succeeding as a noop
+// more info in this PR! https://github.com/filecoin-project/lotus/pull/7637
 func TestSelfSentTxnV15(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Fixes #7596.