### PR TITLE
[nv16] don't clobber test bundles during migration

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -16,7 +16,8 @@ import (
 
 const BootstrappersFile = ""
 const GenesisFile = ""
-const NetworkBundle = "devnet"
+
+var NetworkBundle = "devnet"
 
 const GenesisNetworkVersion = network.Version15
 

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -18,7 +18,8 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 
 const GenesisNetworkVersion = network.Version14
 
-const NetworkBundle = "butterflynet"
+var NetworkBundle = "butterflynet"
+
 const BootstrappersFile = "butterflynet.pi"
 const GenesisFile = "butterflynet.car"
 

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -18,7 +18,8 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 
 const GenesisNetworkVersion = network.Version0
 
-const NetworkBundle = "calibrationnet"
+var NetworkBundle = "calibrationnet"
+
 const BootstrappersFile = "calibnet.pi"
 const GenesisFile = "calibnet.car"
 

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -15,7 +15,8 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-const NetworkBundle = "caterpillarnet"
+var NetworkBundle = "caterpillarnet"
+
 const BootstrappersFile = "interopnet.pi"
 const GenesisFile = "interopnet.car"
 

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -19,7 +19,8 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	UpgradeSmokeHeight: DrandMainnet,
 }
 
-const NetworkBundle = "mainnet"
+var NetworkBundle = "mainnet"
+
 const GenesisNetworkVersion = network.Version0
 
 const BootstrappersFile = "mainnet.pi"

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -136,6 +136,9 @@ func LoadBuiltinActorsTesting(lc fx.Lifecycle, mctx helpers.MetricsCtx, bs dtype
 	testingBundleMx.Lock()
 	defer testingBundleMx.Unlock()
 
+	// don't clobber the bundle during migration
+	build.NetworkBundle = netw
+
 	const basePath = "/tmp/lotus-testing"
 	for av, bd := range build.BuiltinActorReleases {
 		switch {


### PR DESCRIPTION
The bundle preload during migration clobbers testing bundles and results in using the mainnet bundles if the migration happens during a test; not what we want.
This fixes by making NetworkBundle a variable, set by the test DI contraption, to work around this problem.