### PR TITLE
_ci_: More tweaks to snapcraft release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1123,7 +1123,17 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^v\d+\.\d+\.\d+$/
+      - publish-snapcraft:
+          name: publish-snapcraft-candidate
+          channel: candidate
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
       - publish-dockerhub:
           name: publish-dockerhub
           tag: stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,7 +580,7 @@ jobs:
           command: |
             pwd
             ls *.snap
-            snapcraft push lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
+            snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,10 +574,13 @@ jobs:
           command: sudo snap install snapcraft --classic
       - run:
           name: build snap
-          command: snapcraft --use-lxd
+          command: snapcraft --use-lxd --debug
       - run:
           name: publish snap
-          command: snapcraft push *.snap --release << parameters.channel >>
+          command: |
+            pwd
+            ls *.snap
+            snapcraft push lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -580,7 +580,7 @@ jobs:
           command: |
             pwd
             ls *.snap
-            snapcraft push lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
+            snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -883,7 +883,17 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^v\d+\.\d+\.\d+$/
+      - publish-snapcraft:
+          name: publish-snapcraft-candidate
+          channel: candidate
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
       - publish-dockerhub:
           name: publish-dockerhub
           tag: stable

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -574,10 +574,13 @@ jobs:
           command: sudo snap install snapcraft --classic
       - run:
           name: build snap
-          command: snapcraft --use-lxd
+          command: snapcraft --use-lxd --debug
       - run:
           name: publish snap
-          command: snapcraft push *.snap --release << parameters.channel >>
+          command: |
+            pwd
+            ls *.snap
+            snapcraft push lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry


### PR DESCRIPTION
## Related Issues
Even after merging my previous PR, snapcraft publish failed again on the 1.17.0-rc4 release with ```ZeroDivisionError: integer division or modulo by zero```.

## Proposed Changes
1. We shouldn't be publishing to `stable` on RC tags, so instead publish to the `candidate` channel for RC releases.
2. When I ssh in the CircleCI build environment and run the exact same publish command, it works. So the only thing I can think might be the cause is the *.snap isn't matching the built file for some reason. So add extra verbose logging to the snap deploy job to figure out why it keeps erroring. 

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
