### PR TITLE
fix: worker: don't log normal storage stat calls

### DIFF
--- a/extern/sector-storage/stores/local.go
+++ b/extern/sector-storage/stores/local.go
@@ -157,7 +157,9 @@ func (p *path) stat(ls LocalStorage) (fsutil.FsStat, error) {
 		}
 	}
 
-	log.Infow("storage stat", "took", time.Now().Sub(start), "reservations", len(p.reservations))
+	if time.Now().Sub(start) > 5*time.Second {
+		log.Warnw("slow storage stat", "took", time.Now().Sub(start), "reservations", len(p.reservations))
+	}
 
 	return stat, err
 }


### PR DESCRIPTION
Currently we print logs like

```
2022-05-27T19:46:05.586+0200    INFO    stores  stores/local.go:160     storage stat    {"took": 0.000045108, "reservations": 0}
2022-05-27T19:46:05.586+0200    INFO    stores  stores/local.go:160     storage stat    {"took": 0.000022857, "reservations": 0}
2022-05-27T19:46:05.586+0200    INFO    stores  stores/local.go:160     storage stat    {"took": 0.000016145, "reservations": 0}
2022-05-27T19:46:05.586+0200    INFO    stores  stores/local.go:160     storage stat    {"took": 0.000016495, "reservations": 0}
```

On all workers for each storage path every ~10s. This is extremely spammy, especially in larger setups with many workers and many storage paths