### PR TITLE
fix: daemon: listen for SIGINT and SIGTERM even before node starts

### DIFF
--- a/cli/helper.go
+++ b/cli/helper.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	ufcli "github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
@@ -36,6 +38,13 @@ func IncorrectNumArgs(cctx *ufcli.Context) error {
 }
 
 func RunApp(app *ufcli.App) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-c
+		os.Exit(1)
+	}()
+
 	if err := app.Run(os.Args); err != nil {
 		if os.Getenv("LOTUS_DEV") != "" {
 			log.Warnf("%+v", err)

--- a/node/shutdown.go
+++ b/node/shutdown.go
@@ -51,6 +51,7 @@ func MonitorShutdown(triggerCh <-chan struct{}, handlers ...ShutdownHandler) <-c
 		close(out)
 	}()
 
+	signal.Reset(syscall.SIGTERM, syscall.SIGINT)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	return out
 }


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9862

## Proposed Changes
Right now we set up a listener for SIGINT and SIGTERM once we start the node, but there are some cases where we do *a lot* of work before this happens, such as calling `lotus daemon --import-snapshot' where we import the entire snapshot before starting the node.

Now we install a listener before we start running the cli app. We remove this listener in favour of a more graceful shutdown once we start the node.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
