### PR TITLE
fix:cli:Continue instead of return error if no valid value is filled

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -667,6 +667,8 @@ uiLoop:
 
 			state = "miner"
 		case "miner":
+			maddrs = maddrs[:0]
+			ask = ask[:0]
 			afmt.Print("Miner Addresses (f0.. f0..), none to find: ")
 
 			_maddrsStr, _, err := rl.ReadLine()
@@ -802,7 +804,8 @@ uiLoop:
 
 			dealCount, err = strconv.ParseInt(string(dealcStr), 10, 64)
 			if err != nil {
-				return err
+				printErr(xerrors.Errorf("reading deal count: invalid number"))
+				continue
 			}
 
 			color.Blue(".. Picking miners")
@@ -859,12 +862,13 @@ uiLoop:
 
 				a, err := api.ClientQueryAsk(ctx, *mi.PeerId, maddr)
 				if err != nil {
-					printErr(xerrors.Errorf("failed to query ask: %w", err))
+					printErr(xerrors.Errorf("failed to query ask for miner %s: %w", maddr.String(), err))
 					state = "miner"
 					continue uiLoop
 				}
 
 				ask = append(ask, *a)
+
 			}
 
 			// TODO: run more validation


### PR DESCRIPTION
## Related Issues
Fixes #8100

## Proposed Changes
If no valid value are filled in "Deals to make (1)", display an error message and continue to ask 
(instead of return error to make the CLI crash)


## Additional Info
Maybe we can force a default value to 1, instead of asking in loop for a valid value ?