### PR TITLE
chore: cli: Remove unneeded individual color flags

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -1121,11 +1121,6 @@ var clientListRetrievalsCmd = &cli.Command{
 			Usage:   "print verbose deal details",
 		},
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-		&cli.BoolFlag{
 			Name:  "show-failed",
 			Usage: "show failed/failing deals",
 			Value: true,
@@ -1140,10 +1135,6 @@ var clientListRetrievalsCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -1709,11 +1700,6 @@ var clientListDeals = &cli.Command{
 			Usage:   "print verbose deal details",
 		},
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-		&cli.BoolFlag{
 			Name:  "show-failed",
 			Usage: "show failed/failing deals",
 		},
@@ -1723,10 +1709,6 @@ var clientListDeals = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
@@ -2239,11 +2221,6 @@ var clientListTransfers = &cli.Command{
 			Usage:   "print verbose transfer details",
 		},
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-		&cli.BoolFlag{
 			Name:  "completed",
 			Usage: "show completed data transfers",
 		},
@@ -2257,10 +2234,6 @@ var clientListTransfers = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -433,17 +433,8 @@ var actorControlList = &cli.Command{
 		&cli.BoolFlag{
 			Name: "verbose",
 		},
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/dagstore.go
+++ b/cmd/lotus-miner/dagstore.go
@@ -31,18 +31,7 @@ var dagstoreCmd = &cli.Command{
 var dagstoreListShardsCmd = &cli.Command{
 	Name:  "list-shards",
 	Usage: "List all shards known to the dagstore, with their current status",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
 		if err != nil {
 			return err
@@ -64,18 +53,7 @@ var dagstoreRegisterShardCmd = &cli.Command{
 	Name:      "register-shard",
 	ArgsUsage: "[key]",
 	Usage:     "Register a shard",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
 		}
@@ -103,18 +81,7 @@ var dagstoreInitializeShardCmd = &cli.Command{
 	Name:      "initialize-shard",
 	ArgsUsage: "[key]",
 	Usage:     "Initialize the specified shard",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
 		}
@@ -135,18 +102,7 @@ var dagstoreRecoverShardCmd = &cli.Command{
 	Name:      "recover-shard",
 	ArgsUsage: "[key]",
 	Usage:     "Attempt to recover a shard in errored state",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
 		}
@@ -176,17 +132,8 @@ var dagstoreInitializeAllCmd = &cli.Command{
 			Name:  "include-sealed",
 			Usage: "initialize sealed pieces as well",
 		},
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		concurrency := cctx.Uint("concurrency")
 		sealed := cctx.Bool("sealed")
 
@@ -236,18 +183,7 @@ var dagstoreInitializeAllCmd = &cli.Command{
 var dagstoreGcCmd = &cli.Command{
 	Name:  "gc",
 	Usage: "Garbage collect the dagstore",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
 		if err != nil {
 			return err
@@ -317,18 +253,7 @@ var dagstoreLookupPiecesCmd = &cli.Command{
 	Name:      "lookup-pieces",
 	Usage:     "Lookup pieces that a given CID belongs to",
 	ArgsUsage: "<cid>",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
 		}

--- a/cmd/lotus-miner/index_provider.go
+++ b/cmd/lotus-miner/index_provider.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
 
@@ -23,18 +22,7 @@ var indexProvAnnounceCmd = &cli.Command{
 	Name:      "announce",
 	ArgsUsage: "<deal proposal cid>",
 	Usage:     "Announce a deal to indexers so they can download its index",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
 		}
@@ -60,18 +48,7 @@ var indexProvAnnounceCmd = &cli.Command{
 var indexProvAnnounceAllCmd = &cli.Command{
 	Name:  "announce-all",
 	Usage: "Announce all active deals to indexers so they can download the indices",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		marketsApi, closer, err := lcli.GetMarketsAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/market.go
+++ b/cmd/lotus-miner/market.go
@@ -16,7 +16,6 @@ import (
 
 	tm "github.com/buger/goterm"
 	"github.com/docker/go-units"
-	"github.com/fatih/color"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-cidutil/cidenc"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -780,11 +779,6 @@ var transfersListCmd = &cli.Command{
 			Usage:   "print verbose transfer details",
 		},
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-		&cli.BoolFlag{
 			Name:  "completed",
 			Usage: "show completed data transfers",
 		},
@@ -798,10 +792,6 @@ var transfersListCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		api, closer, err := lcli.GetMarketsAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -45,18 +45,7 @@ func workersCmd(sealing bool) *cli.Command {
 	return &cli.Command{
 		Name:  "workers",
 		Usage: "list workers",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:        "color",
-				Usage:       "use color in display output",
-				DefaultText: "depends on output being a TTY",
-			},
-		},
 		Action: func(cctx *cli.Context) error {
-			if cctx.IsSet("color") {
-				color.NoColor = !cctx.Bool("color")
-			}
-
 			minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 			if err != nil {
 				return err
@@ -219,20 +208,11 @@ var sealingJobsCmd = &cli.Command{
 	Usage: "list running jobs",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-		&cli.BoolFlag{
 			Name:  "show-ret-done",
 			Usage: "show returned but not consumed calls",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -279,12 +279,6 @@ var sectorsListCmd = &cli.Command{
 			Aliases: []string{"r"},
 		},
 		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-			Aliases:     []string{"c"},
-		},
-		&cli.BoolFlag{
 			Name:    "fast",
 			Usage:   "don't show on-chain info for better performance",
 			Aliases: []string{"f"},
@@ -315,10 +309,6 @@ var sectorsListCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err

--- a/cmd/lotus-miner/storage.go
+++ b/cmd/lotus-miner/storage.go
@@ -254,21 +254,10 @@ var storageRedeclareCmd = &cli.Command{
 var storageListCmd = &cli.Command{
 	Name:  "list",
 	Usage: "list local storage paths",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Subcommands: []*cli.Command{
 		storageListSectorsCmd,
 	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
@@ -633,18 +622,7 @@ var storageFindCmd = &cli.Command{
 var storageListSectorsCmd = &cli.Command{
 	Name:  "sectors",
 	Usage: "get list of all sector files",
-	Flags: []cli.Flag{
-		&cli.BoolFlag{
-			Name:        "color",
-			Usage:       "use color in display output",
-			DefaultText: "depends on output being a TTY",
-		},
-	},
 	Action: func(cctx *cli.Context) error {
-		if cctx.IsSet("color") {
-			color.NoColor = !cctx.Bool("color")
-		}
-
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -333,7 +333,6 @@ USAGE:
    lotus-miner actor control list [command options] [arguments...]
 
 OPTIONS:
-   --color    use color in display output (default: depends on output being a TTY)
    --verbose  (default: false)
    
 ```
@@ -980,7 +979,6 @@ USAGE:
    lotus-miner data-transfers list [command options] [arguments...]
 
 OPTIONS:
-   --color        use color in display output (default: depends on output being a TTY)
    --completed    show completed data transfers (default: false)
    --show-failed  show failed/cancelled transfers (default: false)
    --verbose, -v  print verbose transfer details (default: false)
@@ -1062,7 +1060,7 @@ USAGE:
    lotus-miner dagstore list-shards [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1075,7 +1073,7 @@ USAGE:
    lotus-miner dagstore register-shard [command options] [key]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1088,7 +1086,7 @@ USAGE:
    lotus-miner dagstore initialize-shard [command options] [key]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1101,7 +1099,7 @@ USAGE:
    lotus-miner dagstore recover-shard [command options] [key]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1114,7 +1112,6 @@ USAGE:
    lotus-miner dagstore initialize-all [command options] [arguments...]
 
 OPTIONS:
-   --color              use color in display output (default: depends on output being a TTY)
    --concurrency value  maximum shards to initialize concurrently at a time; use 0 for unlimited (default: 0)
    --include-sealed     initialize sealed pieces as well (default: false)
    
@@ -1129,7 +1126,7 @@ USAGE:
    lotus-miner dagstore gc [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1142,7 +1139,7 @@ USAGE:
    lotus-miner dagstore lookup-pieces [command options] <cid>
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1173,7 +1170,7 @@ USAGE:
    lotus-miner index announce [command options] <deal proposal cid>
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1186,7 +1183,7 @@ USAGE:
    lotus-miner index announce-all [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -1721,7 +1718,6 @@ USAGE:
    lotus-miner sectors list [command options] [arguments...]
 
 OPTIONS:
-   --color, -c           use color in display output (default: depends on output being a TTY)
    --events, -e          display number of events the sector has received (default: false)
    --fast, -f            don't show on-chain info for better performance (default: false)
    --initial-pledge, -p  display initial pledge (default: false)
@@ -2223,7 +2219,7 @@ USAGE:
    lotus-miner proving workers [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -2371,7 +2367,6 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
    --help, -h  show help (default: false)
    
 ```
@@ -2385,7 +2380,7 @@ USAGE:
    lotus-miner storage list sectors [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 
@@ -2458,7 +2453,6 @@ USAGE:
    lotus-miner sealing jobs [command options] [arguments...]
 
 OPTIONS:
-   --color          use color in display output (default: depends on output being a TTY)
    --show-ret-done  show returned but not consumed calls (default: false)
    
 ```
@@ -2472,7 +2466,7 @@ USAGE:
    lotus-miner sealing workers [command options] [arguments...]
 
 OPTIONS:
-   --color  use color in display output (default: depends on output being a TTY)
+   --help, -h  show help (default: false)
    
 ```
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -686,7 +686,6 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --color        use color in display output (default: depends on output being a TTY)
    --completed    show completed retrievals (default: false)
    --show-failed  show failed/failing deals (default: true)
    --verbose, -v  print verbose deal details (default: false)
@@ -757,7 +756,6 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
-   --color        use color in display output (default: depends on output being a TTY)
    --show-failed  show failed/failing deals (default: false)
    --verbose, -v  print verbose deal details (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
@@ -890,7 +888,6 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --color        use color in display output (default: depends on output being a TTY)
    --completed    show completed data transfers (default: false)
    --show-failed  show failed/cancelled transfers (default: false)
    --verbose, -v  print verbose transfer details (default: false)


### PR DESCRIPTION
## Related Issues
Thanks to @FlattestWhite for https://github.com/filecoin-project/lotus/pull/10022

## Proposed Changes
We now have global color flags for all functions in lotus and lotus-miner cli. 
https://github.com/filecoin-project/lotus/blob/00a73fd88f1a2622105ae88495e293a16c14579b/cmd/lotus/main.go#L56
https://github.com/filecoin-project/lotus/blob/00a73fd88f1a2622105ae88495e293a16c14579b/cmd/lotus-miner/main.go#L74

I've removed all the redundant individual flags.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
