### PR TITLE
chore: vm: Rename tracing envvar to LOTUS_VM_ENABLE_TRACING

### DIFF
--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -60,7 +60,7 @@ func (m *Message) ValueReceived() abi.TokenAmount {
 }
 
 // EnableDetailedTracing, if true, outputs gas tracing in execution traces.
-var EnableDetailedTracing = os.Getenv("LOTUS_VM_ENABLE_GAS_TRACING_VERY_SLOW") == "1"
+var EnableDetailedTracing = os.Getenv("LOTUS_VM_ENABLE_TRACING") == "1"
 
 type Runtime struct {
 	rt7.Message


### PR DESCRIPTION
I don't think the rename will break any setups, but if that's a concern, we can add it as an alias.