### PR TITLE
feat:Client: CLI Display returned value from actor constructor

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -1659,6 +1659,11 @@ var ChainExecCmd = &cli.Command{
 		afmt.Printf("ID Address: %s\n", result.IDAddress)
 		afmt.Printf("Robust Address: %s\n", result.RobustAddress)
 
+		if len(wait.Receipt.Return) > 0 {
+			result := base64.StdEncoding.EncodeToString(wait.Receipt.Return)
+			afmt.Printf("Return: %s\n", result)
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
This fiexes issue #8771 (https://github.com/filecoin-project/lotus/issues/8771)

## Related Issues
https://github.com/filecoin-project/lotus/issues/8771

## Proposed Changes
If after calling the constructor the returned bytes length is not null, the command line will show a base64 of the returned bytes.


## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
