### PR TITLE
chore: improve error message when maxPrice is too low

### DIFF
--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -145,7 +145,7 @@ func retrieve(ctx context.Context, cctx *cli.Context, fapi lapi.FullNode, sel *l
 		}
 
 		if offer.MinPrice.GreaterThan(big.Int(maxPrice)) {
-			return nil, xerrors.Errorf("failed to find offer satisfying maxPrice: %s", maxPrice)
+			return nil, xerrors.Errorf("failed to find offer satisfying maxPrice: %s. Try increasing maxPrice", maxPrice)
 		}
 
 		o := offer.Order(payer)


### PR DESCRIPTION
During a launchpad session we tried to create a retrieval request and got an error because we didn't set the `maxPrice` option and it defaulted to 0. 

The error message was a bit confusing and we thought it would be helpful if the error would provide an action – especially when the user doesn't know that it was set to 0 by default.


## Proposed Changes

- Improve error message

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
