### PR TITLE
fix: sealing: Drop unused PreCommitInfo from pipeline.SectorInfo

### DIFF
--- a/storage/pipeline/cbor_gen.go
+++ b/storage/pipeline/cbor_gen.go
@@ -13,7 +13,6 @@ import (
 	xerrors "golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/go-state-types/abi"
-	miner "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 
 	api "github.com/filecoin-project/lotus/api"
 )
@@ -154,7 +153,7 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write([]byte{184, 32}); err != nil {
+	if _, err := cw.Write([]byte{184, 31}); err != nil {
 		return err
 	}
 
@@ -401,22 +400,6 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	if _, err := cw.Write(t.Proof[:]); err != nil {
-		return err
-	}
-
-	// t.PreCommitInfo (miner.SectorPreCommitInfo) (struct)
-	if len("PreCommitInfo") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"PreCommitInfo\" was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("PreCommitInfo"))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string("PreCommitInfo")); err != nil {
-		return err
-	}
-
-	if err := t.PreCommitInfo.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1127,26 +1110,6 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) (err error) {
 
 			if _, err := io.ReadFull(cr, t.Proof[:]); err != nil {
 				return err
-			}
-			// t.PreCommitInfo (miner.SectorPreCommitInfo) (struct)
-		case "PreCommitInfo":
-
-			{
-
-				b, err := cr.ReadByte()
-				if err != nil {
-					return err
-				}
-				if b != cbg.CborNull[0] {
-					if err := cr.UnreadByte(); err != nil {
-						return err
-					}
-					t.PreCommitInfo = new(miner.SectorPreCommitInfo)
-					if err := t.PreCommitInfo.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling t.PreCommitInfo pointer: %w", err)
-					}
-				}
-
 			}
 			// t.PreCommitDeposit (big.Int) (struct)
 		case "PreCommitDeposit":

--- a/storage/pipeline/fsm_events.go
+++ b/storage/pipeline/fsm_events.go
@@ -205,7 +205,6 @@ type SectorPreCommitted struct {
 func (evt SectorPreCommitted) apply(state *SectorInfo) {
 	state.PreCommitMessage = &evt.Message
 	state.PreCommitDeposit = evt.PreCommitDeposit
-	state.PreCommitInfo = &evt.PreCommitInfo
 }
 
 type SectorSeedReady struct {

--- a/storage/pipeline/states_failed.go
+++ b/storage/pipeline/states_failed.go
@@ -391,11 +391,6 @@ func (m *Sealing) handleDealsExpired(ctx statemachine.Context, sector SectorInfo
 		return xerrors.Errorf("sector is committed on-chain, but we're in DealsExpired")
 	}
 
-	if sector.PreCommitInfo == nil {
-		// TODO: Create a separate state which will remove those pieces, and go back to PC1
-		log.Errorf("non-precommitted sector with expired deals, can't recover from this yet")
-	}
-
 	// Not much to do here, we can't go back in time to commit this sector
 	return ctx.Send(SectorRemove{})
 }

--- a/storage/pipeline/types.go
+++ b/storage/pipeline/types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/builtin/v9/miner"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -74,7 +73,6 @@ type SectorInfo struct {
 	CommR *cid.Cid // SectorKey
 	Proof []byte
 
-	PreCommitInfo    *miner.SectorPreCommitInfo
 	PreCommitDeposit big.Int
 	PreCommitMessage *cid.Cid
 	PreCommitTipSet  types.TipSetKey


### PR DESCRIPTION
## Related Issues
?

## Proposed Changes
Remove `PreCommitInfo` (which is changing in actors v9) from `pipeline.SectorInfo`. All places which use PreCommitInfo in the sealing pipeline get that from the chain with `StateSectorPreCommitInfo`

## Additional Info
This caused `decoding state for key '/872': unmarshaling t.PreCommitInfo pointer: cbor input had wrong number of fields` on startup on existing miners
