### PR TITLE
_ci_ Add CircleCI Dependency caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,23 @@ commands:
           name: fetch all tags
           command: |
             git fetch --all
+  install_go_dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v1-go-mod-{{ arch }}
+            - v1-go-mod-
+      - run:
+          command: make deps
+          no_output_timeout: 30m
+      - save_cache:
+          key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+
   packer_build:
     description: "Run a packer build"
     parameters:
@@ -170,9 +187,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps lotus
-          no_output_timeout: 30m
+      - install_go_dependencies
+      - run: make lotus
       - download-params
       - run:
           name: go test
@@ -213,9 +229,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps lotus
-          no_output_timeout: 30m
+      - install_go_dependencies
+      - run: make lotus
       - download-params
       - when:
           condition:
@@ -259,6 +274,7 @@ jobs:
     executor: golang
     steps:
       - prepare
+      - install_go_dependencies
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -281,6 +297,7 @@ jobs:
           linux: false
           darwin: true
           darwin-architecture: amd64
+      - install_go_dependencies
       - run: make lotus lotus-miner lotus-worker
       - run: otool -hv lotus
       - run:
@@ -305,6 +322,7 @@ jobs:
           linux: false
           darwin: true
           darwin-architecture: arm64
+      - install_go_dependencies
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
@@ -418,7 +436,7 @@ jobs:
     executor: golang
     steps:
       - prepare
-      - run: make deps
+      - install_go_dependencies
       - run: go install golang.org/x/tools/cmd/goimports
       - run: go install github.com/hannahhoward/cbor-gen-for
       - run: make gen
@@ -432,11 +450,11 @@ jobs:
     executor: golang
     steps:
       - prepare
+      - install_go_dependencies
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../pre-openrpc-miner
       - run: zcat build/openrpc/worker.json.gz | jq > ../pre-openrpc-worker
-      - run: make deps
       - run: make docsgen
       - run: zcat build/openrpc/full.json.gz | jq > ../post-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../post-openrpc-miner
@@ -468,9 +486,7 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps
-          no_output_timeout: 30m
+      - install_go_dependencies
       - run:
           name: Lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus
       - download-params
       - run:
@@ -236,6 +237,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus
       - download-params
       - when:
@@ -281,6 +283,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -304,6 +307,7 @@ jobs:
           darwin: true
           darwin-architecture: amd64
       - install_go_dependencies
+      - run: make deps
       - run: make lotus lotus-miner lotus-worker
       - run: otool -hv lotus
       - run:
@@ -329,6 +333,7 @@ jobs:
           darwin: true
           darwin-architecture: arm64
       - install_go_dependencies
+      - run: make deps
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
@@ -443,6 +448,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
       - run: go install github.com/hannahhoward/cbor-gen-for
       - run: make gen
@@ -457,6 +463,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../pre-openrpc-miner
@@ -493,6 +500,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run:
           name: Lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,9 @@ commands:
     steps:
       - run:
           name: Set GOPATH
-          command: echo 'export GOPATH="/opt/go"' >> $BASH_ENV
+          command: |
+            chown -R $USER:$USER /go
+            echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -123,7 +125,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/opt/go/pkg/mod"
+            - "/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
               echo No modules were loaded from the cache
             fi
             go mod download
+            ls $GOPATH/pkg/mod
       - save_cache:
           key: v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,19 +113,22 @@ commands:
             echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
-            - v1-go-mod-{{ arch }}
-            - v1-go-mod-
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v2-go-mod-{{ arch }}
+            - v2-go-mod-
       - run:
           command: |
             echo $GOPATH
-            ls $GOPATH/pkg/mod
-            make deps
-          no_output_timeout: 30m
+            if [[ -d $CIRCLE_SHA ]]; then
+              ls $GOPATH/pkg/mod
+            else
+              echo No modules were loaded from the cache
+            fi
+            go mod download
       - save_cache:
-          key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          key: v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
             - "${HOME}/go/pkg/mod"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,10 @@ commands:
             - v1-go-mod-{{ arch }}
             - v1-go-mod-
       - run:
-          command: make deps
+          command: |
+            echo $GOPATH
+            ls $GOPATH/pkg/mod
+            make deps
           no_output_timeout: 30m
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,6 @@ commands:
                 command: |
                   curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-<<parameters.darwin-architecture>>.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
-            - run:
-                name: Export Go
-                command: |
-                  echo 'export GOPATH="${HOME}/go"' >> $BASH_ENV
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
@@ -111,6 +107,9 @@ commands:
             git fetch --all
   install_go_dependencies:
     steps:
+      - run:
+          name: Set GOPATH
+          command: echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ commands:
       - run:
           name: Set GOPATH
           command: |
