### PR TITLE
ux: wallet: update delete usage

### DIFF
--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -499,7 +499,7 @@ var walletVerify = &cli.Command{
 }
 
 var walletDelete = &cli.Command{
-	Name:      "soft-delete",
+	Name:      "delete",
 	Usage:     "Soft delete an address from the wallet - hard deletion needed for permanent removal",
 	ArgsUsage: "<address> ",
 	Action: func(cctx *cli.Context) error {

--- a/cli/wallet_test.go
+++ b/cli/wallet_test.go
@@ -265,7 +265,7 @@ func TestWalletDelete(t *testing.T) {
 	mockApi.EXPECT().WalletDelete(ctx, addr).Return(nil)
 
 	//stm: @CLI_WALLET_DELETE_001
-	err = app.Run([]string{"wallet", "soft-delete", "f01234"})
+	err = app.Run([]string{"wallet", "delete", "f01234"})
 	assert.NoError(t, err)
 }
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -212,7 +212,7 @@ COMMANDS:
    set-default  Set default wallet address
    sign         sign a message
    verify       verify the signature of a message
-   soft-delete  Soft delete an address from the wallet - hard deletion needed for permanent removal
+   delete       Soft delete an address from the wallet - hard deletion needed for permanent removal
    market       Interact with market balances
    help, h      Shows a list of commands or help for one command
 
@@ -343,13 +343,13 @@ OPTIONS:
    
 ```
 
-### lotus wallet soft-delete
+### lotus wallet delete
 ```
 NAME:
-   lotus wallet soft-delete - Soft delete an address from the wallet - hard deletion needed for permanent removal
+   lotus wallet delete - Soft delete an address from the wallet - hard deletion needed for permanent removal
 
 USAGE:
-   lotus wallet soft-delete [command options] <address> 
+   lotus wallet delete [command options] <address> 
 
 OPTIONS:
    --help, -h  show help (default: false)


### PR DESCRIPTION
Renaming the cmd to soft-delete to better reflect what it does -  and specify that a hard deletion is needed for permanent removal.

Should address #6926 to a degree, becuase it tells the user that extra steps are needed at least.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
