### PR TITLE
Don't include network when publishing mainnet sha image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
                         fi
                         if [[ ! -z $CIRCLE_TAG ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,8 +588,8 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
-                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                         fi
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
@@ -618,8 +618,8 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
-                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                         fi
                         if [[ ! -z $CIRCLE_TAG ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -588,8 +588,8 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
-                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                         fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"
@@ -618,8 +618,8 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
-                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"-<<parameters.network>>
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
+                          docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                         fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_TAG}"-<<parameters.network>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -588,7 +588,7 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA}"
                         fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then


### PR DESCRIPTION
## Related Issues
I accidentally left in a parameter in this docker push that will cause it to error. The image generated for Mainnet doesn't use the `mainnet` suffix, but I left it in there for the SHA publish. This removes it.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
