### PR TITLE
Refactor: Unify EthTx to FilecoinMessage methods

### DIFF
--- a/chain/signatures.go
+++ b/chain/signatures.go
@@ -22,7 +22,7 @@ func AuthenticateMessage(msg *types.SignedMessage, signer address.Address) error
 	typ := msg.Signature.Type
 	switch typ {
 	case crypto.SigTypeDelegated:
-		txArgs, err := ethtypes.EthTxArgsFromMessage(&msg.Message)
+		txArgs, err := ethtypes.EthTxArgsFromUnsignedMessage(&msg.Message)
 		if err != nil {
 			return xerrors.Errorf("failed to reconstruct eth transaction: %w", err)
 		}

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -70,7 +70,7 @@ func TestEthAccountAbstraction(t *testing.T) {
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
 	require.NoError(t, err)
 
-	txArgs, err := ethtypes.EthTxArgsFromMessage(msgFromPlaceholder)
+	txArgs, err := ethtypes.EthTxArgsFromUnsignedMessage(msgFromPlaceholder)
 	require.NoError(t, err)
 
 	digest, err := txArgs.ToRlpUnsignedMsg()
@@ -106,7 +106,7 @@ func TestEthAccountAbstraction(t *testing.T) {
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
 	require.NoError(t, err)
 
-	txArgs, err = ethtypes.EthTxArgsFromMessage(msgFromPlaceholder)
+	txArgs, err = ethtypes.EthTxArgsFromUnsignedMessage(msgFromPlaceholder)
 	require.NoError(t, err)
 
 	digest, err = txArgs.ToRlpUnsignedMsg()
@@ -178,7 +178,7 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	msgFromPlaceholder.Value = abi.TokenAmount(types.MustParseFIL("1000"))
-	txArgs, err := ethtypes.EthTxArgsFromMessage(msgFromPlaceholder)
+	txArgs, err := ethtypes.EthTxArgsFromUnsignedMessage(msgFromPlaceholder)
 	require.NoError(t, err)
 
 	digest, err := txArgs.ToRlpUnsignedMsg()
@@ -216,7 +216,7 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
 	require.NoError(t, err)
 
-	txArgs, err = ethtypes.EthTxArgsFromMessage(msgFromPlaceholder)
+	txArgs, err = ethtypes.EthTxArgsFromUnsignedMessage(msgFromPlaceholder)
 	require.NoError(t, err)
 
 	digest, err = txArgs.ToRlpUnsignedMsg()

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1455,77 +1455,23 @@ func lookupEthAddress(ctx context.Context, addr address.Address, sa StateAPI) (e
 }
 
 func newEthTxFromFilecoinMessage(ctx context.Context, smsg *types.SignedMessage, sa StateAPI) (ethtypes.EthTx, error) {
+	tx, err := ethtypes.EthTxFromSignedMessage(smsg)
+	if err != nil {
+		return ethtypes.EthTx{}, xerrors.Errorf("failed to convert from signed message: %w", err)
+	}
+
 	fromEthAddr, err := lookupEthAddress(ctx, smsg.Message.From, sa)
 	if err != nil {
-		return ethtypes.EthTx{}, err
+		return ethtypes.EthTx{}, xerrors.Errorf("failed to lookup from ethaddress: %w", err)
 	}
 
 	toEthAddr, err := lookupEthAddress(ctx, smsg.Message.To, sa)
 	if err != nil {
-		return ethtypes.EthTx{}, err
+		return ethtypes.EthTx{}, xerrors.Errorf("failed to lookup to ethaddress: %w", err)
 	}
 
-	toAddr := &toEthAddr
-	input := smsg.Message.Params
-	// Check to see if we need to decode as contract deployment.
-	// We don't need to resolve the to address, because there's only one form (an ID).
-	if smsg.Message.To == builtintypes.EthereumAddressManagerActorAddr {
-		switch smsg.Message.Method {
-		case builtintypes.MethodsEAM.Create:
-			toAddr = nil
-			var params eam.CreateParams
-			err = params.UnmarshalCBOR(bytes.NewReader(smsg.Message.Params))
-			input = params.Initcode
-		case builtintypes.MethodsEAM.Create2:
-			toAddr = nil
-			var params eam.Create2Params
-			err = params.UnmarshalCBOR(bytes.NewReader(smsg.Message.Params))
-			input = params.Initcode
-		case builtintypes.MethodsEAM.CreateExternal:
-			toAddr = nil
-			var params abi.CborBytes
-			err = params.UnmarshalCBOR(bytes.NewReader(smsg.Message.Params))
-			input = []byte(params)
-		}
-		if err != nil {
-			return ethtypes.EthTx{}, err
-		}
-	}
-	// Otherwise, try to decode as a cbor byte array.
-	// TODO: Actually check if this is an ethereum call. This code will work for demo purposes, but is not correct.
-	if toAddr != nil {
-		if decodedParams, err := cbg.ReadByteArray(bytes.NewReader(smsg.Message.Params), uint64(len(smsg.Message.Params))); err == nil {
-			input = decodedParams
-		}
-	}
-
-	r, s, v, err := ethtypes.RecoverSignature(smsg.Signature)
-	if err != nil {
-		// we don't want to return error if the message is not an Eth tx
-		r, s, v = ethtypes.EthBigIntZero, ethtypes.EthBigIntZero, ethtypes.EthBigIntZero
-	}
-
-	hash, err := ethtypes.EthHashFromCid(smsg.Cid())
-	if err != nil {
-		return ethtypes.EthTx{}, err
-	}
-
-	tx := ethtypes.EthTx{
-		Hash:                 hash,
-		Nonce:                ethtypes.EthUint64(smsg.Message.Nonce),
-		ChainID:              ethtypes.EthUint64(build.Eip155ChainId),
-		From:                 fromEthAddr,
-		To:                   toAddr,
-		Value:                ethtypes.EthBigInt(smsg.Message.Value),
-		Type:                 ethtypes.EthUint64(2),
-		Gas:                  ethtypes.EthUint64(smsg.Message.GasLimit),
-		MaxFeePerGas:         ethtypes.EthBigInt(smsg.Message.GasFeeCap),
-		MaxPriorityFeePerGas: ethtypes.EthBigInt(smsg.Message.GasPremium),
-		V:                    v,
-		R:                    r,
-		S:                    s,
-		Input:                input,
-	}
+	tx.From = fromEthAddr
+	tx.To = &toEthAddr
 
 	return tx, nil
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#10013 

## Proposed Changes
<!-- A clear list of the changes being made -->

Unifies the common message decoding logic, making `newEthTxFromFilecoinMessage` a much simpler method.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
