### PR TITLE
feat: shed: FIP0036 post poll result processing 

### DIFF
--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
@@ -62,7 +64,7 @@ var fip0036PollResultcmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		//spRBPCmd,
 		//spDealByteCmd,
-		//clientCmd,
+		clientCmd,
 		tokenHolderCmd,
 		//coreDevCmd,
 		//finalResultCmd,
@@ -191,8 +193,8 @@ var tokenHolderCmd = &cli.Command{
 		//get all the msig
 		msigs, err := getAllMsig(tree, store)
 
-		var acceptanceVote []Vote
-		var rejectionVote []Vote
+		acceptanceVote := 0
+		rejectionVote := 0
 		acceptanceBalance := abi.NewTokenAmount(0)
 		rejectionBalance := abi.NewTokenAmount(0)
 		msigPendingVotes := make(map[address.Address]msigVote)
@@ -205,10 +207,10 @@ var tokenHolderCmd = &cli.Command{
 			}
 			//regular account
 			if v.OptionID == APPROVE {
-				acceptanceVote = append(acceptanceVote, v)
+				acceptanceVote += 1
 				acceptanceBalance = types.BigAdd(acceptanceBalance, a.Balance)
 			} else {
-				rejectionVote = append(rejectionVote, v)
+				rejectionVote += 1
 				rejectionBalance = types.BigAdd(rejectionBalance, a.Balance)
 			}
 
@@ -218,7 +220,6 @@ var tokenHolderCmd = &cli.Command{
 				return xerrors.Errorf("cannot resolve singer: ", si)
 			}
 			for _, m := range msigs {
-
 				for _, ms := range m.Signer {
 					if ms == si {
 						if mv, found := msigPendingVotes[m.ID]; found { //other singer has voted
@@ -270,17 +271,152 @@ var tokenHolderCmd = &cli.Command{
 			}
 		}
 
-		fmt.Printf("\nTotoal amount of singers: %v\n ", len(votes))
-		fmt.Printf("Totoal amount of valid multisig vote: %v\n ", len(msigFinalVotes))
+		fmt.Printf("\nTotal amount of singers: %v\n ", len(votes))
+		fmt.Printf("Total amount of valid multisig vote: %v\n ", len(msigFinalVotes))
 		fmt.Printf("Total balance: %v\n", types.BigAdd(acceptanceBalance, rejectionBalance).String())
-		fmt.Printf("Approve: %v\n", acceptanceBalance.String())
-		fmt.Printf("Reject: %v\n", rejectionBalance.String())
+		fmt.Printf("Approve (#): %v\n", acceptanceVote)
+		fmt.Printf("Reject (#): %v\n", rejectionVote)
+		fmt.Printf("Approve (FIL): %v\n", acceptanceBalance.String())
+		fmt.Printf("Reject (FIL): %v\n", rejectionBalance.String())
 		av := types.BigDivFloat(acceptanceBalance, types.BigAdd(acceptanceBalance, rejectionBalance))
 		rv := types.BigDivFloat(rejectionBalance, types.BigAdd(rejectionBalance, acceptanceBalance))
 		if av > 0.05 {
 			fmt.Printf("Token Holder Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
 		} else {
 			fmt.Printf("Token Holder Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		}
+		return nil
+	},
+}
+
+var clientCmd = &cli.Command{
+	Name:      "client",
+	Usage:     "get poll result for client",
+	ArgsUsage: "[state root]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 2 {
+			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
+		}
+
+		ctx := context.TODO()
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass state root")
+		}
+
+		sroot, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		tree, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		//get all the votes' singer address && their vote
+		vj, err := homedir.Expand(cctx.Args().Get(1))
+		if err != nil {
+			return xerrors.Errorf("fail to get votes json")
+		}
+		votes, err := getVoters(vj)
+		if err != nil {
+			return xerrors.Errorf("fail to get votesrs: ", err)
+		}
+
+		//market actor
+		ma, err := tree.GetActor(market.Address)
+		if err != nil {
+			return xerrors.Errorf("fail to get market actor: ", err)
+		}
+
+		ms, err := market.Load(store, ma)
+		if err != nil {
+			return xerrors.Errorf("fail to load market actor: ", err)
+		}
+
+		dps, _ := ms.Proposals()
+		acceptanceBytes := abi.PaddedPieceSize(0)
+		rejectionBytes := abi.PaddedPieceSize(0)
+		acceptanceCount := 0
+		rejectionCount := 0
+		for _, v := range votes {
+			if err != nil {
+				return xerrors.Errorf("fail to get account account for signer: ", v.SignerAddress)
+			}
+			ai, err := tree.LookupID(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("cannot resolve singer: ", ai)
+			}
+			if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
+				p, found, _ := dps.Get(dealID)
+				if found && p.Client == ai {
+					if v.OptionID == APPROVE {
+						acceptanceBytes += p.PieceSize
+						acceptanceCount += 1
+					} else {
+						rejectionBytes += p.PieceSize
+						rejectionCount += 1
+					}
+				}
+				return xerrors.Errorf("cant get deal ", err)
+			}); err != nil {
+				return err
+			}
+		}
+		fmt.Printf("\nTotal amount of clients: %v\n", acceptanceCount+rejectionCount)
+		fmt.Printf("Total deal bytes: %v\n", acceptanceBytes+rejectionBytes)
+		fmt.Printf("Approve (#): %v\n", acceptanceCount)
+		fmt.Printf("Reject (#): %v\n", rejectionCount)
+		fmt.Printf("Approve (byte): %v\n", acceptanceBytes)
+		fmt.Printf("Reject (byte): %v\n", rejectionBytes)
+		av := float64(acceptanceBytes) / float64(acceptanceBytes+rejectionBytes)
+		rv := float64(rejectionBytes) / float64(acceptanceBytes+rejectionBytes)
+		if av > 0.05 {
+			fmt.Printf("Deal Client Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		} else {
+			fmt.Printf("Deal Client Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
 		}
 		return nil
 	},

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -390,17 +390,17 @@ var clientCmd = &cli.Command{
 				return xerrors.Errorf("cannot resolve singer: ", ai)
 			}
 			if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
-				p, found, _ := dps.Get(dealID)
-				if found && p.Client == ai {
+
+				if d.Client == ai {
 					if v.OptionID == APPROVE {
-						acceptanceBytes += p.PieceSize
+						acceptanceBytes += d.PieceSize
 						acceptanceCount += 1
 					} else {
-						rejectionBytes += p.PieceSize
+						rejectionBytes += d.PieceSize
 						rejectionCount += 1
 					}
 				}
-				return xerrors.Errorf("cant get deal ", err)
+				return nil
 			}); err != nil {
 				return err
 			}

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -95,7 +95,7 @@ func getVotesMap(file string, st *state.StateTree) (map[address.Address]uint64 /
 	return vm, nil
 }
 
-func getAllMsigSingerMap(st *state.StateTree, store adt.Store) (map[address.Address][]address.Address /*map[Singer ID address]msigActorId[]*/, error) {
+func getAllMsigSignerMap(st *state.StateTree, store adt.Store) (map[address.Address][]address.Address /*map[Signer ID address]msigActorId[]*/, error) {
 	sm := make(map[address.Address][]address.Address)
 	err := st.ForEach(func(addr address.Address, act *types.Actor) error {
 		if builtin.IsMultisigActor(act.Code) {
@@ -345,7 +345,7 @@ var spRBPAndDealCmd = &cli.Command{
 			return err
 		}
 
-		//get all the votes' singer ID address && their vote
+		//get all the votes' signer ID address && their vote
 		vj, err := homedir.Expand(cctx.Args().Get(1))
 		if err != nil {
 			return xerrors.Errorf("fail to get votes json")
@@ -509,7 +509,7 @@ var tokenHolderCmd = &cli.Command{
 			return err
 		}
 
-		//get all the votes' singer address && their vote
+		//get all the votes' signer address && their vote
 		vj, err := homedir.Expand(cctx.Args().Get(1))
 		if err != nil {
 			return xerrors.Errorf("fail to get votes json")
@@ -519,8 +519,8 @@ var tokenHolderCmd = &cli.Command{
 			return xerrors.Errorf("fail to get voter map ", err)
 		}
 
-		//get all the msig singers & their msigs
-		msigs, err := getAllMsigSingerMap(tree, store)
+		//get all the msig signers & their msigs
+		msigs, err := getAllMsigSignerMap(tree, store)
 
 		approveVote := 0
 		rejectionVote := 0
@@ -545,7 +545,7 @@ var tokenHolderCmd = &cli.Command{
 
 			//process msigs
 			if mss, found := msigs[s]; found {
-				for _, ms := range mss { //get all the msig singer has
+				for _, ms := range mss { //get all the msig signer has
 					if mpv, found := msigPendingVotes[ms]; found { //other signers of the multisig have voted, yet the threshold has not met
 						if v == APPROVE {
 							if mpv.ApproveCount+1 == mpv.Multisig.Threshold { //met threshold
@@ -634,7 +634,7 @@ var tokenHolderCmd = &cli.Command{
 			}
 		}
 
-		fmt.Printf("\nTotal amount of singers: %v\n ", len(vm))
+		fmt.Printf("\nTotal amount of signer: %v\n ", len(vm))
 		fmt.Printf("Total amount of valid multisig vote: %v\n ", msigFinalVotes)
 		fmt.Printf("Total balance: %v\n", types.BigAdd(approveBalance, rejectionBalance).String())
 		fmt.Printf("Approve (#): %v\n", approveVote)
@@ -720,7 +720,7 @@ var clientCmd = &cli.Command{
 			return err
 		}
 
-		//get all the votes' singer ID address && their voted option
+		//get all the votes' signer ID address && their voted option
 		vj, err := homedir.Expand(cctx.Args().Get(1))
 		if err != nil {
 			return xerrors.Errorf("fail to get votes json")

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/store"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+
+	"github.com/filecoin-project/lotus/chain/state"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
+	"github.com/filecoin-project/lotus/chain/types"
+
+	"github.com/mitchellh/go-homedir"
+
+	"golang.org/x/xerrors"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/go-address"
+)
+
+const APPROVE = 49
+
+type Vote struct {
+	OptionID      uint64          `json: "optionId"`
+	SignerAddress address.Address `json: "signerAddress"`
+}
+
+type msigVote struct {
+	Multisig          msigBriefInfo
+	AcceptanceSingers []address.Address
+	RejectionSigners  []address.Address
+}
+
+// https://filpoll.io/poll/16
+// snapshot height: 2162760
+// state root: bafy2bzacebdnzh43hw66bmvguk65wiwr5ssaejlq44fpdei2ysfh3eefpdlqs
+var fip0036PollResultcmd = &cli.Command{
+	Name:      "fip0036poll",
+	Usage:     "Process the FIP0036 FilPoll result",
+	ArgsUsage: "[state root, votes]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Subcommands: []*cli.Command{
+		//spRBPCmd,
+		//spDealByteCmd,
+		//clientCmd,
+		tokenHolderCmd,
+		//coreDevCmd,
+		//finalResultCmd,
+	},
+}
+
+func getVoters(file string) ([]Vote, error) {
+
+	var votes []Vote
+	vb, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, xerrors.Errorf("read vote: %w", err)
+	}
+
+	if err := json.Unmarshal(vb, &votes); err != nil {
+		return nil, xerrors.Errorf("unmarshal vote: %w", err)
+	}
+	return votes, nil
+}
+
+func getAllMsig(st *state.StateTree, store adt.Store) ([]msigBriefInfo, error) {
+
+	var msigActorsInfo []msigBriefInfo
+	err := st.ForEach(func(addr address.Address, act *types.Actor) error {
+		if builtin.IsMultisigActor(act.Code) {
+			ms, err := multisig.Load(store, act)
+			if err != nil {
+				return fmt.Errorf("load msig failed %v", err)
+
+			}
+
+			signers, _ := ms.Signers()
+			threshold, _ := ms.Threshold()
+			info := msigBriefInfo{
+				ID:        addr,
+				Signer:    signers,
+				Balance:   act.Balance,
+				Threshold: threshold,
+			}
+			msigActorsInfo = append(msigActorsInfo, info)
+
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return msigActorsInfo, nil
+}
+
+var tokenHolderCmd = &cli.Command{
+	Name:      "token-holder",
+	Usage:     "get poll result for token holder group",
+	ArgsUsage: "[state root]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 2 {
+			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
+		}
+
+		ctx := context.TODO()
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass state root")
+		}
+
+		sroot, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		tree, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		//get all the votes' singer address && their vote
+		vj, err := homedir.Expand(cctx.Args().Get(1))
+		if err != nil {
+			return xerrors.Errorf("fail to get votes json")
+		}
+		votes, err := getVoters(vj)
+		if err != nil {
+			return xerrors.Errorf("fail to get votesrs: ", err)
+		}
+		//get all the msig
+		msigs, err := getAllMsig(tree, store)
+
+		var acceptanceVote []Vote
+		var rejectionVote []Vote
+		acceptanceBalance := abi.NewTokenAmount(0)
+		rejectionBalance := abi.NewTokenAmount(0)
+		msigPendingVotes := make(map[address.Address]msigVote)
+		msigFinalVotes := make(map[address.Address]msigVote)
+
+		for _, v := range votes {
+			a, err := tree.GetActor(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("fail to get account account for signer: ", v.SignerAddress)
+			}
+			//regular account
+			if v.OptionID == APPROVE {
+				acceptanceVote = append(acceptanceVote, v)
+				acceptanceBalance = types.BigAdd(acceptanceBalance, a.Balance)
+			} else {
+				rejectionVote = append(rejectionVote, v)
+				rejectionBalance = types.BigAdd(rejectionBalance, a.Balance)
+			}
+
+			//msig
+			si, err := tree.LookupID(v.SignerAddress)
+			if err != nil {
+				return xerrors.Errorf("cannot resolve singer: ", si)
+			}
+			for _, m := range msigs {
+
+				for _, ms := range m.Signer {
+					if ms == si {
+						if mv, found := msigPendingVotes[m.ID]; found { //other singer has voted
+
+							if v.OptionID == APPROVE {
+								mv.AcceptanceSingers = append(mv.AcceptanceSingers, v.SignerAddress)
+							} else {
+								mv.RejectionSigners = append(mv.RejectionSigners, v.SignerAddress)
+							}
+
+							//check if threshold meet
+							if uint64(len(mv.AcceptanceSingers)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								acceptanceBalance = types.BigAdd(acceptanceBalance, m.Balance)
+							} else if uint64(len(mv.RejectionSigners)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								rejectionBalance = types.BigAdd(rejectionBalance, m.Balance)
+							} else {
+								msigPendingVotes[m.ID] = mv
+							}
+						} else {
+
+							n := msigVote{
+								Multisig: m,
+							}
+							if v.OptionID == APPROVE {
+								n.AcceptanceSingers = append(n.AcceptanceSingers, v.SignerAddress)
+							} else {
+								n.RejectionSigners = append(n.RejectionSigners, v.SignerAddress)
+							}
+
+							//check if threshold meet
+							if uint64(len(mv.AcceptanceSingers)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								acceptanceBalance = types.BigAdd(acceptanceBalance, m.Balance)
+							} else if uint64(len(mv.RejectionSigners)) == m.Threshold {
+								delete(msigPendingVotes, m.ID)
+								msigFinalVotes[m.ID] = mv
+								rejectionBalance = types.BigAdd(rejectionBalance, m.Balance)
+							} else {
+								msigPendingVotes[m.ID] = mv
+							}
+						}
+					}
+				}
+			}
+		}
+
+		fmt.Printf("\nTotoal amount of singers: %v\n ", len(votes))
+		fmt.Printf("Totoal amount of valid multisig vote: %v\n ", len(msigFinalVotes))
+		fmt.Printf("Total balance: %v\n", types.BigAdd(acceptanceBalance, rejectionBalance).String())
+		fmt.Printf("Approve: %v\n", acceptanceBalance.String())
+		fmt.Printf("Reject: %v\n", rejectionBalance.String())
+		av := types.BigDivFloat(acceptanceBalance, types.BigAdd(acceptanceBalance, rejectionBalance))
+		rv := types.BigDivFloat(rejectionBalance, types.BigAdd(rejectionBalance, acceptanceBalance))
+		if av > 0.05 {
+			fmt.Printf("Token Holder Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		} else {
+			fmt.Printf("Token Holder Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
+		}
+		return nil
+	},
+}

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -6,43 +6,39 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strconv"
 
-	"github.com/urfave/cli/v2"
-
-	"github.com/filecoin-project/go-address"
-	"github.com/mitchellh/go-homedir"
-
-	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
-
-	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
-
-	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
-
-	"github.com/filecoin-project/go-state-types/abi"
-
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
-	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/mitchellh/go-homedir"
+	"github.com/urfave/cli/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/chain/actors/adt"
-	"github.com/filecoin-project/lotus/node/repo"
-
-	"github.com/filecoin-project/lotus/chain/state"
-
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	_init "github.com/filecoin-project/lotus/chain/actors/builtin/init"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/state"
+	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
-
-	"golang.org/x/xerrors"
+	"github.com/filecoin-project/lotus/node/repo"
 )
 
 const APPROVE = 49
 const Reject = 50
 
 type Vote struct {
-	OptionID      uint64          `json: "optionId"`
-	SignerAddress address.Address `json: "signerAddress"`
+	OptionID      uint64
+	SignerAddress address.Address
 }
 
 type msigVote struct {
@@ -65,11 +61,484 @@ var fip36PollCmd = &cli.Command{
 		},
 	},
 	Subcommands: []*cli.Command{
-		spRBPAndDealCmd,
-		clientCmd,
-		tokenHolderCmd,
-		//coreDevCmd,
-		//finalResultCmd,
+		finalResultCmd,
+	},
+}
+
+var finalResultCmd = &cli.Command{
+	Name:      "results",
+	Usage:     "get poll results",
+	ArgsUsage: "[state root] [height] [votes json]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+
+	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 3 {
+			return xerrors.New("filpoll0036 results [state root] [height] [votes.json]")
+		}
+
+		ctx := context.TODO()
+		if !cctx.Args().Present() {
+			return fmt.Errorf("must pass state root")
+		}
+
+		sroot, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
+		if err != nil {
+			return err
+		}
+
+		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
+		defer cs.Close() //nolint:errcheck
+
+		cst := cbor.NewCborStore(bs)
+		store := adt.WrapStore(ctx, cst)
+
+		st, err := state.LoadStateTree(cst, sroot)
+		if err != nil {
+			return err
+		}
+
+		height, err := strconv.Atoi(cctx.Args().Get(1))
+		if err != nil {
+			return err
+		}
+
+		//get all the votes' signer ID address && their vote
+		vj, err := homedir.Expand(cctx.Args().Get(2))
+		if err != nil {
+			return xerrors.Errorf("fail to get votes json")
+		}
+		votes, err := getVotesMap(vj, st)
+		if err != nil {
+			return xerrors.Errorf("failed to get voters: ", err)
+		}
+
+		type minerBriefInfo struct {
+			rawBytePower abi.StoragePower
+			dealPower    abi.StoragePower
+			balance      abi.TokenAmount
+		}
+
+		// power actor
+		pa, err := st.GetActor(power.Address)
+		if err != nil {
+			return xerrors.Errorf("failed to get power actor: \n", err)
+		}
+
+		powerState, err := power.Load(store, pa)
+		if err != nil {
+			return xerrors.Errorf("failed to get power state: \n", err)
+		}
+
+		//market actor
+		ma, err := st.GetActor(market.Address)
+		if err != nil {
+			return xerrors.Errorf("fail to get market actor: ", err)
+		}
+
+		marketState, err := market.Load(store, ma)
+		if err != nil {
+			return xerrors.Errorf("fail to load market state: ", err)
+		}
+
+		//init actor
+		ia, err := st.GetActor(_init.Address)
+		if err != nil {
+			return xerrors.Errorf("fail to get init actor: ", err)
+		}
+
+		initState, err := _init.Load(store, ia)
+		if err != nil {
+			return xerrors.Errorf("fail to load init state: ", err)
+		}
+
+		initMap, err := initState.AddressMap()
+		if err != nil {
+			return xerrors.Errorf("fail to load init map: ", err)
+		}
+
+		lookupId := func(addr address.Address) address.Address {
+			if addr.Protocol() == address.ID {
+				return addr
+			}
+
+			var actorID cbg.CborInt
+			if found, err := initMap.Get(abi.AddrKey(addr), &actorID); err != nil {
+				panic(err)
+			} else if found {
+				// Reconstruct address from the ActorID.
+				idAddr, err := address.NewIDAddress(uint64(actorID))
+				if err != nil {
+					panic(err)
+				}
+				return idAddr
+			}
+
+			panic("didn't find addr")
+		}
+
+		// we need to build several pieces of information, as we traverse the state tree:
+		// a map of accounts to every msig that they are a signer of
+		accountsToMultisigs := make(map[address.Address][]address.Address)
+		// a map of multisigs to some info about them for quick lookup
+		msigActorsInfo := make(map[address.Address]msigBriefInfo)
+		// a map of accounts to every miner that they are an owner of
+		ownerMap := make(map[address.Address][]address.Address)
+		// a map of accounts to every miner that they are a worker of
+		workerMap := make(map[address.Address][]address.Address)
+		// a map of miners to some info aboout them for quick lookup
+		minerActorsInfo := make(map[address.Address]minerBriefInfo)
+		// a map of client addresses to deal data stored in proposals
+		clientToDealStorage := make(map[address.Address]abi.StoragePower)
+
+		fmt.Println("iterating over all actors")
+		count := 0
+		err = st.ForEach(func(addr address.Address, act *types.Actor) error {
+			if count%200000 == 0 {
+				fmt.Println("processed ", count, " actors building maps")
+			}
+			count++
+			if builtin.IsMultisigActor(act.Code) {
+				ms, err := multisig.Load(store, act)
+				if err != nil {
+					return fmt.Errorf("load msig failed %v", err)
+
+				}
+
+				// TODO: Confirm that these are always ID addresses
+				signers, err := ms.Signers()
+				if err != nil {
+					return xerrors.Errorf("fail to get msig signers", err)
+				}
+				for _, s := range signers {
+					signerId := lookupId(s)
+					if m, found := accountsToMultisigs[signerId]; found { //add msig id to signer's collection
+						m = append(m, addr)
+						accountsToMultisigs[signerId] = m
+					} else {
+						n := []address.Address{addr}
+						accountsToMultisigs[signerId] = n
+					}
+				}
+
+				locked, err := ms.LockedBalance(abi.ChainEpoch(height))
+				if err != nil {
+					return xerrors.Errorf("failed to compute locked multisig balance: %w", err)
+				}
+
+				threshold, _ := ms.Threshold()
+				info := msigBriefInfo{
+					ID:        addr,
+					Signer:    signers,
+					Balance:   big.Min(big.Zero(), types.BigSub(act.Balance, locked)),
+					Threshold: threshold,
+				}
+				msigActorsInfo[addr] = info
+			}
+
+			if builtin.IsStorageMinerActor(act.Code) {
+				m, err := miner.Load(store, act)
+				if err != nil {
+					return xerrors.Errorf("fail to load miner actor: \n", err)
+				}
+
+				info, err := m.Info()
+				if err != nil {
+					return xerrors.Errorf("fail to get miner info: \n", err)
+				}
+
+				ownerId := lookupId(info.Owner)
+				if m, found := ownerMap[ownerId]; found { //add miner id to owner list
+					m = append(m, addr)
+					ownerMap[ownerId] = m
+				} else {
+					n := []address.Address{addr}
+					ownerMap[ownerId] = n
+				}
+
+				workerId := lookupId(info.Worker)
+				if m, found := workerMap[workerId]; found { //add miner id to worker list
+					m = append(m, addr)
+					workerMap[workerId] = m
+				} else {
+					n := []address.Address{addr}
+					workerMap[workerId] = n
+				}
+
+				bal, err := m.AvailableBalance(act.Balance)
+				if err != nil {
+					return err
+				}
+
+				pow, ok, err := powerState.MinerPower(addr)
+				if err != nil {
+					return err
+				}
+
+				if !ok {
+					pow.RawBytePower = big.Zero()
+				}
+
+				minerActorsInfo[addr] = minerBriefInfo{
+					rawBytePower: pow.RawBytePower,
+					// gets added up outside this loop
+					dealPower: big.Zero(),
+					balance:   bal,
+				}
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("iterating over proposals")
+		dps, _ := marketState.Proposals()
+		if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
+			clientId := lookupId(d.Client)
+			if cd, found := clientToDealStorage[clientId]; found {
+				clientToDealStorage[clientId] = big.Add(cd, big.NewInt(int64(d.PieceSize)))
+			} else {
+				clientToDealStorage[clientId] = big.NewInt(int64(d.PieceSize))
+			}
+
+			providerId := lookupId(d.Provider)
+			mai, found := minerActorsInfo[providerId]
+
+			if !found {
+				return xerrors.Errorf("didn't find miner %s", providerId)
+			}
+
+			mai.dealPower = big.Add(mai.dealPower, big.NewInt(int64(d.PieceSize)))
+			minerActorsInfo[providerId] = mai
+			return nil
+		}); err != nil {
+			return xerrors.Errorf("fail to get deals")
+		}
+
+		// now tabulate votes
+
+		approveBalance := abi.NewTokenAmount(0)
+		rejectionBalance := abi.NewTokenAmount(0)
+		clientApproveBytes := big.Zero()
+		clientRejectBytes := big.Zero()
+		msigPendingVotes := make(map[address.Address]msigVote) //map[msig ID]msigVote
+		votedMsigs := make(map[address.Address]struct{})
+		votesIncludingMsigs := make(map[address.Address]uint64)
+		fmt.Println("counting account and multisig votes")
+		for signer, v := range votes {
+			signerId := lookupId(signer)
+			//process votes for regular accounts
+			accountActor, err := st.GetActor(signerId)
+			if err != nil {
+				return xerrors.Errorf("fail to get account account for signer: ", err)
+			}
+
+			clientBytes, ok := clientToDealStorage[signerId]
+			if !ok {
+				clientBytes = big.Zero()
+			}
+
+			if v == APPROVE {
+				approveBalance = types.BigAdd(approveBalance, accountActor.Balance)
+				votesIncludingMsigs[signerId] = APPROVE
+				clientApproveBytes = big.Add(clientApproveBytes, clientBytes)
+			} else {
+				rejectionBalance = types.BigAdd(rejectionBalance, accountActor.Balance)
+				votesIncludingMsigs[signerId] = Reject
+				clientRejectBytes = big.Add(clientRejectBytes, clientBytes)
+			}
+
+			//process msigs
+			// TODO: Oh god, oh god, there's a possibility that a multisig has voted in both directions
+			// and we'll pick a winner non-deterministically as we iterate...
+			// We need to factor in vote time if that happens and pick whoever went first
+			if mss, found := accountsToMultisigs[signerId]; found {
+				for _, ms := range mss { //get all the msig signer has
+					if _, ok := votedMsigs[ms]; ok {
+						// msig has already voted, skip
+						continue
+					}
+					if mpv, found := msigPendingVotes[ms]; found { //other signers of the multisig have voted, yet the threshold has not met
+						if v == APPROVE {
+							if mpv.ApproveCount+1 == mpv.Multisig.Threshold { //met threshold
+								approveBalance = types.BigAdd(approveBalance, mpv.Multisig.Balance)
+								delete(msigPendingVotes, ms) //threshold, can skip later signer votes
+								votedMsigs[ms] = struct{}{}
+								votesIncludingMsigs[ms] = APPROVE
+
+							} else {
+								mpv.ApproveCount++
+								msigPendingVotes[ms] = mpv
+							}
+						} else {
+							if mpv.RejectCount+1 == mpv.Multisig.Threshold { //met threshold
+								rejectionBalance = types.BigAdd(rejectionBalance, mpv.Multisig.Balance)
+								delete(msigPendingVotes, ms) //threshold, can skip later signer votes
+								votedMsigs[ms] = struct{}{}
+								votesIncludingMsigs[ms] = Reject
+
+							} else {
+								mpv.RejectCount++
+								msigPendingVotes[ms] = mpv
+							}
+						}
+					} else { //first vote received from one of the signers of the msig
+						msi, ok := msigActorsInfo[ms]
+						if !ok {
+							return xerrors.Errorf("didn't find msig %s in msig map", ms)
+						}
+
+						if msi.Threshold == 1 { //met threshold with this signer's single vote
+							if v == APPROVE {
+								approveBalance = types.BigAdd(approveBalance, msi.Balance)
+								votesIncludingMsigs[ms] = APPROVE
+
+							} else {
+								rejectionBalance = types.BigAdd(rejectionBalance, msi.Balance)
+								votesIncludingMsigs[ms] = Reject
+							}
+							votedMsigs[ms] = struct{}{}
+						} else { //threshold not met, add to pending vote
+							if v == APPROVE {
+								msigPendingVotes[ms] = msigVote{
+									Multisig:     msi,
+									ApproveCount: 1,
+								}
+							} else {
+								msigPendingVotes[ms] = msigVote{
+									Multisig:    msi,
+									RejectCount: 1,
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// time to process miners based on what we know about votesIncludingMsigs
+		minerVotes := make(map[address.Address]uint64)
+		fmt.Println("counting miner votes")
+		for s, v := range votes {
+			if minerInfos, found := ownerMap[s]; found {
+				for _, minerInfo := range minerInfos {
+					minerVotes[minerInfo] = v
+				}
+			}
+			if minerInfos, found := workerMap[s]; found {
+				for _, minerInfo := range minerInfos {
+					if _, ok := minerVotes[minerInfo]; !ok {
+						minerVotes[minerInfo] = v
+					}
+				}
+			}
+		}
+
+		approveRBP := big.Zero()
+		approveDealPower := big.Zero()
+		rejectionRBP := big.Zero()
+		rejectionDealPower := big.Zero()
+		fmt.Println("adding up miner votes")
+		for minerAddr, vote := range minerVotes {
+			mbi, ok := minerActorsInfo[minerAddr]
+			if !ok {
+				return xerrors.Errorf("failed to find miner info for %s", minerAddr)
+			}
+
+			if vote == APPROVE {
+				approveBalance = big.Add(approveBalance, mbi.balance)
+				approveRBP = big.Add(approveRBP, mbi.rawBytePower)
+				approveDealPower = big.Add(approveDealPower, mbi.dealPower)
+			} else {
+				rejectionBalance = big.Add(rejectionBalance, mbi.balance)
+				rejectionRBP = big.Add(rejectionRBP, mbi.rawBytePower)
+				rejectionDealPower = big.Add(rejectionDealPower, mbi.dealPower)
+			}
+		}
+
+		fmt.Println("Total acceptance token: ", approveBalance)
+		fmt.Println("Total rejection token: ", rejectionBalance)
+
+		fmt.Println("Total acceptance SP deal power: ", approveDealPower)
+		fmt.Println("Total rejection SP deal power: ", rejectionDealPower)
+
+		fmt.Println("Total acceptance SP rb power: ", approveRBP)
+		fmt.Println("Total rejection SP rb power: ", rejectionRBP)
+
+		fmt.Println("Total acceptance Client rb power: ", clientApproveBytes)
+		fmt.Println("Total rejection Client rb power: ", clientRejectBytes)
+
+		fmt.Println("\n\nFinal results **drumroll**")
+		if rejectionBalance.GreaterThanEqual(big.Mul(approveBalance, big.NewInt(2))) {
+			fmt.Println("token holders VETO FIP-0036!!!")
+		} else if approveBalance.LessThanEqual(rejectionBalance) {
+			fmt.Println("token holders REJECT FIP-0036 :(")
+		} else {
+			fmt.Println("token holders ACCEPT FIP-0036 :)")
+		}
+
+		if rejectionDealPower.GreaterThanEqual(big.Mul(approveDealPower, big.NewInt(2))) {
+			fmt.Println("SPs by deall data stored VETO FIP-0036!!!")
+		} else if approveDealPower.LessThanEqual(rejectionDealPower) {
+			fmt.Println("SPs by deal data stored REJECT FIP-0036 :(")
+		} else {
+			fmt.Println("SPs by deal data stored ACCEPT FIP-0036 :)")
+		}
+
+		if rejectionRBP.GreaterThanEqual(big.Mul(approveRBP, big.NewInt(2))) {
+			fmt.Println("SPs by total raw byte power VETO FIP-0036!!!")
+		} else if approveRBP.LessThanEqual(rejectionRBP) {
+			fmt.Println("SPs by total raw byte power REJECT FIP-0036 :(")
+		} else {
+			fmt.Println("SPs by total raw byte power ACCEPT FIP-0036 :)")
+		}
+
+		if clientRejectBytes.GreaterThanEqual(big.Mul(clientApproveBytes, big.NewInt(2))) {
+			fmt.Println("Storage Clients VETO FIP-0036!!!")
+		} else if clientApproveBytes.LessThanEqual(clientRejectBytes) {
+			fmt.Println("Storage Clients REJECT FIP-0036 :(")
+		} else {
+			fmt.Println("Storage Clients ACCEPT FIP-0036 :)")
+		}
+
+		return nil
 	},
 }
 
@@ -93,697 +562,4 @@ func getVotesMap(file string, st *state.StateTree) (map[address.Address]uint64 /
 		vm[si] = v.OptionID
 	}
 	return vm, nil
-}
-
-func getAllMsigSignerMap(st *state.StateTree, store adt.Store) (map[address.Address][]address.Address /*map[Signer ID address]msigActorId[]*/, error) {
-	sm := make(map[address.Address][]address.Address)
-	err := st.ForEach(func(addr address.Address, act *types.Actor) error {
-		if builtin.IsMultisigActor(act.Code) {
-			ms, err := multisig.Load(store, act)
-			if err != nil {
-				return fmt.Errorf("load msig failed %v", err)
-
-			}
-
-			ss, err := ms.Signers()
-			if err != nil {
-				return xerrors.Errorf("fail to get msig signers", err)
-			}
-			for _, s := range ss {
-				if m, found := sm[s]; found { //add msig id to signer's collection
-					m = append(m, addr)
-					sm[s] = m
-				} else {
-					n := []address.Address{addr}
-					sm[s] = n
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return sm, nil
-}
-
-func getAllMsigIDMap(st *state.StateTree, store adt.Store) (map[address.Address]msigBriefInfo /*map[Multisig Actor ID]msigBriefInfo*/, error) {
-
-	msigActorsInfo := make(map[address.Address]msigBriefInfo)
-	err := st.ForEach(func(addr address.Address, act *types.Actor) error {
-		if builtin.IsMultisigActor(act.Code) {
-			ms, err := multisig.Load(store, act)
-			if err != nil {
-				return fmt.Errorf("load msig failed %v", err)
-
-			}
-
-			signers, _ := ms.Signers()
-			threshold, _ := ms.Threshold()
-			info := msigBriefInfo{
-				ID:        addr,
-				Signer:    signers,
-				Balance:   act.Balance,
-				Threshold: threshold,
-			}
-			msigActorsInfo[addr] = info
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return msigActorsInfo, nil
-}
-
-type MinerVoteInfo struct {
-	AvailableBalance abi.TokenAmount
-	DealBytes        abi.PaddedPieceSize
-	RBP              abi.StoragePower
-	Option           uint64
-}
-
-func getStorageMinerRBP(miner address.Address, st *state.StateTree, store adt.Store) (abi.StoragePower, error) {
-	pa, err := st.GetActor(power.Address)
-	if err != nil {
-		return types.NewInt(0), xerrors.Errorf("failed to get power actor: \n", err)
-	}
-
-	ps, err := power.Load(store, pa)
-	if err != nil {
-		return types.NewInt(0), xerrors.Errorf("failed to get power state: \n", err)
-	}
-
-	mp, _, err := ps.MinerPower(miner)
-	if err != nil {
-		return types.NewInt(0), xerrors.Errorf("failed to get miner power: \n", err)
-	}
-
-	return mp.RawBytePower, nil
-}
-
-func getStorageMinerVotes(st *state.StateTree, votes map[address.Address]uint64, store adt.Store) (map[address.Address]MinerVoteInfo /*map[Storage Miner Actor]Option*/, error) {
-	smv := make(map[address.Address]MinerVoteInfo)
-	msigs, err := getAllMsigIDMap(st, store)
-	if err != nil {
-		xerrors.Errorf("fail to get msigs", err)
-	}
-	err = st.ForEach(func(addr address.Address, act *types.Actor) error {
-		if builtin.IsStorageMinerActor(act.Code) {
-			m, err := miner.Load(store, act)
-			if err != nil {
-				return xerrors.Errorf("fail to load miner actor: \n", err)
-			}
-
-			info, err := m.Info()
-			if err != nil {
-				return xerrors.Errorf("fail to get miner info: \n", err)
-			}
-			//check if owner voted
-			o := info.Owner
-			if v, found := votes[o]; found {
-				//check if owner is msig
-				if ms, found := msigs[o]; found { //owner is a msig
-					ac := uint64(0)
-					rc := uint64(0)
-					for _, s := range ms.Signer {
-						if v, found := votes[s]; found {
-							if v == APPROVE {
-								ac += 1
-							} else {
-								rc += 1
-							}
-						}
-						mp, err := getStorageMinerRBP(addr, st, store)
-						if err != nil {
-							return xerrors.Errorf("fail to get miner actor rbp", err)
-						}
-						m := MinerVoteInfo{
-							AvailableBalance: act.Balance,
-							RBP:              mp,
-						}
-
-						//check if msig threshold is met for casting the vote
-						if ac == ms.Threshold {
-							m.Option = APPROVE
-							smv[addr] = m
-						} else if rc == ms.Threshold {
-							m.Option = Reject
-							smv[addr] = m
-						} else {
-							smv[addr] = m //no valid vote yet, option value should be 0
-						}
-					}
-				} else { //owner is a regular wallet account
-					mp, err := getStorageMinerRBP(addr, st, store)
-					if err != nil {
-						return xerrors.Errorf("fail to get miner actor rbp", err)
-					}
-					m := MinerVoteInfo{
-						AvailableBalance: act.Balance,
-						RBP:              mp,
-						Option:           v,
-					}
-					smv[addr] = m
-				}
-			}
-
-			//check if owner has not voted but worker voted
-			if _, found := smv[addr]; !found {
-				w := info.Worker
-				if v, found := votes[w]; found {
-					mp, err := getStorageMinerRBP(addr, st, store)
-					if err != nil {
-						return xerrors.Errorf("fail to get miner actor rbp", err)
-					}
-					m := MinerVoteInfo{
-						AvailableBalance: act.Balance,
-						RBP:              mp,
-						Option:           v,
-					}
-					smv[addr] = m
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return smv, nil
-}
-
-var spRBPAndDealCmd = &cli.Command{
-	Name: "sp",
-	Usage: "get poll result for storage group. Weighted by RBP(raw byte power) and deal bytes stored in valid deals." +
-		"\nNote that: if both owner key and worker key has voted, the vote made by owner key will be casted the storage provider actor.",
-	ArgsUsage: "[state root]",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
-		},
-		&cli.BoolFlag{
-			Name:  "rbp-only",
-			Value: false,
-		},
-	},
-
-	Action: func(cctx *cli.Context) error {
-		if cctx.NArg() != 2 {
-			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
-		}
-
-		ctx := context.TODO()
-		if !cctx.Args().Present() {
-			return fmt.Errorf("must pass state root")
-		}
-
-		sroot, err := cid.Decode(cctx.Args().First())
-		if err != nil {
-			return fmt.Errorf("failed to parse input: %w", err)
-		}
-
-		fsrepo, err := repo.NewFS(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		lkrepo, err := fsrepo.Lock(repo.FullNode)
-		if err != nil {
-			return err
-		}
-
-		defer lkrepo.Close() //nolint:errcheck
-
-		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
-		if err != nil {
-			return fmt.Errorf("failed to open blockstore: %w", err)
-		}
-
-		defer func() {
-			if c, ok := bs.(io.Closer); ok {
-				if err := c.Close(); err != nil {
-					log.Warnf("failed to close blockstore: %s", err)
-				}
-			}
-		}()
-
-		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
-		if err != nil {
-			return err
-		}
-
-		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
-		defer cs.Close() //nolint:errcheck
-
-		cst := cbor.NewCborStore(bs)
-		store := adt.WrapStore(ctx, cst)
-
-		tree, err := state.LoadStateTree(cst, sroot)
-		if err != nil {
-			return err
-		}
-
-		//get all the votes' signer ID address && their vote
-		vj, err := homedir.Expand(cctx.Args().Get(1))
-		if err != nil {
-			return xerrors.Errorf("fail to get votes json")
-		}
-		votes, err := getVotesMap(vj, tree)
-		if err != nil {
-			return xerrors.Errorf("fail to get votesrs: ", err)
-		}
-
-		//get all storage miner votes
-		smv, err := getStorageMinerVotes(tree, votes, store)
-		if err != nil {
-			return xerrors.Errorf("fail to get storage miner votes", err)
-		}
-		approveVote := 0
-		rejectionVote := 0
-		approveRBP := abi.NewStoragePower(0)
-		rejectRBP := abi.NewStoragePower(0)
-		approveDealBytes := abi.PaddedPieceSize(0)
-		rejectDealBytes := abi.PaddedPieceSize(0)
-		ownerMsigUnderThreshold := 0
-
-		//get all market proposals, add load the # of the bytes each provider has made
-		pds := make(map[address.Address]abi.PaddedPieceSize)
-		if !cctx.Bool("rbp-only") {
-			ma, err := tree.GetActor(market.Address)
-			if err != nil {
-				return xerrors.Errorf("fail to get market actor: ", err)
-			}
-
-			ms, err := market.Load(store, ma)
-			if err != nil {
-				return xerrors.Errorf("fail to load market actor: ", err)
-			}
-			dps, _ := ms.Proposals()
-			if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
-				if pd, found := pds[d.Provider]; found {
-					s := d.PieceSize + pd
-					pds[d.Provider] = s
-				} else {
-					pds[d.Provider] = d.PieceSize
-				}
-				return xerrors.Errorf("fail to load deals")
-			}); err != nil {
-				return xerrors.Errorf("fail to get deals")
-			}
-		}
-
-		//process the vote
-		for m, mvi := range smv {
-			if mvi.Option == APPROVE {
-				approveVote += 1
-				approveRBP = types.BigAdd(approveRBP, mvi.RBP)
-				if d, found := pds[m]; !cctx.Bool("rbp-only") && found {
-					approveDealBytes += d
-				}
-			} else if mvi.Option == Reject {
-				rejectionVote += 1
-				rejectRBP = types.BigAdd(rejectRBP, mvi.RBP)
-				if d, found := pds[m]; !cctx.Bool("rbp-only") && found {
-					rejectDealBytes += d
-				}
-			} else { //owner is msig and didnt reach threshold
-				ownerMsigUnderThreshold += 1
-			}
-		}
-		fmt.Printf("\nTotal amount of storage provider: %v\n", len(smv))
-		fmt.Printf("Approve (#): %v\n", approveVote)
-		fmt.Printf("Reject (#): %v\n", rejectionVote)
-		fmt.Printf("SP owner is multisig and the vote is invalid due to under threshold: %v\n", ownerMsigUnderThreshold)
-		fmt.Printf("Total RPB voted: %v\n", types.BigAdd(approveRBP, rejectRBP))
-		fmt.Printf("Approve (rbp): %v\n", approveRBP)
-		fmt.Printf("Reject (rbp): %v\n", rejectRBP)
-		av := types.BigDivFloat(approveRBP, types.BigAdd(approveRBP, rejectRBP))
-		rv := types.BigDivFloat(rejectRBP, types.BigAdd(approveRBP, rejectRBP))
-		if av > 0.05 {
-			fmt.Printf("Storage Miner Group By RBP Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
-		} else {
-			fmt.Printf("Storage Miner Group By RBP Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
-		}
-
-		if !cctx.Bool("rbp-only") {
-			fmt.Printf("Total deal bytes: %v\n", approveDealBytes+rejectDealBytes)
-			fmt.Printf("Approve (deal bytes): %v\n", approveDealBytes)
-			fmt.Printf("Reject (byte): %v\n", rejectDealBytes)
-			av := float64(approveDealBytes) / float64(approveDealBytes+rejectDealBytes)
-			rv := float64(rejectDealBytes) / float64(approveDealBytes+rejectDealBytes)
-			if av > 0.05 {
-				fmt.Printf("Storage Miner Group By Deal Bytes Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
-			} else {
-				fmt.Printf("Storage Miner Group By Deal Bytes: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
-			}
-		}
-
-		return nil
-	},
-}
-var tokenHolderCmd = &cli.Command{
-	Name:      "token-holder",
-	Usage:     "get poll result for token holder group. balance includes, regular wallet accounts, multisig wallet that has valid vote that meets threshold, and the available balance of the storage miner actors that voted",
-	ArgsUsage: "[state root]",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
-		},
-	},
-	Action: func(cctx *cli.Context) error {
-		if cctx.NArg() != 2 {
-			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
-		}
-
-		ctx := context.TODO()
-		if !cctx.Args().Present() {
-			return fmt.Errorf("must pass state root")
-		}
-
-		sroot, err := cid.Decode(cctx.Args().First())
-		if err != nil {
-			return fmt.Errorf("failed to parse input: %w", err)
-		}
-
-		fsrepo, err := repo.NewFS(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		lkrepo, err := fsrepo.Lock(repo.FullNode)
-		if err != nil {
-			return err
-		}
-
-		defer lkrepo.Close() //nolint:errcheck
-
-		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
-		if err != nil {
-			return fmt.Errorf("failed to open blockstore: %w", err)
-		}
-
-		defer func() {
-			if c, ok := bs.(io.Closer); ok {
-				if err := c.Close(); err != nil {
-					log.Warnf("failed to close blockstore: %s", err)
-				}
-			}
-		}()
-
-		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
-		if err != nil {
-			return err
-		}
-
-		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
-		defer cs.Close() //nolint:errcheck
-
-		cst := cbor.NewCborStore(bs)
-		store := adt.WrapStore(ctx, cst)
-
-		tree, err := state.LoadStateTree(cst, sroot)
-		if err != nil {
-			return err
-		}
-
-		//get all the votes' signer address && their vote
-		vj, err := homedir.Expand(cctx.Args().Get(1))
-		if err != nil {
-			return xerrors.Errorf("fail to get votes json")
-		}
-		vm, err := getVotesMap(vj, tree)
-		if err != nil {
-			return xerrors.Errorf("fail to get voter map ", err)
-		}
-
-		//get all the msig signers & their msigs
-		msigs, err := getAllMsigSignerMap(tree, store)
-
-		approveVote := 0
-		rejectionVote := 0
-		approveBalance := abi.NewTokenAmount(0)
-		rejectionBalance := abi.NewTokenAmount(0)
-		msigPendingVotes := make(map[address.Address]msigVote) //map[msig ID]msigVote
-		msigFinalVotes := 0
-
-		for s, v := range vm {
-			//process votes for regular accounts
-			a, err := tree.GetActor(s)
-			if err != nil {
-				return xerrors.Errorf("fail to get account account for signer: ", err)
-			}
-			if v == APPROVE {
-				approveVote += 1
-				approveBalance = types.BigAdd(approveBalance, a.Balance)
-			} else {
-				rejectionVote += 1
-				rejectionBalance = types.BigAdd(rejectionBalance, a.Balance)
-			}
-
-			//process msigs
-			if mss, found := msigs[s]; found {
-				for _, ms := range mss { //get all the msig signer has
-					if mpv, found := msigPendingVotes[ms]; found { //other signers of the multisig have voted, yet the threshold has not met
-						if v == APPROVE {
-							if mpv.ApproveCount+1 == mpv.Multisig.Threshold { //met threshold
-								approveVote += 1
-								approveBalance = types.BigAdd(approveBalance, mpv.Multisig.Balance)
-								msigFinalVotes += 1
-								delete(msigPendingVotes, ms) //threshold, can skip later signer votes
-							} else {
-								mpv.ApproveCount += 1
-								msigPendingVotes[ms] = mpv
-							}
-						} else {
-							if mpv.RejectCount+1 == mpv.Multisig.Threshold { //met threshold
-								rejectionVote += 1
-								rejectionBalance = types.BigAdd(rejectionBalance, mpv.Multisig.Balance)
-								msigFinalVotes += 1
-								delete(msigPendingVotes, ms) //threshold, can skip later signer votes
-							} else {
-								mpv.RejectCount += 1
-								msigPendingVotes[ms] = mpv
-							}
-						}
-					} else { //first vote received from one of the signers of the msig
-						msa, err := tree.GetActor(ms)
-						if err != nil {
-							return fmt.Errorf("load msig actor failed %v", err)
-						}
-						msas, err := multisig.Load(store, msa)
-						if err != nil {
-							return fmt.Errorf("load msig failed %v", err)
-
-						}
-						t, _ := msas.Threshold()
-						if t == 1 { //met threshold with this signer's single vote
-							if v == APPROVE {
-								approveVote += 1
-								approveBalance = types.BigAdd(approveBalance, msa.Balance)
-							} else {
-								rejectionVote += 1
-								rejectionBalance = types.BigAdd(rejectionBalance, msa.Balance)
-							}
-							msigFinalVotes += 1
-						} else { //threshold not met, add to pending vote
-							if v == APPROVE {
-								msigPendingVotes[ms] = msigVote{
-									Multisig: msigBriefInfo{
-										Balance:   msa.Balance,
-										Threshold: t,
-									},
-									ApproveCount: 1,
-								}
-							} else {
-								msigPendingVotes[ms] = msigVote{
-									Multisig: msigBriefInfo{
-										Balance:   msa.Balance,
-										Threshold: t,
-									},
-									RejectCount: 1,
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// add miner available balance
-		mvs, err := getStorageMinerVotes(tree, vm, store)
-		if err != nil {
-			return xerrors.Errorf("fail to get storage miner vote ", err)
-		}
-
-		spApproveAvailableBalance := abi.NewTokenAmount(0)
-		spRejectionAvailableBalance := abi.NewTokenAmount(0)
-		for _, mv := range mvs {
-			if mv.Option == APPROVE {
-				approveVote += 1
-				approveBalance = types.BigAdd(approveBalance, mv.AvailableBalance)
-				spApproveAvailableBalance = types.BigAdd(approveBalance, spApproveAvailableBalance)
-			} else if mv.Option == Reject {
-				rejectionVote += 1
-				rejectionBalance = types.BigAdd(rejectionBalance, mv.AvailableBalance)
-				spRejectionAvailableBalance = types.BigAdd(rejectionBalance, spRejectionAvailableBalance)
-			} else {
-				continue
-			}
-		}
-
-		fmt.Printf("\nTotal amount of signer: %v\n ", len(vm))
-		fmt.Printf("Total amount of valid multisig vote: %v\n ", msigFinalVotes)
-		fmt.Printf("Total balance: %v\n", types.BigAdd(approveBalance, rejectionBalance).String())
-		fmt.Printf("Approve (#): %v\n", approveVote)
-		fmt.Printf("Reject (#): %v\n", rejectionVote)
-		fmt.Printf("Approve (FIL): %v\n", approveBalance.String())
-		fmt.Printf("Reject (FIL): %v\n", rejectionBalance.String())
-		fmt.Printf("Approve - Storage Miner Portion (FIL in account): %v\n", spApproveAvailableBalance.String())
-		fmt.Printf("Reject - Storage Miner Portion (FIL in account): %v\n", spRejectionAvailableBalance.String())
-		av := types.BigDivFloat(approveBalance, types.BigAdd(approveBalance, rejectionBalance))
-		rv := types.BigDivFloat(rejectionBalance, types.BigAdd(rejectionBalance, approveBalance))
-		if av > 0.05 {
-			fmt.Printf("Token Holder Group Result: Pass. approve: %.5f, reject: %.5f,\n", av, rv)
-		} else {
-			fmt.Printf("Token Holder Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
-		}
-		return nil
-	},
-}
-
-var clientCmd = &cli.Command{
-	Name:      "client",
-	Usage:     "get poll result for client, weighted by deal bytes that are in valid deals in the storage market.",
-	ArgsUsage: "[state root]",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
-		},
-	},
-	Action: func(cctx *cli.Context) error {
-		if cctx.NArg() != 2 {
-			return xerrors.New("filpoll0036 token-holder [state root] [votes.json]")
-		}
-
-		ctx := context.TODO()
-		if !cctx.Args().Present() {
-			return fmt.Errorf("must pass state root")
-		}
-
-		sroot, err := cid.Decode(cctx.Args().First())
-		if err != nil {
-			return fmt.Errorf("failed to parse input: %w", err)
-		}
-
-		fsrepo, err := repo.NewFS(cctx.String("repo"))
-		if err != nil {
-			return err
-		}
-
-		lkrepo, err := fsrepo.Lock(repo.FullNode)
-		if err != nil {
-			return err
-		}
-
-		defer lkrepo.Close() //nolint:errcheck
-
-		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
-		if err != nil {
-			return fmt.Errorf("failed to open blockstore: %w", err)
-		}
-
-		defer func() {
-			if c, ok := bs.(io.Closer); ok {
-				if err := c.Close(); err != nil {
-					log.Warnf("failed to close blockstore: %s", err)
-				}
-			}
-		}()
-
-		mds, err := lkrepo.Datastore(context.Background(), "/metadata")
-		if err != nil {
-			return err
-		}
-
-		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
-		defer cs.Close() //nolint:errcheck
-
-		cst := cbor.NewCborStore(bs)
-		store := adt.WrapStore(ctx, cst)
-
-		tree, err := state.LoadStateTree(cst, sroot)
-		if err != nil {
-			return err
-		}
-
-		//get all the votes' signer ID address && their voted option
-		vj, err := homedir.Expand(cctx.Args().Get(1))
-		if err != nil {
-			return xerrors.Errorf("fail to get votes json")
-		}
-		vm, err := getVotesMap(vj, tree)
-		if err != nil {
-			return xerrors.Errorf("fail to get votesrs: ", err)
-		}
-
-		//market actor
-		ma, err := tree.GetActor(market.Address)
-		if err != nil {
-			return xerrors.Errorf("fail to get market actor: ", err)
-		}
-
-		ms, err := market.Load(store, ma)
-		if err != nil {
-			return xerrors.Errorf("fail to load market actor: ", err)
-		}
-
-		//get all market proposals, add load the # of the bytes each client has made
-		dps, _ := ms.Proposals()
-		cds := make(map[address.Address]abi.PaddedPieceSize)
-		if err := dps.ForEach(func(dealID abi.DealID, d market.DealProposal) error {
-			if cd, found := cds[d.Client]; found {
-				s := d.PieceSize + cd
-				cds[d.Client] = s
-			} else {
-				cds[d.Client] = d.PieceSize
-			}
-			return xerrors.Errorf("fail to load deals")
-		}); err != nil {
-			return xerrors.Errorf("fail to get deals")
-		}
-
-		approveBytes := abi.PaddedPieceSize(0)
-		rejectionBytes := abi.PaddedPieceSize(0)
-		approveCount := 0
-		rejectionCount := 0
-		for s, o := range vm {
-			if ds, found := cds[s]; found {
-				if o == APPROVE {
-					approveBytes += ds
-					approveCount += 1
-				} else {
-					rejectionBytes += ds
-					rejectionCount += 1
-				}
-			}
-		}
-		fmt.Printf("\nTotal amount of clients: %v\n", approveCount+rejectionCount)
-		fmt.Printf("Total deal bytes: %v\n", approveBytes+rejectionBytes)
-		fmt.Printf("Approve (#): %v\n", approveCount)
-		fmt.Printf("Reject (#): %v\n", rejectionCount)
-		fmt.Printf("Approve (byte): %v\n", approveBytes)
-		fmt.Printf("Reject (byte): %v\n", rejectionBytes)
-		av := float64(approveBytes) / float64(approveBytes+rejectionBytes)
-		rv := float64(rejectionBytes) / float64(approveBytes+rejectionBytes)
-		if av > 0.05 {
-			fmt.Printf("Deal Client Group Result: Pass. approve: %.5f, reject: %.5f\n", av, rv)
-		} else {
-			fmt.Printf("Deal Client Group Result: Not Pass. approve: %.5f, reject: %.5f\n", av, rv)
-		}
-		return nil
-	},
 }

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -74,6 +74,7 @@ func main() {
 		diffCmd,
 		itestdCmd,
 		msigCmd,
+		fip0036PollResultcmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -74,7 +74,7 @@ func main() {
 		diffCmd,
 		itestdCmd,
 		msigCmd,
-		fip0036PollResultcmd,
+		fip36PollCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/msig.go
+++ b/cmd/lotus-shed/msig.go
@@ -25,7 +25,7 @@ import (
 
 type msigBriefInfo struct {
 	ID        address.Address
-	Signer    interface{}
+	Signer    []address.Address
 	Balance   abi.TokenAmount
 	Threshold uint64
 }


### PR DESCRIPTION
## Related Issues and Proposed Changes
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

This is a shed command that tabulates the results of FIP-0036. It is fed in votes from FilPoll, along with the state root and height (for this poll bafy2bzacebdnzh43hw66bmvguk65wiwr5ssaejlq44fpdei2ysfh3eefpdlqs and 2162760). See #9375 for more, this is a slight reworking of that.


## Additional Info
<!-- callouts, links to documentation, and etc-->

`lotus-shed fip36poll results --repo=/mnt/oldnet bafy2bzacebdnzh43hw66bmvguk65wiwr5ssaejlq44fpdei2ysfh3eefpdlqs 2162760 ~/Downloads/votes.json`

Sample output:

```
Total acceptance token:  3641447073483215769868470
Total rejection token:  4546494321191196771637925
Total acceptance SP deal power:  20666424631525888
Total rejection SP deal power:  141508413655663360
Total acceptance SP rb power:  3486069098389962752
Total rejection SP rb power:  2454514779633483776
Total acceptance Client rb power:  15715869958078464
Total rejection Client rb power:  29557281734075904


Final results **drumroll**
token holders REJECT FIP-0036 :(
SPs by deal data stored VETO FIP-0036!!!
SPs by total raw byte power ACCEPT FIP-0036 :)
Storage Clients REJECT FIP-0036 :(
```

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
