### PR TITLE
feat: lotus-cli: Add global color flag

### DIFF
--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/fatih/color"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
@@ -52,6 +53,10 @@ func main() {
 			}
 			jaeger = tracing.SetupJaegerTracing("lotus/" + cmd.Name)
 
+			if cctx.IsSet("color") {
+				color.NoColor = !cctx.Bool("color")
+			}
+
 			if originBefore != nil {
 				return originBefore(cctx)
 			}
@@ -74,6 +79,12 @@ func main() {
 				EnvVars: []string{"LOTUS_PANIC_REPORT_PATH"},
 				Hidden:  true,
 				Value:   "~/.lotus", // should follow --repo default
+			},
+			&cli.BoolFlag{
+				// examined in the Before above
+				Name:        "color",
+				Usage:       "use color in display output",
+				DefaultText: "depends on output being a TTY",
 			},
 			&cli.StringFlag{
 				Name:    "repo",

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -38,6 +38,7 @@ COMMANDS:
      status  Check node status
 
 GLOBAL OPTIONS:
+   --color        use color in display output (default: depends on output being a TTY)
    --force-send   if true, will ignore pre-send checks (default: false)
    --help, -h     show help (default: false)
    --interactive  setting to false will disable interactive functionality of commands (default: false)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

I believe this addresses https://github.com/filecoin-project/lotus/issues/9611
Master seems to be red on ci

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
