### PR TITLE
fix: storage: don't panic in getCommitCutoff when precommit is not found

### DIFF
--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -573,6 +573,9 @@ func (b *CommitBatcher) getCommitCutoff(si SectorInfo) (time.Time, error) {
 		log.Errorf("getting precommit info: %s", err)
 		return time.Now(), err
 	}
+	if pci == nil {
+		return time.Now(), xerrors.Errorf("precommit info not found")
+	}
 	av, err := actors.VersionForNetwork(nv)
 	if err != nil {
 		log.Errorf("unsupported network vrsion: %s", err)


### PR DESCRIPTION
When a sector is added to a commit batcher, and it's precommit info isn't on chain (expired or somehow was never there), lotus-miner will panic with
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x1a39e61]
goroutine 171115825 [running]:
github.com/filecoin-project/lotus/storage/pipeline.(*CommitBatcher).getCommitCutoff(_, {{0x3e1b4a5, 0x15}, 0x137c, 0x8, 0x62f0729>
        /home/magik6k/github.com/filecoin-project/go-lotus/storage/pipeline/commit_batch.go:587 +0x3a1
github.com/filecoin-project/lotus/storage/pipeline.(*CommitBatcher).AddCommit(_, {_, _}, {{0x3e1b4a5, 0x15}, 0x137c, 0x8, 0x62f07>
        /home/magik6k/github.com/filecoin-project/go-lotus/storage/pipeline/commit_batch.go:478 +0x98
github.com/filecoin-project/lotus/storage/pipeline.(*Sealing).handleSubmitCommitAggregate(_, {{_, _}, _}, {{0x3e1b4a5, 0x15}, 0x1>
        /home/magik6k/github.com/filecoin-project/go-lotus/storage/pipeline/states_sealing.go:691 +0x1fb
github.com/filecoin-project/lotus/storage/pipeline.(*Sealing).Plan.func1({{_, _}, _}, {{0x3e1b4a5, 0x15}, 0x137c, 0x8, 0x62f07294>
        /home/magik6k/github.com/filecoin-project/go-lotus/storage/pipeline/fsm.go:32 +0x76
reflect.Value.call({0x3877aa0?, 0xc0183fd330?, 0x13?}, {0x3c905a9, 0x4}, {0xc01ce20f98, 0x2, 0x2?})
        /usr/lib/go/src/reflect/value.go:556 +0x845
reflect.Value.Call({0x3877aa0?, 0xc0183fd330?, 0xc01f5d5480?}, {0xc010a3e798, 0x2, 0x2})
        /usr/lib/go/src/reflect/value.go:339 +0xbf
github.com/filecoin-project/go-statemachine.(*StateMachine).run.func3()
        /home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/go-statemachine@v1.0.2/machine.go:113 +0x329
created by github.com/filecoin-project/go-statemachine.(*StateMachine).run
        /home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/go-statemachine@v1.0.2/machine.go:109 +0x6aa
```

