### PR TITLE
feat: worker: lotus-worker run --no-default

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -189,7 +189,7 @@ var runCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "no-default",
-			Usage: "disable all default tasks, use the worker for storage only",
+			Usage: "disable all default compute tasks, use the worker for storage/fetching only",
 			Value: false,
 		},
 		&cli.IntFlag{

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -182,10 +182,14 @@ var runCmd = &cli.Command{
 			Usage: "enable window post",
 			Value: false,
 		},
-
 		&cli.BoolFlag{
 			Name:  "winningpost",
 			Usage: "enable winning post",
+			Value: false,
+		},
+		&cli.BoolFlag{
+			Name:  "no-default",
+			Usage: "disable all default tasks, use the worker for storage only",
 			Value: false,
 		},
 		&cli.IntFlag{
@@ -308,8 +312,11 @@ var runCmd = &cli.Command{
 		}
 
 		if workerType == "" {
-			workerType = sealtasks.WorkerSealing
 			taskTypes = append(taskTypes, sealtasks.TTFetch, sealtasks.TTCommit1, sealtasks.TTProveReplicaUpdate1, sealtasks.TTFinalize, sealtasks.TTFinalizeReplicaUpdate)
+
+			if !cctx.Bool("no-default") {
+				workerType = sealtasks.WorkerSealing
+			}
 		}
 
 		if (workerType == sealtasks.WorkerSealing || cctx.IsSet("addpiece")) && cctx.Bool("addpiece") {
@@ -335,6 +342,10 @@ var runCmd = &cli.Command{
 		}
 		if (workerType == sealtasks.WorkerSealing || cctx.IsSet("regen-sector-key")) && cctx.Bool("regen-sector-key") {
 			taskTypes = append(taskTypes, sealtasks.TTRegenSectorKey)
+		}
+
+		if cctx.Bool("no-default") && workerType == "" {
+			workerType = sealtasks.WorkerSealing
 		}
 
 		if len(taskTypes) == 0 {

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -49,7 +49,7 @@ OPTIONS:
    --regen-sector-key            enable regen sector key (default: true)
    --windowpost                  enable window post (default: false)
    --winningpost                 enable winning post (default: false)
-   --no-default                  disable all default tasks, use the worker for storage only (default: false)
+   --no-default                  disable all default compute tasks, use the worker for storage/fetching only (default: false)
    --parallel-fetch-limit value  maximum fetch operations to run in parallel (default: 5)
    --post-parallel-reads value   maximum number of parallel challenge reads (0 = no limit) (default: 128)
    --post-read-timeout value     time limit for reading PoSt challenges (0 = no limit) (default: 0s)

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -49,6 +49,7 @@ OPTIONS:
    --regen-sector-key            enable regen sector key (default: true)
    --windowpost                  enable window post (default: false)
    --winningpost                 enable winning post (default: false)
+   --no-default                  disable all default tasks, use the worker for storage only (default: false)
    --parallel-fetch-limit value  maximum fetch operations to run in parallel (default: 5)
    --post-parallel-reads value   maximum number of parallel challenge reads (0 = no limit) (default: 128)
    --post-read-timeout value     time limit for reading PoSt challenges (0 = no limit) (default: 0s)


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
lotus-worker has gained quite a lot of task-type flags, most of which are opt-out, which is a bit annoying, especially when creating storage-only workers. This PR adds a new flag which makes compute tasks opt-in instead of opt-out:

PreCommit1 worker before:
```
./lotus-worker run --precommit2=false --commit=false --prove-replica-update2=false --replica-update=false
```

PreCommit1 worker after:
```
./lotus-worker run --no-default --precommit1
```


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
