### PR TITLE
feat:splitstore:retain tipset references in hot store

### DIFF
--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -905,13 +905,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	walkCnt := new(int64)
 	scanCnt := new(int64)
 
-	// tsRef := func(cids []cid.Cid) (cid.Cid, error) {
-	// 	blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
-	// 	if err != nil {
-	// 		return cid.Undef, err
-	// 	}
-	// 	return blk.Cid(), nil
-	// }
+	tsRef := func(cids []cid.Cid) (cid.Cid, error) {
+		blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
+		if err != nil {
+			return cid.Undef, err
+		}
+		return blk.Cid(), nil
+	}
 
 	stopWalk := func(_ cid.Cid) error { return errStopWalk }
 
@@ -939,13 +939,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		}
 
 		// tipset CID references are retained
-		// pRef, err := tsRef(hdr.Parents)
-		// if err != nil {
-		// 	return xerrors.Errorf("error computing cid reference to parent tipset")
-		// }
-		// if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
-		// 	return xerrors.Errorf("error walking parent tipset cid reference")
-		// }
+		pRef, err := tsRef(hdr.Parents)
+		if err != nil {
+			return xerrors.Errorf("error computing cid reference to parent tipset")
+		}
+		if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
+			return xerrors.Errorf("error walking parent tipset cid reference")
+		}
 
 		// message are retained if within the inclMsgs boundary
 		if hdr.Height >= inclMsgs && hdr.Height > 0 {
@@ -998,13 +998,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	}
 
 	// retain ref to chain head
-	// hRef, err := tsRef(ts.Cids())
-	// if err != nil {
-	// 	return xerrors.Errorf("error computing cid reference to parent tipset")
-	// }
-	// if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
-	// 	return xerrors.Errorf("error walking parent tipset cid reference")
-	// }
+	hRef, err := tsRef(ts.Cids())
+	if err != nil {
+		return xerrors.Errorf("error computing cid reference to parent tipset")
+	}
+	if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
+		return xerrors.Errorf("error walking parent tipset cid reference")
+	}
 
 	for len(toWalk) > 0 {
 		// walking can take a while, so check this with every opportunity

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -905,6 +905,14 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	walkCnt := new(int64)
 	scanCnt := new(int64)
 
+	tsRef := func(cids []cid.Cid) (cid.Cid, error) {
+		blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
+		if err != nil {
+			return cid.Undef, err
+		}
+		return blk.Cid(), nil
+	}
+
 	stopWalk := func(_ cid.Cid) error { return errStopWalk }
 
 	walkBlock := func(c cid.Cid) error {
@@ -926,9 +934,17 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		err = s.view(c, func(data []byte) error {
 			return hdr.UnmarshalCBOR(bytes.NewBuffer(data))
 		})
-
 		if err != nil {
 			return xerrors.Errorf("error unmarshaling block header (cid: %s): %w", c, err)
+		}
+
+		// tipset CID references are retained
+		if pRef, err := tsRef(hdr.Parents); err != nil {
+			return xerrors.Errorf("error computing cid reference to parent tipset")
+		} else {
+			if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
+				return xerrors.Errorf("error walking parent tipset cid reference")
+			}
 		}
 
 		// message are retained if within the inclMsgs boundary
@@ -979,6 +995,15 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		}
 
 		return nil
+	}
+
+	// retain ref to chain head
+	if hRef, err := tsRef(ts.Cids()); err != nil {
+		return xerrors.Errorf("error computing cid reference to parent tipset")
+	} else {
+		if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
+			return xerrors.Errorf("error walking parent tipset cid reference")
+		}
 	}
 
 	for len(toWalk) > 0 {

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -905,13 +905,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	walkCnt := new(int64)
 	scanCnt := new(int64)
 
-	tsRef := func(cids []cid.Cid) (cid.Cid, error) {
-		blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
-		if err != nil {
-			return cid.Undef, err
-		}
-		return blk.Cid(), nil
-	}
+	// tsRef := func(cids []cid.Cid) (cid.Cid, error) {
+	// 	blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
+	// 	if err != nil {
+	// 		return cid.Undef, err
+	// 	}
+	// 	return blk.Cid(), nil
+	// }
 
 	stopWalk := func(_ cid.Cid) error { return errStopWalk }
 
@@ -939,13 +939,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		}
 
 		// tipset CID references are retained
