### PR TITLE
fix: chain: event filter ids are in hexstring format

### DIFF
--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -369,9 +370,10 @@ func (m *EventFilterManager) Install(ctx context.Context, minHeight, maxHeight a
 	if err != nil {
 		return nil, xerrors.Errorf("new uuid: %w", err)
 	}
+	hexId := "0x" + strings.Replace(id.String(), "-", "", -1)
 
 	f := &EventFilter{
-		id:         id.String(),
+		id:         hexId,
 		minHeight:  minHeight,
 		maxHeight:  maxHeight,
 		tipsetCid:  tipsetCid,


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/ref-fvm/issues/1189

## Proposed Changes
Converts event filters ids in UUIDv4 format to hexstring format by prepending "0x" and removing dash characters"-". This results in a hexstring with 32 digits, which is consistent with other EVM RPCs.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
