### PR TITLE
release worker tracker lock when call cb func

### DIFF
--- a/extern/sector-storage/worker_tracked.go
+++ b/extern/sector-storage/worker_tracked.go
@@ -98,7 +98,10 @@ func (wt *workTracker) track(ctx context.Context, ready chan struct{}, wid stori
 		wt.lk.Lock()
 		delete(wt.prepared, prepID)
 	}
+
+	wt.lk.Unlock()
 	callID, err := cb()
+	wt.lk.Lock()
 	if err != nil {
 		return callID, err
 	}


### PR DESCRIPTION
release worker tracker lock when call cb func, so that miner can call the worker api concurrently.