### PR TITLE
Path Traversal Bug

### DIFF
--- a/gen/inline-gen/main.go
+++ b/gen/inline-gen/main.go
@@ -19,7 +19,7 @@ const (
 )
 
 func main() {
-	db, err := ioutil.ReadFile(os.Args[2])
+	db, err := ioutil.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Unsanitized input from os.Args[2] argument flows into io.ioutil.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.

Signed-off-by: Bhaskar <ram@hacker.ind.in>
