### PR TITLE
_ci_ Remove unneeded homebrew deps

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -152,9 +152,6 @@ brews:
     description: "A homebrew cask for installing filecoin-project/lotus on MacOS"
     license: MIT
     dependencies:
-      - name: pkg-config
-      - name: jq
-      - name: bzr
       - name: hwloc
 
 # produced manually so we can include cid checksums


### PR DESCRIPTION
We don't need these homebrew deps now that we install a prebuilt binary rather than building from source.

Additionally, the bzr package was disabled.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
