### PR TITLE
feat: blockstore: Envvar can adjust badger compaction worker poolsize

### DIFF
--- a/node/repo/blockstore_opts.go
+++ b/node/repo/blockstore_opts.go
@@ -1,6 +1,11 @@
 package repo
 
-import badgerbs "github.com/filecoin-project/lotus/blockstore/badger"
+import (
+	"os"
+	"strconv"
+
+	badgerbs "github.com/filecoin-project/lotus/blockstore/badger"
+)
 
 // BadgerBlockstoreOptions returns the badger options to apply for the provided
 // domain.
@@ -42,5 +47,17 @@ func BadgerBlockstoreOptions(domain BlockstoreDomain, path string, readonly bool
 
 	opts.ReadOnly = readonly
 
+	// Envvar LOTUS_CHAIN_BADGERSTORE_COMPACTIONWORKERNUM
+	// Allows the number of compaction workers used by BadgerDB to be adjusted
+	// Unset - leaves the default number of compaction workers (4)
+	// "0" - disables compaction
+	// Positive integer - enables that number of compaction workers
+	if badgerNumCompactors, badgerNumCompactorsSet := os.LookupEnv("LOTUS_CHAIN_BADGERSTORE_COMPACTIONWORKERNUM"); badgerNumCompactorsSet {
+		if numWorkers, err := strconv.Atoi(badgerNumCompactors); err == nil && numWorkers >= 0 {
+			opts.NumCompactors = numWorkers
+		}
+	}
+
 	return opts, nil
+
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
This is a proposal for closing #9972. Happy to add docs or tests as needed.

## Proposed Changes
- Include envvar `LOTUS_CHAIN_BADGERSTORE_COMPACTIONWORKERNUM` which accepts a non-negative int that configures the number of compaction workers for the badger blockstore

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io) (PR: https://github.com/filecoin-project/lotus-docs/pull/463)
project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
