### PR TITLE
fix: cli: actor-cids cli command now defaults to current network

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1900,7 +1900,6 @@ var StateSysActorCIDsCmd = &cli.Command{
 		&cli.UintFlag{
 			Name:  "network-version",
 			Usage: "specify network version",
-			Value: uint(build.NewestNetworkVersion),
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -1916,7 +1915,15 @@ var StateSysActorCIDsCmd = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		nv := network.Version(cctx.Uint64("network-version"))
+		var nv network.Version
+		if cctx.IsSet("network-version") {
+			nv = network.Version(cctx.Uint64("network-version"))
+		} else {
+			nv, err = api.StateNetworkVersion(ctx, types.EmptyTSK)
+			if err != nil {
+				return err
+			}
+		}
 
 		fmt.Printf("Network Version: %d\n", nv)
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2029,7 +2029,7 @@ USAGE:
    lotus state actor-cids [command options] [arguments...]
 
 OPTIONS:
-   --network-version value  specify network version (default: 17)
+   --network-version value  specify network version (default: 0)
    
 ```
 


### PR DESCRIPTION
## Related Issues
closes https://github.com/filecoin-project/lotus/issues/9320

## Proposed Changes
Cli command not uses current network version instead of "newest", which causes problems around network upgrades.


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
