### PR TITLE
avoid panic

### DIFF
--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -39,9 +39,12 @@ func barString(total, y, g float64) string {
 	yBars := int(math.Round(y / total * barCols))
 	gBars := int(math.Round(g / total * barCols))
 	eBars := int(barCols) - yBars - gBars
-	return color.YellowString(strings.Repeat("|", yBars)) +
-		color.GreenString(strings.Repeat("|", gBars)) +
-		strings.Repeat(" ", eBars)
+	var barString = color.YellowString(strings.Repeat("|", yBars)) +
+		color.GreenString(strings.Repeat("|", gBars))
+	if eBars >= 0 {
+		barString += strings.Repeat(" ", eBars)
+	}
+	return barString
 }
 
 var sealingWorkersCmd = &cli.Command{


### PR DESCRIPTION
I found that many users panicked when using **lotus-miner sealing workers**,The reason is that previous versions have checked the value of **eBar** ,But it's ignored here
Worker 8afb3048-9bf5-4927-a380-f2ec13410f36, host  (disabled)
panic: strings: negative Repeat count

```
goroutine 1 [running]:
strings.Repeat(0x39b3742, 0x1, 0x8000000000000000, 0xc0004ee000, 0xc00109efc0)
	/mnt/build/go/src/strings/strings.go:529 +0x5e5
main.barString(0x0, 0x0, 0x0, 0x15, 0xc00109f2b8)
	/home/fc01/compile-quantum/lotus/cmd/lotus-miner/sealing.go:45 +0x126
main.glob..func56(0xc000354cc0, 0x0, 0x0)
	/home/fc01/compile-quantum/lotus/cmd/lotus-miner/sealing.go:132 +0xdca
github.com/urfave/cli/v2.(*Command).Run(0x54f9780, 0xc000354bc0, 0x0, 0x0)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4dd
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc0003a4d80, 0xc0003549c0, 0x0, 0x0)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:427 +0xa49
github.com/urfave/cli/v2.(*Command).startApp(0x54f9c00, 0xc0003549c0, 0x7ffdd3d0c666, 0x7)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:279 +0x6bb
github.com/urfave/cli/v2.(*Command).Run(0x54f9c00, 0xc0003549c0, 0x0, 0x0)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:94 +0x9cd
github.com/urfave/cli/v2.(*App).RunContext(0xc0003a4c00, 0x3f1c090, 0xc0000528f8, 0xc00004e180, 0x3, 0x3, 0x0, 0x0)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
	/home/fc01/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
github.com/filecoin-project/lotus/cli.RunApp(0xc0003a4c00)
	/home/fc01/compile-quantum/lotus/cli/helper.go:35 +0x7c
main.main()
	/home/fc01/compile-quantum/lotus/cmd/lotus-miner/main.go:166 +0xf05
```


