### PR TITLE
feat: cli: set current network version from params

### DIFF
--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -508,12 +508,19 @@ var genesisSetRemainderCmd = &cli.Command{
 }
 
 var genesisSetActorVersionCmd = &cli.Command{
-	Name:      "set-network-version",
-	Usage:     "Set the version that this network will start from",
-	ArgsUsage: "<genesisFile> <actorVersion>",
+	Name:  "set-network-version",
+	Usage: "Set the version that this network will start from",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "network-version",
+			Usage: "network version to start genesis with",
+			Value: int(build.GenesisNetworkVersion),
+		},
+	},
+	ArgsUsage: "<genesisFile>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
-			return fmt.Errorf("must specify genesis file and network version (e.g. '0'")
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("must specify genesis file")
 		}
 
 		genf, err := homedir.Expand(cctx.Args().First())
@@ -531,16 +538,12 @@ var genesisSetActorVersionCmd = &cli.Command{
 			return xerrors.Errorf("unmarshal genesis template: %w", err)
 		}
 
-		nv, err := strconv.ParseUint(cctx.Args().Get(1), 10, 64)
-		if err != nil {
-			return xerrors.Errorf("parsing network version: %w", err)
-		}
-
-		if nv > uint64(build.NewestNetworkVersion) {
+		nv := network.Version(cctx.Int("network-version"))
+		if nv > build.NewestNetworkVersion {
 			return xerrors.Errorf("invalid network version: %d", nv)
 		}
 
-		template.NetworkVersion = network.Version(nv)
+		template.NetworkVersion = nv
 
 		b, err = json.MarshalIndent(&template, "", "  ")
 		if err != nil {


### PR DESCRIPTION
allows automation to correctly set the network version for the currently built network with no variable inputs.

## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

When creating a network, by default, the latest network version (`NewestNetworkVersion`) is used in the genesis network template file. If the network does not start on the default latest network version (eg has upgrade epochs set / `GenesisNetworkVersion` is smaller), the network will fail to startup due to invalid network versions.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Add a flag that will use the build param `GenesisNetworkVersion` to set the network version. This ensures that the genesis network version always matches the network being built (if lotus-seed is built with the network flags).

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
