### PR TITLE
fix: miner: Check for nil returns from StateSectorGetInfo

### DIFF
--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -79,6 +79,7 @@ type State interface {
 	LockedFunds() (LockedFunds, error)
 	FeeDebt() (abi.TokenAmount, error)
 
+    // Returns nil, nil if sector is not found
 	GetSector(abi.SectorNumber) (*SectorOnChainInfo, error)
 	FindSector(abi.SectorNumber) (*SectorLocation, error)
 	GetSectorExpiration(abi.SectorNumber) (*SectorExpiration, error)

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -127,6 +127,7 @@ type State interface {
 	LockedFunds() (LockedFunds, error)
 	FeeDebt() (abi.TokenAmount, error)
 
+	// Returns nil, nil if sector is not found
 	GetSector(abi.SectorNumber) (*SectorOnChainInfo, error)
 	FindSector(abi.SectorNumber) (*SectorLocation, error)
 	GetSectorExpiration(abi.SectorNumber) (*SectorExpiration, error)

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -100,6 +100,7 @@ func (s *state{{.v}}) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state{{.v}}) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -90,6 +90,7 @@ func (s *state0) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state0) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v10.go
+++ b/chain/actors/builtin/miner/v10.go
@@ -90,6 +90,7 @@ func (s *state10) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state10) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -89,6 +89,7 @@ func (s *state2) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state2) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v3.go
+++ b/chain/actors/builtin/miner/v3.go
@@ -90,6 +90,7 @@ func (s *state3) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state3) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v4.go
+++ b/chain/actors/builtin/miner/v4.go
@@ -90,6 +90,7 @@ func (s *state4) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state4) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v5.go
+++ b/chain/actors/builtin/miner/v5.go
@@ -90,6 +90,7 @@ func (s *state5) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state5) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v6.go
+++ b/chain/actors/builtin/miner/v6.go
@@ -90,6 +90,7 @@ func (s *state6) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state6) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v7.go
+++ b/chain/actors/builtin/miner/v7.go
@@ -90,6 +90,7 @@ func (s *state7) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state7) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v8.go
+++ b/chain/actors/builtin/miner/v8.go
@@ -90,6 +90,7 @@ func (s *state8) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state8) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/actors/builtin/miner/v9.go
+++ b/chain/actors/builtin/miner/v9.go
@@ -90,6 +90,7 @@ func (s *state9) PreCommitDeposits() (abi.TokenAmount, error) {
 	return s.State.PreCommitDeposits, nil
 }
 
