### PR TITLE
scheduling optimization

### DIFF
--- a/cmd/lotus-miner/run.go
+++ b/cmd/lotus-miner/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"strconv"
 
 	"github.com/filecoin-project/lotus/api/v1api"
 
@@ -49,6 +50,11 @@ var runCmd = &cli.Command{
 			Usage: "manage open file limit",
 			Value: true,
 		},
+		&cli.IntFlag{
+			Name:  "parallel-p1-limit",
+			Usage: "maximum pre commit1 operations to run in parallel",
+			Value: -1,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Bool("enable-gpu-proving") {
@@ -57,6 +63,8 @@ var runCmd = &cli.Command{
 				return err
 			}
 		}
+
+		os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit")))
 
 		ctx, _ := tag.New(lcli.DaemonContext(cctx),
 			tag.Insert(metrics.Version, build.BuildVersion),

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -152,6 +152,12 @@ func workersCmd(sealing bool) *cli.Command {
 				for _, gpu := range stat.Info.Resources.GPUs {
 					fmt.Printf("\tGPU: %s\n", color.New(gpuCol).Sprintf("%s, %sused", gpu, gpuUse))
 				}
+
+				plConfig, ok := stat.Info.TaskLimits[sealtasks.TTPreCommit1]
+				if ok && plConfig.LimitCount > 0 {
+					fmt.Printf("\tP1LIMIT:  [%s] %d/%d tasks are running\n",
+						barString(float64(plConfig.LimitCount), 0, float64(plConfig.RunCount)), plConfig.RunCount, plConfig.LimitCount)
+				}
 			}
 
 			return nil

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -208,6 +209,11 @@ var runCmd = &cli.Command{
 			Usage: "used when 'listen' is unspecified. must be a valid duration recognized by golang's time.ParseDuration function",
 			Value: "30m",
 		},
+		&cli.IntFlag{
+			Name:  "parallel-p1-limit",
+			Usage: "maximum precommit1 operations to run in parallel",
+			Value: -1,
+		},
 	},
 	Before: func(cctx *cli.Context) error {
 		if cctx.IsSet("address") {
@@ -227,6 +233,8 @@ var runCmd = &cli.Command{
 				return xerrors.Errorf("could not set no-gpu env: %+v", err)
 			}
 		}
+
+		os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit")))
 
 		limit, _, err := ulimit.GetLimit()
 		switch {

--- a/extern/sector-storage/sched_test.go
+++ b/extern/sector-storage/sched_test.go
@@ -161,9 +161,15 @@ func (s *schedTestWorker) Paths(ctx context.Context) ([]storiface.StoragePath, e
 }
 
 func (s *schedTestWorker) Info(ctx context.Context) (storiface.WorkerInfo, error) {
+	taskLimits := make(map[sealtasks.TaskType]*storiface.LimitConfig)
+	taskLimits[sealtasks.TTPreCommit1] = &storiface.LimitConfig{
+		LimitCount: 6,
+		RunCount:   0,
+	}
 	return storiface.WorkerInfo{
 		Hostname:        s.name,
 		IgnoreResources: s.ignoreResources,
+		TaskLimits:      taskLimits,
 		Resources:       s.resources,
 	}, nil
 }

--- a/extern/sector-storage/sched_worker.go
+++ b/extern/sector-storage/sched_worker.go
@@ -526,6 +526,7 @@ func (sw *schedWorker) startProcessingTask(req *workerRequest) error {
 		if err != nil {
 			log.Errorf("error executing worker (withResources): %+v", err)
 		}
+		sh.TaskReduce(req.taskType, sw.wid)
 	}()
 
 	return nil
@@ -555,6 +556,7 @@ func (sw *schedWorker) startProcessingReadyTask(req *workerRequest) error {
 		w.lk.Lock()
 
 		w.active.free(w.info.Resources, needRes)
+		sh.TaskReduce(req.taskType, sw.wid)
 
 		select {
 		case sw.taskDone <- struct{}{}:

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,6 +32,14 @@ type WorkerInfo struct {
 	// Default should be false (zero value, i.e. resources taken into account).
 	IgnoreResources bool
 	Resources       WorkerResources
+
+	TaskLimits  map[sealtasks.TaskType]*LimitConfig
+	TaskLimitLk sync.Mutex
+}
+
+type LimitConfig struct {
+	LimitCount int
+	RunCount   int
 }
 
 type WorkerResources struct {

--- a/extern/sector-storage/worker_local.go
+++ b/extern/sector-storage/worker_local.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -797,9 +798,26 @@ func (l *LocalWorker) Info(context.Context) (storiface.WorkerInfo, error) {
 		return storiface.WorkerInfo{}, xerrors.Errorf("interpreting resource env vars: %w", err)
 	}
 
+	// parallel-p1-limit
+	p1Limit := -1
+	if limit, ok := os.LookupEnv("PARALLEL_P1_LIMIT"); ok {
+		li, err := strconv.Atoi(limit)
+		if err != nil {
+			log.Errorf("failed to parse PARALLEL_P1_LIMIT env var, default=-1")
+		} else {
+			p1Limit = li
+		}
+	}
+	taskLimits := make(map[sealtasks.TaskType]*storiface.LimitConfig)
+	taskLimits[sealtasks.TTPreCommit1] = &storiface.LimitConfig{
+		LimitCount: p1Limit,
+		RunCount:   0,
+	}
+
 	return storiface.WorkerInfo{
 		Hostname:        hostname,
 		IgnoreResources: l.ignoreResources,
+		TaskLimits:      taskLimits,
 		Resources: storiface.WorkerResources{
 			MemPhysical: memPhysical,
 			MemUsed:     memUsed,


### PR DESCRIPTION
Add the --parallel-p1-limit parameter when the worker starts to set the maximum number of PreCommit1 tasks it can accept. When the miner schedules the PreCommit1 task to the worker, it will record the
The number assigned to it, when the number of assigned tasks is equal to the set maximum number of tasks, no new PreCommit1 tasks will be assigned to it, and will not be assigned again until a PreCommit1 task is executed.

The default value of the --parallel-p1-limit parameter is -1, which means no limit, and if the value of --parallel-p1-limit exceeds the maximum number of tasks that the worker hardware configuration can receive
won't work either.
When viewing worker information through lotus-miner sealing workers, the task number information of PreCommit1 will be displayed, as follows:
p1_limit: 15-7, 15 represents the value set by --parallel-p1-limit, 7 represents the number of PreCommit1 tasks currently running.