### PR TITLE
Use correct field for upper epoch range in EthGetLogs

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -783,7 +783,7 @@ func (e *EthEvent) installEthFilterSpec(ctx context.Context, filterSpec *api.Eth
 		} else if *filterSpec.ToBlock == "pending" {
 			return nil, api.ErrNotSupported
 		} else {
-			epoch, err := api.EthUint64FromHex(*filterSpec.FromBlock)
+			epoch, err := api.EthUint64FromHex(*filterSpec.ToBlock)
 			if err != nil {
 				return nil, xerrors.Errorf("invalid epoch")
 			}


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/ref-fvm/issues/1206

## Proposed Changes
In EthGetLogs when `toBlock` contained an epoch the code was incorrectly taking the epoch from `fromBlock` leading to the bizarre behaviour detailed in the linked issue

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
