### PR TITLE
chore:sealing:remove endpoint from cli

### DIFF
--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -92,7 +92,8 @@ type StorageMiner interface {
 	SectorsUpdate(context.Context, abi.SectorNumber, SectorState) error   //perm:admin
 	// SectorRemove removes the sector from storage. It doesn't terminate it on-chain, which can
 	// be done with SectorTerminate. Removing and not terminating live sectors will cause additional penalties.
-	SectorRemove(context.Context, abi.SectorNumber) error //perm:admin
+	SectorRemove(context.Context, abi.SectorNumber) error                           //perm:admin
+	SectorMarkForUpgrade(ctx context.Context, id abi.SectorNumber, snap bool) error //perm:admin
 	// SectorTerminate terminates the sector on-chain (adding it to a termination batch first), then
 	// automatically removes it from storage
 	SectorTerminate(context.Context, abi.SectorNumber) error //perm:admin
@@ -100,8 +101,7 @@ type StorageMiner interface {
 	// Returns null if message wasn't sent
 	SectorTerminateFlush(ctx context.Context) (*cid.Cid, error) //perm:admin
 	// SectorTerminatePending returns a list of pending sector terminations to be sent in the next batch message
-	SectorTerminatePending(ctx context.Context) ([]abi.SectorID, error)             //perm:admin
-	SectorMarkForUpgrade(ctx context.Context, id abi.SectorNumber, snap bool) error //perm:admin
+	SectorTerminatePending(ctx context.Context) ([]abi.SectorID, error) //perm:admin
 	// SectorPreCommitFlush immediately sends a PreCommit message with sectors batched for PreCommit.
 	// Returns null if message wasn't sent
 	SectorPreCommitFlush(ctx context.Context) ([]sealiface.PreCommitBatchRes, error) //perm:admin

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors/builtin"
-
 	"github.com/docker/go-units"
 	"github.com/fatih/color"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -56,7 +53,6 @@ var sectorsCmd = &cli.Command{
 		sectorsRemoveCmd,
 		sectorsSnapUpCmd,
 		sectorsSnapAbortCmd,
-		sectorsMarkForUpgradeCmd,
 		sectorsStartSealCmd,
 		sectorsSealDelayCmd,
 		sectorsCapacityCollateralCmd,
@@ -1565,57 +1561,6 @@ var sectorsSnapAbortCmd = &cli.Command{
 		}
 
 		return nodeApi.SectorAbortUpgrade(ctx, abi.SectorNumber(id))
-	},
-}
-
-var sectorsMarkForUpgradeCmd = &cli.Command{
-	Name:      "mark-for-upgrade",
-	Usage:     "Mark a committed capacity sector for replacement by a sector with deals",
-	ArgsUsage: "<sectorNum>",
-	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
-			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number"))
-		}
-
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
-		api, nCloser, err := lcli.GetFullNodeAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer nCloser()
-		ctx := lcli.ReqContext(cctx)
-
-		nv, err := api.StateNetworkVersion(ctx, types.EmptyTSK)
-		if err != nil {
-			return xerrors.Errorf("failed to get network version: %w", err)
-		}
-		if nv >= network.Version15 {
-			return xerrors.Errorf("classic cc upgrades disabled v15 and beyond, use `snap-up`")
-		}
-
-		// disable mark for upgrade two days before the ntwk v15 upgrade
-		// TODO: remove the following block in v1.15.1
-		head, err := api.ChainHead(ctx)
-		if err != nil {
-			return xerrors.Errorf("failed to get chain head: %w", err)
-		}
-		twoDays := abi.ChainEpoch(2 * builtin.EpochsInDay)
-		if head.Height() > (build.UpgradeOhSnapHeight - twoDays) {
-			return xerrors.Errorf("OhSnap is coming soon, " +
-				"please use `snap-up` to upgrade your cc sectors after the network v15 upgrade!")
-		}
-
-		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
-		if err != nil {
-			return xerrors.Errorf("could not parse sector number: %w", err)
-		}
-
-		return nodeApi.SectorMarkForUpgrade(ctx, abi.SectorNumber(id), false)
 	},
 }
 

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1581,7 +1581,6 @@ COMMANDS:
    remove                Forcefully remove a sector (WARNING: This means losing power and collateral for the removed sector (use 'terminate' for lower penalty))
    snap-up               Mark a committed capacity sector to be filled with deals
    abort-upgrade         Abort the attempted (SnapDeals) upgrade of a CC sector, reverting it to as before
