### PR TITLE
feat:splitstore:single compaction that can handle prune aka two marksets one compaction

### DIFF
--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -98,6 +98,10 @@ type Config struct {
 	// and directly purges cold blocks.
 	DiscardColdBlocks bool
 
+	// UniversalColdBlocks indicates whether all blocks being garbage collected and purged
+	// from the hotstore should be written to the cold store
+	UniversalColdBlocks bool
+
 	// HotstoreMessageRetention indicates the hotstore retention policy for messages.
 	// It has the following semantics:
 	// - a value of 0 will only retain messages within the compaction boundary (4 finalities)

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -115,21 +115,6 @@ type Config struct {
 	// A positive value is the number of compactions before a full GC is performed;
 	// a value of 1 will perform full GC in every compaction.
 	HotStoreFullGCFrequency uint64
-
-	// EnableColdStoreAutoPrune turns on compaction of the cold store i.e. pruning
-	// where hotstore compaction occurs every finality epochs pruning happens every 3 finalities
-	// Default is false
-	EnableColdStoreAutoPrune bool
-
-	// ColdStoreFullGCFrequency specifies how often to performa a full (moving) GC on the coldstore.
-	// Only applies if auto prune is enabled.  A value of 0 disables while a value of 1 will do
-	// full GC in every prune.
-	// Default is 7 (about once every a week)
-	ColdStoreFullGCFrequency uint64
-
-	// ColdStoreRetention specifies the retention policy for data reachable from the chain, in
-	// finalities beyond the compaction boundary, default is 0, -1 retains everything
-	ColdStoreRetention int64
 }
 
 // ChainAccessor allows the Splitstore to access the chain. It will most likely

--- a/blockstore/splitstore/splitstore_check.go
+++ b/blockstore/splitstore/splitstore_check.go
@@ -125,7 +125,7 @@ func (s *SplitStore) doCheck(curTs *types.TipSet) error {
 			}
 
 			return nil
-		})
+		}, func(cid.Cid) error { return nil })
 
 	if err != nil {
 		err = xerrors.Errorf("error walking chain: %w", err)

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -590,7 +590,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 	coldCount := new(int64)
 	fCold := func(c cid.Cid) error {
 		// Nothing gets written to cold store during discard
-		if s.cfg.DiscardColdBlocks { // TODO || cfg.Universal , universal and discard don't write to set
+		if s.cfg.DiscardColdBlocks || s.cfg.UniversalColdBlocks {
 			return nil
 		}
 
@@ -693,7 +693,7 @@ func (s *SplitStore) doCompact(curTs *types.TipSet) error {
 			return xerrors.Errorf("error checking cold mark set for %s: %w", c, err)
 		}
 
-		if !coldMark { // TODO && !s.cfg.unversal, universal mode will just mark everything as cold
+		if !coldMark && !s.cfg.UniversalColdBlocks { // universal mode means mark everything as cold
 			return nil
 		}
 

--- a/blockstore/splitstore/splitstore_prune.go
+++ b/blockstore/splitstore/splitstore_prune.go
@@ -208,7 +208,7 @@ func (s *SplitStore) doPrune(curTs *types.TipSet, retainStateP func(int64) bool,
 	log.Info("collecting dead objects")
 	startCollect := time.Now()
 
-	deadw, err := NewColdSetWriter(s.deadSetPath())
+	deadw, err := NewColdSetWriter(s.discardSetPath())
 	if err != nil {
 		return xerrors.Errorf("error creating coldset: %w", err)
 	}
@@ -267,7 +267,7 @@ func (s *SplitStore) doPrune(curTs *types.TipSet, retainStateP func(int64) bool,
 		return err
 	}
 
-	deadr, err := NewColdSetReader(s.deadSetPath())
+	deadr, err := NewColdSetReader(s.discardSetPath())
 	if err != nil {
 		return xerrors.Errorf("error opening deadset: %w", err)
 	}
@@ -311,10 +311,10 @@ func (s *SplitStore) doPrune(curTs *types.TipSet, retainStateP func(int64) bool,
 		log.Warnf("error removing checkpoint: %s", err)
 	}
 	if err := deadr.Close(); err != nil {
-		log.Warnf("error closing deadset: %s", err)
+		log.Warnf("error closing discard set: %s", err)
 	}
-	if err := os.Remove(s.deadSetPath()); err != nil {
-		log.Warnf("error removing deadset: %s", err)
+	if err := os.Remove(s.discardSetPath()); err != nil {
+		log.Warnf("error removing discard set: %s", err)
 	}
 
 	// we are done; do some housekeeping
@@ -344,7 +344,7 @@ func (s *SplitStore) completePrune() error {
 	}
 	defer checkpoint.Close() //nolint:errcheck
 
-	deadr, err := NewColdSetReader(s.deadSetPath())
+	deadr, err := NewColdSetReader(s.discardSetPath())
 	if err != nil {
 		return xerrors.Errorf("error opening deadset: %w", err)
 	}
@@ -378,7 +378,7 @@ func (s *SplitStore) completePrune() error {
 	if err := deadr.Close(); err != nil {
 		log.Warnf("error closing deadset: %s", err)
 	}
-	if err := os.Remove(s.deadSetPath()); err != nil {
+	if err := os.Remove(s.discardSetPath()); err != nil {
 		log.Warnf("error removing deadset: %s", err)
 	}
 

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -38,6 +38,7 @@ func init() {
 func testSplitStore(t *testing.T, cfg *Config) {
 	ctx := context.Background()
 	chain := &mockChain{t: t}
+	fmt.Printf("Config: %v\n", cfg)
 
 	// the myriads of stores
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
@@ -225,7 +226,7 @@ func TestSplitStoreCompaction(t *testing.T) {
 	//stm: @SPLITSTORE_SPLITSTORE_OPEN_001, @SPLITSTORE_SPLITSTORE_CLOSE_001
 	//stm: @SPLITSTORE_SPLITSTORE_PUT_001, @SPLITSTORE_SPLITSTORE_ADD_PROTECTOR_001
 	//stm: @SPLITSTORE_SPLITSTORE_CLOSE_001
-	testSplitStore(t, &Config{MarkSetType: "map"})
+	testSplitStore(t, &Config{MarkSetType: "map", UniversalColdBlocks: true})
 }
 
 func TestSplitStoreCompactionWithBadger(t *testing.T) {
@@ -237,7 +238,7 @@ func TestSplitStoreCompactionWithBadger(t *testing.T) {
 	t.Cleanup(func() {
 		badgerMarkSetBatchSize = bs
 	})
-	testSplitStore(t, &Config{MarkSetType: "badger"})
+	testSplitStore(t, &Config{MarkSetType: "badger", UniversalColdBlocks: true})
 }
 
 func TestSplitStoreSuppressCompactionNearUpgrade(t *testing.T) {
@@ -283,7 +284,7 @@ func TestSplitStoreSuppressCompactionNearUpgrade(t *testing.T) {
 	path := t.TempDir()
 
 	// open the splitstore
-	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map"})
+	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map", UniversalColdBlocks: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +423,7 @@ func testSplitStoreReification(t *testing.T, f func(context.Context, blockstore.
 
 	path := t.TempDir()
 
-	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map"})
+	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map", UniversalColdBlocks: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,7 +523,7 @@ func testSplitStoreReificationLimit(t *testing.T, f func(context.Context, blocks
 
 	path := t.TempDir()
 
-	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map"})
+	ss, err := Open(path, ds, hot, cold, &Config{MarkSetType: "map", UniversalColdBlocks: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockstore/splitstore/splitstore_warmup.go
+++ b/blockstore/splitstore/splitstore_warmup.go
@@ -110,7 +110,7 @@ func (s *SplitStore) doWarmup(curTs *types.TipSet) error {
 			mx.Unlock()
 
 			return nil
-		})
+		}, func(cid.Cid) error { return nil })
 
 	if err != nil {
 		return err

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -166,11 +166,11 @@
 
   [Chainstore.Splitstore]
     # ColdStoreType specifies the type of the coldstore.
-    # It can be "universal" (default) or "discard" for discarding cold blocks.
+    # It can be "messages" (default) to store only messages, "universal" to store all chain state or "discard" for discarding cold blocks.
     #
     # type: string
     # env var: LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE
-    #ColdStoreType = "universal"
+    #ColdStoreType = "messages"
 
     # HotStoreType specifies the type of the hotstore.
     # Only currently supported value is "badger".
@@ -200,29 +200,5 @@
     # type: uint64
     # env var: LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREFULLGCFREQUENCY
     #HotStoreFullGCFrequency = 20
-
-    # EnableColdStoreAutoPrune turns on compaction of the cold store i.e. pruning
-    # where hotstore compaction occurs every finality epochs pruning happens every 3 finalities
-    # Default is false
-    #
-    # type: bool
-    # env var: LOTUS_CHAINSTORE_SPLITSTORE_ENABLECOLDSTOREAUTOPRUNE
-    #EnableColdStoreAutoPrune = false
-
-    # ColdStoreFullGCFrequency specifies how often to performa a full (moving) GC on the coldstore.
-    # Only applies if auto prune is enabled.  A value of 0 disables while a value of 1 will do
-    # full GC in every prune.
-    # Default is 7 (about once every a week)
-    #
-    # type: uint64
-    # env var: LOTUS_CHAINSTORE_SPLITSTORE_COLDSTOREFULLGCFREQUENCY
-    #ColdStoreFullGCFrequency = 7
-
-    # ColdStoreRetention specifies the retention policy for data reachable from the chain, in
-    # finalities beyond the compaction boundary, default is 0, -1 retains everything
-    #
-    # type: int64
-    # env var: LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORERETENTION
-    #ColdStoreRetention = 0
 
 

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -278,10 +278,14 @@ func SplitstoreUniversal() NodeOpt {
 	})
 }
 
-func SplitstoreAutoPrune() NodeOpt {
+func SplitstoreMessges() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		cfg.Chainstore.Splitstore.EnableColdStoreAutoPrune = true // turn on
-		cfg.Chainstore.Splitstore.ColdStoreFullGCFrequency = 0    // turn off full gc
+		//cfg.Chainstore.Splitstore.HotStoreType = "badger" // default
+		//cfg.Chainstore.Splitstore.MarkSetType = "badger" // default
+		//cfg.Chainstore.Splitstore.HotStoreMessageRetention = 0 // default
+		cfg.Chainstore.EnableSplitstore = true
+		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
+		cfg.Chainstore.Splitstore.ColdStoreType = "pruned"    // universal bs is coldstore, and it accepts messages
 		return nil
 	})
 }

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -256,9 +256,6 @@ type CfgOption func(cfg *config.FullNode) error
 
 func SplitstoreDiscard() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		//cfg.Chainstore.Splitstore.HotStoreType = "badger" // default
-		//cfg.Chainstore.Splitstore.MarkSetType = "badger" // default
-		//cfg.Chainstore.Splitstore.HotStoreMessageRetention = 0 // default
 		cfg.Chainstore.EnableSplitstore = true
 		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
 		cfg.Chainstore.Splitstore.ColdStoreType = "discard"   // no cold store
@@ -268,9 +265,6 @@ func SplitstoreDiscard() NodeOpt {
 
 func SplitstoreUniversal() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		//cfg.Chainstore.Splitstore.HotStoreType = "badger" // default
-		//cfg.Chainstore.Splitstore.MarkSetType = "badger" // default
-		//cfg.Chainstore.Splitstore.HotStoreMessageRetention = 0 // default
 		cfg.Chainstore.EnableSplitstore = true
 		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
 		cfg.Chainstore.Splitstore.ColdStoreType = "universal" // universal bs is coldstore
@@ -280,9 +274,6 @@ func SplitstoreUniversal() NodeOpt {
 
 func SplitstoreMessges() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		//cfg.Chainstore.Splitstore.HotStoreType = "badger" // default
-		//cfg.Chainstore.Splitstore.MarkSetType = "badger" // default
-		//cfg.Chainstore.Splitstore.HotStoreMessageRetention = 0 // default
 		cfg.Chainstore.EnableSplitstore = true
 		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
 		cfg.Chainstore.Splitstore.ColdStoreType = "messages"  // universal bs is coldstore, and it accepts messages

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -285,7 +285,7 @@ func SplitstoreMessges() NodeOpt {
 		//cfg.Chainstore.Splitstore.HotStoreMessageRetention = 0 // default
 		cfg.Chainstore.EnableSplitstore = true
 		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
-		cfg.Chainstore.Splitstore.ColdStoreType = "pruned"    // universal bs is coldstore, and it accepts messages
+		cfg.Chainstore.Splitstore.ColdStoreType = "messages"  // universal bs is coldstore, and it accepts messages
 		return nil
 	})
 }

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -63,7 +63,16 @@ func TestHotstoreCompactCleansGarbage(t *testing.T) {
 
 	// create garbage
 	g := NewGarbager(ctx, t, full)
-	garbage, e := g.Drop(ctx)
+	// state
+	garbageS, eS := g.Drop(ctx)
+	// message
+	garbageM, eM := g.Message(ctx)
+	e := eM
+	if eS > eM {
+		e = eS
+	}
+	assert.True(g.t, g.Exists(ctx, garbageS), "Garbage state not found in splitstore")
+	assert.True(g.t, g.Exists(ctx, garbageM), "Garbage message not found in splitstore")
 
 	// calculate next compaction where we should actually see cleanup
 
@@ -94,7 +103,8 @@ func TestHotstoreCompactCleansGarbage(t *testing.T) {
 	waitForCompaction(ctx, t, garbageCompactionIndex, full)
 
 	// check that garbage is cleaned up
-	assert.False(t, g.Exists(ctx, garbage), "Garbage still exists in blockstore")
+	assert.False(t, g.Exists(ctx, garbageS), "Garbage state still exists in blockstore")
+	assert.False(t, g.Exists(ctx, garbageM), "Garbage message still exists in blockstore")
 }
 
 // Create unreachable state
@@ -168,59 +178,63 @@ func TestColdStorePrune(t *testing.T) {
 	assert.False(g.t, g.Exists(ctx, garbage), "Garbage should be removed from cold store after prune but it's still there")
 }
 
-func TestAutoPrune(t *testing.T) {
-	ctx := context.Background()
-	// disable sync checking because efficient itests require that the node is out of sync : /
-	splitstore.CheckSyncGap = false
-	opts := []interface{}{kit.MockProofs(), kit.SplitstoreUniversal(), kit.SplitstoreAutoPrune(), kit.FsRepo()}
-	full, genesisMiner, ens := kit.EnsembleMinimal(t, opts...)
-	bm := ens.InterconnectAll().BeginMining(4 * time.Millisecond)[0]
-	_ = full
-	_ = genesisMiner
+func TestPruned(t *testing.T) {
 
-	// create garbage
-	g := NewGarbager(ctx, t, full)
-	garbage, e := g.Drop(ctx)
-	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
-
-	// calculate next compaction where we should actually see cleanup
-
-	// pause, check for compacting and get compaction info
-	// we do this to remove the (very unlikely) race where compaction index
-	// and compaction epoch are in the middle of update, or a whole compaction
-	// runs between the two
-	for {
-		bm.Pause()
-		if splitStoreCompacting(ctx, t, full) {
-			bm.Restart()
-			time.Sleep(3 * time.Second)
-		} else {
-			break
-		}
-	}
-	lastCompactionEpoch := splitStoreBaseEpoch(ctx, t, full)
-	garbageCompactionIndex := splitStoreCompactionIndex(ctx, t, full) + 1
-	boundary := lastCompactionEpoch + splitstore.CompactionThreshold - splitstore.CompactionBoundary
-
-	for e > boundary {
-		boundary += splitstore.CompactionThreshold - splitstore.CompactionBoundary
-		garbageCompactionIndex++
-	}
-	bm.Restart()
-
-	// wait for compaction to occur
-	waitForCompaction(ctx, t, garbageCompactionIndex, full)
-
-	bm.Pause()
-
-	// This data should now be moved to the coldstore.
-	// Access it without hotview to keep it there while checking that it still exists
-	// Only state compute uses hot view so garbager Exists backed by ChainReadObj is all good
-	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
-	bm.Restart()
-	waitForPrune(ctx, t, 1, full)
-	assert.False(g.t, g.Exists(ctx, garbage), "Garbage should be removed from cold store through auto prune but it's still there")
 }
+
+// func TestAutoPrune(t *testing.T) {
+// 	ctx := context.Background()
+// 	// disable sync checking because efficient itests require that the node is out of sync : /
+// 	splitstore.CheckSyncGap = false
+// 	opts := []interface{}{kit.MockProofs(), kit.SplitstoreUniversal(), kit.SplitstoreAutoPrune(), kit.FsRepo()}
+// 	full, genesisMiner, ens := kit.EnsembleMinimal(t, opts...)
+// 	bm := ens.InterconnectAll().BeginMining(4 * time.Millisecond)[0]
+// 	_ = full
+// 	_ = genesisMiner
+
+// 	// create garbage
+// 	g := NewGarbager(ctx, t, full)
+// 	garbage, e := g.Drop(ctx)
+// 	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
+
+// 	// calculate next compaction where we should actually see cleanup
+
+// 	// pause, check for compacting and get compaction info
+// 	// we do this to remove the (very unlikely) race where compaction index
+// 	// and compaction epoch are in the middle of update, or a whole compaction
+// 	// runs between the two
+// 	for {
+// 		bm.Pause()
+// 		if splitStoreCompacting(ctx, t, full) {
+// 			bm.Restart()
+// 			time.Sleep(3 * time.Second)
+// 		} else {
+// 			break
+// 		}
+// 	}
+// 	lastCompactionEpoch := splitStoreBaseEpoch(ctx, t, full)
+// 	garbageCompactionIndex := splitStoreCompactionIndex(ctx, t, full) + 1
+// 	boundary := lastCompactionEpoch + splitstore.CompactionThreshold - splitstore.CompactionBoundary
+
+// 	for e > boundary {
+// 		boundary += splitstore.CompactionThreshold - splitstore.CompactionBoundary
+// 		garbageCompactionIndex++
+// 	}
+// 	bm.Restart()
+
+// 	// wait for compaction to occur
+// 	waitForCompaction(ctx, t, garbageCompactionIndex, full)
+
+// 	bm.Pause()
+
+// 	// This data should now be moved to the coldstore.
+// 	// Access it without hotview to keep it there while checking that it still exists
+// 	// Only state compute uses hot view so garbager Exists backed by ChainReadObj is all good
+// 	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
+// 	bm.Restart()
+// 	waitForPrune(ctx, t, 1, full)
+// 	assert.False(g.t, g.Exists(ctx, garbage), "Garbage should be removed from cold store through auto prune but it's still there")
+// }
 
 func waitForCompaction(ctx context.Context, t *testing.T, cIdx int64, n *kit.TestFullNode) {
 	for {
@@ -304,7 +318,7 @@ func NewGarbager(ctx context.Context, t *testing.T, n *kit.TestFullNode) *Garbag
 		latest:     0,
 		maddr4Data: address.Undef,
 	}
-	g.createMiner(ctx)
+	g.createMiner4Data(ctx)
 	g.newPeerID(ctx)
 	return g
 }
@@ -318,6 +332,12 @@ func (g *Garbager) Drop(ctx context.Context) (cid.Cid, abi.ChainEpoch) {
 	// wait for message and return the chain height that the drop occurred at
 	g.latest++
 	return c, g.newPeerID(ctx)
+}
+
+// message returns the cid referencing a message and the chain epoch it went on chain
+func (g *Garbager) Message(ctx context.Context) (cid.Cid, abi.ChainEpoch) {
+	mw := g.createMiner(ctx)
+	return mw.Message, mw.Height
 }
 
 // exists checks whether the cid is reachable through the node
@@ -374,8 +394,15 @@ func (g *Garbager) mInfoCid(ctx context.Context) cid.Cid {
 	return mSt.Info
 }
 
-func (g *Garbager) createMiner(ctx context.Context) {
+func (g *Garbager) createMiner4Data(ctx context.Context) {
 	require.True(g.t, g.maddr4Data == address.Undef, "garbager miner actor already created")
+	mw := g.createMiner(ctx)
+	var retval power6.CreateMinerReturn
+	require.NoError(g.t, retval.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)))
+	g.maddr4Data = retval.IDAddress
+}
+
+func (g *Garbager) createMiner(ctx context.Context) *lapi.MsgLookup {
 	owner, err := g.node.WalletDefaultAddress(ctx)
 	require.NoError(g.t, err)
 	worker := owner
@@ -401,8 +428,5 @@ func (g *Garbager) createMiner(ctx context.Context) {
 	mw, err := g.node.StateWaitMsg(ctx, signed.Cid(), build.MessageConfidence, lapi.LookbackNoLimit, true)
 	require.NoError(g.t, err)
 	require.True(g.t, mw.Receipt.ExitCode == 0, "garbager's internal create miner message failed")
-
-	var retval power6.CreateMinerReturn
-	require.NoError(g.t, retval.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)))
-	g.maddr4Data = retval.IDAddress
+	return mw
 }

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -249,60 +249,6 @@ func TestMessagesMode(t *testing.T) {
 	assert.True(g.t, g.Exists(ctx, garbageM), "Garbage message not found in splitstore")
 }
 
-// func TestAutoPrune(t *testing.T) {
-// 	ctx := context.Background()
-// 	// disable sync checking because efficient itests require that the node is out of sync : /
-// 	splitstore.CheckSyncGap = false
-// 	opts := []interface{}{kit.MockProofs(), kit.SplitstoreUniversal(), kit.SplitstoreAutoPrune(), kit.FsRepo()}
-// 	full, genesisMiner, ens := kit.EnsembleMinimal(t, opts...)
-// 	bm := ens.InterconnectAll().BeginMining(4 * time.Millisecond)[0]
-// 	_ = full
-// 	_ = genesisMiner
-
-// 	// create garbage
-// 	g := NewGarbager(ctx, t, full)
-// 	garbage, e := g.Drop(ctx)
-// 	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
-
-// 	// calculate next compaction where we should actually see cleanup
-
-// 	// pause, check for compacting and get compaction info
-// 	// we do this to remove the (very unlikely) race where compaction index
-// 	// and compaction epoch are in the middle of update, or a whole compaction
-// 	// runs between the two
-// 	for {
-// 		bm.Pause()
-// 		if splitStoreCompacting(ctx, t, full) {
-// 			bm.Restart()
-// 			time.Sleep(3 * time.Second)
-// 		} else {
-// 			break
-// 		}
-// 	}
-// 	lastCompactionEpoch := splitStoreBaseEpoch(ctx, t, full)
-// 	garbageCompactionIndex := splitStoreCompactionIndex(ctx, t, full) + 1
-// 	boundary := lastCompactionEpoch + splitstore.CompactionThreshold - splitstore.CompactionBoundary
-
-// 	for e > boundary {
-// 		boundary += splitstore.CompactionThreshold - splitstore.CompactionBoundary
-// 		garbageCompactionIndex++
-// 	}
-// 	bm.Restart()
-
-// 	// wait for compaction to occur
-// 	waitForCompaction(ctx, t, garbageCompactionIndex, full)
-
-// 	bm.Pause()
-
-// 	// This data should now be moved to the coldstore.
-// 	// Access it without hotview to keep it there while checking that it still exists
-// 	// Only state compute uses hot view so garbager Exists backed by ChainReadObj is all good
-// 	assert.True(g.t, g.Exists(ctx, garbage), "Garbage not found in splitstore")
-// 	bm.Restart()
-// 	waitForPrune(ctx, t, 1, full)
-// 	assert.False(g.t, g.Exists(ctx, garbage), "Garbage should be removed from cold store through auto prune but it's still there")
-// }
-
 func waitForCompaction(ctx context.Context, t *testing.T, cIdx int64, n *kit.TestFullNode) {
 	for {
 		if splitStoreCompactionIndex(ctx, t, n) >= cIdx {

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -181,7 +181,7 @@ func ConfigFullNode(c interface{}) Option {
 		Override(new(dtypes.UniversalBlockstore), modules.UniversalBlockstore),
 
 		If(cfg.Chainstore.EnableSplitstore,
-			If(cfg.Chainstore.Splitstore.ColdStoreType == "universal",
+			If(cfg.Chainstore.Splitstore.ColdStoreType == "universal" || cfg.Chainstore.Splitstore.ColdStoreType == "messages",
 				Override(new(dtypes.ColdBlockstore), From(new(dtypes.UniversalBlockstore)))),
 			If(cfg.Chainstore.Splitstore.ColdStoreType == "discard",
 				Override(new(dtypes.ColdBlockstore), modules.DiscardColdBlockstore)),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -91,12 +91,11 @@ func DefaultFullNode() *FullNode {
 		Chainstore: Chainstore{
 			EnableSplitstore: false,
 			Splitstore: Splitstore{
-				ColdStoreType: "universal",
+				ColdStoreType: "pruned",
 				HotStoreType:  "badger",
 				MarkSetType:   "badger",
 
-				HotStoreFullGCFrequency:  20,
-				ColdStoreFullGCFrequency: 7,
+				HotStoreFullGCFrequency: 20,
 			},
 		},
 	}

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -91,7 +91,7 @@ func DefaultFullNode() *FullNode {
 		Chainstore: Chainstore{
 			EnableSplitstore: false,
 			Splitstore: Splitstore{
-				ColdStoreType: "pruned",
+				ColdStoreType: "messages",
 				HotStoreType:  "badger",
 				MarkSetType:   "badger",
 

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1116,7 +1116,7 @@ submitting proofs to the chain individually`,
 			Type: "string",
 
 			Comment: `ColdStoreType specifies the type of the coldstore.
-It can be "universal" (default) or "discard" for discarding cold blocks.`,
+It can be "messages" (default) to store only messages, "universal" to store all chain state or "discard" for discarding cold blocks.`,
 		},
 		{
 			Name: "HotStoreType",
@@ -1146,30 +1146,6 @@ the compaction boundary; default is 0.`,
 			Comment: `HotStoreFullGCFrequency specifies how often to perform a full (moving) GC on the hotstore.
 A value of 0 disables, while a value 1 will do full GC in every compaction.
 Default is 20 (about once a week).`,
-		},
-		{
-			Name: "EnableColdStoreAutoPrune",
-			Type: "bool",
-
-			Comment: `EnableColdStoreAutoPrune turns on compaction of the cold store i.e. pruning
-where hotstore compaction occurs every finality epochs pruning happens every 3 finalities
-Default is false`,
-		},
-		{
-			Name: "ColdStoreFullGCFrequency",
-			Type: "uint64",
-
-			Comment: `ColdStoreFullGCFrequency specifies how often to performa a full (moving) GC on the coldstore.
-Only applies if auto prune is enabled.  A value of 0 disables while a value of 1 will do
-full GC in every prune.
-Default is 7 (about once every a week)`,
-		},
-		{
-			Name: "ColdStoreRetention",
-			Type: "int64",
-
-			Comment: `ColdStoreRetention specifies the retention policy for data reachable from the chain, in
-finalities beyond the compaction boundary, default is 0, -1 retains everything`,
 		},
 	},
 	"StorageMiner": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -555,7 +555,7 @@ type Chainstore struct {
 
 type Splitstore struct {
 	// ColdStoreType specifies the type of the coldstore.
-	// It can be "universal" (default) or "discard" for discarding cold blocks.
+	// It can be "messages" (default) to store only messages, "universal" to store all chain state or "discard" for discarding cold blocks.
 	ColdStoreType string
 	// HotStoreType specifies the type of the hotstore.
 	// Only currently supported value is "badger".
@@ -571,21 +571,6 @@ type Splitstore struct {
 	// A value of 0 disables, while a value 1 will do full GC in every compaction.
 	// Default is 20 (about once a week).
 	HotStoreFullGCFrequency uint64
-
-	// EnableColdStoreAutoPrune turns on compaction of the cold store i.e. pruning
-	// where hotstore compaction occurs every finality epochs pruning happens every 3 finalities
-	// Default is false
-	EnableColdStoreAutoPrune bool
-
-	// ColdStoreFullGCFrequency specifies how often to performa a full (moving) GC on the coldstore.
-	// Only applies if auto prune is enabled.  A value of 0 disables while a value of 1 will do
-	// full GC in every prune.
-	// Default is 7 (about once every a week)
-	ColdStoreFullGCFrequency uint64
-
-	// ColdStoreRetention specifies the retention policy for data reachable from the chain, in
-	// finalities beyond the compaction boundary, default is 0, -1 retains everything
-	ColdStoreRetention int64
 }
 
 // // Full Node

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -84,11 +84,9 @@ func SplitBlockstore(cfg *config.Chainstore) func(lc fx.Lifecycle, r repo.Locked
 		cfg := &splitstore.Config{
 			MarkSetType:              cfg.Splitstore.MarkSetType,
 			DiscardColdBlocks:        cfg.Splitstore.ColdStoreType == "discard",
+			UniversalColdBlocks:      cfg.Splitstore.ColdStoreType == "universal",
 			HotStoreMessageRetention: cfg.Splitstore.HotStoreMessageRetention,
 			HotStoreFullGCFrequency:  cfg.Splitstore.HotStoreFullGCFrequency,
-			EnableColdStoreAutoPrune: cfg.Splitstore.EnableColdStoreAutoPrune,
-			ColdStoreFullGCFrequency: cfg.Splitstore.ColdStoreFullGCFrequency,
-			ColdStoreRetention:       cfg.Splitstore.ColdStoreRetention,
 		}
 		ss, err := splitstore.Open(path, ds, hot, cold, cfg)
 		if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Discussion kicked off here: https://github.com/filecoin-project/lotus/discussions/9128

## Proposed Changes
<!-- A clear list of the changes being made -->
Prune mode is now just a 3rd mode next to `discard` and `universal`.  There is only ever one compaction running so no need to add 3 new knobs to splitstore config.  

## Additional Info
<!-- Callouts, links to documentation, and etc -->

A quick conversation with @TippyFlitsUK supports the hypothesis that this minimal configuration strategy is a better all around approach.
## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
