### PR TITLE
_ci_ Switch release name template from "Release vX.X.X" to "vX.X.X"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,7 +75,7 @@ release:
     owner: filecoin-project
     name: lotus
   prerelease: auto
-  name_template: "Release v{{.Version}}"
+  name_template: "v{{.Version}}"
 
 brews:
   - tap:


### PR DESCRIPTION
This is a very simple change that updates the default name for releases to no longer include the word `Release`, only the version `vX.X.X`. This has been the practice when manually naming releases, but when I created the automated release workflow I included the extra word by accident. This removes it.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
