### PR TITLE
fix: lotus-wallet: correct network in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ BINS+=lotus-health
 
 lotus-wallet:
 	rm -f lotus-wallet
-	$(GOCC) build -o lotus-wallet ./cmd/lotus-wallet
+	$(GOCC) build $(GOFLAGS) -o lotus-wallet ./cmd/lotus-wallet
 .PHONY: lotus-wallet
 BINS+=lotus-wallet
 


### PR DESCRIPTION
Adding $(GOFLAGS) so that when compiling `lotus-wallet` on calibnet, the correct network is shown, instead of showing just `lotus-wallet version x.xx.x+mainnet`. Should address 2. in #8459

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
