### PR TITLE
feat: #6147: Include worker name in sealing errors

### DIFF
--- a/extern/sector-storage/worker_local.go
+++ b/extern/sector-storage/worker_local.go
@@ -273,7 +273,7 @@ func (l *LocalWorker) asyncCall(ctx context.Context, sector storage.SectorRef, r
 				log.Errorf("get hostname err: %+v", err)
 			}
 
-			err = xerrors.Errorf("%s [Hostname: %s]", err.Error(), hostname)
+			err = xerrors.Errorf("%w [Hostname: %s]", err.Error(), hostname)
 		}
 
 		if doReturn(ctx, rt, ci, l.ret, res, toCallError(err)) {

--- a/extern/sector-storage/worker_local.go
+++ b/extern/sector-storage/worker_local.go
@@ -102,7 +102,13 @@ func newLocalWorker(executor ExecutorFunc, wcfg WorkerConfig, envLookup EnvFunc,
 
 	go func() {
 		for _, call := range unfinished {
-			err := storiface.Err(storiface.ErrTempWorkerRestart, xerrors.New("worker restarted"))
+			hostname, osErr := os.Hostname()
+			if osErr != nil {
+				log.Errorf("get hostname err: %+v", err)
+				hostname = ""
+			}
+
+			err := storiface.Err(storiface.ErrTempWorkerRestart, xerrors.Errorf("worker [Hostname: %s] restarted", hostname))
 
 			// TODO: Handle restarting PC1 once support is merged
 
@@ -259,6 +265,15 @@ func (l *LocalWorker) asyncCall(ctx context.Context, sector storage.SectorRef, r
 					log.Errorf("tracking call (done): %+v", err)
 				}
 			}
+		}
+
+		if err != nil {
+			hostname, osErr := os.Hostname()
+			if osErr != nil {
+				log.Errorf("get hostname err: %+v", err)
+			}
+
+			err = xerrors.Errorf("%s [Hostname: %s]", err.Error(), hostname)
 		}
 
 		if doReturn(ctx, rt, ci, l.ret, res, toCallError(err)) {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/6147

## Additional Info
When a sector is executed incorrectly(delete sc-02-data-layer-2.dat and produce an error),  can see which worker name (hostname) executed it in `lotus-miner sectors status --log`: 
```
SectorID:	2
Status:		ComputeProofFailed
CIDcommD:	baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy
CIDcommR:	bagboea4b5abcaanfg4ensvrat6mxojxn3v6qhvar5xayh7jv2ca3a3h777xwzall
Ticket:		7759ed6454fdf1a162971fb98343c0e88f09c581a09865f515207255f0155e8c
TicketH:	-852
Seed:		fe0a25949d1f48cce6c213895d60cca2fb5460f32c2cc3202bb44e8ef8e6604f
SeedH:		123
Precommit:	bafy2bzacebgaxlgralo4ypndahpsdllgd7ublxdk7hdd4mbtwz5r7yc62paqa
Commit:		<nil>
Deals:		[0]
Retries:	0
--------
Event Log:
0.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorStartCC]	{"User":{"ID":2,"SectorType":5}}
1.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorPacked]	{"User":{"FillerPieces":[{"Size":2048,"PieceCID":{"/":"baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy"}}]}}
2.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorTicket]	{"User":{"TicketValue":"d1ntZFT98aFilx+5g0PA6I8JxYGgmGX1FSByVfAVXow=","TicketEpoch":-852}}
3.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorPreCommit1]	{"User":{"PreCommit1Out":"eyJyZWdpc3RlcmVkX3Byb29mIjoiU3RhY2tlZERyZzJLaUJWMV8xIiwibGFiZWxzIjp7IlN0YWNrZWREcmcyS2lCVjEiOnsibGFiZWxzIjpbeyJwYXRoIjoiL2hvbWUvem91L3pvdS9maWxlY29pbi9kYXRhL2xvdHVzLXdvcmtlci9jYWNoZS9zLXQwMTAwMC0yIiwiaWQiOiJsYXllci0xIiwic2l6ZSI6NjQsInJvd3NfdG9fZGlzY2FyZCI6NX0seyJwYXRoIjoiL2hvbWUvem91L3pvdS9maWxlY29pbi9kYXRhL2xvdHVzLXdvcmtlci9jYWNoZS9zLXQwMTAwMC0yIiwiaWQiOiJsYXllci0yIiwic2l6ZSI6NjQsInJvd3NfdG9fZGlzY2FyZCI6NX1dLCJfaCI6bnVsbH19LCJjb25maWciOnsicGF0aCI6Ii9ob21lL3pvdS96b3UvZmlsZWNvaW4vZGF0YS9sb3R1cy13b3JrZXIvY2FjaGUvcy10MDEwMDAtMiIsImlkIjoidHJlZS1kIiwic2l6ZSI6MTI3LCJyb3dzX3RvX2Rpc2NhcmQiOjV9LCJjb21tX2QiOlsyNTIsMTI2LDE0NiwxMzAsMTUwLDIyOSwyMiwyNTAsMTczLDIzMywxMzQsMTc4LDE0MywxNDYsMjEyLDc0LDc5LDM2LDE4NSw1Myw3Miw4MiwzNSw1NSwxMDYsMTIxLDE0NCwzOSwxODgsMjQsMjQ4LDUxXX0="}}
4.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorPreCommit2]	{"User":{"Sealed":{"/":"bagboea4b5abcaanfg4ensvrat6mxojxn3v6qhvar5xayh7jv2ca3a3h777xwzall"},"Unsealed":{"/":"baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy"}}}
5.	2021-12-23 17:27:05 +0800 CST:	[event;sealing.SectorPreCommitBatch]	{"User":{}}
6.	2021-12-23 17:31:31 +0800 CST:	[event;sealing.SectorPreCommitBatchSent]	{"User":{"Message":{"/":"bafy2bzacebgaxlgralo4ypndahpsdllgd7ublxdk7hdd4mbtwz5r7yc62paqa"}}}
7.	2021-12-23 17:31:55 +0800 CST:	[event;sealing.SectorPreCommitLanded]	{"User":{"TipSet":"AXGg5AIgtHfL/D59ZRmk/g3044OnrY3WOkfORcYaU6gifTh7TnQ="}}
8.	2021-12-23 17:32:35 +0800 CST:	[event;sealing.SectorSeedReady]	{"User":{"SeedValue":"/gollJ0fSMzmwhOJXWDMovtUYPMsLMMgK7ROjvjmYE8=","SeedEpoch":123}}
9.	2021-12-23 17:32:36 +0800 CST:	[event;sealing.SectorComputeProofFailed]	{"User":{}}
	computing seal proof failed(1): storage call error 0: StandaloneSealCommit: Missing store file (or associated split paths): /home/zou/filecoin/data/lotus-worker/cache/s-t01000-2/sc-02-data-layer-2.dat [Hostname: llife]

```