### PR TITLE
feat: sched: Add metrics around sched cycle

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Distribution
-var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 3000, 4000, 5000, 7500, 10000, 20000, 50000, 100000)
+var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 3000, 4000, 5000, 7500, 10000, 20000, 50000, 100_000, 250_000, 500_000, 1000_000)
 var workMillisecondsDistribution = view.Distribution(
 	250, 500, 1000, 2000, 5000, 10_000, 30_000, 60_000, 2*60_000, 5*60_000, 10*60_000, 15*60_000, 30*60_000, // short sealing tasks
 	40*60_000, 45*60_000, 50*60_000, 55*60_000, 60*60_000, 65*60_000, 70*60_000, 75*60_000, 80*60_000, 85*60_000, 100*60_000, 120*60_000, // PC2 / C2 range
@@ -135,6 +135,11 @@ var (
 	StorageReservedBytes    = stats.Int64("storage/path_reserved_bytes", "reserved storage bytes", stats.UnitBytes)
 	StorageLimitUsedBytes   = stats.Int64("storage/path_limit_used_bytes", "used optional storage limit bytes", stats.UnitBytes)
 	StorageLimitMaxBytes    = stats.Int64("storage/path_limit_max_bytes", "optional storage limit", stats.UnitBytes)
+
+	SchedAssignerCycleDuration           = stats.Float64("sched/assigner_cycle_ms", "Duration of scheduler assigner cycle", stats.UnitMilliseconds)
+	SchedAssignerCandidatesDuration      = stats.Float64("sched/assigner_cycle_candidates_ms", "Duration of scheduler assigner candidate matching step", stats.UnitMilliseconds)
+	SchedAssignerWindowSelectionDuration = stats.Float64("sched/assigner_cycle_window_select_ms", "Duration of scheduler window selection step", stats.UnitMilliseconds)
+	SchedAssignerSubmitDuration          = stats.Float64("sched/assigner_cycle_submit_ms", "Duration of scheduler window submit step", stats.UnitMilliseconds)
 
 	DagStorePRInitCount        = stats.Int64("dagstore/pr_init_count", "PieceReader init count", stats.UnitDimensionless)
 	DagStorePRBytesRequested   = stats.Int64("dagstore/pr_requested_bytes", "PieceReader requested bytes", stats.UnitBytes)
@@ -428,6 +433,23 @@ var (
 		TagKeys:     []tag.Key{StorageID},
 	}
 
+	SchedAssignerCycleDurationView = &view.View{
+		Measure:     SchedAssignerCycleDuration,
+		Aggregation: defaultMillisecondsDistribution,
+	}
+	SchedAssignerCandidatesDurationView = &view.View{
+		Measure:     SchedAssignerCandidatesDuration,
+		Aggregation: defaultMillisecondsDistribution,
+	}
+	SchedAssignerWindowSelectionDurationView = &view.View{
+		Measure:     SchedAssignerWindowSelectionDuration,
+		Aggregation: defaultMillisecondsDistribution,
+	}
+	SchedAssignerSubmitDurationView = &view.View{
+		Measure:     SchedAssignerSubmitDuration,
+		Aggregation: defaultMillisecondsDistribution,
+	}
+
 	DagStorePRInitCountView = &view.View{
 		Measure:     DagStorePRInitCount,
 		Aggregation: view.Count(),
@@ -697,6 +719,7 @@ var MinerNodeViews = append([]*view.View{
 	WorkerCallsReturnedCountView,
 	WorkerUntrackedCallsReturnedView,
 	WorkerCallsReturnedDurationView,
+
 	SectorStatesView,
 	StorageFSAvailableView,
 	StorageAvailableView,
@@ -708,6 +731,12 @@ var MinerNodeViews = append([]*view.View{
 	StorageReservedBytesView,
 	StorageLimitUsedBytesView,
 	StorageLimitMaxBytesView,
+
+	SchedAssignerCycleDurationView,
+	SchedAssignerCandidatesDurationView,
+	SchedAssignerWindowSelectionDurationView,
+	SchedAssignerSubmitDurationView,
+
 	DagStorePRInitCountView,
 	DagStorePRBytesRequestedView,
 	DagStorePRBytesDiscardedView,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -22,6 +22,8 @@ var workMillisecondsDistribution = view.Distribution(
 	350*60_000, 400*60_000, 600*60_000, 800*60_000, 1000*60_000, 1300*60_000, 1800*60_000, 4000*60_000, 10000*60_000, // intel PC1 range
 )
 
+var queueSizeDistribution = view.Distribution(0, 1, 2, 3, 5, 7, 10, 15, 25, 35, 50, 70, 90, 130, 200, 300, 500, 1000, 2000, 5000, 10000)
+
 // Global Tags
 var (
 	// common
@@ -140,6 +142,8 @@ var (
 	SchedAssignerCandidatesDuration      = stats.Float64("sched/assigner_cycle_candidates_ms", "Duration of scheduler assigner candidate matching step", stats.UnitMilliseconds)
 	SchedAssignerWindowSelectionDuration = stats.Float64("sched/assigner_cycle_window_select_ms", "Duration of scheduler window selection step", stats.UnitMilliseconds)
 	SchedAssignerSubmitDuration          = stats.Float64("sched/assigner_cycle_submit_ms", "Duration of scheduler window submit step", stats.UnitMilliseconds)
+	SchedCycleOpenWindows                = stats.Int64("sched/assigner_cycle_open_window_count", "Number of open windows in scheduling cycles", stats.UnitDimensionless)
+	SchedCycleQueueSize                  = stats.Int64("sched/assigner_cycle_task_queue_entry_count", "Number of task queue entries in scheduling cycles", stats.UnitDimensionless)
 
 	DagStorePRInitCount        = stats.Int64("dagstore/pr_init_count", "PieceReader init count", stats.UnitDimensionless)
 	DagStorePRBytesRequested   = stats.Int64("dagstore/pr_requested_bytes", "PieceReader requested bytes", stats.UnitBytes)
@@ -449,6 +453,22 @@ var (
 		Measure:     SchedAssignerSubmitDuration,
 		Aggregation: defaultMillisecondsDistribution,
 	}
+	SchedCycleOpenWindowsView = &view.View{
+		Measure:     SchedCycleOpenWindows,
+		Aggregation: queueSizeDistribution,
+	}
+	SchedCycleQueueSizeView = &view.View{
+		Measure:     SchedCycleQueueSize,
+		Aggregation: queueSizeDistribution,
+	}
+	SchedCycleLastOpenWindowsView = &view.View{
+		Measure:     SchedCycleOpenWindows,
+		Aggregation: view.LastValue(),
+	}
+	SchedCycleLastQueueSizeView = &view.View{
+		Measure:     SchedCycleQueueSize,
+		Aggregation: view.LastValue(),
+	}
 
 	DagStorePRInitCountView = &view.View{
 		Measure:     DagStorePRInitCount,
@@ -736,6 +756,10 @@ var MinerNodeViews = append([]*view.View{
 	SchedAssignerCandidatesDurationView,
 	SchedAssignerWindowSelectionDurationView,
 	SchedAssignerSubmitDurationView,
+	SchedCycleOpenWindowsView,
+	SchedCycleQueueSizeView,
+	SchedCycleLastQueueSizeView,
+	SchedCycleLastOpenWindowsView,
 
 	DagStorePRInitCountView,
 	DagStorePRBytesRequestedView,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -142,8 +142,8 @@ var (
 	SchedAssignerCandidatesDuration      = stats.Float64("sched/assigner_cycle_candidates_ms", "Duration of scheduler assigner candidate matching step", stats.UnitMilliseconds)
 	SchedAssignerWindowSelectionDuration = stats.Float64("sched/assigner_cycle_window_select_ms", "Duration of scheduler window selection step", stats.UnitMilliseconds)
 	SchedAssignerSubmitDuration          = stats.Float64("sched/assigner_cycle_submit_ms", "Duration of scheduler window submit step", stats.UnitMilliseconds)
-	SchedCycleOpenWindows                = stats.Int64("sched/assigner_cycle_open_window_count", "Number of open windows in scheduling cycles", stats.UnitDimensionless)
-	SchedCycleQueueSize                  = stats.Int64("sched/assigner_cycle_task_queue_entry_count", "Number of task queue entries in scheduling cycles", stats.UnitDimensionless)
+	SchedCycleOpenWindows                = stats.Int64("sched/assigner_cycle_open_window", "Number of open windows in scheduling cycles", stats.UnitDimensionless)
+	SchedCycleQueueSize                  = stats.Int64("sched/assigner_cycle_task_queue_entry", "Number of task queue entries in scheduling cycles", stats.UnitDimensionless)
 
 	DagStorePRInitCount        = stats.Int64("dagstore/pr_init_count", "PieceReader init count", stats.UnitDimensionless)
 	DagStorePRBytesRequested   = stats.Int64("dagstore/pr_requested_bytes", "PieceReader requested bytes", stats.UnitBytes)
@@ -461,14 +461,6 @@ var (
 		Measure:     SchedCycleQueueSize,
 		Aggregation: queueSizeDistribution,
 	}
-	SchedCycleLastOpenWindowsView = &view.View{
-		Measure:     SchedCycleOpenWindows,
-		Aggregation: view.LastValue(),
-	}
-	SchedCycleLastQueueSizeView = &view.View{
-		Measure:     SchedCycleQueueSize,
-		Aggregation: view.LastValue(),
-	}
 
 	DagStorePRInitCountView = &view.View{
 		Measure:     DagStorePRInitCount,
@@ -758,8 +750,6 @@ var MinerNodeViews = append([]*view.View{
 	SchedAssignerSubmitDurationView,
 	SchedCycleOpenWindowsView,
 	SchedCycleQueueSizeView,
-	SchedCycleLastQueueSizeView,
-	SchedCycleLastOpenWindowsView,
 
 	DagStorePRInitCountView,
 	DagStorePRBytesRequestedView,

--- a/storage/sealer/manager.go
+++ b/storage/sealer/manager.go
@@ -105,7 +105,7 @@ func New(ctx context.Context, lstor *paths.Local, stor paths.Store, ls paths.Loc
 		return nil, xerrors.Errorf("creating prover instance: %w", err)
 	}
 
-	sh, err := newScheduler(sc.Assigner)
+	sh, err := newScheduler(ctx, sc.Assigner)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/sealer/manager_test.go
+++ b/storage/sealer/manager_test.go
@@ -110,7 +110,7 @@ func newTestMgr(ctx context.Context, t *testing.T, ds datastore.Datastore) (*Man
 
 	stor := paths.NewRemote(lstor, si, nil, 6000, &paths.DefaultPartialFileHandler{})
 
-	sh, err := newScheduler("")
+	sh, err := newScheduler(ctx, "")
 	require.NoError(t, err)
 
 	m := &Manager{

--- a/storage/sealer/sched_assigner_common.go
+++ b/storage/sealer/sched_assigner_common.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 
+	"go.opencensus.io/stats"
+
 	"github.com/filecoin-project/lotus/metrics"
 )
 
@@ -37,6 +39,9 @@ func (a *AssignerCommon) TrySched(sh *Scheduler) {
 
 	windowsLen := len(sh.OpenWindows)
 	queueLen := sh.SchedQueue.Len()
+
+	stats.Record(sh.mctx, metrics.SchedCycleOpenWindows.M(int64(windowsLen)))
+	stats.Record(sh.mctx, metrics.SchedCycleQueueSize.M(int64(queueLen)))
 
 	log.Debugf("SCHED %d queued; %d open windows", queueLen, windowsLen)
 

--- a/storage/sealer/sched_test.go
+++ b/storage/sealer/sched_test.go
@@ -226,7 +226,7 @@ func addTestWorker(t *testing.T, sched *Scheduler, index *paths.Index, name stri
 }
 
 func TestSchedStartStop(t *testing.T) {
-	sched, err := newScheduler("")
+	sched, err := newScheduler(context.Background(), "")
 	require.NoError(t, err)
 	go sched.runSched()
 
@@ -356,7 +356,7 @@ func TestSched(t *testing.T) {
 		return func(t *testing.T) {
 			index := paths.NewIndex(nil)
 
-			sched, err := newScheduler("")
+			sched, err := newScheduler(ctx, "")
 			require.NoError(t, err)
 			sched.testSync = make(chan struct{})
 
@@ -609,7 +609,7 @@ func BenchmarkTrySched(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 
-				sched, err := newScheduler("")
+				sched, err := newScheduler(ctx, "")
 				require.NoError(b, err)
 				sched.Workers[storiface.WorkerID{}] = &WorkerHandle{
 					workerRpc: nil,


### PR DESCRIPTION
## Related Issues
This is for AB testing https://github.com/filecoin-project/lotus/pull/9737

## Proposed Changes
Add 4 new duration-distribution metrics to the prometheus endpoint around scheduling cycle duration.

## Additional Info
Those are in `http://127.0.0.1:2345/debug/metrics` (or whatever the miner api address), and look this like:
```
# HELP lotus_sched_assigner_cycle_candidates_ms Duration of scheduler assigner candidate matching step
# TYPE lotus_sched_assigner_cycle_candidates_ms histogram
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.01"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.05"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.1"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.3"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.6"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="0.8"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="1"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="2"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="3"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="4"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="5"} 0
lotus_sched_assigner_cycle_candidates_ms_bucket{le="6"} 3
lotus_sched_assigner_cycle_candidates_ms_bucket{le="8"} 6
lotus_sched_assigner_cycle_candidates_ms_bucket{le="10"} 6
lotus_sched_assigner_cycle_candidates_ms_bucket{le="13"} 7
lotus_sched_assigner_cycle_candidates_ms_bucket{le="16"} 8
lotus_sched_assigner_cycle_candidates_ms_bucket{le="20"} 8
lotus_sched_assigner_cycle_candidates_ms_bucket{le="25"} 8
lotus_sched_assigner_cycle_candidates_ms_bucket{le="30"} 9
lotus_sched_assigner_cycle_candidates_ms_bucket{le="40"} 13
lotus_sched_assigner_cycle_candidates_ms_bucket{le="50"} 13
lotus_sched_assigner_cycle_candidates_ms_bucket{le="65"} 14
lotus_sched_assigner_cycle_candidates_ms_bucket{le="80"} 14
...
lotus_sched_assigner_cycle_candidates_ms_bucket{le="+Inf"} 14
lotus_sched_assigner_cycle_candidates_ms_sum 288.22000499999996
lotus_sched_assigner_cycle_candidates_ms_count 14
# HELP lotus_sched_assigner_cycle_ms Duration of scheduler assigner cycle
# TYPE lotus_sched_assigner_cycle_ms histogram
lotus_sched_assigner_cycle_ms_bucket{le="0.01"} 0
lotus_sched_assigner_cycle_ms_bucket{le="0.05"} 26
lotus_sched_assigner_cycle_ms_bucket{le="0.1"} 28
lotus_sched_assigner_cycle_ms_bucket{le="0.3"} 30
lotus_sched_assigner_cycle_ms_bucket{le="0.6"} 30
lotus_sched_assigner_cycle_ms_bucket{le="0.8"} 30
lotus_sched_assigner_cycle_ms_bucket{le="1"} 30
lotus_sched_assigner_cycle_ms_bucket{le="2"} 30
lotus_sched_assigner_cycle_ms_bucket{le="3"} 30
lotus_sched_assigner_cycle_ms_bucket{le="4"} 30
lotus_sched_assigner_cycle_ms_bucket{le="5"} 30
lotus_sched_assigner_cycle_ms_bucket{le="6"} 33
lotus_sched_assigner_cycle_ms_bucket{le="8"} 36
lotus_sched_assigner_cycle_ms_bucket{le="10"} 36
lotus_sched_assigner_cycle_ms_bucket{le="13"} 37
lotus_sched_assigner_cycle_ms_bucket{le="16"} 38
lotus_sched_assigner_cycle_ms_bucket{le="20"} 38
...
lotus_sched_assigner_cycle_ms_bucket{le="+Inf"} 44
lotus_sched_assigner_cycle_ms_sum 290.674471
lotus_sched_assigner_cycle_ms_count 44
# HELP lotus_sched_assigner_cycle_submit_ms Duration of scheduler window submit step
# TYPE lotus_sched_assigner_cycle_submit_ms histogram
lotus_sched_assigner_cycle_submit_ms_bucket{le="0.01"} 14
lotus_sched_assigner_cycle_submit_ms_bucket{le="0.05"} 14
lotus_sched_assigner_cycle_submit_ms_bucket{le="0.1"} 14
...
lotus_sched_assigner_cycle_submit_ms_bucket{le="+Inf"} 14
lotus_sched_assigner_cycle_submit_ms_sum 0.040256
lotus_sched_assigner_cycle_submit_ms_count 14
# HELP lotus_sched_assigner_cycle_window_select_ms Duration of scheduler window selection step
# TYPE lotus_sched_assigner_cycle_window_select_ms histogram
lotus_sched_assigner_cycle_window_select_ms_bucket{le="0.01"} 0
lotus_sched_assigner_cycle_window_select_ms_bucket{le="0.05"} 0
lotus_sched_assigner_cycle_window_select_ms_bucket{le="0.1"} 14
lotus_sched_assigner_cycle_window_select_ms_bucket{le="0.3"} 14
...
lotus_sched_assigner_cycle_window_select_ms_bucket{le="+Inf"} 14
lotus_sched_assigner_cycle_window_select_ms_sum 0.998292
lotus_sched_assigner_cycle_window_select_ms_count 14
# HELP lotus_sched_assigner_cycle_task_queue_entry Number of task queue entries in scheduling cycles
# TYPE lotus_sched_assigner_cycle_task_queue_entry histogram
lotus_sched_assigner_cycle_task_queue_entry_bucket{le="1"} 16
lotus_sched_assigner_cycle_task_queue_entry_bucket{le="2"} 23
lotus_sched_assigner_cycle_task_queue_entry_bucket{le="3"} 23
...
lotus_sched_assigner_cycle_task_queue_entry_bucket{le="+Inf"} 23
lotus_sched_assigner_cycle_task_queue_entry_sum 7.000000000000002
lotus_sched_assigner_cycle_task_queue_entry_count 23
# HELP lotus_sched_assigner_cycle_open_window Number of open windows in scheduling cycles
# TYPE lotus_sched_assigner_cycle_open_window histogram
lotus_sched_assigner_cycle_open_window_bucket{le="1"} 0
lotus_sched_assigner_cycle_open_window_bucket{le="2"} 0
lotus_sched_assigner_cycle_open_window_bucket{le="3"} 0
lotus_sched_assigner_cycle_open_window_bucket{le="5"} 20
lotus_sched_assigner_cycle_open_window_bucket{le="7"} 21
lotus_sched_assigner_cycle_open_window_bucket{le="10"} 22
lotus_sched_assigner_cycle_open_window_bucket{le="15"} 23
lotus_sched_assigner_cycle_open_window_bucket{le="25"} 23
...
lotus_sched_assigner_cycle_open_window_bucket{le="+Inf"} 23
lotus_sched_assigner_cycle_open_window_sum 102
lotus_sched_assigner_cycle_open_window_count 23
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
