### PR TITLE
Feat: cli: Remove verified data cap

### DIFF
--- a/chain/actors/builtin/verifreg/actor.go.template
+++ b/chain/actors/builtin/verifreg/actor.go.template
@@ -63,9 +63,11 @@ func GetActorCodeID(av actors.Version) (cid.Cid, error) {
 	return cid.Undef, xerrors.Errorf("unknown actor version %d", av)
 }
 
-type RemoveDataCapProposal = verifreg7.RemoveDataCapProposal
-type RmDcProposalID = verifreg7.RmDcProposalID
-const SignatureDomainSeparation_RemoveDataCap = verifreg7.SignatureDomainSeparation_RemoveDataCap
+type RemoveDataCapProposal = verifreg{{.latestVersion}}.RemoveDataCapProposal
+type RemoveDataCapRequest = verifreg{{.latestVersion}}.RemoveDataCapRequest
+type RemoveDataCapParams = verifreg{{.latestVersion}}.RemoveDataCapParams
+type RmDcProposalID = verifreg{{.latestVersion}}.RmDcProposalID
+const SignatureDomainSeparation_RemoveDataCap = verifreg{{.latestVersion}}.SignatureDomainSeparation_RemoveDataCap
 
 type State interface {
 	cbor.Marshaler

--- a/chain/actors/builtin/verifreg/actor.go.template
+++ b/chain/actors/builtin/verifreg/actor.go.template
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
+	verifreg7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/verifreg"
 )
 
 func init() {
@@ -62,6 +63,9 @@ func GetActorCodeID(av actors.Version) (cid.Cid, error) {
 	return cid.Undef, xerrors.Errorf("unknown actor version %d", av)
 }
 
+type RemoveDataCapProposal = verifreg7.RemoveDataCapProposal
+type RmDcProposalID = verifreg7.RmDcProposalID
+const SignatureDomainSeparation_RemoveDataCap = verifreg7.SignatureDomainSeparation_RemoveDataCap
 
 type State interface {
 	cbor.Marshaler
@@ -69,6 +73,7 @@ type State interface {
 	RootKey() (address.Address, error)
 	VerifiedClientDataCap(address.Address) (bool, abi.StoragePower, error)
 	VerifierDataCap(address.Address) (bool, abi.StoragePower, error)
+	RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error)
 	ForEachVerifier(func(addr address.Address, dcap abi.StoragePower) error) error
 	ForEachClient(func(addr address.Address, dcap abi.StoragePower) error) error
 	GetState() interface{}

--- a/chain/actors/builtin/verifreg/state.go.template
+++ b/chain/actors/builtin/verifreg/state.go.template
@@ -61,6 +61,10 @@ func (s *state{{.v}}) VerifierDataCap(addr address.Address) (bool, abi.StoragePo
 	return getDataCap(s.store, actors.Version{{.v}}, s.verifiers, addr)
 }
 
+func (s *state{{.v}}) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version{{.v}}, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state{{.v}}) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version{{.v}}, s.verifiers, cb)
 }
@@ -75,6 +79,11 @@ func (s *state{{.v}}) verifiedClients() (adt.Map, error) {
 
 func (s *state{{.v}}) verifiers() (adt.Map, error) {
 	return adt{{.v}}.AsMap(s.store, s.Verifiers{{if (ge .v 3)}}, builtin{{.v}}.DefaultHamtBitwidth{{end}})
+}
+
+func (s *state{{.v}}) removeDataCapProposalIDs() (adt.Map, error) {
+    {{if le .v 6}}return nil, nil
+    {{else}}return adt{{.v}}.AsMap(s.store, s.RemoveDataCapProposalIDs, builtin{{.v}}.DefaultHamtBitwidth){{end}}
 }
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/util.go
+++ b/chain/actors/builtin/verifreg/util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/specs-actors/v7/actors/builtin/verifreg"
 	"golang.org/x/xerrors"
 )
 
@@ -49,4 +50,26 @@ func forEachCap(store adt.Store, ver actors.Version, root rootFunc, cb func(addr
 		}
 		return cb(a, dcap)
 	})
