### PR TITLE
fix: EthGetTransactionCount should not return error

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -175,11 +175,11 @@ func (a *EthModule) EthGetTransactionByHash(ctx context.Context, txHash *api.Eth
 func (a *EthModule) EthGetTransactionCount(ctx context.Context, sender api.EthAddress, blkParam string) (api.EthUint64, error) {
 	addr, err := sender.ToFilecoinAddress()
 	if err != nil {
-		return api.EthUint64(0), err
+		return api.EthUint64(0), nil
 	}
 	nonce, err := a.Mpool.GetNonce(ctx, addr, types.EmptyTSK)
 	if err != nil {
-		return api.EthUint64(0), err
+		return api.EthUint64(0), nil
 	}
 	return api.EthUint64(nonce), nil
 }
@@ -415,17 +415,21 @@ func (a *EthModule) EthGasPrice(ctx context.Context) (api.EthBigInt, error) {
 }
 
 func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx api.EthBytes) (api.EthHash, error) {
+	fmt.Println(rawTx)
 	txArgs, err := api.ParseEthTxArgs(rawTx)
+	fmt.Println("txArgs", txArgs, err)
 	if err != nil {
 		return api.EmptyEthHash, err
 	}
 
 	smsg, err := txArgs.ToSignedMessage()
+	fmt.Println("smsg", smsg, err)
 	if err != nil {
 		return api.EmptyEthHash, err
 	}
 
 	cid, err := a.MpoolAPI.MpoolPush(ctx, smsg)
+	fmt.Println("cid", cid, err)
 	if err != nil {
 		return api.EmptyEthHash, err
 	}


### PR DESCRIPTION
## Proposed Changes
EthGetTransactionCount should not return error, and should return 0 when there's an error

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
