### PR TITLE
fix:paychan:deflake integration test

### DIFF
--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/lotus/api"
 	aminer "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -82,11 +83,49 @@ func (p *partitionTracker) recordIfPost(t *testing.T, bm *BlockMiner, smsg *type
 	return
 }
 
+func (bm *BlockMiner) forcePoSt(ctx context.Context, ts *types.TipSet, dlinfo *dline.Info) {
+
+	tracker := newPartitionTracker(ctx, dlinfo.Index, bm)
+	if !tracker.done(bm.t) { // need to wait for post
+		bm.t.Logf("expect %d partitions proved but only see %d", len(tracker.partitions), tracker.count(bm.t))
+		poolEvts, err := bm.miner.FullNode.MpoolSub(ctx) //subscribe before checking pending so we don't miss any events
+		require.NoError(bm.t, err)
+
+		// First check pending messages we'll mine this epoch
+		msgs, err := bm.miner.FullNode.MpoolPending(ctx, types.EmptyTSK)
+		require.NoError(bm.t, err)
+		for _, msg := range msgs {
+			tracker.recordIfPost(bm.t, bm, msg)
+		}
+
+		// post not yet in mpool, wait for it
+		if !tracker.done(bm.t) {
+			bm.t.Logf("post missing from mpool, block mining suspended until it arrives")
+		POOL:
+			for {
+				bm.t.Logf("mpool event wait loop at block height %d, ts: %s", ts.Height(), ts.Key())
+				select {
+				case <-ctx.Done():
+					return
+				case evt := <-poolEvts:
+					bm.t.Logf("pool event: %d", evt.Type)
+					if evt.Type == api.MpoolAdd {
+						bm.t.Logf("incoming message %v", evt.Message)
+						if tracker.recordIfPost(bm.t, bm, evt.Message) {
+							break POOL
+						}
+					}
+				}
+			}
+			bm.t.Logf("done waiting on mpool")
+		}
+	}
+}
+
 // Like MineBlocks but refuses to mine until the window post scheduler has wdpost messages in the mempool
 // and everything shuts down if a post fails.  It also enforces that every block mined succeeds
 func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Duration) {
-
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 
 	// wrap context in a cancellable context.
 	ctx, bm.cancel = context.WithCancel(ctx)
@@ -94,8 +133,6 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 	go func() {
 		defer bm.wg.Done()
 
-		activeDeadlines := make(map[int]struct{})
-		_ = activeDeadlines
 		ts, err := bm.miner.FullNode.ChainHead(ctx)
 		require.NoError(bm.t, err)
 		wait := make(chan bool)
@@ -103,7 +140,7 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 		require.NoError(bm.t, err)
 		// read current out
 		curr := <-chg
-		require.Equal(bm.t, ts.Height(), curr[0].Val.Height())
+		require.Equal(bm.t, ts.Height(), curr[0].Val.Height(), "failed sanity check: are multiple miners mining with must post?")
 		for {
 			select {
 			case <-time.After(blocktime):
@@ -111,52 +148,15 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 				return
 			}
 			nulls := atomic.SwapInt64(&bm.nextNulls, 0)
-			require.Equal(bm.t, int64(0), nulls, "Injecting > 0 null blocks while `MustPost` mining is currently unsupported")
 
 			// Wake up and figure out if we are at the end of an active deadline
 			ts, err := bm.miner.FullNode.ChainHead(ctx)
 			require.NoError(bm.t, err)
-			tsk := ts.Key()
 
-			dlinfo, err := bm.miner.FullNode.StateMinerProvingDeadline(ctx, bm.miner.ActorAddr, tsk)
+			dlinfo, err := bm.miner.FullNode.StateMinerProvingDeadline(ctx, bm.miner.ActorAddr, ts.Key())
 			require.NoError(bm.t, err)
-			if ts.Height()+1 == dlinfo.Last() { // Last epoch in dline, we need to check that miner has posted
-
-				tracker := newPartitionTracker(ctx, dlinfo.Index, bm)
-				if !tracker.done(bm.t) { // need to wait for post
-					bm.t.Logf("expect %d partitions proved but only see %d", len(tracker.partitions), tracker.count(bm.t))
-					poolEvts, err := bm.miner.FullNode.MpoolSub(ctx)
-					require.NoError(bm.t, err)
-
-					// First check pending messages we'll mine this epoch
-					msgs, err := bm.miner.FullNode.MpoolPending(ctx, types.EmptyTSK)
-					require.NoError(bm.t, err)
-					for _, msg := range msgs {
-						tracker.recordIfPost(bm.t, bm, msg)
-					}
-
-					// post not yet in mpool, wait for it
-					if !tracker.done(bm.t) {
-						bm.t.Logf("post missing from mpool, block mining suspended until it arrives")
-					POOL:
-						for {
-							bm.t.Logf("mpool event wait loop at block height %d, ts: %s", ts.Height(), ts.Key())
-							select {
-							case <-ctx.Done():
-								return
-							case evt := <-poolEvts:
-								bm.t.Logf("pool event: %d", evt.Type)
-								if evt.Type == api.MpoolAdd {
-									bm.t.Logf("incoming message %v", evt.Message)
-									if tracker.recordIfPost(bm.t, bm, evt.Message) {
-										break POOL
-									}
-								}
-							}
-						}
-						bm.t.Logf("done waiting on mpool")
-					}
-				}
+			if ts.Height()+1+abi.ChainEpoch(nulls) >= dlinfo.Last() { // Next block brings us past the last epoch in dline, we need to wait for miner to post
+				bm.forcePoSt(ctx, ts, dlinfo)
 			}
 
 			var target abi.ChainEpoch
@@ -173,6 +173,12 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 					Done:        reportSuccessFn,
 				})
 				success = <-wait
+				if !success {
+					// if we are mining a new null block and it brings us past deadline boundary we need to wait for miner to post
+					if ts.Height()+1+abi.ChainEpoch(nulls+i) >= dlinfo.Last() {
+						bm.forcePoSt(ctx, ts, dlinfo)
+					}
+				}
 			}
 
 			// Wait until it shows up on the given full nodes ChainHead

--- a/itests/paych_api_test.go
+++ b/itests/paych_api_test.go
@@ -51,7 +51,7 @@ func TestPaymentChannelsAPI(t *testing.T) {
 		Miner(&miner, &paymentCreator, kit.WithAllSubsystems()).
 		Start().
 		InterconnectAll()
-	bms := ens.BeginMining(blockTime)
+	bms := ens.BeginMiningMustPost(blockTime)
 	bm := bms[0]
 
 	// send some funds to register the receiver


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
<!-- provide a clear list of the changes being made-->
1. Improve MineBlocksMustPost, a testing helper I first made to remove flakes from cc upgrade itest
2. Use in paych api test

## Additional Info
<!-- callouts, links to documentation, and etc-->
@TheDivic brought my attention to flaky behavior in a few tests.  Looking at the logs [here](https://app.circleci.com/pipelines/github/filecoin-project/lotus/19402/workflows/6105c7d3-6df9-4f38-b5a4-f49dbfe2ed78/jobs/373079) I saw the same error message from the cc upgrade itest: 
```
2022-02-13T16:16:46.332Z	WARN	vm	vm/runtime.go:350	Abortf: invalid deadline 0 at epoch 718, expected 1
2022-02-13T16:16:46.332Z	WARN	vm	vm/runtime.go:161	VM.Call failure in call from: f0102 to f01000: invalid deadline 0 at epoch 718, expected 1 (RetCode=16):   
```
I had previously debugged this and tracked it down to the behavior of post.  The post scheduler returns no errors so post failures are totally left out of testing logic.  However when mining blocks in integration tests post failures will take down the whole miner and fail the test.

The idea behind MineBlocksMustPost is to force block mining to wait on any expected post messages being included before moving past a deadline.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
