### PR TITLE
fix: cli: renew --only-cc with sectorfile

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -918,6 +918,9 @@ var sectorsRenewCmd = &cli.Command{
 				}
 
 				si, found := activeSectorsInfo[abi.SectorNumber(id)]
+				if len(si.DealIDs) > 0 && cctx.Bool("only-cc") {
+					continue
+				}
 				if !found {
 					return xerrors.Errorf("sector %d is not active", id)
 				}


### PR DESCRIPTION
## Related Issues
During testing of the v1.17.2-rc1/2 [it was uncovered](https://github.com/filecoin-project/lotus/discussions/9349#discussioncomment-3768518) that the --only-cc option does not apply when specifying sectors with a sector-file.

## Proposed Changes
Add the ability to extend/renew only CC-sectors with the `--only-cc` when using a sector-file.

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
