### PR TITLE
optimize PreCommit1 tasks

### DIFF
--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -231,6 +231,9 @@ func init() {
 		uuid.MustParse("ef8d99a2-6865-4189-8ffa-9fef0f806eee"): {
 			Info: storiface.WorkerInfo{
 				Hostname: "host",
+				TaskLimits: map[sealtasks.TaskType]int{
+					sealtasks.TTPreCommit1: 10,
+				},
 				Resources: storiface.WorkerResources{
 					MemPhysical: 256 << 30,
 					MemUsed:     2 << 30,
@@ -241,7 +244,10 @@ func init() {
 					Resources:   storiface.ResourceTable,
 				},
 			},
-			Enabled:    true,
+			Enabled: true,
+			TaskTotal: map[sealtasks.TaskType]int{
+				sealtasks.TTPreCommit1: 5,
+			},
 			MemUsedMin: 0,
 			MemUsedMax: 0,
 			GpuUsed:    0,
@@ -325,6 +331,9 @@ func init() {
 		ConnsOutbound:   4,
 		Conns:           4,
 		FD:              5,
+	})
+	addExample(map[sealtasks.TaskType]int{
+		sealtasks.TTPreCommit1: 10,
 	})
 
 }

--- a/cmd/lotus-miner/run.go
+++ b/cmd/lotus-miner/run.go
@@ -64,7 +64,9 @@ var runCmd = &cli.Command{
 			}
 		}
 
