### PR TITLE
fix: fvm: make exectraces match legacyVM some more

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -339,13 +339,14 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 			return nil, xerrors.Errorf("failed to unmarshal exectrace: %w", err)
 		}
 		et = fvmEt.ToExecutionTrace()
-	} else {
-		et.Msg = vmMsg
-		et.MsgRct = &receipt
-		et.Duration = duration
-		if aerr != nil {
-			et.Error = aerr.Error()
-		}
+	}
+
+	// Set the top-level exectrace info from the message and receipt for backwards compatibility
+	et.Msg = vmMsg
+	et.MsgRct = &receipt
+	et.Duration = duration
+	if aerr != nil {
+		et.Error = aerr.Error()
 	}
 
 	return &ApplyRet{


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

@jennijuju pointed out that the top-level message in the FVM exectrace deviates from the LegacyVM -- it uses resolved (ID) addresses, and excludes some of the information packaged in the message receipt.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Match LegacyVM behaviour by setting the top-level message & rct from the receipt itself, not the exectrace.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
