### PR TITLE
feat: cli: list claims and remove expired claims

### DIFF
--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1210,7 +1210,9 @@ COMMANDS:
      check-notary-datacap           check a notary's remaining bytes
      sign-remove-data-cap-proposal  allows a notary to sign a Remove Data Cap Proposal
      list-allocations               List allocations made by client
+     list-claims                    List claims made by provider
      remove-expired-allocations     remove expired allocations (if no allocations are specified all eligible allocations are removed)
+     remove-expired-claims          remove expired claims (if no claims are specified all eligible claims are removed)
      help, h                        Shows a list of commands or help for one command
 
 OPTIONS:
@@ -1309,6 +1311,19 @@ OPTIONS:
    
 ```
 
+### lotus filplus list-claims
+```
+NAME:
+   lotus filplus list-claims - List claims made by provider
+
+USAGE:
+   lotus filplus list-claims [command options] providerAddress
+
+OPTIONS:
+   --expired  list only expired claims (default: false)
+   
+```
+
 ### lotus filplus remove-expired-allocations
 ```
 NAME:
@@ -1316,6 +1331,19 @@ NAME:
 
 USAGE:
    lotus filplus remove-expired-allocations [command options] clientAddress Optional[...allocationId]
+
+OPTIONS:
+   --from value  optionally specify the account to send the message from
+   
+```
+
+### lotus filplus remove-expired-claims
+```
+NAME:
+   lotus filplus remove-expired-claims - remove expired claims (if no claims are specified all eligible claims are removed)
+
+USAGE:
+   lotus filplus remove-expired-claims [command options] providerAddress Optional[...claimId]
 
 OPTIONS:
    --from value  optionally specify the account to send the message from


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9271

## Proposed Changes
Adds a cli command to list all claims for a given provider.
Adds a cli command to remove expired claims for a given provider.

## Sample Output
<img width="1011" alt="Screenshot 2023-01-12 at 12 43 23 PM" src="https://user-images.githubusercontent.com/9095950/212140401-4ee94e1a-8046-430f-b542-f5df8e14ab0b.png">

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
