### PR TITLE
Fix: state:  Set exec trace subcalls to nil when appropriate

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -60,16 +60,18 @@ func (t *FvmExecutionTrace) ToExecutionTrace() types.ExecutionTrace {
 	}
 
 	ret := types.ExecutionTrace{
-		Msg:        t.Msg,
-		MsgRct:     t.MsgRct,
-		Error:      t.Error,
-		Duration:   0,
-		GasCharges: nil,
-		Subcalls:   make([]types.ExecutionTrace, len(t.Subcalls)),
+		Msg:      t.Msg,
+		MsgRct:   t.MsgRct,
+		Error:    t.Error,
+		Subcalls: nil, // Should be nil when there are no subcalls for backwards compatibility
 	}
 
-	for i, v := range t.Subcalls {
-		ret.Subcalls[i] = v.ToExecutionTrace()
+	if len(t.Subcalls) > 0 {
+		ret.Subcalls = make([]types.ExecutionTrace, len(t.Subcalls))
+
+		for i, v := range t.Subcalls {
+			ret.Subcalls[i] = v.ToExecutionTrace()
+		}
 	}
 
 	return ret


### PR DESCRIPTION
## Proposed Changes
Change exec trace subcalls to be nil instead of empty array to preserve backwards compatibility.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
