### PR TITLE
_ci_: Publish to both `lotus` and `lotus-filecoin` for snap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,14 +587,24 @@ jobs:
           name: install snapcraft
           command: sudo snap install snapcraft --classic
       - run:
-          name: build snap
+          name: build `lotus-filecoin` snap
           command: snapcraft --use-lxd --debug
       - run:
-          name: publish snap
+          name: publish `lotus-filecoin` snap
           command: |
-            pwd
-            ls *.snap
             snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
+      - run:
+          name: Rewrite snapcraft.yaml to use `lotus` name
+          command:
+            cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > lotus-snapcraft.yaml
+            mv lotus-snapcrat.yaml snap/snapcraft.yaml
+      - run:
+          name: build `lotus` snap
+          command: snapcraft --use-lxd --debug
+      - run:
+          name: publish `lotus` snap
+          command: |
+            snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -587,14 +587,24 @@ jobs:
           name: install snapcraft
           command: sudo snap install snapcraft --classic
       - run:
-          name: build snap
+          name: build `lotus-filecoin` snap
           command: snapcraft --use-lxd --debug
       - run:
-          name: publish snap
+          name: publish `lotus-filecoin` snap
           command: |
-            pwd
-            ls *.snap
             snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
+      - run:
+          name: Rewrite snapcraft.yaml to use `lotus` name
+          command:
+            cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > lotus-snapcraft.yaml
+            mv lotus-snapcrat.yaml snap/snapcraft.yaml
+      - run:
+          name: build `lotus` snap
+          command: snapcraft --use-lxd --debug
+      - run:
+          name: publish `lotus` snap
+          command: |
+            snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry


### PR DESCRIPTION
We recently got the access required from Canonical to publish to the Snap package store as `lotus` instead of `filecoin-lotus`. This one line change updates the snapcraft config to use the new package name.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
