### PR TITLE
fix: vm: always set the root message in execution traces in the FVM

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -314,7 +314,8 @@ func NewFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 
 func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet, error) {
 	start := build.Clock.Now()
-	msgBytes, err := cmsg.VMMessage().Serialize()
+	vmMsg := cmsg.VMMessage()
+	msgBytes, err := vmMsg.Serialize()
 	if err != nil {
 		return nil, xerrors.Errorf("serializing msg: %w", err)
 	}
@@ -324,11 +325,11 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 		return nil, xerrors.Errorf("applying msg: %w", err)
 	}
 
-	var et FvmExecutionTrace
-	if len(ret.ExecTraceBytes) != 0 {
-		if err = et.UnmarshalCBOR(bytes.NewReader(ret.ExecTraceBytes)); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal exectrace: %w", err)
-		}
+	duration := time.Since(start)
+	receipt := types.MessageReceipt{
+		Return:   ret.Return,
+		ExitCode: exitcode.ExitCode(ret.ExitCode),
+		GasUsed:  ret.GasUsed,
 	}
 
 	var aerr aerrors.ActorError
@@ -340,12 +341,24 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 		aerr = aerrors.New(exitcode.ExitCode(ret.ExitCode), amsg)
 	}
 
+	var et types.ExecutionTrace
+	if len(ret.ExecTraceBytes) != 0 {
+		var fvmEt FvmExecutionTrace
+		if err = fvmEt.UnmarshalCBOR(bytes.NewReader(ret.ExecTraceBytes)); err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal exectrace: %w", err)
+		}
+		et = fvmEt.ToExecutionTrace()
+	} else {
+		et.Msg = vmMsg
+		et.MsgRct = &receipt
+		et.Duration = duration
+		if aerr != nil {
+			et.Error = aerr.Error()
+		}
+	}
+
 	return &ApplyRet{
-		MessageReceipt: types.MessageReceipt{
-			Return:   ret.Return,
-			ExitCode: exitcode.ExitCode(ret.ExitCode),
-			GasUsed:  ret.GasUsed,
-		},
+		MessageReceipt: receipt,
 		GasCosts: &GasOutputs{
 			BaseFeeBurn:        ret.BaseFeeBurn,
 			OverEstimationBurn: ret.OverEstimationBurn,
@@ -356,14 +369,15 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 			GasBurned:          ret.GasBurned,
 		},
 		ActorErr:       aerr,
-		ExecutionTrace: et.ToExecutionTrace(),
-		Duration:       time.Since(start),
+		ExecutionTrace: et,
+		Duration:       duration,
 	}, nil
 }
 
 func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*ApplyRet, error) {
 	start := build.Clock.Now()
-	msgBytes, err := cmsg.VMMessage().Serialize()
+	vmMsg := cmsg.VMMessage()
+	msgBytes, err := vmMsg.Serialize()
 	if err != nil {
 		return nil, xerrors.Errorf("serializing msg: %w", err)
 	}
@@ -372,11 +386,11 @@ func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*
 		return nil, xerrors.Errorf("applying msg: %w", err)
 	}
 
-	var et FvmExecutionTrace
-	if len(ret.ExecTraceBytes) != 0 {
-		if err = et.UnmarshalCBOR(bytes.NewReader(ret.ExecTraceBytes)); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal exectrace: %w", err)
-		}
+	duration := time.Since(start)
+	receipt := types.MessageReceipt{
+		Return:   ret.Return,
+		ExitCode: exitcode.ExitCode(ret.ExitCode),
+		GasUsed:  ret.GasUsed,
 	}
 
 	var aerr aerrors.ActorError
@@ -388,15 +402,27 @@ func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*
 		aerr = aerrors.New(exitcode.ExitCode(ret.ExitCode), amsg)
 	}
 
+	var et types.ExecutionTrace
+	if len(ret.ExecTraceBytes) != 0 {
+		var fvmEt FvmExecutionTrace
+		if err = fvmEt.UnmarshalCBOR(bytes.NewReader(ret.ExecTraceBytes)); err != nil {
+			return nil, xerrors.Errorf("failed to unmarshal exectrace: %w", err)
+		}
+		et = fvmEt.ToExecutionTrace()
+	} else {
+		et.Msg = vmMsg
+		et.MsgRct = &receipt
+		et.Duration = duration
+		if aerr != nil {
+			et.Error = aerr.Error()
+		}
+	}
+
 	return &ApplyRet{
-		MessageReceipt: types.MessageReceipt{
-			Return:   ret.Return,
-			ExitCode: exitcode.ExitCode(ret.ExitCode),
-			GasUsed:  ret.GasUsed,
-		},
+		MessageReceipt: receipt,
 		ActorErr:       aerr,
-		ExecutionTrace: et.ToExecutionTrace(),
-		Duration:       time.Since(start),
+		ExecutionTrace: et,
+		Duration:       duration,
 	}, nil
 }
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

fixes #8636

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Even when disabled. This mimics the behavior or the lotus VM.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green