### PR TITLE
Fix(security) : Path Traversal

### DIFF
--- a/gen/inline-gen/main.go
+++ b/gen/inline-gen/main.go
@@ -20,6 +20,10 @@ const (
 
 func main() {
 	db, err := ioutil.ReadFile(os.Args[2])
+	switch os.Args[1] {
+	case "build":
+	  err := buildCommand.Parse(os.Args[2:])
+	  bytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Unsanitized input from a CLI argument flows into io.ioutil.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.

Data is 'tainted' if it comes from an insecure source '(os.Args[2])' such as a file, the network, or the user.