### PR TITLE
sealing: Don't panic in ReleaseUnsealed with no ranges

### DIFF
--- a/extern/sector-storage/manager.go
+++ b/extern/sector-storage/manager.go
@@ -705,7 +705,7 @@ func (m *Manager) ReleaseUnsealed(ctx context.Context, sector storage.SectorRef,
 	if err != nil {
 		return err
 	}
-	if len(safeToFree) != 0 || safeToFree[0].Offset != 0 || safeToFree[0].Size.Padded() != abi.PaddedPieceSize(ssize) {
+	if len(safeToFree) == 0 || safeToFree[0].Offset != 0 || safeToFree[0].Size.Padded() != abi.PaddedPieceSize(ssize) {
 		// todo support partial free
 		return nil
 	}


### PR DESCRIPTION
Can happen after aborting upgrade of a snap sector with no deals added to it.