### PR TITLE
fix: miner cli: Estimate deal weight in sector list when upgrading

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -433,7 +433,7 @@ var sectorsListCmd = &cli.Command{
 			const verifiedPowerGainMul = 9
 
 			dw, vp := .0, .0
-			estimate := st.Expiration-st.Activation <= 0
+			estimate := (st.Expiration-st.Activation <= 0) || sealing.IsUpgradeState(sealing.SectorState(st.State))
 			if !estimate {
 				rdw := big.Add(st.DealWeight, st.VerifiedDealWeight)
 				dw = float64(big.Div(rdw, big.NewInt(int64(st.Expiration-st.Activation))).Uint64())

--- a/extern/storage-sealing/sector_state.go
+++ b/extern/storage-sealing/sector_state.go
@@ -169,3 +169,25 @@ func toStatState(st SectorState, finEarly bool) statSectorState {
 
 	return sstFailed
 }
+
+func IsUpgradeState(st SectorState) bool {
+	switch st {
+	case SnapDealsWaitDeals,
+		SnapDealsAddPiece,
+		SnapDealsPacking,
+		UpdateReplica,
+		ProveReplicaUpdate,
+		SubmitReplicaUpdate,
+
+		SnapDealsAddPieceFailed,
+		SnapDealsDealsExpired,
+		SnapDealsRecoverDealIDs,
+		AbortUpgrade,
+		ReplicaUpdateFailed,
+		ReleaseSectorKeyFailed,
+		FinalizeReplicaUpdateFailed:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Without this the dealweight would say `0B` until the upgrade lands on-chain.