### PR TITLE
chore:  seed: add cmd for adding signers to vkh to genesis

### DIFF
--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -42,6 +42,7 @@ var genesisCmd = &cli.Command{
 		genesisSetRemainderCmd,
 		genesisSetActorVersionCmd,
 		genesisCarCmd,
+		genesisSetVRKSignersCmd,
 	},
 }
 
@@ -579,5 +580,91 @@ var genesisCarCmd = &cli.Command{
 
 		_, err := testing.MakeGenesis(ofile, c.Args().First())(bstor, sbldr, jrnl)()
 		return err
+	},
+}
+
+var genesisSetVRKSignersCmd = &cli.Command{
+	Name:  "set-signers",
+	Usage: "",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "threshold",
+			Usage: "change the verifreg signer threshold",
+		},
+		&cli.StringSliceFlag{
+			Name:  "signers",
+			Usage: "verifreg signers",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("must specify template file")
+		}
+
+		genf, err := homedir.Expand(cctx.Args().First())
+		if err != nil {
+			return err
+		}
+
+		var template genesis.Template
+		b, err := ioutil.ReadFile(genf)
+		if err != nil {
+			return xerrors.Errorf("read genesis template: %w", err)
+		}
+
+		if err := json.Unmarshal(b, &template); err != nil {
+			return xerrors.Errorf("unmarshal genesis template: %w", err)
+		}
+
+		var signers []address.Address
+		var rootkeyMultisig genesis.MultisigMeta
+		if cctx.IsSet("signers") {
+			for _, s := range cctx.StringSlice("signers") {
+				signer, err := address.NewFromString(s)
+				if err != nil {
+					return err
+				}
+				signers = append(signers, signer)
+				template.Accounts = append(template.Accounts, genesis.Actor{
+					Type:    genesis.TAccount,
+					Balance: big.Mul(big.NewInt(50_000), big.NewInt(int64(build.FilecoinPrecision))),
+					Meta:    (&genesis.AccountMeta{Owner: signer}).ActorMeta(),
+				})
+			}
+			rootkeyMultisig = genesis.MultisigMeta{
+				Signers:         signers,
+				Threshold:       1,
+				VestingDuration: 0,
+				VestingStart:    0,
+			}
+
+		}
+
+		if cctx.IsSet("threshold") {
+			rootkeyMultisig = genesis.MultisigMeta{
+				Signers:         signers,
+				Threshold:       cctx.Int("threshold"),
+				VestingDuration: 0,
+				VestingStart:    0,
+			}
+		}
+
+		newVrk := genesis.Actor{
+			Type:    genesis.TMultisig,
+			Balance: big.NewInt(0),
+			Meta:    rootkeyMultisig.ActorMeta(),
+		}
+
+		template.VerifregRootKey = newVrk
+
+		b, err = json.MarshalIndent(&template, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		if err := ioutil.WriteFile(genf, b, 0644); err != nil {
+			return err
+		}
+		return nil
 	},
 }


### PR DESCRIPTION

## Proposed Changes
<!-- provide a clear list of the changes being made-->
currently, following [this guide](https://lotus.filecoin.io/developers/local-network/#lotus-node-setup) to spin up a local testnet doesn't give the dev control over the verifreg. 
adding the below command, where dev can specify the signers, they'd like to have for verifreg upon genesis creation. the command also allocate some FIL to the signer account so it easier to test operation later.

```
./lotus-seed genesis add-signers --threshold=<>  --signers <pubkey1> --signers <pubkey2> localnet.json
```


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
