### PR TITLE
shed: include invariant checks as part of migration testing

### DIFF
--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
 	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	v9 "github.com/filecoin-project/go-state-types/builtin/v9"
 	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
 	miner9 "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
@@ -216,25 +217,25 @@ func checkMigrationInvariants(ctx context.Context, v8StateRoot cid.Cid, v9StateR
 	}
 
 	// Load the state root.
-	//var stateRoot types.StateRoot
-	//if err := actorStore.Get(ctx, v9StateRoot, &stateRoot); err != nil {
-	//	return xerrors.Errorf("failed to decode state root: %w", err)
-	//}
-	//
-	//actorCodeCids, err := actors.GetActorCodeIDs(actorstypes.Version9)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//actorTree, err := builtin.LoadTree(actorStore, stateRoot.Actors)
-	//messages, err := v9.CheckStateInvariants(actorTree, epoch, actorCodeCids)
-	//if err != nil {
-	//	return xerrors.Errorf("checking state invariants: %w", err)
-	//}
-	//
-	//for _, message := range messages.Messages() {
-	//	fmt.Println("got the following error: ", message)
-	//}
+	var stateRoot types.StateRoot
+	if err := actorStore.Get(ctx, v9StateRoot, &stateRoot); err != nil {
+		return xerrors.Errorf("failed to decode state root: %w", err)
+	}
+
+	actorCodeCids, err := actors.GetActorCodeIDs(actorstypes.Version9)
+	if err != nil {
+		return err
+	}
+
+	actorTree, err := builtin.LoadTree(actorStore, stateRoot.Actors)
+	messages, err := v9.CheckStateInvariants(actorTree, epoch, actorCodeCids)
+	if err != nil {
+		return xerrors.Errorf("checking state invariants: %w", err)
+	}
+
+	for _, message := range messages.Messages() {
+		fmt.Println("got the following error: ", message)
+	}
 
 	fmt.Println("completed invariant checks, took ", time.Since(startTime))
 

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -253,7 +253,8 @@ func checkDatacaps(stateTreeV8 *state.StateTree, stateTreeV9 *state.StateTree, a
 		return err
 	}
 
-	if len(verifregDatacaps) != len(newDatacaps) {
+	// Should have all the v8 datacaps, plus the verifreg actor itself
+	if len(verifregDatacaps)+1 != len(newDatacaps) {
 		return xerrors.Errorf("size of datacap maps do not match. verifreg: %d, datacap: %d", len(verifregDatacaps), len(newDatacaps))
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Towards #9246

## Proposed Changes
<!-- A clear list of the changes being made -->

You can now run, eg., `lotus-shed migrate-nv17 --check-invariants bafy2bzacedbxlti4ol2ipyd7nqhl5x6242xl4lt6twibwtnqmyt3ivfbub3y6`, which will invoke the full suite of invariant checks (see [here](https://github.com/filecoin-project/go-state-types/pull/100)).

Note that the checks will likely take 2-3 hours to complete, and there are currently some minor invariant failures in the power actor (inherited from v8).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
