### PR TITLE
Make retrieval even faster

### DIFF
--- a/extern/sector-storage/fr32/fr32.go
+++ b/extern/sector-storage/fr32/fr32.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var MTTresh = uint64(32 << 20)
+var MTTresh = uint64(512 << 10)
 
 func mtChunkCount(usz abi.PaddedPieceSize) uint64 {
 	threads := (uint64(usz)) / MTTresh

--- a/extern/sector-storage/fr32/readers.go
+++ b/extern/sector-storage/fr32/readers.go
@@ -16,12 +16,20 @@ type unpadReader struct {
 	work []byte
 }
 
+func BufSize(sz abi.PaddedPieceSize) int {
+	return int(MTTresh * mtChunkCount(sz))
+}
+
 func NewUnpadReader(src io.Reader, sz abi.PaddedPieceSize) (io.Reader, error) {
+	buf := make([]byte, BufSize(sz))
+
+	return NewUnpadReaderBuf(src, sz, buf)
+}
+
+func NewUnpadReaderBuf(src io.Reader, sz abi.PaddedPieceSize, buf []byte) (io.Reader, error) {
 	if err := sz.Validate(); err != nil {
 		return nil, xerrors.Errorf("bad piece size: %w", err)
 	}
-
-	buf := make([]byte, MTTresh*mtChunkCount(sz))
 
 	return &unpadReader{
 		src: src,

--- a/extern/sector-storage/mock/mock.go
+++ b/extern/sector-storage/mock/mock.go
@@ -390,14 +390,16 @@ func (mgr *SectorMgr) ReadPiece(ctx context.Context, sector storage.SectorRef, o
 		panic("implme")
 	}
 
+	br := bytes.NewReader(mgr.pieces[mgr.sectors[sector.ID].pieces[0]][:size])
+
 	return struct {
 		io.ReadCloser
 		io.Seeker
 		io.ReaderAt
 	}{
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(mgr.pieces[mgr.sectors[sector.ID].pieces[0]][:size])),
-		Seeker:     nil,
-		ReaderAt:   nil,
+		ReadCloser: ioutil.NopCloser(br),
+		Seeker:     br,
+		ReaderAt:   br,
 	}, false, nil
 }
 

--- a/extern/sector-storage/piece_provider_test.go
+++ b/extern/sector-storage/piece_provider_test.go
@@ -338,7 +338,7 @@ func (p *pieceProviderTestHarness) isUnsealed(t *testing.T, offset storiface.Unp
 
 func (p *pieceProviderTestHarness) readPiece(t *testing.T, offset storiface.UnpaddedByteIndex, size abi.UnpaddedPieceSize,
 	expectedHadToUnseal bool, expectedBytes []byte) {
-	rd, isUnsealed, err := p.pp.ReadPiece(p.ctx, p.sector, offset, 0, size, p.ticket, p.commD)
+	rd, isUnsealed, err := p.pp.ReadPiece(p.ctx, p.sector, offset, size, p.ticket, p.commD)
 	require.NoError(t, err)
 	require.NotNil(t, rd)
 	require.Equal(t, expectedHadToUnseal, isUnsealed)

--- a/extern/sector-storage/piece_reader.go
+++ b/extern/sector-storage/piece_reader.go
@@ -70,6 +70,9 @@ func (p *pieceReader) Close() error {
 		if err := p.r.Close(); err != nil {
 			return err
 		}
+		if err := p.r.Close(); err != nil {
+			return err
+		}
 		p.r = nil
 	}
 

--- a/extern/sector-storage/stores/http_handler.go
+++ b/extern/sector-storage/stores/http_handler.go
@@ -84,7 +84,6 @@ func (handler *FetchHandler) remoteStatFs(w http.ResponseWriter, r *http.Request
 // remoteGetSector returns the sector file/tared directory byte stream for the sectorID and sector file type sent in the request.
 // returns an error if it does NOT have the required sector file/dir.
 func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Request) {
-	log.Infof("SERVE GET %s", r.URL)
 	vars := mux.Vars(r)
 
 	id, err := storiface.ParseSectorID(vars["id"])

--- a/extern/sector-storage/stores/remote.go
+++ b/extern/sector-storage/stores/remote.go
@@ -719,7 +719,6 @@ func (r *Remote) Reader(ctx context.Context, s storage.SectorRef, offset, size a
 					log.Warnw("reading from remote", "url", url, "error", err)
 					return nil, err
 				}
-				log.Infof("Read remote %s (+%d,%d)", url, offset, size)
 
 				return rd, err
 			}, nil

--- a/extern/sector-storage/stores/remote_test.go
+++ b/extern/sector-storage/stores/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -470,12 +471,20 @@ func TestReader(t *testing.T) {
 
 			remoteStore := stores.NewRemote(lstore, index, nil, 6000, pfhandler)
 
-			rd, err := remoteStore.Reader(ctx, sectorRef, offset, size)
+			rdg, err := remoteStore.Reader(ctx, sectorRef, offset, size)
+			var rd io.ReadCloser
 
 			if tc.errStr != "" {
-				require.Error(t, err)
-				require.Nil(t, rd)
-				require.Contains(t, err.Error(), tc.errStr)
+				if rdg == nil {
+					require.Error(t, err)
+					require.Nil(t, rdg)
+					require.Contains(t, err.Error(), tc.errStr)
+				} else {
+					rd, err = rdg(0)
+					require.Error(t, err)
+					require.Nil(t, rd)
+					require.Contains(t, err.Error(), tc.errStr)
+				}
 			} else {
 				require.NoError(t, err)
 			}
@@ -483,7 +492,10 @@ func TestReader(t *testing.T) {
 			if !tc.expectedNonNilReader {
 				require.Nil(t, rd)
 			} else {
-				require.NotNil(t, rd)
+				require.NotNil(t, rdg)
+				rd, err := rdg(0)
+				require.NoError(t, err)
+
 				defer func() {
 					require.NoError(t, rd.Close())
 				}()

--- a/markets/dagstore/miner_api.go
+++ b/markets/dagstore/miner_api.go
@@ -3,22 +3,21 @@ package dagstore
 import (
 	"context"
 	"fmt"
-	"io"
-
-	"github.com/filecoin-project/dagstore/throttle"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/dagstore/mount"
+	"github.com/filecoin-project/dagstore/throttle"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/shared"
+	"github.com/filecoin-project/go-state-types/abi"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination=mocks/mock_lotus_accessor.go -package=mock_dagstore . MinerAPI
 
 type MinerAPI interface {
-	FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, offset uint64) (io.ReadCloser, abi.UnpaddedPieceSize, error)
+	FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid) (mount.Reader, error)
 	GetUnpaddedCARSize(ctx context.Context, pieceCid cid.Cid) (uint64, error)
 	IsUnsealed(ctx context.Context, pieceCid cid.Cid) (bool, error)
 	Start(ctx context.Context) error
@@ -27,7 +26,7 @@ type MinerAPI interface {
 type SectorAccessor interface {
 	retrievalmarket.SectorAccessor
 
-	UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, pieceOffset abi.UnpaddedPieceSize, startOffset uint64, length abi.UnpaddedPieceSize) (io.ReadCloser, error)
+	UnsealSectorAt(ctx context.Context, sectorID abi.SectorNumber, pieceOffset abi.UnpaddedPieceSize, length abi.UnpaddedPieceSize) (mount.Reader, error)
 }
 
 type minerAPI struct {
@@ -100,10 +99,10 @@ func (m *minerAPI) IsUnsealed(ctx context.Context, pieceCid cid.Cid) (bool, erro
 	return false, nil
 }
 
-func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, offset uint64) (io.ReadCloser, abi.UnpaddedPieceSize, error) {
+func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid) (mount.Reader, error) {
 	err := m.readyMgr.AwaitReady()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	// Throttle this path to avoid flooding the storage subsystem.
@@ -114,11 +113,11 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 	})
 
 	if err != nil {
-		return nil, 0, xerrors.Errorf("failed to fetch pieceInfo for piece %s: %w", pieceCid, err)
+		return nil, xerrors.Errorf("failed to fetch pieceInfo for piece %s: %w", pieceCid, err)
 	}
 
 	if len(pieceInfo.Deals) == 0 {
-		return nil, 0, xerrors.Errorf("no storage deals found for piece %s", pieceCid)
+		return nil, xerrors.Errorf("no storage deals found for piece %s", pieceCid)
 	}
 
 	// prefer an unsealed sector containing the piece if one exists
@@ -126,7 +125,7 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 		deal := deal
 
 		// Throttle this path to avoid flooding the storage subsystem.
-		var reader io.ReadCloser
+		var reader mount.Reader
 		err := m.throttle.Do(ctx, func(ctx context.Context) (err error) {
 			isUnsealed, err := m.sa.IsUnsealed(ctx, deal.SectorID, deal.Offset.Unpadded(), deal.Length.Unpadded())
 			if err != nil {
@@ -136,7 +135,7 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 				return nil
 			}
 			// Because we know we have an unsealed copy, this UnsealSector call will actually not perform any unsealing.
-			reader, err = m.sa.UnsealSectorAt(ctx, deal.SectorID, deal.Offset.Unpadded(), offset, deal.Length.Unpadded())
+			reader, err = m.sa.UnsealSectorAt(ctx, deal.SectorID, deal.Offset.Unpadded(), deal.Length.Unpadded())
 			return err
 		})
 
@@ -147,7 +146,7 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 
 		if reader != nil {
 			// we were able to obtain a reader for an already unsealed piece
-			return reader, deal.Length.Unpadded(), nil
+			return reader, nil
 		}
 	}
 
@@ -158,7 +157,7 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 		// block for a long time with the current PoRep
 		//
 		// This path is unthrottled.
-		reader, err := m.sa.UnsealSectorAt(ctx, deal.SectorID, deal.Offset.Unpadded(), offset, deal.Length.Unpadded())
+		reader, err := m.sa.UnsealSectorAt(ctx, deal.SectorID, deal.Offset.Unpadded(), deal.Length.Unpadded())
 		if err != nil {
 			lastErr = xerrors.Errorf("failed to unseal deal %d: %w", deal.DealID, err)
 			log.Warn(lastErr.Error())
@@ -166,10 +165,10 @@ func (m *minerAPI) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, off
 		}
 
 		// Successfully fetched the deal data so return a reader over the data
-		return reader, deal.Length.Unpadded(), nil
+		return reader, nil
 	}
 
-	return nil, 0, lastErr
+	return nil, lastErr
 }
 
 func (m *minerAPI) GetUnpaddedCARSize(ctx context.Context, pieceCid cid.Cid) (uint64, error) {

--- a/markets/dagstore/miner_api.go
+++ b/markets/dagstore/miner_api.go
@@ -3,6 +3,7 @@ package dagstore
 import (
 	"context"
 	"fmt"
+
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 

--- a/markets/dagstore/mocks/mock_lotus_accessor.go
+++ b/markets/dagstore/mocks/mock_lotus_accessor.go
@@ -6,10 +6,9 @@ package mock_dagstore
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
-	abi "github.com/filecoin-project/go-state-types/abi"
+	mount "github.com/filecoin-project/dagstore/mount"
 	gomock "github.com/golang/mock/gomock"
 	cid "github.com/ipfs/go-cid"
 )
@@ -38,19 +37,18 @@ func (m *MockMinerAPI) EXPECT() *MockMinerAPIMockRecorder {
 }
 
 // FetchUnsealedPiece mocks base method.
-func (m *MockMinerAPI) FetchUnsealedPiece(arg0 context.Context, arg1 cid.Cid, arg2 uint64) (io.ReadCloser, abi.UnpaddedPieceSize, error) {
+func (m *MockMinerAPI) FetchUnsealedPiece(arg0 context.Context, arg1 cid.Cid) (mount.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchUnsealedPiece", arg0, arg1, arg2)
-	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(abi.UnpaddedPieceSize)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "FetchUnsealedPiece", arg0, arg1)
+	ret0, _ := ret[0].(mount.Reader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // FetchUnsealedPiece indicates an expected call of FetchUnsealedPiece.
-func (mr *MockMinerAPIMockRecorder) FetchUnsealedPiece(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMinerAPIMockRecorder) FetchUnsealedPiece(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUnsealedPiece", reflect.TypeOf((*MockMinerAPI)(nil).FetchUnsealedPiece), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUnsealedPiece", reflect.TypeOf((*MockMinerAPI)(nil).FetchUnsealedPiece), arg0, arg1)
 }
 
 // GetUnpaddedCARSize mocks base method.

--- a/markets/dagstore/mount.go
+++ b/markets/dagstore/mount.go
@@ -56,11 +56,7 @@ func (l *LotusMount) Deserialize(u *url.URL) error {
 }
 
 func (l *LotusMount) Fetch(ctx context.Context) (mount.Reader, error) {
-	return (&pieceReader{
-		ctx:      ctx,
-		api:      l.API,
-		pieceCid: l.PieceCid,
-	}).init()
+	return l.API.FetchUnsealedPiece(ctx, l.PieceCid)
 }
 
 func (l *LotusMount) Info() mount.Info {

--- a/markets/dagstore/wrapper_test.go
+++ b/markets/dagstore/wrapper_test.go
@@ -3,7 +3,6 @@ package dagstore
 import (
 	"bytes"
 	"context"
-	"io"
 	"os"
 	"testing"
 	"time"
@@ -11,8 +10,6 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
-
-	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/dagstore"
 	"github.com/filecoin-project/dagstore/mount"
@@ -192,7 +189,7 @@ func (m mockLotusMount) Start(ctx context.Context) error {
 	return nil
 }
 
-func (m mockLotusMount) FetchUnsealedPiece(ctx context.Context, pieceCid cid.Cid, offset uint64) (io.ReadCloser, abi.UnpaddedPieceSize, error) {
+func (m mockLotusMount) FetchUnsealedPiece(context.Context, cid.Cid) (mount.Reader, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
https://github.com/filecoin-project/lotus/pull/7693 made retrieval quite fast, but we can do better

- [x] Move piecereader closer to storage code (making it easier to add lower-level optimizations)
- [x] Reuse one storage lock between piece seeks
- [x] Reduce allocation pressure
- [x] Don't do redundant sector finding / alloc checks
- [ ] (separate PR) Cache reads in a temp file
- [ ] (separate PR) mmaped reader for local sector access