### PR TITLE
fix: miner: Call SyncBasefeeCheck from `lotus info`

### DIFF
--- a/cmd/lotus-miner/info.go
+++ b/cmd/lotus-miner/info.go
@@ -25,7 +25,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/api/v0api"
+	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
@@ -70,7 +70,7 @@ func infoCmdAct(cctx *cli.Context) error {
 	}
 	defer closer()
 
-	fullapi, acloser, err := lcli.GetFullNodeAPI(cctx)
+	fullapi, acloser, err := lcli.GetFullNodeAPIV1(cctx)
 	if err != nil {
 		return err
 	}
@@ -94,33 +94,10 @@ func infoCmdAct(cctx *cli.Context) error {
 
 	fmt.Print("Chain: ")
 
-	head, err := fullapi.ChainHead(ctx)
+	err = lcli.SyncBasefeeCheck(ctx, fullapi)
 	if err != nil {
 		return err
 	}
-
-	switch {
-	case time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelaySecs*3/2): // within 1.5 epochs
-		fmt.Printf("[%s]", color.GreenString("sync ok"))
-	case time.Now().Unix()-int64(head.MinTimestamp()) < int64(build.BlockDelaySecs*5): // within 5 epochs
-		fmt.Printf("[%s]", color.YellowString("sync slow (%s behind)", time.Now().Sub(time.Unix(int64(head.MinTimestamp()), 0)).Truncate(time.Second)))
-	default:
-		fmt.Printf("[%s]", color.RedString("sync behind! (%s behind)", time.Now().Sub(time.Unix(int64(head.MinTimestamp()), 0)).Truncate(time.Second)))
-	}
-
-	basefee := head.MinTicketBlock().ParentBaseFee
-	gasCol := []color.Attribute{color.FgBlue}
-	switch {
-	case basefee.GreaterThan(big.NewInt(7000_000_000)): // 7 nFIL
-		gasCol = []color.Attribute{color.BgRed, color.FgBlack}
-	case basefee.GreaterThan(big.NewInt(3000_000_000)): // 3 nFIL
-		gasCol = []color.Attribute{color.FgRed}
-	case basefee.GreaterThan(big.NewInt(750_000_000)): // 750 uFIL
-		gasCol = []color.Attribute{color.FgYellow}
-	case basefee.GreaterThan(big.NewInt(100_000_000)): // 100 uFIL
-		gasCol = []color.Attribute{color.FgGreen}
-	}
-	fmt.Printf(" [basefee %s]", color.New(gasCol...).Sprint(types.FIL(basefee).Short()))
 
 	fmt.Println()
 
@@ -152,7 +129,7 @@ func infoCmdAct(cctx *cli.Context) error {
 	return nil
 }
 
-func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v0api.FullNode, nodeApi api.StorageMiner) error {
+func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v1api.FullNode, nodeApi api.StorageMiner) error {
 	maddr, err := getActorAddress(ctx, cctx)
 	if err != nil {
 		return err
@@ -615,7 +592,7 @@ func colorTokenAmount(format string, amount abi.TokenAmount) {
 	}
 }
 
-func producedBlocks(ctx context.Context, count int, maddr address.Address, napi v0api.FullNode) error {
+func producedBlocks(ctx context.Context, count int, maddr address.Address, napi v1api.FullNode) error {
 	var err error
 	head, err := napi.ChainHead(ctx)
 	if err != nil {


### PR DESCRIPTION
Call SyncBasefeeCheck from `lotus info` to not duplicate logic. Also switches to V1 api.

## Related Issues
Follow up of https://github.com/filecoin-project/lotus/pull/9233#discussion_r958461092

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
