### PR TITLE
feat: wdpost: Ignore faults in lotus-miner proving compute window-post

### DIFF
--- a/storage/wdpost_run.go
+++ b/storage/wdpost_run.go
@@ -595,6 +595,11 @@ func (s *WindowPoStScheduler) runPoStCycle(ctx context.Context, manual bool, di 
 				if err != nil {
 					return nil, xerrors.Errorf("removing faults from set of sectors to prove: %w", err)
 				}
+				if manual {
+					// this is a check run, we want to prove faulty sectors, even
+					// if they are not declared as recovering.
+					toProve = partition.LiveSectors
+				}
 				toProve, err = bitfield.MergeBitFields(toProve, partition.RecoveringSectors)
 				if err != nil {
 					return nil, xerrors.Errorf("adding recoveries to set of sectors to prove: %w", err)


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/8435

## Proposed Changes
This command is generally only useful in two scenarios:
1. Checking that some changes in proving setup are working (post worker changes, storage changes)
2. Checking that sectors can be proven

(2) is something one would do after having sectors go faulty for whatever reason, just to check that the issue was fixed correctly - but that wasn't really possible when sectors were marked as faulty on-chain and we skipped them in what is meant to be manual provability check..
