### PR TITLE
fix: allow EthCall.From to be nil

### DIFF
--- a/api/eth_types.go
+++ b/api/eth_types.go
@@ -156,7 +156,7 @@ func NewEthBlock() EthBlock {
 }
 
 type EthCall struct {
-	From     EthAddress  `json:"from"`
+	From     *EthAddress `json:"from"`
 	To       *EthAddress `json:"to"`
 	Gas      EthUint64   `json:"gas"`
 	GasPrice EthBigInt   `json:"gasPrice"`


### PR DESCRIPTION
If it is, fill it in with a "zero" address.

NOTE: To actually work, this "zero" account will need to exist on-chain.
But that's a larger change that we can work around right now by manually
creating it.