### PR TITLE
fix incorrect usage of peer.IDFromString (should be peer.Decode)

### DIFF
--- a/node/impl/net/rcmgr.go
+++ b/node/impl/net/rcmgr.go
@@ -82,7 +82,7 @@ func (a *NetAPI) NetStat(ctx context.Context, scope string) (result api.NetStat,
 
 	case strings.HasPrefix(scope, "peer:"):
 		p := scope[5:]
-		pid, err := peer.IDFromString(p)
+		pid, err := peer.Decode(p)
 		if err != nil {
 			return result, xerrors.Errorf("invalid peer ID: %s: %w", p, err)
 		}
@@ -168,7 +168,7 @@ func (a *NetAPI) NetLimit(ctx context.Context, scope string) (result api.NetLimi
 
 	case strings.HasPrefix(scope, "peer:"):
 		p := scope[5:]
-		pid, err := peer.IDFromString(p)
+		pid, err := peer.Decode(p)
 		if err != nil {
 			return result, xerrors.Errorf("invalid peer ID: %s: %w", p, err)
 		}
@@ -255,7 +255,7 @@ func (a *NetAPI) NetSetLimit(ctx context.Context, scope string, limit api.NetLim
 
 	case strings.HasPrefix(scope, "peer:"):
 		p := scope[5:]
-		pid, err := peer.IDFromString(p)
+		pid, err := peer.Decode(p)
 		if err != nil {
 			return xerrors.Errorf("invalid peer ID: %s: %w", p, err)
 		}

--- a/node/modules/lp2p/libp2p.go
+++ b/node/modules/lp2p/libp2p.go
@@ -75,7 +75,7 @@ func ConnectionManager(low, high uint, grace time.Duration, protected []string) 
 		}
 
 		for _, p := range protected {
-			pid, err := peer.IDFromString(p)
+			pid, err := peer.Decode(p)
 			if err != nil {
 				return Libp2pOpts{}, xerrors.Errorf("failed to parse peer ID in protected peers array: %w", err)
 			}


### PR DESCRIPTION
Since this function is nothing but a footgun, we'll be removing it. See https://github.com/libp2p/go-libp2p-core/pull/274 for details.