+}
+
+func getRemoveDataCapProposalID(store adt.Store, ver actors.Version, root rootFunc, verifier address.Address, client address.Address) (bool, uint64, error) {
+	if verifier.Protocol() != address.ID {
+		return false, 0, xerrors.Errorf("can only look up ID addresses")
+	}
+	if client.Protocol() != address.ID {
+		return false, 0, xerrors.Errorf("can only look up ID addresses")
+	}
+	vh, err := root()
+	if err != nil {
+		return false, 0, xerrors.Errorf("loading verifreg: %w", err)
+	}
+
+	var id verifreg.RmDcProposalID
+	if found, err := vh.Get(abi.NewAddrPairKey(verifier, client), &id); err != nil {
+		return false, 0, xerrors.Errorf("looking up addr pair: %w", err)
+	} else if !found {
+		return false, 0, nil
+	}
+
+	return true, id.ProposalID, nil
 }

--- a/chain/actors/builtin/verifreg/util.go
+++ b/chain/actors/builtin/verifreg/util.go
@@ -63,6 +63,9 @@ func getRemoveDataCapProposalID(store adt.Store, ver actors.Version, root rootFu
 	if err != nil {
 		return false, 0, xerrors.Errorf("loading verifreg: %w", err)
 	}
+	if vh == nil {
+		return false, 0, xerrors.Errorf("remove data cap proposal hamt not found. you are probably using an incompatible version of actors")
+	}
 
 	var id verifreg.RmDcProposalID
 	if found, err := vh.Get(abi.NewAddrPairKey(verifier, client), &id); err != nil {

--- a/chain/actors/builtin/verifreg/v0.go
+++ b/chain/actors/builtin/verifreg/v0.go
@@ -53,6 +53,10 @@ func (s *state0) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version0, s.verifiers, addr)
 }
 
+func (s *state0) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version0, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state0) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version0, s.verifiers, cb)
 }
@@ -67,6 +71,11 @@ func (s *state0) verifiedClients() (adt.Map, error) {
 
 func (s *state0) verifiers() (adt.Map, error) {
 	return adt0.AsMap(s.store, s.Verifiers)
+}
+
+func (s *state0) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state0) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v2.go
+++ b/chain/actors/builtin/verifreg/v2.go
@@ -53,6 +53,10 @@ func (s *state2) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version2, s.verifiers, addr)
 }
 
+func (s *state2) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version2, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state2) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version2, s.verifiers, cb)
 }
@@ -67,6 +71,11 @@ func (s *state2) verifiedClients() (adt.Map, error) {
 
 func (s *state2) verifiers() (adt.Map, error) {
 	return adt2.AsMap(s.store, s.Verifiers)
+}
+
+func (s *state2) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state2) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v3.go
+++ b/chain/actors/builtin/verifreg/v3.go
@@ -54,6 +54,10 @@ func (s *state3) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version3, s.verifiers, addr)
 }
 
+func (s *state3) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version3, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state3) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version3, s.verifiers, cb)
 }
@@ -68,6 +72,11 @@ func (s *state3) verifiedClients() (adt.Map, error) {
 
 func (s *state3) verifiers() (adt.Map, error) {
 	return adt3.AsMap(s.store, s.Verifiers, builtin3.DefaultHamtBitwidth)
+}
+
+func (s *state3) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state3) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v4.go
+++ b/chain/actors/builtin/verifreg/v4.go
@@ -54,6 +54,10 @@ func (s *state4) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version4, s.verifiers, addr)
 }
 
+func (s *state4) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version4, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state4) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version4, s.verifiers, cb)
 }
@@ -68,6 +72,11 @@ func (s *state4) verifiedClients() (adt.Map, error) {
 
 func (s *state4) verifiers() (adt.Map, error) {
 	return adt4.AsMap(s.store, s.Verifiers, builtin4.DefaultHamtBitwidth)
+}
+
+func (s *state4) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state4) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v5.go
+++ b/chain/actors/builtin/verifreg/v5.go
@@ -54,6 +54,10 @@ func (s *state5) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version5, s.verifiers, addr)
 }
 
+func (s *state5) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version5, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state5) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version5, s.verifiers, cb)
 }
@@ -68,6 +72,11 @@ func (s *state5) verifiedClients() (adt.Map, error) {
 
 func (s *state5) verifiers() (adt.Map, error) {
 	return adt5.AsMap(s.store, s.Verifiers, builtin5.DefaultHamtBitwidth)
+}
+
+func (s *state5) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state5) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v6.go
+++ b/chain/actors/builtin/verifreg/v6.go
@@ -54,6 +54,10 @@ func (s *state6) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version6, s.verifiers, addr)
 }
 
