### PR TITLE
chore: cli: cleanup and standardize cli

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -114,7 +114,7 @@ this command must be within this base path`,
 		},
 		ArgsUsage: "[backup file path]",
 		Action: func(cctx *cli.Context) error {
-			if cctx.Args().Len() != 1 {
+			if cctx.NArg() != 1 {
 				return xerrors.Errorf("expected 1 argument")
 			}
 

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -115,7 +115,7 @@ this command must be within this base path`,
 		ArgsUsage: "[backup file path]",
 		Action: func(cctx *cli.Context) error {
 			if cctx.NArg() != 1 {
-				return xerrors.Errorf("expected 1 argument")
+				return IncorrectNumArgs(cctx)
 			}
 
 			if cctx.Bool("offline") {

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -947,7 +947,7 @@ var ChainBisectCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() < 4 {
-			return xerrors.New("need at least 4 args")
+			return IncorrectNumArgs(cctx)
 		}
 
 		start, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1313,7 +1313,7 @@ var chainDecodeParamsCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() != 3 {
-			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		to, err := address.NewFromString(cctx.Args().First())
@@ -1392,7 +1392,7 @@ var chainEncodeParamsCmd = &cli.Command{
 		afmt := NewAppFmt(cctx.App)
 
 		if cctx.NArg() != 3 {
-			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		method, err := strconv.ParseInt(cctx.Args().Get(1), 10, 64)

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -946,7 +946,7 @@ var ChainBisectCmd = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() < 4 {
+		if cctx.NArg() < 4 {
 			return xerrors.New("need at least 4 args")
 		}
 
@@ -1312,7 +1312,7 @@ var chainDecodeParamsCmd = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
 		}
 
@@ -1391,7 +1391,7 @@ var chainEncodeParamsCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		afmt := NewAppFmt(cctx.App)
 
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
 		}
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -130,7 +130,7 @@ var clientImportCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() != 1 {
-			return xerrors.New("expected input path as the only arg")
+			return IncorrectNumArgs(cctx)
 		}
 
 		absPath, err := filepath.Abs(cctx.Args().First())
@@ -213,7 +213,7 @@ var clientCommPCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("usage: commP <inputPath>")
+			return IncorrectNumArgs(cctx)
 		}
 
 		ret, err := api.ClientCalcCommP(ctx, cctx.Args().Get(0))
@@ -246,7 +246,7 @@ var clientCarGenCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("usage: generate-car <inputPath> <outputPath>")
+			return IncorrectNumArgs(cctx)
 		}
 
 		ref := lapi.FileRef{
@@ -376,7 +376,7 @@ The minimum value is 518400 (6 months).`,
 		afmt := NewAppFmt(cctx.App)
 
 		if cctx.NArg() != 4 {
-			return xerrors.New(expectedArgsMsg)
+			return IncorrectNumArgs(cctx)
 		}
 
 		// [data, miner, price, dur]

--- a/cli/client.go
+++ b/cli/client.go
@@ -212,7 +212,7 @@ var clientCommPCmd = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("usage: commP <inputPath>")
 		}
 
@@ -245,7 +245,7 @@ var clientCarGenCmd = &cli.Command{
 		defer closer()
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return fmt.Errorf("usage: generate-car <inputPath> <outputPath>")
 		}
 

--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -289,7 +289,7 @@ Examples:
 	}, retrFlagsCommon...),
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		if cctx.Bool("car-export-merkle-proof") {
@@ -405,7 +405,7 @@ var clientRetrieveCatCmd = &cli.Command{
 	}, retrFlagsCommon...),
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ainfo, err := GetAPIInfo(cctx, repo.FullNode)
@@ -484,7 +484,7 @@ var clientRetrieveLsCmd = &cli.Command{
 	}, retrFlagsCommon...),
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ainfo, err := GetAPIInfo(cctx, repo.FullNode)

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -61,7 +61,7 @@ var filplusVerifyClientCmd = &cli.Command{
 			return err
 		}
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return fmt.Errorf("must specify two arguments: address and allowance")
 		}
 
@@ -289,7 +289,7 @@ var filplusSignRemoveDataCapProposal = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return fmt.Errorf("must specify three arguments: notary address, client address, and allowance to remove")
 		}
 

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -62,7 +62,7 @@ var filplusVerifyClientCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must specify two arguments: address and allowance")
+			return IncorrectNumArgs(cctx)
 		}
 
 		target, err := address.NewFromString(cctx.Args().Get(0))
@@ -290,7 +290,7 @@ var filplusSignRemoveDataCapProposal = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must specify three arguments: notary address, client address, and allowance to remove")
+			return IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := GetFullNodeAPI(cctx)

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -120,7 +120,7 @@ var filplusVerifyClientCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("failed to add verified client: %d", mwait.Receipt.ExitCode)
 		}
 

--- a/cli/helper.go
+++ b/cli/helper.go
@@ -31,6 +31,10 @@ func ShowHelp(cctx *ufcli.Context, err error) error {
 	return &PrintHelpErr{Err: err, Ctx: cctx}
 }
 
+func IncorrectNumArgs(cctx *ufcli.Context) error {
+	return ShowHelp(cctx, fmt.Errorf("incorrect number of arguments, got %d", cctx.NArg()))
+}
+
 func RunApp(app *ufcli.App) {
 	if err := app.Run(os.Args); err != nil {
 		if os.Getenv("LOTUS_DEV") != "" {

--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -404,7 +404,7 @@ var MpoolReplaceCmd = &cli.Command{
 
 		var from address.Address
 		var nonce uint64
-		switch cctx.Args().Len() {
+		switch cctx.NArg() {
 		case 1:
 			mcid, err := cid.Decode(cctx.Args().First())
 			if err != nil {
@@ -610,7 +610,7 @@ var MpoolConfig = &cli.Command{
 	Usage:     "get or set current mpool configuration",
 	ArgsUsage: "[new-config]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() > 1 {
+		if cctx.NArg() > 1 {
 			return cli.ShowCommandHelp(cctx, cctx.Command.Name)
 		}
 
@@ -624,7 +624,7 @@ var MpoolConfig = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			cfg, err := api.MpoolGetConfig(ctx)
 			if err != nil {
 				return err

--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -611,7 +611,7 @@ var MpoolConfig = &cli.Command{
 	ArgsUsage: "[new-config]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() > 1 {
-			return cli.ShowCommandHelp(cctx, cctx.Command.Name)
+			return IncorrectNumArgs(cctx)
 		}
 
 		afmt := NewAppFmt(cctx.App)

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -89,7 +89,7 @@ var msigCreateCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
-			return ShowHelp(cctx, fmt.Errorf("multisigs must have at least one signer"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -754,7 +754,7 @@ var msigRemoveProposeCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -841,7 +841,7 @@ var msigAddProposeCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -950,7 +950,7 @@ var msigAddApproveCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 5 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, new signer address, whether to increase threshold"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1041,7 +1041,7 @@ var msigAddCancelCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 4 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, new signer address, whether to increase threshold"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1127,7 +1127,7 @@ var msigSwapProposeCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, old signer address, new signer address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1208,7 +1208,7 @@ var msigSwapApproveCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 5 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, old signer address, new signer address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1299,7 +1299,7 @@ var msigSwapCancelCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 4 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, old signer address, new signer address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1385,7 +1385,7 @@ var msigLockProposeCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 4 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, start epoch, unlock duration, and amount"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1481,7 +1481,7 @@ var msigLockApproveCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 6 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, tx id, start epoch, unlock duration, and amount"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1587,7 +1587,7 @@ var msigLockCancelCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 5 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, tx id, start epoch, unlock duration, and amount"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -1694,7 +1694,7 @@ var msigVestedCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := GetFullNodeAPI(cctx)
@@ -1750,7 +1750,7 @@ var msigProposeThresholdCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and new threshold value"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -167,7 +167,7 @@ var msigCreateCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "actor creation failed!")
 			return err
 		}
@@ -456,7 +456,7 @@ var msigProposeCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -605,7 +605,7 @@ var msigApproveCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("approve returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -730,7 +730,7 @@ var msigCancelCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("cancel returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -810,7 +810,7 @@ var msigRemoveProposeCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("add proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -930,7 +930,7 @@ var msigAddProposeCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("add proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1021,7 +1021,7 @@ var msigAddApproveCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("add approval returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1107,7 +1107,7 @@ var msigAddCancelCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("add cancellation returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1188,7 +1188,7 @@ var msigSwapProposeCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("swap proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1279,7 +1279,7 @@ var msigSwapApproveCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("swap approval returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1365,7 +1365,7 @@ var msigSwapCancelCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("swap cancellation returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1461,7 +1461,7 @@ var msigLockProposeCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("lock proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1567,7 +1567,7 @@ var msigLockApproveCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("lock approval returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1668,7 +1668,7 @@ var msigLockCancelCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("lock cancellation returned exit %d", wait.Receipt.ExitCode)
 		}
 
@@ -1814,7 +1814,7 @@ var msigProposeThresholdCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("change threshold proposal returned exit %d", wait.Receipt.ExitCode)
 		}
 

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -88,7 +88,7 @@ var msigCreateCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			return ShowHelp(cctx, fmt.Errorf("multisigs must have at least one signer"))
 		}
 
@@ -365,11 +365,11 @@ var msigProposeCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 3 {
+		if cctx.NArg() < 3 {
 			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address, destination, and value"))
 		}
 
-		if cctx.Args().Len() > 3 && cctx.Args().Len() != 5 {
+		if cctx.NArg() > 3 && cctx.NArg() != 5 {
 			return ShowHelp(cctx, fmt.Errorf("must either pass three or five arguments"))
 		}
 
@@ -399,7 +399,7 @@ var msigProposeCmd = &cli.Command{
 
 		var method uint64
 		var params []byte
-		if cctx.Args().Len() == 5 {
+		if cctx.NArg() == 5 {
 			m, err := strconv.ParseUint(cctx.Args().Get(3), 10, 64)
 			if err != nil {
 				return err
@@ -487,15 +487,15 @@ var msigApproveCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address and message ID"))
 		}
 
-		if cctx.Args().Len() > 2 && cctx.Args().Len() < 5 {
+		if cctx.NArg() > 2 && cctx.NArg() < 5 {
 			return ShowHelp(cctx, fmt.Errorf("usage: msig approve <msig addr> <message ID> <proposer address> <desination> <value>"))
 		}
 
-		if cctx.Args().Len() > 5 && cctx.Args().Len() != 7 {
+		if cctx.NArg() > 5 && cctx.NArg() != 7 {
 			return ShowHelp(cctx, fmt.Errorf("usage: msig approve <msig addr> <message ID> <proposer address> <desination> <value> [ <method> <params> ]"))
 		}
 
@@ -534,7 +534,7 @@ var msigApproveCmd = &cli.Command{
 		}
 
 		var msgCid cid.Cid
-		if cctx.Args().Len() == 2 {
+		if cctx.NArg() == 2 {
 			proto, err := api.MsigApprove(ctx, msig, txid, from)
 			if err != nil {
 				return err
@@ -571,7 +571,7 @@ var msigApproveCmd = &cli.Command{
 
 			var method uint64
 			var params []byte
-			if cctx.Args().Len() == 7 {
+			if cctx.NArg() == 7 {
 				m, err := strconv.ParseUint(cctx.Args().Get(5), 10, 64)
 				if err != nil {
 					return err
@@ -624,15 +624,15 @@ var msigCancelCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address and message ID"))
 		}
 
-		if cctx.Args().Len() > 2 && cctx.Args().Len() < 4 {
+		if cctx.NArg() > 2 && cctx.NArg() < 4 {
 			return ShowHelp(cctx, fmt.Errorf("usage: msig cancel <msig addr> <message ID> <desination> <value>"))
 		}
 
-		if cctx.Args().Len() > 4 && cctx.Args().Len() != 6 {
+		if cctx.NArg() > 4 && cctx.NArg() != 6 {
 			return ShowHelp(cctx, fmt.Errorf("usage: msig cancel <msig addr> <message ID> <desination> <value> [ <method> <params> ]"))
 		}
 
@@ -671,7 +671,7 @@ var msigCancelCmd = &cli.Command{
 		}
 
 		var msgCid cid.Cid
-		if cctx.Args().Len() == 2 {
+		if cctx.NArg() == 2 {
 			proto, err := api.MsigCancel(ctx, msig, txid, from)
 			if err != nil {
 				return err
@@ -696,7 +696,7 @@ var msigCancelCmd = &cli.Command{
 
 			var method uint64
 			var params []byte
-			if cctx.Args().Len() == 6 {
+			if cctx.NArg() == 6 {
 				m, err := strconv.ParseUint(cctx.Args().Get(4), 10, 64)
 				if err != nil {
 					return err
@@ -753,7 +753,7 @@ var msigRemoveProposeCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
 		}
 
@@ -840,7 +840,7 @@ var msigAddProposeCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and signer address"))
 		}
 
@@ -949,7 +949,7 @@ var msigAddApproveCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 5 {
+		if cctx.NArg() != 5 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, new signer address, whether to increase threshold"))
 		}
 
@@ -1040,7 +1040,7 @@ var msigAddCancelCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 4 {
+		if cctx.NArg() != 4 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, new signer address, whether to increase threshold"))
 		}
 
@@ -1126,7 +1126,7 @@ var msigSwapProposeCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, old signer address, new signer address"))
 		}
 
@@ -1207,7 +1207,7 @@ var msigSwapApproveCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 5 {
+		if cctx.NArg() != 5 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, transaction id, old signer address, new signer address"))
 		}
 
@@ -1298,7 +1298,7 @@ var msigSwapCancelCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 4 {
+		if cctx.NArg() != 4 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, transaction id, old signer address, new signer address"))
 		}
 
@@ -1384,7 +1384,7 @@ var msigLockProposeCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 4 {
+		if cctx.NArg() != 4 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, start epoch, unlock duration, and amount"))
 		}
 
@@ -1480,7 +1480,7 @@ var msigLockApproveCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 6 {
+		if cctx.NArg() != 6 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, proposer address, tx id, start epoch, unlock duration, and amount"))
 		}
 
@@ -1586,7 +1586,7 @@ var msigLockCancelCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 5 {
+		if cctx.NArg() != 5 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address, tx id, start epoch, unlock duration, and amount"))
 		}
 
@@ -1693,7 +1693,7 @@ var msigVestedCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address"))
 		}
 
@@ -1749,7 +1749,7 @@ var msigProposeThresholdCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass multisig address and new threshold value"))
 		}
 

--- a/cli/net.go
+++ b/cli/net.go
@@ -141,7 +141,7 @@ var NetPing = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("please provide a peerID")
 		}
 

--- a/cli/net.go
+++ b/cli/net.go
@@ -142,7 +142,7 @@ var NetPing = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("please provide a peerID")
+			return IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := GetAPI(cctx)

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -50,7 +50,7 @@ var paychAddFundsCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return ShowHelp(cctx, fmt.Errorf("must pass three arguments: <from> <to> <available funds>"))
 		}
 
@@ -112,7 +112,7 @@ var paychStatusByFromToCmd = &cli.Command{
 	Usage:     "Show the status of an active outbound payment channel by from/to addresses",
 	ArgsUsage: "[fromAddress toAddress]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <from address> <to address>"))
 		}
 		ctx := ReqContext(cctx)
@@ -148,7 +148,7 @@ var paychStatusCmd = &cli.Command{
 	Usage:     "Show the status of an outbound payment channel",
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return ShowHelp(cctx, fmt.Errorf("must pass an argument: <channel address>"))
 		}
 		ctx := ReqContext(cctx)
@@ -260,7 +260,7 @@ var paychSettleCmd = &cli.Command{
 	Usage:     "Settle a payment channel",
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must pass payment channel address")
 		}
 
@@ -300,7 +300,7 @@ var paychCloseCmd = &cli.Command{
 	Usage:     "Collect funds for a payment channel",
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must pass payment channel address")
 		}
 
@@ -360,7 +360,7 @@ var paychVoucherCreateCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <channel> <amount>"))
 		}
 
@@ -408,7 +408,7 @@ var paychVoucherCheckCmd = &cli.Command{
 	Usage:     "Check validity of payment channel voucher",
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher to validate"))
 		}
 
@@ -444,7 +444,7 @@ var paychVoucherAddCmd = &cli.Command{
 	Usage:     "Add payment channel voucher to local datastore",
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher"))
 		}
 
@@ -486,7 +486,7 @@ var paychVoucherListCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address"))
 		}
 
@@ -531,7 +531,7 @@ var paychVoucherBestSpendableCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address"))
 		}
 
@@ -602,7 +602,7 @@ var paychVoucherSubmitCmd = &cli.Command{
 	Usage:     "Submit voucher to chain to update payment channel state",
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher"))
 		}
 

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -286,7 +286,7 @@ var paychSettleCmd = &cli.Command{
 		if err != nil {
 			return nil
 		}
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("settle message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 
@@ -326,7 +326,7 @@ var paychCloseCmd = &cli.Command{
 		if err != nil {
 			return nil
 		}
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("collect message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 
@@ -634,7 +634,7 @@ var paychVoucherSubmitCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -51,7 +51,7 @@ var paychAddFundsCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return ShowHelp(cctx, fmt.Errorf("must pass three arguments: <from> <to> <available funds>"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		from, err := address.NewFromString(cctx.Args().Get(0))
@@ -113,7 +113,7 @@ var paychStatusByFromToCmd = &cli.Command{
 	ArgsUsage: "[fromAddress toAddress]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <from address> <to address>"))
+			return IncorrectNumArgs(cctx)
 		}
 		ctx := ReqContext(cctx)
 
@@ -149,7 +149,7 @@ var paychStatusCmd = &cli.Command{
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("must pass an argument: <channel address>"))
+			return IncorrectNumArgs(cctx)
 		}
 		ctx := ReqContext(cctx)
 
@@ -261,7 +261,7 @@ var paychSettleCmd = &cli.Command{
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must pass payment channel address")
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -301,7 +301,7 @@ var paychCloseCmd = &cli.Command{
 	ArgsUsage: "[channelAddress]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must pass payment channel address")
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -361,7 +361,7 @@ var paychVoucherCreateCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass two arguments: <channel> <amount>"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -409,7 +409,7 @@ var paychVoucherCheckCmd = &cli.Command{
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher to validate"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -445,7 +445,7 @@ var paychVoucherAddCmd = &cli.Command{
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -487,7 +487,7 @@ var paychVoucherListCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -532,7 +532,7 @@ var paychVoucherBestSpendableCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))
@@ -603,7 +603,7 @@ var paychVoucherSubmitCmd = &cli.Command{
 	ArgsUsage: "[channelAddress voucher]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass payment channel address and voucher"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		ch, err := address.NewFromString(cctx.Args().Get(0))

--- a/cli/send.go
+++ b/cli/send.go
@@ -67,7 +67,7 @@ var sendCmd = &cli.Command{
 			fmt.Println("'force' flag is deprecated, use global flag 'force-send'")
 		}
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return ShowHelp(cctx, fmt.Errorf("'send' expects two arguments, target and amount"))
 		}
 

--- a/cli/send.go
+++ b/cli/send.go
@@ -68,7 +68,7 @@ var sendCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 2 {
-			return ShowHelp(cctx, fmt.Errorf("'send' expects two arguments, target and amount"))
+			return IncorrectNumArgs(cctx)
 		}
 
 		srv, err := GetFullNodeServices(cctx)

--- a/cli/state.go
+++ b/cli/state.go
@@ -505,8 +505,7 @@ var StateReplayCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			fmt.Println("must provide cid of message to replay")
-			return nil
+			return IncorrectNumArgs(cctx)
 		}
 
 		mcid, err := cid.Decode(cctx.Args().First())
@@ -1581,7 +1580,7 @@ var StateCallCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 2 {
-			return fmt.Errorf("must specify at least actor and method to invoke")
+			return ShowHelp(cctx, fmt.Errorf("must specify at least actor and method to invoke"))
 		}
 
 		api, closer, err := GetFullNodeAPI(cctx)
@@ -1744,7 +1743,7 @@ var StateSectorCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if cctx.NArg() != 2 {
-			return xerrors.Errorf("expected 2 params: minerAddress and sectorNumber")
+			return IncorrectNumArgs(cctx)
 		}
 
 		ts, err := LoadTipSet(ctx, cctx, api)

--- a/cli/state.go
+++ b/cli/state.go
@@ -504,7 +504,7 @@ var StateReplayCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			fmt.Println("must provide cid of message to replay")
 			return nil
 		}
@@ -1580,7 +1580,7 @@ var StateCallCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return fmt.Errorf("must specify at least actor and method to invoke")
 		}
 
@@ -1619,7 +1619,7 @@ var StateCallCmd = &cli.Command{
 
 		var params []byte
 		// If params were passed in, decode them
-		if cctx.Args().Len() > 2 {
+		if cctx.NArg() > 2 {
 			switch cctx.String("encoding") {
 			case "base64":
 				params, err = base64.StdEncoding.DecodeString(cctx.Args().Get(2))
@@ -1743,7 +1743,7 @@ var StateSectorCmd = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return xerrors.Errorf("expected 2 params: minerAddress and sectorNumber")
 		}
 

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -645,7 +645,7 @@ var walletMarketWithdraw = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			afmt.Println(cctx.App.Writer, "withdrawal failed!")
 			return err
 		}

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -959,7 +959,7 @@ var simpleProveReplicaUpdate2 = &cli.Command{
 }
 
 func ParsePieceInfos(cctx *cli.Context, firstArg int) ([]abi.PieceInfo, error) {
-	args := cctx.Args().Len() - firstArg
+	args := cctx.NArg() - firstArg
 	if args%2 != 0 {
 		return nil, xerrors.Errorf("piece info argunemts need to be supplied in pairs")
 	}

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -729,7 +729,7 @@ var actorSetOwnerCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must pass new owner address and sender address")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -290,7 +290,7 @@ var actorWithdrawCmd = &cli.Command{
 			return xerrors.Errorf("Timeout waiting for withdrawal message %s", wait.Message)
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return xerrors.Errorf("Failed to execute withdrawal message %s: %w", wait.Message, wait.Receipt.ExitCode.Error())
 		}
 
@@ -799,7 +799,7 @@ var actorSetOwnerCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println("owner change failed!")
 			return err
 		}
@@ -905,7 +905,7 @@ var actorProposeChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose worker change failed!")
 			return err
 		}
@@ -1011,7 +1011,7 @@ var actorConfirmChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
 			return err
 		}
@@ -1170,7 +1170,7 @@ var actorCompactAllocatedCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println("Propose owner change failed!")
 			return err
 		}

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -81,7 +81,7 @@ var actorSetAddrsCmd = &cli.Command{
 			return fmt.Errorf("unset can only be used with no arguments")
 		}
 
-		nodeAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ var actorSetAddrsCmd = &cli.Command{
 			addrs = append(addrs, maddrNop2p.Bytes())
 		}
 
-		maddr, err := nodeAPI.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ var actorSetPeeridCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -196,7 +196,7 @@ var actorSetPeeridCmd = &cli.Command{
 			return fmt.Errorf("failed to parse input as a peerId: %w", err)
 		}
 
-		maddr, err := nodeAPI.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -258,7 +258,7 @@ var actorWithdrawCmd = &cli.Command{
 			amount = abi.TokenAmount(f)
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -274,9 +274,9 @@ var actorWithdrawCmd = &cli.Command{
 
 		var res cid.Cid
 		if cctx.IsSet("beneficiary") {
-			res, err = nodeApi.BeneficiaryWithdrawBalance(ctx, amount)
+			res, err = minerApi.BeneficiaryWithdrawBalance(ctx, amount)
 		} else {
-			res, err = nodeApi.ActorWithdrawBalance(ctx, amount)
+			res, err = minerApi.ActorWithdrawBalance(ctx, amount)
 		}
 		if err != nil {
 			return err
@@ -326,7 +326,7 @@ var actorRepayDebtCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -340,7 +340,7 @@ var actorRepayDebtCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -441,7 +441,7 @@ var actorControlList = &cli.Command{
 			color.NoColor = !cctx.Bool("color")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -473,7 +473,7 @@ var actorControlList = &cli.Command{
 			tablewriter.Col("balance"),
 		)
 
-		ac, err := nodeApi.ActorAddressConfig(ctx)
+		ac, err := minerApi.ActorAddressConfig(ctx)
 		if err != nil {
 			return err
 		}
@@ -610,7 +610,7 @@ var actorControlSet = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -624,7 +624,7 @@ var actorControlSet = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -826,7 +826,7 @@ var actorProposeChangeWorker = &cli.Command{
 			return fmt.Errorf("must pass address of new worker address")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -850,7 +850,7 @@ var actorProposeChangeWorker = &cli.Command{
 			return err
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -941,7 +941,7 @@ var actorConfirmChangeWorker = &cli.Command{
 			return fmt.Errorf("must pass address of new worker address")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -965,7 +965,7 @@ var actorConfirmChangeWorker = &cli.Command{
 			return err
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -1056,7 +1056,7 @@ var actorCompactAllocatedCmd = &cli.Command{
 			return fmt.Errorf("must pass address of new owner address")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1070,7 +1070,7 @@ var actorCompactAllocatedCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-miner/dagstore.go
+++ b/cmd/lotus-miner/dagstore.go
@@ -77,7 +77,7 @@ var dagstoreRegisterShardCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must provide a single shard key")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		marketsAPI, closer, err := lcli.GetMarketsAPI(cctx)
@@ -116,7 +116,7 @@ var dagstoreInitializeShardCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must provide a single shard key")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
@@ -148,7 +148,7 @@ var dagstoreRecoverShardCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must provide a single shard key")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
@@ -330,7 +330,7 @@ var dagstoreLookupPiecesCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must provide a CID")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		cidStr := cctx.Args().First()

--- a/cmd/lotus-miner/index_provider.go
+++ b/cmd/lotus-miner/index_provider.go
@@ -36,7 +36,7 @@ var indexProvAnnounceCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must provide the deal proposal CID")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		proposalCidStr := cctx.Args().First()

--- a/cmd/lotus-miner/info_all.go
+++ b/cmd/lotus-miner/info_all.go
@@ -16,7 +16,7 @@ var infoAllCmd = &cli.Command{
 	Name:  "all",
 	Usage: "dump all related miner info",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ var infoAllCmd = &cli.Command{
 		// Very Very Verbose info
 		fmt.Println("\n#: Per Sector Info")
 
-		list, err := nodeApi.SectorsList(ctx)
+		list, err := minerApi.SectorsList(ctx)
 		if err != nil {
 			fmt.Println("ERROR: ", err)
 		}

--- a/cmd/lotus-miner/init_restore.go
+++ b/cmd/lotus-miner/init_restore.go
@@ -96,7 +96,7 @@ var restoreCmd = &cli.Command{
 }
 
 func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfig *paths.StorageConfig, manageConfig func(*config.StorageMiner) error, after func(api lapi.FullNode, addr address.Address, peerid peer.ID, mi api.MinerInfo) error) error {
-	if cctx.Args().Len() != 1 {
+	if cctx.NArg() != 1 {
 		return xerrors.Errorf("expected 1 argument")
 	}
 

--- a/cmd/lotus-miner/init_restore.go
+++ b/cmd/lotus-miner/init_restore.go
@@ -97,7 +97,7 @@ var restoreCmd = &cli.Command{
 
 func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfig *paths.StorageConfig, manageConfig func(*config.StorageMiner) error, after func(api lapi.FullNode, addr address.Address, peerid peer.ID, mi api.MinerInfo) error) error {
 	if cctx.NArg() != 1 {
-		return xerrors.Errorf("expected 1 argument")
+		return lcli.IncorrectNumArgs(cctx)
 	}
 
 	log.Info("Trying to connect to full node RPC")

--- a/cmd/lotus-miner/main.go
+++ b/cmd/lotus-miner/main.go
@@ -177,13 +177,13 @@ func getActorAddress(ctx context.Context, cctx *cli.Context) (maddr address.Addr
 		return
 	}
 
-	nodeAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+	minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 	if err != nil {
 		return address.Undef, err
 	}
 	defer closer()
 
-	maddr, err = nodeAPI.ActorAddress(ctx)
+	maddr, err = minerApi.ActorAddress(ctx)
 	if err != nil {
 		return maddr, xerrors.Errorf("getting actor address: %w", err)
 	}

--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -370,7 +370,7 @@ var dealsImportDataCmd = &cli.Command{
 
 		ctx := lcli.DaemonContext(cctx)
 
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return fmt.Errorf("must specify proposal CID and file path")
 		}
 
@@ -617,7 +617,7 @@ var setSealDurationCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass duration in minutes")
 		}
 

--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -370,8 +370,8 @@ var dealsImportDataCmd = &cli.Command{
 
 		ctx := lcli.DaemonContext(cctx)
 
-		if cctx.NArg() < 2 {
-			return fmt.Errorf("must specify proposal CID and file path")
+		if cctx.NArg() != 2 {
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		propCid, err := cid.Decode(cctx.Args().Get(0))
@@ -618,7 +618,7 @@ var setSealDurationCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass duration in minutes")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		hs, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)

--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -315,7 +315,7 @@ var provingDeadlineInfoCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass deadline index")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		dlIdx, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -462,7 +462,7 @@ var provingCheckProvableCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass deadline index")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		dlIdx, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -617,7 +617,7 @@ It will not send any messages to the chain.`,
 	ArgsUsage: "[deadline index]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass deadline index")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		dlIdx, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -662,7 +662,7 @@ var provingRecoverFaultsCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
-			return xerrors.Errorf("must pass at least 1 sector number")
+			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass at least 1 sector number"))
 		}
 
 		arglist := cctx.Args().Slice()

--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -314,7 +314,7 @@ var provingDeadlineInfoCmd = &cli.Command{
 	ArgsUsage: "<deadlineIdx>",
 	Action: func(cctx *cli.Context) error {
 
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass deadline index")
 		}
 
@@ -461,7 +461,7 @@ var provingCheckProvableCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass deadline index")
 		}
 
@@ -616,7 +616,7 @@ var provingComputeWindowPoStCmd = &cli.Command{
 It will not send any messages to the chain.`,
 	ArgsUsage: "[deadline index]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass deadline index")
 		}
 
@@ -661,7 +661,7 @@ var provingRecoverFaultsCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			return xerrors.Errorf("must pass at least 1 sector number")
 		}
 

--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -707,7 +707,7 @@ var provingRecoverFaultsCmd = &cli.Command{
 					return
 				}
 
-				if wait.Receipt.ExitCode != 0 {
+				if wait.Receipt.ExitCode.IsError() {
 					results <- xerrors.Errorf("Failed to execute message %s: %w", wait.Message, wait.Receipt.ExitCode.Error())
 					return
 				}

--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -476,7 +476,7 @@ var provingCheckProvableCmd = &cli.Command{
 		}
 		defer closer()
 
-		sapi, scloser, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, scloser, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -484,7 +484,7 @@ var provingCheckProvableCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		addr, err := sapi.ActorAddress(ctx)
+		addr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -510,7 +510,7 @@ var provingCheckProvableCmd = &cli.Command{
 		var filter map[abi.SectorID]struct{}
 
 		if cctx.IsSet("storage-id") {
-			sl, err := sapi.StorageList(ctx)
+			sl, err := minerApi.StorageList(ctx)
 			if err != nil {
 				return err
 			}
@@ -582,7 +582,7 @@ var provingCheckProvableCmd = &cli.Command{
 				})
 			}
 
-			bad, err := sapi.CheckProvable(ctx, info.WindowPoStProofType, tocheck, cctx.Bool("slow"))
+			bad, err := minerApi.CheckProvable(ctx, info.WindowPoStProofType, tocheck, cctx.Bool("slow"))
 			if err != nil {
 				return err
 			}
@@ -625,7 +625,7 @@ It will not send any messages to the chain.`,
 			return xerrors.Errorf("could not parse deadline index: %w", err)
 		}
 
-		sapi, scloser, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, scloser, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -634,7 +634,7 @@ It will not send any messages to the chain.`,
 		ctx := lcli.ReqContext(cctx)
 
 		start := time.Now()
-		res, err := sapi.ComputeWindowPoSt(ctx, dlIdx, types.EmptyTSK)
+		res, err := minerApi.ComputeWindowPoSt(ctx, dlIdx, types.EmptyTSK)
 		fmt.Printf("Took %s\n", time.Now().Sub(start))
 		if err != nil {
 			return err
@@ -675,7 +675,7 @@ var provingRecoverFaultsCmd = &cli.Command{
 			sectors = append(sectors, abi.SectorNumber(s))
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -689,7 +689,7 @@ var provingRecoverFaultsCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		msgs, err := nodeApi.RecoverFault(ctx, sectors)
+		msgs, err := minerApi.RecoverFault(ctx, sectors)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -372,7 +372,7 @@ var sealingAbortCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("expected 1 argument")
 		}
 
@@ -430,7 +430,7 @@ var sealingDataCidCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 || cctx.Args().Len() > 2 {
+		if cctx.NArg() < 1 || cctx.NArg() > 2 {
 			return xerrors.Errorf("expected 1 or 2 arguments")
 		}
 
@@ -484,7 +484,7 @@ var sealingDataCidCmd = &cli.Command{
 		}
 
 		var psize abi.PaddedPieceSize
-		if cctx.Args().Len() == 2 {
+		if cctx.NArg() == 2 {
 			rps, err := humanize.ParseBytes(cctx.Args().Get(1))
 			if err != nil {
 				return xerrors.Errorf("parsing piece size: %w", err)

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -373,7 +373,7 @@ var sealingAbortCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
@@ -431,7 +431,7 @@ var sealingDataCidCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 || cctx.NArg() > 2 {
-			return xerrors.Errorf("expected 1 or 2 arguments")
+			return lcli.ShowHelp(cctx, xerrors.Errorf("expected 1 or 2 arguments"))
 		}
 
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -57,7 +57,7 @@ func workersCmd(sealing bool) *cli.Command {
 				color.NoColor = !cctx.Bool("color")
 			}
 
-			nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func workersCmd(sealing bool) *cli.Command {
 
 			ctx := lcli.ReqContext(cctx)
 
-			stats, err := nodeApi.WorkerStats(ctx)
+			stats, err := minerApi.WorkerStats(ctx)
 			if err != nil {
 				return err
 			}
@@ -233,7 +233,7 @@ var sealingJobsCmd = &cli.Command{
 			color.NoColor = !cctx.Bool("color")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -241,7 +241,7 @@ var sealingJobsCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		jobs, err := nodeApi.WorkerJobs(ctx)
+		jobs, err := minerApi.WorkerJobs(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting worker jobs: %w", err)
 		}
@@ -275,7 +275,7 @@ var sealingJobsCmd = &cli.Command{
 
 		workerHostnames := map[uuid.UUID]string{}
 
-		wst, err := nodeApi.WorkerStats(ctx)
+		wst, err := minerApi.WorkerStats(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting worker stats: %w", err)
 		}
@@ -337,7 +337,7 @@ var sealingSchedDiagCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -345,7 +345,7 @@ var sealingSchedDiagCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		st, err := nodeApi.SealingSchedDiag(ctx, cctx.Bool("force-sched"))
+		st, err := minerApi.SealingSchedDiag(ctx, cctx.Bool("force-sched"))
 		if err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ var sealingAbortCmd = &cli.Command{
 			return xerrors.Errorf("expected 1 argument")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -385,14 +385,14 @@ var sealingAbortCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.Bool("sched") {
-			err = nodeApi.SealingRemoveRequest(ctx, uuid.Must(uuid.Parse(cctx.Args().First())))
+			err = minerApi.SealingRemoveRequest(ctx, uuid.Must(uuid.Parse(cctx.Args().First())))
 			if err != nil {
 				return xerrors.Errorf("Failed to removed the request with UUID %s: %w", cctx.Args().First(), err)
 			}
 			return nil
 		}
 
-		jobs, err := nodeApi.WorkerJobs(ctx)
+		jobs, err := minerApi.WorkerJobs(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting worker jobs: %w", err)
 		}
@@ -415,7 +415,7 @@ var sealingAbortCmd = &cli.Command{
 
 		fmt.Printf("aborting job %s, task %s, sector %d, running on host %s\n", job.ID.String(), job.Task.Short(), job.Sector.Number, job.Hostname)
 
-		return nodeApi.SealingAbort(ctx, job.ID)
+		return minerApi.SealingAbort(ctx, job.ID)
 	},
 }
 
@@ -434,7 +434,7 @@ var sealingDataCidCmd = &cli.Command{
 			return xerrors.Errorf("expected 1 or 2 arguments")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -500,7 +500,7 @@ var sealingDataCidCmd = &cli.Command{
 			psize = padreader.PaddedSize(sz).Padded()
 		}
 
-		pc, err := nodeApi.ComputeDataCid(ctx, psize.Unpadded(), r)
+		pc, err := minerApi.ComputeDataCid(ctx, psize.Unpadded(), r)
 		if err != nil {
 			return xerrors.Errorf("computing data CID: %w", err)
 		}

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1379,7 +1379,7 @@ var sectorsTerminateCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass sector number")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1489,7 +1489,7 @@ var sectorsRemoveCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass sector number")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1507,7 +1507,7 @@ var sectorsSnapUpCmd = &cli.Command{
 	ArgsUsage: "<sectorNum>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number"))
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
@@ -1588,7 +1588,7 @@ var sectorsStartSealCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass sector number")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1612,7 +1612,7 @@ var sectorsSealDelayCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("must pass duration in minutes")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		hs, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1715,7 +1715,7 @@ var sectorsUpdateCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() < 2 {
-			return xerrors.Errorf("must pass sector number and new state")
+			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number and new state"))
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -2311,7 +2311,7 @@ var sectorsNumbersReserveCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() != 2 {
-			return xerrors.Errorf("expected 2 arguments: [reservation name] [reserved ranges]")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		bf, err := strle.HumanRangesToBitField(cctx.Args().Get(1))
@@ -2336,7 +2336,7 @@ var sectorsNumbersFreeCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument: [reservation name]")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		return minerAPI.SectorNumFree(ctx, cctx.Args().First())

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1378,7 +1378,7 @@ var sectorsTerminateCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass sector number")
 		}
 
@@ -1488,7 +1488,7 @@ var sectorsRemoveCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass sector number")
 		}
 
@@ -1506,7 +1506,7 @@ var sectorsSnapUpCmd = &cli.Command{
 	Usage:     "Mark a committed capacity sector to be filled with deals",
 	ArgsUsage: "<sectorNum>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number"))
 		}
 
@@ -1550,7 +1550,7 @@ var sectorsSnapAbortCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number"))
 		}
 
@@ -1587,7 +1587,7 @@ var sectorsStartSealCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass sector number")
 		}
 
@@ -1611,7 +1611,7 @@ var sectorsSealDelayCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("must pass duration in minutes")
 		}
 
@@ -1714,7 +1714,7 @@ var sectorsUpdateCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return xerrors.Errorf("must pass sector number and new state")
 		}
 
@@ -2310,7 +2310,7 @@ var sectorsNumbersReserveCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return xerrors.Errorf("expected 2 arguments: [reservation name] [reserved ranges]")
 		}
 
@@ -2335,7 +2335,7 @@ var sectorsNumbersFreeCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("expected 1 argument: [reservation name]")
 		}
 

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -69,14 +69,14 @@ var sectorsPledgeCmd = &cli.Command{
 	Name:  "pledge",
 	Usage: "store random data in a sector",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		id, err := nodeApi.PledgeSector(ctx)
+		id, err := minerApi.PledgeSector(ctx)
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ var sectorsStatusCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ var sectorsStatusCmd = &cli.Command{
 		}
 
 		onChainInfo := cctx.Bool("on-chain-info")
-		status, err := nodeApi.SectorsStatus(ctx, abi.SectorNumber(id), onChainInfo)
+		status, err := minerApi.SectorsStatus(ctx, abi.SectorNumber(id), onChainInfo)
 		if err != nil {
 			return err
 		}
@@ -318,7 +318,7 @@ var sectorsListCmd = &cli.Command{
 			color.NoColor = !cctx.Bool("color")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -359,16 +359,16 @@ var sectorsListCmd = &cli.Command{
 		}
 
 		if len(states) == 0 {
-			list, err = nodeApi.SectorsList(ctx)
+			list, err = minerApi.SectorsList(ctx)
 		} else {
-			list, err = nodeApi.SectorsListInStates(ctx, states)
+			list, err = minerApi.SectorsListInStates(ctx, states)
 		}
 
 		if err != nil {
 			return err
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -418,7 +418,7 @@ var sectorsListCmd = &cli.Command{
 		fast := cctx.Bool("fast")
 
 		for _, s := range list {
-			st, err := nodeApi.SectorsStatus(ctx, s, !fast)
+			st, err := minerApi.SectorsStatus(ctx, s, !fast)
 			if err != nil {
 				tw.Write(map[string]interface{}{
 					"ID":    s,
@@ -1372,7 +1372,7 @@ var sectorsTerminateCmd = &cli.Command{
 		if !cctx.Bool("really-do-it") {
 			return xerrors.Errorf("pass --really-do-it to confirm this action")
 		}
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1387,7 +1387,7 @@ var sectorsTerminateCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		return nodeApi.SectorTerminate(ctx, abi.SectorNumber(id))
+		return minerApi.SectorTerminate(ctx, abi.SectorNumber(id))
 	},
 }
 
@@ -1395,14 +1395,14 @@ var sectorsTerminateFlushCmd = &cli.Command{
 	Name:  "flush",
 	Usage: "Send a terminate message if there are sectors queued for termination",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		mcid, err := nodeApi.SectorTerminateFlush(ctx)
+		mcid, err := minerApi.SectorTerminateFlush(ctx)
 		if err != nil {
 			return err
 		}
@@ -1421,7 +1421,7 @@ var sectorsTerminatePendingCmd = &cli.Command{
 	Name:  "pending",
 	Usage: "List sector numbers of sectors pending termination",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1433,12 +1433,12 @@ var sectorsTerminatePendingCmd = &cli.Command{
 		defer nCloser()
 		ctx := lcli.ReqContext(cctx)
 
-		pending, err := nodeApi.SectorTerminatePending(ctx)
+		pending, err := minerAPI.SectorTerminatePending(ctx)
 		if err != nil {
 			return err
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerAPI.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -1482,7 +1482,7 @@ var sectorsRemoveCmd = &cli.Command{
 		if !cctx.Bool("really-do-it") {
 			return xerrors.Errorf("this is a command for advanced users, only use it if you are sure of what you are doing")
 		}
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1497,7 +1497,7 @@ var sectorsRemoveCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		return nodeApi.SectorRemove(ctx, abi.SectorNumber(id))
+		return minerAPI.SectorRemove(ctx, abi.SectorNumber(id))
 	},
 }
 
@@ -1510,7 +1510,7 @@ var sectorsSnapUpCmd = &cli.Command{
 			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number"))
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1535,7 +1535,7 @@ var sectorsSnapUpCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		return nodeApi.SectorMarkForUpgrade(ctx, abi.SectorNumber(id), true)
+		return minerAPI.SectorMarkForUpgrade(ctx, abi.SectorNumber(id), true)
 	},
 }
 
@@ -1560,7 +1560,7 @@ var sectorsSnapAbortCmd = &cli.Command{
 			return fmt.Errorf("--really-do-it must be specified for this action to have an effect; you have been warned")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1572,7 +1572,7 @@ var sectorsSnapAbortCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		return nodeApi.SectorAbortUpgrade(ctx, abi.SectorNumber(id))
+		return minerAPI.SectorAbortUpgrade(ctx, abi.SectorNumber(id))
 	},
 }
 
@@ -1581,7 +1581,7 @@ var sectorsStartSealCmd = &cli.Command{
 	Usage:     "Manually start sealing a sector (filling any unused space with junk)",
 	ArgsUsage: "<sectorNum>",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1596,7 +1596,7 @@ var sectorsStartSealCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		return nodeApi.SectorStartSealing(ctx, abi.SectorNumber(id))
+		return minerAPI.SectorStartSealing(ctx, abi.SectorNumber(id))
 	},
 }
 
@@ -1605,7 +1605,7 @@ var sectorsSealDelayCmd = &cli.Command{
 	Usage:     "Set the time, in minutes, that a new sector waits for deals before sealing starts",
 	ArgsUsage: "<minutes>",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1622,7 +1622,7 @@ var sectorsSealDelayCmd = &cli.Command{
 
 		delay := hs * uint64(time.Minute)
 
-		return nodeApi.SectorSetSealDelay(ctx, time.Duration(delay))
+		return minerAPI.SectorSetSealDelay(ctx, time.Duration(delay))
 	},
 }
 
@@ -1708,7 +1708,7 @@ var sectorsUpdateCmd = &cli.Command{
 		if !cctx.Bool("really-do-it") {
 			return xerrors.Errorf("this is a command for advanced users, only use it if you are sure of what you are doing")
 		}
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1723,7 +1723,7 @@ var sectorsUpdateCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		_, err = nodeApi.SectorsStatus(ctx, abi.SectorNumber(id), false)
+		_, err = minerAPI.SectorsStatus(ctx, abi.SectorNumber(id), false)
 		if err != nil {
 			return xerrors.Errorf("sector %d not found, could not change state", id)
 		}
@@ -1737,7 +1737,7 @@ var sectorsUpdateCmd = &cli.Command{
 			return nil
 		}
 
-		return nodeApi.SectorsUpdate(ctx, abi.SectorNumber(id), api.SectorState(cctx.Args().Get(1)))
+		return minerAPI.SectorsUpdate(ctx, abi.SectorNumber(id), api.SectorState(cctx.Args().Get(1)))
 	},
 }
 
@@ -1765,7 +1765,7 @@ var sectorsExpiredCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1805,7 +1805,7 @@ var sectorsExpiredCmd = &cli.Command{
 			return xerrors.Errorf("getting lookback tipset: %w", err)
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerAPI.ActorAddress(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting actor address: %w", err)
 		}
@@ -1813,7 +1813,7 @@ var sectorsExpiredCmd = &cli.Command{
 		// toCheck is a working bitfield which will only contain terminated sectors
 		toCheck := bitfield.New()
 		{
-			sectors, err := nodeApi.SectorsList(ctx)
+			sectors, err := minerAPI.SectorsList(ctx)
 			if err != nil {
 				return xerrors.Errorf("getting sector list: %w", err)
 			}
@@ -1890,7 +1890,7 @@ var sectorsExpiredCmd = &cli.Command{
 		err = toCheck.ForEach(func(u uint64) error {
 			s := abi.SectorNumber(u)
 
-			st, err := nodeApi.SectorsStatus(ctx, s, true)
+			st, err := minerAPI.SectorsStatus(ctx, s, true)
 			if err != nil {
 				fmt.Printf("%d:\tError getting status: %s\n", u, err)
 				return nil
@@ -1933,7 +1933,7 @@ var sectorsExpiredCmd = &cli.Command{
 			for _, number := range toRemove {
 				fmt.Printf("Removing sector\t%s:\t", color.YellowString("%d", number))
 
-				err := nodeApi.SectorRemove(ctx, number)
+				err := minerAPI.SectorRemove(ctx, number)
 				if err != nil {
 					color.Red("ERROR: %s\n", err.Error())
 				} else {
@@ -1965,7 +1965,7 @@ var sectorsBatchingPendingCommit = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -1973,7 +1973,7 @@ var sectorsBatchingPendingCommit = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.Bool("publish-now") {
-			res, err := api.SectorCommitFlush(ctx)
+			res, err := minerAPI.SectorCommitFlush(ctx)
 			if err != nil {
 				return xerrors.Errorf("flush: %w", err)
 			}
@@ -2000,7 +2000,7 @@ var sectorsBatchingPendingCommit = &cli.Command{
 			return nil
 		}
 
-		pending, err := api.SectorCommitPending(ctx)
+		pending, err := minerAPI.SectorCommitPending(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting pending deals: %w", err)
 		}
@@ -2027,7 +2027,7 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -2035,7 +2035,7 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.Bool("publish-now") {
-			res, err := api.SectorPreCommitFlush(ctx)
+			res, err := minerAPI.SectorPreCommitFlush(ctx)
 			if err != nil {
 				return xerrors.Errorf("flush: %w", err)
 			}
@@ -2058,7 +2058,7 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 			return nil
 		}
 
-		pending, err := api.SectorPreCommitPending(ctx)
+		pending, err := minerAPI.SectorPreCommitPending(ctx)
 		if err != nil {
 			return xerrors.Errorf("getting pending deals: %w", err)
 		}
@@ -2079,14 +2079,14 @@ var sectorsRefreshPieceMatchingCmd = &cli.Command{
 	Name:  "match-pending-pieces",
 	Usage: "force a refreshed match of pending pieces to open sectors without manually waiting for more deals",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if err := nodeApi.SectorMatchPendingPiecesToOpenSectors(ctx); err != nil {
+		if err := minerAPI.SectorMatchPendingPiecesToOpenSectors(ctx); err != nil {
 			return err
 		}
 
@@ -2219,14 +2219,14 @@ var sectorsNumbersInfoCmd = &cli.Command{
 	Name:  "info",
 	Usage: "view sector assigner state",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		am, err := api.SectorNumAssignerMeta(ctx)
+		am, err := minerAPI.SectorNumAssignerMeta(ctx)
 		if err != nil {
 			return err
 		}
@@ -2253,14 +2253,14 @@ var sectorsNumbersReservationsCmd = &cli.Command{
 	Name:  "reservations",
 	Usage: "list sector number reservations",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		rs, err := api.SectorNumReservations(ctx)
+		rs, err := minerAPI.SectorNumReservations(ctx)
 		if err != nil {
 			return err
 		}
@@ -2303,7 +2303,7 @@ var sectorsNumbersReserveCmd = &cli.Command{
 	},
 	ArgsUsage: "[reservation name] [reserved ranges]",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -2319,7 +2319,7 @@ var sectorsNumbersReserveCmd = &cli.Command{
 			return xerrors.Errorf("parsing ranges: %w", err)
 		}
 
-		return api.SectorNumReserve(ctx, cctx.Args().First(), bf, cctx.Bool("force"))
+		return minerAPI.SectorNumReserve(ctx, cctx.Args().First(), bf, cctx.Bool("force"))
 	},
 }
 
@@ -2328,7 +2328,7 @@ var sectorsNumbersFreeCmd = &cli.Command{
 	Usage:     "remove sector number reservations",
 	ArgsUsage: "[reservation name]",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -2339,6 +2339,6 @@ var sectorsNumbersFreeCmd = &cli.Command{
 			return xerrors.Errorf("expected 1 argument: [reservation name]")
 		}
 
-		return api.SectorNumFree(ctx, cctx.Args().First())
+		return minerAPI.SectorNumFree(ctx, cctx.Args().First())
 	},
 }

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -2195,7 +2195,7 @@ var sectorsCompactPartitionsCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println(cctx.App.Writer, "compact partitions failed!")
 			return err
 		}

--- a/cmd/lotus-miner/storage.go
+++ b/cmd/lotus-miner/storage.go
@@ -109,7 +109,7 @@ over time
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -172,7 +172,7 @@ over time
 			}
 		}
 
-		return nodeApi.StorageAddLocal(ctx, p)
+		return minerApi.StorageAddLocal(ctx, p)
 	},
 }
 
@@ -186,7 +186,7 @@ var storageDetachCmd = &cli.Command{
 	},
 	ArgsUsage: "[path]",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -206,7 +206,7 @@ var storageDetachCmd = &cli.Command{
 			return xerrors.Errorf("pass --really-do-it to execute the action")
 		}
 
-		return nodeApi.StorageDetachLocal(ctx, p)
+		return minerApi.StorageDetachLocal(ctx, p)
 	},
 }
 
@@ -228,7 +228,7 @@ var storageRedeclareCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -241,11 +241,11 @@ var storageRedeclareCmd = &cli.Command{
 
 		if cctx.IsSet("id") {
 			id := storiface.ID(cctx.String("id"))
-			return nodeApi.StorageRedeclareLocal(ctx, &id, cctx.Bool("drop-missing"))
+			return minerApi.StorageRedeclareLocal(ctx, &id, cctx.Bool("drop-missing"))
 		}
 
 		if cctx.Bool("all") {
-			return nodeApi.StorageRedeclareLocal(ctx, nil, cctx.Bool("drop-missing"))
+			return minerApi.StorageRedeclareLocal(ctx, nil, cctx.Bool("drop-missing"))
 		}
 
 		return xerrors.Errorf("either --all or --id must be specified")
@@ -270,19 +270,19 @@ var storageListCmd = &cli.Command{
 			color.NoColor = !cctx.Bool("color")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		st, err := nodeApi.StorageList(ctx)
+		st, err := minerApi.StorageList(ctx)
 		if err != nil {
 			return err
 		}
 
-		local, err := nodeApi.StorageLocal(ctx)
+		local, err := minerApi.StorageLocal(ctx)
 		if err != nil {
 			return err
 		}
@@ -295,7 +295,7 @@ var storageListCmd = &cli.Command{
 
 		sorted := make([]fsInfo, 0, len(st))
 		for id, decls := range st {
-			st, err := nodeApi.StorageStat(ctx, id)
+			st, err := minerApi.StorageStat(ctx, id)
 			if err != nil {
 				sorted = append(sorted, fsInfo{ID: id, sectors: decls})
 				continue
@@ -325,7 +325,7 @@ var storageListCmd = &cli.Command{
 			fmt.Printf("%s:\n", s.ID)
 
 			pingStart := time.Now()
-			st, err := nodeApi.StorageStat(ctx, s.ID)
+			st, err := minerApi.StorageStat(ctx, s.ID)
 			if err != nil {
 				fmt.Printf("\t%s: %s:\n", color.RedString("Error"), err)
 				continue
@@ -398,7 +398,7 @@ var storageListCmd = &cli.Command{
 				color.BlueString("Caches: %d", cnt[2]),
 				types.SizeStr(types.NewInt(uint64(st.Reserved))))
 
-			si, err := nodeApi.StorageInfo(ctx, s.ID)
+			si, err := minerApi.StorageInfo(ctx, s.ID)
 			if err != nil {
 				return err
 			}
@@ -469,14 +469,14 @@ var storageFindCmd = &cli.Command{
 	Usage:     "find sector in the storage system",
 	ArgsUsage: "[sector number]",
 	Action: func(cctx *cli.Context) error {
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		ma, err := nodeApi.ActorAddress(ctx)
+		ma, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -500,27 +500,27 @@ var storageFindCmd = &cli.Command{
 			Number: abi.SectorNumber(snum),
 		}
 
-		u, err := nodeApi.StorageFindSector(ctx, sid, storiface.FTUnsealed, 0, false)
+		u, err := minerApi.StorageFindSector(ctx, sid, storiface.FTUnsealed, 0, false)
 		if err != nil {
 			return xerrors.Errorf("finding unsealed: %w", err)
 		}
 
-		s, err := nodeApi.StorageFindSector(ctx, sid, storiface.FTSealed, 0, false)
+		s, err := minerApi.StorageFindSector(ctx, sid, storiface.FTSealed, 0, false)
 		if err != nil {
 			return xerrors.Errorf("finding sealed: %w", err)
 		}
 
-		c, err := nodeApi.StorageFindSector(ctx, sid, storiface.FTCache, 0, false)
+		c, err := minerApi.StorageFindSector(ctx, sid, storiface.FTCache, 0, false)
 		if err != nil {
 			return xerrors.Errorf("finding cache: %w", err)
 		}
 
-		us, err := nodeApi.StorageFindSector(ctx, sid, storiface.FTUpdate, 0, false)
+		us, err := minerApi.StorageFindSector(ctx, sid, storiface.FTUpdate, 0, false)
 		if err != nil {
 			return xerrors.Errorf("finding sealed: %w", err)
 		}
 
-		uc, err := nodeApi.StorageFindSector(ctx, sid, storiface.FTUpdateCache, 0, false)
+		uc, err := minerApi.StorageFindSector(ctx, sid, storiface.FTUpdateCache, 0, false)
 		if err != nil {
 			return xerrors.Errorf("finding cache: %w", err)
 		}
@@ -582,7 +582,7 @@ var storageFindCmd = &cli.Command{
 			sts.updatecache = true
 		}
 
-		local, err := nodeApi.StorageLocal(ctx)
+		local, err := minerApi.StorageLocal(ctx)
 		if err != nil {
 			return err
 		}
@@ -644,7 +644,7 @@ var storageListSectorsCmd = &cli.Command{
 			color.NoColor = !cctx.Bool("color")
 		}
 
-		nodeApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -658,12 +658,12 @@ var storageListSectorsCmd = &cli.Command{
 
 		ctx := lcli.ReqContext(cctx)
 
-		sectors, err := nodeApi.SectorsList(ctx)
+		sectors, err := minerApi.SectorsList(ctx)
 		if err != nil {
 			return xerrors.Errorf("listing sectors: %w", err)
 		}
 
-		maddr, err := nodeApi.ActorAddress(ctx)
+		maddr, err := minerApi.ActorAddress(ctx)
 		if err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ var storageListSectorsCmd = &cli.Command{
 		var list []entry
 
 		for _, sector := range sectors {
-			st, err := nodeApi.SectorsStatus(ctx, sector, false)
+			st, err := minerApi.SectorsStatus(ctx, sector, false)
 			if err != nil {
 				return xerrors.Errorf("getting sector status for sector %d: %w", sector, err)
 			}
@@ -716,7 +716,7 @@ var storageListSectorsCmd = &cli.Command{
 			}
 
 			for _, ft := range storiface.PathTypes {
-				si, err := nodeApi.StorageFindSector(ctx, sid(sector), ft, mi.SectorSize, false)
+				si, err := minerApi.StorageFindSector(ctx, sid(sector), ft, mi.SectorSize, false)
 				if err != nil {
 					return xerrors.Errorf("find sector %d: %w", sector, err)
 				}
@@ -869,7 +869,7 @@ var storageCleanupCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
@@ -884,7 +884,7 @@ var storageCleanupCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.Bool("removed") {
-			if err := cleanupRemovedSectorData(ctx, api, napi); err != nil {
+			if err := cleanupRemovedSectorData(ctx, minerAPI, napi); err != nil {
 				return err
 			}
 		}
@@ -962,20 +962,20 @@ var storageLocks = &cli.Command{
 	Name:  "locks",
 	Usage: "show active sector locks",
 	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetStorageMinerAPI(cctx)
+		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		locks, err := api.StorageGetLocks(ctx)
+		locks, err := minerAPI.StorageGetLocks(ctx)
 		if err != nil {
 			return err
 		}
 
 		for _, lock := range locks.Locks {
-			st, err := api.SectorsStatus(ctx, lock.Sector.Number, false)
+			st, err := minerAPI.SectorsStatus(ctx, lock.Sector.Number, false)
 			if err != nil {
 				return xerrors.Errorf("getting sector status(%d): %w", lock.Sector.Number, err)
 			}

--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -93,7 +93,7 @@ var genesisAddMinerCmd = &cli.Command{
 	Description: "add genesis miner",
 	Flags:       []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return xerrors.New("seed genesis add-miner [genesis.json] [preseal.json]")
 		}
 
@@ -181,7 +181,7 @@ type GenAccountEntry struct {
 var genesisAddMsigsCmd = &cli.Command{
 	Name: "add-msigs",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 2 {
+		if cctx.NArg() < 2 {
 			return fmt.Errorf("must specify template file and csv file with accounts")
 		}
 
@@ -329,7 +329,7 @@ var genesisSetVRKCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must specify template file")
 		}
 
@@ -425,7 +425,7 @@ var genesisSetRemainderCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must specify template file")
 		}
 
@@ -519,7 +519,7 @@ var genesisSetActorVersionCmd = &cli.Command{
 	},
 	ArgsUsage: "<genesisFile>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must specify genesis file")
 		}
 
@@ -597,7 +597,7 @@ var genesisSetVRKSignersCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return fmt.Errorf("must specify template file")
 		}
 

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -144,7 +144,7 @@ var actorWithdrawCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println(cctx.App.Writer, "withdrawal failed!")
 			return err
 		}
@@ -279,7 +279,7 @@ var actorSetOwnerCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println("owner change failed!")
 			return err
 		}
@@ -647,7 +647,7 @@ var actorProposeChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose worker change failed!")
 			return err
 		}
@@ -768,7 +768,7 @@ var actorConfirmChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
 			return err
 		}

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -74,13 +74,13 @@ var actorWithdrawCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -233,13 +233,13 @@ var actorSetOwnerCmd = &cli.Command{
 		}
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -339,13 +339,13 @@ var actorControlList = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -448,13 +448,13 @@ var actorControlSet = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -590,13 +590,13 @@ var actorProposeChangeWorker = &cli.Command{
 		}
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -720,13 +720,13 @@ var actorConfirmChangeWorker = &cli.Command{
 		}
 
 		if maddr.Empty() {
-			minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer closer()
 
-			maddr, err = minerAPI.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -192,7 +192,7 @@ var actorSetOwnerCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must pass new owner address and sender address")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		var maddr address.Address

--- a/cmd/lotus-shed/base16.go
+++ b/cmd/lotus-shed/base16.go
@@ -24,7 +24,7 @@ var base16Cmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		var input io.Reader
 
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = os.Stdin
 		} else {
 			input = strings.NewReader(cctx.Args().First())

--- a/cmd/lotus-shed/base32.go
+++ b/cmd/lotus-shed/base32.go
@@ -24,7 +24,7 @@ var base32Cmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		var input io.Reader
 
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = os.Stdin
 		} else {
 			input = strings.NewReader(cctx.Args().First())

--- a/cmd/lotus-shed/base64.go
+++ b/cmd/lotus-shed/base64.go
@@ -32,7 +32,7 @@ var base64Cmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		var input io.Reader
 
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = os.Stdin
 		} else {
 			input = strings.NewReader(cctx.Args().First())

--- a/cmd/lotus-shed/chain.go
+++ b/cmd/lotus-shed/chain.go
@@ -56,7 +56,7 @@ var computeStateRangeCmd = &cli.Command{
 	ArgsUsage: "[START_TIPSET_REF] [END_TIPSET_REF]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("expected two arguments: a start and an end tipset")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := lcli.GetFullNodeAPI(cctx)

--- a/cmd/lotus-shed/consensus.go
+++ b/cmd/lotus-shed/consensus.go
@@ -84,7 +84,7 @@ var consensusCheckCmd = &cli.Command{
 		filePath := cctx.Args().First()
 
 		var input *bufio.Reader
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = bufio.NewReader(os.Stdin)
 		} else {
 			var err error

--- a/cmd/lotus-shed/datastore.go
+++ b/cmd/lotus-shed/datastore.go
@@ -171,7 +171,7 @@ var datastoreBackupStatCmd = &cli.Command{
 	Description: "validate and print info about datastore backup",
 	ArgsUsage:   "[file]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("expected 1 argument")
 		}
 
@@ -220,7 +220,7 @@ var datastoreBackupListCmd = &cli.Command{
 	},
 	ArgsUsage: "[file]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("expected 1 argument")
 		}
 

--- a/cmd/lotus-shed/datastore.go
+++ b/cmd/lotus-shed/datastore.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/multierr"
 	"golang.org/x/xerrors"
 
+	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/lib/backupds"
 	"github.com/filecoin-project/lotus/node/repo"
 )
@@ -172,7 +173,7 @@ var datastoreBackupStatCmd = &cli.Command{
 	ArgsUsage:   "[file]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		f, err := os.Open(cctx.Args().First())
@@ -221,7 +222,7 @@ var datastoreBackupListCmd = &cli.Command{
 	ArgsUsage: "[file]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		f, err := os.Open(cctx.Args().First())
@@ -308,7 +309,7 @@ var datastoreRewriteCmd = &cli.Command{
 	ArgsUsage:   "source destination",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return xerrors.Errorf("expected 2 arguments, got %d", cctx.NArg())
+			return lcli.IncorrectNumArgs(cctx)
 		}
 		fromPath, err := homedir.Expand(cctx.Args().Get(0))
 		if err != nil {

--- a/cmd/lotus-shed/diff.go
+++ b/cmd/lotus-shed/diff.go
@@ -31,7 +31,7 @@ var diffStateTrees = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() != 2 {
-			return xerrors.Errorf("expected two state-tree roots")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		argA := cctx.Args().Get(0)

--- a/cmd/lotus-shed/export-car.go
+++ b/cmd/lotus-shed/export-car.go
@@ -39,7 +39,7 @@ var exportCarCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return lcli.ShowHelp(cctx, fmt.Errorf("must specify file name and object"))
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		outfile := cctx.Args().First()

--- a/cmd/lotus-shed/export-car.go
+++ b/cmd/lotus-shed/export-car.go
@@ -38,7 +38,7 @@ var exportCarCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return lcli.ShowHelp(cctx, fmt.Errorf("must specify file name and object"))
 		}
 

--- a/cmd/lotus-shed/keyinfo.go
+++ b/cmd/lotus-shed/keyinfo.go
@@ -149,7 +149,7 @@ var keyinfoImportCmd = &cli.Command{
 		flagRepo := cctx.String("repo")
 
 		var input io.Reader
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = os.Stdin
 		} else {
 			var err error
@@ -261,7 +261,7 @@ var keyinfoInfoCmd = &cli.Command{
 		format := cctx.String("format")
 
 		var input io.Reader
-		if cctx.Args().Len() == 0 {
+		if cctx.NArg() == 0 {
 			input = os.Stdin
 		} else {
 			var err error

--- a/cmd/lotus-shed/ledger.go
+++ b/cmd/lotus-shed/ledger.go
@@ -300,7 +300,7 @@ var ledgerNewAddressesCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must pass account index")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		index, err := strconv.ParseUint(cctx.Args().First(), 10, 32)

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/lotus/storage/sealer/ffiwrapper"
 )
@@ -34,7 +35,7 @@ var migrationsCmd = &cli.Command{
 		ctx := context.TODO()
 
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must pass block cid")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		blkCid, err := cid.Decode(cctx.Args().First())

--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -101,7 +101,7 @@ var mmProposeWithdrawBalance = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
 			return err
 		}
@@ -180,7 +180,7 @@ var mmApproveWithdrawBalance = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
 			return err
 		}
@@ -261,7 +261,7 @@ var mmProposeChangeOwner = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
 			return err
 		}
@@ -351,7 +351,7 @@ var mmApproveChangeOwner = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
 			return err
 		}
@@ -448,7 +448,7 @@ var mmProposeChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}
@@ -532,7 +532,7 @@ var mmConfirmChangeWorker = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}
@@ -647,7 +647,7 @@ var mmProposeControlSet = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}

--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -128,7 +128,7 @@ var mmApproveWithdrawBalance = &cli.Command{
 	ArgsUsage: "[amount txnId proposer]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must pass amount, txn Id, and proposer address")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := lcli.GetFullNodeAPI(cctx)
@@ -287,7 +287,7 @@ var mmApproveChangeOwner = &cli.Command{
 	ArgsUsage: "[newOwner txnId proposer]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must pass new owner address, txn Id, and proposer address")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := lcli.GetFullNodeAPI(cctx)

--- a/cmd/lotus-shed/miner-peerid.go
+++ b/cmd/lotus-shed/miner-peerid.go
@@ -20,6 +20,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
@@ -35,7 +36,7 @@ var minerPeeridCmd = &cli.Command{
 		ctx := context.TODO()
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must pass peer id and state root")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		pid, err := peer.Decode(cctx.Args().Get(0))

--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -475,7 +475,7 @@ var sendInvalidWindowPoStCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println(cctx.App.Writer, "Invalid PoST message failed!")
 			return err
 		}
@@ -574,7 +574,7 @@ var generateAndSendConsensusFaultCmd = &cli.Command{
 		}
 
 		// check it executed successfully
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			fmt.Println(cctx.App.Writer, "Report consensus fault failed!")
 			return err
 		}

--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -136,7 +136,7 @@ var minerCreateCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() != 4 {
-			return xerrors.Errorf("expected 4 args (sender owner worker sectorSize)")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		sender, err := address.NewFromString(cctx.Args().First())
@@ -274,7 +274,7 @@ var minerUnpackInfoCmd = &cli.Command{
 	ArgsUsage: "[allinfo.txt] [dir]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 2 {
-			return xerrors.Errorf("expected 2 args")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		src, err := homedir.Expand(cctx.Args().Get(0))
@@ -488,9 +488,10 @@ var generateAndSendConsensusFaultCmd = &cli.Command{
 	Name:        "generate-and-send-consensus-fault",
 	Usage:       "Provided a block CID mined by the miner, will create another block at the same height, and send both block headers to generate a consensus fault.",
 	Description: `Note: This is meant for testing purposes and should NOT be used on mainnet or you will be slashed`,
+	ArgsUsage:   "blockCID",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 arg (blockCID)")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		blockCid, err := cid.Parse(cctx.Args().First())

--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -135,7 +135,7 @@ var minerCreateCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.Args().Len() != 4 {
+		if cctx.NArg() != 4 {
 			return xerrors.Errorf("expected 4 args (sender owner worker sectorSize)")
 		}
 
@@ -273,7 +273,7 @@ var minerUnpackInfoCmd = &cli.Command{
 	Usage:     "unpack miner info all dump",
 	ArgsUsage: "[allinfo.txt] [dir]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return xerrors.Errorf("expected 2 args")
 		}
 

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -28,7 +28,7 @@ var msgCmd = &cli.Command{
 	ArgsUsage: "Message in any form",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		msg, err := messageFromString(cctx, cctx.Args().First())

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -27,7 +27,7 @@ var msgCmd = &cli.Command{
 	Usage:     "Translate message between various formats",
 	ArgsUsage: "Message in any form",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("expected 1 argument")
 		}
 

--- a/cmd/lotus-shed/proofs.go
+++ b/cmd/lotus-shed/proofs.go
@@ -11,6 +11,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	prooftypes "github.com/filecoin-project/go-state-types/proof"
+
+	lcli "github.com/filecoin-project/lotus/cli"
 )
 
 var proofsCmd = &cli.Command{
@@ -43,7 +45,7 @@ var verifySealProofCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must specify commR, commD, and proof to verify")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		commr, err := cid.Decode(cctx.Args().Get(0))

--- a/cmd/lotus-shed/proofs.go
+++ b/cmd/lotus-shed/proofs.go
@@ -42,7 +42,7 @@ var verifySealProofCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return fmt.Errorf("must specify commR, commD, and proof to verify")
 		}
 

--- a/cmd/lotus-shed/rpc.go
+++ b/cmd/lotus-shed/rpc.go
@@ -113,7 +113,7 @@ var rpcCmd = &cli.Command{
 
 		if cctx.Args().Present() {
 			if cctx.NArg() > 2 {
-				return xerrors.Errorf("expected 1 or 2 arguments: method [params]")
+				return lcli.ShowHelp(cctx, xerrors.Errorf("expected 1 or 2 arguments: method [params]"))
 			}
 
 			params := cctx.Args().Get(1)

--- a/cmd/lotus-shed/rpc.go
+++ b/cmd/lotus-shed/rpc.go
@@ -112,7 +112,7 @@ var rpcCmd = &cli.Command{
 		}
 
 		if cctx.Args().Present() {
-			if cctx.Args().Len() > 2 {
+			if cctx.NArg() > 2 {
 				return xerrors.Errorf("expected 1 or 2 arguments: method [params]")
 			}
 

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -64,7 +64,7 @@ var terminateSectorCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			return fmt.Errorf("at least one sector must be specified")
 		}
 
@@ -200,7 +200,7 @@ var terminateSectorPenaltyEstimationCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			return fmt.Errorf("at least one sector must be specified")
 		}
 

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -171,7 +171,7 @@ var terminateSectorCmd = &cli.Command{
 			return err
 		}
 
-		if wait.Receipt.ExitCode != 0 {
+		if wait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("terminate sectors message returned exit %d", wait.Receipt.ExitCode)
 		}
 

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -65,7 +65,7 @@ var terminateSectorCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
-			return fmt.Errorf("at least one sector must be specified")
+			return lcli.ShowHelp(cctx, fmt.Errorf("at least one sector must be specified"))
 		}
 
 		var maddr address.Address
@@ -201,7 +201,7 @@ var terminateSectorPenaltyEstimationCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 1 {
-			return fmt.Errorf("at least one sector must be specified")
+			return lcli.ShowHelp(cctx, fmt.Errorf("at least one sector must be specified"))
 		}
 
 		var maddr address.Address

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -90,13 +90,13 @@ var terminateSectorCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if maddr.Empty() {
-			api, acloser, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, acloser, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer acloser()
 
-			maddr, err = api.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}
@@ -222,13 +222,13 @@ var terminateSectorPenaltyEstimationCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if maddr.Empty() {
-			api, acloser, err := lcli.GetStorageMinerAPI(cctx)
+			minerApi, acloser, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
 			}
 			defer acloser()
 
-			maddr, err = api.ActorAddress(ctx)
+			maddr, err = minerApi.ActorAddress(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/lotus-shed/send-csv.go
+++ b/cmd/lotus-shed/send-csv.go
@@ -34,7 +34,7 @@ var sendCsvCmd = &cli.Command{
 	ArgsUsage: "[csvfile]",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.New("must supply path to csv file")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := lcli.GetFullNodeAPIV1(cctx)

--- a/cmd/lotus-shed/signatures.go
+++ b/cmd/lotus-shed/signatures.go
@@ -32,7 +32,7 @@ var sigsVerifyBlsMsgsCmd = &cli.Command{
 	Usage:       "<blockCid>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return xerrors.Errorf("usage: <blockCid>")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, closer, err := lcli.GetFullNodeAPI(cctx)
@@ -102,7 +102,7 @@ var sigsVerifyVoteCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 
 		if cctx.NArg() != 3 {
-			return xerrors.Errorf("usage: verify-vote <FIPnumber> <signingAddress> <signature>")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		fip, err := strconv.ParseInt(cctx.Args().First(), 10, 64)

--- a/cmd/lotus-shed/signatures.go
+++ b/cmd/lotus-shed/signatures.go
@@ -31,7 +31,7 @@ var sigsVerifyBlsMsgsCmd = &cli.Command{
 	Description: "given a block, verifies the bls signature of the messages in the block",
 	Usage:       "<blockCid>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 1 {
+		if cctx.NArg() != 1 {
 			return xerrors.Errorf("usage: <blockCid>")
 		}
 
@@ -101,7 +101,7 @@ var sigsVerifyVoteCmd = &cli.Command{
 	Usage:       "<FIPnumber> <signingAddress> <signature>",
 	Action: func(cctx *cli.Context) error {
 
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return xerrors.Errorf("usage: verify-vote <FIPnumber> <signingAddress> <signature>")
 		}
 

--- a/cmd/lotus-shed/stateroot-stats.go
+++ b/cmd/lotus-shed/stateroot-stats.go
@@ -174,8 +174,8 @@ var staterootStatCmd = &cli.Command{
 		}
 
 		outcap := 10
-		if cctx.Args().Len() > outcap {
-			outcap = cctx.Args().Len()
+		if cctx.NArg() > outcap {
+			outcap = cctx.NArg()
 		}
 		if len(infos) < outcap {
 			outcap = len(infos)

--- a/cmd/lotus-shed/sync.go
+++ b/cmd/lotus-shed/sync.go
@@ -38,7 +38,7 @@ var syncValidateCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			fmt.Println("usage: <blockCid1> <blockCid2>...")
 			fmt.Println("At least one block cid must be provided")
 			return nil
@@ -75,7 +75,7 @@ var syncScrapePowerCmd = &cli.Command{
 	Usage:     "given a height and a tipset, reports what percentage of mining power had a winning ticket between the tipset and height",
 	ArgsUsage: "[height tipsetkey]",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			fmt.Println("usage: <height> [blockCid1 blockCid2...]")
 			fmt.Println("Any CIDs passed after the height will be used as the tipset key")
 			fmt.Println("If no block CIDs are provided, chain head will be used")
@@ -90,7 +90,7 @@ var syncScrapePowerCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.Args().Len() < 1 {
+		if cctx.NArg() < 1 {
 			fmt.Println("usage: <blockCid1> <blockCid2>...")
 			fmt.Println("At least one block cid must be provided")
 			return nil

--- a/cmd/lotus-shed/sync.go
+++ b/cmd/lotus-shed/sync.go
@@ -39,9 +39,7 @@ var syncValidateCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() < 1 {
-			fmt.Println("usage: <blockCid1> <blockCid2>...")
-			fmt.Println("At least one block cid must be provided")
-			return nil
+			return lcli.ShowHelp(cctx, fmt.Errorf("at least one block cid must be provided"))
 		}
 
 		args := cctx.Args().Slice()
@@ -91,9 +89,7 @@ var syncScrapePowerCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		if cctx.NArg() < 1 {
-			fmt.Println("usage: <blockCid1> <blockCid2>...")
-			fmt.Println("At least one block cid must be provided")
-			return nil
+			return lcli.ShowHelp(cctx, fmt.Errorf("at least one block cid must be provided"))
 		}
 
 		h, err := strconv.ParseInt(cctx.Args().Get(0), 10, 0)

--- a/cmd/lotus-shed/terminations.go
+++ b/cmd/lotus-shed/terminations.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
@@ -40,7 +41,7 @@ var terminationsCmd = &cli.Command{
 		ctx := context.TODO()
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must pass block cid && lookback period")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		blkCid, err := cid.Decode(cctx.Args().First())

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -104,7 +104,7 @@ var verifRegAddVerifierFromMsigCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("failed to add verifier: %d", mwait.Receipt.ExitCode)
 		}
 
@@ -170,7 +170,7 @@ var verifRegAddVerifierFromAccountCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("failed to add verified client: %d", mwait.Receipt.ExitCode)
 		}
 
@@ -246,7 +246,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("failed to add verified client: %d", mwait.Receipt.ExitCode)
 		}
 
@@ -555,7 +555,7 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 			return err
 		}
 
-		if mwait.Receipt.ExitCode != 0 {
+		if mwait.Receipt.ExitCode.IsError() {
 			return fmt.Errorf("failed to removed verified data cap: %d", mwait.Receipt.ExitCode)
 		}
 

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -46,7 +46,7 @@ var verifRegAddVerifierFromMsigCmd = &cli.Command{
 	Usage:     "make a given account a verifier",
 	ArgsUsage: "<message sender> <new verifier> <allowance>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return fmt.Errorf("must specify three arguments: sender, verifier, and allowance")
 		}
 
@@ -119,7 +119,7 @@ var verifRegAddVerifierFromAccountCmd = &cli.Command{
 	Usage:     "make a given account a verifier",
 	ArgsUsage: "<verifier root key> <new verifier> <allowance>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 3 {
+		if cctx.NArg() != 3 {
 			return fmt.Errorf("must specify three arguments: sender, verifier, and allowance")
 		}
 
@@ -201,7 +201,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 			return err
 		}
 
-		if cctx.Args().Len() != 2 {
+		if cctx.NArg() != 2 {
 			return fmt.Errorf("must specify two arguments: address and allowance")
 		}
 
@@ -418,7 +418,7 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 	Usage:     "Remove data cap from verified client",
 	ArgsUsage: "<message sender> <client address> <allowance to remove> <verifier 1 address> <verifier 1 signature> <verifier 2 address> <verifier 2 signature>",
 	Action: func(cctx *cli.Context) error {
-		if cctx.Args().Len() != 7 {
+		if cctx.NArg() != 7 {
 			return fmt.Errorf("must specify seven arguments: sender, client, allowance to remove, verifier 1 address, verifier 1 signature, verifier 2 address, verifier 2 signature")
 		}
 

--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -47,7 +47,7 @@ var verifRegAddVerifierFromMsigCmd = &cli.Command{
 	ArgsUsage: "<message sender> <new verifier> <allowance>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must specify three arguments: sender, verifier, and allowance")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		sender, err := address.NewFromString(cctx.Args().Get(0))
@@ -120,7 +120,7 @@ var verifRegAddVerifierFromAccountCmd = &cli.Command{
 	ArgsUsage: "<verifier root key> <new verifier> <allowance>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 3 {
-			return fmt.Errorf("must specify three arguments: sender, verifier, and allowance")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		sender, err := address.NewFromString(cctx.Args().Get(0))
@@ -202,7 +202,7 @@ var verifRegVerifyClientCmd = &cli.Command{
 		}
 
 		if cctx.NArg() != 2 {
-			return fmt.Errorf("must specify two arguments: address and allowance")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		target, err := address.NewFromString(cctx.Args().Get(0))
@@ -419,7 +419,7 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 	ArgsUsage: "<message sender> <client address> <allowance to remove> <verifier 1 address> <verifier 1 signature> <verifier 2 address> <verifier 2 signature>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 7 {
-			return fmt.Errorf("must specify seven arguments: sender, client, allowance to remove, verifier 1 address, verifier 1 signature, verifier 2 address, verifier 2 signature")
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		srv, err := lcli.GetFullNodeServices(cctx)

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -537,7 +537,7 @@ func (ca *channelAccessor) waitPaychCreateMsg(ctx context.Context, channelID str
 	}
 
 	// If channel creation failed
-	if mwait.Receipt.ExitCode != 0 {
+	if mwait.Receipt.ExitCode.IsError() {
 		ca.lk.Lock()
 		defer ca.lk.Unlock()
 
@@ -651,7 +651,7 @@ func (ca *channelAccessor) waitAddFundsMsg(ctx context.Context, channelID string
 		return err
 	}
 
-	if mwait.Receipt.ExitCode != 0 {
+	if mwait.Receipt.ExitCode.IsError() {
 		err := xerrors.Errorf("voucher channel creation failed: adding funds (exit code %d)", mwait.Receipt.ExitCode)
 		log.Error(err)
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
Standardize cli code/behaviours. 

- minerApi is now named appropriately
- functions all now all `cctx.NArg()` instead of `cctx.Args().Len()`
- (almost) all functions will now print help when supplied the wrong number of arguments.
- functions now use `wait.Receipt.ExitCode.IsError()` instead of `wait.Receipt.ExitCode != 0` 


## Additional Info
PR best viewed commit by commit

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
