### PR TITLE
_ci_: Switches goreleaser notes back to default (keep-existing)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -129,7 +129,6 @@ release:
     owner: filecoin-project
     name: lotus
   prerelease: auto
-  mode: append
   name_template: "Release v{{.Version}}"
 
 


### PR DESCRIPTION
I tried out goreleaser manually on the 1.17.0 release, and it appended a huge changelog that included duplicates of what was already there. This changes goreleaser so it will leave the existing release notes as-is if it finds them.

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
