### PR TITLE
feat: networking: add healthz and livez endpoints

### DIFF
--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -174,7 +174,7 @@ var runCmd = &cli.Command{
 		}
 
 		gwapi := gateway.NewNode(api, lookbackCap, waitLookback)
-		h, err := gateway.Handler(gwapi, serverOptions...)
+		h, err := gateway.Handler(gwapi, api, serverOptions...)
 		if err != nil {
 			return xerrors.Errorf("failed to set up gateway HTTP handler")
 		}

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -5,16 +5,17 @@ import (
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/filecoin-project/go-jsonrpc"
-	"github.com/filecoin-project/lotus/api"
+	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/metrics/proxy"
+	"github.com/filecoin-project/lotus/node"
 	"github.com/gorilla/mux"
 	promclient "github.com/prometheus/client_golang/prometheus"
 )
 
 // Handler returns a gateway http.Handler, to be mounted as-is on the server.
-func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) {
+func Handler(gwapi lapi.Gateway, api lapi.FullNode, opts ...jsonrpc.ServerOption) (http.Handler, error) {
 	m := mux.NewRouter()
 
 	serveRpc := func(path string, hnd interface{}) {
@@ -23,10 +24,10 @@ func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) 
 		m.Handle(path, rpcServer)
 	}
 
-	ma := proxy.MetricedGatewayAPI(a)
+	ma := proxy.MetricedGatewayAPI(gwapi)
 
 	serveRpc("/rpc/v1", ma)
-	serveRpc("/rpc/v0", api.Wrap(new(v1api.FullNodeStruct), new(v0api.WrapperV1Full), ma))
+	serveRpc("/rpc/v0", lapi.Wrap(new(v1api.FullNodeStruct), new(v0api.WrapperV1Full), ma))
 
 	registry := promclient.DefaultRegisterer.(*promclient.Registry)
 	exporter, err := prometheus.NewExporter(prometheus.Options{
@@ -37,6 +38,8 @@ func Handler(a api.Gateway, opts ...jsonrpc.ServerOption) (http.Handler, error) 
 		return nil, err
 	}
 	m.Handle("/debug/metrics", exporter)
+	m.Handle("/health/livez", node.NewLiveHandler(api))
+	m.Handle("/health/readyz", node.NewReadyHandler(api))
 	m.PathPrefix("/").Handler(http.DefaultServeMux)
 
 	/*ah := &auth.Handler{

--- a/itests/gateway_test.go
+++ b/itests/gateway_test.go
@@ -291,7 +291,7 @@ func startNodes(
 
 	// Create a gateway server in front of the full node
 	gwapi := gateway.NewNode(full, lookbackCap, stateWaitLookbackLimit)
-	handler, err := gateway.Handler(gwapi)
+	handler, err := gateway.Handler(gwapi, full)
 	require.NoError(t, err)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/node/health.go
+++ b/node/health.go
@@ -6,8 +6,11 @@ import (
 	"time"
 
 	lapi "github.com/filecoin-project/lotus/api"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/network"
 )
+
+var healthlog = logging.Logger("healthcheck")
 
 type HealthHandler struct {
 	healthy bool
@@ -36,7 +39,9 @@ func NewLiveHandler(api lapi.FullNode) *HealthHandler {
 		minutely := time.NewTicker(time.Minute)
 		headCh, err := api.ChainNotify(ctx)
 		if err != nil {
-			//TODO
+			healthlog.Warnf("failed to instantiate chain notify channel; liveliness cannot be determined. %s", err)
+			h.SetHealthy(false)
+			return
 		}
 		for {
 			select {

--- a/node/health.go
+++ b/node/health.go
@@ -1,0 +1,81 @@
+package node
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+type HealthHandler struct {
+	healthy bool
+}
+
+func (h *HealthHandler) SetHealthy(healthy bool) {
+	h.healthy = healthy
+}
+
+func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.healthy {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// The backend is considered alive so long as there have been recent
+// head changes. Being alive doesn't mean we are up to date, just moving.
+func NewLiveHandler(api lapi.FullNode) *HealthHandler {
+	ctx := context.Background()
+	h := HealthHandler{}
+	go func() {
+		const reset = 5
+		var countdown = 0
+		minutely := time.NewTicker(time.Minute)
+		headCh, err := api.ChainNotify(ctx)
+		if err != nil {
+			//TODO
+		}
+		for {
+			select {
+			case <-minutely.C:
+				countdown = countdown - 1
+				if countdown == 0 {
+					h.SetHealthy(false)
+				}
+			case <-headCh:
+				countdown = reset
+				h.SetHealthy(true)
+			}
+		}
+	}()
+	return &h
+}
+
+// Check if we are ready to handle traffic.
+// 1. sync workers are caught up.
+// 2
+func NewReadyHandler(api lapi.FullNode) *HealthHandler {
+	ctx := context.Background()
+	h := HealthHandler{}
+	go func() {
+		const heightTolerance = uint64(5)
+		var nethealth, synchealth bool
+		minutely := time.NewTicker(time.Minute)
+		for {
+			select {
+			case <-minutely.C:
+				netstat, err := api.NetAutoNatStatus(ctx)
+				nethealth = err == nil && netstat.Reachability != network.ReachabilityUnknown
+
+				nodestat, err := api.NodeStatus(ctx, false)
+				synchealth = err == nil && nodestat.SyncStatus.Behind < heightTolerance
+
+				h.SetHealthy(nethealth && synchealth)
+			}
+		}
+	}()
+	return &h
+}

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -114,6 +114,8 @@ func FullNodeHandler(a v1api.FullNode, permissioned bool, opts ...jsonrpc.Server
 	m.Handle("/debug/pprof-set/mutex", handleFractionOpt("MutexProfileFraction", func(x int) {
 		runtime.SetMutexProfileFraction(x)
 	}))
+	m.Handle("/health/livez", NewLiveHandler(a))
+	m.Handle("/health/readyz", NewReadyHandler(a))
 	m.PathPrefix("/").Handler(http.DefaultServeMux) // pprof
 
 	return m, nil


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes

* New endpoints healthz and livez, this is helpful for kubernetes readiness and liveness probes.

* not included in this change, we will want to add an additional readiness probe to the gateway


## Additional Info
see https://kubernetes.io/docs/reference/using-api/health-checks/
On k8s, health endpoints like this are used to move nodes into and out of service and load balancer pools.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
