### PR TITLE
lib: extract unixfs filestore into lib

### DIFF
--- a/lib/unixfs/filestore_test.go
+++ b/lib/unixfs/filestore_test.go
@@ -1,5 +1,5 @@
 //stm: #unit
-package client
+package unixfs
 
 import (
 	"bytes"
@@ -21,8 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/stores"
-
-	"github.com/filecoin-project/lotus/node/repo/imports"
 )
 
 // This test uses a full "dense" CARv2, and not a filestore (positional mapping).
@@ -42,7 +40,7 @@ func TestRoundtripUnixFS_Dense(t *testing.T) {
 		blockstore.UseWholeCIDs(true))
 	require.NoError(t, err)
 
-	root, err := buildUnixFS(ctx, bytes.NewBuffer(inputContents), bs, false)
+	root, err := Build(ctx, bytes.NewBuffer(inputContents), bs, false)
 	require.NoError(t, err)
 	require.NotEqual(t, cid.Undef, root)
 	require.NoError(t, bs.Finalize())
@@ -78,9 +76,6 @@ func TestRoundtripUnixFS_Dense(t *testing.T) {
 func TestRoundtripUnixFS_Filestore(t *testing.T) {
 	//stm: @CLIENT_DATA_IMPORT_001
 	ctx := context.Background()
-	a := &API{
-		Imports: &imports.Manager{},
-	}
 
 	inputPath, inputContents := genInputFile(t)
 	defer os.Remove(inputPath) //nolint:errcheck
@@ -88,7 +83,7 @@ func TestRoundtripUnixFS_Filestore(t *testing.T) {
 	dst := newTmpFile(t)
 	defer os.Remove(dst) //nolint:errcheck
 
-	root, err := a.createUnixFSFilestore(ctx, inputPath, dst)
+	root, err := CreateFilestore(ctx, inputPath, dst)
 	require.NoError(t, err)
 	require.NotEqual(t, cid.Undef, root)
 


### PR DESCRIPTION
## Proposed Changes
This PR is extracting and exporting the function which creates a UnixFS Filestore - I'd like to be able to use it from other packages, and right now it is private.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