-   mark-for-upgrade      Mark a committed capacity sector for replacement by a sector with deals
    seal                  Manually start sealing a sector (filling any unused space with junk)
    set-seal-delay        Set the time, in minutes, that a new sector waits for deals before sealing starts
    get-cc-collateral     Get the collateral required to pledge a committed capacity sector
@@ -1828,19 +1827,6 @@ USAGE:
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
    --help, -h      show help (default: false)
-   
-```
-
-### lotus-miner sectors mark-for-upgrade
-```
-NAME:
-   lotus-miner sectors mark-for-upgrade - Mark a committed capacity sector for replacement by a sector with deals
-
-USAGE:
-   lotus-miner sectors mark-for-upgrade [command options] <sectorNum>
-
-OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -106,9 +106,6 @@ type Sealing struct {
 	assignedPieces map[abi.SectorID][]cid.Cid
 	creating       *abi.SectorNumber // used to prevent a race where we could create a new sector more than once
 
-	upgradeLk sync.Mutex
-	toUpgrade map[abi.SectorNumber]struct{}
-
 	notifee SectorStateNotifee
 	addrSel AddrSel
 
@@ -168,7 +165,6 @@ func New(mctx context.Context, api SealingAPI, fc config.MinerFeeConfig, events 
 		sectorTimers:   map[abi.SectorID]*time.Timer{},
 		pendingPieces:  map[cid.Cid]*pendingPiece{},
 		assignedPieces: map[abi.SectorID][]cid.Cid{},
-		toUpgrade:      map[abi.SectorNumber]struct{}{},
 
 		notifee: notifee,
 		addrSel: as,

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -279,14 +279,6 @@ func (m *Sealing) handlePreCommit2(ctx statemachine.Context, sector SectorInfo) 
 	})
 }
 
-// TODO: We should probably invoke this method in most (if not all) state transition failures after handlePreCommitting
-func (m *Sealing) remarkForUpgrade(ctx context.Context, sid abi.SectorNumber) {
-	err := m.MarkForUpgrade(ctx, sid)
-	if err != nil {
-		log.Errorf("error re-marking sector %d as for upgrade: %+v", sid, err)
-	}
-}
-
 func (m *Sealing) preCommitParams(ctx statemachine.Context, sector SectorInfo) (*miner.SectorPreCommitInfo, big.Int, TipSetToken, error) {
 	tok, height, err := m.Api.ChainHead(ctx.Context())
 	if err != nil {
@@ -360,16 +352,12 @@ func (m *Sealing) preCommitParams(ctx statemachine.Context, sector SectorInfo) (
 		DealIDs:       sector.dealIDs(),
 	}
 
-	depositMinimum := m.tryUpgradeSector(ctx.Context(), params)
-
 	collateral, err := m.Api.StateMinerPreCommitDepositForPower(ctx.Context(), m.maddr, *params, tok)
 	if err != nil {
 		return nil, big.Zero(), nil, xerrors.Errorf("getting initial pledge collateral: %w", err)
 	}
 
-	deposit := big.Max(depositMinimum, collateral)
-
-	return params, deposit, tok, nil
+	return params, collateral, tok, nil
 }
 
 func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInfo) error {
@@ -423,9 +411,6 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 	log.Infof("submitting precommit for sector %d (deposit: %s): ", sector.SectorNumber, deposit)
 	mcid, err := m.Api.SendMsg(ctx.Context(), from, m.maddr, miner.Methods.PreCommitSector, deposit, big.Int(m.feeCfg.MaxPreCommitGasFee), enc.Bytes())
 	if err != nil {
-		if params.ReplaceCapacity {
-			m.remarkForUpgrade(ctx.Context(), params.ReplaceSectorNumber)
-		}
 		return ctx.Send(SectorChainPreCommitFailed{xerrors.Errorf("pushing message to mpool: %w", err)})
 	}
 

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -4,50 +4,12 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
 )
