### PR TITLE
fix:mpool add gaspremium check when less than maxfee

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -218,6 +218,7 @@ func CapGasFee(mff dtypes.DefaultMaxFeeFunc, msg *types.Message, sendSpec *api.M
 	totalFee := types.BigMul(msg.GasFeeCap, gl)
 
 	if totalFee.LessThanEqual(maxFee) {
+		msg.GasPremium = big.Min(msg.GasFeeCap, msg.GasPremium) // cap premium at FeeCap
 		return
 	}
 

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -1075,3 +1075,40 @@ func TestRemoveMessage(t *testing.T) {
 		assert.Len(t, msgs, 0)
 	}
 }
+
+func TestCapGasFee(t *testing.T) {
+	t.Run("use default maxfee", func(t *testing.T) {
+		msg := &types.Message{
+			GasLimit:   100_000_000,
+			GasFeeCap:  abi.NewTokenAmount(100_000_000),
+			GasPremium: abi.NewTokenAmount(100_000),
+		}
+		CapGasFee(func() (abi.TokenAmount, error) {
+			return abi.NewTokenAmount(100_000_000_000), nil
+		}, msg, nil)
+		assert.Equal(t, msg.GasFeeCap.Int64(), int64(1000))
+		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(1000))
+	})
+
+	t.Run("use spec maxfee", func(t *testing.T) {
+		msg := &types.Message{
+			GasLimit:   100_000_000,
+			GasFeeCap:  abi.NewTokenAmount(100_000_000),
+			GasPremium: abi.NewTokenAmount(100_000),
+		}
+		CapGasFee(nil, msg, &api.MessageSendSpec{MaxFee: abi.NewTokenAmount(100_000_000_000)})
+		assert.Equal(t, msg.GasFeeCap.Int64(), int64(1000))
+		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(1000))
+	})
+
+	t.Run("use smaller feecap value when fee is enough", func(t *testing.T) {
+		msg := &types.Message{
+			GasLimit:   100_000_000,
+			GasFeeCap:  abi.NewTokenAmount(100_000),
+			GasPremium: abi.NewTokenAmount(100_000_000),
+		}
+		CapGasFee(nil, msg, &api.MessageSendSpec{MaxFee: abi.NewTokenAmount(100_000_000_000_000)})
+		assert.Equal(t, msg.GasFeeCap.Int64(), int64(100_000))
+		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(100_000))
+	})
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
in current CapGasFee, skipp gaspremium check when fee is enough
## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ x] Commits have a clear commit message.
- [x ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
