### PR TITLE
feat: refactor: remove NewestNetworkVersion

### DIFF
--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -137,7 +137,7 @@ func init() {
 	addExample(&textSelExample)
 	addExample(&apiSelExample)
 	addExample(network.ReachabilityPublic)
-	addExample(build.NewestNetworkVersion)
+	addExample(build.TestNetworkVersion)
 	addExample(map[string]int{"name": 42})
 	addExample(map[string]time.Time{"name": time.Unix(1615243938, 0).UTC()})
 	addExample(&types.ExecutionTrace{

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -26,14 +26,14 @@ const UnixfsLinksPerLevel = 1024
 
 const AllowableClockDriftSecs = uint64(1)
 
-// TODO: This is still terrible...What's the impact of updating this before mainnet actually upgrades
+// Used by tests and some obscure tooling
 /* inline-gen template
 
-const NewestNetworkVersion = network.Version{{.latestNetworkVersion}}
+const TestNetworkVersion = network.Version{{.latestNetworkVersion}}
 
 /* inline-gen start */
 
-const NewestNetworkVersion = network.Version17
+const TestNetworkVersion = network.Version17
 
 /* inline-gen end */
 

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -624,11 +624,11 @@ func (mp *MessagePool) addLocal(ctx context.Context, m *types.SignedMessage) err
 // sufficiently.
 // For non local messages, if the message cannot be included in the next 20 blocks it returns
 // a (soft) validation error.
-func (mp *MessagePool) verifyMsgBeforeAdd(m *types.SignedMessage, curTs *types.TipSet, local bool) (bool, error) {
+func (mp *MessagePool) verifyMsgBeforeAdd(ctx context.Context, m *types.SignedMessage, curTs *types.TipSet, local bool) (bool, error) {
 	epoch := curTs.Height() + 1
 	minGas := vm.PricelistByEpoch(epoch).OnChainMessage(m.ChainLength())
 
-	if err := m.VMMessage().ValidForBlockInclusion(minGas.Total(), build.NewestNetworkVersion); err != nil {
+	if err := m.VMMessage().ValidForBlockInclusion(minGas.Total(), mp.api.StateNetworkVersion(ctx, epoch)); err != nil {
 		return false, xerrors.Errorf("message will not be included in a block: %w", err)
 	}
 
@@ -671,7 +671,7 @@ func (mp *MessagePool) Push(ctx context.Context, m *types.SignedMessage) (cid.Ci
 	done := metrics.Timer(ctx, metrics.MpoolPushDuration)
 	defer done()
 
-	err := mp.checkMessage(m)
+	err := mp.checkMessage(ctx, m)
 	if err != nil {
 		return cid.Undef, err
 	}
@@ -705,14 +705,14 @@ func (mp *MessagePool) Push(ctx context.Context, m *types.SignedMessage) (cid.Ci
 	return m.Cid(), nil
 }
 
-func (mp *MessagePool) checkMessage(m *types.SignedMessage) error {
+func (mp *MessagePool) checkMessage(ctx context.Context, m *types.SignedMessage) error {
 	// big messages are bad, anti DOS
 	if m.Size() > MaxMessageSize {
 		return xerrors.Errorf("mpool message too large (%dB): %w", m.Size(), ErrMessageTooBig)
 	}
 
 	// Perform syntactic validation, minGas=0 as we check the actual mingas before we add it
-	if err := m.Message.ValidForBlockInclusion(0, build.NewestNetworkVersion); err != nil {
+	if err := m.Message.ValidForBlockInclusion(0, mp.api.StateNetworkVersion(ctx, mp.curTs.Height())); err != nil {
 		return xerrors.Errorf("message not valid for block inclusion: %w", err)
 	}
 
@@ -740,7 +740,7 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 	done := metrics.Timer(ctx, metrics.MpoolAddDuration)
 	defer done()
 
-	err := mp.checkMessage(m)
+	err := mp.checkMessage(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -845,7 +845,7 @@ func (mp *MessagePool) addTs(ctx context.Context, m *types.SignedMessage, curTs 
 	mp.lk.Lock()
 	defer mp.lk.Unlock()
 
-	publish, err := mp.verifyMsgBeforeAdd(m, curTs, local)
+	publish, err := mp.verifyMsgBeforeAdd(ctx, m, curTs, local)
 	if err != nil {
 		return false, err
 	}
@@ -870,7 +870,7 @@ func (mp *MessagePool) addTs(ctx context.Context, m *types.SignedMessage, curTs 
 }
 
 func (mp *MessagePool) addLoaded(ctx context.Context, m *types.SignedMessage) error {
-	err := mp.checkMessage(m)
+	err := mp.checkMessage(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -890,7 +890,7 @@ func (mp *MessagePool) addLoaded(ctx context.Context, m *types.SignedMessage) er
 		return xerrors.Errorf("minimum expected nonce is %d: %w", snonce, ErrNonceTooLow)
 	}
 
-	_, err = mp.verifyMsgBeforeAdd(m, curTs, true)
+	_, err = mp.verifyMsgBeforeAdd(ctx, m, curTs, true)
 	if err != nil {
 		return err
 	}
@@ -1060,7 +1060,7 @@ func (mp *MessagePool) getStateBalance(ctx context.Context, addr address.Address
 //   - extra strict add checks are used when adding the messages to the msgSet
 //     that means: no nonce gaps, at most 10 pending messages for the actor
 func (mp *MessagePool) PushUntrusted(ctx context.Context, m *types.SignedMessage) (cid.Cid, error) {
-	err := mp.checkMessage(m)
+	err := mp.checkMessage(ctx, m)
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/network"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -164,6 +166,10 @@ func (tma *testMpoolAPI) StateAccountKeyAtFinality(ctx context.Context, addr add
 		return address.Undef, fmt.Errorf("given address was not a key addr")
 	}
 	return addr, nil
+}
+
+func (tma *testMpoolAPI) StateNetworkVersion(ctx context.Context, h abi.ChainEpoch) network.Version {
+	return build.TestNetworkVersion
 }
 
 func (tma *testMpoolAPI) MessagesForBlock(ctx context.Context, h *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {

--- a/chain/messagepool/provider.go
+++ b/chain/messagepool/provider.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/go-state-types/network"
+
 	"github.com/ipfs/go-cid"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"golang.org/x/xerrors"
@@ -28,6 +32,7 @@ type Provider interface {
 	PubSubPublish(string, []byte) error
 	GetActorAfter(address.Address, *types.TipSet) (*types.Actor, error)
 	StateAccountKeyAtFinality(context.Context, address.Address, *types.TipSet) (address.Address, error)
+	StateNetworkVersion(context.Context, abi.ChainEpoch) network.Version
 	MessagesForBlock(context.Context, *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error)
 	MessagesForTipset(context.Context, *types.TipSet) ([]types.ChainMsg, error)
 	LoadTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
@@ -102,6 +107,10 @@ func (mpp *mpoolProvider) GetActorAfter(addr address.Address, ts *types.TipSet) 
 
 func (mpp *mpoolProvider) StateAccountKeyAtFinality(ctx context.Context, addr address.Address, ts *types.TipSet) (address.Address, error) {
 	return mpp.sm.ResolveToKeyAddressAtFinality(ctx, addr, ts)
+}
+
+func (mpp *mpoolProvider) StateNetworkVersion(ctx context.Context, height abi.ChainEpoch) network.Version {
+	return mpp.sm.GetNetworkVersion(ctx, height)
 }
 
 func (mpp *mpoolProvider) MessagesForBlock(ctx context.Context, h *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {

--- a/chain/messagepool/provider.go
+++ b/chain/messagepool/provider.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-state-types/abi"
-
-	"github.com/filecoin-project/go-state-types/network"
-
 	"github.com/ipfs/go-cid"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/chain/messagesigner"
 	"github.com/filecoin-project/lotus/chain/stmgr"

--- a/chain/state/statetree_test.go
+++ b/chain/state/statetree_test.go
@@ -48,7 +48,7 @@ func BenchmarkStateTreeSet(b *testing.B) {
 func BenchmarkStateTreeSetFlush(b *testing.B) {
 	//stm: @CHAIN_STATETREE_SET_ACTOR_001
 	cst := cbor.NewMemCborStore()
-	sv, err := VersionForNetwork(build.NewestNetworkVersion)
+	sv, err := VersionForNetwork(build.TestNetworkVersion)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestResolveCache(t *testing.T) {
 	//stm: @CHAIN_STATETREE_SET_ACTOR_001, @CHAIN_STATETREE_GET_ACTOR_001, @CHAIN_STATETREE_VERSION_FOR_NETWORK_001
 	//stm: @CHAIN_STATETREE_SNAPSHOT_001, @CHAIN_STATETREE_SNAPSHOT_CLEAR_001
 	cst := cbor.NewMemCborStore()
-	sv, err := VersionForNetwork(build.NewestNetworkVersion)
+	sv, err := VersionForNetwork(build.TestNetworkVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func BenchmarkStateTree10kGetActor(b *testing.B) {
 	//stm: @CHAIN_STATETREE_SET_ACTOR_001, @CHAIN_STATETREE_GET_ACTOR_001, @CHAIN_STATETREE_VERSION_FOR_NETWORK_001
 	//stm: @CHAIN_STATETREE_FLUSH_001
 	cst := cbor.NewMemCborStore()
-	sv, err := VersionForNetwork(build.NewestNetworkVersion)
+	sv, err := VersionForNetwork(build.TestNetworkVersion)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func BenchmarkStateTree10kGetActor(b *testing.B) {
 func TestSetCache(t *testing.T) {
 	//stm: @CHAIN_STATETREE_SET_ACTOR_001, @CHAIN_STATETREE_GET_ACTOR_001, @CHAIN_STATETREE_VERSION_FOR_NETWORK_001
 	cst := cbor.NewMemCborStore()
-	sv, err := VersionForNetwork(build.NewestNetworkVersion)
+	sv, err := VersionForNetwork(build.TestNetworkVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestSnapshots(t *testing.T) {
 	ctx := context.Background()
 	cst := cbor.NewMemCborStore()
 
-	sv, err := VersionForNetwork(build.NewestNetworkVersion)
+	sv, err := VersionForNetwork(build.TestNetworkVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -816,7 +816,7 @@ func bps(sectorSize abi.SectorSize, sectorNum int, d time.Duration) string {
 }
 
 func spt(ssize abi.SectorSize) abi.RegisteredSealProof {
-	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.NewestNetworkVersion)
+	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/lotus-seed/genesis.go
+++ b/cmd/lotus-seed/genesis.go
@@ -539,7 +539,7 @@ var genesisSetActorVersionCmd = &cli.Command{
 		}
 
 		nv := network.Version(cctx.Int("network-version"))
-		if nv > build.NewestNetworkVersion {
+		if nv > build.TestNetworkVersion {
 			return xerrors.Errorf("invalid network version: %d", nv)
 		}
 

--- a/itests/kit/ensemble_opts.go
+++ b/itests/kit/ensemble_opts.go
@@ -30,7 +30,7 @@ var DefaultEnsembleOpts = ensembleOpts{
 	pastOffset: 10000000 * time.Second, // time sufficiently in the past to trigger catch-up mining.
 	upgradeSchedule: stmgr.UpgradeSchedule{{
 		Height:  -1,
-		Network: build.NewestNetworkVersion,
+		Network: build.TestNetworkVersion,
 	}},
 }
 

--- a/paychmgr/mock_test.go
+++ b/paychmgr/mock_test.go
@@ -250,5 +250,5 @@ func (pchapi *mockPaychAPI) addSigningKey(key []byte) {
 }
 
 func (pchapi *mockPaychAPI) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
-	return build.NewestNetworkVersion, nil
+	return build.TestNetworkVersion, nil
 }

--- a/storage/pipeline/precommit_policy_test.go
+++ b/storage/pipeline/precommit_policy_test.go
@@ -44,7 +44,7 @@ func fakeConfigGetter(stub *fakeConfigStub) dtypes.GetSealingConfigFunc {
 }
 
 func (f *fakeChain) StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error) {
-	return build.NewestNetworkVersion, nil
+	return build.TestNetworkVersion, nil
 }
 
 func (f *fakeChain) ChainHead(ctx context.Context) (*types.TipSet, error) {

--- a/storage/wdpost/wdpost_run_test.go
+++ b/storage/wdpost/wdpost_run_test.go
@@ -53,7 +53,7 @@ func (m *mockStorageMinerAPI) StateMinerInfo(ctx context.Context, a address.Addr
 }
 
 func (m *mockStorageMinerAPI) StateNetworkVersion(ctx context.Context, key types.TipSetKey) (network.Version, error) {
-	return build.NewestNetworkVersion, nil
+	return build.TestNetworkVersion, nil
 }
 
 func (m *mockStorageMinerAPI) StateGetRandomnessFromTickets(ctx context.Context, personalization crypto.DomainSeparationTag, randEpoch abi.ChainEpoch, entropy []byte, tsk types.TipSetKey) (abi.Randomness, error) {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

This field has always been terrible (see TODO above it), and is potentially confusing to users (see https://github.com/filecoin-project/lotus/pull/9319#issuecomment-1248182478).

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Remove its only usage in source code, which is in the messagepool -- just query for the NetworkVersion when needed. If we have concerns that this is slow, we could just set it once at startup, and use that -- it is very rare for this to matter (hasn't mattered since nv7).

Rename remaining usages to TestNetworkVersion.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