+func (s *state6) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version6, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state6) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version6, s.verifiers, cb)
 }
@@ -68,6 +72,11 @@ func (s *state6) verifiedClients() (adt.Map, error) {
 
 func (s *state6) verifiers() (adt.Map, error) {
 	return adt6.AsMap(s.store, s.Verifiers, builtin6.DefaultHamtBitwidth)
+}
+
+func (s *state6) removeDataCapProposalIDs() (adt.Map, error) {
+	return nil, nil
+
 }
 
 func (s *state6) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/v7.go
+++ b/chain/actors/builtin/verifreg/v7.go
@@ -54,6 +54,10 @@ func (s *state7) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, 
 	return getDataCap(s.store, actors.Version7, s.verifiers, addr)
 }
 
+func (s *state7) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version7, s.removeDataCapProposalIDs, verifier, client)
+}
+
 func (s *state7) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
 	return forEachCap(s.store, actors.Version7, s.verifiers, cb)
 }
@@ -68,6 +72,10 @@ func (s *state7) verifiedClients() (adt.Map, error) {
 
 func (s *state7) verifiers() (adt.Map, error) {
 	return adt7.AsMap(s.store, s.Verifiers, builtin7.DefaultHamtBitwidth)
+}
+
+func (s *state7) removeDataCapProposalIDs() (adt.Map, error) {
+	return adt7.AsMap(s.store, s.RemoveDataCapProposalIDs, builtin7.DefaultHamtBitwidth)
 }
 
 func (s *state7) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/verifreg.go
+++ b/chain/actors/builtin/verifreg/verifreg.go
@@ -27,6 +27,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
+	verifreg7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/verifreg"
 )
 
 func init() {
@@ -151,12 +152,18 @@ func GetActorCodeID(av actors.Version) (cid.Cid, error) {
 	return cid.Undef, xerrors.Errorf("unknown actor version %d", av)
 }
 
+type RemoveDataCapProposal = verifreg7.RemoveDataCapProposal
+type RmDcProposalID = verifreg7.RmDcProposalID
+
+const SignatureDomainSeparation_RemoveDataCap = verifreg7.SignatureDomainSeparation_RemoveDataCap
+
 type State interface {
 	cbor.Marshaler
 
 	RootKey() (address.Address, error)
 	VerifiedClientDataCap(address.Address) (bool, abi.StoragePower, error)
 	VerifierDataCap(address.Address) (bool, abi.StoragePower, error)
+	RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error)
 	ForEachVerifier(func(addr address.Address, dcap abi.StoragePower) error) error
 	ForEachClient(func(addr address.Address, dcap abi.StoragePower) error) error
 	GetState() interface{}

--- a/chain/actors/builtin/verifreg/verifreg.go
+++ b/chain/actors/builtin/verifreg/verifreg.go
@@ -153,6 +153,8 @@ func GetActorCodeID(av actors.Version) (cid.Cid, error) {
 }
 
 type RemoveDataCapProposal = verifreg7.RemoveDataCapProposal
+type RemoveDataCapRequest = verifreg7.RemoveDataCapRequest
+type RemoveDataCapParams = verifreg7.RemoveDataCapParams
 type RmDcProposalID = verifreg7.RmDcProposalID
 
 const SignatureDomainSeparation_RemoveDataCap = verifreg7.SignatureDomainSeparation_RemoveDataCap

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -284,7 +284,7 @@ var filplusSignRemoveDataCapProposal = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.Int64Flag{
 			Name:     "id",
-			Usage:    "specify the id of the Remove Data Cap Proposal",
+			Usage:    "specify the RemoveDataCapProposal ID (will look up on chain if unspecified)",
 			Required: false,
 		},
 	},

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -358,12 +358,14 @@ var filplusSignRemoveDataCapProposal = &cli.Command{
 			return err
 		}
 
