### PR TITLE
Eth JSON-RPC API: support f4 addresses.

### DIFF
--- a/api/eth_types.go
+++ b/api/eth_types.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 	"golang.org/x/xerrors"
@@ -22,9 +23,6 @@ import (
 )
 
 type EthUint64 uint64
-
-// EthAddressManagerActorID is the actor ID of the Ethereum Address Manager singleton.
-const EthAddressManagerActorID = 10
 
 func (e EthUint64) MarshalJSON() ([]byte, error) {
 	if e == 0 {
@@ -294,7 +292,7 @@ func (ea EthAddress) ToFilecoinAddress() (address.Address, error) {
 
 	// Otherwise, translate the address into an address controlled by the
 	// Ethereum Address Manager.
-	addr, err := address.NewDelegatedAddress(EthAddressManagerActorID, ea[:])
+	addr, err := address.NewDelegatedAddress(builtin.EthereumAddressManagerActorID, ea[:])
 	if err != nil {
 		return address.Undef, fmt.Errorf("failed to translate supplied address (%s) into a "+
 			"Filecoin f4 address: %w", hex.EncodeToString(ea[:]), err)

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/filecoin-project/go-legs v0.4.4
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.1.11-0.20221003194132-4a2ac9ff4f99
+	github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e
 	github.com/filecoin-project/go-statemachine v1.0.2
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/filecoin-project/dagstore v0.5.2
 	github.com/filecoin-project/filecoin-ffi v0.30.4-0.20200910194244-f640612a1a1f
-	github.com/filecoin-project/go-address v1.0.0
+	github.com/filecoin-project/go-address v1.0.1-0.20221019124855-ac317c37debb
 	github.com/filecoin-project/go-bitfield v0.2.4
 	github.com/filecoin-project/go-cbor-util v0.0.1
 	github.com/filecoin-project/go-commp-utils v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/filecoin-project/go-state-types v0.1.5/go.mod h1:UwGVoMsULoCK+bWjEdd/
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.8/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.10/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.1.11-0.20221003194132-4a2ac9ff4f99 h1:80V66xhPmxFxYKmvWfb2RBV80cEnxclcuynarZ6XmYI=
-github.com/filecoin-project/go-state-types v0.1.11-0.20221003194132-4a2ac9ff4f99/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
+github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e h1:Bl8982sk/ZAfoPNszIddnqjfezOJmvyiuzjMR+YhqOY=
+github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
 github.com/filecoin-project/go-statemachine v1.0.2 h1:421SSWBk8GIoCoWYYTE/d+qCWccgmRH0uXotXRDjUbc=

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/filecoin-project/dagstore v0.5.2/go.mod h1:mdqKzYrRBHf1pRMthYfMv3n37o
 github.com/filecoin-project/go-address v0.0.3/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.5/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.6/go.mod h1:7B0/5DA13n6nHkB8bbGx1gWzG/dbTsZ0fgOJVGsM3TE=
-github.com/filecoin-project/go-address v1.0.0 h1:IrexI0kpADLaPP+CdmU3CVAUqnW/FQC0KTmz4lVKiFU=
-github.com/filecoin-project/go-address v1.0.0/go.mod h1:5t3z6qPmIADZBtuE9EIzi0EwzcRy2nVhpo0I/c1r0OA=
+github.com/filecoin-project/go-address v1.0.1-0.20221019124855-ac317c37debb h1:UvHJms0aGDItERFnspu5FgKYHU7DEiLo67H2C/asrNs=
+github.com/filecoin-project/go-address v1.0.1-0.20221019124855-ac317c37debb/go.mod h1:5t3z6qPmIADZBtuE9EIzi0EwzcRy2nVhpo0I/c1r0OA=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0 h1:t6qDiuGYYngDqaLc2ZUvdtAg4UNxPeOYaXhBWSNsVaM=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0/go.mod h1:nfFPoGyX0CU9SkXX8EoCcSuHN1XcbN0c6KBh7yvP5fs=
 github.com/filecoin-project/go-amt-ipld/v3 v3.0.0/go.mod h1:Qa95YNAbtoVCTSVtX38aAC1ptBnJfPma1R/zZsKmx4o=

--- a/lib/sigs/delegated/init.go
+++ b/lib/sigs/delegated/init.go
@@ -3,6 +3,7 @@ package delegated
 import (
 	"fmt"
 
+	"github.com/filecoin-project/go-state-types/builtin"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/filecoin-project/go-address"
@@ -40,7 +41,11 @@ func (delegatedSigner) Verify(sig []byte, a address.Address, msg []byte) error {
 		return err
 	}
 
-	maybeaddr, err := address.NewSecp256k1Address(pubk)
+	hasher.Reset()
+	hasher.Write(pubk)
+	addrHash := hasher.Sum(nil)
+
+	maybeaddr, err := address.NewDelegatedAddress(builtin.EthereumAddressManagerActorID, addrHash[len(addrHash)-20:])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/filecoin-project/ref-fvm/issues/983

## Proposed Changes

Interprets addresses as Eth delegated addresses when the ID mask doesn't match.

## Additional Info

TODO depends on release of go-address.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
