### PR TITLE
_ci_ Refactor release pipeline to better support m1 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,6 @@ executors:
 
 
 commands:
-  install-deps:
-    steps:
-      - run: |
-          sudo apt update
-          sudo apt install python-is-python3
   prepare:
     parameters:
       linux:
@@ -41,9 +36,8 @@ commands:
     steps:
       - checkout
       - git_fetch_all_tags
-      - checkout
       - when:
-          condition: << parameters.linux >>
+          condition: <<parameters.linux>>
           steps:
             - run:
                 name: Check Go Version
@@ -56,6 +50,8 @@ commands:
                   fi
             - run: sudo apt-get update
             - run: sudo apt-get install ocl-icd-opencl-dev libhwloc-dev
+            - run: sudo apt-get install python-is-python3
+
       - when:
           condition: <<parameters.darwin>>
           steps:
@@ -70,21 +66,12 @@ commands:
                   echo 'export GOPATH="${HOME}/go"' >> $BASH_ENV
             - run: go version
             - run:
-                name: Install pkg-config, goreleaser, and sha512sum
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser coreutils
+                name: Install dependencies with Homebrew
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils hwloc jq
             - run:
                 name: Install Rust
                 command: |
                   curl https://sh.rustup.rs -sSf | sh -s -- -y
-            - run:
-                name: Install hwloc
-                command: |
-                  mkdir ~/hwloc
-                  curl --location https://download.open-mpi.org/release/hwloc/v2.4/hwloc-2.4.1.tar.gz --output ~/hwloc/hwloc-2.4.1.tar.gz
-                  cd ~/hwloc
-                  tar -xvzpf hwloc-2.4.1.tar.gz
-                  cd hwloc-2.4.1
-                  ./configure && make && sudo make install
       - run: git submodule sync
       - run: git submodule update --init
   download-params:
@@ -156,7 +143,6 @@ jobs:
   mod-tidy-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: go mod tidy -v
       - run:
@@ -164,34 +150,9 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
-  build-linux:
-    executor: golang
-    steps:
-      - install-deps
-      - prepare
-      - run: sudo apt-get update
-      - run: sudo apt-get install npm
-      - run:
-          command: make buildall
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - store_artifacts:
-          path: lotus
-      - store_artifacts:
-          path: lotus-miner
-      - store_artifacts:
-          path: lotus-worker
-      - run: mkdir linux && mv lotus lotus-miner lotus-worker linux/
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux
-
   build-debug:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run:
           command: make debug
@@ -224,7 +185,6 @@ jobs:
         description: gotestsum format. https://github.com/gotestyourself/gotestsum#format
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps lotus
@@ -268,7 +228,6 @@ jobs:
           submodule is used.
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps lotus
@@ -311,36 +270,6 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
-  build-ntwk-calibration:
-    description: |
-      Compile lotus binaries for the calibration network
-    parameters:
-      <<: *test-params
-    executor: << parameters.executor >>
-    steps:
-      - install-deps
-      - prepare
-      - run: make calibnet
-      - run: mkdir linux-calibrationnet && mv lotus lotus-miner lotus-worker linux-calibrationnet
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux-calibrationnet
-  build-ntwk-butterfly:
-    description: |
-      Compile lotus binaries for the butterfly network
-    parameters:
-      <<: *test-params
-    executor: << parameters.executor >>
-    steps:
-      - install-deps
-      - prepare
-      - run: make butterflynet
-      - run: mkdir linux-butterflynet && mv lotus lotus-miner lotus-worker linux-butterflynet
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux-butterflynet
   build-lotus-soup:
     description: |
       Compile `lotus-soup` Testground test plan
@@ -348,7 +277,6 @@ jobs:
       <<: *test-params
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run: cd extern/filecoin-ffi && make
       - run:
@@ -364,7 +292,6 @@ jobs:
       <<: *test-params
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           name: "download testground"
@@ -384,16 +311,30 @@ jobs:
       - run:
           name: "trigger payment channel stress testplan on taas"
           command: ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/paych-stress-k8s.toml --metadata-commit=$CIRCLE_SHA1 --metadata-repo=filecoin-project/lotus --metadata-branch=$CIRCLE_BRANCH
-  build-macos:
+
+  build-linux-amd64:
+    executor: golang
+    steps:
+      - prepare
+      - run: sudo apt-get update
+      - run: sudo apt-get install npm
+      - run: make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
+      - run: |
+          mkdir -p /tmp/workspace/linux_amd64_v1 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/linux_amd64_v1/
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - linux_amd64_v1
+
+  build-darwin-amd64:
     description: build darwin lotus binary
