### PR TITLE
feat: Check for allocation expiry when waiting to seal sectors

### DIFF
--- a/storage/pipeline/mocks/mock_precommit_batcher.go
+++ b/storage/pipeline/mocks/mock_precommit_batcher.go
@@ -11,7 +11,9 @@ import (
 	gomock "github.com/golang/mock/gomock"
 
 	address "github.com/filecoin-project/go-address"
+	abi "github.com/filecoin-project/go-state-types/abi"
 	big "github.com/filecoin-project/go-state-types/big"
+	verifreg "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	network "github.com/filecoin-project/go-state-types/network"
 
 	api "github.com/filecoin-project/lotus/api"
@@ -84,6 +86,21 @@ func (m *MockPreCommitBatcherApi) StateAccountKey(arg0 context.Context, arg1 add
 func (mr *MockPreCommitBatcherApiMockRecorder) StateAccountKey(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateAccountKey", reflect.TypeOf((*MockPreCommitBatcherApi)(nil).StateAccountKey), arg0, arg1, arg2)
+}
+
+// StateGetAllocationForPendingDeal mocks base method.
+func (m *MockPreCommitBatcherApi) StateGetAllocationForPendingDeal(arg0 context.Context, arg1 abi.DealID, arg2 types.TipSetKey) (*verifreg.Allocation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateGetAllocationForPendingDeal", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*verifreg.Allocation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StateGetAllocationForPendingDeal indicates an expected call of StateGetAllocationForPendingDeal.
+func (mr *MockPreCommitBatcherApiMockRecorder) StateGetAllocationForPendingDeal(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateGetAllocationForPendingDeal", reflect.TypeOf((*MockPreCommitBatcherApi)(nil).StateGetAllocationForPendingDeal), arg0, arg1, arg2)
 }
 
 // StateLookupID mocks base method.


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9368

## Proposed Changes
Checks for allocation expirations to make sure we don't wait too long before sealing. This is slightly tricky because allocations are allowed to expire, the miner will just not get the increased power for the verified deal.

## Additional Info
This could use some testing. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
