### PR TITLE
misc: builder: env var for managing rcmgr

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
 
 	metricsi "github.com/ipfs/go-metrics-interface"
@@ -222,7 +223,7 @@ var LibP2P = Options(
 
 	// Services (resource management)
 	Override(new(network.ResourceManager), lp2p.ResourceManager),
-	Override(ResourceManagerKey, lp2p.ResourceManagerOption),
+	If(os.Getenv("LOTUS_RCMGR") != "0", Override(ResourceManagerKey, lp2p.ResourceManagerOption)),
 )
 
 func IsType(t repo.RepoType) func(s *Settings) bool {

--- a/node/builder.go
+++ b/node/builder.go
@@ -223,7 +223,7 @@ var LibP2P = Options(
 
 	// Services (resource management)
 	Override(new(network.ResourceManager), lp2p.ResourceManager),
-	If(os.Getenv("LOTUS_RCMGR") != "0", Override(ResourceManagerKey, lp2p.ResourceManagerOption)),
+	If(os.Getenv("LOTUS_RCMGR") != "" && os.Getenv("LOTUS_RCMGR") != "0", Override(ResourceManagerKey, lp2p.ResourceManagerOption)),
 )
 
 func IsType(t repo.RepoType) func(s *Settings) bool {


### PR DESCRIPTION
Also disable it by default for now, until we can figure out what's broken (also disabling by default means that people will not set the envvar to disable rcmgr and keep it after we've fixed issues)