-    parameters:
-      publish:
-        default: false
-        description: publish github release and homebrew?
-        type: boolean
+    working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
     steps:
       - prepare:
           linux: false
@@ -402,30 +343,61 @@ jobs:
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-      - when:
-          condition: << parameters.publish >>
-          steps:
-            - run: goreleaser release --rm-dist
-            - run: ./scripts/generate-checksums.sh
-            - run: ./scripts/publish-checksums.sh
-      - when:
-          condition:
-            not: << parameters.publish >>
-          steps:
-            - run: goreleaser release --rm-dist --snapshot
-            - run: ./scripts/generate-checksums.sh
-      - store_artifacts:
-          path: dist
+      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
       - persist_to_workspace:
-          root: "."
+          root: /tmp/workspace
           paths:
-            - dist
+            - darwin_amd64_v1
       - save_cache:
           name: save cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
           paths:
             - "~/.rustup"
             - "~/.cargo"
+
+  build-darwin-arm64:
+    description: self-hosted m1 runner
+    working_directory: ~/go/src/github.com/filecoin-project/lotus
+    machine: true
+    resource_class: filecoin-project/self-hosted-m1
+    steps:
+      - run: echo 'export PATH=/opt/homebrew/bin:"$PATH"' >> "$BASH_ENV"
+      - prepare:
+          linux: false
+          darwin: true
+      - install_ipfs_macos
+      - restore_cache:
+          name: restore cargo cache
+          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
+      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          mkdir -p /tmp/workspace/darwin_arm64 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - darwin_arm64
+      - save_cache:
+          name: save cargo cache
+          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
+          paths:
+            - "~/.rustup"
+            - "~/.cargo"
+      - run:
+          command: make clean
+          when: always
+
+  release:
+    executor: golang
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: goreleaser release --rm-dist --snapshot
+      - run: ./scripts/generate-checksums.sh
+      - run: ./scripts/publish-checksums.sh
 
   build-appimage:
     machine:
@@ -482,7 +454,6 @@ jobs:
   gofmt:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run:
           command: "! go fmt ./... 2>&1 | read"
@@ -490,7 +461,6 @@ jobs:
   gen-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
@@ -505,7 +475,6 @@ jobs:
   docs-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
@@ -542,7 +511,6 @@ jobs:
           Arguments to pass to golangci-lint
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps
@@ -1121,65 +1089,66 @@ workflows:
               only:
                 - master
       - build-debug
-      - build-linux:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-ntwk-calibration:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-ntwk-butterfly:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-lotus-soup
-      - build-macos:
-          name: publish-macos
-          publish: true
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+$/
-      - build-macos:
+
+      - build-linux-amd64:
+          name: "Build ( linux / amd64 )"
           filters:
             branches:
               only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+-rc\d+$/
-      - build-appimage:
-          filters:
-            branches:
-              only:
+                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - publish:
-          name: publish-linux
-          linux: true
+      - build-darwin-amd64:
+          name: "Build ( darwin / amd64 )"
+          filters:
+            branches:
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - build-darwin-arm64:
+          name: "Build ( darwin / arm64 )"
+          filters:
+            branches:
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - release:
+          name: "Release"
           requires:
-            - build-linux
+            - "Build ( darwin / amd64 )"
+            - "Build ( linux / amd64 )"
+            - "Build ( darwin / arm64 )"
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - build-appimage:
+          name: "Build AppImage"
+          filters:
+            branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
-          name: publish-appimage
+          name: "Publish AppImage"
           appimage: true
           requires:
-            - build-appimage
+            - "Build AppImage"
           filters:
             branches:
               ignore:
@@ -1188,14 +1157,14 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-and-push-image:
-          name: build-and-push/lotus-all-in-one
+          name: "Publish ECR (lotus-all-in-one)"
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-dev
           tag: '${CIRCLE_SHA1:0:8}'
           target: lotus-all-in-one
       - build-and-push-image:
-          name: build-and-push/lotus-test
+          name: "Publish ECR (lotus-test)"
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-test
@@ -1246,7 +1215,7 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
       - publish-dockerhub:
-          name: publish-dockerhub
+          name: "Publish Dockerhub (stable)"
           tag: stable
           filters:
             branches:
@@ -1254,7 +1223,17 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^v\d+\.\d+\.\d+$/
+      - publish-dockerhub:
+          name: "Publish Dockerhub (candidate)"
+          tag: candidate
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils hwloc jq
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
             - run:
                 name: Install Rust
                 command: |
