### PR TITLE
fix: sched: the lost sector tasks during scheduling

### DIFF
--- a/storage/sealer/sched_assigner_common.go
+++ b/storage/sealer/sched_assigner_common.go
@@ -174,6 +174,9 @@ func (a *AssignerCommon) TrySched(sh *Scheduler) {
 		case sh.OpenWindows[wnd].Done <- &window:
 		default:
 			log.Error("expected sh.OpenWindows[wnd].Done to be buffered")
+			for _, request := range window.Todo {
+				sh.SchedQueue.Push(request)
+			}
 		}
 	}
 


### PR DESCRIPTION
The sector sealing task will be removed from the task queue once it is scheduled into schedWindow.
If schedWindow cannot then pass this task to worker successfully, the task will be lost and can only be
recovered by restarting the miner. Such kind of problem is frequently encountered during the operation of nodes.
The longer the operation, the more sectors will get stuck. No task data of the corresponding sector could be
queried even through "lotus-miner sealing scheed-diag". 
The solution is to take the sector task out of schedWindow
when schedWindow fails to pass it to worker via chanal, rejoin this task to the queue of tasks to be assigned,
and wait for the next schedule.
