### PR TITLE
_build_: Fix issues with new goreleaser flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,13 +385,13 @@ jobs:
       - when:
           condition: << parameters.dry-run >>
           steps:
-            - run: goreleaser release --rm-dist --snapshot
+            - run: goreleaser release --rm-dist --snapshot --debug
             - run: ./scripts/generate-checksums.sh
       - when:
           condition:
             not: << parameters.dry-run >>
           steps:
-            - run: goreleaser release --rm-dist
+            - run: goreleaser release --rm-dist --debug
             - run: ./scripts/generate-checksums.sh
             - run: ./scripts/publish-checksums.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ commands:
           sudo bash install.sh
           popd
           rm -rf kubo
+          rm kubo_v0.16.0_linux-amd64.tar.gz
   git_fetch_all_tags:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1143,6 +1143,8 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release"
+          context:
+            - filecoin-goreleaser-key
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
@@ -1156,6 +1158,8 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release (dry-run)"
+          context:
+            - filecoin-goreleaser-key
           dry-run: true
           requires:
             - "Build ( darwin / amd64 )"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -838,6 +838,8 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release"
+          context:
+            - filecoin-goreleaser-key
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
@@ -851,6 +853,8 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release (dry-run)"
+          context:
+            - filecoin-goreleaser-key
           dry-run: true
           requires:
             - "Build ( darwin / amd64 )"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -385,13 +385,13 @@ jobs:
       - when:
           condition: << parameters.dry-run >>
           steps:
-            - run: goreleaser release --rm-dist --snapshot
+            - run: goreleaser release --rm-dist --snapshot --debug
             - run: ./scripts/generate-checksums.sh
       - when:
           condition:
             not: << parameters.dry-run >>
           steps:
-            - run: goreleaser release --rm-dist
+            - run: goreleaser release --rm-dist --debug
             - run: ./scripts/generate-checksums.sh
             - run: ./scripts/publish-checksums.sh
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -97,6 +97,7 @@ commands:
           sudo bash install.sh
           popd
           rm -rf kubo
+          rm kubo_v0.16.0_linux-amd64.tar.gz
   git_fetch_all_tags:
     steps:
       - run:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ universal_binaries:
 
 builds:
   - id: lotus
+    binary: lotus
     builder: prebuilt
     goos:
       - darwin
@@ -28,6 +29,7 @@ builds:
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus
   - id: lotus-miner
+    binary: lotus-miner
     builder: prebuilt
     goos:
       - darwin
@@ -43,6 +45,7 @@ builds:
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-miner
   - id: lotus-worker
+    binary: lotus-worker
     builder: prebuilt
     goos:
       - darwin

--- a/scripts/build-appimage-bundle.sh
+++ b/scripts/build-appimage-bundle.sh
@@ -20,7 +20,7 @@ PID="$!"
 trap "kill -9 ${PID}" EXIT
 sleep 30
 
-cp "../appimage/Lotus-${CIRCLE_TAG}-x86_64.AppImage" .
+cp "/tmp/workspace/appimage/Lotus-${CIRCLE_TAG}-x86_64.AppImage" .
 sha512sum "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.sha512"
 ipfs add -q "Lotus-${CIRCLE_TAG}-x86_64.AppImage" > "Lotus-${CIRCLE_TAG}-x86_64.AppImage.cid"
 popd


### PR DESCRIPTION
## Related Issues
The 1.19.0-rc1 release had a host of minor issues that happened because of some differences between the environment I tested stuff in and CircleCI.
https://app.circleci.com/pipelines/github/filecoin-project/lotus/24401/workflows/bcfbd26f-aebf-41d0-bb48-426f14d12111

## Proposed Changes
This is a series of small fixes:
1. Use the `filecoin-goreleaser-key` CircleCI context, which has the GORELEASER_KEY env variable set (necessary for using the pro version of goreleaser). I also set this in the project env vars, but the context is a more reliable place to find the key, since it's used organization wide.
2. I moved the workspace directly to `/tmp/workspace`, but forgot to update one of the scripts which was using the old directory. This is now fixed.
3. Goreleaser checks to make sure the git state is clean before releasing, and I forgot to delete the kubo archive (kubo_v0.16.0_linux-amd64.tar.gz) after downloading and installing ipfs. This is also now fixed.
4. Add the binary names (i.e. lotus-miner, lotus-worker, lotus) to the goreleaser config. Without that, goreleaser assumes they are all named lotus, after the project. Strangely, this only happens on the linux archive, because goreleaser seems to handle it for us when generating universal mac binaries.
5. Use the `--debug` flag with goreleaser so we get more verbose output in CI to more easily diagnose issues.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
