### PR TITLE
Make cli deal command get Block Delay specific to build

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -624,8 +624,9 @@ uiLoop:
 				continue
 			}
 
-			if days < int(build.MinDealDuration/builtin.EpochsInDay) {
-				printErr(xerrors.Errorf("minimum duration is %d days", int(build.MinDealDuration/builtin.EpochsInDay)))
+			minDealDurationDays := uint64(build.MinDealDuration) / (builtin.SecondsInDay / build.BlockDelaySecs)
+			if days < int(minDealDurationDays) {
+				printErr(xerrors.Errorf("minimum duration is %d days", minDealDurationDays))
 				continue
 			}
 


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/7674

## Proposed Changes
The deal making cli was using mainnet parameters for block time, disallowing any deals shorter than 180 days, but for a devnet with a block time of 4s this is over the maximum lifetime of a deal. This led to the cli not being able to make deals for devnets.


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
