### PR TITLE
feat: FVM: always enable tracing for user-triggered executions

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -89,6 +89,7 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		NetworkVersion: sm.GetNetworkVersion(ctx, pheight+1),
 		BaseFee:        types.NewInt(0),
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
+		Tracing:        true,
 	}
 
 	vmi, err := sm.newVM(ctx, vmopt)
@@ -226,6 +227,7 @@ func (sm *StateManager) CallWithGas(ctx context.Context, msg *types.Message, pri
 		NetworkVersion: sm.GetNetworkVersion(ctx, ts.Height()+1),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
+		Tracing:        true,
 	}
 	vmi, err := sm.newVM(ctx, vmopt)
 	if err != nil {
@@ -318,7 +320,7 @@ func (sm *StateManager) Replay(ctx context.Context, ts *types.TipSet, mcid cid.C
 	// message to find
 	finder.mcid = mcid
 
-	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &finder)
+	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &finder, true)
 	if err != nil && !xerrors.Is(err, errHaltExecution) {
 		return nil, nil, xerrors.Errorf("unexpected error during execution: %w", err)
 	}

--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -60,7 +60,7 @@ func (sm *StateManager) TipSetState(ctx context.Context, ts *types.TipSet) (st c
 		return ts.Blocks()[0].ParentStateRoot, ts.Blocks()[0].ParentMessageReceipts, nil
 	}
 
-	st, rec, err = sm.tsExec.ExecuteTipSet(ctx, sm, ts, sm.tsExecMonitor)
+	st, rec, err = sm.tsExec.ExecuteTipSet(ctx, sm, ts, sm.tsExecMonitor, false)
 	if err != nil {
 		return cid.Undef, cid.Undef, err
 	}
@@ -69,7 +69,7 @@ func (sm *StateManager) TipSetState(ctx context.Context, ts *types.TipSet) (st c
 }
 
 func (sm *StateManager) ExecutionTraceWithMonitor(ctx context.Context, ts *types.TipSet, em ExecMonitor) (cid.Cid, error) {
-	st, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, em)
+	st, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, em, true)
 	return st, err
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -58,7 +58,7 @@ type migration struct {
 
 type Executor interface {
 	NewActorRegistry() *vm.ActorRegistry
-	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor) (stateroot cid.Cid, rectsroot cid.Cid, err error)
+	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor, vmTracing bool) (stateroot cid.Cid, rectsroot cid.Cid, err error)
 }
 
 type StateManager struct {

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -94,6 +94,7 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		NetworkVersion: sm.GetNetworkVersion(ctx, height),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
+		Tracing:        true,
 	}
 	vmi, err := sm.newVM(ctx, vmopt)
 	if err != nil {

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -281,7 +281,7 @@ func defaultFVMOpts(ctx context.Context, opts *VMOpts) (*ffi.FVMOpts, error) {
 		BaseCircSupply: circToReport,
 		NetworkVersion: opts.NetworkVersion,
 		StateBase:      opts.StateBase,
-		Tracing:        EnableDetailedTracing,
+		Tracing:        opts.Tracing || EnableDetailedTracing,
 	}, nil
 
 }

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -59,7 +59,9 @@ func (m *Message) ValueReceived() abi.TokenAmount {
 	return m.msg.Value
 }
 
