### PR TITLE
feat: storage: Force exit GenerateSingleVanillaProof on cancelled context

### DIFF
--- a/lib/result/result.go
+++ b/lib/result/result.go
@@ -1,0 +1,35 @@
+package result
+
+// Result is a small wrapper type encapsulating Value/Error tuples, mostly for
+// use when sending values across channels
+// NOTE: Avoid adding any functionality to this, any "nice" things added here will
+// make it more difficult to switch to a more standardised Result-like type when
+// one gets into the stdlib, or when we will want to switch to a library providing
+// those types.
+type Result[T any] struct {
+	Value T
+	Error error
+}
+
+func Ok[T any](value T) Result[T] {
+	return Result[T]{
+		Value: value,
+	}
+}
+
+func Err[T any](err error) Result[T] {
+	return Result[T]{
+		Error: err,
+	}
+}
+
+func Wrap[T any](value T, err error) Result[T] {
+	return Result[T]{
+		Value: value,
+		Error: err,
+	}
+}
+
+func (r *Result[T]) Unwrap() (T, error) {
+	return r.Value, r.Error
+}

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -806,7 +806,7 @@ func (st *Local) GenerateSingleVanillaProof(ctx context.Context, minerID abi.Act
 		log.Errorw("failed to generate valilla PoSt proof before context cancellation", "err", ctx.Err(), "duration", time.Now().Sub(start), "cache-id", cacheID, "sealed-id", sealedID, "cache", cache, "sealed", sealed)
 
 		// this will leave the GenerateSingleVanillaProof goroutine hanging, but that's still less bad than failing PoSt
-		return nil, xerrors.Errorf("failed to generate valilla proof before context cancellation: %w", ctx.Err())
+		return nil, xerrors.Errorf("failed to generate vanilla proof before context cancellation: %w", ctx.Err())
 	}
 }
 

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -252,6 +253,14 @@ func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check bitfield.B
 func (s *WindowPoStScheduler) runPoStCycle(ctx context.Context, manual bool, di dline.Info, ts *types.TipSet) ([]miner.SubmitWindowedPoStParams, error) {
 	ctx, span := trace.StartSpan(ctx, "storage.runPoStCycle")
 	defer span.End()
+
+	start := time.Now()
+
+	log := log.WithOptions(zap.Fields(zap.Time("cycle", start)))
+	log.Infow("starting PoSt cycle", "manual", manual, "ts", ts, "deadline", di.Index)
+	defer func() {
+		log.Infow("post cycle done", "took", time.Now().Sub(start))
+	}()
 
 	if !manual {
 		// TODO: extract from runPoStCycle, run on fault cutoff boundaries


### PR DESCRIPTION
## Related Issues

## Proposed Changes
* Add some more logs to wdpost cycle logic
* Respect context in local GenerateSingleVanillaProof
  * before it could block forever if underlying storage reads blocked, e.g. with disconnected NFS, which would lead to the entire PoSt failing
  * Now we'll return context error, which should result in only the slow-to-read sectors being skipped; There will also be a big, detailed log message printed.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
