### PR TITLE
one-time-feat: shed: FIP0036 post poll result processing

### DIFF
--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
@@ -62,7 +64,7 @@ var fip0036PollResultcmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		//spRBPCmd,
 		//spDealByteCmd,
-		//clientCmd,
+		clientCmd,
 		tokenHolderCmd,
 		//coreDevCmd,
 		//finalResultCmd,
@@ -191,8 +193,8 @@ var tokenHolderCmd = &cli.Command{
 		//get all the msig
 		msigs, err := getAllMsig(tree, store)
 
-		var acceptanceVote []Vote
-		var rejectionVote []Vote
+		acceptanceVote := 0
+		rejectionVote := 0
 		acceptanceBalance := abi.NewTokenAmount(0)
 		rejectionBalance := abi.NewTokenAmount(0)
 		msigPendingVotes := make(map[address.Address]msigVote)
@@ -205,10 +207,10 @@ var tokenHolderCmd = &cli.Command{
 			}
 			//regular account
 			if v.OptionID == APPROVE {
-				acceptanceVote = append(acceptanceVote, v)
+				acceptanceVote += 1
 				acceptanceBalance = types.BigAdd(acceptanceBalance, a.Balance)
 			} else {
-				rejectionVote = append(rejectionVote, v)
+				rejectionVote += 1
 				rejectionBalance = types.BigAdd(rejectionBalance, a.Balance)
 			}
 
@@ -218,7 +220,6 @@ var tokenHolderCmd = &cli.Command{
 				return xerrors.Errorf("cannot resolve singer: ", si)
 			}
 			for _, m := range msigs {
-
 				for _, ms := range m.Signer {
 					if ms == si {
 						if mv, found := msigPendingVotes[m.ID]; found { //other singer has voted
@@ -270,17 +271,152 @@ var tokenHolderCmd = &cli.Command{
 			}
 		}
 
-		fmt.Printf("\nTotoal amount of singers: %v\n ", len(votes))
-		fmt.Printf("Totoal amount of valid multisig vote: %v\n ", len(msigFinalVotes))
+		fmt.Printf("\nTotal amount of singers: %v\n ", len(votes))
+		fmt.Printf("Total amount of valid multisig vote: %v\n ", len(msigFinalVotes))
 		fmt.Printf("Total balance: %v\n", types.BigAdd(acceptanceBalance, rejectionBalance).String())
-		fmt.Printf("Approve: %v\n", acceptanceBalance.String())
-		fmt.Printf("Reject: %v\n", rejectionBalance.String())
+		fmt.Printf("Approve (#): %v\n", acceptanceVote)
+		fmt.Printf("Reject (#): %v\n", rejectionVote)
+		fmt.Printf("Approve (FIL): %v\n", acceptanceBalance.String())
+		fmt.Printf("Reject (FIL): %v\n", rejectionBalance.String())
 		av := types.BigDivFloat(acceptanceBalance, types.BigAdd(acceptanceBalance, rejectionBalance))
 		rv := types.BigDivFloat(rejectionBalance, types.BigAdd(rejectionBalance, acceptanceBalance))
 		if av > 0.05 {
 			fmt.Printf("Token Holder Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
 		} else {
 			fmt.Printf("Token Holder Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		}
+		return nil
+	},
+}
+
+var clientCmd = &cli.Command{
+	Name:      "client",
+	Usage:     "get poll result for client",
+	ArgsUsage: "[state root]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 2 {
+			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
+		}
+
+		ctx := context.TODO()
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass state root")
+		}
+
+		sroot, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		tree, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		//get all the votes' singer address && their vote
+		vj, err := homedir.Expand(cctx.Args().Get(1))
+		if err != nil {
+			return xerrors.Errorf("fail to get votes json")
+		}
+		votes, err := getVoters(vj)
+		if err != nil {
+			return xerrors.Errorf("fail to get votesrs: ", err)
+		}
+
+		//market actor
+		ma, err := tree.GetActor(market.Address)
+		if err != nil {
+			return xerrors.Errorf("fail to get market actor: ", err)
+		}
+
+		ms, err := market.Load(store, ma)
+		if err != nil {
+			return xerrors.Errorf("fail to load market actor: ", err)
+		}
+
+		dps, _ := ms.Proposals()
+		acceptanceBytes := abi.PaddedPieceSize(0)
+		rejectionBytes := abi.PaddedPieceSize(0)
+		acceptanceCount := 0
+		rejectionCount := 0
+		for _, v := range votes {
+			if err != nil {
+				return xerrors.Errorf("fail to get account account for signer: ", v.SignerAddress)
+			}
+			ai, err := tree.LookupID(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("cannot resolve singer: ", ai)
+			}
+			if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
+				p, found, _ := dps.Get(dealID)
+				if found && p.Client == ai {
+					if v.OptionID == APPROVE {
+						acceptanceBytes += p.PieceSize
+						acceptanceCount += 1
+					} else {
+						rejectionBytes += p.PieceSize
+						rejectionCount += 1
+					}
+				}
+				return xerrors.Errorf("cant get deal ", err)
+			}); err != nil {
+				return err
+			}
+		}
+		fmt.Printf("\nTotal amount of clients: %v\n", acceptanceCount+rejectionCount)
+		fmt.Printf("Total deal bytes: %v\n", acceptanceBytes+rejectionBytes)
+		fmt.Printf("Approve (#): %v\n", acceptanceCount)
+		fmt.Printf("Reject (#): %v\n", rejectionCount)
+		fmt.Printf("Approve (byte): %v\n", acceptanceBytes)
+		fmt.Printf("Reject (byte): %v\n", rejectionBytes)
+		av := float64(acceptanceBytes) / float64(acceptanceBytes+rejectionBytes)
+		rv := float64(rejectionBytes) / float64(acceptanceBytes+rejectionBytes)
+		if av > 0.05 {
+			fmt.Printf("Deal Client Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		} else {
+			fmt.Printf("Deal Client Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
 		}
 		return nil
 	},

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -390,17 +390,17 @@ var clientCmd = &cli.Command{
 				return xerrors.Errorf("cannot resolve singer: ", ai)
 			}
 			if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
-				p, found, _ := dps.Get(dealID)
-				if found && p.Client == ai {
+
+				if d.Client == ai {
 					if v.OptionID == APPROVE {
-						acceptanceBytes += p.PieceSize
+						acceptanceBytes += d.PieceSize
 						acceptanceCount += 1
 					} else {
-						rejectionBytes += p.PieceSize
+						rejectionBytes += d.PieceSize
 						rejectionCount += 1
 					}
 				}
-				return xerrors.Errorf("cant get deal ", err)
+				return nil
 			}); err != nil {
 				return err
 			}

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/store"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+
+	"github.com/filecoin-project/lotus/chain/state"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
+	"github.com/filecoin-project/lotus/chain/types"
+
+	"github.com/mitchellh/go-homedir"
+
+	"golang.org/x/xerrors"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/go-address"
+)
+
+const APPROVE = 49
+
+type Vote struct {
+	OptionID      uint64          `json: "optionId"`
+	SignerAddress address.Address `json: "signerAddress"`
+}
+
+type msigVote struct {
+	Multisig          msigBriefInfo
+	AcceptanceSingers []address.Address
+	RejectionSigners  []address.Address
+}
+
+// https://filpoll.io/poll/16
+// snapshot height: 2162760
+// state root: bafy2bzacebdnzh43hw66bmvguk65wiwr5ssaejlq44fpdei2ysfh3eefpdlqs
+var fip0036PollResultcmd = &cli.Command{
+	Name:      "fip0036poll",
+	Usage:     "Process the FIP0036 FilPoll result",
+	ArgsUsage: "[state root, votes]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Subcommands: []*cli.Command{
+		//spRBPCmd,
+		//spDealByteCmd,
+		//clientCmd,
+		tokenHolderCmd,
+		//coreDevCmd,
+		//finalResultCmd,
+	},
+}
+
+func getVoters(file string) ([]Vote, error) {
+
+	var votes []Vote
+	vb, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, xerrors.Errorf("read vote: %w", err)
+	}
+
+	if err := json.Unmarshal(vb, &votes); err != nil {
+		return nil, xerrors.Errorf("unmarshal vote: %w", err)
+	}
+	return votes, nil
+}
+
+func getAllMsig(st *state.StateTree, store adt.Store) ([]msigBriefInfo, error) {
+
+	var msigActorsInfo []msigBriefInfo
+	err := st.ForEach(func(addr address.Address, act *types.Actor) error {
+		if builtin.IsMultisigActor(act.Code) {
+			ms, err := multisig.Load(store, act)
+			if err != nil {
+				return fmt.Errorf("load msig failed %v", err)
+
+			}
+
+			signers, _ := ms.Signers()
+			threshold, _ := ms.Threshold()
+			info := msigBriefInfo{
+				ID:        addr,
+				Signer:    signers,
+				Balance:   act.Balance,
+				Threshold: threshold,
+			}
+			msigActorsInfo = append(msigActorsInfo, info)
+
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return msigActorsInfo, nil
+}
+
+var tokenHolderCmd = &cli.Command{
+	Name:      "token-holder",
+	Usage:     "get poll result for token holder group",
+	ArgsUsage: "[state root]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 2 {
+			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
+		}
+
+		ctx := context.TODO()
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass state root")
+		}
+
+		sroot, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		tree, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		//get all the votes' singer address && their vote
+		vj, err := homedir.Expand(cctx.Args().Get(1))
+		if err != nil {
+			return xerrors.Errorf("fail to get votes json")
+		}
+		votes, err := getVoters(vj)
+		if err != nil {
+			return xerrors.Errorf("fail to get votesrs: ", err)
+		}
+		//get all the msig
+		msigs, err := getAllMsig(tree, store)
+
+		var acceptanceVote []Vote
+		var rejectionVote []Vote
+		acceptanceBalance := abi.NewTokenAmount(0)
+		rejectionBalance := abi.NewTokenAmount(0)
+		msigPendingVotes := make(map[address.Address]msigVote)
+		msigFinalVotes := make(map[address.Address]msigVote)
+
+		for _, v := range votes {
+			a, err := tree.GetActor(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("fail to get account account for signer: ", v.SignerAddress)
+			}
+			//regular account
+			if v.OptionID == APPROVE {
+				acceptanceVote = append(acceptanceVote, v)
+				acceptanceBalance = types.BigAdd(acceptanceBalance, a.Balance)
+			} else {
+				rejectionVote = append(rejectionVote, v)
+				rejectionBalance = types.BigAdd(rejectionBalance, a.Balance)
+			}
+
+			//msig
+			si, err := tree.LookupID(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("cannot resolve singer: ", si)
+			}
+			for _, m := range msigs {
+
+				for _, ms := range m.Signer {
+					if ms == si {
+						if mv, found := msigPendingVotes[m.ID]; found { //other singer has voted
+
+							if v.OptionID == APPROVE {
+								mv.AcceptanceSingers = append(mv.AcceptanceSingers, v.SignerAddress)
+							} else {
+								mv.RejectionSigners = append(mv.RejectionSigners, v.SignerAddress)
+							}
+
+							//check if threshold meet
+							if uint64(len(mv.AcceptanceSingers)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								acceptanceBalance = types.BigAdd(acceptanceBalance, m.Balance)
+							} else if uint64(len(mv.RejectionSigners)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								rejectionBalance = types.BigAdd(rejectionBalance, m.Balance)
+							} else {
+								msigPendingVotes[m.ID] = mv
+							}
+						} else {
+
+							n := msigVote{
+								Multisig: m,
+							}
+							if v.OptionID == APPROVE {
+								n.AcceptanceSingers = append(n.AcceptanceSingers, v.SignerAddress)
+							} else {
+								n.RejectionSigners = append(n.RejectionSigners, v.SignerAddress)
+							}
+
+							//check if threshold meet
+							if uint64(len(mv.AcceptanceSingers)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								acceptanceBalance = types.BigAdd(acceptanceBalance, m.Balance)
+							} else if uint64(len(mv.RejectionSigners)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								rejectionBalance = types.BigAdd(rejectionBalance, m.Balance)
+							} else {
+								msigPendingVotes[m.ID] = mv
+							}
+						}
+					}
+				}
+			}
+		}
+
+		fmt.Printf("\nTotoal amount of singers: %v\n ", len(votes))
+		fmt.Printf("Totoal amount of valid multisig vote: %v\n ", len(msigFinalVotes))
+		fmt.Printf("Total balance: %v\n", types.BigAdd(acceptanceBalance, rejectionBalance).String())
+		fmt.Printf("Approve: %v\n", acceptanceBalance.String())
+		fmt.Printf("Reject: %v\n", rejectionBalance.String())
+		av := types.BigDivFloat(acceptanceBalance, types.BigAdd(acceptanceBalance, rejectionBalance))
+		rv := types.BigDivFloat(rejectionBalance, types.BigAdd(rejectionBalance, acceptanceBalance))
+		if av > 0.05 {
+			fmt.Printf("Token Holder Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		} else {
+			fmt.Printf("Token Holder Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		}
+		return nil
+	},
+}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -74,6 +74,7 @@ func main() {
 		diffCmd,
 		itestdCmd,
 		msigCmd,
+		fip0036PollResultcmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -74,7 +74,7 @@ func main() {
 		diffCmd,
 		itestdCmd,
 		msigCmd,
-		fip0036PollResultcmd,
+		fip36PollCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/msig.go
+++ b/cmd/lotus-shed/msig.go
@@ -25,7 +25,7 @@ import (
 
 type msigBriefInfo struct {
 	ID        address.Address
-	Signer    interface{}
+	Signer    []address.Address
 	Balance   abi.TokenAmount
 	Threshold uint64
 }


### PR DESCRIPTION
## What the heck is this?

ICYMI
We've got an[ FIP-0036](https://github.com/filecoin-project/FIPs/discussions?discussions_q=label%3AFIP0036)
Then we've got an [FilPoll for FIP-0036](https://filpoll.io/poll/16) - GO VOTE if you haven't already, before that DYOR!
Then we've got some [governance rules ](https://github.com/filecoin-project/FIPs/discussions/464)- in which we got `Who gets to vote?`

This is a set of shed cmd to process the poll result according to the governance rule.

**Disclaimer: code reviews are welcomed -  its possible something was mess-up somewhere, we are going to keep it updated base on feedbacks!**

## So.. how?

We use the offline mode here to inspect the state that the poll snapshot was taken.

A couple source needed:
- a lotus chain datastore that has the state of height `2162760`, state root `bafy2bzacebdnzh43hw66bmvguk65wiwr5ssaejlq44fpdei2ysfh3eefpdlqs` (according to[ filscan](https://filscan.io/tipset/chain?hash=bafy2bzacea5p5gvjfizskl7tkw2z7lrf4naiwmolz4doyntnb3wowky6f7rhq))
- your daemon node thats linked with the datastore needs to be stopped given we need to lock the datastore for accessing the state
- you will need to know who voted: https://api.filpoll.io/api/polls/16/view-votes
- the shed cmd are developed based on the facts/assumption that
    -  fil-poll doesn't take duplicated entry from the same signer
    - we only use fil-poll to get signer address & their vote option
    - vote option can either be `49` - approve, or `50`- reject 
    - everything else, we get the data from the chain state, includes account balances, multisig info, deal info and miner actor info.
- the shed tool took two argument, first one being the state root, the second one being a json file contains the votes that have attributes `signerAddress` and `optionId` for each vote entry.


```
NAME:
   lotus-shed fip36poll - Process the FIP0036 FilPoll result

USAGE:
   lotus-shed fip36poll command [command options] [state root, votes]

COMMANDS:
   sp  get poll result for storage group. Weighted by RBP(raw byte power) and deal bytes stored in valid deals.
Note that: if both owner key and worker key has voted, the vote made by owner key will be casted the storage provider actor.
   client        get poll result for client, weighted by deal bytes that are in valid deals in the storage market.
   token-holder  get poll result for token holder group. balance includes, regular wallet accounts, multisig wallet that has valid vote that meets threshold, and the available balance of the storage miner actors that voted
   help, h       Shows a list of commands or help for one command

OPTIONS:
   --repo value  (default: "~/.lotus")
   --help, -h    show help (default: false)
```
