### PR TITLE
fix: api: Ignore uuid check for messages with uuid not set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -925,6 +925,11 @@ workflows:
           target: "./itests/mempool_test.go"
       
       - test:
+          name: test-itest-mpool_msg_uuid
+          suite: itest-mpool_msg_uuid
+          target: "./itests/mpool_msg_uuid_test.go"
+      
+      - test:
           name: test-itest-multisig
           suite: itest-multisig
           target: "./itests/multisig_test.go"

--- a/itests/mpool_msg_uuid_test.go
+++ b/itests/mpool_msg_uuid_test.go
@@ -2,16 +2,19 @@ package itests
 
 import (
 	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/node/config"
-	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestMsgWithoutUuidWithMaxFee(t *testing.T) {

--- a/itests/mpool_msg_uuid_test.go
+++ b/itests/mpool_msg_uuid_test.go
@@ -1,0 +1,52 @@
+package itests
+
+import (
+	"context"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestMsgWithoutUuidWithMaxFee(t *testing.T) {
+	ctx := context.Background()
+
+	kit.QuietMiningLogs()
+
+	node, _, ens := kit.EnsembleMinimal(t, kit.MockProofs())
+	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
+
+	bal, err := node.WalletBalance(ctx, node.DefaultKey.Address)
+	require.NoError(t, err)
+
+	// send self half of account balance
+	msgHalfBal := &types.Message{
+		From:  node.DefaultKey.Address,
+		To:    node.DefaultKey.Address,
+		Value: big.Div(bal, big.NewInt(2)),
+	}
+	smHalfBal, err := node.MpoolPushMessage(ctx, msgHalfBal, &api.MessageSendSpec{MaxFee: abi.TokenAmount(config.DefaultDefaultMaxFee)})
+	require.NoError(t, err)
+	mLookup, err := node.StateWaitMsg(ctx, smHalfBal.Cid(), 3, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.Equal(t, exitcode.Ok, mLookup.Receipt.ExitCode)
+
+	msgQuarterBal := &types.Message{
+		From:  node.DefaultKey.Address,
+		To:    node.DefaultKey.Address,
+		Value: big.Div(bal, big.NewInt(4)),
+	}
+	smQuarterBal, err := node.MpoolPushMessage(ctx, msgQuarterBal, &api.MessageSendSpec{MaxFee: abi.TokenAmount(config.DefaultDefaultMaxFee)})
+	require.NoError(t, err)
+
+	require.Equal(t, msgQuarterBal.Value, smQuarterBal.Message.Value)
+	mLookup, err = node.StateWaitMsg(ctx, smQuarterBal.Cid(), 3, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.Equal(t, exitcode.Ok, mLookup.Receipt.ExitCode)
+}

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -3,8 +3,8 @@ package full
 import (
 	"context"
 	"encoding/json"
-	"github.com/google/uuid"
 
+	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -3,6 +3,7 @@ package full
 import (
 	"context"
 	"encoding/json"
+	"github.com/google/uuid"
 
 	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
@@ -142,8 +143,8 @@ func (a *MpoolAPI) MpoolPushMessage(ctx context.Context, msg *types.Message, spe
 	msg = &cp
 	inMsg := *msg
 
-	// Check if this uuid has already been processed
-	if spec != nil {
+	// Check if this uuid has already been processed. Ignore if uuid is not populated
+	if (spec != nil) && (spec.MsgUuid != uuid.UUID{}) {
 		signedMessage, err := a.MessageSigner.GetSignedMessage(ctx, spec.MsgUuid)
 		if err == nil {
 			log.Warnf("Message already processed. cid=%s", signedMessage.Cid())
@@ -206,7 +207,7 @@ func (a *MpoolAPI) MpoolPushMessage(ctx context.Context, msg *types.Message, spe
 	}
 
 	// Store uuid->signed message in datastore
-	if spec != nil {
+	if (spec != nil) && (spec.MsgUuid != uuid.UUID{}) {
 		err = a.MessageSigner.StoreSignedMessage(ctx, spec.MsgUuid, signedMsg)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
https://github.com/filecoin-project/lotus/issues/9299

## Proposed Changes
<!-- provide a clear list of the changes being made-->
Enhances the existing uuid to check to also check for non nil spec but with MsgUuid not set

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
