### PR TITLE
feat: infra/ci: add `lotus-test` image as CI build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1037,8 +1037,8 @@ workflows:
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-dev
-          target: lotus-all-in-one
           tag: '${CIRCLE_SHA1:0:8}'
+          target: lotus-all-in-one
       - build-and-push-image:
           dockerfile: Dockerfile.lotus
           path: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,11 @@ jobs:
         default: "latest"
         description: A comma-separated string containing docker image tags to build and push (default = latest)
 
+      target:
+        type: string
+        default: "lotus-all-in-one"
+        description: Docker target to build
+
     steps:
       - run:
           name: Confirm that environment variables are set
@@ -667,6 +672,7 @@ jobs:
 
             docker build \
               <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
+              --target <<parameters.target>> \
               -f <<parameters.path>>/<<parameters.dockerfile>> \
               $docker_tag_args \
               <<parameters.path>>
@@ -1031,7 +1037,14 @@ workflows:
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-dev
+          target: lotus-all-in-one
           tag: '${CIRCLE_SHA1:0:8}'
+      - build-and-push-image:
+          dockerfile: Dockerfile.lotus
+          path: .
+          repo: lotus-test
+          tag: '${CIRCLE_SHA1:0:8}'
+          target: lotus-test
       - publish-packer-mainnet:
           requires:
             - build-all

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -628,6 +628,11 @@ jobs:
         default: "latest"
         description: A comma-separated string containing docker image tags to build and push (default = latest)
 
+      target:
+        type: string
+        default: "lotus-all-in-one"
+        description: Docker target to build
+
     steps:
       - run:
           name: Confirm that environment variables are set
@@ -667,6 +672,7 @@ jobs:
 
             docker build \
               <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
+              --target <<parameters.target>> \
               -f <<parameters.path>>/<<parameters.dockerfile>> \
               $docker_tag_args \
               <<parameters.path>>
@@ -862,6 +868,13 @@ workflows:
           path: .
           repo: lotus-dev
           tag: '${CIRCLE_SHA1:0:8}'
+          target: lotus-all-in-one
+      - build-and-push-image:
+          dockerfile: Dockerfile.lotus
+          path: .
+          repo: lotus-test
+          tag: '${CIRCLE_SHA1:0:8}'
+          target: lotus-test
       - publish-packer-mainnet:
           requires:
             - build-all

--- a/Dockerfile.lotus
+++ b/Dockerfile.lotus
@@ -28,6 +28,14 @@ WORKDIR /opt/filecoin
 RUN make clean deps
 
 
+FROM builder-local AS builder-test
+MAINTAINER Lotus Development Team
+
+WORKDIR /opt/filecoin
+
+RUN make debug
+
+
 FROM builder-local AS builder
 MAINTAINER Lotus Development Team
 
@@ -184,6 +192,43 @@ COPY --from=builder /opt/filecoin/lotus-gateway /usr/local/bin/
 COPY --from=builder /opt/filecoin/lotus-miner /usr/local/bin/
 COPY --from=builder /opt/filecoin/lotus-worker /usr/local/bin/
 COPY --from=builder /opt/filecoin/lotus-stats /usr/local/bin/
+
+RUN mkdir /var/tmp/filecoin-proof-parameters
+RUN mkdir /var/lib/lotus
+RUN mkdir /var/lib/lotus-miner
+RUN mkdir /var/lib/lotus-worker
+RUN mkdir /var/lib/lotus-wallet
+RUN chown fc: /var/tmp/filecoin-proof-parameters
+RUN chown fc: /var/lib/lotus
+RUN chown fc: /var/lib/lotus-miner
+RUN chown fc: /var/lib/lotus-worker
+RUN chown fc: /var/lib/lotus-wallet
+
+
+VOLUME /var/tmp/filecoin-proof-parameters
+VOLUME /var/lib/lotus
+VOLUME /var/lib/lotus-miner
+VOLUME /var/lib/lotus-worker
+VOLUME /var/lib/lotus-wallet
+
+EXPOSE 1234
+EXPOSE 2345
+EXPOSE 3456
+EXPOSE 1777
+
+###
+from base as lotus-test
+
+ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
+ENV LOTUS_MINER_PATH /var/lib/lotus-miner
+ENV LOTUS_PATH /var/lib/lotus
+ENV LOTUS_WORKER_PATH /var/lib/lotus-worker
+ENV WALLET_PATH /var/lib/lotus-wallet
+
+COPY --from=builder-test /opt/filecoin/lotus      /usr/local/bin/
+COPY --from=builder-test /opt/filecoin/lotus-miner /usr/local/bin/
+COPY --from=builder-test /opt/filecoin/lotus-worker /usr/local/bin/
+COPY --from=builder-test /opt/filecoin/lotus-seed /usr/local/bin/
 
 RUN mkdir /var/tmp/filecoin-proof-parameters
 RUN mkdir /var/lib/lotus


### PR DESCRIPTION
This PR is:
1. Adding a `lotus-test` Docker target to `Dockerfile.lotus`
2. Build step to produce `lotus-test` image on commit to `master`.

We need this, because we are using the `--tags=debug` lotus binaries as part of the integration tests for Boost -- https://github.com/filecoin-project/boost/blob/main/.circleci/config.yml#L67

Ideally these images should be produced by `filecoin-project/lotus` build system.

---

TODO:
- [x] create public ECR repository for `lotus-test`, same as `lotus-dev`.