### PR TITLE
Open Redirect in node-forge

### DIFF
--- a/lotuspond/front/package-lock.json
+++ b/lotuspond/front/package-lock.json
@@ -8671,8 +8671,8 @@
       }
     },
     "node-forge": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.0.0.tgz",
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "node-int64": {


### PR DESCRIPTION
parseUrl functionality in node-forge mishandles certain uses of backslash such as https:///\ and interprets the URI as a relative path.

The latest possible version that can be installed is 0.7.5 because of the following conflicting dependency:

react-scripts@3.0.1 requires node-forge@0.7.5 via a transitive dependency on selfsigned@1.10.4

The earliest fixed version is 1.0.0.
