### PR TITLE
build: set NetworkBundle in params file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,23 +68,18 @@ build-devnets: build lotus-seed lotus-shed lotus-wallet lotus-gateway lotus-foun
 .PHONY: build-devnets
 
 debug: GOFLAGS+=-tags=debug
-debug: GOFLAGS+=-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=devnet
 debug: build-devnets
 
 2k: GOFLAGS+=-tags=2k
-2k: GOFLAGS+=-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=devnet
 2k: build-devnets
 
 calibnet: GOFLAGS+=-tags=calibnet
-calibnet: GOFLAGS+=-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=calibnet
 calibnet: build-devnets
 
 butterflynet: GOFLAGS+=-tags=butterflynet
-butterflynet: GOFLAGS+=-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=butterflynet
 butterflynet: build-devnets
 
 interopnet: GOFLAGS+=-tags=interopnet
-interopnet: GOFLAGS+=-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=interopnet
 interopnet: build-devnets
 
 lotus: $(BUILD_DEPS)

--- a/build/bundle.go
+++ b/build/bundle.go
@@ -6,23 +6,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors"
 )
 
-var NetworkBundle string
-
-func GetNetworkBundle() string {
-	switch NetworkBundle {
-	case "devnet":
-		return "devnet"
-	case "calibnet", "calibrationnet":
-		return "calibrationnet"
-	case "butterflynet":
-		return "butterflynet"
-	case "interopnet", "caterpillarnet":
-		return "caterpillarnet"
-	default:
-		return "mainnet"
-	}
-}
-
 //go:embed bundles.toml
 var BuiltinActorBundles []byte
 

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -16,6 +16,7 @@ import (
 
 const BootstrappersFile = ""
 const GenesisFile = ""
+const NetworkBundle = "devnet"
 
 const GenesisNetworkVersion = network.Version15
 

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -18,6 +18,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 
 const GenesisNetworkVersion = network.Version14
 
+const NetworkBundle = "butterflynet"
 const BootstrappersFile = "butterflynet.pi"
 const GenesisFile = "butterflynet.car"
 

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -18,6 +18,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 
 const GenesisNetworkVersion = network.Version0
 
+const NetworkBundle = "calibrationnet"
 const BootstrappersFile = "calibnet.pi"
 const GenesisFile = "calibnet.car"
 

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
+const NetworkBundle = "caterpillarnet"
 const BootstrappersFile = "interopnet.pi"
 const GenesisFile = "interopnet.car"
 

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -19,6 +19,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	UpgradeSmokeHeight: DrandMainnet,
 }
 
+const NetworkBundle = "mainnet"
 const GenesisNetworkVersion = network.Version0
 
 const BootstrappersFile = "mainnet.pi"

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -107,6 +107,7 @@ var (
 	}
 
 	GenesisNetworkVersion = network.Version0
+	NetworkBundle         = "devnet"
 
 	NewestNetworkVersion       = network.Version15
 	ActorUpgradeNetworkVersion = network.Version15

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -72,7 +72,7 @@ func LoadBundle(ctx context.Context, bs blockstore.Blockstore, path string, av a
 
 // utility for blanket loading outside DI
 func FetchAndLoadBundles(ctx context.Context, bs blockstore.Blockstore, bar map[actors.Version]build.Bundle) error {
-	netw := build.GetNetworkBundle()
+	netw := build.NetworkBundle
 
 	path := os.Getenv("LOTUS_PATH")
 	if path == "" {

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -25,7 +25,7 @@ func LoadBuiltinActors(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRe
 
 	// We can't put it as a dep in inputs causes a stack overflow in DI from circular dependency
 	// So we pass it through ldflags instead
-	netw := build.GetNetworkBundle()
+	netw := build.NetworkBundle
 
 	for av, bd := range build.BuiltinActorReleases {
 		// first check to see if we know this release


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

fixes #8684

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Set `NetworkBundle` in params file instead of in the Makefile. Otherwise, we end up overriding the
ldflags.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green