### PR TITLE
_ci_ / _build_ : Snap daemon autorun disable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,7 +85,7 @@ apps:
   lotus-daemon:
     command: snap-lotus-entrypoint.sh
     daemon: simple
-    install-mode: enable
+    install-mode: disable
     plugs:
       - network
       - network-bind

--- a/tools/packer/setup-snap.sh
+++ b/tools/packer/setup-snap.sh
@@ -33,8 +33,6 @@ snap alias lotus.lotus-daemon lotus-daemon
 snap alias lotus.lotus-miner lotus-miner
 snap alias lotus.lotus-worker lotus-worker
 
-snap stop lotus.lotus-daemon
-
 # Setup firewall
 yes | ufw enable
 ufw default deny incoming


### PR DESCRIPTION
Right now, we automatically start the lotus daemon when someone installs lotus via snapcraft, which in turn automatically starts downloading state snapshots. This changes the workflow so that the lotus daemon snap service is still installed, but is disabled by default in order to allow users who only need a lite node to avoid this resource intensive process.

This should not affect users who already have the snap installed, only users who install the snap fresh.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
