### PR TITLE
Disable appimage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -976,19 +976,10 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-appimage:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
           requires:
             - build-all
             - build-macos
-            - build-appimage
           filters:
             branches:
               ignore:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -816,19 +816,10 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-appimage:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
           requires:
             - build-all
             - build-macos
-            - build-appimage
           filters:
             branches:
               ignore:


### PR DESCRIPTION
It appears recently something has changed in circleci and we no longer have access to the /dev/snd device which is causing the appimage tests to fail during setup.