+            mkdir /go
             chown -R $USER:$USER /go
             echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,24 +113,24 @@ commands:
             echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
-            - v2-go-mod-{{ arch }}
-            - v2-go-mod-
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v3-test-go-mod-{{ arch }}
+            - v3-test-go-mod-
       - run:
           command: |
             echo $GOPATH
-            if [[ -d $CIRCLE_SHA ]]; then
+            if [[ -d $GOPATH/pkg/mod ]]; then
               ls $GOPATH/pkg/mod
             else
               echo No modules were loaded from the cache
             fi
             go mod download
       - save_cache:
-          key: v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          key: v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "${HOME}/go/pkg/mod"
+            - ~/go/pkg/mod
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,9 +110,7 @@ commands:
       - run:
           name: Set GOPATH
           command: |
-            mkdir /go
-            chown -R $USER:$USER /go
-            echo 'export GOPATH="/go"' >> $BASH_ENV
+            echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -126,7 +124,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "${HOME}/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ commands:
     steps:
       - run:
           name: Set GOPATH
-          command: echo 'export GOPATH="/go"' >> $BASH_ENV
+          command: echo 'export GOPATH="/opt/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -123,7 +123,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "/opt/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -109,6 +109,23 @@ commands:
           name: fetch all tags
           command: |
             git fetch --all
+  install_go_dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v1-go-mod-{{ arch }}
+            - v1-go-mod-
+      - run:
+          command: make deps
+          no_output_timeout: 30m
+      - save_cache:
+          key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+
   packer_build:
     description: "Run a packer build"
     parameters:
@@ -170,9 +187,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps lotus
-          no_output_timeout: 30m
+      - install_go_dependencies
+      - run: make lotus
       - download-params
       - run:
           name: go test
@@ -213,9 +229,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps lotus
-          no_output_timeout: 30m
+      - install_go_dependencies
+      - run: make lotus
       - download-params
       - when:
           condition:
@@ -259,6 +274,7 @@ jobs:
     executor: golang
     steps:
       - prepare
+      - install_go_dependencies
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -281,6 +297,7 @@ jobs:
           linux: false
           darwin: true
           darwin-architecture: amd64
+      - install_go_dependencies
       - run: make lotus lotus-miner lotus-worker
       - run: otool -hv lotus
       - run:
@@ -305,6 +322,7 @@ jobs:
           linux: false
           darwin: true
           darwin-architecture: arm64
+      - install_go_dependencies
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
@@ -418,7 +436,7 @@ jobs:
     executor: golang
     steps:
       - prepare
-      - run: make deps
+      - install_go_dependencies
       - run: go install golang.org/x/tools/cmd/goimports
       - run: go install github.com/hannahhoward/cbor-gen-for
       - run: make gen
@@ -432,11 +450,11 @@ jobs:
     executor: golang
     steps:
       - prepare
+      - install_go_dependencies
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../pre-openrpc-miner
       - run: zcat build/openrpc/worker.json.gz | jq > ../pre-openrpc-worker
-      - run: make deps
       - run: make docsgen
       - run: zcat build/openrpc/full.json.gz | jq > ../post-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../post-openrpc-miner
@@ -468,9 +486,7 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - prepare
-      - run:
-          command: make deps
-          no_output_timeout: 30m
+      - install_go_dependencies
       - run:
           name: Lint
           command: |

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -194,6 +194,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus
       - download-params
       - run:
@@ -236,6 +237,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus
       - download-params
       - when:
@@ -281,6 +283,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: make lotus lotus-miner lotus-worker
       - run:
           name: check tag and version output match
@@ -304,6 +307,7 @@ jobs:
           darwin: true
           darwin-architecture: amd64
       - install_go_dependencies
+      - run: make deps
       - run: make lotus lotus-miner lotus-worker
       - run: otool -hv lotus
       - run:
@@ -329,6 +333,7 @@ jobs:
           darwin: true
           darwin-architecture: arm64
       - install_go_dependencies
+      - run: make deps
       - run: |
           export CPATH=$(brew --prefix)/include
           export LIBRARY_PATH=$(brew --prefix)/lib
@@ -443,6 +448,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
       - run: go install github.com/hannahhoward/cbor-gen-for
       - run: make gen
@@ -457,6 +463,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run: go install golang.org/x/tools/cmd/goimports
       - run: zcat build/openrpc/full.json.gz | jq > ../pre-openrpc-full
       - run: zcat build/openrpc/miner.json.gz | jq > ../pre-openrpc-miner
@@ -493,6 +500,7 @@ jobs:
     steps:
       - prepare
       - install_go_dependencies
+      - run: make deps
       - run:
           name: Lint
           command: |

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -109,7 +109,9 @@ commands:
     steps:
       - run:
           name: Set GOPATH
