### PR TITLE
VM: Refactor pricelist to be based on network versions

### DIFF
--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -467,7 +467,7 @@ func (filec *FilecoinEC) checkBlockMessages(ctx context.Context, b *types.FullBl
 	}
 
 	nv := filec.sm.GetNetworkVersion(ctx, b.Header.Height)
-	pl := vm.PricelistByEpoch(b.Header.Height)
+	pl := vm.PricelistByEpochAndNetworkVersion(b.Header.Height, nv)
 	var sumGasLimit int64
 	checkMsg := func(msg types.ChainMsg) error {
 		m := msg.VMMessage()

--- a/chain/messagepool/check.go
+++ b/chain/messagepool/check.go
@@ -281,12 +281,11 @@ func (mp *MessagePool) checkMessages(ctx context.Context, msgs []*types.Message,
 		// gas checks
 
 		// 4. Min Gas
-		minGas := vm.PricelistByEpoch(epoch).OnChainMessage(m.ChainLength())
+		minGas := vm.PricelistByEpochAndNetworkVersion(epoch, nv).OnChainMessage(m.ChainLength())
 
 		check = api.MessageCheckStatus{
 			Cid: m.Cid(),
-			CheckStatus: api.CheckStatus{
-				Code: api.CheckStatusMessageMinGas,
+			CheckStatus: api.CheckStatus{Code: api.CheckStatusMessageMinGas,
 				Hint: map[string]interface{}{
 					"minGas": minGas,
 				},

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -629,7 +629,11 @@ func (mp *MessagePool) addLocal(ctx context.Context, m *types.SignedMessage) err
 // a (soft) validation error.
 func (mp *MessagePool) verifyMsgBeforeAdd(m *types.SignedMessage, curTs *types.TipSet, local bool) (bool, error) {
 	epoch := curTs.Height() + 1
-	minGas := vm.PricelistByEpoch(epoch).OnChainMessage(m.ChainLength())
+	nv, err := mp.getNtwkVersion(epoch)
+	if err != nil {
+		return false, xerrors.Errorf("getting network version: %w", err)
+	}
+	minGas := vm.PricelistByEpochAndNetworkVersion(epoch, nv).OnChainMessage(m.ChainLength())
 
 	if err := m.VMMessage().ValidForBlockInclusion(minGas.Total(), build.NewestNetworkVersion); err != nil {
 		return false, xerrors.Errorf("message will not be included in a block: %w", err)

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/filecoin-project/lotus/build"
+
 	"github.com/filecoin-project/specs-actors/v7/actors/migration/nv15"
 
 	"github.com/ipfs/go-cid"
@@ -161,7 +163,8 @@ func (us UpgradeSchedule) GetNtwkVersion(e abi.ChainEpoch) (network.Version, err
 			return u.Network, nil
 		}
 	}
-	return network.Version0, xerrors.Errorf("Epoch %d has no defined network version", e)
+
+	return build.GenesisNetworkVersion, nil
 }
 
 func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, height abi.ChainEpoch, cb ExecMonitor, ts *types.TipSet) (cid.Cid, error) {

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -38,6 +38,7 @@ type FvmExtern struct {
 	Rand
 	blockstore.Blockstore
 	epoch   abi.ChainEpoch
+	nv      network.Version
 	lbState LookbackStateGetter
 	base    cid.Cid
 }
@@ -175,7 +176,7 @@ func (x *FvmExtern) workerKeyAtLookback(ctx context.Context, minerId address.Add
 	}
 
 	cstWithoutGas := cbor.NewCborStore(x.Blockstore)
-	cbb := &gasChargingBlocks{gasAdder, PricelistByEpoch(x.epoch), x.Blockstore}
+	cbb := &gasChargingBlocks{gasAdder, PricelistByEpochAndNetworkVersion(x.epoch, x.nv), x.Blockstore}
 	cstWithGas := cbor.NewCborStore(cbb)
 
 	lbState, err := x.lbState(ctx, height)
@@ -234,7 +235,7 @@ func NewFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 	}
 
 	fvm, err := ffi.CreateFVM(0,
-		&FvmExtern{Rand: opts.Rand, Blockstore: opts.Bstore, lbState: opts.LookbackState, base: opts.StateBase, epoch: opts.Epoch},
+		&FvmExtern{Rand: opts.Rand, Blockstore: opts.Bstore, lbState: opts.LookbackState, base: opts.StateBase, epoch: opts.Epoch, nv: opts.NetworkVersion},
 		opts.Epoch, opts.BaseFee, circToReport, opts.NetworkVersion, opts.StateBase,
 	)
 	if err != nil {

--- a/chain/vm/mkactor.go
+++ b/chain/vm/mkactor.go
@@ -51,7 +51,7 @@ var EmptyObjectCid cid.Cid
 
 // TryCreateAccountActor creates account actors from only BLS/SECP256K1 addresses.
 func TryCreateAccountActor(rt *Runtime, addr address.Address) (*types.Actor, address.Address, aerrors.ActorError) {
-	if err := rt.chargeGasSafe(PricelistByEpoch(rt.height).OnCreateActor()); err != nil {
+	if err := rt.chargeGasSafe(PricelistByEpochAndNetworkVersion(rt.height, rt.NetworkVersion()).OnCreateActor()); err != nil {
 		return nil, address.Undef, err
 	}
 

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -135,7 +135,7 @@ func (vm *LegacyVM) makeRuntime(ctx context.Context, msg *types.Message, parent 
 		gasAvailable:     msg.GasLimit,
 		depth:            0,
 		numActorsCreated: 0,
-		pricelist:        PricelistByEpoch(vm.blockHeight),
+		pricelist:        PricelistByEpochAndNetworkVersion(vm.blockHeight, vm.networkVersion),
 		allowInternal:    true,
 		callerValidated:  false,
 		executionTrace:   types.ExecutionTrace{Msg: msg},
@@ -431,7 +431,7 @@ func (vm *LegacyVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*App
 		return nil, err
 	}
 
-	pl := PricelistByEpoch(vm.blockHeight)
+	pl := PricelistByEpochAndNetworkVersion(vm.blockHeight, vm.networkVersion)
 
 	msgGas := pl.OnChainMessage(cmsg.ChainLength())
 	msgGasCost := msgGas.Total()

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"os/exec"
 	"strconv"
@@ -29,7 +28,6 @@ import (
 	"github.com/filecoin-project/test-vectors/schema"
 
 	"github.com/filecoin-project/lotus/blockstore"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 )
@@ -53,52 +51,6 @@ var TipsetVectorOpts struct {
 	OnTipsetApplied []func(bs blockstore.Blockstore, params *ExecuteTipsetParams, res *ExecuteTipsetResult)
 }
 
-type GasPricingRestoreFn func()
-
-// adjustGasPricing adjusts the global gas price mapping to make sure that the
-// gas pricelist for vector's network version is used at the vector's epoch.
-// Because it manipulates a global, it returns a function that reverts the
-// change. The caller MUST invoke this function or the test vector runner will
-// become invalid.
-func adjustGasPricing(vectorEpoch abi.ChainEpoch, vectorNv network.Version) GasPricingRestoreFn {
-	// Stash the current pricing mapping.
-	// Ok to take a reference instead of a copy, because we override the map
-	// with a new one below.
-	var old = vm.Prices
-
-	// Resolve the epoch at which the vector network version kicks in.
-	var epoch abi.ChainEpoch = math.MaxInt64
-	if vectorNv == network.Version0 {
-		// genesis is not an upgrade.
-		epoch = 0
-	} else {
-		for _, u := range filcns.DefaultUpgradeSchedule() {
-			if u.Network == vectorNv {
-				epoch = u.Height
-				break
-			}
-		}
-	}
-
-	if epoch == math.MaxInt64 {
-		panic(fmt.Sprintf("could not resolve network version %d to height", vectorNv))
-	}
-
-	// Find the right pricelist for this network version.
-	pricelist := vm.PricelistByEpoch(epoch)
-
-	// Override the pricing mapping by setting the relevant pricelist for the
-	// network version at the epoch where the vector runs.
-	vm.Prices = map[abi.ChainEpoch]vm.Pricelist{
-		vectorEpoch: pricelist,
-	}
-
-	// Return a function to restore the original mapping.
-	return func() {
-		vm.Prices = old
-	}
-}
-
 // ExecuteMessageVector executes a message-class test vector.
 func ExecuteMessageVector(r Reporter, vector *schema.TestVector, variant *schema.Variant) (diffs []string, err error) {
 	var (
@@ -116,10 +68,6 @@ func ExecuteMessageVector(r Reporter, vector *schema.TestVector, variant *schema
 
 	// Create a new Driver.
 	driver := NewDriver(ctx, vector.Selector, DriverOpts{DisableVMFlush: true})
-
-	// Monkey patch the gas pricing.
-	revertFn := adjustGasPricing(baseEpoch, nv)
-	defer revertFn()
 
 	// Apply every message.
 	for i, m := range vector.ApplyMessages {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Partially addresses #6652 

This was motivated by trying to sync the new FVM-based caterpillarnet using the LegacyVM. The 2 VMs are expected to interoperate, but don't, because the LegacyVM expects to use the "old" (genesis) pricelist, which is wrong for network v15.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

The proposed change is to make pricelist selection based on both epoch _and_ network version. For anything after network v8, we can select the pricelist based on the version.

The epoch-based selection is preserved for backwards compatibility alone.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
