### PR TITLE
first pass at parameters for ingest pubsub subscription

### DIFF
--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -13,6 +13,7 @@ import (
 
 func BlocksTopic(netName dtypes.NetworkName) string   { return "/fil/blocks/" + string(netName) }
 func MessagesTopic(netName dtypes.NetworkName) string { return "/fil/msgs/" + string(netName) }
+func IngestTopic(netName dtypes.NetworkName) string   { return "/indexer/ingest/" + string(netName) }
 func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
 	return protocol.ID("/fil/kad/" + string(netName))
 }

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -114,6 +114,22 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		InvalidMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
 	}
 
+	ingestTopicParams := &pubsub.TopicScoreParams{
+		// expected ~0.5 confirmed deals / min. sampled
+		TopicWeight: 1,
+
+		TimeInMeshWeight:  0.00027, // ~1/3600
+		TimeInMeshQuantum: time.Second,
+		TimeInMeshCap:     1,
+
+		FirstMessageDeliveriesWeight: 5,
+		FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+		FirstMessageDeliveriesCap:    100, // allowing for burstiness
+
+		InvalidMessageDeliveriesWeight: -1000,
+		InvalidMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+	}
+
 	topicParams := map[string]*pubsub.TopicScoreParams{
 		build.BlocksTopic(in.Nn): {
 			// expected 10 blocks/min
@@ -207,6 +223,9 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		pgTopicWeights[topic] = 5
 		drandTopics = append(drandTopics, topic)
 	}
+
+	// Index ingestion whitelist
+	topicParams[build.IngestTopic(in.Nn)] = ingestTopicParams
 
 	// IP colocation whitelist
 	var ipcoloWhitelist []*net.IPNet
@@ -333,6 +352,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 	allowTopics := []string{
 		build.BlocksTopic(in.Nn),
 		build.MessagesTopic(in.Nn),
+		build.IngestTopic(in.Nn),
 	}
 	allowTopics = append(allowTopics, drandTopics...)
 	options = append(options,


### PR DESCRIPTION
cc @gammazero / @masih 

* This uses `/indexer/ingest/<networkname>` for pubsub topic to subscribe to. We should do some sort of different topic for 'real' publishers versus testnets. Think about what you'd like to see on the indexer side in terms of naming. Also note that the convention seems to be that pubsub topics start with an initial '/', which the `indexer/ingest` topic name the indexer is using doesn't.
* The baseline guess at topic weight is based on observed average deal rate for the last month. We'll need to change that weighting as that increases - i picked a factor of 4 without much evidence, happy to think about if there are better numbers to start with, but probably we don't need to block on getting it to reflect node-observed chain activity.