### PR TITLE
feat: sealing: Sector upgrade queue

### DIFF
--- a/cmd/lotus-miner/info.go
+++ b/cmd/lotus-miner/info.go
@@ -466,6 +466,7 @@ var stateOrder = map[sealing.SectorState]stateMeta{}
 var stateList = []stateMeta{
 	{col: 39, state: "Total"},
 	{col: color.FgGreen, state: sealing.Proving},
+	{col: color.FgGreen, state: sealing.Available},
 	{col: color.FgGreen, state: sealing.UpdateActivating},
 
 	{col: color.FgBlue, state: sealing.Empty},

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -347,7 +347,7 @@ var sectorsListCmd = &cli.Command{
 
 		if cctx.Bool("unproven") {
 			for state := range sealing.ExistSectorStateList {
-				if state == sealing.Proving {
+				if state == sealing.Proving || state == sealing.Available {
 					continue
 				}
 				states = append(states, api.SectorState(state))

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -365,6 +365,12 @@
   # env var: LOTUS_SEALING_FINALIZEEARLY
   #FinalizeEarly = false
 
+  # After sealing CC sectors, make them available for upgrading with deals
+  #
+  # type: bool
+  # env var: LOTUS_SEALING_MAKECCSECTORSAVAILABLE
+  #MakeCCSectorsAvailable = false
+
   # Whether to use available miner balance for sector collateral instead of sending it with each message
   #
   # type: bool

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -283,6 +283,9 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	Proving: planOne(
 		on(SectorFaultReported{}, FaultReported),
 		on(SectorFaulty{}, Faulty),
+		on(SectorMarkForUpdate{}, Available),
+	),
+	Available: planOne(
 		on(SectorStartCCUpdate{}, SnapDealsWaitDeals),
 	),
 	Terminating: planOne(
@@ -558,6 +561,8 @@ func (m *Sealing) plan(events []statemachine.Event, state *SectorInfo) (func(sta
 	// Post-seal
 	case Proving:
 		return m.handleProvingSector, processed, nil
+	case Available:
+		return m.handleAvailableSector, processed, nil
 	case Terminating:
 		return m.handleTerminating, processed, nil
 	case TerminateWait:

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -287,6 +287,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	),
 	Available: planOne(
 		on(SectorStartCCUpdate{}, SnapDealsWaitDeals),
+		on(SectorAbortUpgrade{}, Proving),
 	),
 	Terminating: planOne(
 		on(SectorTerminating{}, TerminateWait),

--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -111,6 +111,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	Committing: planCommitting,
 	CommitFinalize: planOne(
 		on(SectorFinalized{}, SubmitCommit),
+		on(SectorFinalizedAvailable{}, SubmitCommit),
 		on(SectorFinalizeFailed{}, CommitFinalizeFailed),
 	),
 	SubmitCommit: planOne(
@@ -136,6 +137,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 
 	FinalizeSector: planOne(
 		on(SectorFinalized{}, Proving),
+		on(SectorFinalizedAvailable{}, Available),
 		on(SectorFinalizeFailed{}, FinalizeFailed),
 	),
 

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -286,6 +286,10 @@ type SectorFinalized struct{}
 
 func (evt SectorFinalized) apply(*SectorInfo) {}
 
+type SectorFinalizedAvailable struct{}
+
+func (evt SectorFinalizedAvailable) apply(*SectorInfo) {}
+
 type SectorRetryFinalize struct{}
 
 func (evt SectorRetryFinalize) apply(*SectorInfo) {}

--- a/extern/storage-sealing/fsm_events.go
+++ b/extern/storage-sealing/fsm_events.go
@@ -297,6 +297,10 @@ func (evt SectorFinalizeFailed) apply(*SectorInfo)                        {}
 
 // Snap deals // CC update path
 
+type SectorMarkForUpdate struct{}
+
+func (evt SectorMarkForUpdate) apply(state *SectorInfo) {}
+
 type SectorStartCCUpdate struct{}
 
 func (evt SectorStartCCUpdate) apply(state *SectorInfo) {

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -575,8 +575,8 @@ func (m *Sealing) tryGetUpgradeSector(ctx context.Context, sp abi.RegisteredSeal
 			continue
 		}
 
-		slowChecks := func() bool {
-			active, err := m.sectorActive(ctx, TipSetToken{}, s.Number)
+		slowChecks := func(sid abi.SectorNumber) bool {
+			active, err := m.sectorActive(ctx, TipSetToken{}, sid)
 			if err != nil {
 				log.Errorw("checking sector active", "error", err)
 				return false
@@ -592,7 +592,7 @@ func (m *Sealing) tryGetUpgradeSector(ctx context.Context, sp abi.RegisteredSeal
 		// if best is above target, we want lower pledge, but only if still above target
 
 		if bestExpiration < targetExpiration {
-			if expiration > bestExpiration && slowChecks() {
+			if expiration > bestExpiration && slowChecks(s.Number) {
 				bestExpiration = expiration
 				bestPledge = pledge
 				candidate = s
@@ -600,7 +600,7 @@ func (m *Sealing) tryGetUpgradeSector(ctx context.Context, sp abi.RegisteredSeal
 			continue
 		}
 
-		if expiration >= targetExpiration && pledge.LessThan(bestPledge) && slowChecks() {
+		if expiration >= targetExpiration && pledge.LessThan(bestPledge) && slowChecks(s.Number) {
 			bestExpiration = expiration
 			bestPledge = pledge
 			candidate = s

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -570,6 +570,16 @@ func (m *Sealing) tryGetUpgradeSector(ctx context.Context, sp abi.RegisteredSeal
 			continue
 		}
 
+		active, err := m.sectorActive(ctx, TipSetToken{}, s.Number)
+		if err != nil {
+			log.Errorw("checking sector active", "error", err)
+			continue
+		}
+		if !active {
+			log.Debugw("skipping available sector", "reason", "not active")
+			continue
+		}
+
 		// if best is below target, we want larger expirations
 		// if best is above target, we want lower pledge, but only if still above target
 

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -608,7 +608,7 @@ func (m *Sealing) tryGetUpgradeSector(ctx context.Context, sp abi.RegisteredSeal
 	}
 
 	if bestExpiration < minExpiration {
-		log.Infow("Not upgrading any sectors", "available", len(m.available), "bestExp", bestExpiration, "target", targetExpiration, "min", minExpiration, "candidate", candidate)
+		log.Infow("Not upgrading any sectors", "available", len(m.available), "pieces", len(m.pendingPieces), "bestExp", bestExpiration, "target", targetExpiration, "min", minExpiration, "candidate", candidate)
 		// didn't find a good sector / no sectors were available
 		return false, nil
 	}

--- a/extern/storage-sealing/input.go
+++ b/extern/storage-sealing/input.go
@@ -528,7 +528,7 @@ func (m *Sealing) calcTargetExpiration(ctx context.Context, ssize abi.SectorSize
 
 	// earliest expiration first
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].deal.DealProposal.EndEpoch < candidates[i].deal.DealProposal.EndEpoch
+		return candidates[i].deal.DealProposal.EndEpoch < candidates[j].deal.DealProposal.EndEpoch
 	})
 
 	var totalBytes uint64

--- a/extern/storage-sealing/mocks/api.go
+++ b/extern/storage-sealing/mocks/api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	address "github.com/filecoin-project/go-address"
+	bitfield "github.com/filecoin-project/go-bitfield"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	big "github.com/filecoin-project/go-state-types/big"
 	crypto "github.com/filecoin-project/go-state-types/crypto"
@@ -214,10 +215,10 @@ func (mr *MockSealingAPIMockRecorder) StateMarketStorageDealProposal(arg0, arg1,
 }
 
 // StateMinerActiveSectors mocks base method.
-func (m *MockSealingAPI) StateMinerActiveSectors(arg0 context.Context, arg1 address.Address, arg2 sealing.TipSetToken) ([]*miner.SectorOnChainInfo, error) {
+func (m *MockSealingAPI) StateMinerActiveSectors(arg0 context.Context, arg1 address.Address, arg2 sealing.TipSetToken) (bitfield.BitField, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateMinerActiveSectors", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*miner.SectorOnChainInfo)
+	ret0, _ := ret[0].(bitfield.BitField)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/extern/storage-sealing/sealiface/config.go
+++ b/extern/storage-sealing/sealiface/config.go
@@ -20,6 +20,8 @@ type Config struct {
 
 	MakeNewSectorForDeals bool
 
+	MakeCCSectorsAvailable bool
+
 	WaitDealsDelay time.Duration
 
 	CommittedCapacitySectorLifetime time.Duration

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -105,7 +105,7 @@ type Sealing struct {
 	sectorTimers   map[abi.SectorID]*time.Timer
 	pendingPieces  map[cid.Cid]*pendingPiece
 	assignedPieces map[abi.SectorID][]cid.Cid
-	creating       *abi.SectorNumber // used to prevent a race where we could create a new sector more than once
+	nextDealSector *abi.SectorNumber // used to prevent a race where we could create a new sector more than once
 
 	available map[abi.SectorID]struct{}
 

--- a/extern/storage-sealing/sealing.go
+++ b/extern/storage-sealing/sealing.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
@@ -63,7 +64,7 @@ type SealingAPI interface {
 	StateMinerInfo(context.Context, address.Address, TipSetToken) (miner.MinerInfo, error)
 	StateMinerAvailableBalance(context.Context, address.Address, TipSetToken) (big.Int, error)
 	StateMinerSectorAllocated(context.Context, address.Address, abi.SectorNumber, TipSetToken) (bool, error)
-	StateMinerActiveSectors(context.Context, address.Address, TipSetToken) ([]*miner.SectorOnChainInfo, error)
+	StateMinerActiveSectors(context.Context, address.Address, TipSetToken) (bitfield.BitField, error)
 	StateMarketStorageDeal(context.Context, abi.DealID, TipSetToken) (*api.MarketDeal, error)
 	StateMarketStorageDealProposal(context.Context, abi.DealID, TipSetToken) (market.DealProposal, error)
 	StateNetworkVersion(ctx context.Context, tok TipSetToken) (network.Version, error)

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -25,6 +25,7 @@ var ExistSectorStateList = map[SectorState]struct{}{
 	CommitAggregateWait:         {},
 	FinalizeSector:              {},
 	Proving:                     {},
+	Available:                   {},
 	FailedUnrecoverable:         {},
 	SealPreCommit1Failed:        {},
 	SealPreCommit2Failed:        {},
@@ -98,6 +99,7 @@ const (
 
 	FinalizeSector SectorState = "FinalizeSector"
 	Proving        SectorState = "Proving"
+	Available      SectorState = "Available" // proving CC available for SnapDeals
 
 	// snap deals / cc update
 	SnapDealsWaitDeals    SectorState = "SnapDealsWaitDeals"
@@ -161,7 +163,7 @@ func toStatState(st SectorState, finEarly bool) statSectorState {
 			return sstProving
 		}
 		return sstSealing
-	case Proving, UpdateActivating, ReleaseSectorKey, Removed, Removing, Terminating, TerminateWait, TerminateFinality, TerminateFailed:
+	case Proving, Available, UpdateActivating, ReleaseSectorKey, Removed, Removing, Terminating, TerminateWait, TerminateFinality, TerminateFailed:
 		return sstProving
 	}
 

--- a/extern/storage-sealing/states_failed.go
+++ b/extern/storage-sealing/states_failed.go
@@ -238,7 +238,7 @@ func (m *Sealing) handleSubmitReplicaUpdateFailed(ctx statemachine.Context, sect
 	}
 
 	// Abort upgrade for sectors that went faulty since being marked for upgrade
-	active, err := sectorActive(ctx.Context(), m.Api, m.maddr, tok, sector.SectorNumber)
+	active, err := m.sectorActive(ctx.Context(), tok, sector.SectorNumber)
 	if err != nil {
 		log.Errorf("sector active check: api error, not proceeding: %+v", err)
 		return nil

--- a/extern/storage-sealing/states_replica_update.go
+++ b/extern/storage-sealing/states_replica_update.go
@@ -41,7 +41,7 @@ func (m *Sealing) handleProveReplicaUpdate(ctx statemachine.Context, sector Sect
 		log.Errorf("handleProveReplicaUpdate: api error, not proceeding: %+v", err)
 		return nil
 	}
-	active, err := sectorActive(ctx.Context(), m.Api, m.maddr, tok, sector.SectorNumber)
+	active, err := m.sectorActive(ctx.Context(), tok, sector.SectorNumber)
 	if err != nil {
 		log.Errorf("sector active check: api error, not proceeding: %+v", err)
 		return nil

--- a/extern/storage-sealing/states_sealing.go
+++ b/extern/storage-sealing/states_sealing.go
@@ -767,5 +767,8 @@ func (m *Sealing) handleFinalizeSector(ctx statemachine.Context, sector SectorIn
 		return ctx.Send(SectorFinalizeFailed{xerrors.Errorf("finalize sector: %w", err)})
 	}
 
+	if cfg.MakeCCSectorsAvailable && !sector.hasDeals() {
+		return ctx.Send(SectorFinalizedAvailable{})
+	}
 	return ctx.Send(SectorFinalized{})
 }

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -21,11 +21,7 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 		return xerrors.Errorf("can't mark sectors not in the 'Proving' state for upgrade")
 	}
 
-	if len(si.Pieces) != 1 {
-		return xerrors.Errorf("not a committed-capacity sector, expected 1 piece")
-	}
-
-	if si.Pieces[0].DealInfo != nil {
+	if si.hasDeals() {
 		return xerrors.Errorf("not a committed-capacity sector, has deals")
 	}
 
@@ -60,13 +56,5 @@ func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, to
 		return false, xerrors.Errorf("failed to check active sectors: %w", err)
 	}
 
-	// Ensure the upgraded sector is active
-	var found bool
-	for _, si := range active {
-		if si.SectorNumber == sector {
-			found = true
-			break
-		}
-	}
-	return found, nil
+	return active.IsSet(uint64(sector))
 }

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -12,17 +12,6 @@ import (
 )
 
 func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) error {
-	cfg, err := m.getConfig()
-	if err != nil {
-		return xerrors.Errorf("getting storage config: %w", err)
-	}
-
-	curStaging := m.stats.curStaging()
-	if cfg.MaxWaitDealsSectors > 0 && curStaging >= cfg.MaxWaitDealsSectors {
-		return xerrors.Errorf("already waiting for deals in %d >= %d (cfg.MaxWaitDealsSectors) sectors, no free resources to wait for deals in another",
-			curStaging, cfg.MaxWaitDealsSectors)
-	}
-
 	si, err := m.GetSectorInfo(id)
 	if err != nil {
 		return xerrors.Errorf("getting sector info: %w", err)
@@ -62,7 +51,7 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 			"Upgrade expiration before marking for upgrade", id, onChainInfo.Expiration)
 	}
 
-	return m.sectors.Send(uint64(id), SectorStartCCUpdate{})
+	return m.sectors.Send(uint64(id), SectorMarkForUpdate{})
 }
 
 func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, tok TipSetToken, sector abi.SectorNumber) (bool, error) {

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -2,8 +2,6 @@ package sealing
 
 import (
 	"context"
-
-	"github.com/filecoin-project/go-address"
 	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 
 	"golang.org/x/xerrors"
@@ -34,7 +32,7 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 		return xerrors.Errorf("failed to read sector on chain info: %w", err)
 	}
 
-	active, err := sectorActive(ctx, m.Api, m.maddr, tok, id)
+	active, err := m.sectorActive(ctx, tok, id)
 	if err != nil {
 		return xerrors.Errorf("failed to check if sector is active")
 	}
@@ -50,8 +48,8 @@ func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) e
 	return m.sectors.Send(uint64(id), SectorMarkForUpdate{})
 }
 
-func sectorActive(ctx context.Context, api SealingAPI, maddr address.Address, tok TipSetToken, sector abi.SectorNumber) (bool, error) {
-	active, err := api.StateMinerActiveSectors(ctx, maddr, tok)
+func (m *Sealing) sectorActive(ctx context.Context, tok TipSetToken, sector abi.SectorNumber) (bool, error) {
+	active, err := m.Api.StateMinerActiveSectors(ctx, m.maddr, tok)
 	if err != nil {
 		return false, xerrors.Errorf("failed to check active sectors: %w", err)
 	}

--- a/extern/storage-sealing/upgrade_queue.go
+++ b/extern/storage-sealing/upgrade_queue.go
@@ -2,11 +2,11 @@ package sealing
 
 import (
 	"context"
-	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 )
 
 func (m *Sealing) MarkForSnapUpgrade(ctx context.Context, id abi.SectorNumber) error {

--- a/itests/ccupgrade_test.go
+++ b/itests/ccupgrade_test.go
@@ -4,19 +4,20 @@ package itests
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/lotus/api"
-	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
 	"testing"
 	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/lotus/itests/kit"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
+	"github.com/filecoin-project/lotus/itests/kit"
 )
 
 func TestCCUpgrade(t *testing.T) {

--- a/itests/ccupgrade_test.go
+++ b/itests/ccupgrade_test.go
@@ -49,9 +49,6 @@ func runTestCCUpgrade(t *testing.T) *kit.TestFullNode {
 	CCUpgrade := abi.SectorNumber(kit.DefaultPresealsPerBootstrapMiner + 1)
 	fmt.Printf("CCUpgrade: %d\n", CCUpgrade)
 
-	// wait for deadline 0 to pass so that committing starts after post on preseals
-	// this gives max time for post to complete minimizing chances of timeout
-	// waitForDeadline(ctx, t, 1, client, maddr)
 	miner.PledgeSectors(ctx, 1, 0, nil)
 	sl, err := miner.SectorsList(ctx)
 	require.NoError(t, err)
@@ -142,9 +139,6 @@ func TestAbortUpgradeAvailable(t *testing.T) {
 	CCUpgrade := abi.SectorNumber(kit.DefaultPresealsPerBootstrapMiner + 1)
 	fmt.Printf("CCUpgrade: %d\n", CCUpgrade)
 
-	// wait for deadline 0 to pass so that committing starts after post on preseals
-	// this gives max time for post to complete minimizing chances of timeout
-	// waitForDeadline(ctx, t, 1, client, maddr)
 	miner.PledgeSectors(ctx, 1, 0, nil)
 	sl, err := miner.SectorsList(ctx)
 	require.NoError(t, err)

--- a/itests/kit/log.go
+++ b/itests/kit/log.go
@@ -15,5 +15,6 @@ func QuietMiningLogs() {
 	_ = logging.SetLogLevel("storageminer", "ERROR")
 	_ = logging.SetLogLevel("pubsub", "ERROR")
 	_ = logging.SetLogLevel("gen", "ERROR")
+	_ = logging.SetLogLevel("rpc", "ERROR")
 	_ = logging.SetLogLevel("dht/RtRefreshManager", "ERROR")
 }

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -751,6 +751,12 @@ avoid the relatively high cost of unsealing the data later, at the cost of more 
 			Comment: `Run sector finalization before submitting sector proof to the chain`,
 		},
 		{
+			Name: "MakeCCSectorsAvailable",
+			Type: "bool",
+
+			Comment: `After sealing CC sectors, make them available for upgrading with deals`,
+		},
+		{
 			Name: "CollateralFromMinerBalance",
 			Type: "bool",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -250,6 +250,9 @@ type SealingConfig struct {
 	// Run sector finalization before submitting sector proof to the chain
 	FinalizeEarly bool
 
+	// After sealing CC sectors, make them available for upgrading with deals
+	MakeCCSectorsAvailable bool
+
 	// Whether to use available miner balance for sector collateral instead of sending it with each message
 	CollateralFromMinerBalance bool
 	// Minimum available balance to keep in the miner actor before sending it with messages

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -897,6 +897,7 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 				MaxSealingSectorsForDeals:       cfg.MaxSealingSectorsForDeals,
 				CommittedCapacitySectorLifetime: config.Duration(cfg.CommittedCapacitySectorLifetime),
 				WaitDealsDelay:                  config.Duration(cfg.WaitDealsDelay),
+				MakeCCSectorsAvailable:          cfg.MakeCCSectorsAvailable,
 				AlwaysKeepUnsealedCopy:          cfg.AlwaysKeepUnsealedCopy,
 				FinalizeEarly:                   cfg.FinalizeEarly,
 
@@ -935,6 +936,7 @@ func ToSealingConfig(cfg *config.StorageMiner) sealiface.Config {
 		MakeNewSectorForDeals:           cfg.Dealmaking.MakeNewSectorForDeals,
 		CommittedCapacitySectorLifetime: time.Duration(cfg.Sealing.CommittedCapacitySectorLifetime),
 		WaitDealsDelay:                  time.Duration(cfg.Sealing.WaitDealsDelay),
+		MakeCCSectorsAvailable:          cfg.Sealing.MakeCCSectorsAvailable,
 		AlwaysKeepUnsealedCopy:          cfg.Sealing.AlwaysKeepUnsealedCopy,
 		FinalizeEarly:                   cfg.Sealing.FinalizeEarly,
 


### PR DESCRIPTION
## Related Issues
Closes #8231

## Proposed Changes
* Add a new `Available` sector state for CC sectors available for upgrading ('available storage')
* After sectors are marked for upgrade, they go into the `Available` state instead of `SnapDealsWaitDeals`
* When a deal arrives to the sealing pipeline, and it can't be matched to any sectors:
  * We'll try to see if any `Available` sectors can accept it - we'll select a candidate with lowest initial pledge (most rational to upgrade?)
  * If we don't find any good available sectors, we'll just create a new CC sector if that's not disabled in the config

## Additional Info
TODO:
* [ ] Test on a real setup
* [x] Add a config which would make newly sealed sectors automatically become `Available` (maybe a separate PR)
* [x] When considering `Active` sectors run all snapdeal checks
* [x] Support reverting from `Available` to `Proving`

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
