### PR TITLE
fix: FVM: record message applied metrics

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -419,6 +420,7 @@ func NewDebugFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 
 func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet, error) {
 	start := build.Clock.Now()
+	defer atomic.AddUint64(&StatApplied, 1)
 	vmMsg := cmsg.VMMessage()
 	msgBytes, err := vmMsg.Serialize()
 	if err != nil {
@@ -482,6 +484,7 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 
 func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*ApplyRet, error) {
 	start := build.Clock.Now()
+	defer atomic.AddUint64(&StatApplied, 1)
 	cmsg.GasLimit = math.MaxInt64 / 2
 	vmMsg := cmsg.VMMessage()
 	msgBytes, err := vmMsg.Serialize()

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -45,12 +45,6 @@ var (
 	gasOnActorExec = newGasCharge("OnActorExec", 0, 0)
 )
 
-// stat counters
-var (
-	StatSends   uint64
-	StatApplied uint64
-)
-
 // ResolveToKeyAddr returns the public key type of address (`BLS`/`SECP256K1`) of an account actor identified by `addr`.
 func ResolveToKeyAddr(state types.StateTree, cst cbor.IpldStore, addr address.Address) (address.Address, error) {
 	if addr.Protocol() == address.BLS || addr.Protocol() == address.SECP256K1 {

--- a/chain/vm/vmi.go
+++ b/chain/vm/vmi.go
@@ -11,6 +11,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+// stat counters
+var (
+	StatSends   uint64
+	StatApplied uint64
+)
+
 type Interface interface {
 	// Applies the given message onto the VM's current state, returning the result of the execution
 	ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet, error)


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

#9050 

## Proposed Changes
<!-- provide a clear list of the changes being made-->

The stat counters that things like the CLI's "validated X messages" was missing for the FVM. This PR moves the counters themselves to the VM interface, and mutates them in the FVM as appropriate.

Note: We do NOT mutate them in the Dual execution VM / Debug VM, because the Dual Exec VM calls into the FVM::ApplyMessage(), which mutates the counter. This avoids double / triple counting.

## Additional Info
<!-- callouts, links to documentation, and etc-->

Thanks @rjan90 for the nudge!

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
