### PR TITLE
fix: build: params_2k should not have the v16 upgrade set

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -51,7 +51,7 @@ var UpgradeHyperdriveHeight = abi.ChainEpoch(-16)
 var UpgradeChocolateHeight = abi.ChainEpoch(-17)
 
 var UpgradeOhSnapHeight = abi.ChainEpoch(-18)
-var UpgradeSkyrHeight = abi.ChainEpoch(100)
+var UpgradeSkyrHeight = abi.ChainEpoch(-19)
 
 var ActorsCIDs = map[actors.Version]cid.Cid{}
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Starting from v16 (having GenesisNetworkVersion=v16) and having the upgrade set is broken.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

disable the Skyr upgrade

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
