### PR TITLE
fix: miner: dead loop on removing sector

### DIFF
--- a/extern/storage-sealing/fsm.go
+++ b/extern/storage-sealing/fsm.go
@@ -320,7 +320,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	FaultReported: final, // not really supported right now
 
 	FaultedFinal: final,
-	Removed:      final,
+	Removed:      finalRemoved,
 
 	FailedUnrecoverable: final,
 }
@@ -692,6 +692,12 @@ func (m *Sealing) restartSectors(ctx context.Context) error {
 func (m *Sealing) ForceSectorState(ctx context.Context, id abi.SectorNumber, state SectorState) error {
 	m.startupWait.Wait()
 	return m.sectors.Send(id, SectorForceState{state})
+}
+
+// as sector has been removed, it's no needs to care about later events,
+// just returns length of events as `processed` is ok.
+func finalRemoved(events []statemachine.Event, state *SectorInfo) (uint64, error) {
+	return uint64(len(events)), nil
 }
 
 func final(events []statemachine.Event, state *SectorInfo) (uint64, error) {


### PR DESCRIPTION
## Proposed Changes
to remove a sector would cause the fsm(state machine) stuck in dead loop
use following cmd to remove a sector:
```shell
./lotus-miner sectors remove --really-do-it <sid> 
```
the sector state would change from 'any' to 'Removed', and there is a 'plan' in `fsmPlanners` for 'Removed' state:
https://github.com/filecoin-project/lotus/blob/b8b33c4f0666189142d1d9f948f92807c5796ae8/extern/storage-sealing/fsm.go#L309-L312
https://github.com/filecoin-project/lotus/blob/b8b33c4f0666189142d1d9f948f92807c5796ae8/extern/storage-sealing/fsm.go#L323
that is a  function named `final`, defined as following: 
https://github.com/filecoin-project/lotus/blob/b8b33c4f0666189142d1d9f948f92807c5796ae8/extern/storage-sealing/fsm.go#L697-L706
when `plan` above `final` on `SectorRemoved{}` event, the `final` would return an error, 
because  `SectorRemoved` doesn't implement `globalMutator`.
and here, the `Sealing.Plan` never return this error out,  and the `processed ` is 0:
https://github.com/filecoin-project/lotus/blob/b8b33c4f0666189142d1d9f948f92807c5796ae8/extern/storage-sealing/fsm.go#L19-L29
finally, in `statemachine.run`, 
https://github.com/filecoin-project/go-statemachine/blob/27f8fbb86dfde4cff15c0a936fe95bf4c90be168/machine.go#L79-L87
`fsm.mutateUser` would not get a error, and `processed` is 0, 
So, `pendingEvents` wouldn't reduce,  after is a go-routine, which called:
```go
	fsm.stageDone <- struct{}{}
```
as above described,  is a cycle of dead loop.

