### PR TITLE
backport: fix: Allow setting local bundles for Debug FVM for AV9+

### DIFF
--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -39,7 +39,6 @@ import (
 
 var _ Interface = (*FVM)(nil)
 var _ ffi_cgo.Externs = (*FvmExtern)(nil)
-var debugBundleV8path = os.Getenv("LOTUS_FVM_DEBUG_BUNDLE_V8")
 
 type FvmExtern struct {
 	Rand
@@ -423,12 +422,10 @@ func NewDebugFVM(ctx context.Context, opts *VMOpts) (*FVM, error) {
 		return nil, xerrors.Errorf("error determining actors version for network version %d: %w", opts.NetworkVersion, err)
 	}
 
-	switch av {
-	case actorstypes.Version8:
-		if debugBundleV8path != "" {
-			if err := createMapping(debugBundleV8path); err != nil {
-				log.Errorf("failed to create v8 debug mapping")
-			}
+	debugBundlePath := os.Getenv(fmt.Sprintf("LOTUS_FVM_DEBUG_BUNDLE_V%d", av))
+	if debugBundlePath != "" {
+		if err := createMapping(debugBundlePath); err != nil {
+			log.Errorf("failed to create v%d debug mapping", av)
 		}
 	}
 


### PR DESCRIPTION
## Related Issues
Backports https://github.com/filecoin-project/lotus/pull/9509

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
