### PR TITLE
fix: index-provider: change connection initiation direction between daemon and market

### DIFF
--- a/markets/idxprov/mesh.go
+++ b/markets/idxprov/mesh.go
@@ -38,10 +38,13 @@ func (mc Libp2pMeshCreator) Connect(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch full node listen addrs, err: %w", err)
 	}
 
-	// Connect to the full node, ask it to protect the connection and protect the connection on
-	// markets end too.
-	if err := mc.marketsHost.Connect(ctx, faddrs); err != nil {
-		return fmt.Errorf("failed to connect index provider host with the full node: %w", err)
+	// Connect from the full node, ask it to protect the connection and protect the connection on
+	// markets end too. Connection is initiated form full node to avoid the need to expose libp2p port on full node
+	if err := mc.fullnodeApi.NetConnect(ctx, peer.AddrInfo{
+		ID:    mc.marketsHost.ID(),
+		Addrs: mc.marketsHost.Addrs(),
+	}); err != nil {
+		return fmt.Errorf("failed to connect to index provider host from full node: %w", err)
 	}
 	mc.marketsHost.ConnManager().Protect(faddrs.ID, protectTag)
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/9626

## Proposed Changes
<!-- A clear list of the changes being made -->
We need to change the direction of libp2p connection init. Rather than dialling from market to fullNode, we should dial from fullNode to market. Thus removing the requirement to have libp2p exposed.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
