### PR TITLE
Bump url-parse from 1.5.3 to 1.5.10 in /lotuspond/front

### DIFF
--- a/lotuspond/front/package-lock.json
+++ b/lotuspond/front/package-lock.json
@@ -12519,9 +12519,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"


### PR DESCRIPTION
Bumps url-parse from 1.5.3 to 1.5.10.
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/follow-redirects/follow-redirects/commit/13136e95bbe23cabbeaeb74bd0c933aa98dd9b96"><code>13136e9</code></a> Release version 1.14.9 of the npm package.</li>
