### PR TITLE
fix: avoid returning an error when getting embryo state

### DIFF
--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -288,7 +288,8 @@ func DecodeParams(b []byte, out interface{}) error {
 }
 
 func DumpActorState(i *ActorRegistry, act *types.Actor, b []byte) (interface{}, error) {
-	if builtin.IsAccountActor(act.Code) { // Account code special case
+	// Account & Embryo code special case
+	if builtin.IsAccountActor(act.Code) || builtin.IsEmbryo(act.Code) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
We need to add full FEVM state support, but that will require merging
master. This is enough for now.

fixes https://github.com/filecoin-project/ref-fvm/issues/1022