### PR TITLE
itests: Eth JSON-RPC: EthGetBlockByHash and EthGetBlockByNumber

### DIFF
--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -387,10 +387,10 @@ func init() {
 
 	addExample(&uuid.UUID{})
 
-	filterid, _ := ethtypes.EthHashFromHex("0x5CbEeC012345673f25E309Cc264f240bb0664031")
+	filterid, _ := ethtypes.NewEthHashFromHex("0x5CbEeC012345673f25E309Cc264f240bb0664031")
 	addExample(ethtypes.EthFilterID(filterid))
 
-	subid, _ := ethtypes.EthHashFromHex("0x5CbEeCF99d3fDB301234567c264f240bb0664031")
+	subid, _ := ethtypes.NewEthHashFromHex("0x5CbEeCF99d3fDB301234567c264f240bb0664031")
 	addExample(ethtypes.EthSubscriptionID(subid))
 
 	pstring := func(s string) *string { return &s }

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -342,7 +342,7 @@ func (h *EthHash) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	hash, err := EthHashFromHex(s)
+	hash, err := NewEthHashFromHex(s)
 	if err != nil {
 		return err
 	}
@@ -373,10 +373,10 @@ func decodeHexString(s string, length int) ([]byte, error) {
 }
 
 func NewEthHashFromCid(c cid.Cid) (EthHash, error) {
-	return EthHashFromHex(c.Hash().HexString()[8:])
+	return NewEthHashFromHex(c.Hash().HexString()[8:])
 }
 
-func EthHashFromHex(s string) (EthHash, error) {
+func NewEthHashFromHex(s string) (EthHash, error) {
 	handlePrefix(&s)
 	b, err := decodeHexString(s, EthHashLength)
 	if err != nil {

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -158,10 +158,10 @@ func TestUnmarshalEthBytes(t *testing.T) {
 }
 
 func TestEthFilterResultMarshalJSON(t *testing.T) {
-	hash1, err := EthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
+	hash1, err := NewEthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
 	require.NoError(t, err, "eth hash")
 
-	hash2, err := EthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
+	hash2, err := NewEthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
 	require.NoError(t, err, "eth hash")
 
 	addr, err := EthAddressFromHex("d4c5fb16488Aa48081296299d54b0c648C9333dA")
@@ -223,10 +223,10 @@ func TestEthFilterResultMarshalJSON(t *testing.T) {
 }
 
 func TestEthFilterSpecUnmarshalJSON(t *testing.T) {
-	hash1, err := EthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
+	hash1, err := NewEthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
 	require.NoError(t, err, "eth hash")
 
-	hash2, err := EthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
+	hash2, err := NewEthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
 	require.NoError(t, err, "eth hash")
 
 	addr, err := EthAddressFromHex("d4c5fb16488Aa48081296299d54b0c648C9333dA")
@@ -348,10 +348,10 @@ func TestEthAddressListUnmarshalJSON(t *testing.T) {
 }
 
 func TestEthHashListUnmarshalJSON(t *testing.T) {
-	hash1, err := EthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
+	hash1, err := NewEthHashFromHex("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
 	require.NoError(t, err, "eth hash")
 
-	hash2, err := EthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
+	hash2, err := NewEthHashFromHex("ab8653edf9f51785664a643b47605a7ba3d917b5339a0724e7642c114d0e4738")
 	require.NoError(t, err, "eth hash")
 
 	testcases := []struct {

--- a/itests/eth_deploy_test.go
+++ b/itests/eth_deploy_test.go
@@ -148,6 +148,12 @@ func TestDeployment(t *testing.T) {
 	require.NotNil(t, chainTx.TransactionIndex)
 	require.Equal(t, uint64(*chainTx.TransactionIndex), uint64(0)) // only transaction
 
+	// should return error with non-existent block hash
+	nonExistentHash, err := ethtypes.NewEthHashFromHex("0x62a80aa9262a3e1d3db0706af41c8535257b6275a283174cabf9d108d8946059")
+	require.Nil(t, err)
+	_, err = client.EthGetBlockByHash(ctx, nonExistentHash, false)
+	require.NotNil(t, err)
+
 	// verify block information
 	block1, err := client.EthGetBlockByHash(ctx, *chainTx.BlockHash, false)
 	require.Nil(t, err)

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -345,7 +345,7 @@ func ParseEthLog(in map[string]interface{}) (*ethtypes.EthLog, error) {
 		if !ok {
 			return ethtypes.EthHash{}, xerrors.Errorf(k + " not a string")
 		}
-		return ethtypes.EthHashFromHex(s)
+		return ethtypes.NewEthHashFromHex(s)
 	}
 
 	ethUint64 := func(k string, v interface{}) (ethtypes.EthUint64, error) {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/9849

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
