### PR TITLE
[nv16] flexible bundle loading

### DIFF
--- a/build/README-bundle.md
+++ b/build/README-bundle.md
@@ -34,10 +34,10 @@ development = true
 
 - You can also specify a URL, together with a sha256 checksum to avoid downloading from
   github.
-- You can also specify an EnvVar, to provide the path dynamically at runtime.
+- You can also specify an environment variable (`LOTUS_BUILTIN_ACTORS_VX_BUNDLE`), to provide the path dynamically at runtime.
 
 The precedence for bundle fetching/loading is as folllows:
-- Check the EnvVar; use the bundle specified by it.
+- Check the environment variable `LOTUS_BUILTIN_ACTORS_VX_BUNDLE` for version X bundle; use it if set.
 - Check the Path; use the bundle specified by it.
 - Check the URL; use the bundle specified by it, and verify the checksum which must be present.
 - Otherwise, use the release tag and download from github.

--- a/build/README-bundle.md
+++ b/build/README-bundle.md
@@ -6,7 +6,7 @@ The bundles are specified in build/bundles.toml using the following syntax:
 ```toml
 [[bundles]]
 version = X   # actors version
-release = tag # release gag
+release = tag # release tag
 ```
 
 This will add a bundle for version `X`, using the github release `tag`
@@ -29,6 +29,18 @@ release = tag # release gag
 path = /path/to/builtin-actors.car
 development = true
 ```
+
+## Additional Options for Bundles
+
+- You can also specify a URL, together with a sha256 checksum to avoid downloading from
+  github.
+- You can also specify an EnvVar, to provide the path dynamically at runtime.
+
+The precedence for bundle fetching/loading is as folllows:
+- Check the EnvVar; use the bundle specified by it.
+- Check the Path; use the bundle specified by it.
+- Check the URL; use the bundle specified by it, and verify the checksum which must be present.
+- Otherwise, use the release tag and download from github.
 
 ## Local Storage
 

--- a/build/bundle.go
+++ b/build/bundle.go
@@ -21,13 +21,18 @@ type Bundle struct {
 	// Release is the release id
 	Release string
 	// Path is the (optional) bundle path; takes precedence over url
-	Path string
+	Path map[string]string
 	// URL is the (optional) bundle URL; takes precdence over github release
-	URL string
-	// CHecksum is the bundle sha256 checksume in hex, when specifying a URL.
-	Checksum string
+	URL map[string]BundleURL
 	// Devlopment indicates whether this is a development version; when set, in conjunction with path,
 	// it will always load the bundle to the blockstore, without recording the manifest CID in the
 	// datastore.
 	Development bool
+}
+
+type BundleURL struct {
+	// URL is the url of the bundle
+	URL string
+	// Checksum is the sha256 checksum of the bundle
+	Checksum string
 }

--- a/build/bundle.go
+++ b/build/bundle.go
@@ -20,8 +20,14 @@ type Bundle struct {
 	Version actors.Version
 	// Release is the release id
 	Release string
-	// Path is the (optional) bundle path; uses the appropriate release bundle if unset
+	// EnvVar is the (optional) env var specifying the bundle path; takes precdence over path
+	EnvVar string
+	// Path is the (optional) bundle path; takes precedence over url
 	Path string
+	// URL is the (optional) bundle URL; takes precdence over github release
+	URL string
+	// CHecksum is the bundle sha256 checksume in hex, when specifying a URL.
+	Checksum string
 	// Devlopment indicates whether this is a development version; when set, in conjunction with path,
 	// it will always load the bundle to the blockstore, without recording the manifest CID in the
 	// datastore.

--- a/build/bundle.go
+++ b/build/bundle.go
@@ -20,8 +20,6 @@ type Bundle struct {
 	Version actors.Version
 	// Release is the release id
 	Release string
-	// EnvVar is the (optional) env var specifying the bundle path; takes precdence over path
-	EnvVar string
 	// Path is the (optional) bundle path; takes precedence over url
 	Path string
 	// URL is the (optional) bundle URL; takes precdence over github release

--- a/build/bundles.toml
+++ b/build/bundles.toml
@@ -1,3 +1,3 @@
 [[bundles]]
 version = 8
-release = "b71c2ec785aec23d"
+release = "dev/20220517"

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -87,7 +87,7 @@ func FetchAndLoadBundles(ctx context.Context, bs blockstore.Blockstore, bar map[
 	}
 
 	for av, bd := range bar {
-		envvar := fmt.Sprintf("LOGUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
+		envvar := fmt.Sprintf("LOTUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
 		switch {
 		case os.Getenv(envvar) != "":
 			// this is a local bundle, specified by an env var to load from the filesystem

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -86,13 +87,11 @@ func FetchAndLoadBundles(ctx context.Context, bs blockstore.Blockstore, bar map[
 	}
 
 	for av, bd := range bar {
+		envvar := fmt.Sprintf("LOGUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
 		switch {
-		case bd.EnvVar != "":
+		case os.Getenv(envvar) != "":
 			// this is a local bundle, specified by an env var to load from the filesystem
-			path := os.Getenv(bd.EnvVar)
-			if path == "" {
-				return xerrors.Errorf("bundle envvar is empty: %s", bd.EnvVar)
-			}
+			path := os.Getenv(envvar)
 
 			if _, err := LoadBundle(ctx, bs, path, av); err != nil {
 				return err

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -97,13 +97,13 @@ func FetchAndLoadBundles(ctx context.Context, bs blockstore.Blockstore, bar map[
 				return err
 			}
 
-		case bd.Path != "":
-			if _, err := LoadBundle(ctx, bs, bd.Path, av); err != nil {
+		case bd.Path[netw] != "":
+			if _, err := LoadBundle(ctx, bs, bd.Path[netw], av); err != nil {
 				return err
 			}
 
-		case bd.URL != "":
-			if _, err := FetchAndLoadBundleFromURL(ctx, path, bs, av, bd.Release, netw, bd.URL, bd.Checksum); err != nil {
+		case bd.URL[netw].URL != "":
+			if _, err := FetchAndLoadBundleFromURL(ctx, path, bs, av, bd.Release, netw, bd.URL[netw].URL, bd.URL[netw].Checksum); err != nil {
 				return err
 			}
 

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -68,14 +68,11 @@ func LoadBuiltinActors(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRe
 		}
 
 		// we haven't recorded it in the datastore, so we need to load it
+		envvar := fmt.Sprintf("LOGUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
 		var mfCid cid.Cid
 		switch {
-		case bd.EnvVar != "":
-			// this is a local bundle, specified by an env var to load from the filesystem
-			path := os.Getenv(bd.EnvVar)
-			if path == "" {
-				return result, xerrors.Errorf("bundle envvar is empty: %s", bd.EnvVar)
-			}
+		case os.Getenv(envvar) != "":
+			path := os.Getenv(envvar)
 
 			mfCid, err = bundle.LoadBundle(ctx, bs, path, av)
 			if err != nil {

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -67,7 +67,7 @@ func LoadBuiltinActors(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRe
 		}
 
 		// we haven't recorded it in the datastore, so we need to load it
-		envvar := fmt.Sprintf("LOGUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
+		envvar := fmt.Sprintf("LOTUS_BUILTIN_ACTORS_V%d_BUNDLE", av)
 		var mfCid cid.Cid
 		switch {
 		case os.Getenv(envvar) != "":


### PR DESCRIPTION
On top of #8658.

Adds flexibility for bundle fetching, which can use an env var or explicit URL to avoid downloading from github.

cc @travisperson 