### PR TITLE
fix: ux: specify arg in `net ping` cmd

### DIFF
--- a/cli/net.go
+++ b/cli/net.go
@@ -124,8 +124,9 @@ var NetPeers = &cli.Command{
 }
 
 var NetPing = &cli.Command{
-	Name:  "ping",
-	Usage: "Ping peers",
+	Name:      "ping",
+	Usage:     "Ping peers",
+	ArgsUsage: "[peerMultiaddr]",
 	Flags: []cli.Flag{
 		&cli.IntFlag{
 			Name:    "count",

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1241,7 +1241,7 @@ NAME:
    lotus-miner net ping - Ping peers
 
 USAGE:
-   lotus-miner net ping [command options] [arguments...]
+   lotus-miner net ping [command options] [peerMultiaddr]
 
 OPTIONS:
    --count value, -c value     specify the number of times it should ping (default: 10)

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2542,7 +2542,7 @@ NAME:
    lotus net ping - Ping peers
 
 USAGE:
-   lotus net ping [command options] [arguments...]
+   lotus net ping [command options] [peerMultiaddr]
 
 OPTIONS:
    --count value, -c value     specify the number of times it should ping (default: 10)


### PR DESCRIPTION
Specify that you need to ping the `peerMultiaddrs` with the `lotus net ping` and `lotus-miner net ping` commands.

## Related Issues

## Proposed Changes

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
