### PR TITLE
fix: sealing: Stop recovery attempts after fault

### DIFF
--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -211,7 +211,7 @@ func (m *Sealing) handleSubmitReplicaUpdateFailed(ctx statemachine.Context, sect
 
 	tok, _, err := m.Api.ChainHead(ctx.Context())
 	if err != nil {
-		log.Errorf("handleCommitting: api error, not proceeding: %+v", err)
+		log.Errorf("handleSubmitReplicaUpdateFailed: api error, not proceeding: %+v", err)
 		return nil
 	}
 

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -237,6 +237,17 @@ func (m *Sealing) handleSubmitReplicaUpdateFailed(ctx statemachine.Context, sect
 		}
 	}
 
+	// Abort upgrade for sectors that went faulty since being marked for upgrade
+	active, err := sectorActive(ctx.Context(), m.Api, m.maddr, tok, sector.SectorNumber)
+	if err != nil {
+		log.Errorf("sector active check: api error, not proceeding: %+v", err)
+		return nil
+	}
+	if !active {
+		log.Errorf("sector marked for upgrade %d no longer active, aborting upgrade", sector.SectorNumber)
+		return ctx.Send(SectorAbortUpgrade{})
+	}
+
 	if err := failedCooldown(ctx, sector); err != nil {
 		return err
 	}

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -3,6 +3,7 @@ package sealing
 import (
 	"context"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 
@@ -86,19 +87,11 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 		return xerrors.Errorf("failed to read sector on chain info: %w", err)
 	}
 
-	active, err := m.Api.StateMinerActiveSectors(ctx, m.maddr, tok)
+	active, err := sectorActive(ctx, m.Api, m.maddr, tok, id)
 	if err != nil {
-		return xerrors.Errorf("failed to check active sectors: %w", err)
+		return xerrors.Errorf("failed to check if sector is active")
 	}
-	// Ensure the upgraded sector is active
-	var found bool
-	for _, si := range active {
-		if si.SectorNumber == id {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !active {
 		return xerrors.Errorf("cannot mark inactive sector for upgrade")
 	}
 
@@ -108,6 +101,22 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 	}
 
 	return m.sectors.Send(uint64(id), SectorStartCCUpdate{})
+}
+
+func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, tok TipSetToken, sector abi.SectorNumber) (bool, error) {
+	active, err := api.StateMinerActiveSectors(ctx, maddr, tok)
+	if err != nil {
+		return false, xerrors.Errorf("failed to check active sectors: %w", err)
+	}
+	// Ensure the upgraded sector is active
+	var found bool
+	for _, si := range active {
+		if si.SectorNumber == sector {
+			found = true
+			break
+		}
+	}
+	return found, nil
 }
 
 func (m *Sealing) tryUpgradeSector(ctx context.Context, params *miner.SectorPreCommitInfo) big.Int {

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -108,7 +108,7 @@ func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, to
 	if err != nil {
 		return false, xerrors.Errorf("failed to check active sectors: %w", err)
 	}
-	// Ensure the upgraded sector is active
+	// Check if sector is among active sectors
 	var found bool
 	for _, si := range active {
 		if si.SectorNumber == sector {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
#8011

## Proposed Changes
<!-- provide a clear list of the changes being made-->

This addresses the major concern behind #8011 -- too many resources being used when retrying submission of a replica update message after fault.  

The best solution available now is to check for the fault condition after submit replica update has failed.  

It is understandable to want to stop including faulty sectors at deal inclusion as the name of 8011 suggests.   But that is less good.  Faulting could happen immediately after the last deal was included and the scheduler would be in the same bad state.

The totally correct thing that we should work towards in the future is interrupting the scheduler with an fsm event triggered by listening to the chain for faults (and expirations extensions, etc) happening.  But that is too much refactor for right now.

Fun alternate idea: [this ancient todo](https://github.com/filecoin-project/lotus/blob/master/extern/storage-sealing/states_failed.go#L24) about exponential backoff would address this particular bug too.


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
