### PR TITLE
fix:add UnmarshalJSON for EthNonce

### DIFF
--- a/api/eth_types.go
+++ b/api/eth_types.go
@@ -249,6 +249,25 @@ func (n EthNonce) MarshalJSON() ([]byte, error) {
 	return json.Marshal(n.String())
 }
 
+func (n *EthNonce) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	s = strings.Replace(s, "0x", "", -1)
+	if len(s)%2 == 1 {
+		s = "0" + s
+	}
+
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	copy(n[:], decoded[:8])
+	return nil
+}
+
 type EthAddress [EthAddressLength]byte
 
 func (ea EthAddress) String() string {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
`EthNonce` needs to have an `UnmarshalJSON` method, otherwise deserializing json will report an error:
```
unmarshaling result: json: cannot unmarshal string into Go struct field EthBlock.nonce of type api.EthNonce
```

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
