### PR TITLE
feat: gateway: Control access scope through jwt payload

### DIFF
--- a/api/api_gateway.go
+++ b/api/api_gateway.go
@@ -29,6 +29,7 @@ import (
 //  * Generate openrpc blobs
 
 type Gateway interface {
+	AuthVerify(ctx context.Context, token string) (*GatewayPayload, error)
 	ChainHasObj(context.Context, cid.Cid) (bool, error)
 	ChainHead(ctx context.Context) (*types.TipSet, error)
 	ChainGetParentMessages(context.Context, cid.Cid) ([]Message, error)

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -480,6 +480,8 @@ type FullNodeStub struct {
 
 type GatewayStruct struct {
 	Internal struct {
+		AuthVerify func(p0 context.Context, p1 string) (*GatewayPayload, error)
+
 		ChainGetBlockMessages func(p0 context.Context, p1 cid.Cid) (*BlockMessages, error) ``
 
 		ChainGetGenesis func(p0 context.Context) (*types.TipSet, error) ``
@@ -3073,6 +3075,17 @@ func (s *FullNodeStruct) WalletVerify(p0 context.Context, p1 address.Address, p2
 
 func (s *FullNodeStub) WalletVerify(p0 context.Context, p1 address.Address, p2 []byte, p3 *crypto.Signature) (bool, error) {
 	return false, ErrNotSupported
+}
+
+func (s *GatewayStruct) AuthVerify(p0 context.Context, p1 string) (*GatewayPayload, error) {
+	if s.Internal.AuthVerify == nil {
+		return nil, ErrNotSupported
+	}
+	return s.Internal.AuthVerify(p0, p1)
+}
+
+func (s *GatewayStub) AuthVerify(p0 context.Context, p1 cid.Cid) (*BlockMessages, error) {
+	return nil, ErrNotSupported
 }
 
 func (s *GatewayStruct) ChainGetBlockMessages(p0 context.Context, p1 cid.Cid) (*BlockMessages, error) {

--- a/api/types.go
+++ b/api/types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gbrlsnchs/jwt/v3"
 	"time"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -261,4 +262,10 @@ type ExportRef struct {
 
 	FromLocalCAR string // if specified, get data from a local CARv2 file.
 	DealID       retrievalmarket.DealID
+}
+
+type GatewayPayload struct {
+	jwt.Payload
+	LookbackCap            time.Duration `json:"lookbackCap,omitempty"`
+	StateWaitLookbackLimit abi.ChainEpoch `json:"stateWaitLookbackLimit,omitempty"`
 }

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -1,7 +1,14 @@
 package gateway
 
 import (
+	"context"
+	"crypto/rand"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/node/repo"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"net/http"
+	"strings"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/filecoin-project/go-jsonrpc"
@@ -13,6 +20,10 @@ import (
 	promclient "github.com/prometheus/client_golang/prometheus"
 )
 
+var log = logging.Logger("gateway")
+
+const KGatewayHost = "gateway-host"
+
 // Handler returns a gateway http.Handler, to be mounted as-is on the server.
 func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) {
 	m := mux.NewRouter()
@@ -20,7 +31,10 @@ func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) 
 	serveRpc := func(path string, hnd interface{}) {
 		rpcServer := jsonrpc.NewServer(opts...)
 		rpcServer.Register("Filecoin", hnd)
-		m.Handle(path, rpcServer)
+
+		handler := &AuthHandler{Verify: a.AuthVerify, Next: rpcServer.ServeHTTP}
+
+		m.Handle(path, handler)
 	}
 
 	ma := proxy.MetricedGatewayAPI(a)
@@ -45,4 +59,85 @@ func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) 
 	}*/
 
 	return m, nil
+}
+
+func MakeGatewayKey(lr repo.LockedRepo) (crypto.PrivKey, error) {
+	pk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	ks, err := lr.KeyStore()
+	if err != nil {
+		return nil, err
+	}
+
+	kbytes, err := crypto.MarshalPrivateKey(pk)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ks.Put(KGatewayHost, types.KeyInfo{
+		Type:       KGatewayHost,
+		PrivateKey: kbytes,
+	}); err != nil {
+		return nil, err
+	}
+
+	return pk, nil
+}
+
+func GetGatewayKey(lr repo.LockedRepo) (types.KeyInfo, error) {
+	ks, err := lr.KeyStore()
+	if err != nil {
+		return types.KeyInfo{}, err
+	}
+
+	ki, err := ks.Get(KGatewayHost)
+	if err != nil {
+		return types.KeyInfo{}, err
+	}
+
+	return ki, nil
+}
+
+type AuthHandler struct {
+	Verify func(ctx context.Context, token string) (*api.GatewayPayload, error)
+	Next   http.HandlerFunc
+}
+
+func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	token := r.Header.Get("Authorization")
+	if token == "" {
+		token = r.FormValue("token")
+		if token != "" {
+			token = "Bearer " + token
+		}
+	}
+
+	if token != "" {
+		if !strings.HasPrefix(token, "Bearer ") {
+			log.Warn("missing Bearer prefix in auth header")
+			w.WriteHeader(401)
+			return
+		}
+		token = strings.TrimPrefix(token, "Bearer ")
+
+		payload, err := h.Verify(ctx, token)
+		if err != nil {
+			log.Warnf("JWT Verification failed (originating from %s): %s", r.RemoteAddr, err)
+			w.WriteHeader(401)
+			return
+		}
+
+		ctx = WithPerm(ctx, payload)
+	}
+
+	h.Next(w, r.WithContext(ctx))
+}
+
+func WithPerm(ctx context.Context, payload *api.GatewayPayload) context.Context {
+	return context.WithValue(ctx, "payload", *payload)
 }

--- a/gateway/node_test.go
+++ b/gateway/node_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"sync"
 	"testing"
 	"time"
@@ -89,7 +90,8 @@ func TestGatewayAPIChainGetTipSetByHeight(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockGatewayDepsAPI{}
-			a := NewNode(mock, DefaultLookbackCap, DefaultStateWaitLookbackLimit)
+			pk, _ := crypto.UnmarshalEd25519PrivateKey([]byte(""))
+			a, _ := NewNode(mock, DefaultLookbackCap, DefaultStateWaitLookbackLimit, pk)
 
 			// Create tipsets from genesis up to tskh and return the highest
 			ts := mock.createTipSets(tt.args.tskh, tt.args.genesisTS)
@@ -243,7 +245,8 @@ func (m *mockGatewayDepsAPI) Version(context.Context) (api.APIVersion, error) {
 func TestGatewayVersion(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockGatewayDepsAPI{}
-	a := NewNode(mock, DefaultLookbackCap, DefaultStateWaitLookbackLimit)
+	pk, _ := crypto.UnmarshalEd25519PrivateKey([]byte(""))
+	a, _ := NewNode(mock, DefaultLookbackCap, DefaultStateWaitLookbackLimit, pk)
 
 	v, err := a.Version(ctx)
 	require.NoError(t, err)

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -50,6 +50,7 @@ const (
 	Worker
 	Wallet
 	Markets
+	Gateway
 )
 
 func (t RepoType) String() string {
@@ -60,6 +61,7 @@ func (t RepoType) String() string {
 		"Worker",
 		"Wallet",
 		"Markets",
+		"Gateway",
 	}
 	if t < 0 || int(t) > len(s) {
 		return "__invalid__"
@@ -78,6 +80,8 @@ func defConfForType(t RepoType) interface{} {
 	case Worker:
 		return &struct{}{}
 	case Wallet:
+		return &struct{}{}
+	case Gateway:
 		return &struct{}{}
 	default:
 		panic(fmt.Sprintf("unknown RepoType(%d)", int(t)))


### PR DESCRIPTION
## Proposed Changes
Add lotus-gateway command tool, specify --api-max-lookback=24h --api-wait-lookback-limit=10000 --effective-time=1h to control api permissions.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
