### PR TITLE
fix: paych: Print "waiting for confirmation.."

### DIFF
--- a/cli/paych.go
+++ b/cli/paych.go
@@ -92,6 +92,7 @@ var paychAddFundsCmd = &cli.Command{
 		}
 
 		// Wait for the message to be confirmed
+		fmt.Println("waiting for confirmation..")
 		chAddr, err := api.PaychGetWaitReady(ctx, info.WaitSentinel)
 		if err != nil {
 			return err


### PR DESCRIPTION
Prints an "waiting for confirmation.." when running `lotus paych [fromAddress toAddress amount]` to indicate that the command is waiting for the msg to be confirmed and not just hanging.

## Related Issues
Resolves #4138

## Proposed Changes
Add a "waiting for confirmation.." print to improve the UX a tiny bit.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