@@ -372,7 +372,10 @@ jobs:
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          export CPATH=$(brew --prefix)/include
+          export LIBRARY_PATH=$(brew --prefix)/lib
+          make lotus lotus-miner lotus-worker
       - run: |
           mkdir -p /tmp/workspace/darwin_arm64 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
@@ -389,15 +392,33 @@ jobs:
       - run:
           command: make clean
           when: always
+      - run:
+          name: cleanup homebrew
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+          when: always
 
   release:
     executor: golang
+    parameters:
+      dry-run:
+        default: false
+        description: should this release actually publish it's artifacts?
+        type: boolean
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: goreleaser release --rm-dist --snapshot
-      - run: ./scripts/generate-checksums.sh
-      - run: ./scripts/publish-checksums.sh
+      - when:
+          condition: << parameters.dry-run >>
+          steps:
+            - run: goreleaser release --rm-dist --snapshot
+            - run: ./scripts/generate-checksums.sh
+      - when:
+          condition:
+            not: << parameters.dry-run >>
+          steps:
+            - run: goreleaser release --rm-dist
+            - run: ./scripts/generate-checksums.sh
+            - run: ./scripts/publish-checksums.sh
 
   build-appimage:
     machine:
@@ -1122,7 +1143,8 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
-          name: "Release"
+          name: "Release (dry-run)"
+          dry-run: true
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: "."
+          at: /tmp/workspace
       - run:
           name: Update Go
           command: |
@@ -449,13 +449,11 @@ jobs:
           command: |
             sed -i "s/version: latest/version: ${CIRCLE_TAG:-latest}/" AppImageBuilder.yml
             make appimage
-      - run:
-          name: prepare workspace
-          command: |
-            mkdir appimage
-            mv Lotus-*.AppImage appimage
+      - run: |
+            mkdir -p /tmp/workspace/appimage && \
+            mv Lotus-*.AppImage /tmp/workspace/appimage/
       - persist_to_workspace:
-          root: "."
+          root: /tmp/workspace
           paths:
             - appimage
 
@@ -553,7 +551,7 @@ jobs:
       - checkout
       - install_ipfs
       - attach_workspace:
-          at: "."
+          at: /tmp/workspace
       - when:
           condition: << parameters.linux >>
           steps:
@@ -728,8 +726,6 @@ jobs:
       name: packer
     steps:
       - checkout
-      - attach_workspace:
-          at: "."
       - packer_build:
           template: tools/packer/lotus-snap.pkr.hcl
   publish-dockerhub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,8 +300,6 @@ jobs:
     executor: golang
     steps:
       - prepare
-      - run: sudo apt-get update
-      - run: sudo apt-get install npm
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -323,10 +321,10 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - restore_cache:
-          name: restore cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
       - run: make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - run: |
           mkdir -p /tmp/workspace/darwin_amd64_v1 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
@@ -334,12 +332,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - darwin_amd64_v1
-      - save_cache:
-          name: save cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-          paths:
-            - "~/.rustup"
-            - "~/.cargo"
 
   build-darwin-arm64:
     description: self-hosted m1 runner
@@ -351,13 +343,13 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - restore_cache:
-          name: restore cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
           make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - run: |
           mkdir -p /tmp/workspace/darwin_arm64 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
@@ -365,12 +357,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - darwin_arm64
-      - save_cache:
-          name: save cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-          paths:
-            - "~/.rustup"
-            - "~/.cargo"
       - run:
           command: make clean
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config coreutils jq hwloc
             - run:
                 name: Install Rust
                 command: |
@@ -91,28 +91,12 @@ commands:
   install_ipfs:
     steps:
       - run: |
-          apt update
-          apt install -y wget
-          wget https://github.com/ipfs/go-ipfs/releases/download/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz
-          wget https://github.com/ipfs/go-ipfs/releases/download/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz.sha512
-          if [ "$(sha512sum go-ipfs_v0.12.2_linux-amd64.tar.gz)" != "$(cat go-ipfs_v0.12.2_linux-amd64.tar.gz.sha512)" ]
-          then
-            echo "ipfs failed checksum check"
-            exit 1
-          fi
-          tar -xf go-ipfs_v0.12.2_linux-amd64.tar.gz
-          mv go-ipfs/ipfs /usr/local/bin/ipfs
-          chmod +x /usr/local/bin/ipfs
-  install_ipfs_macos:
-    steps:
-      - run: |
-          curl -O https://dist.ipfs.io/kubo/v0.14.0/kubo_v0.14.0_darwin-amd64.tar.gz
-          tar -xvzf kubo_v0.14.0_darwin-amd64.tar.gz
+          curl -O https://dist.ipfs.tech/kubo/v0.16.0/kubo_v0.16.0_linux-amd64.tar.gz
+          tar -xvzf kubo_v0.16.0_linux-amd64.tar.gz
           pushd kubo
           sudo bash install.sh
           popd
