### PR TITLE
feat: Make add piece idempotent

### DIFF
--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -322,7 +322,7 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		}
 	}
 
-	doneCh := make(chan struct{}, 1)
+	doneCh := make(chan struct{})
 	pp := &pendingPiece{
 		doneCh:   doneCh,
 		size:     size,

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -315,7 +315,7 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		m.inputLk.Unlock()
 		select {
 		case <-pp.doneCh:
-			res := pp.resp.Load().(*pieceAcceptResp)
+			res := pp.resp
 			return api.SectorOffset{Sector: res.sn, Offset: res.offset.Padded()}, res.err
 		case <-ctx.Done():
 			return api.SectorOffset{}, ctx.Err()
@@ -331,7 +331,7 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		assigned: false,
 	}
 	pp.accepted = func(sn abi.SectorNumber, offset abi.UnpaddedPieceSize, err error) {
-		pp.resp.Store(&pieceAcceptResp{sn, offset, err})
+		pp.resp = &pieceAcceptResp{sn, offset, err}
 		close(pp.doneCh)
 	}
 
@@ -345,7 +345,7 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 
 	select {
 	case <-doneCh:
-		res := pp.resp.Load().(*pieceAcceptResp)
+		res := pp.resp
 		return api.SectorOffset{Sector: res.sn, Offset: res.offset.Padded()}, res.err
 	case <-ctx.Done():
 		return api.SectorOffset{}, ctx.Err()

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -340,8 +340,12 @@ func (m *Sealing) SectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		}
 	}()
 
-	res := <-resCh
-	return api.SectorOffset{Sector: res.sn, Offset: res.offset.Padded()}, res.err
+	select {
+	case res := <-resCh:
+		return api.SectorOffset{Sector: res.sn, Offset: res.offset.Padded()}, res.err
+	case <-ctx.Done():
+		return api.SectorOffset{}, ctx.Err()
+	}
 }
 
 func (m *Sealing) MatchPendingPiecesToOpenSectors(ctx context.Context) error {

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -147,7 +148,8 @@ type pieceAcceptResp struct {
 }
 
 type pendingPiece struct {
-	resCh chan *pieceAcceptResp
+	doneCh chan struct{}
+	resp   atomic.Value
 
 	size abi.UnpaddedPieceSize
 	deal api.PieceDealInfo

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -140,7 +140,15 @@ func (o *openSector) dealFitsInLifetime(dealEnd abi.ChainEpoch, expF func(sn abi
 	return expiration >= dealEnd, nil
 }
 
+type pieceAcceptResp struct {
+	sn     abi.SectorNumber
+	offset abi.UnpaddedPieceSize
+	err    error
+}
+
 type pendingPiece struct {
+	resCh chan *pieceAcceptResp
+
 	size abi.UnpaddedPieceSize
 	deal api.PieceDealInfo
 

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -149,7 +148,7 @@ type pieceAcceptResp struct {
 
 type pendingPiece struct {
 	doneCh chan struct{}
-	resp   atomic.Value
+	resp   *pieceAcceptResp
 
 	size abi.UnpaddedPieceSize
 	deal api.PieceDealInfo


### PR DESCRIPTION
A very common deal making error we encounter is that Boost/Markets makes a call to `AddPiece` and then restarts.
If it restarts before it's able to persist the fact that it's already called AddPiece, it will call `AddPiece` again for the same piece. In this case, the existing API returns an error as it's not idempotent.

This PR allows the user to call `AddPiece` multiple times for the same piece but ensures that it's handed off to the sealing subsystem only once. 

It also makes the method respect the given context.