### PR TITLE
[Describe]: when excute cmd "lotus-bench sealing" without "benchmark-…

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -276,6 +276,13 @@ var sealBenchCmd = &cli.Command{
 			if err != nil {
 				return xerrors.Errorf("failed to run seals: %w", err)
 			}
+			for _, s := range extendedSealedSectors {
+				sealedSectors = append(sealedSectors, proof.SectorInfo{
+					SealedCID:    s.SealedCID,
+					SectorNumber: s.SectorNumber,
+					SealProof:    s.SealProof,
+				})
+			}
 		} else {
 			// TODO: implement sbfs.List() and use that for all cases (preexisting sectorbuilder or not)
 


### PR DESCRIPTION
 when excute cmd "lotus-bench sealing" without "benchmark-existing-sectorbuilder", panic will occur
when don't set env "benchmark-existing-sectorbuilder"  or the value of env "benchmark-existing-sectorbuilder" is null
var sealedSectors []saproof7.SectorInfo is not filled value,
wpvi1 := saproof2.WindowPoStVerifyInfo{
				Randomness:        challenge[:],
				Proofs:            wproof1,
				ChallengedSectors: sealedSectors,
				Prover:            mid,
			}
ok, err = ffiwrapper.ProofVerifier.VerifyWindowPoSt(context.TODO(), wpvi1)

will hanppen

2022-02-22T18:18:58.520+0800	WARN	lotus-bench	lotus-bench/main.go:117	no replicas supplied

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
   1: filecoin_proofs_api::post::verify_window_post
   2: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
   3: ffi_toolkit::catch_panic_response
   4: fil_verify_window_post
   5: _cgo_24921690cad9_Cfunc_fil_verify_window_post
             at /tmp/go-build/cgo-gcc-prolog:1741
   6: runtime.asmcgocall
             at /home/xjgw/.gvm/gos/go1.17.1/src/runtime/asm_amd64.s:765
github.com/filecoin-project/filecoin-ffi.VerifyWindowPoSt
	/home/xjgw/eben-xgjw-local-network/.opensource-lotus/lotus-project/extern/filecoin-ffi/proofs.go:184
github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper.proofVerifier.VerifyWindowPoSt
	/home/xjgw/eben-xgjw-local-network/.opensource-lotus/lotus-project/extern/sector-storage/ffiwrapper/verifier_cgo.go:163
main.glob..func3
	/home/xjgw/eben-xgjw-local-network/.opensource-lotus/lotus-project/cmd/lotus-bench/main.go:428
github.com/urfave/cli/v2.(*Command).Run
	/home/xjgw/.gvm/pkgsets/go1.17.1/global/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164
github.com/urfave/cli/v2.(*App).RunContext
	/home/xjgw/.gvm/pkgsets/go1.17.1/global/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306
github.com/urfave/cli/v2.(*App).Run
	/home/xjgw/.gvm/pkgsets/go1.17.1/global/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
main.main
	/home/xjgw/eben-xgjw-local-network/.opensource-lotus/lotus-project/cmd/lotus-bench/main.go:116
runtime.main
	/home/xjgw/.gvm/gos/go1.17.1/src/runtime/proc.go:255
runtime.goexit
	/home/xjgw/.gvm/gos/go1.17.1/src/runtime/asm_amd64.s:1581