-          rm -rf kubo/
-          rm kubo_v0.14.0_darwin-amd64.tar.gz
+          rm -rf kubo
   git_fetch_all_tags:
     steps:
       - run:
@@ -339,7 +323,6 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - install_ipfs_macos
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
@@ -368,7 +351,6 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - install_ipfs_macos
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
@@ -394,7 +376,7 @@ jobs:
           when: always
       - run:
           name: cleanup homebrew
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config coreutils jq hwloc
           when: always
 
   release:
@@ -405,6 +387,12 @@ jobs:
         description: should this release actually publish it's artifacts?
         type: boolean
     steps:
+      - checkout
+      - run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser-pro
+      - install_ipfs
       - attach_workspace:
           at: /tmp/workspace
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,7 +547,7 @@ jobs:
     steps:
       - run:
           name: Install git jq curl
-          command: apt update && apt install -y git jq curl
+          command: apt update && apt install -y git jq curl sudo
       - checkout
       - git_fetch_all_tags
       - checkout
@@ -1100,12 +1100,13 @@ workflows:
       - build-debug
       - build-lotus-soup
 
+  release:
+    jobs:
       - build-linux-amd64:
           name: "Build ( linux / amd64 )"
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
@@ -1115,7 +1116,6 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
@@ -1125,8 +1125,20 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - release:
+          name: "Release"
+          requires:
+            - "Build ( darwin / amd64 )"
+            - "Build ( linux / amd64 )"
+            - "Build ( darwin / arm64 )"
+          filters:
+            branches:
+              ignore:
+                - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -1140,11 +1152,7 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-appimage:
           name: "Build AppImage"
           filters:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -23,11 +23,6 @@ executors:
 
 
 commands:
-  install-deps:
-    steps:
-      - run: |
-          sudo apt update
-          sudo apt install python-is-python3
   prepare:
     parameters:
       linux:
@@ -41,9 +36,8 @@ commands:
     steps:
       - checkout
       - git_fetch_all_tags
-      - checkout
       - when:
-          condition: << parameters.linux >>
+          condition: <<parameters.linux>>
           steps:
             - run:
                 name: Check Go Version
@@ -56,6 +50,8 @@ commands:
                   fi
             - run: sudo apt-get update
             - run: sudo apt-get install ocl-icd-opencl-dev libhwloc-dev
+            - run: sudo apt-get install python-is-python3
+
       - when:
           condition: <<parameters.darwin>>
           steps:
@@ -70,21 +66,12 @@ commands:
                   echo 'export GOPATH="${HOME}/go"' >> $BASH_ENV
             - run: go version
             - run:
-                name: Install pkg-config, goreleaser, and sha512sum
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser coreutils
+                name: Install dependencies with Homebrew
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils hwloc jq
             - run:
                 name: Install Rust
                 command: |
                   curl https://sh.rustup.rs -sSf | sh -s -- -y
-            - run:
-                name: Install hwloc
-                command: |
-                  mkdir ~/hwloc
-                  curl --location https://download.open-mpi.org/release/hwloc/v2.4/hwloc-2.4.1.tar.gz --output ~/hwloc/hwloc-2.4.1.tar.gz
-                  cd ~/hwloc
-                  tar -xvzpf hwloc-2.4.1.tar.gz
-                  cd hwloc-2.4.1
-                  ./configure && make && sudo make install
       - run: git submodule sync
       - run: git submodule update --init
   download-params:
@@ -156,7 +143,6 @@ jobs:
   mod-tidy-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: go mod tidy -v
       - run:
@@ -164,34 +150,9 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
-  build-linux:
-    executor: golang
-    steps:
-      - install-deps
-      - prepare
-      - run: sudo apt-get update
-      - run: sudo apt-get install npm
-      - run:
-          command: make buildall
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - store_artifacts:
-          path: lotus
-      - store_artifacts:
-          path: lotus-miner
-      - store_artifacts:
-          path: lotus-worker
-      - run: mkdir linux && mv lotus lotus-miner lotus-worker linux/
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux
-
   build-debug:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run:
           command: make debug
