### PR TITLE
fix:proving:winning post warmup works on snapped up sectors

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1768,6 +1768,9 @@ var StateSectorCmd = &cli.Command{
 		fmt.Println("SectorNumber: ", si.SectorNumber)
 		fmt.Println("SealProof: ", si.SealProof)
 		fmt.Println("SealedCID: ", si.SealedCID)
+		if si.SectorKeyCID != nil {
+			fmt.Println("SectorKeyCID: ", si.SectorKeyCID)
+		}
 		fmt.Println("DealIDs: ", si.DealIDs)
 		fmt.Println()
 		fmt.Println("Activation: ", EpochTime(ts.Height(), si.Activation))

--- a/miner/warmup.go
+++ b/miner/warmup.go
@@ -74,6 +74,7 @@ out:
 			SealProof:    si.SealProof,
 			SectorNumber: sector,
 			SealedCID:    si.SealedCID,
+			SectorKey:    si.SectorKeyCID,
 		},
 	}, r, ts.Height(), nv)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
Resolves #8237 

Also makes state sector command print out sector key info for upgraded sectors
## Proposed Changes
<!-- provide a clear list of the changes being made-->


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
