### PR TITLE
Eth TX Encoding

### DIFF
--- a/api/eth_transactions_test.go
+++ b/api/eth_transactions_test.go
@@ -63,7 +63,7 @@ func TestTxArgs(t *testing.T) {
 
 func TestTransformParams(t *testing.T) {
 	constructorParams, err := actors.SerializeParams(&evm.ConstructorParams{
-		Bytecode: mustDecodeHex("0x1122334455"),
+		Initcode: mustDecodeHex("0x1122334455"),
 	})
 	require.Nil(t, err)
 
@@ -86,7 +86,7 @@ func TestTransformParams(t *testing.T) {
 	err1 = evmParams.UnmarshalCBOR(reader1)
 	require.Nil(t, err1)
 
-	require.Equal(t, mustDecodeHex("0x1122334455"), evmParams.Bytecode)
+	require.Equal(t, mustDecodeHex("0x1122334455"), evmParams.Initcode)
 }
 func TestEcRecover(t *testing.T) {
 	rHex := "0x479ff7fa64cf8bf641eb81635d1e8a698530d2f219951d234539e6d074819529"

--- a/api/eth_types.go
+++ b/api/eth_types.go
@@ -17,7 +17,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
-	init8 "github.com/filecoin-project/go-state-types/builtin/v8/init"
+	"github.com/filecoin-project/go-state-types/builtin/v8/eam"
 
 	"github.com/filecoin-project/lotus/build"
 )
@@ -206,10 +206,14 @@ func NewEthTxReceipt(tx EthTx, lookup *MsgLookup, replay *InvocResult) (EthTxRec
 		Logs:             []string{},
 	}
 
-	contractAddr, err := CheckContractCreation(lookup)
-	if err == nil {
-		receipt.To = nil
-		receipt.ContractAddress = contractAddr
+	if receipt.To == nil && lookup.Receipt.ExitCode.IsSuccess() {
+		// Create and Create2 return the same things.
+		var ret eam.CreateReturn
+		if err := ret.UnmarshalCBOR(bytes.NewReader(lookup.Receipt.Return)); err != nil {
+			return EthTxReceipt{}, xerrors.Errorf("failed to parse contract creation result: %w", err)
+		}
+		addr := EthAddress(ret.EthAddress)
+		receipt.ContractAddress = &addr
 	}
 
 	if lookup.Receipt.ExitCode.IsSuccess() {
@@ -227,21 +231,6 @@ func NewEthTxReceipt(tx EthTx, lookup *MsgLookup, replay *InvocResult) (EthTxRec
 	effectiveGasPrice := big.Div(replay.GasCost.TotalCost, big.NewInt(lookup.Receipt.GasUsed))
 	receipt.EffectiveGasPrice = EthBigInt(effectiveGasPrice)
 	return receipt, nil
-}
-
-func CheckContractCreation(lookup *MsgLookup) (*EthAddress, error) {
-	if lookup.Receipt.ExitCode.IsError() {
-		return nil, xerrors.Errorf("message execution was not successful")
-	}
-	var result init8.ExecReturn
-	ret := bytes.NewReader(lookup.Receipt.Return)
-	if err := result.UnmarshalCBOR(ret); err == nil {
-		contractAddr, err := EthAddressFromFilecoinIDAddress(result.IDAddress)
-		if err == nil {
-			return &contractAddr, nil
-		}
-	}
-	return nil, xerrors.Errorf("not a contract creation tx")
 }
 
 const (

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -1811,7 +1811,7 @@ var ChainExecEVMCmd = &cli.Command{
 		}
 
 		constructorParams, err := actors.SerializeParams(&evm.ConstructorParams{
-			Bytecode: contract,
+			Initcode: contract,
 		})
 		if err != nil {
 			return xerrors.Errorf("failed to serialize constructor params: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba
-	github.com/whyrusleeping/cbor-gen v0.0.0-20220514204315-f29c37e9c44c
+	github.com/whyrusleeping/cbor-gen v0.0.0-20221021053955-c138aae13722
 	github.com/whyrusleeping/ledger-filecoin-go v0.9.1-0.20201010031517-c3dcc1bddce4
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	github.com/xorcare/golden v0.6.1-0.20191112154924-b87f686d7542

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/filecoin-project/go-legs v0.4.4
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e
+	github.com/filecoin-project/go-state-types v0.1.11-0.20221021072238-58379610cafe
 	github.com/filecoin-project/go-statemachine v1.0.2
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/filecoin-project/go-state-types v0.1.5/go.mod h1:UwGVoMsULoCK+bWjEdd/
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.8/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.10/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e h1:Bl8982sk/ZAfoPNszIddnqjfezOJmvyiuzjMR+YhqOY=
-github.com/filecoin-project/go-state-types v0.1.11-0.20221020121916-001de75ef54e/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
+github.com/filecoin-project/go-state-types v0.1.11-0.20221021072238-58379610cafe h1:Wmo0OMEslagGjLvRhlE64wOJIZaBGW01h1w1RATr2bo=
+github.com/filecoin-project/go-state-types v0.1.11-0.20221021072238-58379610cafe/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2-0.20220322104818-27f8fbb86dfd/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
 github.com/filecoin-project/go-statemachine v1.0.2 h1:421SSWBk8GIoCoWYYTE/d+qCWccgmRH0uXotXRDjUbc=

--- a/go.sum
+++ b/go.sum
@@ -2026,8 +2026,8 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2/go.mod h1:f
 github.com/whyrusleeping/cbor-gen v0.0.0-20210303213153-67a261a1d291/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20220323183124-98fa8256a799/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20220514204315-f29c37e9c44c h1:6VPKXBDRt7mDUyiHx9X8ROnPYFDf3L7OfEuKCI5dZDI=
-github.com/whyrusleeping/cbor-gen v0.0.0-20220514204315-f29c37e9c44c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20221021053955-c138aae13722 h1:0HEhvpGQJ2Gd0ngPW83aduQQuF/V9v13+3zpSrR3lrA=
+github.com/whyrusleeping/cbor-gen v0.0.0-20221021053955-c138aae13722/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-ctrlnet v0.0.0-20180313164037-f564fbbdaa95/go.mod h1:SJqKCCPXRfBFCwXjfNT/skfsceF7+MBFLI2OrvuRA7g=

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/builtin/v8/eam"
 	"github.com/filecoin-project/go-state-types/builtin/v8/evm"
 	init8 "github.com/filecoin-project/go-state-types/builtin/v8/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -232,7 +233,7 @@ func (a *EthModule) EthGetCode(ctx context.Context, ethAddr api.EthAddress) (api
 		From:       from,
 		To:         to,
 		Value:      big.Zero(),
-		Method:     abi.MethodNum(3), // GetBytecode
+		Method:     builtintypes.MethodsEVM.GetBytecode,
 		Params:     nil,
 		GasLimit:   build.BlockGasLimit,
 		GasFeeCap:  big.Zero(),
@@ -320,7 +321,7 @@ func (a *EthModule) EthGetStorageAt(ctx context.Context, ethAddr api.EthAddress,
 		From:       from,
 		To:         to,
 		Value:      big.Zero(),
-		Method:     abi.MethodNum(4), // GetStorageAt
+		Method:     builtintypes.MethodsEVM.GetStorageAt,
 		Params:     params,
 		GasLimit:   build.BlockGasLimit,
 		GasFeeCap:  big.Zero(),
@@ -448,7 +449,7 @@ func (a *EthModule) applyEvmMsg(ctx context.Context, tx api.EthCall) (*api.Invoc
 		//  https://github.com/filecoin-project/ref-fvm/issues/992
 		to = builtintypes.InitActorAddr
 		constructorParams, err := actors.SerializeParams(&evm.ConstructorParams{
-			Bytecode: tx.Data,
+			Initcode: tx.Data,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize constructor params: %w", err)
@@ -483,7 +484,7 @@ func (a *EthModule) applyEvmMsg(ctx context.Context, tx api.EthCall) (*api.Invoc
 		From:       from,
 		To:         to,
 		Value:      big.Int(tx.Value),
-		Method:     abi.MethodNum(2),
+		Method:     builtintypes.MethodsEVM.InvokeContract,
 		Params:     params,
 		GasLimit:   build.BlockGasLimit,
 		GasFeeCap:  big.Zero(),
@@ -633,9 +634,31 @@ func (a *EthModule) ethTxFromFilecoinMessageLookup(ctx context.Context, msgLooku
 	}
 
 	toAddr := &toEthAddr
-	_, err = api.CheckContractCreation(msgLookup)
-	if err == nil {
-		toAddr = nil
+	input := msg.Params
+	// Check to see if we need to decode as contract deployment.
+	if toFilAddr == builtintypes.EthereumAddressManagerActorAddr {
+		switch msg.Method {
+		case builtintypes.MethodsEAM.Create:
+			toAddr = nil
+			var params eam.CreateParams
+			err = params.UnmarshalCBOR(bytes.NewReader(msg.Params))
+			input = params.Initcode
+		case builtintypes.MethodsEAM.Create2:
+			toAddr = nil
+			var params eam.Create2Params
+			err = params.UnmarshalCBOR(bytes.NewReader(msg.Params))
+			input = params.Initcode
+		}
+		if err != nil {
+			return api.EthTx{}, err
+		}
+	}
+	// Otherwise, try to decode as a cbor byte array.
+	// TODO: Actually check if this is an ethereum call. This code will work for demo purposes, but is not correct.
+	if toAddr != nil {
+		if decodedParams, err := cbg.ReadByteArray(bytes.NewReader(msg.Params), uint64(len(msg.Params))); err == nil {
+			input = decodedParams
+		}
 	}
 
 	tx := api.EthTx{
@@ -653,9 +676,7 @@ func (a *EthModule) ethTxFromFilecoinMessageLookup(ctx context.Context, msgLooku
 		V:                    api.EthBytes{},
 		R:                    api.EthBytes{},
 		S:                    api.EthBytes{},
-		// TODO: this will be wrong (both for contract creation, and for normal messages).
-		// Do we fix?
-		Input: msg.Params,
+		Input:                input,
 	}
 	return tx, nil
 }


### PR DESCRIPTION
This fixes several issues with Ethereum tx encoding:

- Encode/decode tx params as CBOR (matching a similar change in the EVM).
- Fix a bunch of issues with decoding contract deployment params/returns.