-
-func (m *Sealing) IsMarkedForUpgrade(id abi.SectorNumber) bool {
-	m.upgradeLk.Lock()
-	_, found := m.toUpgrade[id]
-	m.upgradeLk.Unlock()
-	return found
-}
-
-func (m *Sealing) MarkForUpgrade(ctx context.Context, id abi.SectorNumber) error {
-
-	m.upgradeLk.Lock()
-	defer m.upgradeLk.Unlock()
-
-	_, found := m.toUpgrade[id]
-	if found {
-		return xerrors.Errorf("sector %d already marked for upgrade", id)
-	}
-
-	si, err := m.GetSectorInfo(id)
-	if err != nil {
-		return xerrors.Errorf("getting sector info: %w", err)
-	}
-	if si.State != Proving {
-		return xerrors.Errorf("can't mark sectors not in the 'Proving' state for upgrade")
-	}
-	if len(si.Pieces) != 1 {
-		return xerrors.Errorf("not a committed-capacity sector, expected 1 piece")
-	}
-	if si.Pieces[0].DealInfo != nil {
-		return xerrors.Errorf("not a committed-capacity sector, has deals")
-	}
-
-	m.toUpgrade[id] = struct{}{}
-
-	return nil
-}
 
 func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) error {
 	cfg, err := m.getConfig()
@@ -118,61 +80,4 @@ func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, to
 		}
 	}
 	return found, nil
-}
-
-func (m *Sealing) tryUpgradeSector(ctx context.Context, params *miner.SectorPreCommitInfo) big.Int {
-	if len(params.DealIDs) == 0 {
-		return big.Zero()
-	}
-	replace := m.maybeUpgradableSector()
-	if replace != nil {
-		loc, err := m.Api.StateSectorPartition(ctx, m.maddr, *replace, nil)
-		if err != nil {
-			log.Errorf("error calling StateSectorPartition for replaced sector: %+v", err)
-			return big.Zero()
-		}
-
-		params.ReplaceCapacity = true
-		params.ReplaceSectorNumber = *replace
-		params.ReplaceSectorDeadline = loc.Deadline
-		params.ReplaceSectorPartition = loc.Partition
-
-		log.Infof("replacing sector %d with %d", *replace, params.SectorNumber)
-
-		ri, err := m.Api.StateSectorGetInfo(ctx, m.maddr, *replace, nil)
-		if err != nil {
-			log.Errorf("error calling StateSectorGetInfo for replaced sector: %+v", err)
-			return big.Zero()
-		}
-		if ri == nil {
-			log.Errorf("couldn't find sector info for sector to replace: %+v", replace)
-			return big.Zero()
-		}
-
-		if params.Expiration < ri.Expiration {
-			// TODO: Some limit on this
-			params.Expiration = ri.Expiration
-		}
-
-		return ri.InitialPledge
-	}
-
-	return big.Zero()
-}
-
-func (m *Sealing) maybeUpgradableSector() *abi.SectorNumber {
-	m.upgradeLk.Lock()
-	defer m.upgradeLk.Unlock()
-	for number := range m.toUpgrade {
-		// TODO: checks to match actor constraints
-
-		// this one looks good
-		/*if checks */
-		{
-			delete(m.toUpgrade, number)
-			return &number
-		}
-	}
-
-	return nil
 }

--- a/storage/miner_sealing.go
+++ b/storage/miner_sealing.go
@@ -79,11 +79,7 @@ func (m *Miner) MarkForUpgrade(ctx context.Context, id abi.SectorNumber, snap bo
 	if snap {
 		return m.sealing.MarkForSnapUpgrade(ctx, id)
 	}
-	return m.sealing.MarkForUpgrade(ctx, id)
-}
-
-func (m *Miner) IsMarkedForUpgrade(id abi.SectorNumber) bool {
-	return m.sealing.IsMarkedForUpgrade(id)
+	return xerrors.Errorf("Old CC upgrade deprecated, use snap deals CC upgrade")
 }
 
 func (m *Miner) SectorAbortUpgrade(sectorNum abi.SectorNumber) error {
@@ -147,7 +143,7 @@ func (m *Miner) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showOnC
 		PreCommitMsg: info.PreCommitMessage,
 		CommitMsg:    info.CommitMessage,
 		Retries:      info.InvalidProofs,
-		ToUpgrade:    m.IsMarkedForUpgrade(sid),
+		ToUpgrade:    false,
 
 		LastErr: info.LastErr,
 		Log:     log,


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

#7934

## Proposed Changes
<!-- provide a clear list of the changes being made-->
Remove mark-for-upgrade cli command and underlying sealer methods


## Additional Info
<!-- callouts, links to documentation, and etc-->

I'm not yet removing the upgrade field from the FSM's sector info because afaik this would cause failure to reload old sector infos.  @magik6k what's the best way to do this?  Have we migrated fsm sector info data before?

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
