### PR TITLE
_ci_: update snapcraft and release flow logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
-  build-all:
+  build-linux:
     executor: golang
     steps:
       - install-deps
@@ -518,6 +518,19 @@ jobs:
   publish:
     description: publish binary artifacts
     executor: ubuntu
+    parameters:
+      linux:
+        default: false
+        description: publish linux binaries?
+        type: boolean
+      darwin:
+        default: false
+        description: publish darwin binaries?
+        type: boolean
+      appimage:
+        default: false
+        description: publish appimage binaries?
+        type: boolean
     steps:
       - run:
           name: Install git jq curl
@@ -528,12 +541,21 @@ jobs:
       - install_ipfs
       - attach_workspace:
           at: "."
-      - run:
-          name: Create bundles
-          command: ./scripts/build-bundle.sh
-      - run:
-          name: Publish release
-          command: ./scripts/publish-release.sh
+      - when:
+          condition: << parameters.linux >>
+          steps:
+            - run: ./scripts/build-arch-bundle.sh linux
+            - run: ./scripts/publish-arch-release.sh linux
+      - when:
+          condition: << parameters.darwin>>
+          steps:
+            - run: ./scripts/build-arch-bundle.sh darwin
+            - run: ./scripts/publish-arch-release.sh darwin
+      - when:
+          condition: << parameters.appimage >>
+          steps:
+            - run: ./scripts/build-appimage-bundle.sh
+            - run: ./scripts/publish-arch-release.sh appimage
 
   publish-snapcraft:
     description: build and push snapcraft
@@ -550,11 +572,6 @@ jobs:
       - run:
           name: install snapcraft
           command: sudo snap install snapcraft --classic
-      - run:
-          name: create snapcraft config file
-          command: |
-            mkdir -p ~/.config/snapcraft
-            echo "$SNAPCRAFT_LOGIN_FILE" | base64 -d > ~/.config/snapcraft/snapcraft.cfg
       - run:
           name: build snap
           command: snapcraft --use-lxd
@@ -1020,7 +1037,7 @@ workflows:
               only:
                 - master
       - build-debug
-      - build-all:
+      - build-linux:
           filters:
             tags:
               only:
@@ -1044,15 +1061,39 @@ workflows:
       - build-appimage:
           filters:
             branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - publish:
+          name: publish-macos
+          darwin: true
+          requires:
+            - build-macos
+          filters:
+            branches:
               ignore:
                 - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
+          name: publish-linux
+          linux: true
           requires:
-            - build-all
-            - build-macos
+            - build-linux
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - publish:
+          name: publish-appimage
+          appimage: true
+          requires:
             - build-appimage
           filters:
             branches:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -115,7 +115,7 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
-  build-all:
+  build-linux:
     executor: golang
     steps:
       - install-deps
@@ -518,6 +518,19 @@ jobs:
   publish:
     description: publish binary artifacts
     executor: ubuntu
+    parameters:
+      linux:
+        default: false
+        description: publish linux binaries?
+        type: boolean
+      darwin:
+        default: false
+        description: publish darwin binaries?
+        type: boolean
+      appimage:
+        default: false
+        description: publish appimage binaries?
+        type: boolean
     steps:
       - run:
           name: Install git jq curl
@@ -528,12 +541,21 @@ jobs:
       - install_ipfs
       - attach_workspace:
           at: "."
-      - run:
-          name: Create bundles
-          command: ./scripts/build-bundle.sh
-      - run:
-          name: Publish release
-          command: ./scripts/publish-release.sh
+      - when:
+          condition: << parameters.linux >>
+          steps:
+            - run: ./scripts/build-arch-bundle.sh linux
+            - run: ./scripts/publish-arch-release.sh linux
+      - when:
+          condition: << parameters.darwin>>
+          steps:
+            - run: ./scripts/build-arch-bundle.sh darwin
+            - run: ./scripts/publish-arch-release.sh darwin
+      - when:
+          condition: << parameters.appimage >>
+          steps:
+            - run: ./scripts/build-appimage-bundle.sh
+            - run: ./scripts/publish-arch-release.sh appimage
 
   publish-snapcraft:
     description: build and push snapcraft
@@ -550,11 +572,6 @@ jobs:
       - run:
           name: install snapcraft
           command: sudo snap install snapcraft --classic
