### PR TITLE
[nv16] add support for v7 release bundles

### DIFF
--- a/build/bundles.toml
+++ b/build/bundles.toml
@@ -1,3 +1,7 @@
 [[bundles]]
 version = 8
 release = "b71c2ec785aec23d"
+
+[[bundles]]
+version = 7
+release = "8df1101fc15b616b"

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"bytes"
 	"context"
-	"os"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -288,7 +287,7 @@ func NewFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 		Tracing:        EnableDetailedTracing,
 	}
 
-	if os.Getenv("LOTUS_USE_FVM_CUSTOM_BUNDLE") == "1" {
+	if opts.NetworkVersion < network.Version16 {
 		av, err := actors.VersionForNetwork(opts.NetworkVersion)
 		if err != nil {
 			return nil, xerrors.Errorf("mapping network version to actors version: %w", err)

--- a/node/bundle/bundle.go
+++ b/node/bundle/bundle.go
@@ -18,7 +18,7 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("bundle-fetcher")
+var log = logging.Logger("bundle")
 
 type BundleFetcher struct {
 	path string

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -30,17 +30,17 @@ func FetchAndLoadBundle(ctx context.Context, basePath string, bs blockstore.Bloc
 
 	f, err := os.Open(path)
 	if err != nil {
-		return cid.Undef, xerrors.Errorf("error opening bundle for builtin-actors vresion %d: %w", av, err)
+		return cid.Undef, xerrors.Errorf("error opening bundle for builtin-actors version %d: %w", av, err)
 	}
 	defer f.Close() //nolint
 
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return cid.Undef, xerrors.Errorf("error reading bundle for builtin-actors vresion %d: %w", av, err)
+		return cid.Undef, xerrors.Errorf("error reading bundle for builtin-actors version %d: %w", av, err)
 	}
 
 	if err := actors.LoadBundle(ctx, bs, av, data); err != nil {
-		return cid.Undef, xerrors.Errorf("error loading bundle for builtin-actors vresion %d: %w", av, err)
+		return cid.Undef, xerrors.Errorf("error loading bundle for builtin-actors version %d: %w", av, err)
 	}
 
 	mfCid, ok := actors.GetManifest(av)

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -68,6 +68,12 @@ func FetchAndLoadBundles(ctx context.Context, bs blockstore.Blockstore, bar map[
 	}
 
 	for av, rel := range bar {
+		// if it is prior to v8 and not mainnet, then we don't really have a bundle
+		if av < actors.Version8 && netw != "mainnet" {
+			log.Warnf("no builtin-actors bundle for %s/v%d", netw, av)
+			continue
+		}
+
 		if _, err := FetchAndLoadBundle(ctx, path, bs, av, rel, netw); err != nil {
 			return err
 		}

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -30,6 +30,12 @@ func LoadBuiltinActors(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRe
 	}
 
 	for av, rel := range build.BuiltinActorReleases {
+		// if it is prior to v8 and not mainnet, then we don't really have a bundle
+		if av < actors.Version8 && netw != "mainnet" {
+			log.Warnf("no builtin-actors bundle for %s/v%d", netw, av)
+			continue
+		}
+
 		// first check to see if we know this release
 		key := dstore.NewKey(fmt.Sprintf("/builtin-actors/v%d/%s", av, rel))
 


### PR DESCRIPTION
So that we can finally sever the dependency between fvm and builtin-actors.