### PR TITLE
feat: wdpost: Add ability to only have single partition per msg for partitions with recovery sectors

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -380,11 +380,9 @@
   # A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
   # 
   # The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
-  # means that a single message can prove at most 10 partinions
+  # means that a single message can prove at most 10 partitions
   # 
-  # In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
-  # too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
-  # than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+  # Note that setting this value lower may result in less efficient gas use - more messages will be sent,
   # to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
   # 
   # Setting this value above the network limit has no effect
@@ -402,6 +400,19 @@
   # type: int
   # env var: LOTUS_PROVING_MAXPARTITIONSPERRECOVERYMESSAGE
   #MaxPartitionsPerRecoveryMessage = 0
+
+  # Enable single partition per Post Message for partitions containing recovery sectors
+  # 
+  # In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
+  # too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
+  # with recovery sectors in the post message
+  # 
+  # Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+  # to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
+  #
+  # type: bool
+  # env var: LOTUS_PROVING_SINGLERECOVERINGPARTITIONPERPOSTMESSAGE
+  #SingleRecoveringPartitionPerPostMessage = false
 
 
 [Sealing]

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -401,11 +401,11 @@
   # env var: LOTUS_PROVING_MAXPARTITIONSPERRECOVERYMESSAGE
   #MaxPartitionsPerRecoveryMessage = 0
 
-  # Enable single partition per Post Message for partitions containing recovery sectors
+  # Enable single partition per PoSt Message for partitions containing recovery sectors
   # 
   # In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
   # too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
-  # with recovery sectors in the post message
+  # with recovering sectors in the post message
   # 
   # Note that setting this value lower may result in less efficient gas use - more messages will be sent,
   # to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -719,11 +719,11 @@ resulting in more total gas use (but each message will have lower gas limit)`,
 			Name: "SingleRecoveringPartitionPerPostMessage",
 			Type: "bool",
 
-			Comment: `Enable single partition per Post Message for partitions containing recovery sectors
+			Comment: `Enable single partition per PoSt Message for partitions containing recovery sectors
 
 In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
 too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
-with recovery sectors in the post message
+with recovering sectors in the post message
 
 Note that setting this value lower may result in less efficient gas use - more messages will be sent,
 to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)`,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -698,11 +698,9 @@ After changing this option, confirm that the new value works in your setup by in
 A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
 
 The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
-means that a single message can prove at most 10 partinions
+means that a single message can prove at most 10 partitions
 
-In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
-too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
-than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+Note that setting this value lower may result in less efficient gas use - more messages will be sent,
 to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
 
 Setting this value above the network limit has no effect`,
