### PR TITLE
_ci_: Rely on local env varibale instead of context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1021,8 +1021,6 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release"
-          context:
-            - filecoin-goreleaser-key
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
@@ -1036,8 +1034,6 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release (dry-run)"
-          context:
-            - filecoin-goreleaser-key
           dry-run: true
           requires:
             - "Build ( darwin / amd64 )"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -716,8 +716,6 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release"
-          context:
-            - filecoin-goreleaser-key
           requires:
             - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
@@ -731,8 +729,6 @@ workflows:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - release:
           name: "Release (dry-run)"
-          context:
-            - filecoin-goreleaser-key
           dry-run: true
           requires:
             - "Build ( darwin / amd64 )"


### PR DESCRIPTION
We have this env varible set in the project settings as well as the CircleCI context. Due to what seems like a bug on CircleCI's eng, the using the context causes our release flow to halt when some member of the team initiate releases, but not others. So for now, it's safest to rely on the project settings, which definitely won't cause this issue.

Specifically, if we don't merge this if @shrenujbansal creates the release tag again it will likely not work, but if that happens any other member of the filecoin-project or should be able to rebuild and have it work.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
