### PR TITLE
refactor: chain/actors: expose address map bitwidth and hash function

### DIFF
--- a/chain/actors/builtin/init/actor.go.template
+++ b/chain/actors/builtin/init/actor.go.template
@@ -87,6 +87,9 @@ type State interface {
 	// Sets the address map for the init actor. This should only be used for testing.
 	SetAddressMap(mcid cid.Cid) error
 
-	AddressMap() (adt.Map, error)
 	GetState() interface{}
+
+	AddressMap() (adt.Map, error)
+	AddressMapBitWidth() int
+	AddressMapHashFunction() func(input []byte) []byte
 }

--- a/chain/actors/builtin/init/init.go
+++ b/chain/actors/builtin/init/init.go
@@ -130,6 +130,9 @@ type State interface {
 	// Sets the address map for the init actor. This should only be used for testing.
 	SetAddressMap(mcid cid.Cid) error
 
-	AddressMap() (adt.Map, error)
 	GetState() interface{}
+
+	AddressMap() (adt.Map, error)
+	AddressMapBitWidth() int
+	AddressMapHashFunction() func(input []byte) []byte
 }

--- a/chain/actors/builtin/init/state.go.template
+++ b/chain/actors/builtin/init/state.go.template
@@ -1,6 +1,7 @@
 package init
 
 import (
+    "crypto/sha256"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
@@ -119,10 +120,25 @@ func (s *state{{.v}}) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state{{.v}}) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state{{.v}}) AddressMap() (adt.Map, error) {
 	return adt{{.v}}.AsMap(s.store, s.State.AddressMap{{if (ge .v 3)}}, builtin{{.v}}.DefaultHamtBitwidth{{end}})
 }
 
-func (s *state{{.v}}) GetState() interface{} {
-	return &s.State
+func (s *state{{.v}}) AddressMapBitWidth() int {
+    {{- if (ge .v 3)}}
+        return builtin{{.v}}.DefaultHamtBitwidth
+    {{- else}}
+        return 5
+    {{- end}}
+}
+
+func (s *state{{.v}}) AddressMapHashFunction() func(input []byte) []byte {
+    return func(input []byte) []byte {
+        res := sha256.Sum256(input)
+        return res[:]
+    }
 }

--- a/chain/actors/builtin/init/v0.go
+++ b/chain/actors/builtin/init/v0.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -103,10 +105,21 @@ func (s *state0) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state0) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state0) AddressMap() (adt.Map, error) {
 	return adt0.AsMap(s.store, s.State.AddressMap)
 }
 
-func (s *state0) GetState() interface{} {
-	return &s.State
+func (s *state0) AddressMapBitWidth() int {
+	return 5
+}
+
+func (s *state0) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v2.go
+++ b/chain/actors/builtin/init/v2.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -103,10 +105,21 @@ func (s *state2) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state2) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state2) AddressMap() (adt.Map, error) {
 	return adt2.AsMap(s.store, s.State.AddressMap)
 }
 
-func (s *state2) GetState() interface{} {
-	return &s.State
+func (s *state2) AddressMapBitWidth() int {
+	return 5
+}
+
+func (s *state2) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v3.go
+++ b/chain/actors/builtin/init/v3.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state3) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state3) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state3) AddressMap() (adt.Map, error) {
 	return adt3.AsMap(s.store, s.State.AddressMap, builtin3.DefaultHamtBitwidth)
 }
 
-func (s *state3) GetState() interface{} {
-	return &s.State
+func (s *state3) AddressMapBitWidth() int {
+	return builtin3.DefaultHamtBitwidth
+}
+
+func (s *state3) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v4.go
+++ b/chain/actors/builtin/init/v4.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state4) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state4) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state4) AddressMap() (adt.Map, error) {
 	return adt4.AsMap(s.store, s.State.AddressMap, builtin4.DefaultHamtBitwidth)
 }
 
-func (s *state4) GetState() interface{} {
-	return &s.State
+func (s *state4) AddressMapBitWidth() int {
+	return builtin4.DefaultHamtBitwidth
+}
+
+func (s *state4) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v5.go
+++ b/chain/actors/builtin/init/v5.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state5) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state5) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state5) AddressMap() (adt.Map, error) {
 	return adt5.AsMap(s.store, s.State.AddressMap, builtin5.DefaultHamtBitwidth)
 }
 
-func (s *state5) GetState() interface{} {
-	return &s.State
+func (s *state5) AddressMapBitWidth() int {
+	return builtin5.DefaultHamtBitwidth
+}
+
+func (s *state5) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v6.go
+++ b/chain/actors/builtin/init/v6.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state6) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state6) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state6) AddressMap() (adt.Map, error) {
 	return adt6.AsMap(s.store, s.State.AddressMap, builtin6.DefaultHamtBitwidth)
 }
 
-func (s *state6) GetState() interface{} {
-	return &s.State
+func (s *state6) AddressMapBitWidth() int {
+	return builtin6.DefaultHamtBitwidth
+}
+
+func (s *state6) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v7.go
+++ b/chain/actors/builtin/init/v7.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state7) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state7) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state7) AddressMap() (adt.Map, error) {
 	return adt7.AsMap(s.store, s.State.AddressMap, builtin7.DefaultHamtBitwidth)
 }
 
-func (s *state7) GetState() interface{} {
-	return &s.State
+func (s *state7) AddressMapBitWidth() int {
+	return builtin7.DefaultHamtBitwidth
+}
+
+func (s *state7) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v8.go
+++ b/chain/actors/builtin/init/v8.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state8) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state8) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state8) AddressMap() (adt.Map, error) {
 	return adt8.AsMap(s.store, s.State.AddressMap, builtin8.DefaultHamtBitwidth)
 }
 
-func (s *state8) GetState() interface{} {
-	return &s.State
+func (s *state8) AddressMapBitWidth() int {
+	return builtin8.DefaultHamtBitwidth
+}
+
+func (s *state8) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }

--- a/chain/actors/builtin/init/v9.go
+++ b/chain/actors/builtin/init/v9.go
@@ -1,6 +1,8 @@
 package init
 
 import (
+	"crypto/sha256"
+
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -104,10 +106,21 @@ func (s *state9) SetAddressMap(mcid cid.Cid) error {
 	return nil
 }
 
+func (s *state9) GetState() interface{} {
+	return &s.State
+}
+
 func (s *state9) AddressMap() (adt.Map, error) {
 	return adt9.AsMap(s.store, s.State.AddressMap, builtin9.DefaultHamtBitwidth)
 }
 
-func (s *state9) GetState() interface{} {
-	return &s.State
+func (s *state9) AddressMapBitWidth() int {
+	return builtin9.DefaultHamtBitwidth
+}
+
+func (s *state9) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
exposes the init actors address map's BitWidth and Hash function on the init actor api

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
