### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/lib/backupds/backupds_test.go
+++ b/lib/backupds/backupds_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,7 +73,7 @@ func TestLogRestore(t *testing.T) {
 
 	require.NoError(t, bds.Close())
 
-	fls, err := ioutil.ReadDir(logdir)
+	fls, err := os.ReadDir(logdir)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(fls))
 

--- a/lib/backupds/log.go
+++ b/lib/backupds/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,7 +22,7 @@ func (d *Datastore) startLog(logdir string) error {
 		return xerrors.Errorf("mkdir logdir ('%s'): %w", logdir, err)
 	}
 
-	files, err := ioutil.ReadDir(logdir)
+	files, err := os.ReadDir(logdir)
 	if err != nil {
 		return xerrors.Errorf("read logdir ('%s'): %w", logdir, err)
 	}

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -370,7 +370,7 @@ func (st *Local) declareSectors(ctx context.Context, p string, id storiface.ID, 
 	}
 
 	for _, t := range storiface.PathTypes {
-		ents, err := ioutil.ReadDir(filepath.Join(p, t.String()))
+		ents, err := os.ReadDir(filepath.Join(p, t.String()))
 		if err != nil {
 			if os.IsNotExist(err) {
 				if err := os.MkdirAll(filepath.Join(p, t.String()), 0755); err != nil { // nolint

--- a/storage/sealer/ffiwrapper/sealer_test.go
+++ b/storage/sealer/ffiwrapper/sealer_test.go
@@ -585,7 +585,7 @@ func BenchmarkWriteWithAlignment(b *testing.B) {
 }
 
 func openFDs(t *testing.T) int {
-	dent, err := ioutil.ReadDir("/proc/self/fd")
+	dent, err := os.ReadDir("/proc/self/fd")
 	require.NoError(t, err)
 
 	var skip int
@@ -611,7 +611,7 @@ func requireFDsClosed(t *testing.T, start int) {
 	openNow := openFDs(t)
 
 	if start != openNow {
-		dent, err := ioutil.ReadDir("/proc/self/fd")
+		dent, err := os.ReadDir("/proc/self/fd")
 		require.NoError(t, err)
 
 		for _, info := range dent {

--- a/storage/sealer/tarutil/systar.go
+++ b/storage/sealer/tarutil/systar.go
@@ -3,7 +3,6 @@ package tarutil
 import (
 	"archive/tar"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -52,13 +51,18 @@ func ExtractTar(body io.Reader, dir string, buf []byte) error {
 func TarDirectory(dir string, w io.Writer, buf []byte) error {
 	tw := tar.NewWriter(w)
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	for _, file := range files {
-		h, err := tar.FileInfoHeader(file, "")
+		info, err := file.Info()
+		if err != nil {
+			return xerrors.Errorf("getting file info for file %s: %w", file.Name(), err)
+		}
+
+		h, err := tar.FileInfoHeader(info, "")
 		if err != nil {
 			return xerrors.Errorf("getting header for file %s: %w", file.Name(), err)
 		}

--- a/testplans/lotus-soup/sanity.go
+++ b/testplans/lotus-soup/sanity.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -24,7 +23,7 @@ func sanityCheck() {
 		panic(enhanceMsg("/var/tmp/filecoin-proof-parameters is not a directory; aborting"))
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		panic(enhanceMsg("failed list directory /var/tmp/filecoin-proof-parameters: %s", err))
 	}


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
`ioutil.ReadDir` has been deprecated in Go 1.16. The new `os.ReadDir` is a more efficient implementation than `ioutil.ReadDir`.

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

## Proposed Changes
<!-- provide a clear list of the changes being made-->

1. Replaces `ioutil.ReadDir` with `os.ReadDir`.

## Additional Info
<!-- callouts, links to documentation, and etc-->

https://pkg.go.dev/io/ioutil#ReadDir

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
