### PR TITLE
[nv16] fix handling of predefined manifests

### DIFF
--- a/build/bundle.go
+++ b/build/bundle.go
@@ -22,6 +22,8 @@ type Bundle struct {
 	Path map[string]string
 	// URL is the (optional) bundle URL; takes precedence over github release
 	URL map[string]BundleURL
+	// ManifestCID is the (optional) per network manifest CIDs for verification at load time
+	ManifestCID map[string]string
 	// Devlopment indicates whether this is a development version; when set, in conjunction with path,
 	// it will always load the bundle to the blockstore, without recording the manifest CID in the
 	// datastore.

--- a/build/bundles.toml
+++ b/build/bundles.toml
@@ -1,3 +1,4 @@
 [[bundles]]
 version = 8
 release = "dev/20220525"
+manifestcid = { "caterpillarnet" = "bafy2bzaceadr77tamp35bbb3rtio4ver4pnk2cbxqif3nn3mrmxra2nlvwoce" }

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 )
 

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -53,8 +53,6 @@ var UpgradeChocolateHeight = abi.ChainEpoch(-17)
 var UpgradeOhSnapHeight = abi.ChainEpoch(-18)
 var UpgradeFVM1Height = abi.ChainEpoch(-19)
 
-var ActorsCIDs = map[actors.Version]cid.Cid{}
-
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandMainnet,
 }

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/ipfs/go-cid"

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -49,8 +49,6 @@ const UpgradeOhSnapHeight = 240
 
 var UpgradeFVM1Height = abi.ChainEpoch(99999999999999)
 
-var ActorsCIDs = map[actors.Version]cid.Cid{}
-
 func init() {
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(2 << 30))
 	policy.SetSupportedProofTypes(

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 	"github.com/ipfs/go-cid"

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -62,8 +62,6 @@ const UpgradeOhSnapHeight = 682006
 
 var UpgradeFVM1Height = abi.ChainEpoch(99999999999999)
 
-var ActorsCIDs = map[actors.Version]cid.Cid{}
-
 func init() {
 	policy.SetConsensusMinerMinPower(abi.NewStoragePower(32 << 30))
 	policy.SetSupportedProofTypes(

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/filecoin-project/lotus/chain/actors"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -53,10 +53,6 @@ var UpgradeChocolateHeight = abi.ChainEpoch(-17)
 var UpgradeOhSnapHeight = abi.ChainEpoch(-18)
 var UpgradeFVM1Height = abi.ChainEpoch(100)
 
-var ActorsCIDs = map[actors.Version]cid.Cid{
-	actors.Version8: MustParseCid("bafy2bzaceadr77tamp35bbb3rtio4ver4pnk2cbxqif3nn3mrmxra2nlvwoce"),
-}
-
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandMainnet,
 }

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -77,8 +77,6 @@ var UpgradeOhSnapHeight = abi.ChainEpoch(1594680)
 
 var UpgradeFVM1Height = abi.ChainEpoch(99999999999999)
 
-var ActorsCIDs = map[actors.Version]cid.Cid{}
-
 func init() {
 	if os.Getenv("LOTUS_USE_TEST_ADDRESSES") != "1" {
 		SetAddressNetwork(address.Mainnet)

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -7,9 +7,6 @@ import (
 	"math"
 	"os"
 
-	"github.com/filecoin-project/lotus/chain/actors"
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/go-address"

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -17,7 +17,6 @@ import (
 
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 )
 

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -122,5 +122,3 @@ var (
 )
 
 const BootstrapPeerThreshold = 1
-
-var ActorsCIDs = map[actors.Version]cid.Cid{}

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -1395,12 +1395,6 @@ func upgradeActorsV8Common(
 		return cid.Undef, xerrors.Errorf("no manifest CID for v8 upgrade")
 	}
 
-	if val, ok := build.ActorsCIDs[actors.Version8]; ok {
-		if val != manifest {
-			return cid.Undef, xerrors.Errorf("actors V8 manifest CID %s did not match CID given in params file: %s", manifest, val)
-		}
-	}
-
 	// Perform the migration
 	newHamtRoot, err := nv16.MigrateStateTree(ctx, store, manifest, stateRoot.Actors, epoch, config, migrationLogger{}, cache)
 	if err != nil {

--- a/node/bundle/manifest.go
+++ b/node/bundle/manifest.go
@@ -70,12 +70,6 @@ func LoadBundle(ctx context.Context, bs blockstore.Blockstore, path string, av a
 
 	// TODO: check that this only has one root?
 	manifestCid := hdr.Roots[0]
-
-	if val, ok := build.ActorsCIDs[av]; ok {
-		if val != manifestCid {
-			return cid.Undef, xerrors.Errorf("actors V%d manifest CID %s did not match CID given in params file: %s", av, manifestCid, val)
-		}
-	}
 	actors.AddManifest(av, manifestCid)
 
 	mfCid, ok := actors.GetManifest(av)

--- a/node/modules/builtin_actors.go
+++ b/node/modules/builtin_actors.go
@@ -48,11 +48,6 @@ func LoadBuiltinActors(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRe
 
 			if has {
 				// it's there, no need to reload the bundle to the blockstore; just add it to the manifest list.
-				if val, ok := build.ActorsCIDs[av]; ok {
-					if val != mfCid {
-						return result, xerrors.Errorf("actors V%d manifest CID %s did not match CID given in params file: %s", av, mfCid, val)
-					}
-				}
 				actors.AddManifest(av, mfCid)
 				continue
 			}


### PR DESCRIPTION
Originally implemented in #8732 but it made a mess; this does it cleanly.