### PR TITLE
feat:  multisig: lotus-sheed miner-multisig change-worker command.

### DIFF
--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -8,6 +8,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	miner5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 
+    miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+
 	msig5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/multisig"
 
 	"github.com/filecoin-project/go-address"
@@ -29,6 +31,8 @@ var minerMultisigsCmd = &cli.Command{
 		mmApproveWithdrawBalance,
 		mmProposeChangeOwner,
 		mmApproveChangeOwner,
+		mmProposeChangeWorker,
+		mmConfirmChangeWorker,
 	},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
@@ -363,6 +367,186 @@ var mmApproveChangeOwner = &cli.Command{
 			fmt.Printf("Return Value: %x\n", retval.Ret)
 		} else {
 			fmt.Println("Transaction was approved, but not executed")
+		}
+		return nil
+	},
+}
+
+var mmProposeChangeWorker = &cli.Command{
+	Name:      "propose-change-worker",
+	Usage:     "Propose an worker address change",
+	ArgsUsage: "[newWorker]",
+	Action: func(cctx *cli.Context) error {
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass new owner address")
+		}
+
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		multisigAddr, sender, minerAddr, err := getInputs(cctx)
+		if err != nil {
+			return err
+		}
+
+		na, err := address.NewFromString(cctx.Args().First())
+		if err != nil {
+			return err
+		}
+
+		newAddr, err := api.StateLookupID(ctx, na, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		mi, err := api.StateMinerInfo(ctx, minerAddr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		if mi.NewWorker.Empty() {
+			if mi.Worker == newAddr {
+				return fmt.Errorf("worker address already set to %s", na)
+			}
+		} else {
+			if mi.NewWorker == newAddr {
+				fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
+				fmt.Fprintf(cctx.App.Writer, "Call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
+				return fmt.Errorf("change to worker address %s already pending", na)
+			}
+		}
+
+		cwp := &miner2.ChangeWorkerAddressParams{
+			NewWorker:       newAddr,
+			NewControlAddrs: mi.ControlAddresses,
+		}
+
+		fmt.Fprintf(cctx.App.Writer, "newAddr: %s\n", newAddr)
+		fmt.Fprintf(cctx.App.Writer, "NewControlAddrs: %s\n", mi.ControlAddresses)
+
+		sp, err := actors.SerializeParams(cwp)
+		if err != nil {
+			return xerrors.Errorf("serializing params: %w", err)
+		}
+
+		pcid, err := api.MsigPropose(ctx, multisigAddr, minerAddr, big.Zero(), sender, uint64(miner.Methods.ChangeWorkerAddress), sp)
+		if err != nil {
+			return xerrors.Errorf("proposing message: %w", err)
+		}
+
+		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+
+		// wait for it to get mined into a block
+		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
+		if err != nil {
+			return err
+		}
+
+		// check it executed successfully
+		if wait.Receipt.ExitCode != 0 {
+			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
+			return err
+		}
+
+		var retval msig5.ProposeReturn
+		if err := retval.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
+			return fmt.Errorf("failed to unmarshal propose return value: %w", err)
+		}
+
+		fmt.Printf("Transaction ID: %d\n", retval.TxnID)
+		if retval.Applied {
+			fmt.Printf("Transaction was executed during propose\n")
+			fmt.Printf("Exit Code: %d\n", retval.Code)
+			fmt.Printf("Return Value: %x\n", retval.Ret)
+		}
+
+		return nil
+	},
+}
+
+var mmConfirmChangeWorker = &cli.Command{
+	Name:      "Confirm-change-worker",
+	Usage:     "Confirm an worker address change",
+	ArgsUsage: "[newWorker]",
+	Action: func(cctx *cli.Context) error {
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass new owner address")
+		}
+
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		multisigAddr, sender, minerAddr, err := getInputs(cctx)
+		if err != nil {
+			return err
+		}
+
+		na, err := address.NewFromString(cctx.Args().First())
+		if err != nil {
+			return err
+		}
+
+		newAddr, err := api.StateLookupID(ctx, na, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		mi, err := api.StateMinerInfo(ctx, minerAddr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		if mi.NewWorker.Empty() {
+			return xerrors.Errorf("no worker key change proposed")
+		} else if mi.NewWorker != newAddr {
+			return xerrors.Errorf("worker key %s does not match current worker key proposal %s", newAddr, mi.NewWorker)
+		}
+
+		if head, err := api.ChainHead(ctx); err != nil {
+			return xerrors.Errorf("failed to get the chain head: %w", err)
+		} else if head.Height() < mi.WorkerChangeEpoch {
+			return xerrors.Errorf("worker key change cannot be confirmed until %d, current height is %d", mi.WorkerChangeEpoch, head.Height())
+		}
+
+		pcid, err := api.MsigPropose(ctx, multisigAddr, minerAddr, big.Zero(), sender, uint64(miner.Methods.ConfirmUpdateWorkerKey), nil)
+		if err != nil {
+			return xerrors.Errorf("proposing message: %w", err)
+		}
+
+		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+
+		// wait for it to get mined into a block
+		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
+		if err != nil {
+			return err
+		}
+
+		// check it executed successfully
+		if wait.Receipt.ExitCode != 0 {
+			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
+			return err
+		}
+
+		var retval msig5.ProposeReturn
+		if err := retval.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
+			return fmt.Errorf("failed to unmarshal propose return value: %w", err)
+		}
+
+		fmt.Printf("Transaction ID: %d\n", retval.TxnID)
+		if retval.Applied {
+			fmt.Printf("Transaction was executed during propose\n")
+			fmt.Printf("Exit Code: %d\n", retval.Code)
+			fmt.Printf("Return Value: %x\n", retval.Ret)
 		}
 		return nil
 	},

--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	miner5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 
-    miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
+	miner2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/miner"
 
 	msig5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/multisig"
 
@@ -471,7 +471,7 @@ var mmProposeChangeWorker = &cli.Command{
 }
 
 var mmConfirmChangeWorker = &cli.Command{
-	Name:      "Confirm-change-worker",
+	Name:      "confirm-change-worker",
 	Usage:     "Confirm an worker address change",
 	ArgsUsage: "[newWorker]",
 	Action: func(cctx *cli.Context) error {
@@ -554,7 +554,7 @@ var mmConfirmChangeWorker = &cli.Command{
 }
 
 var mmProposeControlSet = &cli.Command{
-	Name:      "ProposeControlSet",
+	Name:      "propose-control-set",
 	Usage:     "Set control address(-es)",
 	ArgsUsage: "[...address]",
 	Action: func(cctx *cli.Context) error {


### PR DESCRIPTION
## Related Issues
[lotus-shed miner-multisig add change-worker command](https://github.com/filecoin-project/lotus/issues/8280)

## Proposed Changes
Added two subcommands, propose-change-worker and Confirm-change-worker.


## Additional Info
lotus-shed miner-multisig --from <sigle-address> --miner <miner-actor> --multisig <multisigAddress messageId> propose-change-worker <new-worker>
lotus msig approve --from <approve-account> <multisigAddress messageId> <proposerAddress destination value>

lotus-shed miner-multisig --from <sigle-address> --miner <miner-actor> --multisig <multisigAddress messageId> Confirm-change-worker <new-worker>
lotus msig approve --from <approve-account> <multisigAddress messageId> <proposerAddress destination value>

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
