### PR TITLE
build: deps: add uninstall make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,18 @@ install-worker:
 install-app:
 	install -C ./$(APP) /usr/local/bin/$(APP)
 
+uninstall: uninstall-daemon uninstall-miner uninstall-worker
+.PHONY: uninstall
+
+uninstall-daemon:
+	rm -f /usr/local/bin/lotus
+
+uninstall-miner:
+	rm -f /usr/local/bin/lotus-miner
+
+uninstall-worker:
+	rm -f /usr/local/bin/lotus-worker
+
 # TOOLS
 
 lotus-seed: $(BUILD_DEPS)


### PR DESCRIPTION
cc @walkerlj0

## Related Issues
Closes #8812 

## Proposed Changes

The `uninstall` make target deletes all the binaries and directories mentioned here: https://github.com/filecoin-project/lotus/issues/5416#issuecomment-770111683

Run `sudo make uninstall` to uninstall lotus from your computer. You can then remove the entire `lotus` directory.

## Additional Info

I have this error when running it:
```
bash: line 1: go: command not found
expr: syntax error: unexpected argument ‘1016000’
```
I don't know why - but I already get the _same_ error when running `sudo make install`.

Also not sure if the `deps` area makes sense. Didn't find one related to chore.

I still need to update documentations in `lotus-docs` repo.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x ] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
