### PR TITLE
fix: test: flaky TestDeadlineToggling around nulls

### DIFF
--- a/itests/deadlines_test.go
+++ b/itests/deadlines_test.go
@@ -185,7 +185,7 @@ func TestDeadlineToggling(t *testing.T) {
 			require.NoError(t, err)
 
 			// cron happened on the same epoch some other condition would have happened
-			if di.Open == ts.Height() {
+			if di.Open <= ts.Height() {
 				act, err := mst.DeadlineCronActive()
 				require.NoError(t, err)
 				require.Equal(t, activeIfCron, act)


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Fixes #7809

Okay, here's the flaky failure that motivated this: https://app.circleci.com/pipelines/github/filecoin-project/lotus/23151/workflows/058fcc2a-e606-4407-93f6-5050b6b8ab32/jobs/587417.

A miner has just terminated all their sectors. We expect them to have power 0, but still have Cron active -- cron should deactivated upon the next deadline close. The test asserts that cron should be active (true) unless the tipset that executes the TerminateSectors message (one after the tipset that includes the message) is exactly equal to a deadline.Open, in which case the test asserts that cron should be inactive.

BUT, if the TerminateSectors message is included at height X, and the deadline opens at height X+1, BUT X+1 was null, then this doesn't work! The tipset that executed the TerminateSectors message is height X+2, it DOES run the cron that flips cron for this miner to inactive, but its height is NOT exactly equal to deadline.Open (it's one greater).

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Make it `di.Open <= ts.Height()`.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
