### PR TITLE
fix: test: deflake TestQuotePriceForUnsealedRetrieval

### DIFF
--- a/itests/deals_pricing_test.go
+++ b/itests/deals_pricing_test.go
@@ -29,7 +29,7 @@ func TestQuotePriceForUnsealedRetrieval(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, miner, ens := kit.EnsembleMinimal(t)
-	ens.InterconnectAll().BeginMining(blocktime)
+	ens.InterconnectAll().BeginMiningMustPost(blocktime)
 
 	var (
 		ppb         = int64(1)
@@ -131,7 +131,7 @@ func TestZeroPricePerByteRetrieval(t *testing.T) {
 	)
 
 	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs())
-	ens.InterconnectAll().BeginMining(blockTime)
+	ens.InterconnectAll().BeginMiningMustPost(blockTime)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

This test failed flakily [here](https://app.circleci.com/pipelines/github/filecoin-project/lotus/22311/workflows/6c730f91-23cb-4123-8ffd-16ba2abce120/jobs/533522).

The underlying issue is that the (only) miner on the network was busy sealing a sector, and so missed its PoSt. That led to it being slashed, which halts the network since the power is 0. The test eventually times out.

## Proposed Changes
<!-- provide a clear list of the changes being made-->

The bad news is that this issue affects many tests. The good news is that @ZenGround0 already has a fix, which is the `BeginMiningMustPost` method. We just need to use this method!

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
