### PR TITLE
feat: miner paramfetch: Don't fetch param files when not needed

### DIFF
--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -94,6 +94,10 @@ func ConfigStorageMiner(c interface{}) Option {
 		Override(new(paths.Store), From(new(*paths.Remote))),
 		Override(new(dtypes.RetrievalPricingFunc), modules.RetrievalPricingFunc(cfg.Dealmaking)),
 
+		If(cfg.Subsystems.EnableMining || cfg.Subsystems.EnableSealing,
+			Override(GetParamsKey, modules.GetParams(!cfg.Proving.DisableBuiltinWindowPoSt || !cfg.Proving.DisableBuiltinWinningPoSt || cfg.Storage.AllowCommit || cfg.Storage.AllowProveReplicaUpdate2)),
+		),
+
 		If(!cfg.Subsystems.EnableMining,
 			If(cfg.Subsystems.EnableSealing, Error(xerrors.Errorf("sealing can only be enabled on a mining node"))),
 			If(cfg.Subsystems.EnableSectorStorage, Error(xerrors.Errorf("sealing can only be enabled on a mining node"))),
@@ -106,9 +110,6 @@ func ConfigStorageMiner(c interface{}) Option {
 			Override(new(storiface.Verifier), ffiwrapper.ProofVerifier),
 			Override(new(storiface.Prover), ffiwrapper.ProofProver),
 			Override(new(storiface.ProverPoSt), From(new(sectorstorage.SectorManager))),
-
-			// Sealing (todo should be under EnableSealing, but storagefsm is currently bundled with storage.Miner)
-			Override(GetParamsKey, modules.GetParams),
 
 			Override(new(dtypes.SetSealingConfigFunc), modules.NewSetSealConfigFunc),
 			Override(new(dtypes.GetSealingConfigFunc), modules.NewGetSealConfigFunc),

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -110,24 +110,31 @@ func minerAddrFromDS(ds dtypes.MetadataDS) (address.Address, error) {
 	return address.NewFromBytes(maddrb)
 }
 
-func GetParams(spt abi.RegisteredSealProof) error {
-	ssize, err := spt.SectorSize()
-	if err != nil {
-		return err
-	}
+func GetParams(prover bool) func(spt abi.RegisteredSealProof) error {
+	return func(spt abi.RegisteredSealProof) error {
+		ssize, err := spt.SectorSize()
+		if err != nil {
+			return err
+		}
 
-	// If built-in assets are disabled, we expect the user to have placed the right
-	// parameters in the right location on the filesystem (/var/tmp/filecoin-proof-parameters).
-	if build.DisableBuiltinAssets {
+		// If built-in assets are disabled, we expect the user to have placed the right
+		// parameters in the right location on the filesystem (/var/tmp/filecoin-proof-parameters).
+		if build.DisableBuiltinAssets {
+			return nil
+		}
+
+		var provingSize uint64
+		if prover {
+			provingSize = uint64(ssize)
+		}
+
+		// TODO: We should fetch the params for the actual proof type, not just based on the size.
+		if err := paramfetch.GetParams(context.TODO(), build.ParametersJSON(), build.SrsJSON(), provingSize); err != nil {
+			return xerrors.Errorf("fetching proof parameters: %w", err)
+		}
+
 		return nil
 	}
-
-	// TODO: We should fetch the params for the actual proof type, not just based on the size.
-	if err := paramfetch.GetParams(context.TODO(), build.ParametersJSON(), build.SrsJSON(), uint64(ssize)); err != nil {
-		return xerrors.Errorf("fetching proof parameters: %w", err)
-	}
-
-	return nil
 }
 
 func MinerAddress(ds dtypes.MetadataDS) (dtypes.MinerAddress, error) {


### PR DESCRIPTION
## Proposed Changes
On lotus-miner nodes with disabled local PoSt / C2 / PR2 no snarks are ever computed, which means that we don't need .param files for anything. This makes node startup much faster, reducing downtime by a lot when restarts are needed.


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
