### PR TITLE
cli: Don't panic with no providers in client retrieve

### DIFF
--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -315,6 +315,9 @@ Examples:
 		if err != nil {
 			return err
 		}
+		if eref == nil {
+			return xerrors.Errorf("failed to find providers")
+		}
 
 		if s != nil {
 			eref.DAGs = append(eref.DAGs, lapi.DagSpec{DataSelector: s, ExportMerkleProof: cctx.Bool("car-export-merkle-proof")})


### PR DESCRIPTION
Should address some gateway test flakiness like https://app.circleci.com/pipelines/github/filecoin-project/lotus/22805/workflows/2907bba9-2f9b-420b-9309-1078350bb9bb/jobs/564691

```
--- FAIL: TestGatewayCLIDealFlow (5.40s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a941e2]

goroutine 25183 [running]:
testing.tRunner.func1.2({0x3a279a0, 0x5eebe00})
	/usr/local/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1392 +0x39f
panic({0x3a279a0, 0x5eebe00})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/filecoin-project/lotus/cli.glob..func41(0xc0024542c0)
	/home/circleci/project/cli/client_retr.go:323 +0x502
github.com/filecoin-project/lotus/itests/kit.(*MockCLIClient).RunCmdRaw(0xc003497e80, {0xc00d7f7dc0?, 0x7f4dd406f0d0?, 0x38?})
	/home/circleci/project/itests/kit/mockcli.go:111 +0x323
github.com/filecoin-project/lotus/itests/kit.(*MockCLIClient).RunCmd(0xc003497e80, {0xc00d7f7dc0?, 0x0?, 0x0?})
	/home/circleci/project/itests/kit/mockcli.go:62 +0x2d
github.com/filecoin-project/lotus/itests/kit.RunClientTest(0x4545118?, {0x5f0a3c0, 0x12, 0x12}, 0xc0145e5c20)
	/home/circleci/project/itests/kit/client.go:119 +0x121d
command-line-arguments.TestGatewayCLIDealFlow(0xc010b922f0?)
	/home/circleci/project/itests/gateway_test.go:234 +0x6f
testing.tRunner(0xc014534820, 0x4244600)
	/usr/local/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1486 +0x35f
```