### PR TITLE
Override `testnetnet` to `mainnet` in indexer ingest topic

### DIFF
--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -14,7 +14,15 @@ import (
 func BlocksTopic(netName dtypes.NetworkName) string   { return "/fil/blocks/" + string(netName) }
 func MessagesTopic(netName dtypes.NetworkName) string { return "/fil/msgs/" + string(netName) }
 func IndexerIngestTopic(netName dtypes.NetworkName) string {
-	return "/indexer/ingest/" + string(netName)
+
+	nn := string(netName)
+	// The network name testnetnet is here for historical reasons.
+	// Going forward we aim to use the name `mainnet` where possible.
+	if nn == "testnetnet" {
+		nn = "mainnet"
+	}
+
+	return "/indexer/ingest/" + nn
 }
 func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
 	return protocol.ID("/fil/kad/" + string(netName))


### PR DESCRIPTION
Override `testnetnet` to `mainnet` when constructing indexer ingestion
topic.

Relates to: https://github.com/filecoin-project/lotus/pull/7313
