### PR TITLE
feat: Manually triggered window PoSt

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -9,8 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	proof7 "github.com/filecoin-project/specs-actors/v7/actors/runtime/proof"
-
 	"github.com/filecoin-project/lotus/chain/rand"
 
 	"github.com/filecoin-project/go-state-types/network"
@@ -29,7 +27,9 @@ import (
 	"github.com/ipld/go-car"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
 	proof5 "github.com/filecoin-project/specs-actors/v5/actors/runtime/proof"
+	proof7 "github.com/filecoin-project/specs-actors/v7/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/blockstore"
@@ -621,9 +621,16 @@ func (mca mca) WalletSign(ctx context.Context, a address.Address, v []byte) (*cr
 type WinningPoStProver interface {
 	GenerateCandidates(context.Context, abi.PoStRandomness, uint64) ([]uint64, error)
 	ComputeProof(context.Context, []proof5.SectorInfo, abi.PoStRandomness) ([]proof5.PoStProof, error)
+
+	GenerateWindowPoSt(ctx context.Context, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, err error)
 }
 
 type wppProvider struct{}
+
+func (wpp *wppProvider) GenerateWindowPoSt(ctx context.Context, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, err error) {
+	//TODO implement me
+	panic("implement me")
+}
 
 func (wpp *wppProvider) GenerateCandidates(ctx context.Context, _ abi.PoStRandomness, _ uint64) ([]uint64, error) {
 	return []uint64{0}, nil

--- a/miner/warmup.go
+++ b/miner/warmup.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"crypto/rand"
 	"math"
+	"os"
 	"time"
 
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	proof2 "github.com/filecoin-project/specs-actors/v2/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
 )
 
 func (m *Miner) winPoStWarmup(ctx context.Context) error {
@@ -46,8 +49,31 @@ out:
 	}
 
 	if sector == math.MaxUint64 {
-		log.Info("skipping winning PoSt warmup, no sectors")
-		return nil
+	out2:
+		for dlIdx := range deadlines {
+			partitions, err := m.api.StateMinerPartitions(ctx, m.address, uint64(dlIdx), types.EmptyTSK)
+			if err != nil {
+				return xerrors.Errorf("getting partitions for deadline %d: %w", dlIdx, err)
+			}
+
+			for _, partition := range partitions {
+				b, err := partition.LiveSectors.First()
+				if err == bitfield.ErrNoBitsSet {
+					continue
+				}
+				if err != nil {
+					return err
+				}
+
+				sector = abi.SectorNumber(b)
+				break out2
+			}
+		}
+
+		if sector == math.MaxUint64 {
+			log.Info("skipping winning PoSt warmup, no sectors")
+			return nil
+		}
 	}
 
 	log.Infow("starting winning PoSt warmup", "sector", sector)
@@ -61,18 +87,68 @@ out:
 		return xerrors.Errorf("getting sector info: %w", err)
 	}
 
-	_, err = m.epp.ComputeProof(ctx, []proof2.SectorInfo{
+	sis := []proof2.SectorInfo{
 		{
 			SealProof:    si.SealProof,
 			SectorNumber: sector,
 			SealedCID:    si.SealedCID,
 		},
-	}, r)
+	}
+
+	wp, err := m.epp.ComputeProof(ctx, sis, r)
 	if err != nil {
 		return xerrors.Errorf("failed to compute proof: %w", err)
 	}
 
 	log.Infow("winning PoSt warmup successful", "took", time.Now().Sub(start))
+
+	aid, err := address.IDFromAddress(m.address)
+	if err != nil {
+		return xerrors.Errorf("getting id from address: %w", err)
+	}
+
+	ok, err := ffiwrapper.ProofVerifier.VerifyWinningPoSt(ctx, proof2.WinningPoStVerifyInfo{
+		Randomness:        r,
+		Proofs:            wp,
+		ChallengedSectors: sis,
+		Prover:            abi.ActorID(aid),
+	})
+	if err != nil {
+		return xerrors.Errorf("verifying warmup winning post: %w", err)
+	}
+	if !ok {
+		log.Error("winning PoSt warmup failed to verify")
+	} else {
+		log.Info("winning PoSt warmup validated successfully")
+	}
+
+	if os.Getenv("WARMUP_WINDOW_POST") == "1" {
+		wp, sk, err := m.epp.GenerateWindowPoSt(ctx, sis, r)
+		if err != nil {
+			return xerrors.Errorf("computing window post: %w", err)
+		}
+		if len(sk) > 0 {
+			log.Errorf("skipped sectors in winning post: %+v", sk)
+		}
+
+		log.Infow("window PoSt warmup successful", "took", time.Now().Sub(start))
+
+		ok, err := ffiwrapper.ProofVerifier.VerifyWindowPoSt(ctx, proof2.WindowPoStVerifyInfo{
+			Randomness:        r,
+			Proofs:            wp,
+			ChallengedSectors: sis,
+			Prover:            abi.ActorID(aid),
+		})
+		if err != nil {
+			return xerrors.Errorf("verifying warmup window post: %w", err)
+		}
+		if !ok {
+			log.Error("window PoSt warmup failed to verify")
+		} else {
+			log.Info("window PoSt warmup validated successfully")
+		}
+	}
+
 	return nil
 }
 

--- a/storage/miner.go
+++ b/storage/miner.go
@@ -21,6 +21,7 @@ import (
 
 	sectorstorage "github.com/filecoin-project/lotus/extern/sector-storage"
 	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
+	"github.com/filecoin-project/specs-actors/v5/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
@@ -247,6 +248,14 @@ type StorageWpp struct {
 	verifier ffiwrapper.Verifier
 	miner    abi.ActorID
 	winnRpt  abi.RegisteredPoStProof
+
+	w interface {
+		GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, err error)
+	}
+}
+
+func (wpp *StorageWpp) GenerateWindowPoSt(ctx context.Context, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, err error) {
+	return wpp.w.GenerateWindowPoSt(ctx, wpp.miner, sectorInfo, randomness)
 }
 
 func NewWinningPoStProver(api v1api.FullNode, prover storage.Prover, verifier ffiwrapper.Verifier, miner dtypes.MinerID) (*StorageWpp, error) {
@@ -266,7 +275,7 @@ func NewWinningPoStProver(api v1api.FullNode, prover storage.Prover, verifier ff
 		log.Warn("*****************************************************************************")
 	}
 
-	return &StorageWpp{prover, verifier, abi.ActorID(miner), mi.WindowPoStProofType}, nil
+	return &StorageWpp{prover, verifier, abi.ActorID(miner), mi.WindowPoStProofType, prover}, nil
 }
 
 var _ gen.WinningPoStProver = (*StorageWpp)(nil)


### PR DESCRIPTION
## Related Issues

(probably exist)

## Proposed Changes

Right now this PR adds an env var which will run window post compute after winning post warmup - this makes it possible to check that drivers are working correctly.

After #7600 lands, this will probably turn into a CLI command, maybe.

Blocked on https://github.com/filecoin-project/lotus/pull/7600

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
