### PR TITLE
_ci_ : Change default shell options for snapcraft publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,6 +591,7 @@ jobs:
           command: snapcraft --use-lxd --debug
       - run:
           name: publish `lotus-filecoin` snap
+          shell: /bin/bash -o pipefail
           command: |
             snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
       - run:
@@ -603,6 +604,7 @@ jobs:
           command: snapcraft --use-lxd --debug
       - run:
           name: publish `lotus` snap
+          shell: /bin/bash -o pipefail
           command: |
             snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -591,6 +591,7 @@ jobs:
           command: snapcraft --use-lxd --debug
       - run:
           name: publish `lotus-filecoin` snap
+          shell: /bin/bash -o pipefail
           command: |
             snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
       - run:
@@ -603,6 +604,7 @@ jobs:
           command: snapcraft --use-lxd --debug
       - run:
           name: publish `lotus` snap
+          shell: /bin/bash -o pipefail
           command: |
             snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
 


### PR DESCRIPTION
The builds were erroring only in CircleCI, when run manually the same
command worked fine. I reached out to CircleCI support, and got the
following message:

> The reason you are seeing this error when running in CircleCI and not while debugging with SSH is due to the -e set in #!/bin/bash -eo pipefail at the beginning of the shell while the debugging shell would just be #!/bin/bash. The -e sets to exit to the shell when any non zero [0] exit code status.
>
> Since you say the command works when debugging with SSH you can set the shell to use /bin/bash -o pipefail using a default shell options. Here is an example:
>
>       - run:
>          name: <<command name>>
>          shell: /bin/bash -o pipefail
>          command: |
>            << some commands>>
>
> Notice that I still added -o pipefail as that prevents errors in a pipeline from being masked.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
