### PR TITLE
_build_: Fix docker deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,6 +587,10 @@ jobs:
                       name: Docker push
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        if [[ ! -z $CIRCLE_SHA ]]; then
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                        fi
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
@@ -613,6 +617,10 @@ jobs:
                       name: Docker push
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        if [[ ! -z $CIRCLE_SHA ]]; then
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                        fi
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1286,6 +1286,51 @@ workflows:
             branches:
               only:
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
+      - build-docker:
+          name: "Docker push (lotus / stable / mainnet)"
+          image: lotus
+          channel: stable
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+$/
+      - build-docker:
+          name: "Docker push (lotus / candidate / mainnet)"
+          image: lotus
+          channel: candidate
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
+      - build-docker:
+          name: "Docker push (lotus / master / mainnet)"
+          image: lotus
+          channel: master
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              only:
+                - master
+      - build-docker:
+          name: "Docker build (lotus / mainnet)"
+          image: lotus
+          network: mainnet
+          push: false
+          filters:
+            branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1133,6 +1133,16 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
       - build-docker:
+          name: "Docker push (lotus-all-in-one / edge / mainnet)"
+          image: lotus-all-in-one
+          channel: master
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              only:
+                - master
+      - build-docker:
           name: "Docker build (lotus-all-in-one / mainnet)"
           image: lotus-all-in-one
           network: mainnet
@@ -1167,6 +1177,16 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
+      - build-docker:
+          name: "Docker push (lotus-all-in-one / edge / butterflynet)"
+          image: lotus-all-in-one
+          channel: master
+          network: butterflynet
+          push: true
+          filters:
+            branches:
+              only:
+                - master
       - build-docker:
           name: "Docker build (lotus-all-in-one / butterflynet)"
           image: lotus-all-in-one
@@ -1203,6 +1223,16 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
       - build-docker:
+          name: "Docker push (lotus-all-in-one / edge / calibnet)"
+          image: lotus-all-in-one
+          channel: master
+          network: calibnet
+          push: true
+          filters:
+            branches:
+              only:
+                - master
+      - build-docker:
           name: "Docker build (lotus-all-in-one / calibnet)"
           image: lotus-all-in-one
           network: calibnet
@@ -1237,6 +1267,16 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
+      - build-docker:
+          name: "Docker push (lotus-all-in-one / edge / debug)"
+          image: lotus-all-in-one
+          channel: master
+          network: debug
+          push: true
+          filters:
+            branches:
+              only:
+                - master
       - build-docker:
           name: "Docker build (lotus-all-in-one / debug)"
           image: lotus-all-in-one

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,10 +586,10 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        echo docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
-                          echo docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
                         fi
             - unless:
                 condition: <<parameters.push>>
@@ -612,10 +612,10 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        echo docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
-                          echo docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
                         fi
             - unless:
                 condition: <<parameters.push>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -818,6 +818,51 @@ workflows:
               only:
                 - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
       [[- end]]
+      - build-docker:
+          name: "Docker push (lotus / stable / mainnet)"
+          image: lotus
+          channel: stable
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+$/
+      - build-docker:
+          name: "Docker push (lotus / candidate / mainnet)"
+          image: lotus
+          channel: candidate
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+-rc\d+$/
+      - build-docker:
+          name: "Docker push (lotus / master / mainnet)"
+          image: lotus
+          channel: master
+          network: mainnet
+          push: true
+          filters:
+            branches:
+              only:
+                - master
+      - build-docker:
+          name: "Docker build (lotus / mainnet)"
+          image: lotus
+          network: mainnet
+          push: false
+          filters:
+            branches:
+              only:
+                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
 
   nightly:
     triggers:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -586,10 +586,10 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        echo docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
-                          echo docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
                         fi
             - unless:
                 condition: <<parameters.push>>
@@ -612,10 +612,10 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        echo docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
-                          echo docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
                         fi
             - unless:
                 condition: <<parameters.push>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -799,6 +799,16 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+-rc\d+$/
       - build-docker:
+          name: "Docker push (lotus-all-in-one / edge / [[.]])"
+          image: lotus-all-in-one
+          channel: master
+          network: [[.]]
+          push: true
+          filters:
+            branches:
+              only:
+                - master
+      - build-docker:
           name: "Docker build (lotus-all-in-one / [[.]])"
           image: lotus-all-in-one
           network: [[.]]

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -587,6 +587,10 @@ jobs:
                       name: Docker push
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                        fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
@@ -613,6 +617,10 @@ jobs:
                       name: Docker push
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                        fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/libp2p/go-libp2p-consensus v0.0.1
+	github.com/libp2p/go-libp2p-core v0.20.1
 	github.com/libp2p/go-libp2p-gorpc v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.18.0
 	github.com/libp2p/go-libp2p-pubsub v0.8.2
@@ -262,7 +263,6 @@ require (
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-connmgr v0.4.0 // indirect
-	github.com/libp2p/go-libp2p-core v0.20.1 // indirect
 	github.com/libp2p/go-libp2p-gostream v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-noise v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,6 @@ require (
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/libp2p/go-libp2p-consensus v0.0.1
-	github.com/libp2p/go-libp2p-core v0.20.1
 	github.com/libp2p/go-libp2p-gorpc v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.18.0
 	github.com/libp2p/go-libp2p-pubsub v0.8.2
@@ -263,6 +262,7 @@ require (
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-connmgr v0.4.0 // indirect
+	github.com/libp2p/go-libp2p-core v0.20.1 // indirect
 	github.com/libp2p/go-libp2p-gostream v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.5.0 // indirect
 	github.com/libp2p/go-libp2p-noise v0.5.0 // indirect

--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )

--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p/core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 var log = logging.Logger("lotus-tracer")

--- a/node/modules/tracer/tracer_test.go
+++ b/node/modules/tracer/tracer_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 

--- a/node/modules/tracer/tracer_test.go
+++ b/node/modules/tracer/tracer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Related Issues
**This is a p0 update**
When I refactored the docker image publishing process earlier, I forgot two critical pieces which broke our docker releases. We haven't pushed any images in the last 11 days as a result, since `1.18.1`
1. I used `echo` in the publish jobs to sanity check that they were working without publishing new images, and forgot to remove those `echo` calls when it was merged, meaning none of our docker publish jobs were actually publishing images.
2. I forgot to also create build / publish jobs for the `lotus` image, instead only building `lotus-all-in-one`.

## Proposed Changes
In addition to fixing the two issues above, this PR:
1. Builds and pushes a container on every master merge to the `master` branch.
2. Pushes containers to immutable SHA tags in additional to the mutable channel tags (i.e. stable, master, etc)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
