### PR TITLE
fix: drop nv14 support from the FVM

### DIFF
--- a/chain/consensus/filcns/compute_state.go
+++ b/chain/consensus/filcns/compute_state.go
@@ -2,7 +2,6 @@ package filcns
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 
 	"github.com/filecoin-project/lotus/chain/rand"
@@ -107,19 +106,6 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context, sm *stmgr.StateManager
 			NetworkVersion: sm.GetNetworkVersion(ctx, e),
 			BaseFee:        baseFee,
 			LookbackState:  stmgr.LookbackStateGetterForTipset(sm, ts),
-		}
-
-		if os.Getenv("LOTUS_USE_FVM_EXPERIMENTAL") == "1" {
-			// This is needed so that the FVM does not have to duplicate the genesis vesting schedule, one
-			// of the components of the circ supply calc.
-			// This field is NOT needed by the LegacyVM, and also NOT needed by the FVM from v15 onwards.
-			filVested, err := sm.GetFilVested(ctx, e)
-			if err != nil {
-				return nil, err
-			}
-
-			vmopt.FilVested = filVested
-			return vm.NewFVM(ctx, vmopt)
 		}
 
 		return sm.VMConstructor()(ctx, vmopt)

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -491,7 +491,6 @@ func VerifyPreSealedData(ctx context.Context, cs *store.ChainStore, sys vm.Sysca
 		Actors:         filcns.NewActorRegistry(),
 		Syscalls:       mkFakedSigSyscalls(sys),
 		CircSupplyCalc: csc,
-		FilVested:      big.Zero(),
 		NetworkVersion: nv,
 		BaseFee:        big.Zero(),
 	}

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -96,7 +96,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 		CircSupplyCalc: csc,
 		NetworkVersion: nv,
 		BaseFee:        big.Zero(),
-		FilVested:      big.Zero(),
 	}
 
 	vm, err := vm.NewLegacyVM(ctx, vmopt)

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -80,11 +80,6 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		return nil, fmt.Errorf("failed to handle fork: %w", err)
 	}
 
-	filVested, err := sm.GetFilVested(ctx, vmHeight)
-	if err != nil {
-		return nil, err
-	}
-
 	vmopt := &vm.VMOpts{
 		StateBase:      bstate,
 		Epoch:          vmHeight,
@@ -95,7 +90,6 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		CircSupplyCalc: sm.GetVMCirculatingSupply,
 		NetworkVersion: sm.GetNetworkVersion(ctx, pheight+1),
 		BaseFee:        types.NewInt(0),
-		FilVested:      filVested,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
 	}
 
@@ -218,11 +212,6 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		)
 	}
 
-	filVested, err := sm.GetFilVested(ctx, vmHeight)
-	if err != nil {
-		return nil, err
-	}
-
 	buffStore := blockstore.NewTieredBstore(sm.cs.StateBlockstore(), blockstore.NewMemorySync())
 	vmopt := &vm.VMOpts{
 		StateBase:      stateCid,
@@ -234,7 +223,6 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		CircSupplyCalc: sm.GetVMCirculatingSupply,
 		NetworkVersion: sm.GetNetworkVersion(ctx, ts.Height()+1),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
-		FilVested:      filVested,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
 	}
 	vmi, err := sm.newVM(ctx, vmopt)

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -79,11 +79,6 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		// future. It's not guaranteed to be accurate... but that's fine.
 	}
 
-	filVested, err := sm.GetFilVested(ctx, height)
-	if err != nil {
-		return cid.Undef, nil, err
-	}
-
 	r := rand.NewStateRand(sm.cs, ts.Cids(), sm.beacon, sm.GetNetworkVersion)
 	vmopt := &vm.VMOpts{
 		StateBase:      base,
@@ -95,7 +90,6 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		CircSupplyCalc: sm.GetVMCirculatingSupply,
 		NetworkVersion: sm.GetNetworkVersion(ctx, height),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
-		FilVested:      filVested,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
 	}
 	vmi, err := sm.newVM(ctx, vmopt)

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -258,19 +258,15 @@ type FVM struct {
 
 func NewFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 	log.Info("using the FVM, this is experimental!")
-	circToReport := opts.FilVested
-	// For v14 (and earlier), we perform the FilVested portion of the calculation, and let the FVM dynamically do the rest
-	// v15 and after, the circ supply is always constant per epoch, so we calculate the base and report it at creation
-	if opts.NetworkVersion >= network.Version15 {
-		state, err := state.LoadStateTree(cbor.NewCborStore(opts.Bstore), opts.StateBase)
-		if err != nil {
-			return nil, err
-		}
 
-		circToReport, err = opts.CircSupplyCalc(ctx, opts.Epoch, state)
-		if err != nil {
-			return nil, err
-		}
+	state, err := state.LoadStateTree(cbor.NewCborStore(opts.Bstore), opts.StateBase)
+	if err != nil {
+		return nil, err
+	}
+
+	circToReport, err := opts.CircSupplyCalc(ctx, opts.Epoch, state)
+	if err != nil {
+		return nil, err
 	}
 
 	fvmOpts := ffi.FVMOpts{

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -227,8 +227,6 @@ type VMOpts struct {
 	Actors         *ActorRegistry
 	Syscalls       SyscallBuilder
 	CircSupplyCalc CircSupplyCalculator
-	// Amount of FIL vested from genesis actors.
-	FilVested      abi.TokenAmount
 	NetworkVersion network.Version
 	BaseFee        abi.TokenAmount
 	LookbackState  LookbackStateGetter

--- a/chain/vm/vmi.go
+++ b/chain/vm/vmi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/filecoin-project/go-state-types/network"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 )
@@ -18,8 +19,10 @@ type Interface interface {
 	Flush(ctx context.Context) (cid.Cid, error)
 }
 
+var experimentalUseFvm = os.Getenv("LOTUS_USE_FVM_EXPERIMENTAL") == "1"
+
 func NewVM(ctx context.Context, opts *VMOpts) (Interface, error) {
-	if os.Getenv("LOTUS_USE_FVM_EXPERIMENTAL") == "1" {
+	if experimentalUseFvm && opts.NetworkVersion >= network.Version15 {
 		return NewFVM(ctx, opts)
 	}
 


### PR DESCRIPTION
## Proposed Changes
<!-- provide a clear list of the changes being made-->

Drop nv14 support from the FVM. The next FVM version will only support nv15+.

This change also disables the FVM before nv15, even if enabled through the environment variable. This allows "catching up" from before nv15, when the environment variable is set.


## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
