### PR TITLE
fix: stmgr: bubble up errors properly from ApplyImplicitMessage

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -133,7 +133,9 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 
 	// TODO: maybe just use the invoker directly?
 	ret, err := vmi.ApplyImplicitMessage(ctx, msg)
-	// Don't check for error here, we want to bubble it up, but also return ret as an InvocResult
+	if err != nil && ret == nil {
+		return nil, xerrors.Errorf("apply message failed: %w", err)
+	}
 
 	var errs string
 	if ret.ActorErr != nil {


### PR DESCRIPTION
## Related Issues
@simlecode pointed out that the change in https://github.com/filecoin-project/lotus/pull/9557 does not properly bubble up some errors because ret can be nil.

## Proposed Changes
Bubbles up real errors but allows us to return the call information when the call itself errors.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
