### PR TITLE
feat: dealpublisher: check for duplicate deals before adding

### DIFF
--- a/itests/deals_retry_deal_no_funds_test.go
+++ b/itests/deals_retry_deal_no_funds_test.go
@@ -101,7 +101,7 @@ func testDealsRetryLackOfFunds(t *testing.T, publishStorageAccountFunds abi.Toke
 	propcid := *deal
 
 	go func() {
-		time.Sleep(3 * time.Second)
+		time.Sleep(30 * time.Second)
 
 		kit.SendFunds(ctx, t, minerFullNode, publishStorageDealKey.Address, types.FromFil(1))
 


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

TestDealsRetryLackOfFunds fails flakily (see eg here https://app.circleci.com/pipelines/github/filecoin-project/lotus/23264/workflows/87a70d59-974d-46d8-971a-54e1bba3afd3/jobs/595498)

This test sets up a SP with insufficient $$ to publish a deal (with the expectation, but not an assertion that the first try will fail), then after 3 seconds funds the publish key and triggers MarketRetryPublishDeal, and waits for the deal to succeed.

The cause of the flakiness is that the funding of the publish key and triggering MarketRetryPublishDeal can happen at a few different points wrt the first attempt to publish the deal (which involves adding to the publisher, waiting a second, and then validating and pushing to mempool). 

## Proposed Changes
<!-- provide a clear list of the changes being made-->

There seem to be a few different things at play here:

- 3 seconds doesn't seem enough to test intended behaviour here. 
  - This PR increases that time to 30. Overkill in the extreme, but still much better than the time lost dealing with the flakiness of this test.
- If MarketRetryPublishDeal is triggered on a deal that's in the publish queue, we seem to add the deal a second time. This is funky, but not ultimately a cause of failure. 
  - This PR adds a dedup check when `processNewDeal`ing.
- It seems like when MarketRetryPublishDeal is triggered on a deal in the StorageDealPublish stage, we "do nothing" except retrigger the handler for StorageDealPublish. We should:
  - confirm I'm right about this behaviour
  - confirm that's intentional?
  - if so, think about more edge-cases for potentially trying to republish a deal


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
