### PR TITLE
_ci_: Use golang 1.18.1 to build appimage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,6 +425,12 @@ jobs:
       - attach_workspace:
           at: "."
       - run:
+          name: Update Go
+          command: |
+            curl -L https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
+            sudo tar -C /usr/local -xvf /tmp/go.tar.gz
+      - run: go version
+      - run:
           name: install appimage-builder
           command: |
             # appimage-builder requires /dev/snd to exist. It creates containers during the testing phase

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -425,6 +425,12 @@ jobs:
       - attach_workspace:
           at: "."
       - run:
+          name: Update Go
+          command: |
+            curl -L https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
+            sudo tar -C /usr/local -xvf /tmp/go.tar.gz
+      - run: go version
+      - run:
           name: install appimage-builder
           command: |
             # appimage-builder requires /dev/snd to exist. It creates containers during the testing phase


### PR DESCRIPTION
## Related Issues
Updating golang to 1.18.1 broke the AppImage build: https://app.circleci.com/pipelines/github/filecoin-project/lotus/23339/workflows/0d8285e1-5977-4b8e-aa25-45d55ac61ac3/jobs/600644

It seems we were relying on an implicitly installed go version in the underlying ubuntu-2004 machine image. This should be backported to the 1.17.2 release branch , or else it will not include an AppImage release artifact.

## Proposed Changes
This explicitly downloads and installs a specific golang version (in this case, 1.18.1) onto the machine image before running the app image builder. This should allow us to easily update the version in the future, and will hopefully make it clear when upgrading the go version that the app image builder needs to be updated too.

## Checklist

Before you mark the PR ready for review, please make sure that:
- [X] All commits have a clear commit message.
- [X] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [X] This PR has tests for new functionality or change in behaviour
- [X] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] CI is green
