### PR TITLE
fix: docsgen: revert rename of API Name to Num

### DIFF
--- a/node/config/cfgdocgen/gen.go
+++ b/node/config/cfgdocgen/gen.go
@@ -94,7 +94,7 @@ func run() error {
 package config
 
 type DocField struct {
-	Num    string
+	Name    string
 	Type    string
 	Comment string
 }
@@ -109,7 +109,7 @@ var Doc = map[string][]DocField{
 
 		for _, f := range typ {
 			fmt.Println("\t\t{")
-			fmt.Printf("\t\t\tNum: \"%s\",\n", f.Name)
+			fmt.Printf("\t\t\tName: \"%s\",\n", f.Name)
 			fmt.Printf("\t\t\tType: \"%s\",\n\n", f.Type)
 			fmt.Printf("\t\t\tComment: `%s`,\n", f.Comment)
 			fmt.Println("\t\t},")

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -3,7 +3,7 @@
 package config
 
 type DocField struct {
-	Num     string
+	Name    string
 	Type    string
 	Comment string
 }
@@ -11,19 +11,19 @@ type DocField struct {
 var Doc = map[string][]DocField{
 	"API": []DocField{
 		{
-			Num:  "ListenAddress",
+			Name: "ListenAddress",
 			Type: "string",
 
 			Comment: `Binding address for the Lotus API`,
 		},
 		{
-			Num:  "RemoteListenAddress",
+			Name: "RemoteListenAddress",
 			Type: "string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Timeout",
+			Name: "Timeout",
 			Type: "Duration",
 
 			Comment: ``,
@@ -31,7 +31,7 @@ var Doc = map[string][]DocField{
 	},
 	"Backup": []DocField{
 		{
-			Num:  "DisableMetadataLog",
+			Name: "DisableMetadataLog",
 			Type: "bool",
 
 			Comment: `When set to true disables metadata log (.lotus/kvlog). This can save disk
@@ -43,13 +43,13 @@ your node if metadata log is disabled`,
 	},
 	"BatchFeeConfig": []DocField{
 		{
-			Num:  "Base",
+			Name: "Base",
 			Type: "types.FIL",
 
 			Comment: ``,
 		},
 		{
-			Num:  "PerSector",
+			Name: "PerSector",
 			Type: "types.FIL",
 
 			Comment: ``,
@@ -57,13 +57,13 @@ your node if metadata log is disabled`,
 	},
 	"Chainstore": []DocField{
 		{
-			Num:  "EnableSplitstore",
+			Name: "EnableSplitstore",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Splitstore",
+			Name: "Splitstore",
 			Type: "Splitstore",
 
 			Comment: ``,
@@ -71,45 +71,45 @@ your node if metadata log is disabled`,
 	},
 	"Client": []DocField{
 		{
-			Num:  "UseIpfs",
+			Name: "UseIpfs",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "IpfsOnlineMode",
+			Name: "IpfsOnlineMode",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "IpfsMAddr",
+			Name: "IpfsMAddr",
 			Type: "string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "IpfsUseForRetrieval",
+			Name: "IpfsUseForRetrieval",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "SimultaneousTransfersForStorage",
+			Name: "SimultaneousTransfersForStorage",
 			Type: "uint64",
 
 			Comment: `The maximum number of simultaneous data transfers between the client
 and storage providers for storage deals`,
 		},
 		{
-			Num:  "SimultaneousTransfersForRetrieval",
+			Name: "SimultaneousTransfersForRetrieval",
 			Type: "uint64",
 
 			Comment: `The maximum number of simultaneous data transfers between the client
 and storage providers for retrieval deals`,
 		},
 		{
-			Num:  "OffChainRetrieval",
+			Name: "OffChainRetrieval",
 			Type: "bool",
 
 			Comment: `Require that retrievals perform no on-chain operations. Paid retrievals
@@ -119,31 +119,31 @@ of automatically performing on-chain operations.`,
 	},
 	"Common": []DocField{
 		{
-			Num:  "API",
+			Name: "API",
 			Type: "API",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Backup",
+			Name: "Backup",
 			Type: "Backup",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Logging",
+			Name: "Logging",
 			Type: "Logging",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Libp2p",
+			Name: "Libp2p",
 			Type: "Libp2p",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Pubsub",
+			Name: "Pubsub",
 			Type: "Pubsub",
 
 			Comment: ``,
@@ -151,7 +151,7 @@ of automatically performing on-chain operations.`,
 	},
 	"DAGStoreConfig": []DocField{
 		{
-			Num:  "RootDir",
+			Name: "RootDir",
 			Type: "string",
 
 			Comment: `Path to the dagstore root directory. This directory contains three
@@ -166,7 +166,7 @@ Default value: <LOTUS_MARKETS_PATH>/dagstore (split deployment) or
 <LOTUS_MINER_PATH>/dagstore (monolith deployment)`,
 		},
 		{
-			Num:  "MaxConcurrentIndex",
+			Name: "MaxConcurrentIndex",
 			Type: "int",
 
 			Comment: `The maximum amount of indexing jobs that can run simultaneously.
@@ -174,7 +174,7 @@ Default value: <LOTUS_MARKETS_PATH>/dagstore (split deployment) or
 Default value: 5.`,
 		},
 		{
-			Num:  "MaxConcurrentReadyFetches",
+			Name: "MaxConcurrentReadyFetches",
 			Type: "int",
 
 			Comment: `The maximum amount of unsealed deals that can be fetched simultaneously
@@ -182,7 +182,7 @@ from the storage subsystem. 0 means unlimited.
 Default value: 0 (unlimited).`,
 		},
 		{
-			Num:  "MaxConcurrentUnseals",
+			Name: "MaxConcurrentUnseals",
 			Type: "int",
 
 			Comment: `The maximum amount of unseals that can be processed simultaneously
@@ -190,7 +190,7 @@ from the storage subsystem. 0 means unlimited.
 Default value: 0 (unlimited).`,
 		},
 		{
-			Num:  "MaxConcurrencyStorageCalls",
+			Name: "MaxConcurrencyStorageCalls",
 			Type: "int",
 
 			Comment: `The maximum number of simultaneous inflight API calls to the storage
@@ -198,7 +198,7 @@ subsystem.
 Default value: 100.`,
 		},
 		{
-			Num:  "GCInterval",
+			Name: "GCInterval",
 			Type: "Duration",
 
 			Comment: `The time between calls to periodic dagstore GC, in time.Duration string
@@ -208,49 +208,49 @@ Default value: 1 minute.`,
 	},
 	"DealmakingConfig": []DocField{
 		{
-			Num:  "ConsiderOnlineStorageDeals",
+			Name: "ConsiderOnlineStorageDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept online deals`,
 		},
 		{
-			Num:  "ConsiderOfflineStorageDeals",
+			Name: "ConsiderOfflineStorageDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept offline deals`,
 		},
 		{
-			Num:  "ConsiderOnlineRetrievalDeals",
+			Name: "ConsiderOnlineRetrievalDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept retrieval deals`,
 		},
 		{
-			Num:  "ConsiderOfflineRetrievalDeals",
+			Name: "ConsiderOfflineRetrievalDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept offline retrieval deals`,
 		},
 		{
-			Num:  "ConsiderVerifiedStorageDeals",
+			Name: "ConsiderVerifiedStorageDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept verified deals`,
 		},
 		{
-			Num:  "ConsiderUnverifiedStorageDeals",
+			Name: "ConsiderUnverifiedStorageDeals",
 			Type: "bool",
 
 			Comment: `When enabled, the miner can accept unverified deals`,
 		},
 		{
-			Num:  "PieceCidBlocklist",
+			Name: "PieceCidBlocklist",
 			Type: "[]cid.Cid",
 
 			Comment: `A list of Data CIDs to reject when making deals`,
 		},
 		{
-			Num:  "ExpectedSealDuration",
+			Name: "ExpectedSealDuration",
 			Type: "Duration",
 
 			Comment: `Maximum expected amount of time getting the deal into a sealed sector will take
@@ -258,47 +258,47 @@ This includes the time the deal will need to get transferred and published
 before being assigned to a sector`,
 		},
 		{
-			Num:  "MaxDealStartDelay",
+			Name: "MaxDealStartDelay",
 			Type: "Duration",
 
 			Comment: `Maximum amount of time proposed deal StartEpoch can be in future`,
 		},
 		{
-			Num:  "PublishMsgPeriod",
+			Name: "PublishMsgPeriod",
 			Type: "Duration",
 
 			Comment: `When a deal is ready to publish, the amount of time to wait for more
 deals to be ready to publish before publishing them all as a batch`,
 		},
 		{
-			Num:  "MaxDealsPerPublishMsg",
+			Name: "MaxDealsPerPublishMsg",
 			Type: "uint64",
 
 			Comment: `The maximum number of deals to include in a single PublishStorageDeals
 message`,
 		},
 		{
-			Num:  "MaxProviderCollateralMultiplier",
+			Name: "MaxProviderCollateralMultiplier",
 			Type: "uint64",
 
 			Comment: `The maximum collateral that the provider will put up against a deal,
 as a multiplier of the minimum collateral bound`,
 		},
 		{
-			Num:  "MaxStagingDealsBytes",
+			Name: "MaxStagingDealsBytes",
 			Type: "int64",
 
 			Comment: `The maximum allowed disk usage size in bytes of staging deals not yet
 passed to the sealing node by the markets service. 0 is unlimited.`,
 		},
 		{
-			Num:  "SimultaneousTransfersForStorage",
+			Name: "SimultaneousTransfersForStorage",
 			Type: "uint64",
 
 			Comment: `The maximum number of parallel online data transfers for storage deals`,
 		},
 		{
-			Num:  "SimultaneousTransfersForStoragePerClient",
+			Name: "SimultaneousTransfersForStoragePerClient",
 			Type: "uint64",
 
 			Comment: `The maximum number of simultaneous data transfers from any single client
@@ -309,33 +309,33 @@ across all storage clients is bound by SimultaneousTransfersForStorage
 regardless of this number.`,
 		},
 		{
-			Num:  "SimultaneousTransfersForRetrieval",
+			Name: "SimultaneousTransfersForRetrieval",
 			Type: "uint64",
 
 			Comment: `The maximum number of parallel online data transfers for retrieval deals`,
 		},
 		{
-			Num:  "StartEpochSealingBuffer",
+			Name: "StartEpochSealingBuffer",
 			Type: "uint64",
 
 			Comment: `Minimum start epoch buffer to give time for sealing of sector with deal.`,
 		},
 		{
-			Num:  "Filter",
+			Name: "Filter",
 			Type: "string",
 
 			Comment: `A command used for fine-grained evaluation of storage deals
 see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#using-filters-for-fine-grained-storage-and-retrieval-deal-acceptance for more details`,
 		},
 		{
-			Num:  "RetrievalFilter",
+			Name: "RetrievalFilter",
 			Type: "string",
 
 			Comment: `A command used for fine-grained evaluation of retrieval deals
 see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#using-filters-for-fine-grained-storage-and-retrieval-deal-acceptance for more details`,
 		},
 		{
-			Num:  "RetrievalPricing",
+			Name: "RetrievalPricing",
 			Type: "*RetrievalPricing",
 
 			Comment: ``,
@@ -343,7 +343,7 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 	},
 	"FeeConfig": []DocField{
 		{
-			Num:  "DefaultMaxFee",
+			Name: "DefaultMaxFee",
 			Type: "types.FIL",
 
 			Comment: ``,
@@ -351,25 +351,25 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 	},
 	"FullNode": []DocField{
 		{
-			Num:  "Client",
+			Name: "Client",
 			Type: "Client",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Wallet",
+			Name: "Wallet",
 			Type: "Wallet",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Fees",
+			Name: "Fees",
 			Type: "FeeConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Chainstore",
+			Name: "Chainstore",
 			Type: "Chainstore",
 
 			Comment: ``,
@@ -377,14 +377,14 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 	},
 	"IndexProviderConfig": []DocField{
 		{
-			Num:  "Enable",
+			Name: "Enable",
 			Type: "bool",
 
 			Comment: `Enable set whether to enable indexing announcement to the network and expose endpoints that
 allow indexer nodes to process announcements. Enabled by default.`,
 		},
 		{
-			Num:  "EntriesCacheCapacity",
+			Name: "EntriesCacheCapacity",
 			Type: "int",
 
 			Comment: `EntriesCacheCapacity sets the maximum capacity to use for caching the indexing advertisement
@@ -395,7 +395,7 @@ with the default EntriesCacheCapacity, and EntriesChunkSize means the cache size
 256MiB when full.`,
 		},
 		{
-			Num:  "EntriesChunkSize",
+			Name: "EntriesChunkSize",
 			Type: "int",
 
 			Comment: `EntriesChunkSize sets the maximum number of multihashes to include in a single entries chunk.
@@ -403,7 +403,7 @@ Defaults to 16384 if not specified. Note that chunks are chained together for in
 advertisements that include more multihashes than the configured EntriesChunkSize.`,
 		},
 		{
-			Num:  "TopicName",
+			Name: "TopicName",
 			Type: "string",
 
 			Comment: `TopicName sets the topic name on which the changes to the advertised content are announced.
@@ -412,7 +412,7 @@ in following format: '/indexer/ingest/<network-name>'
 Defaults to empty, which implies the topic name is inferred from network name.`,
 		},
 		{
-			Num:  "PurgeCacheOnStart",
+			Name: "PurgeCacheOnStart",
 			Type: "bool",
 
 			Comment: `PurgeCacheOnStart sets whether to clear any cached entries chunks when the provider engine
@@ -422,14 +422,14 @@ datastore if any is present.`,
 	},
 	"Libp2p": []DocField{
 		{
-			Num:  "ListenAddresses",
+			Name: "ListenAddresses",
 			Type: "[]string",
 
 			Comment: `Binding address for the libp2p host - 0 means random port.
 Format: multiaddress; see https://multiformats.io/multiaddr/`,
 		},
 		{
-			Num:  "AnnounceAddresses",
+			Name: "AnnounceAddresses",
 			Type: "[]string",
 
 			Comment: `Addresses to explicitally announce to other peers. If not specified,
@@ -437,26 +437,26 @@ all interface addresses are announced
 Format: multiaddress`,
 		},
 		{
-			Num:  "NoAnnounceAddresses",
+			Name: "NoAnnounceAddresses",
 			Type: "[]string",
 
 			Comment: `Addresses to not announce
 Format: multiaddress`,
 		},
 		{
-			Num:  "BootstrapPeers",
+			Name: "BootstrapPeers",
 			Type: "[]string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "ProtectedPeers",
+			Name: "ProtectedPeers",
 			Type: "[]string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "DisableNatPortMap",
+			Name: "DisableNatPortMap",
 			Type: "bool",
 
 			Comment: `When not disabled (default), lotus asks NAT devices (e.g., routers), to
@@ -465,14 +465,14 @@ When this works (i.e., when your router supports NAT port forwarding),
 it makes the local lotus node accessible from the public internet`,
 		},
 		{
-			Num:  "ConnMgrLow",
+			Name: "ConnMgrLow",
 			Type: "uint",
 
 			Comment: `ConnMgrLow is the number of connections that the basic connection manager
 will trim down to.`,
 		},
 		{
-			Num:  "ConnMgrHigh",
+			Name: "ConnMgrHigh",
 			Type: "uint",
 
 			Comment: `ConnMgrHigh is the number of connections that, when exceeded, will trigger
@@ -480,7 +480,7 @@ a connection GC operation. Note: protected/recently formed connections don't
 count towards this limit.`,
 		},
 		{
-			Num:  "ConnMgrGrace",
+			Name: "ConnMgrGrace",
 			Type: "Duration",
 
 			Comment: `ConnMgrGrace is a time duration that new connections are immune from being
@@ -489,7 +489,7 @@ closed by the connection manager.`,
 	},
 	"Logging": []DocField{
 		{
-			Num:  "SubsystemLevels",
+			Name: "SubsystemLevels",
 			Type: "map[string]string",
 
 			Comment: `SubsystemLevels specify per-subsystem log levels`,
@@ -497,38 +497,38 @@ closed by the connection manager.`,
 	},
 	"MinerAddressConfig": []DocField{
 		{
-			Num:  "PreCommitControl",
+			Name: "PreCommitControl",
 			Type: "[]string",
 
 			Comment: `Addresses to send PreCommit messages from`,
 		},
 		{
-			Num:  "CommitControl",
+			Name: "CommitControl",
 			Type: "[]string",
 
 			Comment: `Addresses to send Commit messages from`,
 		},
 		{
-			Num:  "TerminateControl",
+			Name: "TerminateControl",
 			Type: "[]string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "DealPublishControl",
+			Name: "DealPublishControl",
 			Type: "[]string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "DisableOwnerFallback",
+			Name: "DisableOwnerFallback",
 			Type: "bool",
 
 			Comment: `DisableOwnerFallback disables usage of the owner address for messages
 sent automatically`,
 		},
 		{
-			Num:  "DisableWorkerFallback",
+			Name: "DisableWorkerFallback",
 			Type: "bool",
 
 			Comment: `DisableWorkerFallback disables usage of the worker address for messages
@@ -539,49 +539,49 @@ over the worker address if this flag is set.`,
 	},
 	"MinerFeeConfig": []DocField{
 		{
-			Num:  "MaxPreCommitGasFee",
+			Name: "MaxPreCommitGasFee",
 			Type: "types.FIL",
 
 			Comment: ``,
 		},
 		{
-			Num:  "MaxCommitGasFee",
+			Name: "MaxCommitGasFee",
 			Type: "types.FIL",
 
 			Comment: ``,
 		},
 		{
-			Num:  "MaxPreCommitBatchGasFee",
+			Name: "MaxPreCommitBatchGasFee",
 			Type: "BatchFeeConfig",
 
 			Comment: `maxBatchFee = maxBase + maxPerSector * nSectors`,
 		},
 		{
-			Num:  "MaxCommitBatchGasFee",
+			Name: "MaxCommitBatchGasFee",
 			Type: "BatchFeeConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "MaxTerminateGasFee",
+			Name: "MaxTerminateGasFee",
 			Type: "types.FIL",
 
 			Comment: ``,
 		},
 		{
-			Num:  "MaxWindowPoStGasFee",
+			Name: "MaxWindowPoStGasFee",
 			Type: "types.FIL",
 
 			Comment: `WindowPoSt is a high-value operation, so the default fee should be high.`,
 		},
 		{
-			Num:  "MaxPublishDealsFee",
+			Name: "MaxPublishDealsFee",
 			Type: "types.FIL",
 
 			Comment: ``,
 		},
 		{
-			Num:  "MaxMarketBalanceAddFee",
+			Name: "MaxMarketBalanceAddFee",
 			Type: "types.FIL",
 
 			Comment: ``,
@@ -589,37 +589,37 @@ over the worker address if this flag is set.`,
 	},
 	"MinerSubsystemConfig": []DocField{
 		{
-			Num:  "EnableMining",
+			Name: "EnableMining",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "EnableSealing",
+			Name: "EnableSealing",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "EnableSectorStorage",
+			Name: "EnableSectorStorage",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "EnableMarkets",
+			Name: "EnableMarkets",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "SealerApiInfo",
+			Name: "SealerApiInfo",
 			Type: "string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "SectorIndexApiInfo",
+			Name: "SectorIndexApiInfo",
 			Type: "string",
 
 			Comment: ``,
@@ -627,7 +627,7 @@ over the worker address if this flag is set.`,
 	},
 	"ProvingConfig": []DocField{
 		{
-			Num:  "ParallelCheckLimit",
+			Name: "ParallelCheckLimit",
 			Type: "int",
 
 			Comment: `Maximum number of sector checks to run in parallel. (0 = unlimited)
@@ -640,7 +640,7 @@ After changing this option, confirm that the new value works in your setup by in
 'lotus-miner proving compute window-post 0'`,
 		},
 		{
-			Num:  "DisableBuiltinWindowPoSt",
+			Name: "DisableBuiltinWindowPoSt",
 			Type: "bool",
 
 			Comment: `Disable Window PoSt computation on the lotus-miner process even if no window PoSt workers are present.
@@ -652,7 +652,7 @@ After changing this option, confirm that the new value works in your setup by in
 'lotus-miner proving compute window-post 0'`,
 		},
 		{
-			Num:  "DisableBuiltinWinningPoSt",
+			Name: "DisableBuiltinWinningPoSt",
 			Type: "bool",
 
 			Comment: `Disable Winning PoSt computation on the lotus-miner process even if no winning PoSt workers are present.
@@ -661,7 +661,7 @@ WARNING: If no WinningPoSt workers are connected, Winning PoSt WILL FAIL resulti
 Before enabling this option, make sure your PoSt workers work correctly.`,
 		},
 		{
-			Num:  "DisableWDPoStPreChecks",
+			Name: "DisableWDPoStPreChecks",
 			Type: "bool",
 
 			Comment: `Disable WindowPoSt provable sector readability checks.
@@ -690,7 +690,7 @@ After changing this option, confirm that the new value works in your setup by in
 'lotus-miner proving compute window-post 0'`,
 		},
 		{
-			Num:  "MaxPartitionsPerPoStMessage",
+			Name: "MaxPartitionsPerPoStMessage",
 			Type: "int",
 
 			Comment: `Maximum number of partitions to prove in a single SubmitWindowPoSt messace. 0 = network limit (10 in nv16)
@@ -708,7 +708,7 @@ to prove each deadline, resulting in more total gas use (but each message will h
 Setting this value above the network limit has no effect`,
 		},
 		{
-			Num:  "MaxPartitionsPerRecoveryMessage",
+			Name: "MaxPartitionsPerRecoveryMessage",
 			Type: "int",
 
 			Comment: `In some cases when submitting DeclareFaultsRecovered messages,
@@ -720,13 +720,13 @@ resulting in more total gas use (but each message will have lower gas limit)`,
 	},
 	"Pubsub": []DocField{
 		{
-			Num:  "Bootstrapper",
+			Name: "Bootstrapper",
 			Type: "bool",
 
 			Comment: `Run the node in bootstrap-node mode`,
 		},
 		{
-			Num:  "DirectPeers",
+			Name: "DirectPeers",
 			Type: "[]string",
 
 			Comment: `DirectPeers specifies peers with direct peering agreements. These peers are
@@ -737,13 +737,13 @@ symmetrically configured at both ends.
 Type: Array of multiaddress peerinfo strings, must include peerid (/p2p/12D3K...`,
 		},
 		{
-			Num:  "IPColocationWhitelist",
+			Name: "IPColocationWhitelist",
 			Type: "[]string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "RemoteTracer",
+			Name: "RemoteTracer",
 			Type: "string",
 
 			Comment: ``,
@@ -751,19 +751,19 @@ Type: Array of multiaddress peerinfo strings, must include peerid (/p2p/12D3K...
 	},
 	"RetrievalPricing": []DocField{
 		{
-			Num:  "Strategy",
+			Name: "Strategy",
 			Type: "string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Default",
+			Name: "Default",
 			Type: "*RetrievalPricingDefault",
 
 			Comment: ``,
 		},
 		{
-			Num:  "External",
+			Name: "External",
 			Type: "*RetrievalPricingExternal",
 
 			Comment: ``,
@@ -771,7 +771,7 @@ Type: Array of multiaddress peerinfo strings, must include peerid (/p2p/12D3K...
 	},
 	"RetrievalPricingDefault": []DocField{
 		{
-			Num:  "VerifiedDealsFreeTransfer",
+			Name: "VerifiedDealsFreeTransfer",
 			Type: "bool",
 
 			Comment: `VerifiedDealsFreeTransfer configures zero fees for data transfer for a retrieval deal
@@ -782,7 +782,7 @@ default value is true`,
 	},
 	"RetrievalPricingExternal": []DocField{
 		{
-			Num:  "Path",
+			Name: "Path",
 			Type: "string",
 
 			Comment: `Path of the external script that will be run to price a retrieval deal.
@@ -791,68 +791,68 @@ This parameter is ONLY applicable if the retrieval pricing policy strategy has b
 	},
 	"SealerConfig": []DocField{
 		{
-			Num:  "ParallelFetchLimit",
+			Name: "ParallelFetchLimit",
 			Type: "int",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowAddPiece",
+			Name: "AllowAddPiece",
 			Type: "bool",
 
 			Comment: `Local worker config`,
 		},
 		{
-			Num:  "AllowPreCommit1",
+			Name: "AllowPreCommit1",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowPreCommit2",
+			Name: "AllowPreCommit2",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowCommit",
+			Name: "AllowCommit",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowUnseal",
+			Name: "AllowUnseal",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowReplicaUpdate",
+			Name: "AllowReplicaUpdate",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowProveReplicaUpdate2",
+			Name: "AllowProveReplicaUpdate2",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "AllowRegenSectorKey",
+			Name: "AllowRegenSectorKey",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "LocalWorkerName",
+			Name: "LocalWorkerName",
 			Type: "string",
 
 			Comment: `LocalWorkerName specifies a custom name for the builtin worker.
 If set to an empty string (default) os hostname will be used`,
 		},
 		{
-			Num:  "Assigner",
+			Name: "Assigner",
 			Type: "string",
 
 			Comment: `Assigner specifies the worker assigner to use when scheduling tasks.
@@ -860,7 +860,7 @@ If set to an empty string (default) os hostname will be used`,
 "spread" - assign tasks to as many distinct workers as possible.`,
 		},
 		{
-			Num:  "DisallowRemoteFinalize",
+			Name: "DisallowRemoteFinalize",
 			Type: "bool",
 
 			Comment: `DisallowRemoteFinalize when set to true will force all Finalize tasks to
@@ -876,7 +876,7 @@ If you see stuck Finalize tasks after enabling this setting, check
 'lotus-miner sealing sched-diag' and 'lotus-miner storage find [sector num]'`,
 		},
 		{
-			Num:  "ResourceFiltering",
+			Name: "ResourceFiltering",
 			Type: "sealer.ResourceFilteringStrategy",
 
 			Comment: `ResourceFiltering instructs the system which resource filtering strategy
@@ -886,7 +886,7 @@ to "hardware".`,
 	},
 	"SealingConfig": []DocField{
 		{
-			Num:  "MaxWaitDealsSectors",
+			Name: "MaxWaitDealsSectors",
 			Type: "uint64",
 
 			Comment: `Upper bound on how many sectors can be waiting for more deals to be packed in it before it begins sealing at any given time.
@@ -896,19 +896,19 @@ Note that setting this number too high in relation to deal ingestion rate may re
 0 = no limit`,
 		},
 		{
-			Num:  "MaxSealingSectors",
+			Name: "MaxSealingSectors",
 			Type: "uint64",
 
 			Comment: `Upper bound on how many sectors can be sealing+upgrading at the same time when creating new CC sectors (0 = unlimited)`,
 		},
 		{
-			Num:  "MaxSealingSectorsForDeals",
+			Name: "MaxSealingSectorsForDeals",
 			Type: "uint64",
 
 			Comment: `Upper bound on how many sectors can be sealing+upgrading at the same time when creating new sectors with deals (0 = unlimited)`,
 		},
 		{
-			Num:  "PreferNewSectorsForDeals",
+			Name: "PreferNewSectorsForDeals",
 			Type: "bool",
 
 			Comment: `Prefer creating new sectors even if there are sectors Available for upgrading.
@@ -917,13 +917,13 @@ possible to use fast sector upgrades to handle high volumes of storage deals, wh
 flow when the volume of storage deals is lower.`,
 		},
 		{
-			Num:  "MaxUpgradingSectors",
+			Name: "MaxUpgradingSectors",
 			Type: "uint64",
 
 			Comment: `Upper bound on how many sectors can be sealing+upgrading at the same time when upgrading CC sectors with deals (0 = MaxSealingSectorsForDeals)`,
 		},
 		{
-			Num:  "CommittedCapacitySectorLifetime",
+			Name: "CommittedCapacitySectorLifetime",
 			Type: "Duration",
 
 			Comment: `CommittedCapacitySectorLifetime is the duration a Committed Capacity (CC) sector will
@@ -931,27 +931,27 @@ live before it must be extended or converted into sector containing deals before
 terminated. Value must be between 180-540 days inclusive`,
 		},
 		{
-			Num:  "WaitDealsDelay",
+			Name: "WaitDealsDelay",
 			Type: "Duration",
 
 			Comment: `Period of time that a newly created sector will wait for more deals to be packed in to before it starts to seal.
 Sectors which are fully filled will start sealing immediately`,
 		},
 		{
-			Num:  "AlwaysKeepUnsealedCopy",
+			Name: "AlwaysKeepUnsealedCopy",
 			Type: "bool",
 
 			Comment: `Whether to keep unsealed copies of deal data regardless of whether the client requested that. This lets the miner
 avoid the relatively high cost of unsealing the data later, at the cost of more storage space`,
 		},
 		{
-			Num:  "FinalizeEarly",
+			Name: "FinalizeEarly",
 			Type: "bool",
 
 			Comment: `Run sector finalization before submitting sector proof to the chain`,
 		},
 		{
-			Num:  "MakeNewSectorForDeals",
+			Name: "MakeNewSectorForDeals",
 			Type: "bool",
 
 			Comment: `Whether new sectors are created to pack incoming deals
@@ -959,111 +959,111 @@ When this is set to false no new sectors will be created for sealing incoming de
 This is useful for forcing all deals to be assigned as snap deals to sectors marked for upgrade`,
 		},
 		{
-			Num:  "MakeCCSectorsAvailable",
+			Name: "MakeCCSectorsAvailable",
 			Type: "bool",
 
 			Comment: `After sealing CC sectors, make them available for upgrading with deals`,
 		},
 		{
-			Num:  "CollateralFromMinerBalance",
+			Name: "CollateralFromMinerBalance",
 			Type: "bool",
 
 			Comment: `Whether to use available miner balance for sector collateral instead of sending it with each message`,
 		},
 		{
-			Num:  "AvailableBalanceBuffer",
+			Name: "AvailableBalanceBuffer",
 			Type: "types.FIL",
 
 			Comment: `Minimum available balance to keep in the miner actor before sending it with messages`,
 		},
 		{
-			Num:  "DisableCollateralFallback",
+			Name: "DisableCollateralFallback",
 			Type: "bool",
 
 			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor`,
 		},
 		{
-			Num:  "BatchPreCommits",
+			Name: "BatchPreCommits",
 			Type: "bool",
 
 			Comment: `enable / disable precommit batching (takes effect after nv13)`,
 		},
 		{
-			Num:  "MaxPreCommitBatch",
+			Name: "MaxPreCommitBatch",
 			Type: "int",
 
 			Comment: `maximum precommit batch size - batches will be sent immediately above this size`,
 		},
 		{
-			Num:  "PreCommitBatchWait",
+			Name: "PreCommitBatchWait",
 			Type: "Duration",
 
 			Comment: `how long to wait before submitting a batch after crossing the minimum batch size`,
 		},
 		{
-			Num:  "PreCommitBatchSlack",
+			Name: "PreCommitBatchSlack",
 			Type: "Duration",
 
 			Comment: `time buffer for forceful batch submission before sectors/deal in batch would start expiring`,
 		},
 		{
-			Num:  "AggregateCommits",
+			Name: "AggregateCommits",
 			Type: "bool",
 
 			Comment: `enable / disable commit aggregation (takes effect after nv13)`,
 		},
 		{
-			Num:  "MinCommitBatch",
+			Name: "MinCommitBatch",
 			Type: "int",
 
 			Comment: `minimum batched commit size - batches above this size will eventually be sent on a timeout`,
 		},
 		{
-			Num:  "MaxCommitBatch",
+			Name: "MaxCommitBatch",
 			Type: "int",
 
 			Comment: `maximum batched commit size - batches will be sent immediately above this size`,
 		},
 		{
-			Num:  "CommitBatchWait",
+			Name: "CommitBatchWait",
 			Type: "Duration",
 
 			Comment: `how long to wait before submitting a batch after crossing the minimum batch size`,
 		},
 		{
-			Num:  "CommitBatchSlack",
+			Name: "CommitBatchSlack",
 			Type: "Duration",
 
 			Comment: `time buffer for forceful batch submission before sectors/deals in batch would start expiring`,
 		},
 		{
-			Num:  "BatchPreCommitAboveBaseFee",
+			Name: "BatchPreCommitAboveBaseFee",
 			Type: "types.FIL",
 
 			Comment: `network BaseFee below which to stop doing precommit batching, instead
 sending precommit messages to the chain individually`,
 		},
 		{
-			Num:  "AggregateAboveBaseFee",
+			Name: "AggregateAboveBaseFee",
 			Type: "types.FIL",
 
 			Comment: `network BaseFee below which to stop doing commit aggregation, instead
 submitting proofs to the chain individually`,
 		},
 		{
-			Num:  "TerminateBatchMax",
+			Name: "TerminateBatchMax",
 			Type: "uint64",
 
 			Comment: ``,
 		},
 		{
-			Num:  "TerminateBatchMin",
+			Name: "TerminateBatchMin",
 			Type: "uint64",
 
 			Comment: ``,
 		},
 		{
-			Num:  "TerminateBatchWait",
+			Name: "TerminateBatchWait",
 			Type: "Duration",
 
 			Comment: ``,
@@ -1071,35 +1071,35 @@ submitting proofs to the chain individually`,
 	},
 	"Splitstore": []DocField{
 		{
-			Num:  "ColdStoreType",
+			Name: "ColdStoreType",
 			Type: "string",
 
 			Comment: `ColdStoreType specifies the type of the coldstore.
 It can be "universal" (default) or "discard" for discarding cold blocks.`,
 		},
 		{
-			Num:  "HotStoreType",
+			Name: "HotStoreType",
 			Type: "string",
 
 			Comment: `HotStoreType specifies the type of the hotstore.
 Only currently supported value is "badger".`,
 		},
 		{
-			Num:  "MarkSetType",
+			Name: "MarkSetType",
 			Type: "string",
 
 			Comment: `MarkSetType specifies the type of the markset.
 It can be "map" for in memory marking or "badger" (default) for on-disk marking.`,
 		},
 		{
-			Num:  "HotStoreMessageRetention",
+			Name: "HotStoreMessageRetention",
 			Type: "uint64",
 
 			Comment: `HotStoreMessageRetention specifies the retention policy for messages, in finalities beyond
 the compaction boundary; default is 0.`,
 		},
 		{
-			Num:  "HotStoreFullGCFrequency",
+			Name: "HotStoreFullGCFrequency",
 			Type: "uint64",
 
 			Comment: `HotStoreFullGCFrequency specifies how often to perform a full (moving) GC on the hotstore.
@@ -1107,7 +1107,7 @@ A value of 0 disables, while a value 1 will do full GC in every compaction.
 Default is 20 (about once a week).`,
 		},
 		{
-			Num:  "EnableColdStoreAutoPrune",
+			Name: "EnableColdStoreAutoPrune",
 			Type: "bool",
 
 			Comment: `EnableColdStoreAutoPrune turns on compaction of the cold store i.e. pruning
@@ -1115,7 +1115,7 @@ where hotstore compaction occurs every finality epochs pruning happens every 3 f
 Default is false`,
 		},
 		{
-			Num:  "ColdStoreFullGCFrequency",
+			Name: "ColdStoreFullGCFrequency",
 			Type: "uint64",
 
 			Comment: `ColdStoreFullGCFrequency specifies how often to performa a full (moving) GC on the coldstore.
@@ -1124,7 +1124,7 @@ full GC in every prune.
 Default is 7 (about once every a week)`,
 		},
 		{
-			Num:  "ColdStoreRetention",
+			Name: "ColdStoreRetention",
 			Type: "int64",
 
 			Comment: `ColdStoreRetention specifies the retention policy for data reachable from the chain, in
@@ -1133,55 +1133,55 @@ finalities beyond the compaction boundary, default is 0, -1 retains everything`,
 	},
 	"StorageMiner": []DocField{
 		{
-			Num:  "Subsystems",
+			Name: "Subsystems",
 			Type: "MinerSubsystemConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Dealmaking",
+			Name: "Dealmaking",
 			Type: "DealmakingConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "IndexProvider",
+			Name: "IndexProvider",
 			Type: "IndexProviderConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Proving",
+			Name: "Proving",
 			Type: "ProvingConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Sealing",
+			Name: "Sealing",
 			Type: "SealingConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Storage",
+			Name: "Storage",
 			Type: "SealerConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Fees",
+			Name: "Fees",
 			Type: "MinerFeeConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "Addresses",
+			Name: "Addresses",
 			Type: "MinerAddressConfig",
 
 			Comment: ``,
 		},
 		{
-			Num:  "DAGStore",
+			Name: "DAGStore",
 			Type: "DAGStoreConfig",
 
 			Comment: ``,
@@ -1189,19 +1189,19 @@ finalities beyond the compaction boundary, default is 0, -1 retains everything`,
 	},
 	"Wallet": []DocField{
 		{
-			Num:  "RemoteBackend",
+			Name: "RemoteBackend",
 			Type: "string",
 
 			Comment: ``,
 		},
 		{
-			Num:  "EnableLedger",
+			Name: "EnableLedger",
 			Type: "bool",
 
 			Comment: ``,
 		},
 		{
-			Num:  "DisableLocal",
+			Name: "DisableLocal",
 			Type: "bool",
 
 			Comment: ``,

--- a/node/config/doc_util.go
+++ b/node/config/doc_util.go
@@ -16,7 +16,7 @@ func findDoc(root interface{}, section, name string) *DocField {
 	return findDocSect("Common", section, name)
 }
 
-func findDocSect(root, section, num string) *DocField {
+func findDocSect(root, section, name string) *DocField {
 	path := strings.Split(section, ".")
 
 	docSection := Doc[root]
@@ -26,7 +26,7 @@ func findDocSect(root, section, num string) *DocField {
 		}
 
 		for _, field := range docSection {
-			if field.Num == e {
+			if field.Name == e {
 				docSection = Doc[field.Type]
 				break
 			}
@@ -35,7 +35,7 @@ func findDocSect(root, section, num string) *DocField {
 	}
 
 	for _, df := range docSection {
-		if df.Num == num {
+		if df.Name == name {
 			return &df
 		}
 	}


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

This was an accidental rename caused by an overzealous IDE refactor in #9267

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Revert the reanem.

## Additional Info
<!-- callouts, links to documentation, and etc-->

Thank you @magik6k for the catch

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
