### PR TITLE
feat: bench: simple sealing operations commands

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -109,6 +109,7 @@ func main() {
 		Commands: []*cli.Command{
 			proveCmd,
 			sealBenchCmd,
+			simpleCmd,
 			importBenchCmd,
 		},
 	}

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -280,7 +280,7 @@ var simpleWindowPost = &cli.Command{
 			Value: "t01000",
 		},
 	},
-	ArgsUsage: "[sealed] [cache] [comm R]",
+	ArgsUsage: "[sealed] [cache] [comm R] [sector num]",
 	Action: func(cctx *cli.Context) error {
 		maddr, err := address.NewFromString(cctx.String("miner-addr"))
 		if err != nil {
@@ -310,7 +310,13 @@ var simpleWindowPost = &cli.Command{
 			return err
 		}
 
-		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{1})
+		snum, err := strconv.ParseUint(cctx.Args().Get(3), 10, 64)
+		if err != nil {
+			return xerrors.Errorf("parsing sector num: %w", err)
+		}
+		sn := abi.SectorNumber(snum)
+
+		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{sn})
 		if err != nil {
 			return xerrors.Errorf("generating challenges: %w", err)
 		}
@@ -320,13 +326,13 @@ var simpleWindowPost = &cli.Command{
 		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
 			SectorInfo: prf.SectorInfo{
 				SealProof:    spt(sectorSize),
-				SectorNumber: 1,
+				SectorNumber: sn,
 				SealedCID:    commr,
 			},
 			CacheDirPath:     cctx.Args().Get(1),
 			PoStProofType:    wpt,
 			SealedSectorPath: cctx.Args().Get(0),
-		}, ch.Challenges[1])
+		}, ch.Challenges[sn])
 		if err != nil {
 			return err
 		}
@@ -361,7 +367,7 @@ var simpleWinningPost = &cli.Command{
 			Value: "t01000",
 		},
 	},
-	ArgsUsage: "[sealed] [cache] [comm R]",
+	ArgsUsage: "[sealed] [cache] [comm R] [sector num]",
 	Action: func(cctx *cli.Context) error {
 		maddr, err := address.NewFromString(cctx.String("miner-addr"))
 		if err != nil {
@@ -391,7 +397,13 @@ var simpleWinningPost = &cli.Command{
 			return err
 		}
 
-		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{1})
+		snum, err := strconv.ParseUint(cctx.Args().Get(3), 10, 64)
+		if err != nil {
+			return xerrors.Errorf("parsing sector num: %w", err)
+		}
+		sn := abi.SectorNumber(snum)
+
+		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{sn})
 		if err != nil {
 			return xerrors.Errorf("generating challenges: %w", err)
 		}
