### PR TITLE
splitstore: set badger as the default default markset type

### DIFF
--- a/blockstore/splitstore/README.md
+++ b/blockstore/splitstore/README.md
@@ -49,10 +49,9 @@ These are options in the `[Chainstore.Splitstore]` section of the configuration:
   blockstore and discards writes; this is necessary to support syncing from a snapshot.
 - `MarkSetType` -- specifies the type of markset to use during compaction.
   The markset is the data structure used by compaction/gc to track live objects.
-  The default value is `"map"`, which will use an in-memory map; if you are limited
-  in memory (or indeed see compaction run out of memory), you can also specify
-  `"badger"` which will use an disk backed markset, using badger. This will use
-  much less memory, but will also make compaction slower.
+  The default value is "badger", which will use a disk backed markset using badger.
+  If you have a lot of memory (40G or more) you can also use "map", which will use
+  an in memory markset, speeding up compaction at the cost of higher memory usage.
 - `HotStoreMessageRetention` -- specifies how many finalities, beyond the 4
   finalities maintained by default, to maintain messages and message receipts in the
   hotstore. This is useful for assistive nodes that want to support syncing for other

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -163,11 +163,11 @@
     #HotStoreType = "badger"
 
     # MarkSetType specifies the type of the markset.
-    # It can be "map" (default) for in memory marking or "badger" for on-disk marking.
+    # It can be "map" for in memory marking or "badger" (default) for on-disk marking.
     #
     # type: string
     # env var: LOTUS_CHAINSTORE_SPLITSTORE_MARKSETTYPE
-    #MarkSetType = "map"
+    #MarkSetType = "badger"
 
     # HotStoreMessageRetention specifies the retention policy for messages, in finalities beyond
     # the compaction boundary; default is 0.

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -85,7 +85,7 @@ func DefaultFullNode() *FullNode {
 			Splitstore: Splitstore{
 				ColdStoreType: "universal",
 				HotStoreType:  "badger",
-				MarkSetType:   "map",
+				MarkSetType:   "badger",
 
 				HotStoreFullGCFrequency: 20,
 			},

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -802,7 +802,7 @@ Only currently supported value is "badger".`,
 			Type: "string",
 
 			Comment: `MarkSetType specifies the type of the markset.
-It can be "map" (default) for in memory marking or "badger" for on-disk marking.`,
+It can be "map" for in memory marking or "badger" (default) for on-disk marking.`,
 		},
 		{
 			Name: "HotStoreMessageRetention",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -359,7 +359,7 @@ type Splitstore struct {
 	// Only currently supported value is "badger".
 	HotStoreType string
 	// MarkSetType specifies the type of the markset.
-	// It can be "map" (default) for in memory marking or "badger" for on-disk marking.
+	// It can be "map" for in memory marking or "badger" (default) for on-disk marking.
 	MarkSetType string
 
 	// HotStoreMessageRetention specifies the retention policy for messages, in finalities beyond


### PR DESCRIPTION
On top of #8008.

Sets badger as the default markset type, so that we can work out of the box if we have <40G of RAM.