### PR TITLE
fix: cli: Reset miner/ask lists in interactive deal 'miner' step

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -868,7 +868,6 @@ uiLoop:
 				}
 
 				ask = append(ask, *a)
-
 			}
 
 			// TODO: run more validation

--- a/cli/client.go
+++ b/cli/client.go
@@ -667,6 +667,8 @@ uiLoop:
 
 			state = "miner"
 		case "miner":
+			maddrs = maddrs[:0]
+			ask = ask[:0]
 			afmt.Print("Miner Addresses (f0.. f0..), none to find: ")
 
 			_maddrsStr, _, err := rl.ReadLine()
@@ -802,7 +804,8 @@ uiLoop:
 
 			dealCount, err = strconv.ParseInt(string(dealcStr), 10, 64)
 			if err != nil {
-				return err
+				printErr(xerrors.Errorf("reading deal count: invalid number"))
+				continue
 			}
 
 			color.Blue(".. Picking miners")
@@ -859,12 +862,13 @@ uiLoop:
 
 				a, err := api.ClientQueryAsk(ctx, *mi.PeerId, maddr)
 				if err != nil {
-					printErr(xerrors.Errorf("failed to query ask: %w", err))
+					printErr(xerrors.Errorf("failed to query ask for miner %s: %w", maddr.String(), err))
 					state = "miner"
 					continue uiLoop
 				}
 
 				ask = append(ask, *a)
+
 			}
 
 			// TODO: run more validation


### PR DESCRIPTION
## Related Issues
Fixes #8095 

## Proposed Changes
Clear the list of miners addresses set on the first attempt, because without clearing the list, on the next attempt, faulty miner is always in the list, so error is throw again.

Also, clear the list of all successfull get-ask before asking new addresses, because :

- First attempt : first miner in the list is good miner and the second one faulty ;
- Second attempt : only good miner in the list : summary will show two miner (because the first successfull one isn't removed)