@@ -401,13 +413,13 @@ var simpleWinningPost = &cli.Command{
 		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
 			SectorInfo: prf.SectorInfo{
 				SealProof:    spt(sectorSize),
-				SectorNumber: 1,
+				SectorNumber: sn,
 				SealedCID:    commr,
 			},
 			CacheDirPath:     cctx.Args().Get(1),
 			PoStProofType:    wpt,
 			SealedSectorPath: cctx.Args().Get(0),
-		}, ch.Challenges[1])
+		}, ch.Challenges[sn])
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -1,0 +1,450 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/ipfs/go-cid"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/extern/sector-storage/ffiwrapper"
+	"github.com/filecoin-project/lotus/extern/sector-storage/storiface"
+	prf "github.com/filecoin-project/specs-actors/actors/runtime/proof"
+	"github.com/filecoin-project/specs-storage/storage"
+)
+
+var simpleCmd = &cli.Command{
+	Name:  "simple",
+	Usage: "Run basic sector operations",
+	Subcommands: []*cli.Command{
+		simpleAddPiece,
+		simplePreCommit1,
+		simplePreCommit2,
+		simpleWindowPost,
+		simpleWinningPost,
+	},
+}
+
+type benchSectorProvider map[storiface.SectorFileType]string
+
+func (b benchSectorProvider) AcquireSector(ctx context.Context, id storage.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, ptype storiface.PathType) (storiface.SectorPaths, func(), error) {
+	out := storiface.SectorPaths{
+		ID:          id.ID,
+		Unsealed:    b[storiface.FTUnsealed],
+		Sealed:      b[storiface.FTSealed],
+		Cache:       b[storiface.FTCache],
+		Update:      b[storiface.FTUpdate],
+		UpdateCache: b[storiface.FTUpdateCache],
+	}
+	return out, func() {}, nil
+}
+
+var _ ffiwrapper.SectorProvider = &benchSectorProvider{}
+
+var simpleAddPiece = &cli.Command{
+	Name:      "addpiece",
+	ArgsUsage: "[data] [unsealed]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "sector-size",
+			Value: "512MiB",
+			Usage: "size of the sectors in bytes, i.e. 32GiB",
+		},
+		&cli.StringFlag{
+			Name:  "miner-addr",
+			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
+			Value: "t01000",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := cctx.Context
+
+		maddr, err := address.NewFromString(cctx.String("miner-addr"))
+		if err != nil {
+			return err
+		}
+		amid, err := address.IDFromAddress(maddr)
+		if err != nil {
+			return err
+		}
+		mid := abi.ActorID(amid)
+
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("sector-size"))
+		if err != nil {
+			return err
+		}
+		sectorSize := abi.SectorSize(sectorSizeInt)
+
+		pp := benchSectorProvider{
+			storiface.FTUnsealed: cctx.Args().Get(1),
+		}
+		sealer, err := ffiwrapper.New(pp)
+		if err != nil {
+			return err
+		}
+
+		sr := storage.SectorRef{
+			ID: abi.SectorID{
+				Miner:  mid,
+				Number: 1,
+			},
+			ProofType: spt(sectorSize),
+		}
+
+		data, err := os.Open(cctx.Args().First())
+		if err != nil {
+			return xerrors.Errorf("open data file: %w", err)
+		}
+
+		start := time.Now()
+
+		pi, err := sealer.AddPiece(ctx, sr, []abi.UnpaddedPieceSize{}, abi.PaddedPieceSize(sectorSize).Unpadded(), data)
+		if err != nil {
+			return xerrors.Errorf("add piece: %w", err)
+		}
+
+		took := time.Now().Sub(start)
+
+		fmt.Printf("AddPiece %s (%s)\n", took, bps(abi.SectorSize(pi.Size), 1, took))
+		fmt.Printf("%s %d\n", pi.PieceCID, pi.Size)
+
+		return nil
+	},
+}
+
+var simplePreCommit1 = &cli.Command{
+	Name: "precommit1",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "sector-size",
+			Value: "512MiB",
+			Usage: "size of the sectors in bytes, i.e. 32GiB",
+		},
+		&cli.StringFlag{
+			Name:  "miner-addr",
+			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
+			Value: "t01000",
+		},
+	},
+	ArgsUsage: "[unsealed] [sealed] [cache] [[piece cid] [piece size]]...",
+	Action: func(cctx *cli.Context) error {
+		ctx := cctx.Context
+
+		maddr, err := address.NewFromString(cctx.String("miner-addr"))
+		if err != nil {
+			return err
+		}
+		amid, err := address.IDFromAddress(maddr)
+		if err != nil {
+			return err
+		}
+		mid := abi.ActorID(amid)
+
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("sector-size"))
+		if err != nil {
+			return err
+		}
+		sectorSize := abi.SectorSize(sectorSizeInt)
+
+		pp := benchSectorProvider{
+			storiface.FTUnsealed: cctx.Args().Get(0),
+			storiface.FTSealed:   cctx.Args().Get(1),
+			storiface.FTCache:    cctx.Args().Get(2),
+		}
+		sealer, err := ffiwrapper.New(pp)
+		if err != nil {
+			return err
+		}
+
+		sr := storage.SectorRef{
+			ID: abi.SectorID{
+				Miner:  mid,
+				Number: 1,
+			},
+			ProofType: spt(sectorSize),
+		}
+
+		var ticket [32]byte // all zero
+
+		pieces, err := ParsePieceInfos(cctx)
+		if err != nil {
+			return err
+		}
+
+		start := time.Now()
+
+		p1o, err := sealer.SealPreCommit1(ctx, sr, ticket[:], pieces)
+		if err != nil {
+			return xerrors.Errorf("precommit1: %w", err)
+		}
+
+		took := time.Now().Sub(start)
+
+		fmt.Printf("PreCommit1 %s (%s)\n", took, bps(sectorSize, 1, took))
+		fmt.Println(base64.StdEncoding.EncodeToString(p1o))
+		return nil
+	},
+}
+
+var simplePreCommit2 = &cli.Command{
+	Name: "precommit2",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "sector-size",
+			Value: "512MiB",
+			Usage: "size of the sectors in bytes, i.e. 32GiB",
+		},
+		&cli.StringFlag{
+			Name:  "miner-addr",
+			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
+			Value: "t01000",
+		},
+	},
+	ArgsUsage: "[sealed] [cache] [pc1 out]",
+	Action: func(cctx *cli.Context) error {
+		ctx := cctx.Context
+
+		maddr, err := address.NewFromString(cctx.String("miner-addr"))
+		if err != nil {
+			return err
+		}
+		amid, err := address.IDFromAddress(maddr)
+		if err != nil {
+			return err
+		}
+		mid := abi.ActorID(amid)
+
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("sector-size"))
+		if err != nil {
+			return err
+		}
+		sectorSize := abi.SectorSize(sectorSizeInt)
+
+		pp := benchSectorProvider{
+			storiface.FTSealed: cctx.Args().Get(0),
+			storiface.FTCache:  cctx.Args().Get(1),
+		}
+		sealer, err := ffiwrapper.New(pp)
+		if err != nil {
+			return err
+		}
+
+		p1o, err := base64.StdEncoding.DecodeString(cctx.Args().Get(2))
+		if err != nil {
+			return err
+		}
+
+		sr := storage.SectorRef{
+			ID: abi.SectorID{
+				Miner:  mid,
+				Number: 1,
+			},
+			ProofType: spt(sectorSize),
+		}
+
+		start := time.Now()
+
+		p2o, err := sealer.SealPreCommit2(ctx, sr, p1o)
+		if err != nil {
+			return xerrors.Errorf("precommit2: %w", err)
+		}
+
+		took := time.Now().Sub(start)
+
+		fmt.Printf("PreCommit2 %s (%s)\n", took, bps(sectorSize, 1, took))
+		fmt.Printf("d:%s r:%s\n", p2o.Unsealed, p2o.Sealed)
+		return nil
+	},
+}
+
+var simpleWindowPost = &cli.Command{
+	Name: "window-post",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "sector-size",
+			Value: "512MiB",
+			Usage: "size of the sectors in bytes, i.e. 32GiB",
+		},
+		&cli.StringFlag{
+			Name:  "miner-addr",
+			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
+			Value: "t01000",
+		},
+	},
+	ArgsUsage: "[sealed] [cache] [comm R]",
+	Action: func(cctx *cli.Context) error {
+		maddr, err := address.NewFromString(cctx.String("miner-addr"))
+		if err != nil {
+			return err
+		}
+		amid, err := address.IDFromAddress(maddr)
+		if err != nil {
+			return err
+		}
+		mid := abi.ActorID(amid)
+
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("sector-size"))
+		if err != nil {
+			return err
+		}
+		sectorSize := abi.SectorSize(sectorSizeInt)
+
+		var rand [32]byte // all zero
+
+		commr, err := cid.Parse(cctx.Args().Get(2))
+		if err != nil {
+			return xerrors.Errorf("parse commr: %w", err)
+		}
+
+		wpt, err := spt(sectorSize).RegisteredWindowPoStProof()
+		if err != nil {
+			return err
+		}
+
+		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{1})
+		if err != nil {
+			return xerrors.Errorf("generating challenges: %w", err)
+		}
+
+		start := time.Now()
+
+		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
+			SectorInfo: prf.SectorInfo{
+				SealProof:    spt(sectorSize),
+				SectorNumber: 1,
+				SealedCID:    commr,
+			},
+			CacheDirPath:     cctx.Args().Get(1),
+			PoStProofType:    wpt,
+			SealedSectorPath: cctx.Args().Get(0),
+		}, ch.Challenges[1])
+		if err != nil {
+			return err
+		}
+
+		challenge := time.Now()
+
+		proof, err := ffi.GenerateSinglePartitionWindowPoStWithVanilla(wpt, mid, rand[:], [][]byte{vp}, 0)
+		if err != nil {
+			return xerrors.Errorf("generate post: %w", err)
+		}
+
+		end := time.Now()
+
+		fmt.Printf("Vanilla %s (%s)\n", challenge.Sub(start), bps(sectorSize, 1, challenge.Sub(start)))
+		fmt.Printf("Proof %s (%s)\n", end.Sub(challenge), bps(sectorSize, 1, end.Sub(challenge)))
+		fmt.Println(base64.StdEncoding.EncodeToString(proof.ProofBytes))
+		return nil
+	},
+}
+
+var simpleWinningPost = &cli.Command{
+	Name: "winning-post",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "sector-size",
+			Value: "512MiB",
+			Usage: "size of the sectors in bytes, i.e. 32GiB",
+		},
+		&cli.StringFlag{
+			Name:  "miner-addr",
+			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
+			Value: "t01000",
+		},
+	},
+	ArgsUsage: "[sealed] [cache] [comm R]",
+	Action: func(cctx *cli.Context) error {
+		maddr, err := address.NewFromString(cctx.String("miner-addr"))
+		if err != nil {
+			return err
+		}
+		amid, err := address.IDFromAddress(maddr)
+		if err != nil {
+			return err
+		}
+		mid := abi.ActorID(amid)
+
+		sectorSizeInt, err := units.RAMInBytes(cctx.String("sector-size"))
+		if err != nil {
+			return err
+		}
+		sectorSize := abi.SectorSize(sectorSizeInt)
+
+		var rand [32]byte // all zero
+
+		commr, err := cid.Parse(cctx.Args().Get(2))
+		if err != nil {
+			return xerrors.Errorf("parse commr: %w", err)
+		}
+
+		wpt, err := spt(sectorSize).RegisteredWinningPoStProof()
+		if err != nil {
+			return err
+		}
+
+		ch, err := ffi.GeneratePoStFallbackSectorChallenges(wpt, mid, rand[:], []abi.SectorNumber{1})
+		if err != nil {
+			return xerrors.Errorf("generating challenges: %w", err)
+		}
+
+		start := time.Now()
+
+		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
+			SectorInfo: prf.SectorInfo{
+				SealProof:    spt(sectorSize),
+				SectorNumber: 1,
+				SealedCID:    commr,
+			},
+			CacheDirPath:     cctx.Args().Get(1),
+			PoStProofType:    wpt,
+			SealedSectorPath: cctx.Args().Get(0),
+		}, ch.Challenges[1])
+		if err != nil {
+			return err
+		}
+
+		challenge := time.Now()
+
+		proof, err := ffi.GenerateWinningPoStWithVanilla(wpt, mid, rand[:], [][]byte{vp})
+		if err != nil {
+			return xerrors.Errorf("generate post: %w", err)
+		}
+
+		end := time.Now()
+
+		fmt.Printf("Vanilla %s (%s)\n", challenge.Sub(start), bps(sectorSize, 1, challenge.Sub(start)))
+		fmt.Printf("Proof %s (%s)\n", end.Sub(challenge), bps(sectorSize, 1, end.Sub(challenge)))
+		fmt.Println(base64.StdEncoding.EncodeToString(proof[0].ProofBytes))
+		return nil
+	},
+}
+
+func ParsePieceInfos(cctx *cli.Context) ([]abi.PieceInfo, error) {
+	// supports only one for now
+
+	c, err := cid.Parse(cctx.Args().Get(3))
+	if err != nil {
+		return nil, xerrors.Errorf("parse piece cid: %w", err)
+	}
+
+	psize, err := strconv.ParseUint(cctx.Args().Get(4), 10, 64)
+	if err != nil {
+		return nil, xerrors.Errorf("parse piece size: %w", err)
+	}
+
+	return []abi.PieceInfo{
+		{
+			Size:     abi.PaddedPieceSize(psize),
+			PieceCID: c,
+		},
+	}, nil
+}

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -40,7 +40,7 @@ baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy 2048
 
 > Run PreCommit1
 
