### PR TITLE
Support creation and signing of Eth keys

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -304,7 +304,7 @@ func EthAddressFromHex(s string) (EthAddress, error) {
 func EthAddressFromBytes(b []byte) (EthAddress, error) {
 	var a EthAddress
 	if len(b) != EthAddressLength {
-		return EthAddress{}, xerrors.Errorf("cannot parse bytes into anœ EthAddress: incorrect input length")
+		return EthAddress{}, xerrors.Errorf("cannot parse bytes into an EthAddress: incorrect input length")
 	}
 	copy(a[:], b[:])
 	return a, nil

--- a/lib/sigs/delegated/init.go
+++ b/lib/sigs/delegated/init.go
@@ -27,8 +27,16 @@ func (delegatedSigner) ToPublic(pk []byte) ([]byte, error) {
 	return gocrypto.PublicKey(pk), nil
 }
 
-func (delegatedSigner) Sign(pk []byte, msg []byte) ([]byte, error) {
-	return nil, fmt.Errorf("not implemented")
+func (s delegatedSigner) Sign(pk []byte, msg []byte) ([]byte, error) {
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write(msg)
+	hashSum := hasher.Sum(nil)
+	sig, err := gocrypto.Sign(pk, hashSum)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
 }
 
 func (delegatedSigner) Verify(sig []byte, a address.Address, msg []byte) error {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Not having this functionality was making testing EthAccount abstraction difficult.

## Proposed Changes
<!-- A clear list of the changes being made -->

Support creating Eth keys, and generating signatures with them. Assumes all Delegated keytypes are Ethereum Account senders.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
