### PR TITLE
chore: create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Related Issues
+<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
+
+## Proposed Changes
+<!-- provide a clear list of the changes being made-->
+
+
+## Additional Info
+<!-- callouts, links to documentation, and etc-->
+
+## Checklist
+
+Before you mark the PR ready for review, please make sure that:
+- [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
+    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
+    - `PR type`: _fix_, _feat_, _BREAKING CHANGE_, _build_, _chore_, _ci_, _docs_, _perf_, _refactor_, _revert_, _style_, _test_
+    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
+- [ ] This PR has tests for new functionality or change in behaviour
+- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
+- [ ] CI is green

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 ## Checklist
 
 Before you mark the PR ready for review, please make sure that:
+- [ ] All commits have a clear commit message.
 - [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
     - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
     - `PR type`: _fix_, _feat_, _BREAKING CHANGE_, _build_, _chore_, _ci_, _docs_, _perf_, _refactor_, _revert_, _style_, _test_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Before you mark the PR ready for review, please make sure that:
 - [ ] All commits have a clear commit message.
 - [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
     - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
-    - `PR type`: _fix_, _feat_, _BREAKING CHANGE_, _build_, _chore_, _ci_, _docs_, _perf_, _refactor_, _revert_, _style_, _test_
+    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_,_perf_, _refactor_, _revert_, _style_, _test_
     - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
 - [ ] This PR has tests for new functionality or change in behaviour
 - [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)


### PR DESCRIPTION
This is the very first iteration of the lotus PR template. The goal of adding PR template is to standardize PR requests and encourage contributors to:
- come up with good PR descriptions to give code reviewers a clear overview of what's in the PR 
- have a clear PR title as lotus generates a changelog based on it
- check that tests and documentation for the codes that changed are included 

The PR type follows the https://www.conventionalcommits.org/en/v1.0.0-beta.2/.  
The [contribution guideline](https://github.com/filecoin-project/lotus#contribute) should be updated with how to create a pr after the template is accepted.