### PR TITLE
feat: wdpost: Config for maximum partition count per message

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -375,6 +375,24 @@
   # env var: LOTUS_PROVING_DISABLEWDPOSTPRECHECKS
   #DisableWDPoStPreChecks = false
 
+  # Maximum number of partitions to prove in a single SubmitWindowPoSt messace. 0 = network limit (10 in nv16)
+  # 
+  # A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
+  # 
+  # The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
+  # means that a single message can prove at most 10 partinions
+  # 
+  # In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
+  # too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
+  # than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+  # to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
+  # 
+  # Setting this value above the network limit has no effect
+  #
+  # type: int
+  # env var: LOTUS_PROVING_MAXPARTITIONSPERMESSAGE
+  #MaxPartitionsPerMessage = 0
+
 
 [Sealing]
   # Upper bound on how many sectors can be waiting for more deals to be packed in it before it begins sealing at any given time.

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -689,6 +689,24 @@ sent to the chain
 After changing this option, confirm that the new value works in your setup by invoking
 'lotus-miner proving compute window-post 0'`,
 		},
+		{
+			Name: "MaxPartitionsPerMessage",
+			Type: "int",
+
+			Comment: `Maximum number of partitions to prove in a single SubmitWindowPoSt messace. 0 = network limit (10 in nv16)
+
+A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
+
+The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
+means that a single message can prove at most 10 partinions
+
+In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
+too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
+than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
+
+Setting this value above the network limit has no effect`,
+		},
 	},
 	"Pubsub": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -270,6 +270,21 @@ type ProvingConfig struct {
 	// After changing this option, confirm that the new value works in your setup by invoking
 	// 'lotus-miner proving compute window-post 0'
 	DisableWDPoStPreChecks bool
+
+	// Maximum number of partitions to prove in a single SubmitWindowPoSt messace. 0 = network limit (10 in nv16)
+	//
+	// A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
+	//
+	// The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
+	// means that a single message can prove at most 10 partinions
+	//
+	// In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
+	// too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
+	// than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+	// to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
+	//
+	// Setting this value above the network limit has no effect
+	MaxPartitionsPerMessage int
 }
 
 type SealingConfig struct {

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -517,6 +517,13 @@ func (s *WindowPoStScheduler) batchPartitions(partitions []api.Partition, nv net
 		partitionsPerMsg = declMax
 	}
 
+	// respect user config if set
+	if s.maxPartitionsPerMessage > 0 {
+		if partitionsPerMsg > s.maxPartitionsPerMessage {
+			partitionsPerMsg = s.maxPartitionsPerMessage
+		}
+	}
+
 	// The number of messages will be:
 	// ceiling(number of partitions / partitions per message)
 	batchCount := len(partitions) / partitionsPerMsg

--- a/storage/wdpost/wdpost_sched.go
+++ b/storage/wdpost/wdpost_sched.go
@@ -62,16 +62,17 @@ type NodeAPI interface {
 // WindowPoStScheduler watches the chain though the changeHandler, which in turn
 // turn calls the scheduler when the time arrives to do work.
 type WindowPoStScheduler struct {
-	api              NodeAPI
-	feeCfg           config.MinerFeeConfig
-	addrSel          *ctladdr.AddressSelector
-	prover           storiface.ProverPoSt
-	verifier         storiface.Verifier
-	faultTracker     sealer.FaultTracker
-	proofType        abi.RegisteredPoStProof
-	partitionSectors uint64
-	disablePreChecks bool
-	ch               *changeHandler
+	api                     NodeAPI
+	feeCfg                  config.MinerFeeConfig
+	addrSel                 *ctladdr.AddressSelector
+	prover                  storiface.ProverPoSt
+	verifier                storiface.Verifier
+	faultTracker            sealer.FaultTracker
+	proofType               abi.RegisteredPoStProof
+	partitionSectors        uint64
+	disablePreChecks        bool
+	maxPartitionsPerMessage int
+	ch                      *changeHandler
 
 	actor address.Address
 
@@ -98,15 +99,16 @@ func NewWindowedPoStScheduler(api NodeAPI,
 	}
 
 	return &WindowPoStScheduler{
-		api:              api,
-		feeCfg:           cfg,
-		addrSel:          as,
-		prover:           sp,
-		verifier:         verif,
-		faultTracker:     ft,
-		proofType:        mi.WindowPoStProofType,
-		partitionSectors: mi.WindowPoStPartitionSectors,
-		disablePreChecks: pcfg.DisableWDPoStPreChecks,
+		api:                     api,
+		feeCfg:                  cfg,
+		addrSel:                 as,
+		prover:                  sp,
+		verifier:                verif,
+		faultTracker:            ft,
+		proofType:               mi.WindowPoStProofType,
+		partitionSectors:        mi.WindowPoStPartitionSectors,
+		disablePreChecks:        pcfg.DisableWDPoStPreChecks,
+		maxPartitionsPerMessage: pcfg.MaxPartitionsPerMessage,
 
 		actor: actor,
 		evtTypes: [...]journal.EventType{


### PR DESCRIPTION
## Related Issues
Some users see windowPoSt messages exceed block gas limit.

## Proposed Changes

Add a new config value which allows limiting the number of partitions per deadline to values lower that the network limit
```toml
[Proving]
  # Maximum number of partitions to prove in a single SubmitWindowPoSt messace. 0 = network limit (10 in nv16)
  # 
  # A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
  # 
  # The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
  # means that a single message can prove at most 10 partinions
  # 
  # In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
  # too high to fit in the block gas limit; In those cases it may be necesary to set this value to something lower
  # than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
  # to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
  # 
  # Setting this value above the network limit has no effect
  #
  # type: int
  # env var: LOTUS_PROVING_MAXPARTITIONSPERMESSAGE
  #MaxPartitionsPerMessage = 0
```

I don't have good data to suggest safe values, but this gas use in a few random messages which landed recently on mainnet:
[1 partition with 1.1B limit](https://filfox.info/en/message/bafy2bzaceajr2wjixilw2ercbiqf2o2g5dkrqkyj6242wvttosokzcoh2vaco)
    [2 partitions with 2.1B limit](https://filfox.info/en/message/bafy2bzacednavdl47lxytx74cx3ktbdj4wp4njjbwul6nrnfraghmqy4ute7e)
    [2 partitions with 2.9B limit](https://filfox.info/en/message/bafy2bzaceazfmisc3rit5jauovh33qbhl2betxtqkzwy4lgn3xnitncm4anze)
    [2 partitions with 4.1B limit](https://filfox.info/en/message/bafy2bzaceau62jogw5iixp3wkcc7glqybbrn4kkav25jk5q5qtiuc4iqxcxdm)
    [5 partitions with 8.1B limit](https://filscan.io/tipset/message-detail?cid=bafy2bzaceaqkzlkbzercdx46slhranx72fxvwzf4rie73msi75lhxt4rexvqs)
    [3 partitions with 5.3B limit](https://filscan.io/tipset/message-detail?cid=bafy2bzaceackmxvm5gkmsonotjfidd5hq54w63gedatxvuvr3aysbqoiqozau)

This would suggest that:
* 1 partition per message is as conservative as one can get
* 2/3 are most likely safe in all cases (more data needed though)
* 4+ depend on the miner actor (may or may not be safe, more data needed)

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
