### PR TITLE
fix: bstore: Handle codecs correctly in membstore Get

### DIFF
--- a/blockstore/mem.go
+++ b/blockstore/mem.go
@@ -47,6 +47,9 @@ func (m MemBlockstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error)
 	if !ok {
 		return nil, ipld.ErrNotFound{Cid: k}
 	}
+	if b.Cid().Prefix().Codec != k.Prefix().Codec {
+		return blocks.NewBlockWithCid(b.RawData(), k)
+	}
 	return b, nil
 }
 

--- a/blockstore/mem_test.go
+++ b/blockstore/mem_test.go
@@ -1,0 +1,45 @@
+package blockstore
+
+import (
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemGetCodec(t *testing.T) {
+	ctx := context.Background()
+	bs := NewMemory()
+
+	cborArr := []byte{0x82, 1, 2}
+
+	h, err := mh.Sum(cborArr, mh.SHA2_256, -1)
+	require.NoError(t, err)
+
+	rawCid := cid.NewCidV1(cid.Raw, h)
+	rawBlk, err := blocks.NewBlockWithCid(cborArr, rawCid)
+	require.NoError(t, err)
+
+	err = bs.Put(ctx, rawBlk)
+	require.NoError(t, err)
+
+	cborCid := cid.NewCidV1(cid.DagCBOR, h)
+
+	cborBlk, err := bs.Get(ctx, cborCid)
+	require.NoError(t, err)
+
+	require.Equal(t, cborCid.Prefix(), cborBlk.Cid().Prefix())
+	require.EqualValues(t, cborArr, cborBlk.RawData())
+
+	// was allocated
+	require.NotEqual(t, cborBlk, rawBlk)
+
+	gotRawBlk, err := bs.Get(ctx, rawCid)
+	require.NoError(t, err)
+
+	// not allocated
+	require.Equal(t, rawBlk, gotRawBlk)
+}


### PR DESCRIPTION
## Related Issues
Initially fixed in https://github.com/filecoin-project/lotus/pull/9382, pulling this out into a smaller PR with a test

## Proposed Changes
<!-- provide a clear list of the changes being made-->


## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [ ] CI is green
