### PR TITLE
_ci_: Run snap builds for lotus and lotus-filecoin in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,32 +581,29 @@ jobs:
         type: string
         default: "edge"
         description: snapcraft channel
+      snap-name:
+        type: string
+        default: 'lotus-filecoin'
+        description: name of snap in snap store
     steps:
       - checkout
       - run:
-          name: install snapcraft
+          name: Install snapcraft
           command: sudo snap install snapcraft --classic
       - run:
-          name: build `lotus-filecoin` snap
-          command: snapcraft --use-lxd --debug
+          name: Build << parameters.snap-name >> snap
+          command: |
+            if [ "<< parameters.snap-name >>" != 'lotus-filecoin' ]; then
+              cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > edited-snapcraft.yaml
+              mv edited-snapcraft.yaml snap/snapcraft.yaml
+            fi
+
+            snapcraft --use-lxd --debug
       - run:
-          name: publish `lotus-filecoin` snap
+          name: Publish snap to << parameters.channel >> channel
           shell: /bin/bash -o pipefail
           command: |
-            snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
-      - run:
-          name: Rewrite snapcraft.yaml to use `lotus` name
-          command:
-            cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > lotus-snapcraft.yaml
-            mv lotus-snapcrat.yaml snap/snapcraft.yaml
-      - run:
-          name: build `lotus` snap
-          command: snapcraft --use-lxd --debug
-      - run:
-          name: publish `lotus` snap
-          shell: /bin/bash -o pipefail
-          command: |
-            snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
+            snapcraft upload *.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry
@@ -1150,8 +1147,9 @@ workflows:
           tag: '${CIRCLE_SHA1:0:8}'
           target: lotus-test
       - publish-snapcraft:
-          name: publish-snapcraft-stable
+          name: "Publish Snapcraft (lotus-filecoin / candidate)"
           channel: stable
+          snap-name: lotus-filecoin
           filters:
             branches:
               ignore:
@@ -1160,8 +1158,31 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+$/
       - publish-snapcraft:
-          name: publish-snapcraft-candidate
+          name: "Publish Snapcraft (lotus-filecoin / candidate)"
           channel: candidate
+          snap-name: lotus-filecoin
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
+      - publish-snapcraft:
+          name: "Publish Snapcraft (lotus / stable)"
+          channel: stable
+          snap-name: lotus
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+$/
+      - publish-snapcraft:
+          name: "Publish Snapcraft (lotus / candidate)"
+          channel: candidate
+          snap-name: lotus
           filters:
             branches:
               ignore:
@@ -1190,8 +1211,13 @@ workflows:
                 - master
     jobs:
       - publish-snapcraft:
-          name: publish-snapcraft-nightly
+          name: "Publish Snapcraft Nightly (lotus-filecoin / edge)"
           channel: edge
+          snap-name: lotus-filecoin
+      - publish-snapcraft:
+          name: "Publish Snapcraft Nightly (lotus / edge)"
+          channel: edge
+          snap-name: lotus
       - publish-dockerhub:
           name: publish-dockerhub-nightly
           tag: nightly

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -581,32 +581,29 @@ jobs:
         type: string
         default: "edge"
         description: snapcraft channel
+      snap-name:
+        type: string
+        default: 'lotus-filecoin'
+        description: name of snap in snap store
     steps:
       - checkout
       - run:
-          name: install snapcraft
+          name: Install snapcraft
           command: sudo snap install snapcraft --classic
       - run:
-          name: build `lotus-filecoin` snap
-          command: snapcraft --use-lxd --debug
+          name: Build << parameters.snap-name >> snap
+          command: |
+            if [ "<< parameters.snap-name >>" != 'lotus-filecoin' ]; then
+              cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > edited-snapcraft.yaml
+              mv edited-snapcraft.yaml snap/snapcraft.yaml
+            fi
+
+            snapcraft --use-lxd --debug
       - run:
-          name: publish `lotus-filecoin` snap
+          name: Publish snap to << parameters.channel >> channel
           shell: /bin/bash -o pipefail
           command: |
-            snapcraft upload lotus-filecoin_latest_amd64.snap --release << parameters.channel >>
-      - run:
-          name: Rewrite snapcraft.yaml to use `lotus` name
-          command:
-            cat snap/snapcraft.yaml | sed 's/lotus-filecoin/lotus/' > lotus-snapcraft.yaml
-            mv lotus-snapcrat.yaml snap/snapcraft.yaml
-      - run:
-          name: build `lotus` snap
-          command: snapcraft --use-lxd --debug
-      - run:
-          name: publish `lotus` snap
-          shell: /bin/bash -o pipefail
-          command: |
-            snapcraft upload lotus_latest_amd64.snap --release << parameters.channel >>
+            snapcraft upload *.snap --release << parameters.channel >>
 
   build-and-push-image:
     description: build and push docker images to public AWS ECR registry
@@ -910,8 +907,9 @@ workflows:
           tag: '${CIRCLE_SHA1:0:8}'
           target: lotus-test
       - publish-snapcraft:
-          name: publish-snapcraft-stable
+          name: "Publish Snapcraft (lotus-filecoin / candidate)"
           channel: stable
+          snap-name: lotus-filecoin
           filters:
             branches:
               ignore:
@@ -920,8 +918,31 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+$/
       - publish-snapcraft:
-          name: publish-snapcraft-candidate
+          name: "Publish Snapcraft (lotus-filecoin / candidate)"
           channel: candidate
+          snap-name: lotus-filecoin
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
+      - publish-snapcraft:
+          name: "Publish Snapcraft (lotus / stable)"
+          channel: stable
+          snap-name: lotus
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+$/
+      - publish-snapcraft:
+          name: "Publish Snapcraft (lotus / candidate)"
+          channel: candidate
+          snap-name: lotus
           filters:
             branches:
               ignore:
@@ -950,8 +971,13 @@ workflows:
                 - master
     jobs:
       - publish-snapcraft:
-          name: publish-snapcraft-nightly
+          name: "Publish Snapcraft Nightly (lotus-filecoin / edge)"
           channel: edge
+          snap-name: lotus-filecoin
+      - publish-snapcraft:
+          name: "Publish Snapcraft Nightly (lotus / edge)"
+          channel: edge
+          snap-name: lotus
       - publish-dockerhub:
           name: publish-dockerhub-nightly
           tag: nightly


### PR DESCRIPTION
This fixes a typo in my snapcraft config that causes it to fail after publishing the first snap but before building the second:
https://app.circleci.com/pipelines/github/filecoin-project/lotus/22519/workflows/7727083f-3fdf-45da-bb2d-ca2c7ff30d37/jobs/549504

While fixing it, I also tweaked it so we can run the two snap jobs in parallel. We still need to publish under both the new `lotus` snap name and the legacy `lotus-filecoin` snap name until all our users have migrated to the `lotus` one.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
