### PR TITLE
Make `--lite` option visible in the lotus daemon help text 

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -121,7 +121,6 @@ var DaemonCmd = &cli.Command{
 		&cli.BoolFlag{
 			Name:   "lite",
 			Usage:  "start lotus in lite mode",
-			Hidden: true,
 		},
 		&cli.StringFlag{
 			Name:  "pprof",

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -119,8 +119,8 @@ var DaemonCmd = &cli.Command{
 			Usage: "halt the process after importing chain from file",
 		},
 		&cli.BoolFlag{
-			Name:   "lite",
-			Usage:  "start lotus in lite mode",
+			Name:  "lite",
+			Usage: "start lotus in lite mode",
 		},
 		&cli.StringFlag{
 			Name:  "pprof",

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -63,6 +63,7 @@ OPTIONS:
    --import-chain value      on first run, load chain from given file or url and validate
    --import-snapshot value   import chain state from a given chain export file or url
    --halt-after-import       halt the process after importing chain from file (default: false)
+   --lite                    start lotus in lite mode (default: false)
    --pprof value             specify name of file for writing cpu profile to
    --profile value           specify type of node
    --manage-fdlimit          manage open file limit (default: true)


### PR DESCRIPTION
Makes the --lite option visibile in the lotus daemon help text. Fixes https://github.com/filecoin-project/lotus/issues/7442. If it´s desired to keep the `--lite` option hidden in the lotus daemon helptext, then this PR can be discarded and issue [7442](https://github.com/filecoin-project/lotus/issues/7442) can be closed.