### PR TITLE
fix: sealing: Set all path types for Unseal pipeline to sealing storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,6 +1026,11 @@ workflows:
           target: "./itests/sector_terminate_test.go"
       
       - test:
+          name: test-itest-sector_unseal
+          suite: itest-sector_unseal
+          target: "./itests/sector_unseal_test.go"
+      
+      - test:
           name: test-itest-self_sent_txn
           suite: itest-self_sent_txn
           target: "./itests/self_sent_txn_test.go"

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -708,6 +708,7 @@ func (n *Ensemble) Start() *Ensemble {
 					scfg.Storage.AllowPreCommit1 = false
 					scfg.Storage.AllowPreCommit2 = false
 					scfg.Storage.AllowCommit = false
+					scfg.Storage.AllowUnseal = false
 				}
 
 				scfg.Storage.Assigner = assigner

--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -1,0 +1,87 @@
+package itests
+
+import (
+	"context"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/filecoin-project/lotus/storage/sealer/sealtasks"
+	"github.com/filecoin-project/lotus/storage/sealer/storiface"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestUnsealPiece(t *testing.T) {
+	ctx := context.Background()
+	blockTime := 1 * time.Millisecond
+	kit.QuietMiningLogs()
+
+	_, miner, ens := kit.EnsembleMinimal(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+		kit.NoStorage(), // no storage to have better control over path settings
+		kit.MutateSealingConfig(func(sc *config.SealingConfig) {
+			sc.FinalizeEarly = true
+			sc.AlwaysKeepUnsealedCopy = false
+		})) // no mock proofs
+
+	var worker kit.TestWorker
+	ens.Worker(miner, &worker, kit.ThroughRPC(), kit.NoStorage(), // no storage to have better control over path settings
+		kit.WithTaskTypes([]sealtasks.TaskType{
+			sealtasks.TTFetch, sealtasks.TTAddPiece,
+			sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTPreCommit1, sealtasks.TTPreCommit2, sealtasks.TTCommit2,
+			sealtasks.TTReplicaUpdate, sealtasks.TTUnseal, // only first update step, later steps will not run and we'll abort
+		}),
+	)
+
+	ens.Start().InterconnectAll().BeginMiningMustPost(blockTime)
+
+	maddr, err := miner.ActorAddress(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get storage paths
+
+	// store-only path on the miner
+	miner.AddStorage(ctx, t, func(cfg *storiface.LocalStorageMeta) {
+		cfg.CanSeal = false
+		cfg.CanStore = true
+	})
+
+	mlocal, err := miner.StorageLocal(ctx)
+	require.NoError(t, err)
+	require.Len(t, mlocal, 2) // genesis and one local
+
+	// we want a seal-only path on the worker disconnected from miner path
+	worker.AddStorage(ctx, t, func(cfg *storiface.LocalStorageMeta) {
+		cfg.CanSeal = true
+		cfg.CanStore = false
+	})
+
+	wpaths, err := worker.Paths(ctx)
+	require.NoError(t, err)
+	require.Len(t, wpaths, 1)
+
+	// get a sector for upgrading
+	miner.PledgeSectors(ctx, 1, 0, nil)
+	sl, err := miner.SectorsListNonGenesis(ctx)
+	require.NoError(t, err)
+	require.Len(t, sl, 1, "expected 1 sector")
+
+	sector := sl[0]
+
+	sinfo, err := miner.SectorsStatus(ctx, sector, false)
+	require.NoError(t, err)
+
+	minerId, err := address.IDFromAddress(maddr)
+	require.NoError(t, err)
+
+	sectorRef := storiface.SectorRef{
+		ID:        abi.SectorID{Miner: abi.ActorID(minerId), Number: sector},
+		ProofType: sinfo.SealProof,
+	}
+
+	err = miner.SectorsUnsealPiece(ctx, sectorRef, 0, 0, sinfo.Ticket.Value, sinfo.CommD)
+	require.NoError(t, err)
+}

--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -2,15 +2,18 @@ package itests
 
 import (
 	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/storage/sealer/sealtasks"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
-	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestUnsealPiece(t *testing.T) {

--- a/storage/sealer/ffiwrapper/sealer_cgo.go
+++ b/storage/sealer/ffiwrapper/sealer_cgo.go
@@ -405,7 +405,7 @@ func (sb *Sealer) pieceCid(spt abi.RegisteredSealProof, in []byte) (cid.Cid, err
 }
 
 func (sb *Sealer) tryDecodeUpdatedReplica(ctx context.Context, sector storiface.SectorRef, commD cid.Cid, unsealedPath string, randomness abi.SealRandomness) (bool, error) {
-	replicaPath, done, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTUpdate|storiface.FTUpdateCache, storiface.FTNone, storiface.PathStorage)
+	replicaPath, done, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTUpdate|storiface.FTUpdateCache, storiface.FTNone, storiface.PathSealing)
 	if xerrors.Is(err, storiface.ErrSectorNotFound) {
 		return false, nil
 	} else if err != nil {
@@ -464,12 +464,12 @@ func (sb *Sealer) UnsealPiece(ctx context.Context, sector storiface.SectorRef, o
 	maxPieceSize := abi.PaddedPieceSize(ssize)
 
 	// try finding existing
-	unsealedPath, done, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTUnsealed, storiface.FTNone, storiface.PathStorage)
+	unsealedPath, done, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTUnsealed, storiface.FTNone, storiface.PathSealing)
 	var pf *partialfile.PartialFile
 
 	switch {
 	case xerrors.Is(err, storiface.ErrSectorNotFound):
-		unsealedPath, done, err = sb.sectors.AcquireSector(ctx, sector, storiface.FTNone, storiface.FTUnsealed, storiface.PathStorage)
+		unsealedPath, done, err = sb.sectors.AcquireSector(ctx, sector, storiface.FTNone, storiface.FTUnsealed, storiface.PathSealing)
 		if err != nil {
 			return xerrors.Errorf("acquire unsealed sector path (allocate): %w", err)
 		}
@@ -516,7 +516,7 @@ func (sb *Sealer) UnsealPiece(ctx context.Context, sector storiface.SectorRef, o
 	}
 
 	// Piece data sealed in sector
-	srcPaths, srcDone, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTCache|storiface.FTSealed, storiface.FTNone, storiface.PathStorage)
+	srcPaths, srcDone, err := sb.sectors.AcquireSector(ctx, sector, storiface.FTCache|storiface.FTSealed, storiface.FTNone, storiface.PathSealing)
 	if err != nil {
 		return xerrors.Errorf("acquire sealed sector paths: %w", err)
 	}

--- a/storage/sealer/manager.go
+++ b/storage/sealer/manager.go
@@ -353,6 +353,21 @@ func (m *Manager) SectorsUnsealPiece(ctx context.Context, sector storiface.Secto
 		return xerrors.Errorf("worker UnsealPiece call: %s", err)
 	}
 
+	// get a selector for moving unsealed sector into long-term storage
+	fetchSel := newMoveSelector(m.index, sector.ID, storiface.FTUnsealed, storiface.PathStorage, !m.disallowRemoteFinalize)
+
+	// move unsealed sector to long-term storage
+	// Possible TODO: Add an option to not keep the unsealed sector in long term storage?
+	err = m.sched.Schedule(ctx, sector, sealtasks.TTFetch, fetchSel,
+		m.schedFetch(sector, storiface.FTUnsealed, storiface.PathStorage, storiface.AcquireMove),
+		func(ctx context.Context, w Worker) error {
+			_, err := m.waitSimpleCall(ctx)(w.MoveStorage(ctx, sector, storiface.FTUnsealed))
+			return err
+		})
+	if err != nil {
+		return xerrors.Errorf("moving unsealed sector to long term storage: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/9159

## Proposed Changes
<!-- A clear list of the changes being made -->
Currently when unsealing a sector, its expected that the unsealing worker has access to long term storage and stores the unsealed data there. We need to be able to unseal data and deliver it to the miner without having access to long term storage for retrievals.
Instead of using long term storage, use sealing storage to in the unsealing pipeline

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
