### PR TITLE
fix: documentation: fix description error in documentation about method StateReplay

### DIFF
--- a/documentation/en/api-v0-methods.md
+++ b/documentation/en/api-v0-methods.md
@@ -6195,7 +6195,7 @@ Response:
 ### StateReplay
 StateReplay replays a given message, assuming it was included in a block in the specified tipset.
 
-If a tipset key is provided, and a replacing message is found on chain,
+If a tipset key is provided, and a replacing message is not found on chain,
 the method will return an error saying that the message wasn't found
 
 If no tipset key is provided, the appropriate tipset is looked up, and if

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -6663,7 +6663,7 @@ Response:
 ### StateReplay
 StateReplay replays a given message, assuming it was included in a block in the specified tipset.
 
-If a tipset key is provided, and a replacing message is found on chain,
+If a tipset key is provided, and a replacing message is not found on chain,
 the method will return an error saying that the message wasn't found
 
 If no tipset key is provided, the appropriate tipset is looked up, and if


### PR DESCRIPTION
## Related Issues
There is description error in documentation about method StateReplay

## Proposed Changes
fix description error in below files:
api-v0-methods.md
api-v1-unstable-methods.md


## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
