### PR TITLE
feat: fvm: add support for looking up past tipset CIDs

### DIFF
--- a/chain/consensus/filcns/compute_state.go
+++ b/chain/consensus/filcns/compute_state.go
@@ -100,6 +100,7 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 			NetworkVersion: sm.GetNetworkVersion(ctx, e),
 			BaseFee:        baseFee,
 			LookbackState:  stmgr.LookbackStateGetterForTipset(sm, ts),
+			TipSetGetter:   stmgr.TipSetGetterForTipset(sm.ChainStore(), ts),
 			Tracing:        vmTracing,
 		}
 

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -151,6 +151,7 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 		NetworkVersion: nvGetter(ctx, vmHeight),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
+		TipSetGetter:   TipSetGetterForTipset(sm.cs, ts),
 		Tracing:        true,
 	}
 	vmi, err := sm.newVM(ctx, vmopt)

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -95,6 +95,7 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		NetworkVersion: sm.GetNetworkVersion(ctx, height),
 		BaseFee:        ts.Blocks()[0].ParentBaseFee,
 		LookbackState:  LookbackStateGetterForTipset(sm, ts),
+		TipSetGetter:   TipSetGetterForTipset(sm.cs, ts),
 		Tracing:        true,
 	}
 	vmi, err := sm.newVM(ctx, vmopt)
@@ -128,6 +129,16 @@ func LookbackStateGetterForTipset(sm *StateManager, ts *types.TipSet) vm.Lookbac
 			return nil, err
 		}
 		return sm.StateTree(st)
+	}
+}
+
+func TipSetGetterForTipset(cs *store.ChainStore, ts *types.TipSet) vm.TipSetGetter {
+	return func(ctx context.Context, round abi.ChainEpoch) (types.TipSetKey, error) {
+		ts, err := cs.GetTipsetByHeight(ctx, round, ts, true)
+		if err != nil {
+			return types.EmptyTSK, err
+		}
+		return ts.Key(), nil
 	}
 }
 

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -45,6 +45,7 @@ type FvmExtern struct {
 	blockstore.Blockstore
 	epoch   abi.ChainEpoch
 	lbState LookbackStateGetter
+	tsGet   TipSetGetter
 	base    cid.Cid
 }
 
@@ -97,6 +98,14 @@ func (t *FvmExecutionTrace) ToExecutionTrace() types.ExecutionTrace {
 	}
 
 	return ret
+}
+
+func (x *FvmExtern) TipsetCid(ctx context.Context, epoch abi.ChainEpoch) (cid.Cid, error) {
+	tsk, err := x.tsGet(ctx, epoch)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return tsk.Cid()
 }
 
 // VerifyConsensusFault is similar to the one in syscalls.go used by the Lotus VM, except it never errors
@@ -294,6 +303,7 @@ func defaultFVMOpts(ctx context.Context, opts *VMOpts) (*ffi.FVMOpts, error) {
 			Rand:       opts.Rand,
 			Blockstore: opts.Bstore,
 			lbState:    opts.LookbackState,
+			tsGet:      opts.TipSetGetter,
 			base:       opts.StateBase,
 			epoch:      opts.Epoch,
 		},

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -192,6 +192,7 @@ type (
 	CircSupplyCalculator func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error)
 	NtwkVersionGetter    func(context.Context, abi.ChainEpoch) network.Version
 	LookbackStateGetter  func(context.Context, abi.ChainEpoch) (*state.StateTree, error)
+	TipSetGetter         func(context.Context, abi.ChainEpoch) (types.TipSetKey, error)
 )
 
 var _ Interface = (*LegacyVM)(nil)
@@ -223,6 +224,7 @@ type VMOpts struct {
 	NetworkVersion network.Version
 	BaseFee        abi.TokenAmount
 	LookbackState  LookbackStateGetter
+	TipSetGetter   TipSetGetter
 	Tracing        bool
 }
 

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -203,6 +203,9 @@ type ExecuteMessageParams struct {
 
 	// Lookback is the LookbackStateGetter; returns the state tree at a given epoch.
 	Lookback vm.LookbackStateGetter
+
+	// TipSetGetter returns the tipset key at any given epoch.
+	TipSetGetter vm.TipSetGetter
 }
 
 // ExecuteMessage executes a conformance test vector message in a temporary VM.
@@ -217,15 +220,26 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, params ExecuteMessageP
 		params.Rand = NewFixedRand()
 	}
 
-	// TODO: This lookback state returns the supplied precondition state tree, unconditionally.
-	//  This is obviously not correct, but the lookback state tree is only used to validate the
-	//  worker key when verifying a consensus fault. If the worker key hasn't changed in the
-	//  current finality window, this workaround is enough.
-	//  The correct solutions are documented in https://github.com/filecoin-project/ref-fvm/issues/381,
-	//  but they're much harder to implement, and the tradeoffs aren't clear.
-	var lookback vm.LookbackStateGetter = func(ctx context.Context, epoch abi.ChainEpoch) (*state.StateTree, error) {
-		cst := cbor.NewCborStore(bs)
-		return state.LoadStateTree(cst, params.Preroot)
+	if params.TipSetGetter == nil {
+		// TODO: If/when we start writing conformance tests against the EVM, we'll need to
+		// actually implement this and (unfortunately) capture any tipsets looked up by
+		// messages.
+		params.TipSetGetter = func(context.Context, abi.ChainEpoch) (types.TipSetKey, error) {
+			return types.EmptyTSK, nil
+		}
+	}
+
+	if params.Lookback == nil {
+		// TODO: This lookback state returns the supplied precondition state tree, unconditionally.
+		//  This is obviously not correct, but the lookback state tree is only used to validate the
+		//  worker key when verifying a consensus fault. If the worker key hasn't changed in the
+		//  current finality window, this workaround is enough.
+		//  The correct solutions are documented in https://github.com/filecoin-project/ref-fvm/issues/381,
+		//  but they're much harder to implement, and the tradeoffs aren't clear.
+		params.Lookback = func(ctx context.Context, epoch abi.ChainEpoch) (*state.StateTree, error) {
+			cst := cbor.NewCborStore(bs)
+			return state.LoadStateTree(cst, params.Preroot)
+		}
 	}
 
 	vmOpts := &vm.VMOpts{
@@ -239,7 +253,8 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, params ExecuteMessageP
 		Rand:           params.Rand,
 		BaseFee:        params.BaseFee,
 		NetworkVersion: params.NetworkVersion,
-		LookbackState:  lookback,
+		LookbackState:  params.Lookback,
+		TipSetGetter:   params.TipSetGetter,
 	}
 
 	var vmi vm.Interface


### PR DESCRIPTION
We do this by adding yet another "getter" to the VM that resolves an epoch into a TipSetKey.

Alternatively, we could stick this functionality on `Rand`, but then it wouldn't really be "rand" but something else...

Depends on https://github.com/filecoin-project/filecoin-ffi/pull/339

Merge plan:

1. Merge https://github.com/filecoin-project/filecoin-ffi/pull/339.
2. Rebase this PR on _master_.
3. Merge this PR to master.
4. Port this change to the nv18 branches.

Unfortunately, it needs to land on master because it bubbles a breaking change in the FFI (where the FVM now needs the ability to lookup tipset CIDs).

Alternatively, we could make this _optional_ with a runtime type assertion. That is, if we find that we're using "v3" inside the FFI, we could type-assert that the "externs" supports the `TipsetCid` method. That would let us merge the FFI changes _without_ making any changes to the interface.