+// Returns nil, nil if sector is not found
 func (s *state9) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
 	info, ok, err := s.State.GetSector(s.store, num)
 	if !ok || err != nil {

--- a/chain/stmgr/actors.go
+++ b/chain/stmgr/actors.go
@@ -103,6 +103,7 @@ func PreCommitInfo(ctx context.Context, sm *StateManager, maddr address.Address,
 	return mas.GetPrecommittedSector(sid)
 }
 
+// Returns nil, nil if sector is not found
 func MinerSectorInfo(ctx context.Context, sm *StateManager, maddr address.Address, sid abi.SectorNumber, ts *types.TipSet) (*miner.SectorOnChainInfo, error) {
 	act, err := sm.LoadActor(ctx, maddr, ts)
 	if err != nil {

--- a/itests/ccupgrade_test.go
+++ b/itests/ccupgrade_test.go
@@ -71,6 +71,7 @@ func runTestCCUpgrade(t *testing.T) *kit.TestFullNode {
 	{
 		si, err := client.StateSectorGetInfo(ctx, maddr, CCUpgrade, types.EmptyTSK)
 		require.NoError(t, err)
+		require.NotNil(t, si)
 		require.Less(t, 50000, int(si.Expiration))
 	}
 	client.WaitForSectorActive(ctx, t, CCUpgrade, maddr)

--- a/itests/sector_make_cc_avail_test.go
+++ b/itests/sector_make_cc_avail_test.go
@@ -44,6 +44,7 @@ func TestMakeAvailable(t *testing.T) {
 	{
 		si, err := client.StateSectorGetInfo(ctx, maddr, CCUpgrade, types.EmptyTSK)
 		require.NoError(t, err)
+		require.NotNil(t, si)
 		require.Less(t, 50000, int(si.Expiration))
 	}
 	client.WaitForSectorActive(ctx, t, CCUpgrade, maddr)

--- a/itests/sector_prefer_no_upgrade_test.go
+++ b/itests/sector_prefer_no_upgrade_test.go
@@ -46,6 +46,7 @@ func TestPreferNoUpgrade(t *testing.T) {
 		{
 			si, err := client.StateSectorGetInfo(ctx, maddr, CCUpgrade, types.EmptyTSK)
 			require.NoError(t, err)
+			require.NotNil(t, si)
 			require.Less(t, 50000, int(si.Expiration))
 		}
 		client.WaitForSectorActive(ctx, t, CCUpgrade, maddr)

--- a/itests/sector_revert_available_test.go
+++ b/itests/sector_revert_available_test.go
@@ -42,6 +42,7 @@ func TestAbortUpgradeAvailable(t *testing.T) {
 	{
 		si, err := client.StateSectorGetInfo(ctx, maddr, CCUpgrade, types.EmptyTSK)
 		require.NoError(t, err)
+		require.NotNil(t, si)
 		require.Less(t, 50000, int(si.Expiration))
 	}
 	client.WaitForSectorActive(ctx, t, CCUpgrade, maddr)

--- a/miner/warmup.go
+++ b/miner/warmup.go
@@ -59,6 +59,9 @@ out:
 	if err != nil {
 		return xerrors.Errorf("getting sector info: %w", err)
 	}
+	if si == nil {
+		return xerrors.Errorf("sector not found %d", sector)
+	}
 
 	ts, err := m.api.ChainHead(ctx)
 	if err != nil {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1046,6 +1046,7 @@ func (a *StateAPI) StateSectorPreCommitInfo(ctx context.Context, maddr address.A
 	return pci, err
 }
 
+// Returns nil, nil if sector is not found
 func (m *StateModule) StateSectorGetInfo(ctx context.Context, maddr address.Address, n abi.SectorNumber, tsk types.TipSetKey) (*miner.SectorOnChainInfo, error) {
 	ts, err := m.Chain.GetTipSetFromKey(ctx, tsk)
 	if err != nil {

--- a/storage/pipeline/states_replica_update.go
+++ b/storage/pipeline/states_replica_update.go
@@ -143,6 +143,10 @@ func (m *Sealing) handleSubmitReplicaUpdate(ctx statemachine.Context, sector Sec
 		log.Errorf("handleSubmitReplicaUpdate: api error, not proceeding: %+v", err)
 		return nil
 	}
+	if onChainInfo == nil {
+		return xerrors.Errorf("sector not found %d", sector.SectorNumber)
+	}
+
 	sp, err := m.currentSealProof(ctx.Context())
 	if err != nil {
 		log.Errorf("sealer failed to return current seal proof not proceeding: %+v", err)

--- a/storage/pipeline/upgrade_queue.go
+++ b/storage/pipeline/upgrade_queue.go
@@ -33,6 +33,9 @@ func (m *Sealing) MarkForUpgrade(ctx context.Context, id abi.SectorNumber) error
 	if err != nil {
 		return xerrors.Errorf("failed to read sector on chain info: %w", err)
 	}
+	if onChainInfo == nil {
+		return xerrors.Errorf("sector not found %d", id)
+	}
 
 	active, err := m.sectorActive(ctx, ts.Key(), id)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
`StateSectorGetInfo()` returns `nil, nil` in the case that the given sector number isn't found. Many functions that call `StateSectorGetInfo()` do not check if the resulting `SectorOnChainInfo` is nil or not, so this PR adds those checks. This was originally discovered because of https://github.com/filecoin-project/lotus/pull/9822/files

The API is designed this way to allow for indicating that the sector is not found. We don't want to break the current functionality of the API, but in the future we could probably send a typed error instead of returning `nil, nil`.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
