### PR TITLE
Fix: chain: create a new VM for each epoch

### DIFF
--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -824,17 +824,6 @@ func (vm *VM) StateTree() types.StateTree {
 	return vm.cstate
 }
 
-func (vm *VM) SetBlockHeight(ctx context.Context, h abi.ChainEpoch) error {
-	vm.blockHeight = h
-	ncirc, err := vm.circSupplyCalc(ctx, vm.blockHeight, vm.cstate)
-	if err != nil {
-		return err
-	}
-
-	vm.baseCircSupply = ncirc
-	return nil
-}
-
 func (vm *VM) Invoke(act *types.Actor, rt *Runtime, method abi.MethodNum, params []byte) ([]byte, aerrors.ActorError) {
 	ctx, span := trace.StartSpan(rt.ctx, "vm.Invoke")
 	defer span.End()


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Fixes bug introduced in #7818. The VM's network version was always being determined based on `epoch`, the input to the `ApplyBlocks` method, even though the vm executes (potentially) multiple epochs worth of messages. The result is that if there was a null epoch before the upgrade epoch, the VM used the wrong network version (the new version) for running cron before the migration.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Although this was a fairly specific case, I think this issue shows the risks of trying to hamfistedly reuse the VM for multiple epochs of execution (see #7890 for a similar issue). This PR changes behaviour to make VMs one-per-epoch. We remove the old `SetBlockHeight` method entirely, and always create a new VM when moving between epochs. The result is that fields that need updating between epochs (like network version) are guaranteed to update this way.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
