### PR TITLE
Migration: Use autobatch bs

### DIFF
--- a/blockstore/autobatch.go
+++ b/blockstore/autobatch.go
@@ -192,7 +192,7 @@ func (bs *AutobatchBlockstore) Get(ctx context.Context, c cid.Cid) (block.Block,
 		return v, nil
 	}
 
-	return bs.Get(ctx, c)
+	return nil, ipld.ErrNotFound{Cid: c}
 }
 
 func (bs *AutobatchBlockstore) DeleteBlock(context.Context, cid.Cid) error {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

The migration is taking significantly longer on machines with 64 GiB RAM or less. 

## Proposed Changes
<!-- A clear list of the changes being made -->

Use the autobatch blockstore that we created in https://github.com/filecoin-project/lotus/pull/7933 for this purpose.
Also includes a bugfix from @Kubuxu to the autobatch bs itself.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
