### PR TITLE
fix: sealing: Avoid nil dereference in debug log

### DIFF
--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 var log = logging.Logger("lotus-tracer")

--- a/node/modules/tracer/tracer_test.go
+++ b/node/modules/tracer/tracer_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -449,6 +449,9 @@ func (m *Sealing) updateInput(ctx context.Context, sp abi.RegisteredSealProof) e
 		if err != nil {
 			return 0, big.Zero(), err
 		}
+		if onChainInfo == nil {
+			return 0, big.Zero(), xerrors.Errorf("sector info for sector %d not found", sn)
+		}
 		memo[sn] = struct {
 			e abi.ChainEpoch
 			p abi.TokenAmount

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -494,10 +494,6 @@ func (m *Sealing) updateInput(ctx context.Context, sp abi.RegisteredSealProof) e
 				continue
 			}
 			if !ok {
-				exp, _, _ := getExpirationCached(sector.number)
-
-				// todo move this log into checkDealAssignable, make more detailed about the reason
-				log.Debugf("CC update sector %d cannot fit deal, expiration %d before deal end epoch %d", id, exp, piece.deal.DealProposal.EndEpoch)
 				continue
 			}
 

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -142,8 +142,21 @@ type openSector struct {
 }
 
 func (o *openSector) checkDealAssignable(piece *pendingPiece, expF expFn) (bool, error) {
+	log := log.With(
+		"sector", o.number,
+
+		"deal", piece.deal.DealID,
+		"dealEnd", piece.deal.DealProposal.EndEpoch,
+		"dealStart", piece.deal.DealProposal.StartEpoch,
+		"dealClaimEnd", piece.claimTerms.claimTermEnd,
+
+		"lastAssignedDealEnd", o.lastDealEnd,
+		"update", o.ccUpdate,
+	)
+
 	// if there are deals assigned, check that no assigned deal expires after termMax
 	if o.lastDealEnd > piece.claimTerms.claimTermEnd {
+		log.Debugw("deal not assignable to sector", "reason", "term end beyond last assigned deal end")
 		return false, nil
 	}
 
@@ -153,15 +166,26 @@ func (o *openSector) checkDealAssignable(piece *pendingPiece, expF expFn) (bool,
 	}
 	sectorExpiration, _, err := expF(o.number)
 	if err != nil {
+		log.Debugw("deal not assignable to sector", "reason", "error getting sector expiranion", "error", err)
 		return false, err
 	}
 
+	log = log.With(
+		"sectorExpiration", sectorExpiration,
+	)
+
 	// check that in case of upgrade sector, it's expiration isn't above deals claim TermMax
 	if sectorExpiration > piece.claimTerms.claimTermEnd {
+		log.Debugw("deal not assignable to sector", "reason", "term end beyond sector expiration")
 		return false, nil
 	}
 
-	return sectorExpiration >= piece.deal.DealProposal.EndEpoch, nil
+	if sectorExpiration < piece.deal.DealProposal.EndEpoch {
+		log.Debugw("deal not assignable to sector", "reason", "sector expiration less than deal expiration")
+		return false, nil
+	}
+
+	return true, nil
 }
 
 type pieceAcceptResp struct {


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/9769

## Proposed Changes
Don't panic, also improve assigner debug logs

## Additional Info
Before the Shark upgrade `checkDealAssignable` would only ever return `false` if the sector was an upgrade sector.

When that happened we'd try to get sector expiration for the `CC update sector %d cannot fit deal...` debug log, which would panic when we try that on non-upgrade sectors - which can now happen due to the new TermMax handling logic in `checkDealAssignable` when the sector has some deals assigned, and we have an incoming deal which can't fit into the sector.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
