### PR TITLE
fix: chainstore: store tipsetkeys in the blockstore

### DIFF
--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -468,10 +468,6 @@ func (cg *ChainGen) NextTipSetFromMinersWithMessagesAndNulls(base *types.TipSet,
 					return nil, xerrors.Errorf("making a block for next tipset failed: %w", err)
 				}
 
-				if err := cg.cs.PersistBlockHeaders(context.TODO(), fblk.Header); err != nil {
-					return nil, xerrors.Errorf("chainstore AddBlock: %w", err)
-				}
-
 				blks = append(blks, fblk)
 			}
 		}

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -306,13 +306,13 @@ func (tu *syncTestUtil) addSourceNode(gen int) {
 	require.NoError(tu.t, err)
 	tu.t.Cleanup(func() { _ = stop(context.Background()) })
 
-	lastTs := blocks[len(blocks)-1].Blocks
-	for _, lastB := range lastTs {
-		cs := out.(*impl.FullNodeAPI).ChainAPI.Chain
+	lastTs := blocks[len(blocks)-1]
+	cs := out.(*impl.FullNodeAPI).ChainAPI.Chain
+	for _, lastB := range lastTs.Blocks {
 		require.NoError(tu.t, cs.AddToTipSetTracker(context.Background(), lastB.Header))
-		err = cs.AddBlock(tu.ctx, lastB.Header)
-		require.NoError(tu.t, err)
 	}
+	err = cs.PutTipSet(tu.ctx, lastTs.TipSet())
+	require.NoError(tu.t, err)
 
 	tu.genesis = genesis
 	tu.blocks = blocks

--- a/cmd/lotus-sim/simulation/block.go
+++ b/cmd/lotus-sim/simulation/block.go
@@ -74,14 +74,17 @@ func (sim *Simulation) makeTipSet(ctx context.Context, messages []*types.Message
 		Timestamp:             uts,
 		ElectionProof:         &types.ElectionProof{WinCount: 1},
 	}}
-	err = sim.Node.Chainstore.PersistBlockHeaders(ctx, blks...)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to persist block headers: %w", err)
-	}
+
 	newTipSet, err := types.NewTipSet(blks)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create new tipset: %w", err)
 	}
+
+	err = sim.Node.Chainstore.PersistTipset(ctx, newTipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to persist block headers: %w", err)
+	}
+
 	now := time.Now()
 	_, _, err = sim.StateManager.TipSetState(ctx, newTipSet)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

https://github.com/filecoin-project/ref-fvm/issues/1053

## Proposed Changes
<!-- A clear list of the changes being made -->

- Introduce a new `PersistTipset` method that replacs `PersistBlockHeaders` at all callsites (it's what we always want to do)
- Store the TSK in the `PersistTipset` method
- Drop unused `AddBlock` method

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