-		msg, err := api.WalletSign(ctx, verifier, paramBuf.Bytes())
+		sig, err := api.WalletSign(ctx, verifier, paramBuf.Bytes())
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(hex.EncodeToString(msg.Data))
+		sigBytes := append([]byte{byte(sig.Type)}, sig.Data...)
+
+		fmt.Println(hex.EncodeToString(sigBytes))
 
 		return nil
 	},

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -417,7 +417,7 @@ var verifRegCheckVerifierCmd = &cli.Command{
 var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 	Name:      "remove-verified-client-data-cap",
 	Usage:     "Remove data cap from verified client",
-	ArgsUsage: "<message sender> <verified client ID> <allowance to remove> <verifier 1 ID> <verifier 1 signature> <verifier 2 ID> <verifier 2 signature>",
+	ArgsUsage: "<message sender> <client address> <allowance to remove> <verifier 1 address> <verifier 1 signature> <verifier 2 address> <verifier 2 signature>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.Args().Len() != 7 {
 			return fmt.Errorf("must specify seven arguments: sender, client, allowance to remove, verifier 1 ID, verifier 1 signature, verifier 2 ID, verifier 2 signature")

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -422,7 +422,7 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 	ArgsUsage: "<message sender> <client address> <allowance to remove> <verifier 1 address> <verifier 1 signature> <verifier 2 address> <verifier 2 signature>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.Args().Len() != 7 {
-			return fmt.Errorf("must specify seven arguments: sender, client, allowance to remove, verifier 1 ID, verifier 1 signature, verifier 2 ID, verifier 2 signature")
+			return fmt.Errorf("must specify seven arguments: sender, client, allowance to remove, verifier 1 address, verifier 1 signature, verifier 2 address, verifier 2 signature")
 		}
 
 		srv, err := lcli.GetFullNodeServices(cctx)

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1234,12 +1234,13 @@ USAGE:
    lotus filplus command [command options] [arguments...]
 
 COMMANDS:
-   grant-datacap         give allowance to the specified verified client address
-   list-notaries         list all notaries
-   list-clients          list all verified clients
-   check-client-datacap  check verified client remaining bytes
-   check-notary-datacap  check a notary's remaining bytes
-   help, h               Shows a list of commands or help for one command
+   grant-datacap                  give allowance to the specified verified client address
+   list-notaries                  list all notaries
+   list-clients                   list all verified clients
+   check-client-datacap           check verified client remaining bytes
+   check-notary-datacap           check a notary's remaining bytes
+   sign-remove-data-cap-proposal  TODO
+   help, h                        Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h     show help (default: false)
@@ -1309,6 +1310,20 @@ USAGE:
    lotus filplus check-notary-datacap [command options] [arguments...]
 
 OPTIONS:
+   --help, -h  show help (default: false)
+   
+```
+
+### lotus filplus sign-remove-data-cap-proposal
+```
+NAME:
+   lotus filplus sign-remove-data-cap-proposal - TODO
+
+USAGE:
+   lotus filplus sign-remove-data-cap-proposal [command options] [arguments...]
+
+OPTIONS:
+   --id value  specify the id of the Remove Data Cap Proposal (default: 0)
    --help, -h  show help (default: false)
    
 ```

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1239,7 +1239,7 @@ COMMANDS:
    list-clients                   list all verified clients
    check-client-datacap           check verified client remaining bytes
    check-notary-datacap           check a notary's remaining bytes
-   sign-remove-data-cap-proposal  TODO
+   sign-remove-data-cap-proposal  allows a notary to sign a Remove Data Cap Proposal
    help, h                        Shows a list of commands or help for one command
 
 OPTIONS:
@@ -1317,13 +1317,13 @@ OPTIONS:
 ### lotus filplus sign-remove-data-cap-proposal
 ```
 NAME:
-   lotus filplus sign-remove-data-cap-proposal - TODO
+   lotus filplus sign-remove-data-cap-proposal - allows a notary to sign a Remove Data Cap Proposal
 
 USAGE:
    lotus filplus sign-remove-data-cap-proposal [command options] [arguments...]
 
 OPTIONS:
-   --id value  specify the id of the Remove Data Cap Proposal (default: 0)
+   --id value  specify the RemoveDataCapProposal ID (will look up on chain if unspecified) (default: 0)
    --help, -h  show help (default: false)
    
 ```


### PR DESCRIPTION
## Related Issues
Closes Issue #7863 

## Proposed Changes
Added the following cli commands:
lotus filplus sign-remove-data-cap-proposal 
lotus-shed verifreg remove-verified-client-data-cap


## Additional Info
Tested on devnet. Works as expected.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
