### PR TITLE
perf: chain: Disable fsync on the chainstore by default

### DIFF
--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -347,10 +347,11 @@ func (fsr *fsLockedRepo) Blockstore(ctx context.Context, domain BlockstoreDomain
 
 		//
 		// Tri-state environment variable LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC
-		// - unset == the default (currently fsync enabled)
+		// - unset == the default (currently fsync disabled)
 		// - set with a false-y value == fsync enabled no matter what a future default is
 		// - set with any other value == fsync is disabled ignored defaults (recommended for day-to-day use)
 		//
+		opts.SyncWrites = false
 		if nosyncBs, nosyncBsSet := os.LookupEnv("LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC"); nosyncBsSet {
 			nosyncBs = strings.ToLower(nosyncBs)
 			if nosyncBs == "" || nosyncBs == "0" || nosyncBs == "false" || nosyncBs == "no" {


### PR DESCRIPTION
Use LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC=false to reenable

The amount of PutMany and Put calls caused by IPLD churn is too high for an average
non-nvme SSD to keep up. Since the chainstore is something that does get reset every
so often anyway, it should be acceptable to loosen the crash-resilience in order to
enable more full validating nodes in the wild.
