### PR TITLE
add a basic FEVM integration test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,6 +770,11 @@ workflows:
           target: "./itests/eth_account_abstraction_test.go"
       
       - test:
+          name: test-itest-eth_deploy
+          suite: itest-eth_deploy
+          target: "./itests/eth_deploy_test.go"
+      
+      - test:
           name: test-itest-eth_filter
           suite: itest-eth_filter
           target: "./itests/eth_filter_test.go"

--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -581,7 +581,7 @@ func (filec *FilecoinEC) checkBlockMessages(ctx context.Context, b *types.FullBl
 			if err != nil {
 				return err
 			}
-			msg, err := txArgs.OriginalRlpMsg()
+			msg, err := txArgs.ToRlpUnsignedMsg()
 			if err != nil {
 				return err
 			}

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -809,7 +809,7 @@ func (mp *MessagePool) VerifyMsgSig(m *types.SignedMessage) error {
 		if err != nil {
 			return xerrors.Errorf("failed to convert to eth tx args: %w", err)
 		}
-		msg, err := txArgs.OriginalRlpMsg()
+		msg, err := txArgs.ToRlpUnsignedMsg()
 		if err != nil {
 			return err
 		}

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	mathbig "math/big"
 
-	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/crypto/sha3"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 )
 
 const Eip1559TxType = 2

--- a/chain/types/ethtypes/eth_transactions_test.go
+++ b/chain/types/ethtypes/eth_transactions_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 
@@ -42,7 +43,7 @@ func TestTxArgs(t *testing.T) {
 		txArgs, err := ParseEthTxArgs(tc.Input)
 		require.NoError(t, err)
 
-		msgRecovered, err := txArgs.OriginalRlpMsg()
+		msgRecovered, err := txArgs.ToRlpUnsignedMsg()
 		require.NoError(t, err)
 		require.Equal(t, tc.NosigTx, "0x"+hex.EncodeToString(msgRecovered), comment)
 
@@ -198,14 +199,8 @@ func TestDelegatedSigner(t *testing.T) {
 	r := mustDecodeHex(rHex)
 	s := mustDecodeHex(sHex)
 
-	if pubk[0] == 0x04 {
-		pubk = pubk[1:]
-	}
-
-	hasher := sha3.NewLegacyKeccak256()
-	hasher.Reset()
-	hasher.Write(pubk)
-	addrHash := hasher.Sum(nil)
+	addrHash, err := delegated.EthAddressFromPubKey(pubk)
+	require.NoError(t, err)
 
 	from, err := address.NewDelegatedAddress(builtintypes.EthereumAddressManagerActorID, addrHash[12:])
 	require.NoError(t, err)

--- a/chain/types/ethtypes/eth_transactions_test.go
+++ b/chain/types/ethtypes/eth_transactions_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 
@@ -21,6 +20,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	_ "github.com/filecoin-project/lotus/lib/sigs/delegated"
 )
 

--- a/chain/wallet/key/key.go
+++ b/chain/wallet/key/key.go
@@ -1,7 +1,6 @@
 package key
 
 import (
-	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 )
 
 func GenerateKey(typ types.KeyType) (*Key, error) {

--- a/chain/wallet/key/key.go
+++ b/chain/wallet/key/key.go
@@ -1,7 +1,7 @@
 package key
 
 import (
-	"golang.org/x/crypto/sha3"
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -54,17 +54,12 @@ func NewKey(keyinfo types.KeyInfo) (*Key, error) {
 		}
 	case types.KTDelegated:
 		// Assume eth for now
-		hasher := sha3.NewLegacyKeccak256()
-		pubk := k.PublicKey
-		// if we get an uncompressed public key (that's what we get from the library,
-		// but putting this check here for defensiveness), strip the prefix
-		if pubk[0] == 0x04 {
-			pubk = pubk[1:]
+		ethAddr, err := delegated.EthAddressFromPubKey(k.PublicKey)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to calculate Eth address from public key: %w", err)
 		}
 
-		hasher.Write(pubk)
-
-		k.Address, err = address.NewDelegatedAddress(builtin.EthereumAddressManagerActorID, hasher.Sum(nil)[12:])
+		k.Address, err = address.NewDelegatedAddress(builtin.EthereumAddressManagerActorID, ethAddr)
 		if err != nil {
 			return nil, xerrors.Errorf("converting Delegated to address: %w", err)
 		}

--- a/itests/eth/deploy_test.go
+++ b/itests/eth/deploy_test.go
@@ -1,0 +1,135 @@
+package itests
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/manifest"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+)
+
+// TestDeployment smoke tests the deployment of a contract via the
+// Ethereum JSON-RPC endpoint, from an EEOA.
+func TestDeployment(t *testing.T) {
+	// TODO the contract installation and invocation can be lifted into utility methods
+	// He who writes the second test, shall do that.
+	// kit.QuietMiningLogs()
+
+	blockTime := 1 * time.Second
+	client, _, ens := kit.EnsembleMinimal(
+		t,
+		kit.MockProofs(),
+		kit.ThroughRPC(),
+		kit.WithCfgOpt(func(cfg *config.FullNode) error {
+			cfg.ActorEvent.EnableRealTimeFilterAPI = true
+			return nil
+		}),
+	)
+	ens.InterconnectAll().BeginMining(blockTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// install contract
+	contractHex, err := os.ReadFile("../contracts/SimpleCoin.bin")
+	require.NoError(t, err)
+
+	contract, err := hex.DecodeString(string(contractHex))
+	require.NoError(t, err)
+
+	// create a new Ethereum account
+	key, ethAddr, deployer := client.EVM().NewAccount()
+
+	// send some funds to the f410 address
+	kit.SendFunds(ctx, t, client, deployer, types.FromFil(10))
+
+	// verify balances.
+	bal := client.EVM().AssertAddressBalanceConsistent(ctx, deployer)
+	require.Equal(t, types.FromFil(10), bal)
+
+	// verify the deployer address is an embryo.
+	client.AssertActorType(ctx, deployer, manifest.EmbryoKey)
+
+	gaslimit, err := client.EthEstimateGas(ctx, ethtypes.EthCall{
+		From: &ethAddr,
+		Data: contract,
+	})
+	require.NoError(t, err)
+
+	maxPriorityFeePerGas, err := client.EthMaxPriorityFeePerGas(ctx)
+	require.NoError(t, err)
+
+	// now deploy a contract from the embryo, and validate it went well
+	tx := ethtypes.EthTxArgs{
+		ChainID:              build.Eip155ChainId,
+		Value:                big.Zero(),
+		Nonce:                0,
+		MaxFeePerGas:         types.NanoFil,
+		MaxPriorityFeePerGas: big.Int(maxPriorityFeePerGas),
+		GasLimit:             int(gaslimit),
+		Input:                contract,
+		V:                    big.Zero(),
+		R:                    big.Zero(),
+		S:                    big.Zero(),
+	}
+
+	client.EVM().SignTransaction(&tx, key.PrivateKey)
+
+	pendingFilter, err := client.EthNewPendingTransactionFilter(ctx)
+	require.NoError(t, err)
+
+	hash := client.EVM().SubmitTransaction(ctx, &tx)
+	fmt.Println(hash)
+
+	changes, err := client.EthGetFilterChanges(ctx, pendingFilter)
+	require.NoError(t, err)
+	require.Len(t, changes.Results, 1)
+	require.Equal(t, hash.String(), changes.Results[0])
+
+	time.Sleep(5 * time.Second)
+
+	var receipt *api.EthTxReceipt
+	for i := 0; i < 10000000000; i++ {
+		receipt, err = client.EthGetTransactionReceipt(ctx, hash)
+		fmt.Println(receipt, err)
+		if err != nil || receipt == nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	// No error.
+	require.EqualValues(t, 0, receipt.Status)
+
+	// Verify that the deployer is now an account.
+	client.AssertActorType(ctx, deployer, manifest.EthAccountKey)
+
+	// Verify that the nonce was incremented.
+	nonce, err := client.MpoolGetNonce(ctx, deployer)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, nonce)
+
+	// Verify that the deployer is now an account.
+	client.AssertActorType(ctx, deployer, manifest.EthAccountKey)
+
+	// Get contract address.
+	contractAddr, err := client.EVM().ComputeContractAddress(ethAddr, 0).ToFilecoinAddress()
+	require.NoError(t, err)
+
+	client.AssertActorType(ctx, contractAddr, "evm")
+}

--- a/itests/eth/deploy_test.go
+++ b/itests/eth/deploy_test.go
@@ -8,16 +8,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/manifest"
-	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/types/ethtypes"
-	"github.com/filecoin-project/lotus/node/config"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/node/config"
 )
 
 // TestDeployment smoke tests the deployment of a contract via the

--- a/itests/eth/deploy_test.go
+++ b/itests/eth/deploy_test.go
@@ -27,7 +27,7 @@ func TestDeployment(t *testing.T) {
 	// He who writes the second test, shall do that.
 	// kit.QuietMiningLogs()
 
-	blockTime := 1 * time.Second
+	blockTime := 100 * time.Millisecond
 	client, _, ens := kit.EnsembleMinimal(
 		t,
 		kit.MockProofs(),
@@ -113,8 +113,8 @@ func TestDeployment(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
-	// No error.
-	require.EqualValues(t, 0, receipt.Status)
+	// Success.
+	require.EqualValues(t, ethtypes.EthUint64(0x1), receipt.Status)
 
 	// Verify that the deployer is now an account.
 	client.AssertActorType(ctx, deployer, manifest.EthAccountKey)

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -71,7 +71,7 @@ func TestEthAccountAbstraction(t *testing.T) {
 	txArgs, err := ethtypes.NewEthTxArgsFromMessage(msgFromEmbryo)
 	require.NoError(t, err)
 
-	digest, err := txArgs.OriginalRlpMsg()
+	digest, err := txArgs.ToRlpUnsignedMsg()
 	require.NoError(t, err)
 
 	siggy, err := client.WalletSign(ctx, embryoAddress, digest)
@@ -107,7 +107,7 @@ func TestEthAccountAbstraction(t *testing.T) {
 	txArgs, err = ethtypes.NewEthTxArgsFromMessage(msgFromEmbryo)
 	require.NoError(t, err)
 
-	digest, err = txArgs.OriginalRlpMsg()
+	digest, err = txArgs.ToRlpUnsignedMsg()
 	require.NoError(t, err)
 
 	siggy, err = client.WalletSign(ctx, embryoAddress, digest)

--- a/itests/eth_deploy_test.go
+++ b/itests/eth_deploy_test.go
@@ -44,7 +44,7 @@ func TestDeployment(t *testing.T) {
 	defer cancel()
 
 	// install contract
-	contractHex, err := os.ReadFile("../contracts/SimpleCoin.bin")
+	contractHex, err := os.ReadFile("./contracts/SimpleCoin.bin")
 	require.NoError(t, err)
 
 	contract, err := hex.DecodeString(string(contractHex))

--- a/itests/kit/evm.go
+++ b/itests/kit/evm.go
@@ -6,6 +6,12 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-varint"
+	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/crypto/sha3"
+
 	"github.com/filecoin-project/go-address"
 	amt4 "github.com/filecoin-project/go-amt-ipld/v4"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -13,19 +19,14 @@ import (
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v10/eam"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/lotus/chain/types/ethtypes"
-	"github.com/filecoin-project/lotus/chain/wallet/key"
-	"github.com/filecoin-project/lotus/lib/sigs"
-	"github.com/filecoin-project/lotus/lib/sigs/delegated"
-	"github.com/ipfs/go-cid"
-	"github.com/multiformats/go-varint"
-	"github.com/stretchr/testify/require"
-	cbg "github.com/whyrusleeping/cbor-gen"
-	"golang.org/x/crypto/sha3"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+	"github.com/filecoin-project/lotus/chain/wallet/key"
+	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/lib/sigs/delegated"
 )
 
 // EVM groups EVM-related actions.
@@ -240,14 +241,6 @@ func (ht *apiIpldStore) Get(ctx context.Context, c cid.Cid, out interface{}) err
 
 func (ht *apiIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {
 	panic("No mutations allowed")
-}
-
-func formatBigInt(val big.Int) ([]byte, error) {
-	b, err := val.Bytes()
-	if err != nil {
-		return nil, err
-	}
-	return removeLeadingZeros(b), nil
 }
 
 func formatInt(val int) ([]byte, error) {

--- a/itests/kit/state.go
+++ b/itests/kit/state.go
@@ -3,11 +3,13 @@ package kit
 import (
 	"context"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-address"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
+
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/stretchr/testify/require"
 )
 
 // AssertActorType verifies that the supplied address is an actor of the

--- a/itests/kit/state.go
+++ b/itests/kit/state.go
@@ -1,0 +1,31 @@
+package kit
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertActorType verifies that the supplied address is an actor of the
+// specified type (as per its manifest key).
+func (f *TestFullNode) AssertActorType(ctx context.Context, addr address.Address, actorType string) {
+	// validate that an embryo was created
+	act, err := f.StateGetActor(ctx, addr, types.EmptyTSK)
+	require.NoError(f.t, err)
+
+	nv, err := f.StateNetworkVersion(ctx, types.EmptyTSK)
+	require.NoError(f.t, err)
+
+	av, err := actorstypes.VersionForNetwork(nv)
+	require.NoError(f.t, err)
+
+	codecid, exists := actors.GetActorCodeID(av, actorType)
+	require.True(f.t, exists)
+
+	// check the code CID
+	require.Equal(f.t, codecid, act.Code)
+}

--- a/lib/sigs/delegated/eth.go
+++ b/lib/sigs/delegated/eth.go
@@ -1,0 +1,26 @@
+package delegated
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// EthAddressFromPubKey returns the Ethereum address corresponding to an
+// uncompressed secp256k1 public key.
+//
+// TODO move somewhere else, this likely doesn't belong here.
+func EthAddressFromPubKey(pubk []byte) ([]byte, error) {
+	// if we get an uncompressed public key (that's what we get from the library,
+	// but putting this check here for defensiveness), strip the prefix
+	if pubk[0] != 0x04 {
+		return nil, fmt.Errorf("expected first byte of secp256k1 to be 0x04 (uncompressed)")
+	}
+	pubk = pubk[1:]
+
+	// Calculate the Ethereum address based on the keccak hash of the pubkey.
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write(pubk)
+	ethAddr := hasher.Sum(nil)[12:]
+	return ethAddr, nil
+}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -278,7 +278,7 @@ func (a *EthModule) EthGetTransactionReceipt(ctx context.Context, txHash ethtype
 		return nil, nil
 	}
 
-	tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, -1, a.Chain, a.ChainAPI, a.StateAPI)
+	tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, -1, a.Chain, a.StateAPI)
 	if err != nil {
 		return nil, nil
 	}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1533,6 +1533,7 @@ func newEthTxFromFilecoinMessageLookup(ctx context.Context, msgLookup *api.MsgLo
 		for i, msg := range msgs {
 			if msg.Cid() == msgLookup.Message {
 				txIdx = i
+				break
 			}
 		}
 		if txIdx < 0 {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -228,7 +228,7 @@ func (a *EthModule) EthGetTransactionByHash(ctx context.Context, txHash *ethtype
 	// first, try to get the cid from mined transactions
 	msgLookup, err := a.StateAPI.StateSearchMsg(ctx, types.EmptyTSK, cid, api.LookbackNoLimit, true)
 	if err == nil {
-		tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, -1, a.Chain, a.ChainAPI, a.StateAPI)
+		tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, -1, a.Chain, a.StateAPI)
 		if err == nil {
 			return &tx, nil
 		}
@@ -1364,7 +1364,7 @@ func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTx
 		gasUsed += msgLookup.Receipt.GasUsed
 
 		if fullTxInfo {
-			tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, txIdx, cs, ca, sa)
+			tx, err := newEthTxFromFilecoinMessageLookup(ctx, msgLookup, txIdx, cs, sa)
 			if err != nil {
 				return ethtypes.EthBlock{}, nil
 			}
@@ -1498,7 +1498,7 @@ func newEthTxFromFilecoinMessage(ctx context.Context, smsg *types.SignedMessage,
 // newEthTxFromFilecoinMessageLookup creates an ethereum transaction from filecoin message lookup. If a negative txIdx is passed
 // into the function, it looksup the transaction index of the message in the tipset, otherwise it uses the txIdx passed into the
 // function
-func newEthTxFromFilecoinMessageLookup(ctx context.Context, msgLookup *api.MsgLookup, txIdx int, cs *store.ChainStore, ca ChainAPI, sa StateAPI) (ethtypes.EthTx, error) {
+func newEthTxFromFilecoinMessageLookup(ctx context.Context, msgLookup *api.MsgLookup, txIdx int, cs *store.ChainStore, sa StateAPI) (ethtypes.EthTx, error) {
 	if msgLookup == nil {
 		return ethtypes.EthTx{}, fmt.Errorf("msg does not exist")
 	}


### PR DESCRIPTION
Adds a basic FEVM integration test that exercises:

- Ethereum JSON-RPC API, including filters, transaction submission, and various methods.
- f4 addresses
- placeholder/embryo creation
- placeholder/embryo promotion to Ethereum account
- instantiation of the EVM smart contract
- nonce update

It adds the following to the itest kit:
- New reusable utilities to the EVM namespace to make future test development faster/easier. Concretely:
	- NewAccount
	- AssertAddressBalanceConsistent
	- SignTransaction
	- SubmitTransaction
	- ComputeContractAddress
- New reusable utility:
	- AssertActorType

We also conduct some minor refactors to tidy things up.