### PR TITLE
fix: FEVM: signature validation cache for messages with Delegated signatures.

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -3,7 +3,6 @@ package messagepool
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -285,7 +284,7 @@ func (ms *msgSet) add(m *types.SignedMessage, mp *MessagePool, strict, untrusted
 		}
 
 		ms.requiredFunds.Sub(ms.requiredFunds, exms.Message.RequiredFunds().Int)
-		//ms.requiredFunds.Sub(ms.requiredFunds, exms.Message.Value.Int)
+		// ms.requiredFunds.Sub(ms.requiredFunds, exms.Message.Value.Int)
 	}
 
 	if !has && strict && len(ms.msgs) >= maxActorPendingMessages {
@@ -301,7 +300,7 @@ func (ms *msgSet) add(m *types.SignedMessage, mp *MessagePool, strict, untrusted
 	ms.nextNonce = nextNonce
 	ms.msgs[m.Message.Nonce] = m
 	ms.requiredFunds.Add(ms.requiredFunds, m.Message.RequiredFunds().Int)
-	//ms.requiredFunds.Add(ms.requiredFunds, m.Message.Value.Int)
+	// ms.requiredFunds.Add(ms.requiredFunds, m.Message.Value.Int)
 
 	return !has, nil
 }
@@ -321,7 +320,7 @@ func (ms *msgSet) rm(nonce uint64, applied bool) {
 	}
 
 	ms.requiredFunds.Sub(ms.requiredFunds, m.Message.RequiredFunds().Int)
-	//ms.requiredFunds.Sub(ms.requiredFunds, m.Message.Value.Int)
+	// ms.requiredFunds.Sub(ms.requiredFunds, m.Message.Value.Int)
 	delete(ms.msgs, nonce)
 
 	// adjust next nonce
@@ -347,7 +346,7 @@ func (ms *msgSet) getRequiredFunds(nonce uint64) types.BigInt {
 	m, has := ms.msgs[nonce]
 	if has {
 		requiredFunds.Sub(requiredFunds, m.Message.RequiredFunds().Int)
-		//requiredFunds.Sub(requiredFunds, m.Message.Value.Int)
+		// requiredFunds.Sub(requiredFunds, m.Message.Value.Int)
 	}
 
 	return types.BigInt{Int: requiredFunds}
@@ -771,22 +770,10 @@ func sigCacheKey(m *types.SignedMessage) (string, error) {
 		if len(m.Signature.Data) != ffi.SignatureBytes {
 			return "", fmt.Errorf("bls signature incorrectly sized")
 		}
-
 		hashCache := blake2b.Sum256(append(m.Cid().Bytes(), m.Signature.Data...))
-
 		return string(hashCache[:]), nil
-	case crypto.SigTypeSecp256k1:
+	case crypto.SigTypeSecp256k1, crypto.SigTypeDelegated:
 		return string(m.Cid().Bytes()), nil
-	case crypto.SigTypeDelegated:
-		txArgs, err := ethtypes.NewEthTxArgsFromMessage(&m.Message)
-		if err != nil {
-			return "", err
-		}
-		msg, err := txArgs.HashedOriginalRlpMsg()
-		if err != nil {
-			return "", err
-		}
-		return hex.EncodeToString(msg), nil
 	default:
 		return "", xerrors.Errorf("unrecognized signature type: %d", m.Signature.Type)
 	}
@@ -837,7 +824,7 @@ func (mp *MessagePool) checkBalance(ctx context.Context, m *types.SignedMessage,
 	}
 
 	// add Value for soft failure check
-	//requiredFunds = types.BigAdd(requiredFunds, m.Message.Value)
+	// requiredFunds = types.BigAdd(requiredFunds, m.Message.Value)
 
 	mset, ok, err := mp.getPendingMset(ctx, m.Message.From)
 	if err != nil {

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -183,18 +183,6 @@ func (tx *EthTxArgs) ToSignedMessage() (*types.SignedMessage, error) {
 
 }
 
-func (tx *EthTxArgs) HashedOriginalRlpMsg() ([]byte, error) {
-	msg, err := tx.OriginalRlpMsg()
-	if err != nil {
-		return nil, err
-	}
-
-	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write(msg)
-	hash := hasher.Sum(nil)
-	return hash, nil
-}
-
 func (tx *EthTxArgs) OriginalRlpMsg() ([]byte, error) {
 	chainId, err := formatInt(tx.ChainID)
 	if err != nil {


### PR DESCRIPTION
## Related Issues

Signature cache entry was constructed with the wrong cache key which did not cover the signature.
Plus, a little bit of gofmt on touched files.

## Proposed Changes

Cover the signature by relying on the CID from the SignedMessage, which for the Delegated signature type covers the signature.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
