### PR TITLE
Test run build / publish jobs on all release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1045,7 +1045,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1057,7 +1057,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1079,7 +1079,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1089,7 +1089,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1044,8 +1044,8 @@ workflows:
       - build-appimage:
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1056,8 +1056,8 @@ workflows:
             - build-appimage
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1078,8 +1078,8 @@ workflows:
           channel: stable
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1088,8 +1088,8 @@ workflows:
           tag: stable
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /^release/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/


### PR DESCRIPTION
## Related Issues
The 1.16.0 release to linux / snapcraft based environments failed. This is because the actual build (https://app.circleci.com/pipelines/github/filecoin-project/lotus/21961/workflows/3bb820f2-4f7a-43d9-880f-7fe4dfecdc72/jobs/513420) failed to run successfully.

## Proposed Changes
This change runs all release builds (such as `publish-snapcraft`) on release branches in addition to tags. This means we will know if the build failed during testing on the release branch, before we cut a release / create the git tag.

While this isn't a final or very robust solution, it will allow us to diagnose and discover build errors sooner.

After menter
