### PR TITLE
fix: cli: Check upper bound for deal duration

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -627,7 +627,13 @@ uiLoop:
 
 			minDealDurationDays := uint64(build.MinDealDuration) / (builtin.SecondsInDay / build.BlockDelaySecs)
 			if days < int(minDealDurationDays) {
-				printErr(xerrors.Errorf("minimum duration is %d days", minDealDurationDays))
+				printErr(xerrors.Errorf("minimum duration is %d days, got %d", minDealDurationDays, days))
+				continue
+			}
+
+			maxDealDurationDays := uint64(build.MaxDealDuration) / (builtin.SecondsInDay / build.BlockDelaySecs)
+			if days > int(maxDealDurationDays) {
+				printErr(xerrors.Errorf("maximum duration is %d days, got %d", maxDealDurationDays, days))
 				continue
 			}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Deal cli wasn't checking upper limit for deals, which was easy to mess up on devnets because of the lower block time.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
