### PR TITLE
fix: itests: Don't hang on exit in MineBlocksMustPost

### DIFF
--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -192,7 +192,11 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 					InjectNulls: abi.ChainEpoch(nulls + i),
 					Done:        reportSuccessFn,
 				})
-				success = <-wait
+				select {
+				case success = <-wait:
+				case <-ctx.Done():
+					return
+				}
 				if !success {
 					// if we are mining a new null block and it brings us past deadline boundary we need to wait for miner to post
 					if ts.Height()+1+abi.ChainEpoch(nulls+i) >= dlinfo.Last() {


### PR DESCRIPTION
## Proposed Changes
`MineBlocksMustPost` could hang during test cleanup, causing tests to randomly time out. The issue seems to be that we're waiting for a block to be mined, but the block mining logic has already shut down (this is quite racy, but happens a lot more it tests with very low block delays).

## Additional Info
Happened in https://app.circleci.com/pipelines/github/filecoin-project/lotus/20105/workflows/1c498222-3542-4b64-bb14-5667927379e6/jobs/409257

Relevant goroutines:
```
goroutine 85 [semacquire, 28 minutes]:
sync.runtime_Semacquire(0xc0038ad250)
	/usr/local/go/src/runtime/sema.go:56 +0x45
sync.(*WaitGroup).Wait(0xc0038ad248)
	/usr/local/go/src/sync/waitgroup.go:130 +0x65
github.com/filecoin-project/lotus/itests/kit.(*BlockMiner).Stop(0xc0038ad230)
	/home/circleci/project/itests/kit/blockminer.go:324 +0x9a
testing.(*common).Cleanup.func1()
	/usr/local/go/src/testing/testing.go:901 +0xef
testing.(*common).runCleanup(0xc000592a80, 0x0, 0x0, 0x0)
	/usr/local/go/src/testing/testing.go:1007 +0x8c
testing.tRunner.func2(0xc000592a80)
	/usr/local/go/src/testing/testing.go:1187 +0x48
testing.tRunner(0xc000592a80, 0x4ae9e68)
	/usr/local/go/src/testing/testing.go:1197 +0x10e
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3



goroutine 894 [chan receive, 28 minutes]:
github.com/filecoin-project/lotus/itests/kit.(*BlockMiner).MineBlocksMustPost.func1(0xc0038ad230, 0x4d80178, 0xc001c42140, 0xf4240)
	/home/circleci/project/itests/kit/blockminer.go:195 +0x3c5
created by github.com/filecoin-project/lotus/itests/kit.(*BlockMiner).MineBlocksMustPost
	/home/circleci/project/itests/kit/blockminer.go:153 +0xd3
```


## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
