### PR TITLE
Chore: Use abi.MethodNum instead of uint64 for method nums

### DIFF
--- a/chain/actors/builtin/registry.go
+++ b/chain/actors/builtin/registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/builtin"
 	account10 "github.com/filecoin-project/go-state-types/builtin/v10/account"
@@ -53,14 +54,14 @@ import (
 type RegistryEntry struct {
 	state   cbor.Er
 	code    cid.Cid
-	methods map[uint64]builtin.MethodMeta
+	methods map[abi.MethodNum]builtin.MethodMeta
 }
 
 func (r RegistryEntry) State() cbor.Er {
 	return r.state
 }
 
-func (r RegistryEntry) Exports() map[uint64]builtin.MethodMeta {
+func (r RegistryEntry) Exports() map[abi.MethodNum]builtin.MethodMeta {
 	return r.methods
 }
 
@@ -72,10 +73,10 @@ func MakeRegistryLegacy(actors []rtt.VMActor) []RegistryEntry {
 	registry := make([]RegistryEntry, 0)
 
 	for _, actor := range actors {
-		methodMap := make(map[uint64]builtin.MethodMeta)
+		methodMap := make(map[abi.MethodNum]builtin.MethodMeta)
 		for methodNum, method := range actor.Exports() {
 			if method != nil {
-				methodMap[uint64(methodNum)] = makeMethodMeta(method)
+				methodMap[abi.MethodNum(methodNum)] = makeMethodMeta(method)
 			}
 		}
 		registry = append(registry, RegistryEntry{

--- a/chain/actors/builtin/registry.go.template
+++ b/chain/actors/builtin/registry.go.template
@@ -29,19 +29,20 @@ import (
 	"github.com/filecoin-project/go-state-types/cbor"
 	rtt "github.com/filecoin-project/go-state-types/rt"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/go-state-types/abi"
 )
 
 type RegistryEntry struct {
 	state   cbor.Er
 	code    cid.Cid
-	methods map[uint64]builtin.MethodMeta
+	methods map[abi.MethodNum]builtin.MethodMeta
 }
 
 func (r RegistryEntry) State() cbor.Er {
 	return r.state
 }
 
-func (r RegistryEntry) Exports() map[uint64]builtin.MethodMeta {
+func (r RegistryEntry) Exports() map[abi.MethodNum]builtin.MethodMeta {
 	return r.methods
 }
 
@@ -53,10 +54,10 @@ func MakeRegistryLegacy(actors []rtt.VMActor) []RegistryEntry {
 	registry := make([]RegistryEntry, 0)
 
     for _, actor := range actors {
-        methodMap := make(map[uint64]builtin.MethodMeta)
+        methodMap := make(map[abi.MethodNum]builtin.MethodMeta)
         for methodNum, method := range actor.Exports() {
 			if method != nil {
-				methodMap[uint64(methodNum)] = makeMethodMeta(method)
+				methodMap[abi.MethodNum(methodNum)] = makeMethodMeta(method)
 			}
 	    }
         registry = append(registry, RegistryEntry{

--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -53,7 +53,7 @@ func ActorsVersionPredicate(ver actorstypes.Version) ActorPredicate {
 }
 
 type invokeFunc func(rt vmr.Runtime, params []byte) ([]byte, aerrors.ActorError)
-type nativeCode map[uint64]invokeFunc
+type nativeCode map[abi.MethodNum]invokeFunc
 
 type actorInfo struct {
 	methods nativeCode
@@ -78,10 +78,10 @@ func (ar *ActorRegistry) Invoke(codeCid cid.Cid, rt vmr.Runtime, method abi.Meth
 	if err := act.predicate(rt, codeCid); err != nil {
 		return nil, aerrors.Newf(exitcode.SysErrorIllegalActor, "unsupported actor: %s", err)
 	}
-	if act.methods[uint64(method)] == nil {
+	if act.methods[method] == nil {
 		return nil, aerrors.Newf(exitcode.SysErrInvalidMethod, "no method %d on actor", method)
 	}
-	return act.methods[uint64(method)](rt, params)
+	return act.methods[method](rt, params)
 
 }
 
@@ -156,7 +156,7 @@ func (ar *ActorRegistry) Register(av actorstypes.Version, pred ActorPredicate, v
 				mm.Params = et.In(0)
 			}
 
-			methods[abi.MethodNum(number)] = mm
+			methods[number] = mm
 		}
 		if realCode.Defined() {
 			ar.Methods[realCode] = methods
@@ -185,7 +185,7 @@ func (ar *ActorRegistry) Create(codeCid cid.Cid, rt vmr.Runtime) (*types.Actor, 
 }
 
 type invokee interface {
-	Exports() map[uint64]builtinst.MethodMeta
+	Exports() map[abi.MethodNum]builtinst.MethodMeta
 }
 
 func (*ActorRegistry) transform(instance invokee) (nativeCode, error) {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/filecoin-project/go-legs v0.4.4
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.10.0-alpha-3
+	github.com/filecoin-project/go-state-types v0.10.0-alpha-4
 	github.com/filecoin-project/go-statemachine v1.0.2
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psS
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.8/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.1.10/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.10.0-alpha-3 h1:8iM9uz+rWRbrg1Zet+YlTJN4XEPNqRkqa3zay2pwV7w=
-github.com/filecoin-project/go-state-types v0.10.0-alpha-3/go.mod h1:FPgQE05BFwZxKw/vCuIaIrzfJKo4RPQQMMPGd43dAFI=
+github.com/filecoin-project/go-state-types v0.10.0-alpha-4 h1:qFuw0C+ShmpyRTpJIYAB+u11F6fYqI/4vU138EFc3ps=
+github.com/filecoin-project/go-state-types v0.10.0-alpha-4/go.mod h1:FPgQE05BFwZxKw/vCuIaIrzfJKo4RPQQMMPGd43dAFI=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2 h1:421SSWBk8GIoCoWYYTE/d+qCWccgmRH0uXotXRDjUbc=
 github.com/filecoin-project/go-statemachine v1.0.2/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Integrates https://github.com/filecoin-project/go-state-types/pull/133

Makes method metadata much cleaner :)

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
