### PR TITLE
fix: test: Deflake raft test

### DIFF
--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -122,7 +122,7 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return xerrors.Errorf("block was from the future (now=%d, blk=%d): %w", now, h.Timestamp, consensus.ErrTemporal)
 	}
 	if h.Timestamp > now {
-		log.Warn("Got block from the future, but within threshold ", h.Timestamp, build.Clock.Now().Unix())
+		log.Warn("Got block from the future, but within threshold", h.Timestamp, build.Clock.Now().Unix())
 	}
 
 	msgsCheck := async.Err(func() error {

--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -122,7 +122,7 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return xerrors.Errorf("block was from the future (now=%d, blk=%d): %w", now, h.Timestamp, consensus.ErrTemporal)
 	}
 	if h.Timestamp > now {
-		log.Warn("Got block from the future, but within threshold", h.Timestamp, build.Clock.Now().Unix())
+		log.Warn("Got block from the future, but within threshold ", h.Timestamp, build.Clock.Now().Unix())
 	}
 
 	msgsCheck := async.Err(func() error {

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -194,7 +194,7 @@ func (n *Ensemble) FullNode(full *TestFullNode, opts ...NodeOpt) *Ensemble {
 		require.NoError(n.t, err)
 	}
 
-	key, err := key.GenerateKey(types.KTBLS)
+	k, err := key.GenerateKey(types.KTBLS)
 	require.NoError(n.t, err)
 
 	if !n.bootstrapped && !options.balance.IsZero() {
@@ -204,19 +204,19 @@ func (n *Ensemble) FullNode(full *TestFullNode, opts ...NodeOpt) *Ensemble {
 		genacc := genesis.Actor{
 			Type:    genesis.TAccount,
 			Balance: options.balance,
-			Meta:    (&genesis.AccountMeta{Owner: key.Address}).ActorMeta(),
+			Meta:    (&genesis.AccountMeta{Owner: k.Address}).ActorMeta(),
 		}
 
 		n.genesis.accounts = append(n.genesis.accounts, genacc)
 	}
 
-	*full = TestFullNode{t: n.t, options: options, DefaultKey: key}
+	*full = TestFullNode{t: n.t, options: options, DefaultKey: k}
 
 	n.inactive.fullnodes = append(n.inactive.fullnodes, full)
 	return n
 }
 
-// Miner enrolls a new miner, using the provided full node for chain
+// MinerEnroll enrolls a new miner, using the provided full node for chain
 // interactions.
 func (n *Ensemble) MinerEnroll(minerNode *TestMiner, full *TestFullNode, opts ...NodeOpt) *Ensemble {
 	require.NotNil(n.t, full, "full node required when instantiating miner")
@@ -679,9 +679,9 @@ func (n *Ensemble) Start() *Ensemble {
 
 		var mineBlock = make(chan lotusminer.MineReq)
 
-		copy := *m.FullNode
-		copy.FullNode = modules.MakeUuidWrapper(copy.FullNode)
-		m.FullNode = &copy
+		cp := *m.FullNode
+		cp.FullNode = modules.MakeUuidWrapper(cp.FullNode)
+		m.FullNode = &cp
 
 		//m.FullNode.FullNode = modules.MakeUuidWrapper(fn.FullNode)
 

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -188,7 +188,7 @@ func OwnerAddr(wk *key.Key) NodeOpt {
 // the node.
 func ConstructorOpts(extra ...node.Option) NodeOpt {
 	return func(opts *nodeOpts) error {
-		opts.extraNodeOpts = extra
+		opts.extraNodeOpts = append(opts.extraNodeOpts, extra...)
 		return nil
 	}
 }

--- a/lib/consensus/raft/config.go
+++ b/lib/consensus/raft/config.go
@@ -97,7 +97,7 @@ func NewClusterRaftConfig(userRaftConfig *config.UserRaftConfig) *ClusterRaftCon
 
 }
 
-// Validate checks that this configuration has working values,
+// ValidateConfig checks that this configuration has working values,
 // at least in appearance.
 func ValidateConfig(cfg *ClusterRaftConfig) error {
 	if cfg.RaftConfig == nil {

--- a/lib/consensus/raft/consensus.go
+++ b/lib/consensus/raft/consensus.go
@@ -304,7 +304,7 @@ func (cc *Consensus) Trust(ctx context.Context, pid peer.ID) error { return nil 
 // Distrust is a no-Op.
 func (cc *Consensus) Distrust(ctx context.Context, pid peer.ID) error { return nil }
 
-// returns true if the operation was redirected to the leader
+// RedirectToLeader returns true if the operation was redirected to the leader
 // note that if the leader just dissappeared, the rpc call will
 // fail because we haven't heard that it's gone.
 func (cc *Consensus) RedirectToLeader(method string, arg interface{}, ret interface{}) (bool, error) {
@@ -439,7 +439,7 @@ func (cc *Consensus) RmPeer(ctx context.Context, pid peer.ID) error {
 	return finalErr
 }
 
-// RaftState retrieves the current consensus RaftState. It may error if no RaftState has
+// State retrieves the current consensus RaftState. It may error if no RaftState has
 // been agreed upon or the state is not consistent. The returned RaftState is the
 // last agreed-upon RaftState known by this node. No writes are allowed, as all
 // writes to the shared state should happen through the Consensus component


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9735

## Proposed Changes
This test has 3 nodes in a cluster, and one on its own. The one on its own was accidentally being passed `initPeerSet` which would cause it to connect to the cluster, and occasionally be the leader, which caused the test to flake.

I also added some small changes to make my linter happy while I was here.

## Additional Info
Ran this test x100 on my machine with no failures. It was failing 25% of the time before.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