@@ -224,7 +185,6 @@ jobs:
         description: gotestsum format. https://github.com/gotestyourself/gotestsum#format
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps lotus
@@ -268,7 +228,6 @@ jobs:
           submodule is used.
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps lotus
@@ -311,36 +270,6 @@ jobs:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
-  build-ntwk-calibration:
-    description: |
-      Compile lotus binaries for the calibration network
-    parameters:
-      <<: *test-params
-    executor: << parameters.executor >>
-    steps:
-      - install-deps
-      - prepare
-      - run: make calibnet
-      - run: mkdir linux-calibrationnet && mv lotus lotus-miner lotus-worker linux-calibrationnet
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux-calibrationnet
-  build-ntwk-butterfly:
-    description: |
-      Compile lotus binaries for the butterfly network
-    parameters:
-      <<: *test-params
-    executor: << parameters.executor >>
-    steps:
-      - install-deps
-      - prepare
-      - run: make butterflynet
-      - run: mkdir linux-butterflynet && mv lotus lotus-miner lotus-worker linux-butterflynet
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - linux-butterflynet
   build-lotus-soup:
     description: |
       Compile `lotus-soup` Testground test plan
@@ -348,7 +277,6 @@ jobs:
       <<: *test-params
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run: cd extern/filecoin-ffi && make
       - run:
@@ -364,7 +292,6 @@ jobs:
       <<: *test-params
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           name: "download testground"
@@ -384,16 +311,30 @@ jobs:
       - run:
           name: "trigger payment channel stress testplan on taas"
           command: ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/paych-stress-k8s.toml --metadata-commit=$CIRCLE_SHA1 --metadata-repo=filecoin-project/lotus --metadata-branch=$CIRCLE_BRANCH
-  build-macos:
+
+  build-linux-amd64:
+    executor: golang
+    steps:
+      - prepare
+      - run: sudo apt-get update
+      - run: sudo apt-get install npm
+      - run: make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
+      - run: |
+          mkdir -p /tmp/workspace/linux_amd64_v1 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/linux_amd64_v1/
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - linux_amd64_v1
+
+  build-darwin-amd64:
     description: build darwin lotus binary
-    parameters:
-      publish:
-        default: false
-        description: publish github release and homebrew?
-        type: boolean
+    working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
     steps:
       - prepare:
           linux: false
@@ -402,30 +343,61 @@ jobs:
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-      - when:
-          condition: << parameters.publish >>
-          steps:
-            - run: goreleaser release --rm-dist
-            - run: ./scripts/generate-checksums.sh
-            - run: ./scripts/publish-checksums.sh
-      - when:
-          condition:
-            not: << parameters.publish >>
-          steps:
-            - run: goreleaser release --rm-dist --snapshot
-            - run: ./scripts/generate-checksums.sh
-      - store_artifacts:
-          path: dist
+      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
       - persist_to_workspace:
-          root: "."
+          root: /tmp/workspace
           paths:
-            - dist
+            - darwin_amd64_v1
       - save_cache:
           name: save cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
           paths:
             - "~/.rustup"
             - "~/.cargo"
+
+  build-darwin-arm64:
+    description: self-hosted m1 runner
+    working_directory: ~/go/src/github.com/filecoin-project/lotus
+    machine: true
+    resource_class: filecoin-project/self-hosted-m1
+    steps:
+      - run: echo 'export PATH=/opt/homebrew/bin:"$PATH"' >> "$BASH_ENV"
+      - prepare:
+          linux: false
+          darwin: true
+      - install_ipfs_macos
+      - restore_cache:
+          name: restore cargo cache
+          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
+      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          mkdir -p /tmp/workspace/darwin_arm64 && \
+          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - darwin_arm64
+      - save_cache:
+          name: save cargo cache
+          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
+          paths:
+            - "~/.rustup"
+            - "~/.cargo"
+      - run:
+          command: make clean
+          when: always
+
+  release:
+    executor: golang
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: goreleaser release --rm-dist --snapshot
+      - run: ./scripts/generate-checksums.sh
+      - run: ./scripts/publish-checksums.sh
 
   build-appimage:
     machine:
@@ -482,7 +454,6 @@ jobs:
   gofmt:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run:
           command: "! go fmt ./... 2>&1 | read"
@@ -490,7 +461,6 @@ jobs:
   gen-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
@@ -505,7 +475,6 @@ jobs:
   docs-check:
     executor: golang
     steps:
-      - install-deps
       - prepare
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
@@ -542,7 +511,6 @@ jobs:
           Arguments to pass to golangci-lint
     executor: << parameters.executor >>
     steps:
-      - install-deps
       - prepare
       - run:
           command: make deps
@@ -846,65 +814,66 @@ workflows:
               only:
                 - master
       - build-debug
-      - build-linux:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-ntwk-calibration:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-ntwk-butterfly:
-          filters:
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-lotus-soup
-      - build-macos:
-          name: publish-macos
-          publish: true
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+$/
-      - build-macos:
+
+      - build-linux-amd64:
+          name: "Build ( linux / amd64 )"
           filters:
             branches:
               only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+-rc\d+$/
