### PR TITLE
tvx: supply network version when extracting messages.

### DIFF
--- a/cmd/tvx/codenames.go
+++ b/cmd/tvx/codenames.go
@@ -24,6 +24,15 @@ var ProtocolCodenames = []struct {
 	{build.UpgradeTapeHeight + 1, "tape"},
 	{build.UpgradeLiftoffHeight + 1, "liftoff"},
 	{build.UpgradeKumquatHeight + 1, "postliftoff"},
+	{build.UpgradeCalicoHeight + 1, "calico"},
+	{build.UpgradePersianHeight + 1, "persian"},
+	{build.UpgradeOrangeHeight + 1, "orange"},
+	{build.UpgradeTrustHeight + 1, "trust"},
+	{build.UpgradeNorwegianHeight + 1, "norwegian"},
+	{build.UpgradeTurboHeight + 1, "turbo"},
+	{build.UpgradeHyperdriveHeight + 1, "hyperdrive"},
+	{build.UpgradeChocolateHeight + 1, "chocolate"},
+	{build.UpgradeOhSnapHeight + 1, "ohsnap"},
 }
 
 // GetProtocolCodename gets the protocol codename associated with a height.

--- a/cmd/tvx/simulate.go
+++ b/cmd/tvx/simulate.go
@@ -129,6 +129,7 @@ func runSimulateCmd(_ *cli.Context) error {
 		CircSupply: circSupply.FilCirculating,
 		BaseFee:    baseFee,
 		Rand:       rand,
+		// TODO NetworkVersion
 	})
 	if err != nil {
 		return fmt.Errorf("failed to apply message: %w", err)


### PR DESCRIPTION
This PR fixes the `tvx` tool to pass in the relevant network version when extracting test vectors.