### PR TITLE
fix: node: Fix market node startup

### DIFF
--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -93,7 +93,7 @@ type StorageMinerAPI struct {
 	storiface.WorkerReturn `optional:"true"`
 	AddrSel                *storage.AddressSelector
 
-	WdPoSt *storage.WindowPoStScheduler
+	WdPoSt *storage.WindowPoStScheduler `optional:"true"`
 
 	Epp gen.WinningPoStProver `optional:"true"`
 	DS  dtypes.MetadataDS


### PR DESCRIPTION
Got broken in the [window-post API/CLI PR](https://github.com/filecoin-project/lotus/pull/8389)

On startup market nodes get:
```
ERROR: creating node: starting node: missing dependencies for function "reflect".makeFuncStub (/usr/lib/go/src/reflect/asm_amd64.s:30): missing type: *storage.WindowPoStScheduler

```
