### PR TITLE
_ci_ Forgot to include linux binaries in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,33 +16,45 @@ builds:
     builder: prebuilt
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
     goamd64:
       - v1
+    ignore:
+      - goos: linux
+        goarch: arm64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus
   - id: lotus-miner
     builder: prebuilt
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
     goamd64:
       - v1
+    ignore:
+      - goos: linux
+        goarch: arm64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-miner
   - id: lotus-worker
     builder: prebuilt
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64
     goamd64:
       - v1
+    ignore:
+      - goos: linux
+        goarch: arm64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-worker
 


### PR DESCRIPTION
## Related Issues
Original PR: filecoin-project/lotus#9600

## Proposed Changes
I accidentally forgot to include linux in the list of platfroms we should release for. This should be backported into 1.19 as early as possible to ensure linux binaries get published.

## Checklist
Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green