### PR TITLE
fix: Clean up vanilla proof fetching errors for proper display

### DIFF
--- a/extern/sector-storage/stores/remote.go
+++ b/extern/sector-storage/stores/remote.go
@@ -827,7 +827,7 @@ func (r *Remote) GenerateSingleVanillaProof(ctx context.Context, minerID abi.Act
 					log.Error("response close: ", err)
 				}
 
-				return nil, xerrors.Errorf("non-200 code from %s: '%s'", url, string(body))
+				return nil, xerrors.Errorf("non-200 code from %s: '%s'", url, strings.TrimSpace(string(body)))
 			}
 
 			body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Results;
```
2  0  2374  good
2  0  2409  good
2  0  2282  bad (generating vanilla proof: non-200 code from http://10.224.3.83:1123/remote/vanilla/single: 'fsstat: path not found
')
2  0  2579  good
2  0  2338  good
```

This PR should change that to;
```
2  0  2374  good
2  0  2409  good
2  0  2282  bad (generating vanilla proof: non-200 code from http://10.224.3.83:1123/remote/vanilla/single: 'fsstat: path not found')
2  0  2579  good
2  0  2338  good
```

## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
<!-- provide a clear list of the changes being made-->


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
