### PR TITLE
fix make docsgen-cli use python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ snap: lotus lotus-miner lotus-worker
 
 # separate from gen because it needs binaries
 docsgen-cli: lotus lotus-miner lotus-worker
-	python ./scripts/generate-lotus-cli.py
+	python3 ./scripts/generate-lotus-cli.py
 	./lotus config default > documentation/en/default-lotus-config.toml
 	./lotus-miner config default > documentation/en/default-lotus-miner-config.toml
 .PHONY: docsgen-cli

--- a/scripts/generate-lotus-cli.py
+++ b/scripts/generate-lotus-cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Generate lotus command lines documents as text and markdown in folder "lotus/documentation/en".
-# Python 2.7
+# Python 3
 
 import os
 


### PR DESCRIPTION

## Related Issues
`make docsgen-cli` was failing on mac

## Proposed Changes
changing Makefile to explicitly call python3 

## Additional Info
we're discussing rewriting ./scripts/generate-lotus-cli.py into go to not require python. However since we already are compatible with python3 and python 2 is not supported anymore, the explicit change to python3 is good. Simialrly once we rewrite generate lotus cli in GO, it's not bad that we've accepted this change, we can then still rip out python, but in the meantime having it supported on more. machines is good.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
