### PR TITLE
Revert appimage removal

### DIFF
--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -49,4 +49,7 @@ do
 
     ipfs add -q "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.cid"
 done
+cp "../appimage/Lotus-${CIRCLE_TAG}-x86_64.AppImage" .
+sha512sum "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.sha512"
+ipfs add -q "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.cid"
 popd

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -68,6 +68,9 @@ artifacts=(
   "lotus_${CIRCLE_TAG}_darwin-amd64.tar.gz"
   "lotus_${CIRCLE_TAG}_darwin-amd64.tar.gz.cid"
   "lotus_${CIRCLE_TAG}_darwin-amd64.tar.gz.sha512"
+  "Lotus-${CIRCLE_TAG}-x86_64.AppImage"
+  "Lotus-${CIRCLE_TAG}-x86_64.AppImage.cid"
+  "Lotus-${CIRCLE_TAG}-x86_64.AppImage.sha512"
 )
 
 for RELEASE_FILE in "${artifacts[@]}"


### PR DESCRIPTION
this reverts two commits that were used to remove the appimage from release bundles.

https://github.com/filecoin-project/lotus/commit/6b0868089bf43fa5d2dc22784ad36e48b6fe6ec8
https://github.com/filecoin-project/lotus/commit/7d65a2664d795aee6eb0d811eddd4bd6b30cc26b


## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
<!-- provide a clear list of the changes being made-->


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
