### PR TITLE
fix: sealer: Tweak confidence for handleUpdateActivating

### DIFF
--- a/storage/pipeline/states_replica_update.go
+++ b/storage/pipeline/states_replica_update.go
@@ -335,7 +335,7 @@ func (m *Sealing) handleUpdateActivating(ctx statemachine.Context, sector Sector
 
 		lb := policy.GetWinningPoStSectorSetLookback(nv)
 
-		targetHeight := mw.Height + lb + InteractivePoRepConfidence
+		targetHeight := mw.Height + lb
 
 		return m.events.ChainAt(context.Background(), func(context.Context, *types.TipSet, abi.ChainEpoch) error {
 			return ctx.Send(SectorUpdateActive{})


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Discovered while investigating #8415 

## Proposed Changes
<!-- A clear list of the changes being made -->

The event handler [already factors in the provided confidence](https://github.com/filecoin-project/lotus/blob/e65fae28de2a44947dd24af8c7dafcade29af1a4/chain/events/events_height.go#L64), so the current code has the effect of waiting for it twice -- seems wrong to me.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
