### PR TITLE
chore: release: Update `release_issue_template`

### DIFF
--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -66,14 +66,13 @@ Testing an RC:
   - [ ] Update the [CHANGELOG.md](https://github.com/filecoin-project/lotus/blob/master/CHANGELOG.md) to the state that can be used as release note.
   - [ ] Invite the wider community through (link to the release issue)
     
-- [ ] **Stage 4 - Release**
+- [ ] **Stage 4 - Stable Release**
   - [ ] Final preparation
-    - [ ] Verify that version string in [`version.go`](https://github.com/ipfs/go-ipfs/tree/master/version.go) has been updated.
-    - [ ] Prep the changelog using `scripts/mkreleaselog`, and add it to `CHANGELOG.md`. Ensure that [CHANGELOG.md](https://github.com/filecoin-project/lotus/blob/master/CHANGELOG.md) is up to date
+    - [ ] Verify that version string in [`version.go`](https://github.com/filecoin-project/lotus/blob/master/build/version.go) has been updated.
+    - [ ] Ensure that [CHANGELOG.md](https://github.com/filecoin-project/lotus/blob/master/CHANGELOG.md) is up to date
     - [ ] Merge `release-vX.Y.Z` into the `releases` branch.
     - [ ] Tag this merge commit (on the `releases` branch) with `vX.Y.Z`
-    - [ ] Cut the release [here](https://github.com/filecoin-project/lotus/releases/new?prerelease=true&target=releases).
-      - [ ] Check `Create a discussion for this release`
+    - [ ] Cut the release [here](https://github.com/filecoin-project/lotus/releases/new?prerelease=false&target=releases).
 
 
 - [ ] **Post-Release**


### PR DESCRIPTION
Updates the release_issue_template with some improvements:

- Changed some wrong links (links pointed to version.go in IPFS-repo)
- Removed `Create a discussion for this release`
- Removed "Prep the changelog using `scripts/mkreleaselog`, and add it to `CHANGELOG.md`" since this already has been captured in the first pre-release/release-candiadte step. Left that you should make sure that the CHANGELOG is up to date.
- Changed the `Cut the release`-link to be `prerelease=false` in the Stable Release step.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
