### PR TITLE
fix: itests: Add missing task type in TestUnsealPiece

### DIFF
--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -33,7 +33,7 @@ func TestUnsealPiece(t *testing.T) {
 	ens.Worker(miner, &worker, kit.ThroughRPC(), kit.NoStorage(), // no storage to have better control over path settings
 		kit.WithTaskTypes([]sealtasks.TaskType{
 			sealtasks.TTFetch, sealtasks.TTAddPiece,
-			sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTPreCommit1, sealtasks.TTPreCommit2, sealtasks.TTCommit2,
+			sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTFinalizeUnsealed, sealtasks.TTPreCommit1, sealtasks.TTPreCommit2, sealtasks.TTCommit2,
 			sealtasks.TTReplicaUpdate, sealtasks.TTUnseal, // only first update step, later steps will not run and we'll abort
 		}),
 	)


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/pull/9648 added a new task type, and https://github.com/filecoin-project/lotus/pull/9694 was opened before it was in master, but landed after breaking tests

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
