### PR TITLE
feat: market utils: Support unixfsnode in TraverseDag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/ipfs/go-metrics-prometheus v0.0.2
 	github.com/ipfs/go-path v0.0.7
 	github.com/ipfs/go-unixfs v0.3.1
+	github.com/ipfs/go-unixfsnode v1.2.0
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/ipld/go-car v0.3.3
 	github.com/ipld/go-car/v2 v2.1.1

--- a/markets/utils/selectors.go
+++ b/markets/utils/selectors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	mdagipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-unixfsnode"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -62,6 +63,7 @@ func TraverseDag(
 
 		return bytes.NewBuffer(node.RawData()), nil
 	}
+	unixfsnode.AddUnixFSReificationToLinkSystem(&linkSystem)
 
 	// this is how we pull the start node out of the DS
 	startLink := cidlink.Link{Cid: startFrom}


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
This adds support for UnixFS ADLs in client parts of lotus.


## Additional Info
Client-side only. Providers already have support for those through Graphsync - https://github.com/ipfs/go-graphsync/blob/8c66ab9e2f562386c59fba2700bb1fcf8c743675/storeutil/storeutil.go#L46 
