### PR TITLE
remove markets data from `lotus-miner info`

### DIFF
--- a/cmd/lotus-miner/info.go
+++ b/cmd/lotus-miner/info.go
@@ -65,12 +65,6 @@ func infoCmdAct(cctx *cli.Context) error {
 	}
 	defer closer()
 
-	marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
-	if err != nil {
-		return err
-	}
-	defer closer()
-
 	fullapi, acloser, err := lcli.GetFullNodeAPI(cctx)
 	if err != nil {
 		return err
@@ -85,13 +79,6 @@ func infoCmdAct(cctx *cli.Context) error {
 	}
 
 	fmt.Println("Enabled subsystems (from miner API):", subsystems)
-
-	subsystems, err = marketsApi.RuntimeSubsystems(ctx)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Enabled subsystems (from markets API):", subsystems)
 
 	fmt.Print("Chain: ")
 
@@ -141,11 +128,6 @@ func infoCmdAct(cctx *cli.Context) error {
 	}
 
 	err = handleMiningInfo(ctx, cctx, fullapi, minerApi)
-	if err != nil {
-		return err
-	}
-
-	err = handleMarketsInfo(ctx, marketsApi)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed Changes
This PR is proposing to remove information about `markets` from the `lotus-miner info` command.

It looks like we are going in the direction of separating `markets` from the Lotus codebase, so it doesn't make sense to have client-side tools query `markets` or Boost from within Lotus.

Currently the `lotus-miner info` command fails for folks who have installed Boost, instead of `lotus-miner markets`. We'll add the missing APIs in order to be backward compatible, but going forward it might make sense to differentiate between the services and have separate command line utilities.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
