### PR TITLE
fix: worker: Download proofs if PRU2 is enabled

### DIFF
--- a/cmd/lotus-wallet/main.go
+++ b/cmd/lotus-wallet/main.go
@@ -144,7 +144,7 @@ var runCmd = &cli.Command{
 			Hidden: true,
 		},
 	},
-	Description: "For setup instructions see 'lotus-wallet --help'",
+	Description: "Needs FULLNODE_API_INFO env-var to be set before running (see lotus-wallet --help for setup instructions)",
 	Action: func(cctx *cli.Context) error {
 		log.Info("Starting lotus wallet")
 

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -295,6 +295,12 @@ var runCmd = &cli.Command{
 			}
 		}
 
+		if cctx.Bool("prove-replica-update2") {
+			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
+				return xerrors.Errorf("get params: %w", err)
+			}
+		}
+
 		var taskTypes []sealtasks.TaskType
 		var workerType string
 

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -289,13 +289,7 @@ var runCmd = &cli.Command{
 			return err
 		}
 
-		if cctx.Bool("commit") {
-			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
-				return xerrors.Errorf("get params: %w", err)
-			}
-		}
-
-		if cctx.Bool("prove-replica-update2") {
+		if cctx.Bool("commit") || cctx.Bool("prove-replica-update2") {
 			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
 				return xerrors.Errorf("get params: %w", err)
 			}


### PR DESCRIPTION
Currently the lotus-worker does not check or download the params if Prove Replica Update tasks are enabled, meaning that you get an param-error if you for example a run a new 'PC1 / RU / PRU2' worker and a SnapDeal gets assigned to it. Reported in #8549.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