-      - run:
-          name: create snapcraft config file
-          command: |
-            mkdir -p ~/.config/snapcraft
-            echo "$SNAPCRAFT_LOGIN_FILE" | base64 -d > ~/.config/snapcraft/snapcraft.cfg
       - run:
           name: build snap
           command: snapcraft --use-lxd
@@ -780,7 +797,7 @@ workflows:
               only:
                 - master
       - build-debug
-      - build-all:
+      - build-linux:
           filters:
             tags:
               only:
@@ -804,15 +821,39 @@ workflows:
       - build-appimage:
           filters:
             branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - publish:
+          name: publish-macos
+          darwin: true
+          requires:
+            - build-macos
+          filters:
+            branches:
               ignore:
                 - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
+          name: publish-linux
+          linux: true
           requires:
-            - build-all
-            - build-macos
+            - build-linux
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - publish:
+          name: publish-appimage
+          appimage: true
+          requires:
             - build-appimage
           filters:
             branches:

--- a/scripts/build-appimage-bundle.sh
+++ b/scripts/build-appimage-bundle.sh
@@ -13,12 +13,6 @@ done
 mkdir bundle
 pushd bundle
 
-BINARIES=(
-    "lotus"
-    "lotus-miner"
-    "lotus-worker"
-)
-
 export IPFS_PATH=`mktemp -d`
 ipfs init
 ipfs daemon &

--- a/scripts/build-appimage-bundle.sh
+++ b/scripts/build-appimage-bundle.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-ARCHS=(
-    "darwin"
-    "linux"
-)
-
 REQUIRED=(
     "ipfs"
     "sha512sum"
@@ -31,24 +26,6 @@ PID="$!"
 trap "kill -9 ${PID}" EXIT
 sleep 30
 
-for ARCH in "${ARCHS[@]}"
-do
-    mkdir -p "${ARCH}/lotus"
-    pushd "${ARCH}"
-    for BINARY in "${BINARIES[@]}"
-    do
-        cp "../../${ARCH}/${BINARY}" "lotus/"
-        chmod +x "lotus/${BINARY}"
-    done
-
-    tar -zcvf "../lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" lotus
-    popd
-    rm -rf "${ARCH}"
-
-    sha512sum "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.sha512"
-
-    ipfs add -q "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.cid"
-done
 cp "../appimage/Lotus-${CIRCLE_TAG}-x86_64.AppImage" .
 sha512sum "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.sha512"
 ipfs add -q "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.cid"

--- a/scripts/build-arch-bundle
+++ b/scripts/build-arch-bundle
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -ex
+
+ARCH=$1
+
+REQUIRED=(
+    "ipfs"
+    "sha512sum"
+)
+for REQUIRE in "${REQUIRED[@]}"
+do
+    command -v "${REQUIRE}" >/dev/null 2>&1 || echo >&2 "'${REQUIRE}' must be installed"
+done
+
+mkdir bundle
+pushd bundle
+
+BINARIES=(
+    "lotus"
+    "lotus-miner"
+    "lotus-worker"
+)
+
+export IPFS_PATH=`mktemp -d`
+ipfs init
+ipfs daemon &
+PID="$!"
+trap "kill -9 ${PID}" EXIT
+sleep 30
+
+mkdir -p "${ARCH}/lotus"
+pushd "${ARCH}"
+for BINARY in "${BINARIES[@]}"
+do
+    cp "../../${ARCH}/${BINARY}" "lotus/"
+    chmod +x "lotus/${BINARY}"
+done
+
+tar -zcvf "../lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" lotus
+popd
+rm -rf "${ARCH}"
+
+sha512sum "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.sha512"
+
+ipfs add -q "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz" > "lotus_${CIRCLE_TAG}_${ARCH}-amd64.tar.gz.cid"
+popd


### PR DESCRIPTION
## Related Issues
https://app.circleci.com/pipelines/github/filecoin-project/lotus/21961/workflows/3bb820f2-4f7a-43d9-880f-7fe4dfecdc72/jobs/513420
Snap builds were previously failing due to an authentication issue. I think it was likely caused by outdated credentials, but snapcraft has also changed their auth method to use an env variable recently and deprecated the old value. So I set that new env var in CircleCI project settings, meaning we should be able to remove this section of CI where we write the old auth file.

I also tweaked the jobs for snapcraft and dockerhub to do trial-runs on all release branches, but still only publish on release tags. While it wouldn't have caught this issue, since it was publish related, I think it's still good practice to add this as a small sanity check.