### PR TITLE
disable mplex stream muxer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,6 @@ require (
 	github.com/libp2p/go-libp2p-core v0.9.0
 	github.com/libp2p/go-libp2p-discovery v0.5.1
 	github.com/libp2p/go-libp2p-kad-dht v0.13.0
-	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-noise v0.2.2
 	github.com/libp2p/go-libp2p-peerstore v0.3.0
 	github.com/libp2p/go-libp2p-pubsub v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -388,7 +388,6 @@ github.com/filecoin-project/specs-actors/v3 v3.1.1/go.mod h1:mpynccOLlIRy0QnR008
 github.com/filecoin-project/specs-actors/v4 v4.0.0/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
 github.com/filecoin-project/specs-actors/v4 v4.0.1 h1:AiWrtvJZ63MHGe6rn7tPu4nSUY8bA1KDNszqJaD5+Fg=
 github.com/filecoin-project/specs-actors/v4 v4.0.1/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
-github.com/filecoin-project/specs-actors/v5 v5.0.0-20210512015452-4fe3889fff57/go.mod h1:283yBMMUSDB2abcjP/hhrwTkhb9h3sfM6KGrep/ZlBI=
 github.com/filecoin-project/specs-actors/v5 v5.0.4 h1:OY7BdxJWlUfUFXWV/kpNBYGXNPasDIedf42T3sGx08s=
 github.com/filecoin-project/specs-actors/v5 v5.0.4/go.mod h1:5BAKRAMsOOlD8+qCw4UvT/lTLInCJ3JwOWZbX8Ipwq4=
 github.com/filecoin-project/specs-actors/v6 v6.0.1 h1:laxvHNsvrq83Y9n+W7znVCePi3oLyRf0Rkl4jFO8Wew=

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,7 @@ github.com/filecoin-project/specs-actors/v3 v3.1.1/go.mod h1:mpynccOLlIRy0QnR008
 github.com/filecoin-project/specs-actors/v4 v4.0.0/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
 github.com/filecoin-project/specs-actors/v4 v4.0.1 h1:AiWrtvJZ63MHGe6rn7tPu4nSUY8bA1KDNszqJaD5+Fg=
 github.com/filecoin-project/specs-actors/v4 v4.0.1/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
+github.com/filecoin-project/specs-actors/v5 v5.0.0-20210512015452-4fe3889fff57/go.mod h1:283yBMMUSDB2abcjP/hhrwTkhb9h3sfM6KGrep/ZlBI=
 github.com/filecoin-project/specs-actors/v5 v5.0.4 h1:OY7BdxJWlUfUFXWV/kpNBYGXNPasDIedf42T3sGx08s=
 github.com/filecoin-project/specs-actors/v5 v5.0.4/go.mod h1:5BAKRAMsOOlD8+qCw4UvT/lTLInCJ3JwOWZbX8Ipwq4=
 github.com/filecoin-project/specs-actors/v6 v6.0.1 h1:laxvHNsvrq83Y9n+W7znVCePi3oLyRf0Rkl4jFO8Wew=

--- a/node/builder.go
+++ b/node/builder.go
@@ -177,7 +177,7 @@ var LibP2P = Options(
 	// Host settings
 	Override(DefaultTransportsKey, lp2p.DefaultTransports),
 	Override(AddrsFactoryKey, lp2p.AddrsFactory(nil, nil)),
-	Override(SmuxTransportKey, lp2p.SmuxTransport(true)),
+	Override(SmuxTransportKey, lp2p.SmuxTransport(false)),
 	Override(RelayKey, lp2p.NoRelay()),
 	Override(SecurityKey, lp2p.Security(true, false)),
 

--- a/node/builder.go
+++ b/node/builder.go
@@ -177,7 +177,7 @@ var LibP2P = Options(
 	// Host settings
 	Override(DefaultTransportsKey, lp2p.DefaultTransports),
 	Override(AddrsFactoryKey, lp2p.AddrsFactory(nil, nil)),
-	Override(SmuxTransportKey, lp2p.SmuxTransport(false)),
+	Override(SmuxTransportKey, lp2p.SmuxTransport()),
 	Override(RelayKey, lp2p.NoRelay()),
 	Override(SecurityKey, lp2p.Security(true, false)),
 

--- a/node/modules/lp2p/smux.go
+++ b/node/modules/lp2p/smux.go
@@ -2,17 +2,13 @@ package lp2p
 
 import (
 	"os"
-	"strings"
 
 	"github.com/libp2p/go-libp2p"
-	smux "github.com/libp2p/go-libp2p-core/mux"
-	mplex "github.com/libp2p/go-libp2p-mplex"
 	yamux "github.com/libp2p/go-libp2p-yamux"
 )
 
-func makeSmuxTransportOption(mplexExp bool) libp2p.Option {
+func makeSmuxTransportOption() libp2p.Option {
 	const yamuxID = "/yamux/1.0.0"
-	const mplexID = "/mplex/6.7.0"
 
 	ymxtpt := *yamux.DefaultTransport
 	ymxtpt.AcceptBacklog = 512
@@ -21,34 +17,12 @@ func makeSmuxTransportOption(mplexExp bool) libp2p.Option {
 		ymxtpt.LogOutput = os.Stderr
 	}
 
-	muxers := map[string]smux.Multiplexer{yamuxID: &ymxtpt}
-	if mplexExp {
-		muxers[mplexID] = mplex.DefaultTransport
-	}
-
-	// Allow muxer preference order overriding
-	order := []string{yamuxID, mplexID}
-	if prefs := os.Getenv("LIBP2P_MUX_PREFS"); prefs != "" {
-		order = strings.Fields(prefs)
-	}
-
-	opts := make([]libp2p.Option, 0, len(order))
-	for _, id := range order {
-		tpt, ok := muxers[id]
-		if !ok {
-			log.Warnf("unknown or duplicate muxer in LIBP2P_MUX_PREFS: %s", id)
-			continue
-		}
-		delete(muxers, id)
-		opts = append(opts, libp2p.Muxer(id, tpt))
-	}
-
-	return libp2p.ChainOptions(opts...)
+	return libp2p.Muxer(yamuxID, &ymxtpt)
 }
 
-func SmuxTransport(mplex bool) func() (opts Libp2pOpts, err error) {
+func SmuxTransport() func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		opts.Opts = append(opts.Opts, makeSmuxTransportOption(mplex))
+		opts.Opts = append(opts.Opts, makeSmuxTransportOption())
 		return
 	}
 }


### PR DESCRIPTION
Compatibility considerations: The reason we have mplex in IPFS is that js-libp2p doesn't support yamux, so mplex is the fallback stream muxer there. We don't care about js-libp2p in lotus. As far as I know (someone with more ecosystem insight please double check!), all Filecoin implementations support yamux (at least Venus does), so there's no need for a fallback.