### PR TITLE
feat: state: add a second premigration for nv17

### DIFF
--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -197,8 +197,13 @@ func DefaultUpgradeSchedule() stmgr.UpgradeSchedule {
 		Migration: UpgradeActorsV9,
 		PreMigrations: []stmgr.PreMigration{{
 			PreMigration:    PreUpgradeActorsV9,
-			StartWithin:     180,
+			StartWithin:     240,
 			DontStartWithin: 60,
+			StopWithin:      5,
+		}, {
+			PreMigration:    PreUpgradeActorsV9,
+			StartWithin:     15,
+			DontStartWithin: 10,
 			StopWithin:      5,
 		}},
 		Expensive: true,

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -199,7 +199,7 @@ func DefaultUpgradeSchedule() stmgr.UpgradeSchedule {
 			PreMigration:    PreUpgradeActorsV9,
 			StartWithin:     240,
 			DontStartWithin: 60,
-			StopWithin:      5,
+			StopWithin:      20,
 		}, {
 			PreMigration:    PreUpgradeActorsV9,
 			StartWithin:     15,

--- a/cmd/lotus-shed/diff.go
+++ b/cmd/lotus-shed/diff.go
@@ -91,28 +91,6 @@ var diffMinerStates = &cli.Command{
 			return err
 		}
 
-		//minerCode, err := cid.Decode("bafk2bzacedxmikgiz7du7e36vzsbmmhhozdtsucjkdo4uzkhj7nacajm33rx4")
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//minerStIntA, err := miner.Load(actorStore, &types.Actor{Head: stCidA, Code: minerCode})
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//minerStIntB, err := miner.Load(actorStore, &types.Actor{Head: stCidB, Code: minerCode})
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//dlDiff, err := miner.DiffDeadlines(minerStIntA, minerStIntB)
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//fmt.Println(dlDiff)
-
 		fmt.Println(minerStA.Deadlines)
 		fmt.Println(minerStB.Deadlines)
 
@@ -165,18 +143,6 @@ var diffMinerStates = &cli.Command{
 
 						if !ok {
 							fmt.Println(i, "isn't found in infoB!!")
-						}
-
-						if infoA.SimpleQAPower != infoB.SimpleQAPower {
-							fmt.Println("gfreak1")
-						}
-
-						if infoA.SectorKeyCID != infoB.SectorKeyCID {
-							fmt.Println("gfreak2")
-						}
-
-						if infoA.SealedCID != infoB.SealedCID {
-							fmt.Println("gfreak3")
 						}
 
 						if !infoA.DealWeight.Equals(infoB.DealWeight) {

--- a/cmd/lotus-shed/diff.go
+++ b/cmd/lotus-shed/diff.go
@@ -1,20 +1,211 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-state-types/abi"
+	miner9 "github.com/filecoin-project/go-state-types/builtin/v9/miner"
+
+	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/node/repo"
 )
 
 var diffCmd = &cli.Command{
-	Name:        "diff",
-	Usage:       "diff state objects",
-	Subcommands: []*cli.Command{diffStateTrees},
+	Name:  "diff",
+	Usage: "diff state objects",
+	Subcommands: []*cli.Command{
+		diffStateTrees,
+		diffMinerStates,
+	},
+}
+
+var diffMinerStates = &cli.Command{
+	Name:      "miner-states",
+	Usage:     "diff two miner-states",
+	ArgsUsage: "<stateCidA> <stateCidB>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := context.TODO()
+
+		if cctx.NArg() != 2 {
+			return lcli.IncorrectNumArgs(cctx)
+		}
+
+		stCidA, err := cid.Decode(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		stCidB, err := cid.Decode(cctx.Args().Get(1))
+		if err != nil {
+			return fmt.Errorf("failed to parse input: %w", err)
+		}
+
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		lkrepo, err := fsrepo.Lock(repo.FullNode)
+		if err != nil {
+			return err
+		}
+
+		defer lkrepo.Close() //nolint:errcheck
+
+		bs, err := lkrepo.Blockstore(ctx, repo.UniversalBlockstore)
+		if err != nil {
+			return fmt.Errorf("failed to open blockstore: %w", err)
+		}
+
+		defer func() {
+			if c, ok := bs.(io.Closer); ok {
+				if err := c.Close(); err != nil {
+					log.Warnf("failed to close blockstore: %s", err)
+				}
+			}
+		}()
+
+		actorStore := store.ActorStore(ctx, bs)
+
+		var minerStA miner9.State
+		if err = actorStore.Get(ctx, stCidA, &minerStA); err != nil {
+			return err
+		}
+
+		var minerStB miner9.State
+		if err = actorStore.Get(ctx, stCidB, &minerStB); err != nil {
+			return err
+		}
+
+		//minerCode, err := cid.Decode("bafk2bzacedxmikgiz7du7e36vzsbmmhhozdtsucjkdo4uzkhj7nacajm33rx4")
+		//if err != nil {
+		//	return err
+		//}
+		//
+		//minerStIntA, err := miner.Load(actorStore, &types.Actor{Head: stCidA, Code: minerCode})
+		//if err != nil {
+		//	return err
+		//}
+		//
+		//minerStIntB, err := miner.Load(actorStore, &types.Actor{Head: stCidB, Code: minerCode})
+		//if err != nil {
+		//	return err
+		//}
+		//
+		//dlDiff, err := miner.DiffDeadlines(minerStIntA, minerStIntB)
+		//if err != nil {
+		//	return err
+		//}
+		//
+		//fmt.Println(dlDiff)
+
+		fmt.Println(minerStA.Deadlines)
+		fmt.Println(minerStB.Deadlines)
+
+		minerDeadlinesA, err := minerStA.LoadDeadlines(actorStore)
+		if err != nil {
+			return err
+		}
+
+		minerDeadlinesB, err := minerStB.LoadDeadlines(actorStore)
+		if err != nil {
+			return err
+		}
+
+		for i, dACid := range minerDeadlinesA.Due {
+			dBCid := minerDeadlinesB.Due[i]
+			if dACid != dBCid {
+				fmt.Println("Difference at index ", i, dACid, " != ", dBCid)
+				dA, err := minerDeadlinesA.LoadDeadline(actorStore, uint64(i))
+				if err != nil {
+					return err
+				}
+
+				dB, err := minerDeadlinesB.LoadDeadline(actorStore, uint64(i))
+				if err != nil {
+					return err
+				}
+
+				if dA.SectorsSnapshot != dB.SectorsSnapshot {
+					fmt.Println("They differ at Sectors snapshot ", dA.SectorsSnapshot, " != ", dB.SectorsSnapshot)
+
+					sectorsSnapshotA, err := miner9.LoadSectors(actorStore, dA.SectorsSnapshot)
+					if err != nil {
+						return err
+					}
+					sectorsSnapshotB, err := miner9.LoadSectors(actorStore, dB.SectorsSnapshot)
+					if err != nil {
+						return err
+					}
+
+					if sectorsSnapshotA.Length() != sectorsSnapshotB.Length() {
+						fmt.Println("sector snapshots have different lengts!")
+					}
+
+					var infoA miner9.SectorOnChainInfo
+					err = sectorsSnapshotA.ForEach(&infoA, func(i int64) error {
+						infoB, ok, err := sectorsSnapshotB.Get(abi.SectorNumber(i))
+						if err != nil {
+							return err
+						}
+
+						if !ok {
+							fmt.Println(i, "isn't found in infoB!!")
+						}
+
+						if infoA.SimpleQAPower != infoB.SimpleQAPower {
+							fmt.Println("gfreak1")
+						}
+
+						if infoA.SectorKeyCID != infoB.SectorKeyCID {
+							fmt.Println("gfreak2")
+						}
+
+						if infoA.SealedCID != infoB.SealedCID {
+							fmt.Println("gfreak3")
+						}
+
+						if !infoA.DealWeight.Equals(infoB.DealWeight) {
+							fmt.Println("Deal Weights differ! ", infoA.DealWeight, infoB.DealWeight)
+						}
+
+						if !infoA.VerifiedDealWeight.Equals(infoB.VerifiedDealWeight) {
+							fmt.Println("Verified Deal Weights differ! ", infoA.VerifiedDealWeight, infoB.VerifiedDealWeight)
+						}
+
+						infoStrA := fmt.Sprint(infoA)
+						infoStrB := fmt.Sprint(*infoB)
+						if infoStrA != infoStrB {
+							fmt.Println(infoStrA)
+							fmt.Println(infoStrB)
+						}
+
+						return nil
+					})
+					if err != nil {
+						return err
+					}
+
+				}
+			}
+		}
+
+		return nil
+	},
 }
 
 var diffStateTrees = &cli.Command{

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -176,7 +176,7 @@ var migrationsCmd = &cli.Command{
 		fmt.Println("completed round actual (without cache), took ", uncachedMigrationTime)
 
 		if cctx.Bool("check-invariants") {
-			err = checkStateInvariants(ctx, blk.ParentStateRoot, newCid1, bs, blk.Height-1)
+			err = checkMigrationInvariants(ctx, blk.ParentStateRoot, newCid1, bs, blk.Height-1)
 			if err != nil {
 				return err
 			}
@@ -186,7 +186,7 @@ var migrationsCmd = &cli.Command{
 	},
 }
 
-func checkStateInvariants(ctx context.Context, v8StateRoot cid.Cid, v9StateRoot cid.Cid, bs blockstore.Blockstore, epoch abi.ChainEpoch) error {
+func checkMigrationInvariants(ctx context.Context, v8StateRoot cid.Cid, v9StateRoot cid.Cid, bs blockstore.Blockstore, epoch abi.ChainEpoch) error {
 	actorStore := store.ActorStore(ctx, bs)
 	startTime := time.Now()
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

More work towards optimizing the migration

## Proposed Changes
<!-- A clear list of the changes being made -->

We move the first premigration back to be 2 hours before the upgrade.
- Motivation: This is the part we _really_ care about. We do not want any users entering the upgrade without at least one premigration, if possible.

We add a second premigration 7.5 minutes before the upgrade.
- Motivation: This covers any state that's changed since the first premigration, and seems to give a 20% speed up to the actual migration time. If this doesn't complete on time, it isn't important.

This PR also adds more functionality to the lotus-shed tools around migrations and state diffs.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
