### PR TITLE
chore: config: default-disable kvlog

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -20,7 +20,7 @@
   #
   # type: bool
   # env var: LOTUS_BACKUP_DISABLEMETADATALOG
-  #DisableMetadataLog = false
+  #DisableMetadataLog = true
 
 
 [Logging]

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -20,7 +20,7 @@
   #
   # type: bool
   # env var: LOTUS_BACKUP_DISABLEMETADATALOG
-  #DisableMetadataLog = false
+  #DisableMetadataLog = true
 
 
 [Logging]

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -52,6 +52,9 @@ func defCommon() Common {
 				"example-subsystem": "INFO",
 			},
 		},
+		Backup: Backup{
+			DisableMetadataLog: true,
+		},
 		Libp2p: Libp2p{
 			ListenAddresses: []string{
 				"/ip4/0.0.0.0/tcp/0",


### PR DESCRIPTION
KVLog in its current form isn't generated correctly, and so far we didn't see any metadata corruption which couldn't be repaired with normal leveldb repair tools;

At some point it may be worth implementing a v2 of kvlog, but for now I think it's better to disable it by default as it seems to be a constant source of problems.