-          command: echo 'export GOPATH="/opt/go"' >> $BASH_ENV
+          command: |
+            chown -R $USER:$USER /go
+            echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -123,7 +125,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/opt/go/pkg/mod"
+            - "/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -113,24 +113,24 @@ commands:
             echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
-            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
-            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
-            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
-            - v2-test-go-mod-{{ arch }}
-            - v2-test-go-mod-
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v3-test-go-mod-{{ arch }}
+            - v3-test-go-mod-
       - run:
           command: |
             echo $GOPATH
-            if [["[[ -d $CIRCLE_SHA ]]"]]; then
+            if [["[[ -d $GOPATH/pkg/mod ]]"]]; then
               ls $GOPATH/pkg/mod
             else
               echo No modules were loaded from the cache
             fi
             go mod download
       - save_cache:
-          key: v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          key: v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "${HOME}/go/pkg/mod"
+            - ~/go/pkg/mod
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -113,19 +113,22 @@ commands:
             echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
-            - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
-            - v1-go-mod-{{ arch }}
-            - v1-go-mod-
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v2-go-mod-{{ arch }}
+            - v2-go-mod-
       - run:
           command: |
             echo $GOPATH
-            ls $GOPATH/pkg/mod
-            make deps
-          no_output_timeout: 30m
+            if [["[[ -d $CIRCLE_SHA ]]"]]; then
+              ls $GOPATH/pkg/mod
+            else
+              echo No modules were loaded from the cache
+            fi
+            go mod download
       - save_cache:
-          key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          key: v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
             - "${HOME}/go/pkg/mod"
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -127,6 +127,7 @@ commands:
               echo No modules were loaded from the cache
             fi
             go mod download
+            ls $GOPATH/pkg/mod
       - save_cache:
           key: v3-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -119,7 +119,10 @@ commands:
             - v1-go-mod-{{ arch }}
             - v1-go-mod-
       - run:
-          command: make deps
+          command: |
+            echo $GOPATH
+            ls $GOPATH/pkg/mod
+            make deps
           no_output_timeout: 30m
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -65,10 +65,6 @@ commands:
                 command: |
                   curl https://dl.google.com/go/go`cat GO_VERSION_MIN`.darwin-<<parameters.darwin-architecture>>.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
-            - run:
-                name: Export Go
-                command: |
-                  echo 'export GOPATH="${HOME}/go"' >> $BASH_ENV
             - run: go version
             - run:
                 name: Install dependencies with Homebrew
@@ -111,6 +107,9 @@ commands:
             git fetch --all
   install_go_dependencies:
     steps:
+      - run:
+          name: Set GOPATH
+          command: echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -110,6 +110,7 @@ commands:
       - run:
           name: Set GOPATH
           command: |
+            mkdir /go
             chown -R $USER:$USER /go
             echo 'export GOPATH="/go"' >> $BASH_ENV
       - restore_cache:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -113,11 +113,11 @@ commands:
             echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
-            - v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
-            - v2-go-mod-{{ arch }}
-            - v2-go-mod-
+            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}
+            - v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}
+            - v2-test-go-mod-{{ arch }}
+            - v2-test-go-mod-
       - run:
           command: |
             echo $GOPATH
@@ -128,7 +128,7 @@ commands:
             fi
             go mod download
       - save_cache:
-          key: v2-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
+          key: v2-test-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
             - "${HOME}/go/pkg/mod"
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -110,9 +110,7 @@ commands:
       - run:
           name: Set GOPATH
           command: |
-            mkdir /go
-            chown -R $USER:$USER /go
-            echo 'export GOPATH="/go"' >> $BASH_ENV
+            echo 'export GOPATH=${HOME}/go' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -126,7 +124,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "${HOME}/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -109,7 +109,7 @@ commands:
     steps:
       - run:
           name: Set GOPATH
-          command: echo 'export GOPATH="/go"' >> $BASH_ENV
+          command: echo 'export GOPATH="/opt/go"' >> $BASH_ENV
       - restore_cache:
           keys:
             - v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
@@ -123,7 +123,7 @@ commands:
       - save_cache:
           key: v1-go-mod-{{ arch }}-{{ checksum "GO_VERSION_MIN" }}-{{ checksum "go.mod" }}-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "/opt/go/pkg/mod"
 
   packer_build:
     description: "Run a packer build"


### PR DESCRIPTION

## Related Issues
None, but this will speed up most jobs by about 60 seconds

## Proposed Changes
Cache our go dependencies

## Additional Info
Cache keys are prefix matched, so if the checksum of the `go.sum` or `go.mod` fails to match, it will load the most recent dependencies for the current GO_VERSION_MIN and call make deps to update them, saving them under the full key.

See full documentation to understand how the cache keys work:
  https://circleci.com/docs/caching/
  
## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
