### PR TITLE
Fix: PaychGetRestartAfterAddFundsMsg may stuck in forever waiting

### DIFF
--- a/paychmgr/manager.go
+++ b/paychmgr/manager.go
@@ -87,6 +87,7 @@ func newManager(pchstore *Store, pchapi managerAPI) (*Manager, error) {
 		channels: make(map[string]*channelAccessor),
 		pchapi:   pchapi,
 	}
+	pm.ctx, pm.shutdown = context.WithCancel(context.Background())
 	return pm, pm.Start()
 }
 

--- a/paychmgr/mock_test.go
+++ b/paychmgr/mock_test.go
@@ -136,7 +136,7 @@ func newMockPaychAPI() *mockPaychAPI {
 func (pchapi *mockPaychAPI) StateWaitMsg(ctx context.Context, mcid cid.Cid, confidence uint64, limit abi.ChainEpoch, allowReplaced bool) (*api.MsgLookup, error) {
 	pchapi.lk.Lock()
 
-	response := make(chan types.MessageReceipt)
+	response := make(chan types.MessageReceipt, 1)
 
 	if response, ok := pchapi.waitingResponses[mcid]; ok {
 		defer pchapi.lk.Unlock()
@@ -151,8 +151,12 @@ func (pchapi *mockPaychAPI) StateWaitMsg(ctx context.Context, mcid cid.Cid, conf
 	pchapi.waitingCalls[mcid] = &waitingCall{response: response}
 	pchapi.lk.Unlock()
 
-	receipt := <-response
-	return &api.MsgLookup{Receipt: receipt}, nil
+	select {
+	case receipt := <-response:
+		return &api.MsgLookup{Receipt: receipt}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (pchapi *mockPaychAPI) receiveMsgResponse(mcid cid.Cid, receipt types.MessageReceipt) {

--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -631,7 +631,7 @@ func TestPaychGetRestartAfterAddFundsMsg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simulate shutting down system
-	mock.close()
+	require.NoError(t, mgr.Stop())
 
 	// Create a new manager with the same datastore
 	mock2 := newMockManagerAPI()

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -3,6 +3,7 @@ package paychmgr
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -351,6 +352,11 @@ func (ca *channelAccessor) queueSize() int {
 // msgWaitComplete is called when the message for a previous task is confirmed
 // or there is an error.
 func (ca *channelAccessor) msgWaitComplete(ctx context.Context, mcid cid.Cid, err error) {
+	// if context is canceled, should Not mark message to 'bad', just return.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
 	ca.lk.Lock()
 	defer ca.lk.Unlock()
 


### PR DESCRIPTION
### TestPaychGetRestartAfterAddFundsMsg may stuck in forever waiting
as following state diagram shows:
```mermaid
stateDiagram-v2
  state "pm.store.WithPendingAddFunds"  as queryMsgFromStore
  Test: TestPaychGetRestartAfterAddFundsMsg
  state "_, mcid2, err := : mgr.GetPaych(ctx, from, to, amt2)"as GetPaych
  waitForAddFundsMsg:channelAccessor.waitForAddFundsMsg
  state "mockPaychAPI.WaitMsg(mcid2..." as WaitMsg
  state "receipt := <- response " as waitReceiptResponse
  concurrency: concurrency operations
  state  "mgr2, err := newManager(...)" as Mgr2
  state "done := make(chan struct{})
pchapi.waitingResponses[mcid] = &waitingResponse{receipt: receipt, done: done}
pchapi.lk.Unlock()
<-done
" as WaitCode
  
  Test --> GetPaych
  GetPaych --> channelAccessor.GetPaych
  channelAccessor.GetPaych --> channelAccessor.addFunds: this is started by mgr1, in another go-routine
  channelAccessor.GetPaych --> mock.close
mock.close --> Mgr2
Mgr2 --> manager.Start
mock.close --> waitReceiptResponse: Msg `mcid2` received receipt,\nthis will unblock the waiting
note left of waitReceiptResponse
            blocked here, waiting for Receipt of `mcid2` to continue
        end note

state concurrency {
  channelAccessor.addFunds --> waitForAddFundsMsg
  waitForAddFundsMsg --> WaitMsg
  WaitMsg --> waitReceiptResponse
waitReceiptResponse --> channelAccessor.mutateChannelInfo: ChannelInfo.AddFundsMsg = nil
channelAccessor.mutateChannelInfo --> store.SaveChannelInfo: actually the message of `mcid2`, is set as complete.
note right of store.SaveChannelInfo 
marked as C
end note
--
manager.Start --> manager.restartPending
manager.restartPending --> queryMsgFromStore
note right of queryMsgFromStore
            read uncompleted `AddFunds` Messages from store, re-waiting receipts on chain
        end note
queryMsgFromStore --> mockPaychAPI.WaitMsg(mcid2,..: run in go-routine
queryMsgFromStore --> mockPaychAPI.receiveMsgResponse(mcid2,...
mockPaychAPI.receiveMsgResponse(mcid2,... --> WaitCode

note right of mockPaychAPI.WaitMsg(mcid2,..
marked as A
end note
note right of WaitCode 
marked as B
end note
}
```
the `A`, `B`, `C` are execute asynchronously, their execution order are unpredictable.
if the order is in `bad` path:  `C` -> `B`, 
in that case, the `A`(`mockPaychAPI.StateWaitMsg` of `mcid2`) would never happen, 
the `B` would blocked by `receiveMsgResponse(mcid2, )`
https://github.com/filecoin-project/lotus/blob/e3f1eb29a14c7acb198e21b86aba1ada74c2cbb1/paychmgr/paychget_test.go#L646-L649
waiting `<-done` forever.  the test would fail of timeout.
