### PR TITLE
fix: FVM: add finality check for consensus faults

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/filecoin-project/lotus/chain/actors/policy"
+
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/go-state-types/big"
@@ -169,6 +171,10 @@ func (x *FvmExtern) VerifyBlockSig(ctx context.Context, blk *types.BlockHeader) 
 }
 
 func (x *FvmExtern) workerKeyAtLookback(ctx context.Context, minerId address.Address, height abi.ChainEpoch) (address.Address, int64, error) {
+	if height < x.epoch-policy.ChainFinality {
+		return address.Undef, 0, xerrors.Errorf("cannot get worker key (currEpoch %d, height %d)", x.epoch, height)
+	}
+
 	gasUsed := int64(0)
 	gasAdder := func(gc GasCharge) {
 		// technically not overflow safe, but that's fine


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

This caused a state mismatch on _some_ FVM nodes on mainnet when executing message `bafy2bzacedvprfrgzze2fvqutxl5za3jtwaqzgq7nwzlewf6e3q7pk7fuh3e6`. While the fix is easy, we should try to understand why only some nodes lost consensus -- my guess is that those nodes that _stayed_ in consensus were using snaphots that did not have the state root in question, and so failed with a different error, but the same gas usage.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Add the missing fix.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
