### PR TITLE
fix: lotus-wallet: pass correct repo type to repo.Init

### DIFF
--- a/cmd/lotus-wallet/main.go
+++ b/cmd/lotus-wallet/main.go
@@ -278,7 +278,7 @@ func openRepo(cctx *cli.Context) (repo.LockedRepo, types.KeyStore, error) {
 		return nil, nil, err
 	}
 	if !ok {
-		if err := r.Init(repo.Worker); err != nil {
+		if err := r.Init(repo.Wallet); err != nil {
 			return nil, nil, err
 		}
 	}


### PR DESCRIPTION
Apparently this doesn't matter as neither wallet nor worker repos have config, but this is more correct.