-// EnableDetailedTracing, if true, outputs gas tracing in execution traces.
+// EnableDetailedTracing has different behaviour in the LegacyVM and FVM.
+// In the LegacyVM, it enables detailed gas tracing, slowing down execution.
+// In the FVM, it enables execution traces, which are primarily used to observe subcalls.
 var EnableDetailedTracing = os.Getenv("LOTUS_VM_ENABLE_TRACING") == "1"
 
 type Runtime struct {

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -229,6 +229,7 @@ type VMOpts struct {
 	NetworkVersion network.Version
 	BaseFee        abi.TokenAmount
 	LookbackState  LookbackStateGetter
+	Tracing        bool
 }
 
 func NewLegacyVM(ctx context.Context, opts *VMOpts) (*LegacyVM, error) {

--- a/chain/vm/vmi.go
+++ b/chain/vm/vmi.go
@@ -21,8 +21,6 @@ type Interface interface {
 	Flush(ctx context.Context) (cid.Cid, error)
 }
 
-var useFvmForMainnetV15 = os.Getenv("LOTUS_USE_FVM_TO_SYNC_MAINNET_V15") == "1"
-
 // WARNING: You will not affect your node's execution by misusing this feature, but you will confuse yourself thoroughly!
 // An envvar that allows the user to specify debug actors bundles to be used by the FVM
 // alongside regular execution. This is basically only to be used to print out specific logging information.

--- a/chain/vm/vmi.go
+++ b/chain/vm/vmi.go
@@ -37,13 +37,5 @@ func NewVM(ctx context.Context, opts *VMOpts) (Interface, error) {
 		return NewFVM(ctx, opts)
 	}
 
-	// Remove after v16 upgrade, this is only to support testing and validation of the FVM
-	if useFvmForMainnetV15 && opts.NetworkVersion >= network.Version15 {
-		if useFvmDebug {
-			return NewDualExecutionFVM(ctx, opts)
-		}
-		return NewFVM(ctx, opts)
-	}
-
 	return NewLegacyVM(ctx, opts)
 }

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -169,6 +169,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 		params.ExecEpoch,
 		params.Rand,
 		recordOutputs,
+		true,
 		params.BaseFee,
 		nil,
 	)

--- a/itests/multisig_test.go
+++ b/itests/multisig_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	lmultisig "github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/itests/multisig"
 )
@@ -36,7 +35,6 @@ func TestMultisig(t *testing.T) {
 
 	//stm: @CHAIN_INCOMING_HANDLE_INCOMING_BLOCKS_001, @CHAIN_INCOMING_VALIDATE_BLOCK_PUBSUB_001, @CHAIN_INCOMING_VALIDATE_MESSAGE_PUBSUB_001
 	kit.QuietMiningLogs()
-	vm.EnableDetailedTracing = true
 
 	blockTime := 5 * time.Millisecond
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
@@ -47,8 +45,6 @@ func TestMultisig(t *testing.T) {
 
 // TestMultisigReentrant sends an infinitely recursive message to a multisig.
 func TestMultisigReentrant(t *testing.T) {
-	tracing := vm.EnableDetailedTracing
-	vm.EnableDetailedTracing = true
 	//stm: @CHAIN_SYNCER_LOAD_GENESIS_001, @CHAIN_SYNCER_FETCH_TIPSET_001,
 	//stm: @CHAIN_SYNCER_START_001, @CHAIN_SYNCER_SYNC_001, @BLOCKCHAIN_BEACON_VALIDATE_BLOCK_VALUES_01
 	//stm: @CHAIN_SYNCER_COLLECT_CHAIN_001, @CHAIN_SYNCER_COLLECT_HEADERS_001, @CHAIN_SYNCER_VALIDATE_TIPSET_001
@@ -138,7 +134,6 @@ func TestMultisigReentrant(t *testing.T) {
 	require.NoError(t, err, "failed to replay reentrant propose message (StateWaitMsg)")
 
 	require.Equal(t, 1025, countDepth(sl.ExecutionTrace))
-	vm.EnableDetailedTracing = tracing
 }
 
 func countDepth(trace types.ExecutionTrace) int {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Closes #8926 

## Proposed Changes
<!-- provide a clear list of the changes being made-->

- If `LOTUS_VM_ENABLE_TRACING` is set to 1, the FVM always produces execution traces.
- If `LOTUS_VM_ENABLE_TRACING` is not set to 1, the FVM produces execution traces on calls from `StateCompute`, `StateReplay`, and `StateCall`. It does not do so during regular execution.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
