### PR TITLE
fix: avoid racy memstores when estimating gas

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/state"
 
-	"github.com/filecoin-project/lotus/blockstore"
-
 	"github.com/filecoin-project/lotus/chain/rand"
 
 	"github.com/filecoin-project/go-address"
@@ -223,12 +221,11 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		return nil, err
 	}
 
-	buffStore := blockstore.NewBuffered(sm.cs.StateBlockstore())
 	vmopt := &vm.VMOpts{
 		StateBase:      stateCid,
 		Epoch:          vmHeight,
 		Rand:           r,
-		Bstore:         buffStore,
+		Bstore:         sm.cs.StateBlockstore(),
 		Actors:         sm.tsExec.NewActorRegistry(),
 		Syscalls:       sm.Syscalls,
 		CircSupplyCalc: sm.GetVMCirculatingSupply,
@@ -255,7 +252,7 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		return nil, xerrors.Errorf("flushing vm: %w", err)
 	}
 
-	stTree, err := state.LoadStateTree(cbor.NewCborStore(buffStore), stateCid)
+	stTree, err := state.LoadStateTree(cbor.NewCborStore(sm.cs.StateBlockstore()), stateCid)
 	if err != nil {
 		return nil, xerrors.Errorf("loading state tree: %w", err)
 	}


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

We've noticed some uncertainty when estimating gas with the new memstore introduced to the `CallWithGas` method in https://github.com/filecoin-project/lotus/pull/8293. 

## Proposed Changes
<!-- provide a clear list of the changes being made-->

We can investigate and fix later, but this PR just removes the buffered store for now.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
