### PR TITLE
fix: sealing pipeline: Clear CreationTime when starting sector upgrade

### DIFF
--- a/storage/pipeline/fsm_events.go
+++ b/storage/pipeline/fsm_events.go
@@ -461,6 +461,7 @@ func (evt SectorRevertUpgradeToProving) apply(state *SectorInfo) {
 	state.ReplicaUpdateMessage = nil
 	state.Pieces = state.CCPieces
 	state.CCPieces = nil
+	state.CreationTime = 0
 }
 
 type SectorRetrySubmitReplicaUpdateWait struct{}

--- a/storage/pipeline/fsm_events.go
+++ b/storage/pipeline/fsm_events.go
@@ -323,6 +323,9 @@ func (evt SectorStartCCUpdate) apply(state *SectorInfo) {
 	// Clear filler piece but remember in case of abort
 	state.CCPieces = state.Pieces
 	state.Pieces = nil
+
+	// Clear CreationTime in case this sector was accepting piece data previously
+	state.CreationTime = 0
 }
 
 type SectorReplicaUpdate struct {

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -2,6 +2,7 @@ package sealing
 
 import (
 	"context"
+	"go.uber.org/zap"
 	"sort"
 	"time"
 
@@ -91,12 +92,17 @@ func (m *Sealing) handleWaitDeals(ctx statemachine.Context, sector SectorInfo) e
 }
 
 func (m *Sealing) maybeStartSealing(ctx statemachine.Context, sector SectorInfo, used abi.UnpaddedPieceSize) (bool, error) {
+	log := log.WithOptions(zap.Fields(
+		zap.Uint64("sector", uint64(sector.SectorNumber)),
+		zap.Int("deals", len(sector.dealIDs())),
+	))
+
 	now := time.Now()
 	st := m.sectorTimers[m.minerSectorID(sector.SectorNumber)]
 	if st != nil {
 		if !st.Stop() { // timer expired, SectorStartPacking was/is being sent
 			// we send another SectorStartPacking in case one was sent in the handleAddPiece state
-			log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "wait-timeout")
+			log.Infow("starting to seal deal sector", "trigger", "wait-timeout")
 			return true, ctx.Send(SectorStartPacking{})
 		}
 	}
@@ -113,13 +119,13 @@ func (m *Sealing) maybeStartSealing(ctx statemachine.Context, sector SectorInfo,
 
 	if len(sector.dealIDs()) >= maxDeals {
 		// can't accept more deals
-		log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "maxdeals")
+		log.Infow("starting to seal deal sector", "trigger", "maxdeals")
 		return true, ctx.Send(SectorStartPacking{})
 	}
 
 	if used.Padded() == abi.PaddedPieceSize(ssize) {
 		// sector full
-		log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "filled")
+		log.Infow("starting to seal deal sector", "trigger", "filled")
 		return true, ctx.Send(SectorStartPacking{})
 	}
 
@@ -149,15 +155,15 @@ func (m *Sealing) maybeStartSealing(ctx statemachine.Context, sector SectorInfo,
 		}
 
 		if now.After(sealTime) {
-			log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "wait-timeout")
+			log.Infow("starting to seal deal sector", "trigger", "wait-timeout", "creation", sector.CreationTime)
 			return true, ctx.Send(SectorStartPacking{})
 		}
 
 		m.sectorTimers[m.minerSectorID(sector.SectorNumber)] = time.AfterFunc(sealTime.Sub(now), func() {
-			log.Infow("starting to seal deal sector", "sector", sector.SectorNumber, "trigger", "wait-timer")
+			log.Infow("starting to seal deal sector", "trigger", "wait-timer")
 
 			if err := ctx.Send(SectorStartPacking{}); err != nil {
-				log.Errorw("sending SectorStartPacking event failed", "sector", sector.SectorNumber, "error", err)
+				log.Errorw("sending SectorStartPacking event failed", "error", err)
 			}
 		})
 	}

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -2,11 +2,11 @@ package sealing
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"sort"
 	"time"
 
 	"github.com/ipfs/go-cid"
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-commp-utils/zerocomm"


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/9478

## Proposed Changes
Clear sector.CreationTime when starting sector upgrade

## Additional Info
The sector state has a `CreationTime` field which holds the time of the first AddPiece performed on a sector.

Initially when a sector is created, this field will be 0, but after the first deal is inserted into the sector, we set that field to `now`.

If the sector isn't 100% full after `AddPiece`, it will return to `WaitDeals` to wait for more date, and use `CreationTime+WaitDealsDelay` to decide how long to wait for:
* This is fine for new sectors because they have just been created
* This is also fine for SnapDeals on CC sectors
* But it is not fine when doing SnapDeals on a sector which previously accepted deal data, for example aborted SnapDeals sector - because CreationTime was already set on it, we may have assigned some deals to the sector, entered SnapDealsWaitDeals, and looked at CreationTime, which was already there, set to some old value, and immediately went to Packing - which lost all assigned deals, and failed the upgrade because the sector had no deals..

The fix is to simply clear `CreationTime` when starting sector upgrade.

Example input logs when that happened:
```
2022-11-11T17:56:29.748+0100	INFO	sectors	pipeline/input.go:279	Adding piece for deal 15xxxxxx (publish msg: bafy2....)
2022-11-11T17:56:29.751+0100	DEBUG	sectors	pipeline/input.go:477	updateInput matching	{"matches": 0, "toAssign": 3, "openSectors": 0, "pieces": 3}
2022-11-11T17:56:29.751+0100	DEBUG	sectors	pipeline/input.go:512	updateInput matching done	{"matches": 0, "toAssign": 3, "assigned": 0, "openSectors": 0, "pieces": 3}
2022-11-11T17:56:29.751+0100	ERROR	sectors	pipeline/input.go:515	we are trying to create a new sector with open sectors map[]
2022-11-11T17:56:29.751+0100	INFO	sectors	pipeline/input.go:699	new deal sector decision	{"sealing": 0, "maxSeal": 0, "maxUpgrade": 0, "preferNew": false, "canCreate": true, "canUpgrade": true, "shouldUpgrade": true}
2022-11-11T17:56:29.758+0100	INFO	sectors	pipeline/input.go:645	Upgrading sector	{"number": "2000", "type": "deal", "proofType": 8, "expiration": "38xxxxx", "pledge": "0.26.. FIL"}
2022-11-11T17:56:29.761+0100	INFO	sectors	pipeline/input.go:145	starting to seal deal sector	{"sector": "2000", "trigger": "wait-timeout"}

```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
