### PR TITLE
NV18:  update go-state-types

### DIFF
--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -14,8 +14,8 @@ import (
 	"github.com/filecoin-project/go-state-types/cbor"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
-	markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"
-	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	markettypes "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/market"
+	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/verifreg"
 {{range .versions}}
     {{if (le . 7)}}
 	    builtin{{.}} "github.com/filecoin-project/specs-actors{{import .}}actors/builtin"

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -19,19 +19,25 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
-	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/verifreg"
 
 {{if (le .v 7)}}
 	market{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/builtin/market"
 	adt{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/util/adt"
 {{else}}
 	market{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}market"
-	markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"
+	markettypes "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/market"
 	adt{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/adt"
 {{end}}
 {{if (ge .v 9)}}
 	"github.com/filecoin-project/go-state-types/builtin"
+{{if (lt .v .latestVersion)}}
+	marketX "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/market"
+   	verifreg{{.v}} "github.com/filecoin-project/go-state-types/builtin/v{{.v}}/verifreg"
+   	verifregX "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/verifreg"
 {{end}}
+{{end}}
+
 )
 
 var _ State = (*state{{.v}})(nil)
@@ -215,10 +221,31 @@ func fromV{{.v}}DealState(v{{.v}} market{{.v}}.DealState) DealState {
         SlashEpoch: v{{.v}}.SlashEpoch,
         VerifiedClaim: 0,
     }
+    {{else if (lt .v .latestVersion)}}
+    return marketX.DealState {
+      SectorStartEpoch: v{{.v}}.SectorStartEpoch,
+      LastUpdatedEpoch: v{{.v}}.LastUpdatedEpoch,
+      SlashEpoch: v{{.v}}.SlashEpoch,
+      VerifiedClaim: verifregX.AllocationId(v{{.v}}.VerifiedClaim),
+    }
     {{else}}
     return (DealState)(v{{.v}})
     {{end}}
 }
+
+{{if (gt .v 8)}}
+{{if (lt .v .latestVersion)}}
+func AsV{{.v}}DealState(st DealState) market{{.v}}.DealState {
+    return market{{.v}}.DealState {
+      SectorStartEpoch: st.SectorStartEpoch,
+      LastUpdatedEpoch: st.LastUpdatedEpoch,
+      SlashEpoch: st.SlashEpoch,
+      VerifiedClaim: verifreg{{.v}}.AllocationId(st.VerifiedClaim),
+    }
+}
+{{end}}
+{{end}}
+
 
 type dealProposals{{.v}} struct {
 	adt.Array
@@ -318,6 +345,36 @@ func fromV{{.v}}DealProposal(v{{.v}} market{{.v}}.DealProposal) (DealProposal, e
     }
 {{end}}
 
+{{if (gt .v 8)}}
+{{if (lt .v .latestVersion)}}
+func AsV{{.v}}DealProposal(p DealProposal) market{{.v}}.DealProposal {
+  return market{{.v}}.DealProposal{
+        PieceCID: p.PieceCID,
+        PieceSize: p.PieceSize,
+        VerifiedDeal: p.VerifiedDeal,
+        Client: p.Client,
+        Provider: p.Provider,
+        Label: AsV{{.v}}DealLabel(p.Label),
+        StartEpoch: p.StartEpoch,
+        EndEpoch: p.EndEpoch,
+        StoragePricePerEpoch: p.StoragePricePerEpoch,
+        ProviderCollateral: p.ProviderCollateral,
+        ClientCollateral: p.ClientCollateral,
+  }
+}
+
+func AsV{{.v}}DealLabel(lbl DealLabel) (result market{{.v}}.DealLabel) {
+  if lbl.IsString() {
+    s, _ := lbl.ToString()
+    result, _ = market{{.v}}.NewLabelFromString(s)
+  } else {
+    bs, _ := lbl.ToBytes()
+    result, _ = market{{.v}}.NewLabelFromBytes(bs)
+  }
+  return result
+}
+{{end}}
+{{end}}
 
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -31,6 +31,11 @@ import (
 	adt{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/adt"
 	builtin{{.v}} "github.com/filecoin-project/go-state-types/builtin"
 {{end}}
+{{if (gt .v 8)}}
+{{if (lt .v .latestVersion)}}
+  minerX "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/miner"
+{{end}}
+{{end}}
 )
 
 var _ State = (*state{{.v}})(nil)
@@ -417,13 +422,38 @@ func (s *state{{.v}}) Info() (MinerInfo, error) {
 		WindowPoStPartitionSectors: info.WindowPoStPartitionSectors,
 		ConsensusFaultElapsed:      {{if (ge .v 2)}}info.ConsensusFaultElapsed{{else}}-1{{end}},
 		{{if (ge .v 9)}}
-		Beneficiary:                info.Beneficiary,
+   		Beneficiary:                info.Beneficiary,
+        {{if (lt .v .latestVersion)}}
+		BeneficiaryTerm:            minerX.BeneficiaryTerm{
+          Quota: info.BeneficiaryTerm.Quota,
+          UsedQuota: info.BeneficiaryTerm.UsedQuota,
+          Expiration: info.BeneficiaryTerm.Expiration,
+        },
+		PendingBeneficiaryTerm:     convertX{{.v}}PendingBeneficiaryChange(info.PendingBeneficiaryTerm),
+        {{else}}
 		BeneficiaryTerm:            info.BeneficiaryTerm,
-		PendingBeneficiaryTerm:     info.PendingBeneficiaryTerm,{{end}}
+		PendingBeneficiaryTerm:     info.PendingBeneficiaryTerm,
+        {{end}}
+        {{end}}
 	}
 
 	return mi, nil
 }
+
+{{if (gt .v 8)}}
+{{if (lt .v .latestVersion)}}
+func convertX{{.v}}PendingBeneficiaryChange(p *miner{{.v}}.PendingBeneficiaryChange) *minerX.PendingBeneficiaryChange {
+  if p == nil { return nil }
+  return &minerX.PendingBeneficiaryChange{
+          NewBeneficiary: p.NewBeneficiary,
+          NewQuota: p.NewQuota,
+          NewExpiration: p.NewExpiration,
+          ApprovedByBeneficiary: p.ApprovedByBeneficiary,
+          ApprovedByNominee: p.ApprovedByNominee,
+        }
+}
+{{end}}
+{{end}}
 
 func (s *state{{.v}}) DeadlineInfo(epoch abi.ChainEpoch) (*dline.Info, error) {
 	return s.State.{{if (ge .v 4)}}Recorded{{end}}DeadlineInfo(epoch), nil
@@ -587,7 +617,8 @@ func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorO
 }
 
 func fromV{{.v}}SectorPreCommitOnChainInfo(v{{.v}} miner{{.v}}.SectorPreCommitOnChainInfo) minertypes.SectorPreCommitOnChainInfo {
-	{{if (le .v 8)}}return minertypes.SectorPreCommitOnChainInfo{
+	{{if (le .v 8)}}
+    return minertypes.SectorPreCommitOnChainInfo{
 		Info:               minertypes.SectorPreCommitInfo{
 			SealProof:     v{{.v}}.Info.SealProof,
 			SectorNumber:  v{{.v}}.Info.SectorNumber,
@@ -599,7 +630,24 @@ func fromV{{.v}}SectorPreCommitOnChainInfo(v{{.v}} miner{{.v}}.SectorPreCommitOn
 		},
 		PreCommitDeposit:   v{{.v}}.PreCommitDeposit,
 		PreCommitEpoch:     v{{.v}}.PreCommitEpoch,
-	}{{else}}return v{{.v}}{{end}}
+	}
+    {{else if (lt .v .latestVersion)}}
+        return minertypes.SectorPreCommitOnChainInfo{
+		Info:               minertypes.SectorPreCommitInfo{
+			SealProof:     v{{.v}}.Info.SealProof,
+			SectorNumber:  v{{.v}}.Info.SectorNumber,
+			SealedCID:     v{{.v}}.Info.SealedCID,
+			SealRandEpoch: v{{.v}}.Info.SealRandEpoch,
+			DealIDs:       v{{.v}}.Info.DealIDs,
+			Expiration:    v{{.v}}.Info.Expiration,
+			UnsealedCid:   v{{.v}}.Info.UnsealedCid,
+		},
+		PreCommitDeposit:   v{{.v}}.PreCommitDeposit,
+		PreCommitEpoch:     v{{.v}}.PreCommitEpoch,
+	}
+    {{else}}
+      return v{{.v}}
+    {{end}}
 }
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/verifreg/actor.go.template
+++ b/chain/actors/builtin/verifreg/actor.go.template
@@ -19,7 +19,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
-    verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+    verifregtypes "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/verifreg"
 )
 
 var (

--- a/chain/actors/builtin/verifreg/state.go.template
+++ b/chain/actors/builtin/verifreg/state.go.template
@@ -24,12 +24,8 @@ import (
 {{end}}
 {{if (ge .v 9)}}
 	"github.com/filecoin-project/go-state-types/big"
-{{if (gt .v 9)}}
-    verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 {{end}}
-{{else}}
-    verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
-{{end}}
+    verifregX "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/verifreg"
 )
 
 var _ State = (*state{{.v}})(nil)
@@ -121,33 +117,97 @@ func (s *state{{.v}}) GetState() interface{} {
 	return &s.State
 }
 
-func (s *state{{.v}}) GetAllocation(clientIdAddr address.Address, allocationId verifreg9.AllocationId) (*verifreg9.Allocation, bool, error) {
+{{if (gt .v 8)}}
+{{if (lt .v .latestVersion)}}
+func convertX{{.v}}Allocation(alloc *verifreg{{.v}}.Allocation) *verifregX.Allocation {
+     if alloc == nil { return nil }
+     return &verifregX.Allocation{
+       Client: alloc.Client,
+       Provider: alloc.Provider,
+       Data: alloc.Data,
+       Size: alloc.Size,
+       TermMin: alloc.TermMin,
+       TermMax: alloc.TermMax,
+       Expiration: alloc.Expiration,
+    }
+}
+
+func convertX{{.v}}Claim(claim *verifreg{{.v}}.Claim) *verifregX.Claim {
+     if claim == nil { return nil }
+     return &verifregX.Claim{
+       Provider: claim.Provider,
+       Client: claim.Client,
+       Data: claim.Data,
+       Size: claim.Size,
+       TermMin: claim.TermMin,
+       TermMax: claim.TermMax,
+       TermStart: claim.TermStart,
+       Sector: claim.Sector,
+    }
+}
+
+{{end}}
+{{end}}
+
+func (s *state{{.v}}) GetAllocation(clientIdAddr address.Address, allocationId verifregX.AllocationId) (*verifregX.Allocation, bool, error) {
 {{if (le .v 8)}}
     return nil, false, xerrors.Errorf("unsupported in actors v{{.v}}")
+{{else if (lt .v .latestVersion)}}
+    alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, verifreg{{.v}}.AllocationId(allocationId))
+    if err != nil {
+      return nil, ok, err
+   }
+   return convertX{{.v}}Allocation(alloc), ok, err
 {{else}}
     return s.FindAllocation(s.store, clientIdAddr, allocationId)
 {{end}}
 }
 
-func (s *state{{.v}}) GetAllocations(clientIdAddr address.Address) (map[verifreg9.AllocationId]verifreg9.Allocation, error) {
+func (s *state{{.v}}) GetAllocations(clientIdAddr address.Address) (map[verifregX.AllocationId]verifregX.Allocation, error) {
 {{if (le .v 8)}}
     return nil, xerrors.Errorf("unsupported in actors v{{.v}}")
+{{else if (lt .v .latestVersion)}}
+   allocs, err := s.LoadAllocationsToMap(s.store, clientIdAddr)
+   if err != nil {
+     return nil, err
+   }
+   res := make(map[verifregX.AllocationId]verifregX.Allocation, len(allocs))
+   for id, alloc := range allocs {
+       res[verifregX.AllocationId(id)] = *convertX{{.v}}Allocation(&alloc)
+   }
+   return res, nil
 {{else}}
 	return s.LoadAllocationsToMap(s.store, clientIdAddr)
 {{end}}
 }
 
-func (s *state{{.v}}) GetClaim(providerIdAddr address.Address, claimId verifreg9.ClaimId) (*verifreg9.Claim, bool, error) {
+func (s *state{{.v}}) GetClaim(providerIdAddr address.Address, claimId verifregX.ClaimId) (*verifregX.Claim, bool, error) {
 {{if (le .v 8)}}
     return nil, false, xerrors.Errorf("unsupported in actors v{{.v}}")
+{{else if (lt .v .latestVersion)}}
+    claim, ok, err := s.FindClaim(s.store, providerIdAddr, verifreg{{.v}}.ClaimId(claimId))
+    if err != nil {
+      return nil, ok, err
+   }
+   return convertX{{.v}}Claim(claim), ok, err
 {{else}}
 	return s.FindClaim(s.store, providerIdAddr, claimId)
 {{end}}
 }
 
-func (s *state{{.v}}) GetClaims(providerIdAddr address.Address) (map[verifreg9.ClaimId]verifreg9.Claim, error) {
+func (s *state{{.v}}) GetClaims(providerIdAddr address.Address) (map[verifregX.ClaimId]verifregX.Claim, error) {
 {{if (le .v 8)}}
     return nil, xerrors.Errorf("unsupported in actors v{{.v}}")
+{{else if (lt .v .latestVersion)}}
+   claims, err := s.LoadClaimsToMap(s.store, providerIdAddr)
+   if err != nil {
+     return nil, err
+   }
+   res := make(map[verifregX.ClaimId]verifregX.Claim, len(claims))
+   for id, claim := range claims {
+       res[verifregX.ClaimId(id)] = *convertX{{.v}}Claim(&claim)
+   }
+   return res, nil
 {{else}}
 	return s.LoadClaimsToMap(s.store, providerIdAddr)
 {{end}}

--- a/chain/stmgr/actors.go
+++ b/chain/stmgr/actors.go
@@ -281,9 +281,14 @@ func GetStorageDeal(ctx context.Context, sm *StateManager, dealID abi.DealID, ts
 		st = market.EmptyDealState()
 	}
 
+	// the api returns v9 market type explicitly, so we abide.
+	// this is an artifact of (my imho deeply flawed, but that's another story) policy of
+	// copying types in go-state-types.
+	// If you want to fix this to return the latest version type, be my guest, i am not going
+	// down this rabbit hole.
 	return &api.MarketDeal{
-		Proposal: *proposal,
-		State:    *st,
+		Proposal: market.AsV9DealProposal(*proposal),
+		State:    market.AsV9DealState(*st),
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/filecoin-project/go-legs v0.4.4
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.9.10-0.20221116233942-e49c83ccf23b
+	github.com/filecoin-project/go-state-types v0.10.0-alpha-1
 	github.com/filecoin-project/go-statemachine v1.0.2
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psS
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.8/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.10/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.9.10-0.20221116233942-e49c83ccf23b h1:seLs+8DkIOu5k01y2RLygOqH8F/NWjXSkzhlVK6tZaA=
-github.com/filecoin-project/go-state-types v0.9.10-0.20221116233942-e49c83ccf23b/go.mod h1:7ty480tvttEAqWKywhAaDCElk7ksTqEXtXWAzTSdEKo=
+github.com/filecoin-project/go-state-types v0.10.0-alpha-1 h1:4I0UQTaH9VVj1EwJI6NX7cdQwYVcM3qV/ZXqXCHLiPw=
+github.com/filecoin-project/go-state-types v0.10.0-alpha-1/go.mod h1:7ty480tvttEAqWKywhAaDCElk7ksTqEXtXWAzTSdEKo=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2 h1:421SSWBk8GIoCoWYYTE/d+qCWccgmRH0uXotXRDjUbc=
 github.com/filecoin-project/go-statemachine v1.0.2/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=


### PR DESCRIPTION
Ok, so we changed the aliases to copies and everything should be fine, right? Nope.

This so far fixes the chain compilation errors, but all hell breaks loose with hardcoded references to v9 scattered around the codebase.

Notes:
Do make gen first (or chain/actors/agen) and see for yourself.
@arajasek I am ready to give up here, all this because we don't have nice aliases any longer.