### PR TITLE
fix: dont change the latest network version 

### DIFF
--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -33,7 +33,7 @@ const NewestNetworkVersion = network.Version{{.latestNetworkVersion}}
 
 /* inline-gen start */
 
-const NewestNetworkVersion = network.Version17
+const NewestNetworkVersion = network.Version16
 
 /* inline-gen end */
 


### PR DESCRIPTION
dont think newest network version  should be nv17 in v1.17.2 

(shall only be updated close to v1.18.0 -rc