### PR TITLE
Fix getting event logs by topic

### DIFF
--- a/chain/types/event.go
+++ b/chain/types/event.go
@@ -24,3 +24,9 @@ type EventEntry struct {
 }
 
 type FilterID [32]byte // compatible with EthHash
+
+// EventEntry flags defined in fvm_shared
+const (
+	EventFlagIndexedKey   = 0b00000001
+	EventFlagIndexedValue = 0b00000010
+)

--- a/itests/fevm_events_test.go
+++ b/itests/fevm_events_test.go
@@ -29,6 +29,7 @@ func TestFEVMEvents(t *testing.T) {
 	defer cancel()
 
 	// install contract
+	// See https://github.com/filecoin-project/builtin-actors/blob/next/actors/evm/tests/events.rs#L12
 	contractHex, err := os.ReadFile("contracts/events.bin")
 	require.NoError(err)
 
@@ -65,17 +66,18 @@ func TestFEVMEvents(t *testing.T) {
 	ret := client.EVM().InvokeSolidity(ctx, fromAddr, idAddr, []byte{0x00, 0x00, 0x00, 0x00}, nil)
 	require.True(ret.Receipt.ExitCode.IsSuccess(), "contract execution failed")
 	require.NotNil(ret.Receipt.EventsRoot)
-	fmt.Println(client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
+	fmt.Println(ret)
+	fmt.Printf("Events:\n %+v\n", client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
 
 	// log a zero topic event with no data
 	ret = client.EVM().InvokeSolidity(ctx, fromAddr, idAddr, []byte{0x00, 0x00, 0x00, 0x01}, nil)
 	require.True(ret.Receipt.ExitCode.IsSuccess(), "contract execution failed")
 	fmt.Println(ret)
-	fmt.Println(client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
+	fmt.Printf("Events:\n %+v\n", client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
 
 	// log a four topic event with data
 	ret = client.EVM().InvokeSolidity(ctx, fromAddr, idAddr, []byte{0x00, 0x00, 0x00, 0x02}, nil)
 	require.True(ret.Receipt.ExitCode.IsSuccess(), "contract execution failed")
 	fmt.Println(ret)
-	fmt.Println(client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
+	fmt.Printf("Events:\n %+v\n", client.EVM().LoadEvents(ctx, *ret.Receipt.EventsRoot))
 }


### PR DESCRIPTION
## Related Issues
Fixes  https://github.com/filecoin-project/ref-fvm/issues/1207

## Proposed Changes
Finding event logs in the historical index by topic was broken for a few separate reasons:
 1. sometime between original implementation and FIP-0049 landing the indexable flag was split into 2 distinct flags - this PR adds these as constants in the types package
 2. decoding the cbor encoded byte array values was added as a fix in the api but didn't find its way into the database code which was recording cbor encoded versions of the entry values
 3. the query code was not accounting for zero padding of the topic byte arrays

Points 1+2 result in bad data in the database so any existing indexed events will not be retrievable by topic even after this PR is merged. They are still retrievable via other criteria. New events logged after this merge is deployed should be fine.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
