### PR TITLE
fix: Remove workaround that is no longer needed

### DIFF
--- a/storage/pipeline/checks.go
+++ b/storage/pipeline/checks.go
@@ -3,7 +3,6 @@ package sealing
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"golang.org/x/xerrors"
 
@@ -133,8 +132,6 @@ func checkPrecommit(ctx context.Context, maddr address.Address, si SectorInfo, t
 	if err != nil {
 		return xerrors.Errorf("checking if sector is allocated: %w", err)
 	}
-	// TODO This is a very bad hack!! We are only using this while we investigate the compiler issue here.
-	time.Sleep(time.Nanosecond)
 	if alloc {
 		//committed P2 message  but commit C2 message too late, pci should be null in this case
 		return &ErrSectorNumberAllocated{xerrors.Errorf("sector %d is allocated, but PreCommit info wasn't found on chain", si.SectorNumber)}
@@ -164,8 +161,6 @@ func (m *Sealing) checkCommit(ctx context.Context, si SectorInfo, proof []byte, 
 		if err != nil {
 			return xerrors.Errorf("checking if sector is allocated: %w", err)
 		}
-		// TODO This is a very bad hack!! We are only using this while we investigate the compiler issue here.
-		time.Sleep(time.Nanosecond)
 		if alloc {
 			// not much more we can check here, basically try to wait for commit,
 			// and hope that this will work


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9053

## Proposed Changes
Removed workaround. The issue was fixed by golang v1.18.6
Now that we're building using 1.18.8 as the minimum version, the workaround is no longer needed.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
