### PR TITLE
_build_: Fix Macos M1 and universal binary builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ commands:
         default: false
         description: is a darwin build environment?
         type: boolean
+      darwin-architecture:
+        default: "amd64"
+        description: which darwin architecture is being used?
+        type: string
     steps:
       - checkout
       - git_fetch_all_tags
@@ -59,7 +63,7 @@ commands:
             - run:
                 name: Install Go
                 command: |
-                  curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-amd64.pkg -o /tmp/go.pkg && \
+                  curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-<<parameters.darwin-architecture>>.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
             - run:
                 name: Export Go
@@ -276,6 +280,7 @@ jobs:
       - prepare:
           linux: false
           darwin: true
+          darwin-architecture: amd64
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -298,6 +303,7 @@ jobs:
       - prepare:
           linux: false
           darwin: true
+          darwin-architecture: arm64
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
           darwin: true
           darwin-architecture: amd64
       - run: make lotus lotus-miner lotus-worker
+      - run: otool -hv lotus
       - run:
           name: check tag and version output match
           command: ./scripts/version-check.sh ./lotus
@@ -308,6 +309,7 @@ jobs:
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
           make lotus lotus-miner lotus-worker
+      - run: otool -hv lotus
       - run:
           name: check tag and version output match
           command: ./scripts/version-check.sh ./lotus

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -34,6 +34,10 @@ commands:
         default: false
         description: is a darwin build environment?
         type: boolean
+      darwin-architecture:
+        default: "amd64"
+        description: which darwin architecture is being used?
+        type: string
     steps:
       - checkout
       - git_fetch_all_tags
@@ -59,7 +63,7 @@ commands:
             - run:
                 name: Install Go
                 command: |
-                  curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-amd64.pkg -o /tmp/go.pkg && \
+                  curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-<<parameters.darwin-architecture>>.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
             - run:
                 name: Export Go
@@ -276,6 +280,7 @@ jobs:
       - prepare:
           linux: false
           darwin: true
+          darwin-architecture: amd64
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -298,6 +303,7 @@ jobs:
       - prepare:
           linux: false
           darwin: true
+          darwin-architecture: arm64
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -282,6 +282,7 @@ jobs:
           darwin: true
           darwin-architecture: amd64
       - run: make lotus lotus-miner lotus-worker
+      - run: otool -hv lotus
       - run:
           name: check tag and version output match
           command: ./scripts/version-check.sh ./lotus
@@ -308,6 +309,7 @@ jobs:
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
           make lotus lotus-miner lotus-worker
+      - run: otool -hv lotus
       - run:
           name: check tag and version output match
           command: ./scripts/version-check.sh ./lotus

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,6 +65,7 @@ archives:
   - id: primary
     format: tar.gz
     wrap_in_directory: true
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       # this is a dumb but required hack so it doesn't include the default files
       # https://github.com/goreleaser/goreleaser/issues/602
@@ -105,4 +106,4 @@ checksum:
   disable: true
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  name_template: "{{ .Version }}"


### PR DESCRIPTION
## Related Issues
This fixes a bug in the new MacOs release process. I accidentally downloaded installed the amd64 go in the new arm64 / Mac M1 environment, which means that it produced a very confused build that was trying to build and amd64 binary linked against arm64 libraries which didn't work. I already updated the 1.19.0 release with the correct binaries, but they will keep breaking until this released.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