-      - build-appimage:
-          filters:
-            branches:
-              only:
+                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - publish:
-          name: publish-linux
-          linux: true
+      - build-darwin-amd64:
+          name: "Build ( darwin / amd64 )"
+          filters:
+            branches:
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - build-darwin-arm64:
+          name: "Build ( darwin / arm64 )"
+          filters:
+            branches:
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - release:
+          name: "Release"
           requires:
-            - build-linux
+            - "Build ( darwin / amd64 )"
+            - "Build ( linux / amd64 )"
+            - "Build ( darwin / arm64 )"
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - goreleaser-prebuilt-m1
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - build-appimage:
+          name: "Build AppImage"
+          filters:
+            branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - publish:
-          name: publish-appimage
+          name: "Publish AppImage"
           appimage: true
           requires:
-            - build-appimage
+            - "Build AppImage"
           filters:
             branches:
               ignore:
@@ -913,14 +882,14 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-and-push-image:
-          name: build-and-push/lotus-all-in-one
+          name: "Publish ECR (lotus-all-in-one)"
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-dev
           tag: '${CIRCLE_SHA1:0:8}'
           target: lotus-all-in-one
       - build-and-push-image:
-          name: build-and-push/lotus-test
+          name: "Publish ECR (lotus-test)"
           dockerfile: Dockerfile.lotus
           path: .
           repo: lotus-test
@@ -971,7 +940,7 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
       - publish-dockerhub:
-          name: publish-dockerhub
+          name: "Publish Dockerhub (stable)"
           tag: stable
           filters:
             branches:
@@ -979,7 +948,17 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+                - /^v\d+\.\d+\.\d+$/
+      - publish-dockerhub:
+          name: "Publish Dockerhub (candidate)"
+          tag: candidate
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
 
   nightly:
     triggers:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -547,7 +547,7 @@ jobs:
     steps:
       - run:
           name: Install git jq curl
-          command: apt update && apt install -y git jq curl
+          command: apt update && apt install -y git jq curl sudo
       - checkout
       - git_fetch_all_tags
       - checkout
@@ -825,12 +825,13 @@ workflows:
       - build-debug
       - build-lotus-soup
 
+  release:
+    jobs:
       - build-linux-amd64:
           name: "Build ( linux / amd64 )"
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
@@ -840,7 +841,6 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
             tags:
               only:
@@ -850,8 +850,20 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
+      - release:
+          name: "Release"
+          requires:
+            - "Build ( darwin / amd64 )"
+            - "Build ( linux / amd64 )"
+            - "Build ( darwin / arm64 )"
+          filters:
+            branches:
+              ignore:
+                - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
@@ -865,11 +877,7 @@ workflows:
           filters:
             branches:
               only:
-                - goreleaser-prebuilt-m1
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-appimage:
           name: "Build AppImage"
           filters:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -414,7 +414,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: "."
+          at: /tmp/workspace
       - run:
           name: Update Go
           command: |
@@ -449,13 +449,11 @@ jobs:
           command: |
             sed -i "s/version: latest/version: ${CIRCLE_TAG:-latest}/" AppImageBuilder.yml
             make appimage
-      - run:
-          name: prepare workspace
-          command: |
-            mkdir appimage
-            mv Lotus-*.AppImage appimage
+      - run: |
+            mkdir -p /tmp/workspace/appimage && \
+            mv Lotus-*.AppImage /tmp/workspace/appimage/
       - persist_to_workspace:
-          root: "."
+          root: /tmp/workspace
           paths:
             - appimage
 
@@ -553,7 +551,7 @@ jobs:
       - checkout
       - install_ipfs
       - attach_workspace:
-          at: "."
+          at: /tmp/workspace
       - when:
           condition: << parameters.linux >>
           steps:
@@ -728,8 +726,6 @@ jobs:
       name: packer
     steps:
       - checkout
-      - attach_workspace:
-          at: "."
       - packer_build:
           template: tools/packer/lotus-snap.pkr.hcl
   publish-dockerhub:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -300,8 +300,6 @@ jobs:
     executor: golang
     steps:
       - prepare
-      - run: sudo apt-get update
-      - run: sudo apt-get install npm
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -323,10 +321,10 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - restore_cache:
-          name: restore cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
       - run: make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - run: |
           mkdir -p /tmp/workspace/darwin_amd64_v1 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
