### PR TITLE
refactor: cli: enhance api info error message

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -123,7 +123,7 @@ var AuthApiInfoToken = &cli.Command{
 
 		ainfo, err := GetAPIInfo(cctx, t)
 		if err != nil {
-			return xerrors.Errorf("could not get API info for %s: %w", t, err)
+			return xerrors.Errorf("could not get API info for %s: %w is FULLNODE_API_INFO set?", t, err)
 		}
 
 		// TODO: Log in audit log when it is implemented

--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -405,7 +405,7 @@ var clientRetrieveCatCmd = &cli.Command{
 
 		ainfo, err := GetAPIInfo(cctx, repo.FullNode)
 		if err != nil {
-			return xerrors.Errorf("could not get API info: %w", err)
+			return xerrors.Errorf("could not get API info: %w is FULLNODE_API_INFO set?", err)
 		}
 
 		fapi, closer, err := GetFullNodeAPIV1(cctx)
@@ -484,7 +484,7 @@ var clientRetrieveLsCmd = &cli.Command{
 
 		ainfo, err := GetAPIInfo(cctx, repo.FullNode)
 		if err != nil {
-			return xerrors.Errorf("could not get API info: %w", err)
+			return xerrors.Errorf("could not get API info: %w is FULLNODE_API_INFO set?", err)
 		}
 
 		fapi, closer, err := GetFullNodeAPIV1(cctx)

--- a/cli/pprof.go
+++ b/cli/pprof.go
@@ -34,7 +34,7 @@ var PprofGoroutines = &cli.Command{
 		}
 		ainfo, err := GetAPIInfo(cctx, t)
 		if err != nil {
-			return xerrors.Errorf("could not get API info for %s: %w", t, err)
+			return xerrors.Errorf("could not get API info for %s: %w is FULLNODE_API_INFO set?", t, err)
 		}
 		addr, err := ainfo.Host()
 		if err != nil {

--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -181,7 +181,7 @@ func GetAPIInfo(ctx *cli.Context, t repo.RepoType) (APIInfo, error) {
 func GetRawAPI(ctx *cli.Context, t repo.RepoType, version string) (string, http.Header, error) {
 	ainfo, err := GetAPIInfo(ctx, t)
 	if err != nil {
-		return "", nil, xerrors.Errorf("could not get API info for %s: %w", t, err)
+		return "", nil, xerrors.Errorf("could not get API info for %s: %w is FULLNODE_API_INFO set?", t, err)
 	}
 
 	addr, err := ainfo.DialArgs(version)


### PR DESCRIPTION
## Related Issues
#8261 

## Proposed Changes
Currently, the error reads: `could not get API info for FullNode....`. Added `is FULLNODE_API_INFO set?` to that.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ x ] All commits have a clear commit message.
- [ x ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour **(not applicable)**
- [ x ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
