### PR TITLE
feat: cli: New commands for testing.

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -2152,7 +2152,7 @@ var sectorsCompactPartitionsCmd = &cli.Command{
 			partitions.Set(uint64(partition))
 		}
 
-		params := miner5.CompactPartitionsParams{
+		params := miner.CompactPartitionsParams{
 			Deadline:   deadline,
 			Partitions: partitions,
 		}
@@ -2165,7 +2165,7 @@ var sectorsCompactPartitionsCmd = &cli.Command{
 		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
 			From:   minfo.Worker,
 			To:     maddr,
-			Method: miner.Methods.CompactPartitions,
+			Method: builtin.MethodsMiner.CompactPartitions,
 			Value:  big.Zero(),
 			Params: sp,
 		}, nil)

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -59,6 +59,7 @@ var sectorsCmd = &cli.Command{
 		sectorsCapacityCollateralCmd,
 		sectorsBatching,
 		sectorsRefreshPieceMatchingCmd,
+		sectorsCompactPartitionsCmd,
 	},
 }
 
@@ -2088,4 +2089,92 @@ func yesno(b bool) string {
 		return color.GreenString("YES")
 	}
 	return color.RedString("NO")
+}
+
+var sectorsCompactPartitionsCmd = &cli.Command{
+	Name:  "compact-partitions",
+	Usage: "removes dead sectors from partitions and reduces the number of partitions used if possible",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name:     "deadline",
+			Usage:    "the deadline to compact the partitions in",
+			Required: true,
+		},
+		&cli.Int64SliceFlag{
+			Name:     "partitions",
+			Usage:    "list of partitions to compact sectors in",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "really-do-it",
+			Usage: "Actually send transaction performing the action",
+			Value: false,
+		},
+		&cli.StringFlag{
+			Name:  "actor",
+			Usage: "TODO",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if !cctx.Bool("really-do-it") {
+			fmt.Println("Pass --really-do-it to actually execute this action")
+			return nil
+		}
+
+		api, acloser, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer acloser()
+
+		ctx := lcli.ReqContext(cctx)
+
+		maddr, err := getActorAddress(ctx, cctx)
+		if err != nil {
+			return err
+		}
+
+		minfo, err := api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		deadline := cctx.Uint64("deadline")
+
+		parts := cctx.Int64Slice("partitions")
+		if len(parts) <= 0 {
+			return fmt.Errorf("must include at least one partition to compact")
+		}
+		fmt.Printf("compacting %d paritions\n", len(parts))
+
+		partitions := bitfield.New()
+		for _, partition := range parts {
+			partitions.Set(uint64(partition))
+		}
+
+		params := miner5.CompactPartitionsParams{
+			Deadline:   deadline,
+			Partitions: partitions,
+		}
+
+		sp, err := actors.SerializeParams(&params)
+		if err != nil {
+			return xerrors.Errorf("serializing params: %w", err)
+		}
+
+		smsg, err := api.MpoolPushMessage(ctx, &types.Message{
+			From:   minfo.Worker,
+			To:     maddr,
+			Method: miner.Methods.CompactPartitions,
+			Value:  big.Zero(),
+			Params: sp,
+		}, nil)
+		if err != nil {
+			return xerrors.Errorf("mpool push: %w", err)
+		}
+
+		fmt.Println("Message CID:", smsg.Cid())
+
+		return nil
+	},
 }

--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -389,7 +389,7 @@ var sendInvalidWindowPoStCmd = &cli.Command{
 
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
-			return err
+			return xerrors.Errorf("getting api: %w", err)
 		}
 		defer acloser()
 
