### PR TITLE
_build_ Set noexecstack on snapcraft builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
       - libhwloc15
       - ocl-icd-libopencl1
     override-build: |
-      LDFLAGS="" make lotus lotus-miner lotus-worker
+      LDFLAGS="-z noexecstack" make lotus lotus-miner lotus-worker
       cp lotus lotus-miner lotus-worker $SNAPCRAFT_PART_INSTALL
       cp scripts/snap-lotus-entrypoint.sh $SNAPCRAFT_PART_INSTALL
 


### PR DESCRIPTION
We're currently failing the automated security review on snapcraft because the lotus binary has the execstack value set:
  https://linux.die.net/man/8/execstack

This commit passes the appropriate flags to ld to disable the execstack flag when building the binaries for snapcraft:
  https://linux.die.net/man/1/ld

We may want to consider disabling this as part of the main build. Research seems to indicate that allow the executable stack can lead to security issues, but I am not enough of a security expert to know for sure what the right call here is:
  https://f0rm2l1n.github.io/2022-04-02-What-is-happended-to-execstack/

## Related Issues
https://app.circleci.com/pipelines/github/filecoin-project/lotus/24812/workflows/caf64d82-58af-4985-85ad-8a8e838fd174
https://filecoinproject.slack.com/archives/C029MT4PQB1/p1670971371929079

## Proposed Changes
Set the `noexecstack` ld flag on snapcraft builds.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
