### PR TITLE
chore: stop using the deprecated github.com/libp2p/go-libp2p-yamux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,6 @@ require (
 	github.com/libp2p/go-libp2p-record v0.1.3
 	github.com/libp2p/go-libp2p-resource-manager v0.3.0
 	github.com/libp2p/go-libp2p-routing-helpers v0.2.3
-	github.com/libp2p/go-libp2p-yamux v0.9.1
 	github.com/libp2p/go-maddr-filter v0.1.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1

--- a/go.sum
+++ b/go.sum
@@ -1386,7 +1386,6 @@ github.com/libp2p/go-libp2p-yamux v0.7.0/go.mod h1:fMyA0CsPfHkIuBU0wjRGrCjTBFiXT
 github.com/libp2p/go-libp2p-yamux v0.8.0/go.mod h1:yTkPgN2ib8FHyU1ZcVD7aelzyAqXXwEPbyx+aSKm9h8=
 github.com/libp2p/go-libp2p-yamux v0.8.1/go.mod h1:rUozF8Jah2dL9LLGyBaBeTQeARdwhefMCTQVQt6QobE=
 github.com/libp2p/go-libp2p-yamux v0.8.2/go.mod h1:rUozF8Jah2dL9LLGyBaBeTQeARdwhefMCTQVQt6QobE=
-github.com/libp2p/go-libp2p-yamux v0.9.1 h1:oplewiRix8s45SOrI30rCPZG5mM087YZp+VYhXAh4+c=
 github.com/libp2p/go-libp2p-yamux v0.9.1/go.mod h1:wRc6wvyxQINFcKe7daL4BeQ02Iyp+wxyC8WCNfngBrA=
 github.com/libp2p/go-maddr-filter v0.0.1/go.mod h1:6eT12kSQMA9x2pvFQa+xesMKUBlj9VImZbj3B9FBH/Q=
 github.com/libp2p/go-maddr-filter v0.0.4/go.mod h1:6eT12kSQMA9x2pvFQa+xesMKUBlj9VImZbj3B9FBH/Q=

--- a/node/modules/lp2p/smux.go
+++ b/node/modules/lp2p/smux.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/libp2p/go-libp2p"
-	yamux "github.com/libp2p/go-libp2p-yamux"
+	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 )
 
 func makeSmuxTransportOption() libp2p.Option {


### PR DESCRIPTION
Followup to https://github.com/filecoin-project/lotus/pull/8996.

Looks like the reason for these fixes is that the update procedure as described in [Release Notes](https://github.com/libp2p/go-libp2p/releases/tag/v0.20.0) was not followed (and apparently Lotus is not running `staticcheck` on CI).