### PR TITLE
Revert "_build_ Set noexecstack on snapcraft builds"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
       - libhwloc15
       - ocl-icd-libopencl1
     override-build: |
-      LDFLAGS="-z noexecstack" make lotus lotus-miner lotus-worker
+      LDFLAGS="" make lotus lotus-miner lotus-worker
       cp lotus lotus-miner lotus-worker $SNAPCRAFT_PART_INSTALL
       cp scripts/snap-lotus-entrypoint.sh $SNAPCRAFT_PART_INSTALL
 


### PR DESCRIPTION
Reverts filecoin-project/lotus#9868

Ok, passing LDFLAGS in that way didn't work, I did some more experimentation, and couldn't get it to work at all. So just revert it for now, and I'll chat with the Snapcraft folks to see if we can get an exception.