@@ -334,12 +332,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - darwin_amd64_v1
-      - save_cache:
-          name: save cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-          paths:
-            - "~/.rustup"
-            - "~/.cargo"
 
   build-darwin-arm64:
     description: self-hosted m1 runner
@@ -351,13 +343,13 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - restore_cache:
-          name: restore cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
           make lotus lotus-miner lotus-worker
+      - run:
+          name: check tag and version output match
+          command: ./scripts/version-check.sh ./lotus
       - run: |
           mkdir -p /tmp/workspace/darwin_arm64 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
@@ -365,12 +357,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - darwin_arm64
-      - save_cache:
-          name: save cargo cache
-          key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-          paths:
-            - "~/.rustup"
-            - "~/.cargo"
       - run:
           command: make clean
           when: always

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -67,7 +67,7 @@ commands:
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils hwloc jq
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
             - run:
                 name: Install Rust
                 command: |
@@ -372,7 +372,10 @@ jobs:
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
-      - run: make lotus lotus-miner lotus-worker
+      - run: |
+          export CPATH=$(brew --prefix)/include
+          export LIBRARY_PATH=$(brew --prefix)/lib
+          make lotus lotus-miner lotus-worker
       - run: |
           mkdir -p /tmp/workspace/darwin_arm64 && \
           mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_arm64/
@@ -389,15 +392,33 @@ jobs:
       - run:
           command: make clean
           when: always
+      - run:
+          name: cleanup homebrew
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+          when: always
 
   release:
     executor: golang
+    parameters:
+      dry-run:
+        default: false
+        description: should this release actually publish it's artifacts?
+        type: boolean
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: goreleaser release --rm-dist --snapshot
-      - run: ./scripts/generate-checksums.sh
-      - run: ./scripts/publish-checksums.sh
+      - when:
+          condition: << parameters.dry-run >>
+          steps:
+            - run: goreleaser release --rm-dist --snapshot
+            - run: ./scripts/generate-checksums.sh
+      - when:
+          condition:
+            not: << parameters.dry-run >>
+          steps:
+            - run: goreleaser release --rm-dist
+            - run: ./scripts/generate-checksums.sh
+            - run: ./scripts/publish-checksums.sh
 
   build-appimage:
     machine:
@@ -847,7 +868,8 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
-          name: "Release"
+          name: "Release (dry-run)"
+          dry-run: true
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -67,7 +67,7 @@ commands:
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
-                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+                command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config coreutils jq hwloc
             - run:
                 name: Install Rust
                 command: |
@@ -91,28 +91,12 @@ commands:
   install_ipfs:
     steps:
       - run: |
-          apt update
-          apt install -y wget
-          wget https://github.com/ipfs/go-ipfs/releases/download/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz
-          wget https://github.com/ipfs/go-ipfs/releases/download/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz.sha512
-          if [ "$(sha512sum go-ipfs_v0.12.2_linux-amd64.tar.gz)" != "$(cat go-ipfs_v0.12.2_linux-amd64.tar.gz.sha512)" ]
-          then
-            echo "ipfs failed checksum check"
-            exit 1
-          fi
-          tar -xf go-ipfs_v0.12.2_linux-amd64.tar.gz
-          mv go-ipfs/ipfs /usr/local/bin/ipfs
-          chmod +x /usr/local/bin/ipfs
-  install_ipfs_macos:
-    steps:
-      - run: |
-          curl -O https://dist.ipfs.io/kubo/v0.14.0/kubo_v0.14.0_darwin-amd64.tar.gz
-          tar -xvzf kubo_v0.14.0_darwin-amd64.tar.gz
+          curl -O https://dist.ipfs.tech/kubo/v0.16.0/kubo_v0.16.0_linux-amd64.tar.gz
+          tar -xvzf kubo_v0.16.0_linux-amd64.tar.gz
           pushd kubo
           sudo bash install.sh
           popd
-          rm -rf kubo/
-          rm kubo_v0.14.0_darwin-amd64.tar.gz
+          rm -rf kubo
   git_fetch_all_tags:
     steps:
       - run:
@@ -339,7 +323,6 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - install_ipfs_macos
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
@@ -368,7 +351,6 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - install_ipfs_macos
       - restore_cache:
           name: restore cargo cache
           key: v3-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/lotus/go.sum" }}
@@ -394,7 +376,7 @@ jobs:
           when: always
       - run:
           name: cleanup homebrew
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config goreleaser/tap/goreleaser-pro coreutils jq hwloc
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall pkg-config coreutils jq hwloc
           when: always
 
   release:
@@ -405,6 +387,12 @@ jobs:
         description: should this release actually publish it's artifacts?
         type: boolean
     steps:
