### PR TITLE
fix: actors: fix verifreg checking notary balance

### DIFF
--- a/chain/actors/builtin/verifreg/util.go
+++ b/chain/actors/builtin/verifreg/util.go
@@ -28,15 +28,8 @@ func getDataCap(store adt.Store, ver actors.Version, root rootFunc, addr address
 		return false, big.Zero(), xerrors.Errorf("loading verifreg: %w", err)
 	}
 
-	var keyedAddr abi.Keyer
-	if ver <= 8 {
-		keyedAddr = abi.AddrKey(addr)
-	} else {
-		keyedAddr = abi.IdAddrKey(addr)
-	}
-
 	var dcap abi.StoragePower
-	if found, err := vh.Get(keyedAddr, &dcap); err != nil {
+	if found, err := vh.Get(abi.AddrKey(addr), &dcap); err != nil {
 		return false, big.Zero(), xerrors.Errorf("looking up addr: %w", err)
 	} else if !found {
 		return false, big.Zero(), nil

--- a/itests/verifreg_test.go
+++ b/itests/verifreg_test.go
@@ -226,7 +226,8 @@ func TestRemoveDataCap(t *testing.T) {
 	// make the 2 verifiers
 
 	makeVerifier := func(addr address.Address) error {
-		params, aerr := actors.SerializeParams(&verifregst.AddVerifierParams{Address: addr, Allowance: big.NewInt(100000000000)})
+		allowance := big.NewInt(100000000000)
+		params, aerr := actors.SerializeParams(&verifregst.AddVerifierParams{Address: addr, Allowance: allowance})
 		require.NoError(t, aerr)
 
 		msg := &types.Message{
@@ -244,6 +245,10 @@ func TestRemoveDataCap(t *testing.T) {
 		res, err := api.StateWaitMsg(ctx, sm.Cid(), 1, lapi.LookbackNoLimit, true)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, res.Receipt.ExitCode)
+
+		verifierAllowance, err := api.StateVerifierStatus(ctx, addr, types.EmptyTSK)
+		require.NoError(t, err)
+		require.Equal(t, allowance, *verifierAllowance)
 
 		return nil
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
New datacap actor uses actorID keys instead of ID addresses. This was erroneously duplicated in verifreg actor which has no change to HAMT keys.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