-		os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit")))
+		if err := os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit"))); err != nil {
+			return xerrors.Errorf("could not set parallel p1 limit env: %+v", err)
+		}
 
 		ctx, _ := tag.New(lcli.DaemonContext(cctx),
 			tag.Insert(metrics.Version, build.BuildVersion),

--- a/cmd/lotus-miner/run.go
+++ b/cmd/lotus-miner/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"strconv"
 
 	"github.com/filecoin-project/lotus/api/v1api"
 
@@ -49,6 +50,11 @@ var runCmd = &cli.Command{
 			Usage: "manage open file limit",
 			Value: true,
 		},
+		&cli.IntFlag{
+			Name:  "parallel-p1-limit",
+			Usage: "maximum pre commit1 operations to run in parallel",
+			Value: -1,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Bool("enable-gpu-proving") {
@@ -57,6 +63,8 @@ var runCmd = &cli.Command{
 				return err
 			}
 		}
+
+		os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit")))
 
 		ctx, _ := tag.New(lcli.DaemonContext(cctx),
 			tag.Insert(metrics.Version, build.BuildVersion),

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -118,7 +118,12 @@ func workersCmd(sealing bool) *cli.Command {
 			*/
 
 			for _, stat := range st {
-				// Worker uuid + name
+				gpuUse := "not "
+				gpuCol := color.FgBlue
+				if stat.GpuUsed > 0 {
+					gpuCol = color.FgGreen
+					gpuUse = ""
+				}
 
 				var disabled string
 				if !stat.Enabled {
@@ -221,6 +226,12 @@ func workersCmd(sealing bool) *cli.Command {
 				}
 				for _, gpu := range stat.Info.Resources.GPUs {
 					fmt.Printf("\tGPU: %s\n", color.New(gpuCol).Sprintf("%s, %sused", gpu, gpuUse))
+				}
+
+				plConfig, ok := stat.Info.TaskLimits[sealtasks.TTPreCommit1]
+				if ok && plConfig.LimitCount > 0 {
+					fmt.Printf("\tP1LIMIT:  [%s] %d/%d tasks are running\n",
+						barString(float64(plConfig.LimitCount), 0, float64(plConfig.RunCount)), plConfig.RunCount, plConfig.LimitCount)
 				}
 			}
 

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -118,12 +118,7 @@ func workersCmd(sealing bool) *cli.Command {
 			*/
 
 			for _, stat := range st {
-				gpuUse := "not "
-				gpuCol := color.FgBlue
-				if stat.GpuUsed > 0 {
-					gpuCol = color.FgGreen
-					gpuUse = ""
-				}
+				// Worker uuid + name
 
 				var disabled string
 				if !stat.Enabled {
@@ -209,6 +204,13 @@ func workersCmd(sealing bool) *cli.Command {
 					types.SizeStr(types.NewInt(vmemTasks+vmemReserved)),
 					types.SizeStr(types.NewInt(vmemTotal)))
 
+				taskLimit, ok := stat.Info.TaskLimits[sealtasks.TTPreCommit1]
+				if ok && taskLimit > 0 {
+					runCount := stat.TaskTotal[sealtasks.TTPreCommit1]
+					fmt.Printf("      P1LIMIT:[%s] %d/%d tasks are running\n",
+						barString(float64(taskLimit), 0, float64(runCount)), runCount, taskLimit)
+				}
+
 				// GPU use
 
 				if len(stat.Info.Resources.GPUs) > 0 {
@@ -226,12 +228,6 @@ func workersCmd(sealing bool) *cli.Command {
 				}
 				for _, gpu := range stat.Info.Resources.GPUs {
 					fmt.Printf("\tGPU: %s\n", color.New(gpuCol).Sprintf("%s, %sused", gpu, gpuUse))
-				}
-
-				plConfig, ok := stat.Info.TaskLimits[sealtasks.TTPreCommit1]
-				if ok && plConfig.LimitCount > 0 {
-					fmt.Printf("\tP1LIMIT:  [%s] %d/%d tasks are running\n",
-						barString(float64(plConfig.LimitCount), 0, float64(plConfig.RunCount)), plConfig.RunCount, plConfig.LimitCount)
 				}
 			}
 

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -238,7 +238,9 @@ var runCmd = &cli.Command{
 			}
 		}
 
-		os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit")))
+		if err := os.Setenv("PARALLEL_P1_LIMIT", strconv.Itoa(cctx.Int("parallel-p1-limit"))); err != nil {
+			return xerrors.Errorf("could not set parallel p1 limit env: %+v", err)
+		}
 
 		limit, _, err := ulimit.GetLimit()
 		switch {
@@ -301,12 +303,6 @@ var runCmd = &cli.Command{
 			return err
 		}
 
-		if cctx.Bool("commit") || cctx.Bool("prove-replica-update2") {
-			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
-				return xerrors.Errorf("get params: %w", err)
-			}
-		}
-
 		var taskTypes []sealtasks.TaskType
 		var workerType string
 		var needParams bool
@@ -323,7 +319,6 @@ var runCmd = &cli.Command{
 		}
 
 		if workerType == "" {
-			workerType = sealtasks.WorkerSealing
 			taskTypes = append(taskTypes, sealtasks.TTFetch, sealtasks.TTCommit1, sealtasks.TTProveReplicaUpdate1, sealtasks.TTFinalize, sealtasks.TTFinalizeReplicaUpdate)
 
 			if !cctx.Bool("no-default") {

--- a/documentation/en/api-v0-methods-miner.md
+++ b/documentation/en/api-v0-methods-miner.md
@@ -4970,9 +4970,15 @@ Response:
             }
           }
         }
+      },
+      "TaskLimits": {
+        "seal/v0/precommit/1": 10
       }
     },
     "Tasks": null,
+    "TaskTotal": {
+      "seal/v0/precommit/1": 5
+    },
     "Enabled": true,
     "MemUsedMin": 0,
     "MemUsedMax": 0,

--- a/documentation/en/api-v0-methods-worker.md
+++ b/documentation/en/api-v0-methods-worker.md
@@ -1401,6 +1401,9 @@ Response:
         }
       }
     }
+  },
+  "TaskLimits": {
+    "seal/v0/precommit/1": 10
   }
 }
 ```

--- a/extern/sector-storage/sched.go
+++ b/extern/sector-storage/sched.go
@@ -88,6 +88,9 @@ type WorkerHandle struct {
 	preparing *ActiveResources // use with WorkerHandle.lk
 	active    *ActiveResources // use with WorkerHandle.lk
 
+	TaskTotal   map[sealtasks.TaskType]int
+	TaskTotalLk sync.Mutex
+
 	lk sync.Mutex // can be taken inside sched.workersLk.RLock
 
 	wndLk         sync.Mutex // can be taken inside sched.workersLk.RLock
@@ -302,6 +305,8 @@ func (sh *Scheduler) runSched() {
 					}
 				}
 
+				sh.TaskClean(req.wid)
+
 				openWindows := make([]*SchedWindowRequest, 0, len(sh.OpenWindows))
 				for _, window := range sh.OpenWindows {
 					if window.Worker != req.wid {
@@ -390,4 +395,64 @@ func (sh *Scheduler) Close(ctx context.Context) error {
 		return ctx.Err()
 	}
 	return nil
+}
+
+func (sh *Scheduler) CanHandleTask(taskType sealtasks.TaskType, wid storiface.WorkerID) bool {
+	if wh, ok := sh.Workers[wid]; ok {
+		if taskLimit, ok := wh.Info.TaskLimits[taskType]; ok {
+			if taskLimit > 0 {
+				wh.TaskTotalLk.Lock()
+				defer wh.TaskTotalLk.Unlock()
+
+				runCount := wh.TaskTotal[taskType]
+				freeCount := taskLimit - runCount
+				if freeCount <= 0 {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func (sh *Scheduler) TaskAdd(taskType sealtasks.TaskType, wid storiface.WorkerID) {
+	if wh, ok := sh.Workers[wid]; ok {
+		if _, ok := wh.Info.TaskLimits[taskType]; ok {
+			wh.TaskTotalLk.Lock()
+			defer wh.TaskTotalLk.Unlock()
+
+			runCount := wh.TaskTotal[taskType]
+			runCount++
+			wh.TaskTotal[taskType] = runCount
+		}
+	}
+}
+
+func (sh *Scheduler) TaskReduce(taskType sealtasks.TaskType, wid storiface.WorkerID) {
+	if wh, ok := sh.Workers[wid]; ok {
+		if _, ok := wh.Info.TaskLimits[taskType]; ok {
+			wh.TaskTotalLk.Lock()
+			defer wh.TaskTotalLk.Unlock()
+
+			runCount := wh.TaskTotal[taskType]
+			if runCount > 0 {
+				runCount--
+				wh.TaskTotal[taskType] = runCount
+			}
+		}
+	}
+
+}
+
+func (sh *Scheduler) TaskClean(wid storiface.WorkerID) {
+	if wh, ok := sh.Workers[wid]; ok {
+		wh.TaskTotalLk.Lock()
+		defer wh.TaskTotalLk.Unlock()
+
+		for k, _ := range wh.Info.TaskLimits {
+			wh.Info.TaskLimits[k] = 0
+		}
+	}
+
 }

--- a/extern/sector-storage/sched_assigner_spread.go
+++ b/extern/sector-storage/sched_assigner_spread.go
@@ -38,6 +38,10 @@ func SpreadWS(sh *Scheduler, queueLen int, acceptableWindows [][]int, windows []
 				continue
 			}
 
+			if !sh.CanHandleTask(task.TaskType, wid) {
+				continue
+			}
+
 			wu, _ := workerAssigned[wid]
 			if wu >= bestAssigned {
 				continue
@@ -66,6 +70,8 @@ func SpreadWS(sh *Scheduler, queueLen int, acceptableWindows [][]int, windows []
 		workerAssigned[bestWid]++
 		windows[selectedWindow].Allocated.Add(task.SealTask(), info.Resources, needRes)
 		windows[selectedWindow].Todo = append(windows[selectedWindow].Todo, task)
+
+		sh.TaskAdd(task.TaskType, bestWid)
 
 		rmQueue = append(rmQueue, sqi)
 		scheduled++

--- a/extern/sector-storage/sched_assigner_utilization.go
+++ b/extern/sector-storage/sched_assigner_utilization.go
@@ -39,6 +39,10 @@ func LowestUtilizationWS(sh *Scheduler, queueLen int, acceptableWindows [][]int,
 				continue
 			}
 
+			if !sh.CanHandleTask(task.TaskType, wid) {
+				continue
+			}
+
 			wu, found := workerUtil[wid]
 			if !found {
 				wu = w.Utilization()
@@ -83,6 +87,8 @@ func LowestUtilizationWS(sh *Scheduler, queueLen int, acceptableWindows [][]int,
 
 		workerUtil[bestWid] += windows[selectedWindow].Allocated.Add(task.SealTask(), info.Resources, needRes)
 		windows[selectedWindow].Todo = append(windows[selectedWindow].Todo, task)
+
+		sh.TaskAdd(task.TaskType, bestWid)
 
 		rmQueue = append(rmQueue, sqi)
 		scheduled++

--- a/extern/sector-storage/sched_test.go
+++ b/extern/sector-storage/sched_test.go
@@ -161,9 +161,12 @@ func (s *schedTestWorker) Paths(ctx context.Context) ([]storiface.StoragePath, e
 }
 
 func (s *schedTestWorker) Info(ctx context.Context) (storiface.WorkerInfo, error) {
+	taskLimits := make(map[sealtasks.TaskType]int)
+	taskLimits[sealtasks.TTPreCommit1] = 8
 	return storiface.WorkerInfo{
 		Hostname:        s.name,
 		IgnoreResources: s.ignoreResources,
+		TaskLimits:      taskLimits,
 		Resources:       s.resources,
 	}, nil
 }

--- a/extern/sector-storage/sched_worker.go
+++ b/extern/sector-storage/sched_worker.go
@@ -38,6 +38,8 @@ func newWorkerHandle(ctx context.Context, w Worker) (*WorkerHandle, error) {
 		active:    NewActiveResources(),
 		Enabled:   true,
 
+		TaskTotal: map[sealtasks.TaskType]int{},
+
 		closingMgr: make(chan struct{}),
 		closedMgr:  make(chan struct{}),
 	}
@@ -526,6 +528,7 @@ func (sw *schedWorker) startProcessingTask(req *WorkerRequest) error {
 		if err != nil {
 			log.Errorf("error executing worker (withResources): %+v", err)
 		}
+		sh.TaskReduce(req.TaskType, sw.wid)
 	}()
 
 	return nil
@@ -555,6 +558,8 @@ func (sw *schedWorker) startProcessingReadyTask(req *WorkerRequest) error {
 		w.lk.Lock()
 
 		w.active.Free(req.SealTask(), w.Info.Resources, needRes)
+
+		sh.TaskReduce(req.TaskType, sw.wid)
 
 		select {
 		case sw.taskDone <- struct{}{}:

--- a/extern/sector-storage/stats.go
+++ b/extern/sector-storage/stats.go
@@ -34,6 +34,7 @@ func (m *Manager) WorkerStats(ctx context.Context) map[uuid.UUID]storiface.Worke
 		out[uuid.UUID(id)] = storiface.WorkerStats{
 			Info:       handle.Info,
 			Tasks:      taskList,
+			TaskTotal:  handle.TaskTotal,
 			Enabled:    handle.Enabled,
 			MemUsedMin: handle.active.memUsedMin,
 			MemUsedMax: handle.active.memUsedMax,

--- a/extern/sector-storage/storiface/worker.go
+++ b/extern/sector-storage/storiface/worker.go
@@ -31,6 +31,8 @@ type WorkerInfo struct {
 	// Default should be false (zero value, i.e. resources taken into account).
 	IgnoreResources bool
 	Resources       WorkerResources
+
+	TaskLimits map[sealtasks.TaskType]int
 }
 
 type WorkerResources struct {
@@ -67,9 +69,10 @@ func (wr WorkerResources) ResourceSpec(spt abi.RegisteredSealProof, tt sealtasks
 }
 
 type WorkerStats struct {
-	Info    WorkerInfo
-	Tasks   []sealtasks.TaskType
-	Enabled bool
+	Info      WorkerInfo
+	Tasks     []sealtasks.TaskType
+	TaskTotal map[sealtasks.TaskType]int
+	Enabled   bool
 
 	MemUsedMin uint64
 	MemUsedMax uint64


### PR DESCRIPTION
Introduction:
Group task scheduling optimization, adding a limit on the number of PreCommit1 tasks for workers

Statement of needs:
In the original scheduling, there is no limit to the number of workers running PreCommit1 at the same time, and the maximum task configuration size includes the number of CPU cores, available memory, and hard disk space.
There is no reasonable limit. Although workers can execute when they receive too many tasks, they cannot fully exert their computing performance. The parallel PreCommit1 tasks can be reasonably controlled according to the hardware configuration.
Can improve the overall task completion speed.

improve proposals:
When the worker starts, the --parallel-p1-limit parameter sets the maximum PreCommit1 task it can accept. It will be recorded when the miner schedules the PreCommit1 task to the worker
Quantity allocated to it When the number of tasks already allocated reaches the set maximum number of tasks, it will not be allocated to a new task until 1 task is completed, and the allocation will be submitted in advance.

The default value of the --parallel-p1-limit parameter is -1, which means no limit, and if --parallel-p1-limit--parallel-p1-limit--parallel-p1-limit exceeds all the values ​​​​of the hardware configuration of the on-duty worker maximum reception time of
won't work either.
When viewing worker information through lotus-miner sealed workers, the task number information of PreCommit1 will be displayed, as follows:
p1_limit: 15-7, 15 represents the value set by --parallel-p1-limit, and 7 represents the number of PreCommit1 tasks currently running.