@@ -716,6 +714,19 @@ there may be too many recoveries to fit in a BlockGasLimit.
 In those cases it may be necessary to set this value to something low (eg 1);
 Note that setting this value lower may result in less efficient gas use - more messages will be sent than needed,
 resulting in more total gas use (but each message will have lower gas limit)`,
+		},
+		{
+			Name: "SingleRecoveringPartitionPerPostMessage",
+			Type: "bool",
+
+			Comment: `Enable single partition per Post Message for partitions containing recovery sectors
+
+In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
+too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
+with recovery sectors in the post message
+
+Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)`,
 		},
 	},
 	"Pubsub": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -276,11 +276,9 @@ type ProvingConfig struct {
 	// A single partition may contain up to 2349 32GiB sectors, or 2300 64GiB sectors.
 	//
 	// The maximum number of sectors which can be proven in a single PoSt message is 25000 in network version 16, which
-	// means that a single message can prove at most 10 partinions
+	// means that a single message can prove at most 10 partitions
 	//
-	// In some cases when submitting PoSt messages which are recovering sectors, the default network limit may still be
-	// too high to fit in the block gas limit; In those cases it may be necessary to set this value to something lower
-	// than 10; Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+	// Note that setting this value lower may result in less efficient gas use - more messages will be sent,
 	// to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
 	//
 	// Setting this value above the network limit has no effect
@@ -294,6 +292,16 @@ type ProvingConfig struct {
 	// Note that setting this value lower may result in less efficient gas use - more messages will be sent than needed,
 	// resulting in more total gas use (but each message will have lower gas limit)
 	MaxPartitionsPerRecoveryMessage int
+
+	// Enable single partition per Post Message for partitions containing recovery sectors
+	//
+	// In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
+	// too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
+	// with recovery sectors in the post message
+	//
+	// Note that setting this value lower may result in less efficient gas use - more messages will be sent,
+	// to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)
+	SingleRecoveringPartitionPerPostMessage bool
 }
 
 type SealingConfig struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -293,11 +293,11 @@ type ProvingConfig struct {
 	// resulting in more total gas use (but each message will have lower gas limit)
 	MaxPartitionsPerRecoveryMessage int
 
-	// Enable single partition per Post Message for partitions containing recovery sectors
+	// Enable single partition per PoSt Message for partitions containing recovery sectors
 	//
 	// In cases when submitting PoSt messages which contain recovering sectors, the default network limit may still be
 	// too high to fit in the block gas limit. In those cases, it becomes useful to only house the single partition
-	// with recovery sectors in the post message
+	// with recovering sectors in the post message
 	//
 	// Note that setting this value lower may result in less efficient gas use - more messages will be sent,
 	// to prove each deadline, resulting in more total gas use (but each message will have lower gas limit)

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -529,8 +529,8 @@ func (s *WindowPoStScheduler) BatchPartitions(partitions []api.Partition, nv net
 	batches := [][]api.Partition{}
 
 	currBatch := []api.Partition{}
-	for i := 0; i < len(partitions); i++ {
-		recSectors, err := partitions[i].RecoveringSectors.Count()
+	for _, partition := range partitions {
+		recSectors, err := partition.RecoveringSectors.Count()
 		if err != nil {
 			return nil, err
 		}
@@ -542,13 +542,13 @@ func (s *WindowPoStScheduler) BatchPartitions(partitions []api.Partition, nv net
 				batches = append(batches, currBatch)
 				currBatch = []api.Partition{}
 			}
-			batches = append(batches, []api.Partition{partitions[i]})
+			batches = append(batches, []api.Partition{partition})
 		} else {
 			if len(currBatch) >= partitionsPerMsg {
 				batches = append(batches, currBatch)
 				currBatch = []api.Partition{}
 			}
-			currBatch = append(currBatch, partitions[i])
+			currBatch = append(currBatch, partition)
 		}
 	}
 	if len(currBatch) > 0 {

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -286,7 +286,7 @@ func (s *WindowPoStScheduler) runPoStCycle(ctx context.Context, manual bool, di 
 
 	// Split partitions into batches, so as not to exceed the number of sectors
 	// allowed in a single message
-	partitionBatches, err := s.batchPartitions(partitions, nv)
+	partitionBatches, err := s.BatchPartitions(partitions, nv)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +492,9 @@ func (s *WindowPoStScheduler) runPoStCycle(ctx context.Context, manual bool, di 
 	return posts, nil
 }
 
-func (s *WindowPoStScheduler) batchPartitions(partitions []api.Partition, nv network.Version) ([][]api.Partition, error) {
+// Note: Partition order within batches must match original partition order in order
+// for code following the user code to work
+func (s *WindowPoStScheduler) BatchPartitions(partitions []api.Partition, nv network.Version) ([][]api.Partition, error) {
 	// We don't want to exceed the number of sectors allowed in a message.
 	// So given the number of sectors in a partition, work out the number of
 	// partitions that can be in a message without exceeding sectors per
@@ -524,21 +526,33 @@ func (s *WindowPoStScheduler) batchPartitions(partitions []api.Partition, nv net
 		}
 	}
 
-	// The number of messages will be:
-	// ceiling(number of partitions / partitions per message)
-	batchCount := len(partitions) / partitionsPerMsg
-	if len(partitions)%partitionsPerMsg != 0 {
-		batchCount++
-	}
+	batches := [][]api.Partition{}
 
-	// Split the partitions into batches
-	batches := make([][]api.Partition, 0, batchCount)
-	for i := 0; i < len(partitions); i += partitionsPerMsg {
-		end := i + partitionsPerMsg
-		if end > len(partitions) {
-			end = len(partitions)
+	currBatch := []api.Partition{}
+	for i := 0; i < len(partitions); i++ {
+		recSectors, err := partitions[i].RecoveringSectors.Count()
+		if err != nil {
+			return nil, err
 		}
-		batches = append(batches, partitions[i:end])
+
+		// Only add single partition to a batch if it contains recovery sectors
+		// and has the below user config set
+		if s.singleRecoveringPartitionPerPostMessage && recSectors > 0 {
+			if len(currBatch) > 0 {
+				batches = append(batches, currBatch)
+				currBatch = []api.Partition{}
+			}
+			batches = append(batches, []api.Partition{partitions[i]})
+		} else {
+			if len(currBatch) >= partitionsPerMsg {
+				batches = append(batches, currBatch)
+				currBatch = []api.Partition{}
+			}
+			currBatch = append(currBatch, partitions[i])
+		}
+	}
+	if len(currBatch) > 0 {
+		batches = append(batches, currBatch)
 	}
 
 	return batches, nil

--- a/storage/wdpost/wdpost_sched.go
+++ b/storage/wdpost/wdpost_sched.go
@@ -64,18 +64,19 @@ type NodeAPI interface {
 // WindowPoStScheduler watches the chain though the changeHandler, which in turn
 // turn calls the scheduler when the time arrives to do work.
 type WindowPoStScheduler struct {
-	api                             NodeAPI
-	feeCfg                          config.MinerFeeConfig
-	addrSel                         *ctladdr.AddressSelector
-	prover                          storiface.ProverPoSt
-	verifier                        storiface.Verifier
-	faultTracker                    sealer.FaultTracker
-	proofType                       abi.RegisteredPoStProof
-	partitionSectors                uint64
-	disablePreChecks                bool
-	maxPartitionsPerPostMessage     int
-	maxPartitionsPerRecoveryMessage int
-	ch                              *changeHandler
+	api                                     NodeAPI
+	feeCfg                                  config.MinerFeeConfig
+	addrSel                                 *ctladdr.AddressSelector
+	prover                                  storiface.ProverPoSt
+	verifier                                storiface.Verifier
+	faultTracker                            sealer.FaultTracker
+	proofType                               abi.RegisteredPoStProof
+	partitionSectors                        uint64
+	disablePreChecks                        bool
+	maxPartitionsPerPostMessage             int
+	maxPartitionsPerRecoveryMessage         int
+	singleRecoveringPartitionPerPostMessage bool
+	ch                                      *changeHandler
 
 	actor address.Address
 
@@ -102,18 +103,19 @@ func NewWindowedPoStScheduler(api NodeAPI,
 	}
 
 	return &WindowPoStScheduler{
-		api:                             api,
-		feeCfg:                          cfg,
-		addrSel:                         as,
-		prover:                          sp,
-		verifier:                        verif,
-		faultTracker:                    ft,
-		proofType:                       mi.WindowPoStProofType,
-		partitionSectors:                mi.WindowPoStPartitionSectors,
-		disablePreChecks:                pcfg.DisableWDPoStPreChecks,
-		maxPartitionsPerPostMessage:     pcfg.MaxPartitionsPerPoStMessage,
-		maxPartitionsPerRecoveryMessage: pcfg.MaxPartitionsPerRecoveryMessage,
-		actor:                           actor,
+		api:                                     api,
+		feeCfg:                                  cfg,
+		addrSel:                                 as,
+		prover:                                  sp,
+		verifier:                                verif,
+		faultTracker:                            ft,
+		proofType:                               mi.WindowPoStProofType,
+		partitionSectors:                        mi.WindowPoStPartitionSectors,
+		disablePreChecks:                        pcfg.DisableWDPoStPreChecks,
+		maxPartitionsPerPostMessage:             pcfg.MaxPartitionsPerPoStMessage,
+		maxPartitionsPerRecoveryMessage:         pcfg.MaxPartitionsPerRecoveryMessage,
+		singleRecoveringPartitionPerPostMessage: pcfg.SingleRecoveringPartitionPerPostMessage,
+		actor:                                   actor,
 		evtTypes: [...]journal.EventType{
 			evtTypeWdPoStScheduler:  j.RegisterEventType("wdpost", "scheduler"),
 			evtTypeWdPoStProofs:     j.RegisterEventType("wdpost", "proofs_processed"),


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->
https://github.com/filecoin-project/lotus/issues/9041

## Proposed Changes
<!-- provide a clear list of the changes being made-->
Add a user config which allows partitions with recovery sectors to be the only partition in a PoST message. This helps in keeping the message gas limit lower for messages with recovery sectors which can exceed the default network limit and resulting in PoST failures


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green
