### PR TITLE
fix: sealing: Abort upgrades in sectors with no deals

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -442,6 +442,30 @@
   # env var: LOTUS_SEALING_MAXUPGRADINGSECTORS
   #MaxUpgradingSectors = 0
 
+  # When set to a non-zero value, minimum number of epochs until sector expiration required for sectors to be considered
+  # for upgrades (0 = DealMinDuration = 180 days = 518400 epochs)
+  # 
+  # Note that if all deals waiting in the input queue have lifetimes longer than this value, upgrade sectors will be
+  # required to have expiration of at least the soonest-ending deal
+  #
+  # type: uint64
+  # env var: LOTUS_SEALING_MINUPGRADESECTOREXPIRATION
+  #MinUpgradeSectorExpiration = 0
+
+  # When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
+  # be selected based on lowest initial pledge.
+  # 
+  # Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
+  # selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
+  # where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
+  # 
+  # Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
+  # initial pledge - upgrade sectors will always be chosen based on longest expiration
+  #
+  # type: uint64
+  # env var: LOTUS_SEALING_MINTARGETUPGRADESECTOREXPIRATION
+  #MinTargetUpgradeSectorExpiration = 0
+
   # CommittedCapacitySectorLifetime is the duration a Committed Capacity (CC) sector will
   # live before it must be extended or converted into sector containing deals before it is
   # terminated. Value must be between 180-540 days inclusive

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -923,6 +923,30 @@ flow when the volume of storage deals is lower.`,
 			Comment: `Upper bound on how many sectors can be sealing+upgrading at the same time when upgrading CC sectors with deals (0 = MaxSealingSectorsForDeals)`,
 		},
 		{
+			Name: "MinUpgradeSectorExpiration",
+			Type: "uint64",
+
+			Comment: `When set to a non-zero value, minimum number of epochs until sector expiration required for sectors to be considered
+for upgrades (0 = DealMinDuration = 180 days = 518400 epochs)
+
+Note that if all deals waiting in the input queue have lifetimes longer than this value, upgrade sectors will be
+required to have expiration of at least the soonest-ending deal`,
+		},
+		{
+			Name: "MinTargetUpgradeSectorExpiration",
+			Type: "uint64",
+
+			Comment: `When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
+be selected based on lowest initial pledge.
+
+Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
+selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
+where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
+
+Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
+initial pledge - upgrade sectors will always be chosen based on longest expiration`,
+		},
+		{
 			Name: "CommittedCapacitySectorLifetime",
 			Type: "Duration",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -319,6 +319,24 @@ type SealingConfig struct {
 	// Upper bound on how many sectors can be sealing+upgrading at the same time when upgrading CC sectors with deals (0 = MaxSealingSectorsForDeals)
 	MaxUpgradingSectors uint64
 
+	// When set to a non-zero value, minimum number of epochs until sector expiration required for sectors to be considered
+	// for upgrades (0 = DealMinDuration = 180 days = 518400 epochs)
+	//
+	// Note that if all deals waiting in the input queue have lifetimes longer than this value, upgrade sectors will be
+	// required to have expiration of at least the soonest-ending deal
+	MinUpgradeSectorExpiration uint64
+
+	// When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
+	// be selected based on lowest initial pledge.
+	//
+	// Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
+	// selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
+	// where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
+	//
+	// Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
+	// initial pledge - upgrade sectors will always be chosen based on longest expiration
+	MinTargetUpgradeSectorExpiration uint64
+
 	// CommittedCapacitySectorLifetime is the duration a Committed Capacity (CC) sector will
 	// live before it must be extended or converted into sector containing deals before it is
 	// terminated. Value must be between 180-540 days inclusive

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -983,17 +983,19 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 	return func(cfg sealiface.Config) (err error) {
 		err = mutateSealingCfg(r, func(c config.SealingConfiger) {
 			newCfg := config.SealingConfig{
-				MaxWaitDealsSectors:             cfg.MaxWaitDealsSectors,
-				MaxSealingSectors:               cfg.MaxSealingSectors,
-				MaxSealingSectorsForDeals:       cfg.MaxSealingSectorsForDeals,
-				PreferNewSectorsForDeals:        cfg.PreferNewSectorsForDeals,
-				MaxUpgradingSectors:             cfg.MaxUpgradingSectors,
-				CommittedCapacitySectorLifetime: config.Duration(cfg.CommittedCapacitySectorLifetime),
-				WaitDealsDelay:                  config.Duration(cfg.WaitDealsDelay),
-				MakeNewSectorForDeals:           cfg.MakeNewSectorForDeals,
-				MakeCCSectorsAvailable:          cfg.MakeCCSectorsAvailable,
-				AlwaysKeepUnsealedCopy:          cfg.AlwaysKeepUnsealedCopy,
-				FinalizeEarly:                   cfg.FinalizeEarly,
+				MaxWaitDealsSectors:              cfg.MaxWaitDealsSectors,
+				MaxSealingSectors:                cfg.MaxSealingSectors,
+				MaxSealingSectorsForDeals:        cfg.MaxSealingSectorsForDeals,
+				PreferNewSectorsForDeals:         cfg.PreferNewSectorsForDeals,
+				MaxUpgradingSectors:              cfg.MaxUpgradingSectors,
+				CommittedCapacitySectorLifetime:  config.Duration(cfg.CommittedCapacitySectorLifetime),
+				WaitDealsDelay:                   config.Duration(cfg.WaitDealsDelay),
+				MakeNewSectorForDeals:            cfg.MakeNewSectorForDeals,
+				MinUpgradeSectorExpiration:       cfg.MinUpgradeSectorExpiration,
+				MinTargetUpgradeSectorExpiration: cfg.MinTargetUpgradeSectorExpiration,
+				MakeCCSectorsAvailable:           cfg.MakeCCSectorsAvailable,
+				AlwaysKeepUnsealedCopy:           cfg.AlwaysKeepUnsealedCopy,
+				FinalizeEarly:                    cfg.FinalizeEarly,
 
 				CollateralFromMinerBalance: cfg.CollateralFromMinerBalance,
 				AvailableBalanceBuffer:     types.FIL(cfg.AvailableBalanceBuffer),
@@ -1024,11 +1026,14 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 
 func ToSealingConfig(dealmakingCfg config.DealmakingConfig, sealingCfg config.SealingConfig) sealiface.Config {
 	return sealiface.Config{
-		MaxWaitDealsSectors:             sealingCfg.MaxWaitDealsSectors,
-		MaxSealingSectors:               sealingCfg.MaxSealingSectors,
-		MaxSealingSectorsForDeals:       sealingCfg.MaxSealingSectorsForDeals,
-		PreferNewSectorsForDeals:        sealingCfg.PreferNewSectorsForDeals,
-		MaxUpgradingSectors:             sealingCfg.MaxUpgradingSectors,
+		MaxWaitDealsSectors:              sealingCfg.MaxWaitDealsSectors,
+		MaxSealingSectors:                sealingCfg.MaxSealingSectors,
+		MaxSealingSectorsForDeals:        sealingCfg.MaxSealingSectorsForDeals,
+		PreferNewSectorsForDeals:         sealingCfg.PreferNewSectorsForDeals,
+		MinUpgradeSectorExpiration:       sealingCfg.MinUpgradeSectorExpiration,
+		MinTargetUpgradeSectorExpiration: sealingCfg.MinTargetUpgradeSectorExpiration,
+		MaxUpgradingSectors:              sealingCfg.MaxUpgradingSectors,
+
 		StartEpochSealingBuffer:         abi.ChainEpoch(dealmakingCfg.StartEpochSealingBuffer),
 		MakeNewSectorForDeals:           sealingCfg.MakeNewSectorForDeals,
 		CommittedCapacitySectorLifetime: time.Duration(sealingCfg.CommittedCapacitySectorLifetime),

--- a/storage/pipeline/sealiface/config.go
+++ b/storage/pipeline/sealiface/config.go
@@ -20,6 +20,10 @@ type Config struct {
 
 	PreferNewSectorsForDeals bool
 
+	MinUpgradeSectorExpiration uint64
+
+	MinTargetUpgradeSectorExpiration uint64
+
 	MaxUpgradingSectors uint64
 
 	MakeNewSectorForDeals bool

--- a/storage/pipeline/states_replica_update.go
+++ b/storage/pipeline/states_replica_update.go
@@ -21,6 +21,11 @@ import (
 )
 
 func (m *Sealing) handleReplicaUpdate(ctx statemachine.Context, sector SectorInfo) error {
+	// if the sector ended up not having any deals, abort the upgrade
+	if !sector.hasDeals() {
+		return ctx.Send(SectorAbortUpgrade{xerrors.New("sector had no deals")})
+	}
+
 	if err := checkPieces(ctx.Context(), m.maddr, sector, m.Api, true); err != nil { // Sanity check state
 		return handleErrors(ctx, err, sector)
 	}

--- a/storage/pipeline/states_replica_update.go
+++ b/storage/pipeline/states_replica_update.go
@@ -302,6 +302,6 @@ func handleErrors(ctx statemachine.Context, err error, sector SectorInfo) error 
 	case *ErrExpiredDeals: // Probably not much we can do here, maybe re-pack the sector?
 		return ctx.Send(SectorDealsExpired{xerrors.Errorf("expired dealIDs in sector: %w", err)})
 	default:
-		return xerrors.Errorf("checkPieces sanity check error: %w", err)
+		return xerrors.Errorf("checkPieces sanity check error: %w (%+v)", err, err)
 	}
 }

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -49,6 +49,11 @@ func (m *Sealing) handlePacking(ctx statemachine.Context, sector SectorInfo) err
 	delete(m.assignedPieces, m.minerSectorID(sector.SectorNumber))
 	m.inputLk.Unlock()
 
+	// if this is a snapdeals sector, but it ended up not having any deals, abort the upgrade
+	if sector.State == SnapDealsPacking && !sector.hasDeals() {
+		return ctx.Send(SectorAbortUpgrade{xerrors.New("sector had no deals")})
+	}
+
 	log.Infow("performing filling up rest of the sector...", "sector", sector.SectorNumber)
 
 	var allocated abi.UnpaddedPieceSize


### PR DESCRIPTION
## Related Issues
Fixes #8686 (will need some testing)

## Proposed Changes
* Auto-abort upgrading sectors which didn't get any deals assigned
* In calcTargetExpiration, don't pick the lowest possible deal duration as minExpiration when there isn't an entire sector worth of deals in the input queue - use the expiration from lowest-expiration deal in the queue (note that in this case the _target_ expiration will be max deal duration, so we'll still try to find sectors with longer expiration in that case; but in case there are no better upgradable sectors we could pick one with way too low expiration to be useful)
* Add 2 config fields to configure minimums for minimumExpiration and targetExpiration

## Additional Info
When testing it will be really useful to see debug logs from the `sectors` subsystem - `lotus-miner log set-level --system sectors debug`

