### PR TITLE
fix: cli: fix panic in `lotus-miner actor control list`

### DIFF
--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -513,7 +513,7 @@ var actorControlList = &cli.Command{
 			}
 			kstr := k.String()
 			if !cctx.Bool("verbose") {
-				kstr = kstr[:9] + "..."
+				kstr = kstr[:6] + "..."
 			}
 
 			bstr := types.FIL(b).String()

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -513,7 +513,9 @@ var actorControlList = &cli.Command{
 			}
 			kstr := k.String()
 			if !cctx.Bool("verbose") {
-				kstr = kstr[:6] + "..."
+				if len(kstr) > 9 {
+					kstr = kstr[:6] + "..."
+				}
 			}
 
 			bstr := types.FIL(b).String()

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -367,7 +367,7 @@ var actorControlList = &cli.Command{
 
 			kstr := k.String()
 			if !cctx.Bool("verbose") {
-				kstr = kstr[:9] + "..."
+				kstr = kstr[:6] + "..."
 			}
 
 			bstr := types.FIL(b).String()

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -367,7 +367,9 @@ var actorControlList = &cli.Command{
 
 			kstr := k.String()
 			if !cctx.Bool("verbose") {
-				kstr = kstr[:6] + "..."
+				if len(kstr) > 9 {
+					kstr = kstr[:6] + "..."
+				}
 			}
 
 			bstr := types.FIL(b).String()


### PR DESCRIPTION
Tuning down slice to only 6 characters to avoid panics if the multisig-actor is of a really low character length.

## Related Issues
fixes #9239 

## Proposed Changes

## Additional Info
```
lotus-miner actor control list
name    ID      key        use    balance                   
owner   t01044  t01044...         2 FIL                     
worker  t01041  t3wxxc...  other  7.999999626974119012 FIL  
```

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
