### PR TITLE
lotus: add alias for `lotus daemon` - `lotus run`

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -76,10 +76,11 @@ var daemonStopCmd = &cli.Command{
 	},
 }
 
-// DaemonCmd is the `go-lotus daemon` command
+// DaemonCmd is the `lotus daemon` command
 var DaemonCmd = &cli.Command{
 	Name:  "daemon",
 	Usage: "Start a lotus daemon process",
+	Aliases: []string{"run"},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "api",


### PR DESCRIPTION
## Related Issues
none

## Proposed Changes
all other `lotus-*` daemons are started with `lotus-* run`. adding the alias will provide consistent behavior without breaking the existing `lotus daemon` command

old comment fixed along the way


## Additional Info
not needed, straight forward addition

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
