### PR TITLE
Add retrieval deal ID and bytes transferred to retrieval output

### DIFF
--- a/cli/client_retr.go
+++ b/cli/client_retr.go
@@ -181,12 +181,14 @@ func retrieve(ctx context.Context, cctx *cli.Context, fapi lapi.FullNode, sel *l
 				event = retrievalmarket.ClientEvents[*evt.Event]
 			}
 
-			printf("Recv %s, Paid %s, %s (%s), %s\n",
+			printf("Recv %s, Paid %s, %s (%s), %s [%d|%d]\n",
 				types.SizeStr(types.NewInt(evt.BytesReceived)),
 				types.FIL(evt.TotalPaid),
 				strings.TrimPrefix(event, "ClientEvent"),
 				strings.TrimPrefix(retrievalmarket.DealStatuses[evt.Status], "DealStatus"),
 				time.Now().Sub(start).Truncate(time.Millisecond),
+				evt.ID,
+				types.NewInt(evt.BytesReceived),
 			)
 
 			switch evt.Status {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/8573

## Proposed Changes
This appends new output to the client retrival CLI;

## Example
```
Recv 0 B, Paid 0 FIL, Open (New), 0s [1664369728694055774|0]
Recv 0 B, Paid 0 FIL, DealProposed (WaitForAcceptance), 2ms [1664369728694055774|0]
Recv 0 B, Paid 0 FIL, DealAccepted (Accepted), 19ms [1664369728694055774|0]
Recv 0 B, Paid 0 FIL, PaymentChannelSkip (Ongoing), 21ms [1664369728694055774|0]
Recv 108 B, Paid 0 FIL, BlocksReceived (Ongoing), 68ms [1664369728694055774|108]
Recv 108 B, Paid 0 FIL, AllBlocksReceived (BlocksComplete), 70ms [1664369728694055774|108]
Recv 108 B, Paid 0 FIL, Complete (CheckComplete), 74ms [1664369728694055774|108]
Recv 108 B, Paid 0 FIL, CompleteVerified (FinalizingBlockstore), 76ms [1664369728694055774|108]
Recv 108 B, Paid 0 FIL, BlockstoreFinalized (Completed), 77ms [1664369728694055774|108]
```

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
