### PR TITLE
fix: cli: check found before dereferencing SectorInfo

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -919,11 +919,11 @@ var sectorsRenewCmd = &cli.Command{
 				}
 
 				si, found := activeSectorsInfo[abi.SectorNumber(id)]
-				if len(si.DealIDs) > 0 && cctx.Bool("only-cc") {
-					continue
-				}
 				if !found {
 					return xerrors.Errorf("sector %d is not active", id)
+				}
+				if len(si.DealIDs) > 0 && cctx.Bool("only-cc") {
+					continue
 				}
 
 				sis = append(sis, si)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Panics at this line were reported on Slack, regression in #9402.

## Proposed Changes
<!-- A clear list of the changes being made -->

We should fail on not-found before dereferencing SectorInfos.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
