### PR TITLE
temporarily disable reification

### DIFF
--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -10,7 +10,13 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
+var EnableReification = false
+
 func (s *SplitStore) reifyColdObject(c cid.Cid) {
+	if !EnableReification {
+		return
+	}
+
 	if !s.isWarm() {
 		return
 	}

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -496,6 +496,7 @@ func testSplitStoreReification(t *testing.T, f func(context.Context, blockstore.
 }
 
 func TestSplitStoreReification(t *testing.T) {
+	EnableReification = true
 	t.Log("test reification with Has")
 	testSplitStoreReification(t, func(ctx context.Context, s blockstore.Blockstore, c cid.Cid) error {
 		_, err := s.Has(ctx, c)


### PR DESCRIPTION
big reifications can use a lot of memory during sync apparently.

Temporarily disabling reification until I can sort out the memory usage during sync.