### PR TITLE
fix: market: Reuse the market `PubSub` in index provider

### DIFF
--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -75,6 +75,11 @@ func ConfigStorageMiner(c interface{}) Option {
 	enableLibp2pNode := cfg.Subsystems.EnableMarkets // we enable libp2p nodes if the storage market subsystem is enabled, otherwise we don't
 
 	return Options(
+
+		// Needed to instantiate pubsub used by index provider via ConfigCommon
+		Override(new(dtypes.DrandSchedule), modules.BuiltinDrandConfig),
+		Override(new(dtypes.BootstrapPeers), modules.BuiltinBootstrap),
+		Override(new(dtypes.DrandBootstrap), modules.DrandBootstrap),
 		ConfigCommon(&cfg.Common, enableLibp2pNode),
 
 		Override(CheckFDLimit, modules.CheckFdLimit(build.MinerFDLimit)), // recommend at least 100k FD limit to miners


### PR DESCRIPTION
## Related Issues
N/A
## Proposed Changes
* The markets process instantiates its own `PubSub` instance with all validators, peer scoring, etc. set up. Use that instance to join the indexing topic, otherwise the default topic instantiated by index-provider internally (via go-legs) has no validators.

* Fixes the construction of `PubSub` via dependency injection mechanism in markets by binding its dependencies: bootstrap peers, drand related config.

~**Looks like DI for `PubSub` in markets is broken since it seems it was never used in markets before; waiting for confirmation that we indeed want validators for the gossipsub used by provider engine before spending time on fixing it.**~

## Additional Info
N/A

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
