### PR TITLE
Add indexer pubsub message authentication and rate limiting

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -481,15 +481,15 @@ func (v *IndexerMessageValidator) Validate(ctx context.Context, pid peer.ID, msg
 	// This chain-node should not be publishing its own messages.  These are
 	// relayed from market-nodes.  If a node appears to be local, reject it.
 	if pid == v.self {
-		log.Warnf("refusing to relay indexer message from self")
+		log.Debug("ignoring indexer message from self")
 		stats.Record(ctx, metrics.IndexerMessageValidationFailure.M(1))
-		return pubsub.ValidationReject
+		return pubsub.ValidationIgnore
 	}
 	originPeer := msg.GetFrom()
 	if originPeer == v.self {
-		log.Warnf("refusing to relay indexer message originating from self")
+		log.Debug("ignoring indexer message originating from self")
 		stats.Record(ctx, metrics.IndexerMessageValidationFailure.M(1))
-		return pubsub.ValidationReject
+		return pubsub.ValidationIgnore
 	}
 
 	idxrMsg := dtsync.Message{}

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	address "github.com/filecoin-project/go-address"
-	//"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/consensus"
@@ -465,7 +464,7 @@ type IndexerMessageValidator struct {
 }
 
 func NewIndexerMessageValidator(self peer.ID, chainApi full.ChainModuleAPI, stateApi full.StateModuleAPI) *IndexerMessageValidator {
-	peerCache, _ := lru.New2Q(1024)
+	peerCache, _ := lru.New2Q(8192)
 
 	return &IndexerMessageValidator{
 		self:      self,
@@ -498,7 +497,7 @@ func (v *IndexerMessageValidator) Validate(ctx context.Context, pid peer.ID, msg
 	}
 
 	if minerID == "" {
-		log.Warnw("ignoring messsage missing miner id", "peer", originPeer)
+		log.Debugw("ignoring messsage missing miner id", "peer", originPeer)
 		return pubsub.ValidationIgnore
 	}
 

--- a/chain/sub/ratelimit/queue.go
+++ b/chain/sub/ratelimit/queue.go
@@ -1,0 +1,89 @@
+package ratelimit
+
+import "errors"
+
+var ErrRate = errors.New("rate exceeded")
+
+type queue struct {
+	buf   []int64
+	count int
+	head  int
+	tail  int
+}
+
+// cap returns the queue capacity
+func (q *queue) cap() int {
+	return len(q.buf)
+}
+
+// len returns the number of items in the queue
+func (q *queue) len() int {
+	return q.count
+}
+
+// push adds an element to the end of the queue.
+func (q *queue) push(elem int64) error {
+	if q.count == len(q.buf) {
+		return ErrRate
+	}
+
+	q.buf[q.tail] = elem
+	// Calculate new tail position.
+	q.tail = q.next(q.tail)
+	q.count++
+	return nil
+}
+
+// pop removes and returns the element from the front of the queue.
+func (q *queue) pop() int64 {
+	if q.count <= 0 {
+		panic("pop from empty queue")
+	}
+	ret := q.buf[q.head]
+
+	// Calculate new head position.
+	q.head = q.next(q.head)
+	q.count--
+
+	return ret
+}
+
+// front returns the element at the front of the queue.  This is the element
+// that would be returned by pop().  This call panics if the queue is empty.
+func (q *queue) front() int64 {
+	if q.count <= 0 {
+		panic("front() called when empty")
+	}
+	return q.buf[q.head]
+}
+
+// back returns the element at the back of the queue.  This call panics if the
+// queue is empty.
+func (q *queue) back() int64 {
+	if q.count <= 0 {
+		panic("back() called when empty")
+	}
+	return q.buf[q.prev(q.tail)]
+}
+
+// prev returns the previous buffer position wrapping around buffer.
+func (q *queue) prev(i int) int {
+	if i == 0 {
+		return len(q.buf) - 1
+	}
+	return (i - 1) % len(q.buf)
+}
+
+// next returns the next buffer position wrapping around buffer.
+func (q *queue) next(i int) int {
+	return (i + 1) % len(q.buf)
+}
+
+// truncate pops values that are less than or equal the specified threshold.
+func (q *queue) truncate(threshold int64) {
+	for q.count != 0 && q.buf[q.head] <= threshold {
+		// pop() without returning a value
+		q.head = q.next(q.head)
+		q.count--
+	}
+}

--- a/chain/sub/ratelimit/queue.go
+++ b/chain/sub/ratelimit/queue.go
@@ -2,7 +2,7 @@ package ratelimit
 
 import "errors"
 
-var ErrRate = errors.New("rate exceeded")
+var ErrRateLimitExceeded = errors.New("rate limit exceeded")
 
 type queue struct {
 	buf   []int64
@@ -24,7 +24,7 @@ func (q *queue) len() int {
 // push adds an element to the end of the queue.
 func (q *queue) push(elem int64) error {
 	if q.count == len(q.buf) {
-		return ErrRate
+		return ErrRateLimitExceeded
 	}
 
 	q.buf[q.tail] = elem

--- a/chain/sub/ratelimit/window.go
+++ b/chain/sub/ratelimit/window.go
@@ -1,0 +1,70 @@
+package ratelimit
+
+import "time"
+
+// Window is a time windows for counting events within a span of time.  The
+// windows slides forward in time so that it spans from the most recent event
+// to size time in the past.
+type Window struct {
+	q    *queue
+	size int64
+}
+
+// NewWindow creates a new Window that limits the number of events to maximum
+// count of events withing a duration of time.  The capacity sets the maximum
+// number of events, and size sets the span of time over which the events are
+// counted.
+func NewWindow(capacity int, size time.Duration) *Window {
+	return &Window{
+		q: &queue{
+			buf: make([]int64, capacity),
+		},
+		size: int64(size),
+	}
+}
+
+// Add attempts to append a new timestamp into the current window.  Previously
+// added values that are not not within `size` difference from the value being
+// added are first removed.  Add fails if adding the value would cause the
+// window to exceed capacity.
+func (w *Window) Add() error {
+	now := time.Now().UnixNano()
+	if w.Len() != 0 {
+		w.q.truncate(now - w.size)
+	}
+	return w.q.push(now)
+}
+
+// Cap returns the maximum number of items the window can hold.
+func (w *Window) Cap() int {
+	return w.q.cap()
+}
+
+// Len returns the number of elements currently in the window.
+func (w *Window) Len() int {
+	return w.q.len()
+}
+
+// Span returns the distance from the first to the last item in the window.
+func (w *Window) Span() time.Duration {
+	if w.q.len() < 2 {
+		return 0
+	}
+	return time.Duration(w.q.back() - w.q.front())
+}
+
+// Oldest returns the oldest timestamp in the window.
+func (w *Window) Oldest() time.Time {
+	if w.q.len() == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, w.q.front())
+}
+
+// Newest returns the newest timestamp in the window.
+func (w *Window) Newest() time.Time {
+	if w.q.len() == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, w.q.back())
+}

--- a/chain/sub/ratelimit/window.go
+++ b/chain/sub/ratelimit/window.go
@@ -11,7 +11,7 @@ type Window struct {
 }
 
 // NewWindow creates a new Window that limits the number of events to maximum
-// count of events withing a duration of time.  The capacity sets the maximum
+// count of events within a duration of time.  The capacity sets the maximum
 // number of events, and size sets the span of time over which the events are
 // counted.
 func NewWindow(capacity int, size time.Duration) *Window {

--- a/chain/sub/ratelimit/window_test.go
+++ b/chain/sub/ratelimit/window_test.go
@@ -1,0 +1,61 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWindow(t *testing.T) {
+	const (
+		maxEvents = 3
+		timeLimit = 100 * time.Millisecond
+	)
+	w := NewWindow(maxEvents, timeLimit)
+	if w.Len() != 0 {
+		t.Fatal("q.Len() =", w.Len(), "expect 0")
+	}
+	if w.Cap() != maxEvents {
+		t.Fatal("q.Cap() =", w.Cap(), "expect 3")
+	}
+	if !w.Newest().IsZero() {
+		t.Fatal("expected newest to be zero time with empty window")
+	}
+	if !w.Oldest().IsZero() {
+		t.Fatal("expected oldest to be zero time with empty window")
+	}
+	if w.Span() != 0 {
+		t.Fatal("expected span to be zero time with empty window")
+	}
+
+	var err error
+	for i := 0; i < maxEvents; i++ {
+		err = w.Add()
+		if err != nil {
+			t.Fatalf("cannot add event %d", i)
+		}
+	}
+	if w.Len() != maxEvents {
+		t.Fatalf("q.Len() is %d, expected %d", w.Len(), maxEvents)
+	}
+	if err = w.Add(); err == nil {
+		t.Fatalf("add event %d within time limit should have failed", maxEvents+1)
+	}
+
+	time.Sleep(timeLimit)
+	if err = w.Add(); err != nil {
+		t.Fatalf("cannot add event after time limit: %s", err)
+	}
+
+	prev := w.Newest()
+	time.Sleep(timeLimit)
+	err = w.Add()
+	if err != nil {
+		t.Fatalf("cannot add event")
+	}
+	if w.Newest().Before(prev) {
+		t.Fatal("newest is before previous value")
+	}
+	if w.Oldest().Before(prev) {
+		t.Fatal("oldest is before previous value")
+	}
+}

--- a/chain/sub/ratelimit/window_test.go
+++ b/chain/sub/ratelimit/window_test.go
@@ -37,8 +37,8 @@ func TestWindow(t *testing.T) {
 	if w.Len() != maxEvents {
 		t.Fatalf("q.Len() is %d, expected %d", w.Len(), maxEvents)
 	}
-	if err = w.Add(); err == nil {
-		t.Fatalf("add event %d within time limit should have failed", maxEvents+1)
+	if err = w.Add(); err != ErrRateLimitExceeded {
+		t.Fatalf("add event %d within time limit should have failed with err: %s", maxEvents+1, ErrRateLimitExceeded)
 	}
 
 	time.Sleep(timeLimit)

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v1.19.1-0.20220203152434-8790cca614d3
 	github.com/filecoin-project/go-indexer-core v0.2.8
 	github.com/filecoin-project/go-jsonrpc v0.1.5
+	github.com/filecoin-project/go-legs v0.3.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.3-0.20220111000201-e42866db1a53
 	github.com/filecoin-project/go-state-types v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -350,8 +350,9 @@ github.com/filecoin-project/go-indexer-core v0.2.8 h1:h1SRdZKTVcaXlzex3UevHh4OWD
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
 github.com/filecoin-project/go-jsonrpc v0.1.5 h1:ckxqZ09ivBAVf5CSmxxrqqNHC7PJm3GYGtYKiNQ+vGk=
 github.com/filecoin-project/go-jsonrpc v0.1.5/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
-github.com/filecoin-project/go-legs v0.2.7 h1:+b1BQv4QKkRNsDUE8Z4sEhLXhfVQ+iGpHhANpYqxJlA=
 github.com/filecoin-project/go-legs v0.2.7/go.mod h1:NrdELuDbtAH8/xqRMgyOYms67aliQajExInLS6g8zFM=
+github.com/filecoin-project/go-legs v0.3.0 h1:1rDNdPdXbgetmmvRcYZV5YIplIO8LtBVQ7ZttKCrTrM=
+github.com/filecoin-project/go-legs v0.3.0/go.mod h1:x6nwM+DuN7NzlPndOoJuiHYCX+pze6+efPRx17nIA7M=
 github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=
 github.com/filecoin-project/go-padreader v0.0.1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -116,13 +116,13 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 
 	ingestTopicParams := &pubsub.TopicScoreParams{
 		// expected ~0.5 confirmed deals / min. sampled
-		TopicWeight: 1,
+		TopicWeight: 0.1,
 
 		TimeInMeshWeight:  0.00027, // ~1/3600
 		TimeInMeshQuantum: time.Second,
 		TimeInMeshCap:     1,
 
-		FirstMessageDeliveriesWeight: 5,
+		FirstMessageDeliveriesWeight: 0.5,
 		FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
 		FirstMessageDeliveriesCap:    100, // allowing for burstiness
 

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -114,6 +114,22 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		InvalidMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
 	}
 
+	ingestTopicParams := &pubsub.TopicScoreParams{
+		// expected ~0.5 confirmed deals / min. sampled
+		TopicWeight: 1,
+
+		TimeInMeshWeight:  0.00027, // ~1/3600
+		TimeInMeshQuantum: time.Second,
+		TimeInMeshCap:     1,
+
+		FirstMessageDeliveriesWeight: 5,
+		FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+		FirstMessageDeliveriesCap:    100, // allowing for burstiness
+
+		InvalidMessageDeliveriesWeight: -1000,
+		InvalidMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+	}
+
 	topicParams := map[string]*pubsub.TopicScoreParams{
 		build.BlocksTopic(in.Nn): {
 			// expected 10 blocks/min
@@ -207,6 +223,9 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		pgTopicWeights[topic] = 5
 		drandTopics = append(drandTopics, topic)
 	}
+
+	// Index ingestion whitelist
+	topicParams[build.IndexerIngestTopic(in.Nn)] = ingestTopicParams
 
 	// IP colocation whitelist
 	var ipcoloWhitelist []*net.IPNet

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -20,7 +20,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/discovery"
 	discoveryimpl "github.com/filecoin-project/go-fil-markets/discovery/impl"
 
-	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/beacon"
@@ -36,6 +35,7 @@ import (
 	"github.com/filecoin-project/lotus/lib/peermgr"
 	marketevents "github.com/filecoin-project/lotus/markets/loggers"
 	"github.com/filecoin-project/lotus/node/hello"
+	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -199,12 +199,10 @@ func HandleIncomingMessages(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub
 	waitForSync(stmgr, pubsubMsgsSyncEpochs, subscribe)
 }
 
-func RelayIndexerMessages(lc fx.Lifecycle, ps *pubsub.PubSub, nn dtypes.NetworkName, h host.Host) error {
+func RelayIndexerMessages(lc fx.Lifecycle, ps *pubsub.PubSub, nn dtypes.NetworkName, h host.Host, chainModule full.ChainModule, stateModule full.StateModule) error {
 	topicName := build.IndexerIngestTopic(nn)
 
-	// TODO: How do this get set?
-	var fullNode api.FullNode
-	v := sub.NewIndexerMessageValidator(h.ID(), fullNode)
+	v := sub.NewIndexerMessageValidator(h.ID(), &chainModule, &stateModule)
 
 	if err := ps.RegisterTopicValidator(topicName, v.Validate); err != nil {
 		return xerrors.Errorf("failed to register validator for topic %s, err: %w", topicName, err)

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -199,10 +199,10 @@ func HandleIncomingMessages(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub
 	waitForSync(stmgr, pubsubMsgsSyncEpochs, subscribe)
 }
 
-func RelayIndexerMessages(lc fx.Lifecycle, ps *pubsub.PubSub, nn dtypes.NetworkName, h host.Host, chainModule full.ChainModule, stateModule full.StateModule) error {
+func RelayIndexerMessages(lc fx.Lifecycle, ps *pubsub.PubSub, nn dtypes.NetworkName, h host.Host, chainModule full.ChainModuleAPI, stateModule full.StateModuleAPI) error {
 	topicName := build.IndexerIngestTopic(nn)
 
-	v := sub.NewIndexerMessageValidator(h.ID(), &chainModule, &stateModule)
+	v := sub.NewIndexerMessageValidator(h.ID(), chainModule, stateModule)
 
 	if err := ps.RegisterTopicValidator(topicName, v.Validate); err != nil {
 		return xerrors.Errorf("failed to register validator for topic %s, err: %w", topicName, err)

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/discovery"
 	discoveryimpl "github.com/filecoin-project/go-fil-markets/discovery/impl"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/beacon"
@@ -201,7 +202,9 @@ func HandleIncomingMessages(mctx helpers.MetricsCtx, lc fx.Lifecycle, ps *pubsub
 func RelayIndexerMessages(lc fx.Lifecycle, ps *pubsub.PubSub, nn dtypes.NetworkName, h host.Host) error {
 	topicName := build.IndexerIngestTopic(nn)
 
-	v := sub.NewIndexerMessageValidator(h.ID())
+	// TODO: How do this get set?
+	var fullNode api.FullNode
+	v := sub.NewIndexerMessageValidator(h.ID(), fullNode)
 
 	if err := ps.RegisterTopicValidator(topicName, v.Validate); err != nil {
 		return xerrors.Errorf("failed to register validator for topic %s, err: %w", topicName, err)


### PR DESCRIPTION
This PR authenticates indexer pubsub messages against the blockchain and does rate-limiting of these messages.

## Proposed Changes
- Authenticate that peer that sent the message is the peer that appears in the miner info.
- Rate limit overall messages
- Rate limit repeated announcements
