### PR TITLE
fix ReplicaUpdate log

### DIFF
--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -763,7 +763,7 @@ func (m *Manager) Remove(ctx context.Context, sector storage.SectorRef) error {
 func (m *Manager) ReplicaUpdate(ctx context.Context, sector storage.SectorRef, pieces []abi.PieceInfo) (out storage.ReplicaUpdateOut, err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	log.Errorf("manager is doing replica update")
+	log.Infow("manager is doing replica update", "sid", sector.ID.Number)
 	wk, wait, cancel, err := m.getWork(ctx, sealtasks.TTReplicaUpdate, sector, pieces)
 	if err != nil {
 		return storage.ReplicaUpdateOut{}, xerrors.Errorf("getWork: %w", err)


### PR DESCRIPTION
Fix `func (m *Manager) ReplicaUpdate` log level and add sector id to log.