### PR TITLE
fix: autobatch: remove potential deadlock when a block is missing

### DIFF
--- a/blockstore/autobatch_test.go
+++ b/blockstore/autobatch_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAutobatchBlockstore(t *testing.T) {

--- a/blockstore/autobatch_test.go
+++ b/blockstore/autobatch_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	ipld "github.com/ipfs/go-ipld-format"
 )
 
 func TestAutobatchBlockstore(t *testing.T) {
@@ -28,6 +30,10 @@ func TestAutobatchBlockstore(t *testing.T) {
 	v2, err := ab.Get(ctx, b2.Cid())
 	require.NoError(t, err)
 	require.Equal(t, b2.RawData(), v2.RawData())
+
+	// Regression test for a deadlock.
+	_, err = ab.Get(ctx, b3.Cid())
+	require.True(t, ipld.IsNotFound(err))
 
 	require.NoError(t, ab.Flush(ctx))
 	require.NoError(t, ab.Shutdown(ctx))

--- a/blockstore/union_test.go
+++ b/blockstore/union_test.go
@@ -13,6 +13,7 @@ var (
 	b0 = blocks.NewBlock([]byte("abc"))
 	b1 = blocks.NewBlock([]byte("foo"))
 	b2 = blocks.NewBlock([]byte("bar"))
+	b3 = blocks.NewBlock([]byte("baz"))
 )
 
 func TestUnionBlockstore_Get(t *testing.T) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes

Check the _underlying_ blockstore instead of recursing. Also, drop the
lock before we do that.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green