### PR TITLE
Fix: cli: Break out of retrieval if provider cancels

### DIFF
--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -194,6 +194,8 @@ func retrieve(ctx context.Context, cctx *cli.Context, fapi lapi.FullNode, sel *l
 				break readEvents
 			case retrievalmarket.DealStatusRejected:
 				return nil, xerrors.Errorf("Retrieval Proposal Rejected: %s", evt.Message)
+			case retrievalmarket.DealStatusCancelled:
+				return nil, xerrors.Errorf("Retrieval Proposal Cancelled: %s", evt.Message)
 			case
 				retrievalmarket.DealStatusDealNotFound,
 				retrievalmarket.DealStatusErrored:


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
Miner can send a `Cancelled` message if they are unable to unseal data. There is currently no return value for this case, so the client will hang. Client will now exit if they receive a `Cancelled` message.


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
