### PR TITLE
Update xcode version for macos builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
         description: publish github release and homebrew?
         type: boolean
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     steps:
       - prepare:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -382,7 +382,7 @@ jobs:
         description: publish github release and homebrew?
         type: boolean
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     steps:
       - prepare:


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/pull/9164

## Proposed Changes
Updates the xcode version in our build files so that releases can build properly.

Already backported to v1.17.1

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
