### PR TITLE
api: ethrpc: fix a potential panic when querying block info

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -659,7 +659,7 @@ func (a *EthModule) ethBlockFromFilecoinTipSet(ctx context.Context, ts *types.Ti
 	for _, blkMsg := range blkMsgs {
 		for _, msg := range append(blkMsg.BlsMessages, blkMsg.SecpkMessages...) {
 			msgLookup, err := a.StateAPI.StateSearchMsg(ctx, types.EmptyTSK, msg.Cid(), api.LookbackNoLimit, true)
-			if err != nil {
+			if err != nil || msgLookup == nil {
 				return api.EthBlock{}, nil
 			}
 			gasUsed += msgLookup.Receipt.GasUsed


### PR DESCRIPTION
## Proposed Changes
fix a potential panic when querying block info

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green