### PR TITLE
_ci_: Have apt-get wait until it can get a lock in packer builds

### DIFF
--- a/tools/packer/setup-snap.sh
+++ b/tools/packer/setup-snap.sh
@@ -23,7 +23,8 @@ MANAGED_FILES=(
 )
 
 # this is required on digitalocean, which does not have snap seeded correctly at this phase.
-apt-get -y update && apt-get -y reinstall snapd
+apt-get -y -o DPkg::Lock::Timeout=3 update \
+  && apt-get -y -o DPkg::Lock::Timeout=3 reinstall snapd
 
 snap install lotus
 


### PR DESCRIPTION
## Related Issues
I've been debugging issues with the packer builds for a bit, and this is the next PR in that line. The digital ocean build was previously failing because it couldn't get an apt-get lock, I think because of some ubuntu auto-update functionality. 

## Proposed Changes
This has the packer build wait for 3 seconds and then try to get the lock again.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green