### PR TITLE
fix: client: calculate commps for pieces bigger than 32GB

### DIFF
--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -1272,7 +1272,7 @@ func (a *API) ClientCalcCommP(ctx context.Context, inpath string) (*api.CommPRet
 	//
 	// IF/WHEN this changes in the future we will have to be able to calculate
 	// "old style" commP, and thus will need to introduce a version switch or similar
-	arbitraryProofType := abi.RegisteredSealProof_StackedDrg32GiBV1_1
+	arbitraryProofType := abi.RegisteredSealProof_StackedDrg64GiBV1_1
 
 	rdr, err := os.Open(inpath)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

A user pointed out on Slack that trying to make a deal with a 64GB SP with piece size of 55GB fails 

```
lotus client deal bafykbzacedpyjxesatqb7s4ltsdcfldupqjpqepahxsthgkcdtsa7f3ldlcb4 t031080 0 518400
ERROR: failed to start deal: computing commP failed: commpWriter.Sum failed: generating unsealed CID: Piece is larger than sector.
```

## Proposed Changes
<!-- provide a clear list of the changes being made-->

I _think_ it is safe to just assume the largest supported sector size here (64 GB) and leave it at that, but I'm not sure.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
