### PR TITLE
fix: vm: support raw blocks in chain export

### DIFF
--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car"
 	carutil "github.com/ipld/go-car/util"
+	mh "github.com/multiformats/go-multihash"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
@@ -142,7 +143,18 @@ func (cs *ChainStore) WalkSnapshot(ctx context.Context, ts *types.TipSet, inclRe
 
 		for _, c := range out {
 			if seen.Visit(c) {
-				if c.Prefix().Codec != cid.DagCBOR {
+				prefix := c.Prefix()
+
+				// Don't include identity CIDs.
+				if prefix.MhType == mh.IDENTITY {
+					continue
+				}
+
+				// We only include raw and dagcbor, for now.
+				// Raw for "code" CIDs.
+				switch prefix.Codec {
+				case cid.Raw, cid.DagCBOR:
+				default:
 					continue
 				}
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Support raw blocks in chain export. We now visit them, we just don't recurs on them.

We need this for NV16 to include code in chain snapshots.

NOTE: I've also checked the splitstore, and we appear to be doing the right thing there already.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green