### PR TITLE
fix: ux: Check for client deal addrs on-chain

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -559,6 +559,10 @@ func interactiveDeal(cctx *cli.Context) error {
 		a = def
 	}
 
+	if _, err := api.StateGetActor(ctx, a, types.EmptyTSK); err != nil {
+		return xerrors.Errorf("address not initialized on chain: %w", err)
+	}
+
 	fromBal, err := api.WalletBalance(ctx, a)
 	if err != nil {
 		return xerrors.Errorf("checking from address balance: %w", err)


### PR DESCRIPTION
Checks if the address used in `lotus client deal` is "initialized" on-chain before running the `uiLoop`.

## Related Issues
Resolves #8817

## Proposed Changes
Adds a check to see if the actor (address in this case) is on chain before starting the `lotus client deal` - interactiveDeal uiLoop
 
## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
