### PR TITLE
feat: sched: Improve worker assigning logic

### DIFF
--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -76,6 +76,10 @@ type scheduler struct {
 type workerHandle struct {
 	workerRpc Worker
 
+	tasksCache  map[sealtasks.TaskType]struct{}
+	tasksUpdate time.Time
+	tasksLk     sync.Mutex
+
 	info storiface.WorkerInfo
 
 	preparing *activeResources // use with workerHandle.lk

--- a/extern/sector-storage/selector_alloc.go
+++ b/extern/sector-storage/selector_alloc.go
@@ -27,7 +27,7 @@ func newAllocSelector(index stores.SectorIndex, alloc storiface.SectorFileType, 
 }
 
 func (s *allocSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredSealProof, whnd *workerHandle) (bool, error) {
-	tasks, err := whnd.workerRpc.TaskTypes(ctx)
+	tasks, err := whnd.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
 	}

--- a/extern/sector-storage/selector_existing.go
+++ b/extern/sector-storage/selector_existing.go
@@ -29,7 +29,7 @@ func newExistingSelector(index stores.SectorIndex, sector abi.SectorID, alloc st
 }
 
 func (s *existingSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredSealProof, whnd *workerHandle) (bool, error) {
-	tasks, err := whnd.workerRpc.TaskTypes(ctx)
+	tasks, err := whnd.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
 	}

--- a/extern/sector-storage/selector_task.go
+++ b/extern/sector-storage/selector_task.go
@@ -20,7 +20,7 @@ func newTaskSelector() *taskSelector {
 }
 
 func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredSealProof, whnd *workerHandle) (bool, error) {
-	tasks, err := whnd.workerRpc.TaskTypes(ctx)
+	tasks, err := whnd.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
 	}
@@ -30,11 +30,12 @@ func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.
 }
 
 func (s *taskSelector) Cmp(ctx context.Context, _ sealtasks.TaskType, a, b *workerHandle) (bool, error) {
-	atasks, err := a.workerRpc.TaskTypes(ctx)
+	atasks, err := a.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
 	}
-	btasks, err := b.workerRpc.TaskTypes(ctx)
+
+	btasks, err := b.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
 	}


### PR DESCRIPTION
## Related Issues
Should fix things like https://github.com/filecoin-project/lotus/issues/7607

## Proposed Changes
Currently when the scheduler is assigning tasks to workers, it creates a list of `task->[]worker`. This list is sorted by worker utilization at the start of scheduling cycle, but it isn't re-sorted when assigning many tasks to many workers in one cycle. 

We could simply run the scheduling algorithm for each task in the queue separately, but this is unfortunately way too slow, so we have to do scheduling in batches, at least if we want to avoid rewriting it in a bigger way.

This PR aims to fix this issue by tracking change in worker utilization while processing the `acceptableWindows` array, which should result in much better scheduling decisions with only small increase of compute cost in scheduling.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
