### PR TITLE
fix: ux: better ledger rejection error

### DIFF
--- a/cli/send.go
+++ b/cli/send.go
@@ -155,9 +155,8 @@ var sendCmd = &cli.Command{
 		if err != nil {
 			if strings.Contains(err.Error(), "no current EF") {
 				return xerrors.Errorf("transaction rejected on ledger: %w", err)
-			} else {
-				return err
 			}
+			return err
 		}
 
 		fmt.Fprintf(cctx.App.Writer, "%s\n", sm.Cid())

--- a/cli/send.go
+++ b/cli/send.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
@@ -152,7 +153,11 @@ var sendCmd = &cli.Command{
 
 		sm, err := InteractiveSend(ctx, cctx, srv, proto)
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "no current EF") {
+				return xerrors.Errorf("transaction rejected on ledger: %w", err)
+			} else {
+				return err
+			}
 		}
 
 		fmt.Fprintf(cctx.App.Writer, "%s\n", sm.Cid())


### PR DESCRIPTION
Print a more understandable error message when signing a transaction is being rejected on ledger.

## Related Issues
resolves #5335

## Proposed Changes
Prints out a more understandable error message.
```
./lotus send --from=t1ybav9myh3cb6ltslejecasegosgnggcx6ld2nwi t3qcixsxivj5ygpqhi2ima526btslwexuzwl2urlto4wweszdkb4cs6bq65bwcsw7uvfpvmhxbn4norpne6zza 0.01
ERROR: transaction rejected on ledger: publishing message: failed to sign message: [APDU_CODE_COMMAND_NOT_ALLOWED] Command not allowed (no current EF)
```

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