-$ ./lotus-bench simple precommit1 --sector-size 2k /tmp/unsealed /tmp/sealed /tmp/cache baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy 2048 
+$ ./lotus-bench simple precommit1 --sector-size 2k /tmp/unsealed /tmp/sealed /tmp/cache baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy 2048
 PreCommit1 30.151666ms (66.33 KiB/s)
 eyJfbG90dXNfU2VhbFJhbmRvbW5lc3MiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB[...]==
 
@@ -959,22 +959,32 @@ var simpleProveReplicaUpdate2 = &cli.Command{
 }
 
 func ParsePieceInfos(cctx *cli.Context, firstArg int) ([]abi.PieceInfo, error) {
-	// supports only one for now
-
-	c, err := cid.Parse(cctx.Args().Get(firstArg))
-	if err != nil {
-		return nil, xerrors.Errorf("parse piece cid: %w", err)
+	args := cctx.Args().Len() - firstArg
+	if args%2 != 0 {
+		return nil, xerrors.Errorf("piece info argunemts need to be supplied in pairs")
+	}
+	if args < 2 {
+		return nil, xerrors.Errorf("need at least one piece info argument")
 	}
 
-	psize, err := strconv.ParseUint(cctx.Args().Get(firstArg+1), 10, 64)
-	if err != nil {
-		return nil, xerrors.Errorf("parse piece size: %w", err)
-	}
+	out := make([]abi.PieceInfo, args/2)
 
-	return []abi.PieceInfo{
-		{
+	for i := 0; i < args/2; i++ {
+		c, err := cid.Parse(cctx.Args().Get(firstArg + (i * 2)))
+		if err != nil {
+			return nil, xerrors.Errorf("parse piece cid: %w", err)
+		}
+
+		psize, err := strconv.ParseUint(cctx.Args().Get(firstArg+(i*2)+1), 10, 64)
+		if err != nil {
+			return nil, xerrors.Errorf("parse piece size: %w", err)
+		}
+
+		out[i] = abi.PieceInfo{
 			Size:     abi.PaddedPieceSize(psize),
 			PieceCID: c,
-		},
-	}, nil
+		}
+	}
+
+	return out, nil
 }

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -30,6 +30,81 @@ import (
 var simpleCmd = &cli.Command{
 	Name:  "simple",
 	Usage: "Run basic sector operations",
+	Description: `Example sealing steps:
+
+> Create unsealed sector file
+
+$ ./lotus-bench simple addpiece --sector-size 2K /dev/zero /tmp/unsealed
+AddPiece 25.23225ms (79.26 KiB/s)
+baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy 2048
+
+> Run PreCommit1
+
+$ ./lotus-bench simple precommit1 --sector-size 2k /tmp/unsealed /tmp/sealed /tmp/cache baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy 2048 
+PreCommit1 30.151666ms (66.33 KiB/s)
+eyJfbG90dXNfU2VhbFJhbmRvbW5lc3MiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB[...]==
+
+> Run PreCommit2
+
+$ ./lotus-bench simple precommit2 --sector-size 2k /tmp/sealed /tmp/cache eyJfbG90dXNfU2VhbFJhbmRvbW5lc3MiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB[...]==
+PreCommit2 75.320167ms (26.55 KiB/s)
+d:baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy r:bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c
+
+> Run Commit1
+
+$ ./lotus-bench simple commit1 --sector-size 2k /tmp/sl /tmp/cac baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c /tmp/c1.json
+Commit1 20.691875ms (96.66 KiB/s)
+
+> Run Commit2
+
+$ ./lotus-bench simple commit2 /tmp/c1.json
+[...]
+Commit2: 13.829147792s (148 B/s)
+proof: 8b624a6a4b272a6196517f858d07205c586cfae77fc026e8e9340acefbb8fc1d5af25b33724756c0a4481a800e14ff1ea914c3ce20bf6e2932296ad8ffa32867989ceae62e50af1479ca56a1ea5228cc8acf5ca54bc0b8e452bf74194b758b2c12ece76599a8b93f6b3dd9f0b1bb2e023bf311e9a404c7d453aeddf284e46025b63b631610de6ff6621bc6f630a14dd3ad59edbe6e940fdebbca3d97bea2708fd21764ea929f4699ebc93d818037a74be3363bdb2e8cc29b3e386c6376ff98fa
+
+----
+Example PoSt steps:
+
+> Try window-post
+
+$ ./lotus-bench simple window-post --sector-size 2k /tmp/sealed /tmp/cache bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c 1
+Vanilla 14.192625ms (140.9 KiB/s)
+Proof 387.819333ms (5.156 KiB/s)
+mI6TdveK9wMqHwVsRlVa90q44yGEIsNqLpTQLB...
+
+> Try winning-post
+
+$ ./lotus-bench simple winning-post --sector-size 2k /tmp/sealed /tmp/cache bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c 1
+Vanilla 19.266625ms (103.8 KiB/s)
+Proof 1.234634708s (1.619 KiB/s)
+o4VBUf2wBHuvmm58XY8wgCC/1xBqfujlgmNs...
+
+----
+Example SnapDeals steps:
+
+> Create unsealed update file
+
+$ ./lotus-bench simple addpiece --sector-size 2K /dev/random /tmp/new-unsealed
+AddPiece 23.845958ms (83.87 KiB/s)
+baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy 2048
+
+> Create updated sealed file
+
+$ ./lotus-bench simple replicaupdate --sector-size 2K /tmp/sealed /tmp/cache /tmp/new-unsealed /tmp/update /tmp/update-cache baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy 2048
+ReplicaUpdate 63.0815ms (31.7 KiB/s)
+d:baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy r:bagboea4b5abcaydcwlbtdx5dph2a3efpqt42emxpn3be76iu4e4lx3ltrpmpi7af
+
+> Run ProveReplicaUpdate1
+
+$ ./lotus-bench simple provereplicaupdate1 --sector-size 2K /tmp/sl /tmp/cac /tmp/update /tmp/update-cache bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c bagboea4b5abcaydcwlbtdx5dph2a3efpqt42emxpn3be76iu4e4lx3ltrpmpi7af baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy /tmp/pr1.json
+ProveReplicaUpdate1 18.373375ms (108.9 KiB/s)
+
+> Run ProveReplicaUpdate2
+
+$ ./lotus-bench simple provereplicaupdate2 --sector-size 2K bagboea4b5abcbrshxgmmpaucffwp2elaofbcrvb7hmcu3653o4lsw2arlor4hn3c bagboea4b5abcaydcwlbtdx5dph2a3efpqt42emxpn3be76iu4e4lx3ltrpmpi7af baga6ea4seaqkt24j5gbf2ye2wual5gn7a5yl2tqb52v2sk4nvur4bdy7lg76cdy /tmp/pr1.json
+ProveReplicaUpdate2 7.339033459s (279 B/s)
+p: pvC0JBrEyUqtIIUvB2UUx/2a24c3Cvnu6AZ0D3IMBYAu...
+`,
 	Subcommands: []*cli.Command{
 		simpleAddPiece,
 		simplePreCommit1,
@@ -783,7 +858,7 @@ var simpleProveReplicaUpdate1 = &cli.Command{
 
 		vpjb, err := json.Marshal(&rvp)
 		if err != nil {
-			return xerrors.Errorf("json marshal vanillla proofs: %w", err)
+			return xerrors.Errorf("json marshal vanilla proofs: %w", err)
 		}
 
 		if err := ioutil.WriteFile(cctx.Args().Get(7), vpjb, 0666); err != nil {


### PR DESCRIPTION
## Related Issues
This is (eventually going to be) adding new lotus bench commands, mostly aimed to make new PoSt methods in https://github.com/filecoin-project/lotus/pull/7971 benchmarkable.

## Proposed Changes
This PR adds a bunch of new commands to lotus-bench which make it possible to execute individual sealing operations on sector files manually

Todo:
* [x] PoSt challenge generation
* [x] Distributed PoSt ops
* [x] Commit 1/2
* [x] SnapDeals
* [x] Output timing info
* [x] Good usage in the `lotus-bench simple` command
* [ ] <s>Flags to make it possible to reproduce any sector (miner, sector num, ticket, etc.)</s> - can be done later
* [ ] Full run script

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