@@ -397,15 +397,18 @@ var sendInvalidWindowPoStCmd = &cli.Command{
 
 		maddr, err := address.NewFromString(cctx.String("actor"))
 		if err != nil {
-			return err
+			return xerrors.Errorf("getting actor address: %w", err)
 		}
 
 		minfo, err := api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
 		if err != nil {
-			return err
+			return xerrors.Errorf("getting mienr info: %w", err)
 		}
 
 		deadline, err := api.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
+		if err != nil {
+			return xerrors.Errorf("getting deadline: %w", err)
+		}
 
 		partitionIndices := cctx.Int64Slice("partitions")
 		if len(partitionIndices) <= 0 {
@@ -418,6 +421,9 @@ var sendInvalidWindowPoStCmd = &cli.Command{
 		}
 
 		checkRand, err := api.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, deadline.Challenge, nil, chainHead.Key())
+		if err != nil {
+			return xerrors.Errorf("getting randomness: %w", err)
+		}
 
 		proofSize, err := minfo.WindowPoStProofType.ProofSize()
 		if err != nil {
@@ -495,12 +501,12 @@ var generateAndSendConsensusFaultCmd = &cli.Command{
 
 		blockCid, err := cid.Parse(cctx.Args().First())
 		if err != nil {
-			return err
+			return xerrors.Errorf("getting first arg: %w", err)
 		}
 
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
-			return err
+			return xerrors.Errorf("getting chain head: %w", err)
 		}
 		defer acloser()
 
@@ -517,6 +523,9 @@ var generateAndSendConsensusFaultCmd = &cli.Command{
 		}
 
 		blockHeader, err := api.ChainGetBlock(ctx, blockCid)
+		if err != nil {
+			return xerrors.Errorf("getting block header: %w", err)
+		}
 
 		blockHeaderCopy := *blockHeader
 		blockHeaderCopy.ForkSignaling = blockHeader.ForkSignaling + 1

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -195,7 +195,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		fmt.Println("DEPRECATED: This behavior is being moved to `lotus verifreg`")
+		fmt.Println("DEPRECATED: This behavior is being moved to `lotus filplus`")
 		froms := cctx.String("from")
 		if froms == "" {
 			return fmt.Errorf("must specify from address with --from")
@@ -264,7 +264,7 @@ var verifRegListVerifiersCmd = &cli.Command{
 	Usage:  "list all verifiers",
 	Hidden: true,
 	Action: func(cctx *cli.Context) error {
-		fmt.Println("DEPRECATED: This behavior is being moved to `lotus verifreg`")
+		fmt.Println("DEPRECATED: This behavior is being moved to `lotus filplus`")
 		api, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -296,7 +296,7 @@ var verifRegListClientsCmd = &cli.Command{
 	Usage:  "list all verified clients",
 	Hidden: true,
 	Action: func(cctx *cli.Context) error {
-		fmt.Println("DEPRECATED: This behavior is being moved to `lotus verifreg`")
+		fmt.Println("DEPRECATED: This behavior is being moved to `lotus filplus`")
 		api, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -328,7 +328,7 @@ var verifRegCheckClientCmd = &cli.Command{
 	Usage:  "check verified client remaining bytes",
 	Hidden: true,
 	Action: func(cctx *cli.Context) error {
-		fmt.Println("DEPRECATED: This behavior is being moved to `lotus verifreg`")
+		fmt.Println("DEPRECATED: This behavior is being moved to `lotus filplus`")
 		if !cctx.Args().Present() {
 			return fmt.Errorf("must specify client address to check")
 		}
@@ -364,7 +364,7 @@ var verifRegCheckVerifierCmd = &cli.Command{
 	Usage:  "check verifiers remaining bytes",
 	Hidden: true,
 	Action: func(cctx *cli.Context) error {
-		fmt.Println("DEPRECATED: This behavior is being moved to `lotus verifreg`")
+		fmt.Println("DEPRECATED: This behavior is being moved to `lotus filplus`")
 		if !cctx.Args().Present() {
 			return fmt.Errorf("must specify verifier address to check")
 		}

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -2039,7 +2039,7 @@ OPTIONS:
    --deadline value    the deadline to compact the partitions in (default: 0)
    --partitions value  list of partitions to compact sectors in
    --really-do-it      Actually send transaction performing the action (default: false)
-   --actor value       TODO
+   --actor value       Specify the address of the miner to run this command
    --help, -h          show help (default: false)
    
 ```

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1685,6 +1685,7 @@ COMMANDS:
    get-cc-collateral     Get the collateral required to pledge a committed capacity sector
    batching              manage batch sector operations
    match-pending-pieces  force a refreshed match of pending pieces to open sectors without manually waiting for more deals
+   compact-partitions    removes dead sectors from partitions and reduces the number of partitions used if possible
    help, h               Shows a list of commands or help for one command
 
 OPTIONS:
@@ -2023,6 +2024,23 @@ USAGE:
 
 OPTIONS:
    --help, -h  show help (default: false)
+   
+```
+
+### lotus-miner sectors compact-partitions
+```
+NAME:
+   lotus-miner sectors compact-partitions - removes dead sectors from partitions and reduces the number of partitions used if possible
+
+USAGE:
+   lotus-miner sectors compact-partitions [command options] [arguments...]
+
+OPTIONS:
+   --deadline value    the deadline to compact the partitions in (default: 0)
+   --partitions value  list of partitions to compact sectors in
+   --really-do-it      Actually send transaction performing the action (default: false)
+   --actor value       TODO
+   --help, -h          show help (default: false)
    
 ```
 


### PR DESCRIPTION
## Proposed Changes
Implements 3 new cli commands.
`compact-paritions` for general use. We never had a way to call this before.
`send-invalid-windowed-post` and `generate-and-send-consensus-fault` for testing purposes.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
