### PR TITLE
ux: print absolute time for proving period start in proving cli

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1777,8 +1777,8 @@ var StateSectorCmd = &cli.Command{
 		}
 		fmt.Println("DealIDs: ", si.DealIDs)
 		fmt.Println()
-		fmt.Println("Activation: ", EpochTime(ts.Height(), si.Activation))
-		fmt.Println("Expiration: ", EpochTime(ts.Height(), si.Expiration))
+		fmt.Println("Activation: ", EpochTimeTs(ts.Height(), si.Activation, ts))
+		fmt.Println("Expiration: ", EpochTimeTs(ts.Height(), si.Expiration, ts))
 		fmt.Println()
 		fmt.Println("DealWeight: ", si.DealWeight)
 		fmt.Println("VerifiedDealWeight: ", si.VerifiedDealWeight)

--- a/cli/util.go
+++ b/cli/util.go
@@ -56,3 +56,23 @@ func EpochTime(curr, e abi.ChainEpoch) string {
 
 	panic("math broke")
 }
+
+// EpochTimeTs is like EpochTime, but also outputs absolute time. `ts` is only
+// used to provide a timestamp at some epoch to calculate time from. It can be
+// a genesis tipset.
+//
+// Example output: `1944975 (01 Jul 22 08:07 CEST, 10 hours 29 minutes ago)`
+func EpochTimeTs(curr, e abi.ChainEpoch, ts *types.TipSet) string {
+	timeStr := time.Unix(int64(ts.MinTimestamp()+(uint64(e-ts.Height())*build.BlockDelaySecs)), 0).Format(time.RFC822)
+
+	switch {
+	case curr > e:
+		return fmt.Sprintf("%d (%s, %s ago)", e, timeStr, durafmt.Parse(time.Second*time.Duration(int64(build.BlockDelaySecs)*int64(curr-e))).LimitFirstN(2))
+	case curr == e:
+		return fmt.Sprintf("%d (%s, now)", e, timeStr)
+	case curr < e:
+		return fmt.Sprintf("%d (%s, in %s)", e, timeStr, durafmt.Parse(time.Second*time.Duration(int64(build.BlockDelaySecs)*int64(e-curr))).LimitFirstN(2))
+	}
+
+	panic("math broke")
+}

--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -178,8 +178,8 @@ var provingInfoCmd = &cli.Command{
 		fmt.Printf("Current Epoch:           %d\n", cd.CurrentEpoch)
 
 		fmt.Printf("Proving Period Boundary: %d\n", cd.PeriodStart%cd.WPoStProvingPeriod)
-		fmt.Printf("Proving Period Start:    %s\n", lcli.EpochTime(cd.CurrentEpoch, cd.PeriodStart))
-		fmt.Printf("Next Period Start:       %s\n\n", lcli.EpochTime(cd.CurrentEpoch, cd.PeriodStart+cd.WPoStProvingPeriod))
+		fmt.Printf("Proving Period Start:    %s\n", lcli.EpochTimeTs(cd.CurrentEpoch, cd.PeriodStart, head))
+		fmt.Printf("Next Period Start:       %s\n\n", lcli.EpochTimeTs(cd.CurrentEpoch, cd.PeriodStart+cd.WPoStProvingPeriod, head))
 
 		fmt.Printf("Faults:      %d (%.2f%%)\n", faults, faultPerc)
 		fmt.Printf("Recovering:  %d\n", recovering)


### PR DESCRIPTION
## Proposed Changes
Print absolute time for (next) proving period start in `lotus-miner proving info`.

Example output now:

```cobol
Current Epoch:           1946257
Proving Period Boundary: 975
Proving Period Start:    1944975 (01 Jul 22 08:07 CEST, 10 hours 41 minutes ago)
Next Period Start:       1947855 (02 Jul 22 08:07 CEST, in 13 hours 19 minutes)

Faults:      0 (0.00%)
Recovering:  0
Deadline Index:       21
Deadline Sectors:     0
Deadline Open:        1946235 (11 minutes ago)
Deadline Close:       1946295 (in 19 minutes)
Deadline Challenge:   1946215 (21 minutes ago)
Deadline FaultCutoff: 1946165 (46 minutes ago)

```