-		pRef, err := tsRef(hdr.Parents)
-		if err != nil {
-			return xerrors.Errorf("error computing cid reference to parent tipset")
-		}
-		if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
-			return xerrors.Errorf("error walking parent tipset cid reference")
-		}
+		// pRef, err := tsRef(hdr.Parents)
+		// if err != nil {
+		// 	return xerrors.Errorf("error computing cid reference to parent tipset")
+		// }
+		// if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
+		// 	return xerrors.Errorf("error walking parent tipset cid reference")
+		// }
 
 		// message are retained if within the inclMsgs boundary
 		if hdr.Height >= inclMsgs && hdr.Height > 0 {
@@ -998,13 +998,13 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	}
 
 	// retain ref to chain head
-	hRef, err := tsRef(ts.Cids())
-	if err != nil {
-		return xerrors.Errorf("error computing cid reference to parent tipset")
-	}
-	if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
-		return xerrors.Errorf("error walking parent tipset cid reference")
-	}
+	// hRef, err := tsRef(ts.Cids())
+	// if err != nil {
+	// 	return xerrors.Errorf("error computing cid reference to parent tipset")
+	// }
+	// if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
+	// 	return xerrors.Errorf("error walking parent tipset cid reference")
+	// }
 
 	for len(toWalk) > 0 {
 		// walking can take a while, so check this with every opportunity

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -905,12 +905,8 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	walkCnt := new(int64)
 	scanCnt := new(int64)
 
-	tsRef := func(cids []cid.Cid) (cid.Cid, error) {
-		blk, err := types.NewTipSetKey(cids...).ToStorageBlock()
-		if err != nil {
-			return cid.Undef, err
-		}
-		return blk.Cid(), nil
+	tsRef := func(blkCids []cid.Cid) (cid.Cid, error) {
+		return types.NewTipSetKey(blkCids...).Cid()
 	}
 
 	stopWalk := func(_ cid.Cid) error { return errStopWalk }

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -939,12 +939,12 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		}
 
 		// tipset CID references are retained
-		if pRef, err := tsRef(hdr.Parents); err != nil {
+		pRef, err := tsRef(hdr.Parents)
+		if err != nil {
 			return xerrors.Errorf("error computing cid reference to parent tipset")
-		} else {
-			if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
-				return xerrors.Errorf("error walking parent tipset cid reference")
-			}
+		}
+		if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
+			return xerrors.Errorf("error walking parent tipset cid reference")
 		}
 
 		// message are retained if within the inclMsgs boundary
@@ -998,12 +998,12 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	}
 
 	// retain ref to chain head
-	if hRef, err := tsRef(ts.Cids()); err != nil {
+	hRef, err := tsRef(ts.Cids())
+	if err != nil {
 		return xerrors.Errorf("error computing cid reference to parent tipset")
-	} else {
-		if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
-			return xerrors.Errorf("error walking parent tipset cid reference")
-		}
+	}
+	if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
+		return xerrors.Errorf("error walking parent tipset cid reference")
 	}
 
 	for len(toWalk) > 0 {

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -262,9 +262,8 @@ func TestCompactRetainsTipSetRef(t *testing.T) {
 	check, err := full.ChainHead(ctx)
 	require.NoError(t, err)
 	e := check.Height()
-	rawKey, err := check.Key().ToStorageBlock()
+	checkRef, err := check.Key().Cid()
 	require.NoError(t, err)
-	checkRef := rawKey.Cid()
 	assert.True(t, ipldExists(ctx, t, checkRef, full)) // reference to tipset key should be persisted before compaction
 
 	// Determine index of compaction that covers tipset "check" and wait for compaction

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -290,6 +290,7 @@ func TestCompactRetainsTipSetRef(t *testing.T) {
 	// wait for compaction to occur
 	waitForCompaction(ctx, t, garbageCompactionIndex, full)
 	assert.True(t, ipldExists(ctx, t, checkRef, full)) // reference to tipset key should be persisted after compaction
+	bm.Stop()
 }
 
 func waitForCompaction(ctx context.Context, t *testing.T, cIdx int64, n *kit.TestFullNode) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
#9799

## Proposed Changes
<!-- A clear list of the changes being made -->
FEVM is introducing H(TipSetKey) to get a single blockhash to return in places where ethereum wants a single hash.  This PR ensures that splitstore compaction will keep these cids pinned in the hotstore.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
WIP as this still needs tests
Also I don't think we're actually writing tipset references to the chain store yet if I'm right about this we'll need to do that to actually test this out.
## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
