### PR TITLE
fix: post workers: check proving params on startup

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -293,7 +293,7 @@ var runCmd = &cli.Command{
 			return err
 		}
 
-		if cctx.Bool("commit") || cctx.Bool("prove-replica-update2") {
+		if cctx.Bool("commit") || cctx.Bool("prove-replica-update2") || cctx.Bool("windowpost") || cctx.Bool("winningpost") {
 			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
 				return xerrors.Errorf("get params: %w", err)
 			}


### PR DESCRIPTION
PoSt workers are doing snarks, so they need proof params