### PR TITLE
fix: market: Infer index provider topic from network name by default

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -291,11 +291,13 @@
   #EntriesChunkSize = 16384
 
   # TopicName sets the topic name on which the changes to the advertised content are announced.
-  # Defaults to '/indexer/ingest/mainnet' if not specified.
+  # If not explicitly specified, the topic name is automatically inferred from the network name
+  # in following format: '/indexer/ingest/<network-name>'
+  # Defaults to empty, which implies the topic name is inferred from network name.
   #
   # type: string
   # env var: LOTUS_INDEXPROVIDER_TOPICNAME
-  #TopicName = "/indexer/ingest/mainnet"
+  #TopicName = ""
 
   # PurgeCacheOnStart sets whether to clear any cached entries chunks when the provider engine
   # starts. By default, the cache is rehydrated from previously cached entries stored in

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -199,8 +199,10 @@ func DefaultStorageMiner() *StorageMiner {
 			Enable:               true,
 			EntriesCacheCapacity: 1024,
 			EntriesChunkSize:     16384,
-			TopicName:            "/indexer/ingest/mainnet",
-			PurgeCacheOnStart:    false,
+			// The default empty TopicName means it is inferred from network name, in the following
+			// format: "/indexer/ingest/<network-name>"
+			TopicName:         "",
+			PurgeCacheOnStart: false,
 		},
 
 		Subsystems: MinerSubsystemConfig{

--- a/node/config/def_test.go
+++ b/node/config/def_test.go
@@ -74,8 +74,8 @@ func TestDefaultMinerRoundtrip(t *testing.T) {
 	require.True(t, reflect.DeepEqual(c, c2))
 }
 
-func TestDefaultStorageMiner_SetsIndexIngestTopic(t *testing.T) {
+func TestDefaultStorageMiner_IsEmpty(t *testing.T) {
 	subject := DefaultStorageMiner()
 	require.True(t, subject.IndexProvider.Enable)
-	require.Equal(t, "/indexer/ingest/mainnet", subject.IndexProvider.TopicName)
+	require.Equal(t, "", subject.IndexProvider.TopicName)
 }

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -404,7 +404,9 @@ advertisements that include more multihashes than the configured EntriesChunkSiz
 			Type: "string",
 
 			Comment: `TopicName sets the topic name on which the changes to the advertised content are announced.
-Defaults to '/indexer/ingest/mainnet' if not specified.`,
+If not explicitly specified, the topic name is automatically inferred from the network name
+in following format: '/indexer/ingest/<network-name>'
+Defaults to empty, which implies the topic name is inferred from network name.`,
 		},
 		{
 			Name: "PurgeCacheOnStart",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -186,7 +186,9 @@ type IndexProviderConfig struct {
 	EntriesChunkSize int
 
 	// TopicName sets the topic name on which the changes to the advertised content are announced.
-	// Defaults to '/indexer/ingest/mainnet' if not specified.
+	// If not explicitly specified, the topic name is automatically inferred from the network name
+	// in following format: '/indexer/ingest/<network-name>'
+	// Defaults to empty, which implies the topic name is inferred from network name.
 	TopicName string
 
 	// PurgeCacheOnStart sets whether to clear any cached entries chunks when the provider engine

--- a/node/modules/storageminer_idxprov_test.go
+++ b/node/modules/storageminer_idxprov_test.go
@@ -1,0 +1,97 @@
+package modules_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	provider "github.com/filecoin-project/index-provider"
+	"github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/filecoin-project/lotus/node/modules"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+)
+
+func Test_IndexProviderTopic(t *testing.T) {
+	tests := []struct {
+		name                 string
+		givenAllowedTopics   []string
+		givenConfiguredTopic string
+		givenNetworkName     dtypes.NetworkName
+		wantErr              string
+	}{
+		{
+			name:                 "Joins configured topic when allowed",
+			givenAllowedTopics:   []string{"fish"},
+			givenConfiguredTopic: "fish",
+		},
+		{
+			name:               "Joins topic inferred from network name when allowed",
+			givenAllowedTopics: []string{"/indexer/ingest/fish"},
+			givenNetworkName:   "fish",
+		},
+		{
+			name:                 "Fails to join configured topic when disallowed",
+			givenAllowedTopics:   []string{"/indexer/ingest/fish"},
+			givenConfiguredTopic: "lobster",
+			wantErr:              "joining indexer topic lobster: topic is not allowed by the subscription filter",
+		},
+		{
+			name:               "Fails to join topic inferred from network name when disallowed",
+			givenAllowedTopics: []string{"/indexer/ingest/fish"},
+			givenNetworkName:   "lobster",
+			wantErr:            "joining indexer topic /indexer/ingest/lobster: topic is not allowed by the subscription filter",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			h, err := libp2p.New()
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, h.Close())
+			}()
+
+			filter := pubsub.WithSubscriptionFilter(pubsub.NewAllowlistSubscriptionFilter(test.givenAllowedTopics...))
+			ps, err := pubsub.NewGossipSub(ctx, h, filter)
+			require.NoError(t, err)
+
+			app := fx.New(
+				fx.Provide(
+					func() host.Host { return h },
+					func() dtypes.NetworkName { return test.givenNetworkName },
+					func() dtypes.MinerAddress { return dtypes.MinerAddress(address.TestAddress) },
+					func() dtypes.ProviderDataTransfer { return nil },
+					func() *pubsub.PubSub { return ps },
+					func() dtypes.MetadataDS { return datastore.NewMapDatastore() },
+					modules.IndexProvider(config.IndexProviderConfig{
+						Enable:    true,
+						TopicName: test.givenConfiguredTopic,
+					}),
+				),
+				fx.Invoke(func(p provider.Interface) {}),
+			)
+			err = app.Start(ctx)
+
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				err = app.Stop(ctx)
+				require.NoError(t, err)
+			} else {
+				require.True(t, strings.HasSuffix(err.Error(), test.wantErr))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related Issues
Fixes #8510

## Proposed Changes

Instead of a fixed default, the changes here infer the allowed indexer
topic name from network name automatically if the topic configuration is
left empty.


## Additional Info
Index provider integration uses a gossipsub topic to announce changes to
the advertised content. The topic name was fixed to the default topic
which is `/indexer/ingest/mainnet`.

In the case of lotus, the gossipsub validators enforce a list of topics
the instance is permitted to join by setting subscription filter option
when `PubSub` instance is constructed via DI.

Having the fixed topic name meant that any SP starting up a node on a
network other than `mainnet` would have to override the default config
to avoid the node crashing when index provider is enabled.


## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