+      - checkout
+      - run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser-pro
+      - install_ipfs
       - attach_workspace:
           at: /tmp/workspace
       - when:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,112 +8,47 @@ universal_binaries:
   - id: lotus
     replace: true
     name_template: lotus
-    ids:
-      - lotus_darwin_amd64
-      - lotus_darwin_arm64
   - id: lotus-miner
     replace: true
     name_template: lotus-miner
-    ids:
-      - lotus-miner_darwin_amd64
-      - lotus-miner_darwin_arm64
   - id: lotus-worker
     replace: true
     name_template: lotus-worker
-    ids:
-      - lotus-worker_darwin_amd64
-      - lotus-worker_darwin_arm64
 
 builds:
-  - id: lotus_darwin_amd64
-    main: ./cmd/lotus
-    binary: lotus
+  - id: lotus
+    builder: prebuilt
     goos:
       - darwin
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-  - id: lotus-miner_darwin_amd64
-    main: ./cmd/lotus-miner
-    binary: lotus-miner
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus
+  - id: lotus-miner
+    builder: prebuilt
     goos:
       - darwin
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-  - id: lotus-worker_darwin_amd64
-    main: ./cmd/lotus-worker
-    binary: lotus-worker
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-miner
+  - id: lotus-worker
+    builder: prebuilt
     goos:
       - darwin
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-  - id: lotus_darwin_arm64
-    main: ./cmd/lotus
-    binary: lotus
-    goos:
-      - darwin
-    goarch:
       - arm64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-      - CPATH=/opt/homebrew/include
-      - LIBRARY_PATH=/opt/homebrew/lib
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-  - id: lotus-miner_darwin_arm64
-    main: ./cmd/lotus-miner
-    binary: lotus-miner
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-      - CPATH=/opt/homebrew/include
-      - LIBRARY_PATH=/opt/homebrew/lib
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-  - id: lotus-worker_darwin_arm64
-    main: ./cmd/lotus-worker
-    binary: lotus-worker
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    env:
-      - CGO_ENABLED=1
-      - FFI_BUILD_FROM_SOURCE=1
-      - CPATH=/opt/homebrew/include
-      - LIBRARY_PATH=/opt/homebrew/lib
-    ldflags:
-      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
-#  - id: linux
-#    main: ./cmd/lotus
-#    binary: lotus
-#    goos:
-#      - linux
-#    goarch:
-#      - amd64
-#    env:
-#      - CGO_ENABLED=1
-#    ldflags:
-#      - -X=github.com/filecoin-project/lotus/build.CurrentCommit=+git.{{.ShortCommit}}
+    goamd64:
+      - v1
+    prebuilt:
+      path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-worker
 
 archives:
   - id: primary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,4 @@
 project_name: lotus
-before:
-  hooks:
-    - go mod tidy
-    - make deps
 
 universal_binaries:
   - id: lotus

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,7 +62,6 @@ release:
   prerelease: auto
   name_template: "Release v{{.Version}}"
 
-
 brews:
   - tap:
       owner: filecoin-project
@@ -82,6 +81,7 @@ brews:
     homepage: "https://filecoin.io"
     description: "A homebrew cask for installing filecoin-project/lotus on MacOS"
     license: MIT
+    skip_upload: auto
     dependencies:
       - name: hwloc
 


### PR DESCRIPTION
If possible, I would like to merge this in before the 1.18.0 release, otherwise I will have to manually build and update the binaries for that release myself. I know it's kinda big and last minute though, so I understand if you want to wait until 1.18.1-rc1 to put this in action.

## Related Issues
Right now, our m1 builds are broken, and don't generate working universal binaries during releases. On pre-releases, they aren't built at all.

## Proposed Changes
This does a few things:
- Uses a custom m1 mac runner running in aws to build darwin-arm64 binaries
- Prebuilds binaries for darwin-arm64, darwin-amd64, and linux-amd64 in three separate build jobs
- Pull those binaries together in a release job which makes a release using goreleaser, pubishing that to the Github Release
- It will now successfully publish the binaries on all releases, including pre-releases (i.e. *-rc) , but will only publish to homebrew on final releases.
- removes the build-ntwk-calibration and build-ntwk-butterfly jobs, as no one is using / relying on those anymore. In a future PR I will be tweaking our docker publishing flow to include docker builds for those networks.
- Removed a bunch of seemingly unnecessary cruft in our build process (like caching the cargo dependencies on jobs that we don't use rust)

## Testing
This was extensively tested on my test branch, but given the nature of the release process it can't be fully tested until it's run in a release environment. Please let me know when the next release is that will ship these changes, and I will make sure I am on call to fix any issues during the release.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
