### PR TITLE
feat: cli: Hide sector nums in 'proving deadline' by default

### DIFF
--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -268,8 +268,15 @@ var provingDeadlinesCmd = &cli.Command{
 }
 
 var provingDeadlineInfoCmd = &cli.Command{
-	Name:      "deadline",
-	Usage:     "View the current proving period deadline information by its index ",
+	Name:  "deadline",
+	Usage: "View the current proving period deadline information by its index",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "sector-nums",
+			Aliases: []string{"n"},
+			Usage:   "Print sector/fault numbers belonging to this deadline",
+		},
+	},
 	ArgsUsage: "<deadlineIdx>",
 	Action: func(cctx *cli.Context) error {
 
@@ -342,10 +349,14 @@ var provingDeadlineInfoCmd = &cli.Command{
 			}
 
 			fmt.Printf("Partition Index:          %d\n", pIdx)
-			fmt.Printf("Sectors:                  %d\n", sectorCount)
-			fmt.Printf("Sector Numbers:           %v\n", sectorNumbers)
-			fmt.Printf("Faults:                   %d\n", faultsCount)
-			fmt.Printf("Faulty Sectors:           %d\n", fn)
+			fmt.Printf("\tSectors:                  %d\n", sectorCount)
+			if cctx.Bool("sector-nums") {
+				fmt.Printf("\tSector Numbers:           %v\n", sectorNumbers)
+			}
+			fmt.Printf("\tFaults:                   %d\n", faultsCount)
+			if cctx.Bool("sector-nums") {
+				fmt.Printf("\tFaulty Sectors:           %d\n", fn)
+			}
 		}
 		return nil
 	},

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -2007,7 +2007,7 @@ USAGE:
 COMMANDS:
    info       View current state information
    deadlines  View the current proving period deadlines information
-   deadline   View the current proving period deadline information by its index 
+   deadline   View the current proving period deadline information by its index
    faults     View the currently known proving faulty sectors information
    check      Check sectors provable
    workers    list workers
@@ -2048,13 +2048,13 @@ OPTIONS:
 ### lotus-miner proving deadline
 ```
 NAME:
-   lotus-miner proving deadline - View the current proving period deadline information by its index 
+   lotus-miner proving deadline - View the current proving period deadline information by its index
 
 USAGE:
    lotus-miner proving deadline [command options] <deadlineIdx>
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --sector-nums, -n  Print sector/fault numbers belonging to this deadline (default: false)
    
 ```
 


### PR DESCRIPTION
## Proposed Changes
Make the `lotus-miner proving deadline [num]` command not print 1000s of numbers by default.