### PR TITLE
chore: calibnet: update calibnet upgrade heights

### DIFF
--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -61,16 +61,16 @@ const UpgradeTurboHeight = 390
 
 const UpgradeHyperdriveHeight = 420
 
-const UpgradeChocolateHeight = 312746
+const UpgradeChocolateHeight = 450
 
 // 2022-02-10T19:23:00Z
-const UpgradeOhSnapHeight = 682006
+const UpgradeOhSnapHeight = 480
 
 // 2022-06-16T17:30:00Z
-const UpgradeSkyrHeight = 1044660
+const UpgradeSkyrHeight = 510
 
 // 2022-10-20T16:00:07Z
-const UpgradeSharkHeight = 1407374
+const UpgradeSharkHeight = 20670 // 20160 + 510
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -63,14 +63,11 @@ const UpgradeHyperdriveHeight = 420
 
 const UpgradeChocolateHeight = 450
 
-// 2022-02-10T19:23:00Z
 const UpgradeOhSnapHeight = 480
 
-// 2022-06-16T17:30:00Z
 const UpgradeSkyrHeight = 510
 
-// 2022-10-20T16:00:07Z
-const UpgradeSharkHeight = 20670 // 20160 + 510
+const UpgradeSharkHeight = 16800 // 6 days after genesis
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Change calibnet upgrade schedule. We will quickly upgrade up to nv16. The nv17 upgrade will be one week later, on Tuesday November 8.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
