### PR TITLE
test: Add invariance checks to v17 migration test

### DIFF
--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -584,7 +584,7 @@ func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorO
 }
 
 func fromV{{.v}}SectorPreCommitOnChainInfo(v{{.v}} miner{{.v}}.SectorPreCommitOnChainInfo) minertypes.SectorPreCommitOnChainInfo {
-	return minertypes.SectorPreCommitOnChainInfo{
+	{{if (le .v 8)}}return minertypes.SectorPreCommitOnChainInfo{
 		Info:               minertypes.SectorPreCommitInfo{
 			SealProof:     v{{.v}}.Info.SealProof,
 			SectorNumber:  v{{.v}}.Info.SectorNumber,
@@ -596,7 +596,7 @@ func fromV{{.v}}SectorPreCommitOnChainInfo(v{{.v}} miner{{.v}}.SectorPreCommitOn
 		},
 		PreCommitDeposit:   v{{.v}}.PreCommitDeposit,
 		PreCommitEpoch:     v{{.v}}.PreCommitEpoch,
-	}
+	}{{else}}return v{{.v}}{{end}}
 }
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/miner/v9.go
+++ b/chain/actors/builtin/miner/v9.go
@@ -546,19 +546,7 @@ func fromV9SectorOnChainInfo(v9 miner9.SectorOnChainInfo) SectorOnChainInfo {
 }
 
 func fromV9SectorPreCommitOnChainInfo(v9 miner9.SectorPreCommitOnChainInfo) minertypes.SectorPreCommitOnChainInfo {
-	return minertypes.SectorPreCommitOnChainInfo{
-		Info: minertypes.SectorPreCommitInfo{
-			SealProof:     v9.Info.SealProof,
-			SectorNumber:  v9.Info.SectorNumber,
-			SealedCID:     v9.Info.SealedCID,
-			SealRandEpoch: v9.Info.SealRandEpoch,
-			DealIDs:       v9.Info.DealIDs,
-			Expiration:    v9.Info.Expiration,
-			UnsealedCid:   nil,
-		},
-		PreCommitDeposit: v9.PreCommitDeposit,
-		PreCommitEpoch:   v9.PreCommitEpoch,
-	}
+	return v9
 }
 
 func (s *state9) GetState() interface{} {

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -167,17 +167,17 @@ func checkStateInvariants(ctx context.Context, v8StateRoot cid.Cid, v9StateRoot 
 		return err
 	}
 
-	err = checkDatacaps(*stateTreeV8, *stateTreeV9, actorStore)
+	err = checkDatacaps(stateTreeV8, stateTreeV9, actorStore)
 	if err != nil {
 		return err
 	}
 
-	err = checkPendingVerifiedDeals(*stateTreeV8, *stateTreeV9, actorStore)
+	err = checkPendingVerifiedDeals(stateTreeV8, stateTreeV9, actorStore)
 	if err != nil {
 		return err
 	}
 
-	err = checkAllMinersUnsealedCID(*stateTreeV9, actorStore)
+	err = checkAllMinersUnsealedCID(stateTreeV9, actorStore)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func checkStateInvariants(ctx context.Context, v8StateRoot cid.Cid, v9StateRoot 
 	return nil
 }
 
-func checkDatacaps(stateTreeV8 state.StateTree, stateTreeV9 state.StateTree, actorStore adt.Store) error {
+func checkDatacaps(stateTreeV8 *state.StateTree, stateTreeV9 *state.StateTree, actorStore adt.Store) error {
 	verifregDatacaps, err := getVerifreg8Datacaps(stateTreeV8, actorStore)
 	if err != nil {
 		return err
@@ -213,7 +213,7 @@ func checkDatacaps(stateTreeV8 state.StateTree, stateTreeV9 state.StateTree, act
 	return nil
 }
 
-func getVerifreg8Datacaps(stateTreeV8 state.StateTree, actorStore adt.Store) (map[address.Address]abi.StoragePower, error) {
+func getVerifreg8Datacaps(stateTreeV8 *state.StateTree, actorStore adt.Store) (map[address.Address]abi.StoragePower, error) {
 	verifregStateV8, err := getVerifregActorV8(stateTreeV8, actorStore)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get verifreg actor state: %w", err)
@@ -231,7 +231,7 @@ func getVerifreg8Datacaps(stateTreeV8 state.StateTree, actorStore adt.Store) (ma
 	return verifregDatacaps, nil
 }
 
-func getDatacap9Datacaps(stateTreeV9 state.StateTree, actorStore adt.Store) (map[address.Address]abi.StoragePower, error) {
+func getDatacap9Datacaps(stateTreeV9 *state.StateTree, actorStore adt.Store) (map[address.Address]abi.StoragePower, error) {
 	datacapStateV9, err := getDatacapActorV9(stateTreeV9, actorStore)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get datacap actor state: %w", err)
@@ -249,7 +249,7 @@ func getDatacap9Datacaps(stateTreeV9 state.StateTree, actorStore adt.Store) (map
 	return datacaps, nil
 }
 
-func checkPendingVerifiedDeals(stateTreeV8 state.StateTree, stateTreeV9 state.StateTree, actorStore adt.Store) error {
+func checkPendingVerifiedDeals(stateTreeV8 *state.StateTree, stateTreeV9 *state.StateTree, actorStore adt.Store) error {
 	marketActorV9, err := getMarketActorV9(stateTreeV9, actorStore)
 	if err != nil {
 		return err
@@ -360,7 +360,7 @@ func checkPendingVerifiedDeals(stateTreeV8 state.StateTree, stateTreeV9 state.St
 	return nil
 }
 
-func getMarketStateV8(stateTreeV8 state.StateTree, actorStore adt.Store) (market8.State, error) {
+func getMarketStateV8(stateTreeV8 *state.StateTree, actorStore adt.Store) (market8.State, error) {
 	marketV8, err := stateTreeV8.GetActor(market.Address)
 	if err != nil {
 		return market8.State{}, err
@@ -374,7 +374,7 @@ func getMarketStateV8(stateTreeV8 state.StateTree, actorStore adt.Store) (market
 	return marketStateV8, nil
 }
 
-func getMarketStateV9(stateTreeV9 state.StateTree, actorStore adt.Store) (market9.State, error) {
+func getMarketStateV9(stateTreeV9 *state.StateTree, actorStore adt.Store) (market9.State, error) {
 	marketV9, err := stateTreeV9.GetActor(market.Address)
 	if err != nil {
 		return market9.State{}, err
@@ -388,7 +388,7 @@ func getMarketStateV9(stateTreeV9 state.StateTree, actorStore adt.Store) (market
 	return marketStateV9, nil
 }
 
-func getMarketActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (market.State, error) {
+func getMarketActorV9(stateTreeV9 *state.StateTree, actorStore adt.Store) (market.State, error) {
 	marketV9, err := stateTreeV9.GetActor(market.Address)
 	if err != nil {
 		return nil, err
@@ -397,7 +397,7 @@ func getMarketActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (market
 	return market.Load(actorStore, marketV9)
 }
 
-func getVerifregActorV8(stateTreeV8 state.StateTree, actorStore adt.Store) (verifreg.State, error) {
+func getVerifregActorV8(stateTreeV8 *state.StateTree, actorStore adt.Store) (verifreg.State, error) {
 	verifregV8, err := stateTreeV8.GetActor(verifreg.Address)
 	if err != nil {
 		return nil, err
@@ -406,7 +406,7 @@ func getVerifregActorV8(stateTreeV8 state.StateTree, actorStore adt.Store) (veri
 	return verifreg.Load(actorStore, verifregV8)
 }
 
-func getVerifregActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (verifreg.State, error) {
+func getVerifregActorV9(stateTreeV9 *state.StateTree, actorStore adt.Store) (verifreg.State, error) {
 	verifregV9, err := stateTreeV9.GetActor(verifreg.Address)
 	if err != nil {
 		return nil, err
@@ -415,7 +415,7 @@ func getVerifregActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (veri
 	return verifreg.Load(actorStore, verifregV9)
 }
 
-func getVerifregStateV9(stateTreeV9 state.StateTree, actorStore adt.Store) (verifreg9.State, error) {
+func getVerifregStateV9(stateTreeV9 *state.StateTree, actorStore adt.Store) (verifreg9.State, error) {
 	verifregV9, err := stateTreeV9.GetActor(verifreg.Address)
 	if err != nil {
 		return verifreg9.State{}, err
@@ -429,7 +429,7 @@ func getVerifregStateV9(stateTreeV9 state.StateTree, actorStore adt.Store) (veri
 	return verifregStateV9, nil
 }
 
-func getDatacapActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (datacap.State, error) {
+func getDatacapActorV9(stateTreeV9 *state.StateTree, actorStore adt.Store) (datacap.State, error) {
 	datacapV9, err := stateTreeV9.GetActor(datacap.Address)
 	if err != nil {
 		return nil, err
@@ -438,7 +438,7 @@ func getDatacapActorV9(stateTreeV9 state.StateTree, actorStore adt.Store) (datac
 	return datacap.Load(actorStore, datacapV9)
 }
 
-func checkAllMinersUnsealedCID(stateTreeV9 state.StateTree, store adt.Store) error {
+func checkAllMinersUnsealedCID(stateTreeV9 *state.StateTree, store adt.Store) error {
 	minerCodeCid, found := actors.GetActorCodeID(actorstypes.Version9, actors.MinerKey)
 	if !found {
 		return xerrors.Errorf("could not find code cid for miner actor")
@@ -457,7 +457,7 @@ func checkAllMinersUnsealedCID(stateTreeV9 state.StateTree, store adt.Store) err
 	})
 }
 
-func checkMinerUnsealedCID(act *types.Actor, stateTreeV9 state.StateTree, store adt.Store) error {
+func checkMinerUnsealedCID(act *types.Actor, stateTreeV9 *state.StateTree, store adt.Store) error {
 	minerCodeCid, found := actors.GetActorCodeID(actorstypes.Version9, actors.MinerKey)
 	if !found {
 		return xerrors.Errorf("could not find code cid for miner actor")

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -6,10 +6,9 @@ import (
 	"io"
 	"time"
 
-	cbg "github.com/whyrusleeping/cbor-gen"
-
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -145,6 +145,11 @@ var migrationsCmd = &cli.Command{
 
 		fmt.Println("new cid", newCid2)
 
+		if newCid1 != newCid2 {
+			return xerrors.Errorf("got different results with and without the cache: %s, %s", newCid1,
+				newCid2)
+		}
+
 		err = checkStateInvariants(ctx, blk.ParentStateRoot, newCid2, bs)
 		if err != nil {
 			return err

--- a/itests/pending_deal_allocation_test.go
+++ b/itests/pending_deal_allocation_test.go
@@ -194,4 +194,7 @@ func TestGetAllocationForPendingDeal(t *testing.T) {
 	for _, alloc := range allocations {
 		require.Equal(t, alloc, *allocation)
 	}
+
+	marketDeal, err := api.StateMarketStorageDeal(ctx, dealIds[0], types.EmptyTSK)
+	require.Equal(t, marketDeal.State.SectorStartEpoch, abi.ChainEpoch(-1))
 }


### PR DESCRIPTION
## Related Issues
Implements part of https://github.com/filecoin-project/lotus/issues/9246

## Proposed Changes
Tests the following invariants for the v17 migration:
- that for each pending, verified deal in v8 market, there is a corresponding allocation in v9 verifreg Allocations
- that nextAllocationID is equal to the number of pending, verified deals in v8 market
- that for each pending, verified deal in v8 market, there is a corresponding entry in v9 market PendingDealAllocationIds
- that all miners that have PreCommits with deals in them have non-nil UnsealedCid, and this CID is correctly calculated:


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
