### PR TITLE
fix: sealing: stub out the FileSize function on Windows

### DIFF
--- a/storage/sealer/fsutil/filesize_unix.go
+++ b/storage/sealer/fsutil/filesize_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package fsutil
 
 import (

--- a/storage/sealer/fsutil/filesize_windows.go
+++ b/storage/sealer/fsutil/filesize_windows.go
@@ -1,0 +1,16 @@
+package fsutil
+
+import (
+	"fmt"
+)
+
+type SizeInfo struct {
+	OnDisk int64
+}
+
+// FileSize returns bytes used by a file or directory on disk
+// NOTE: We care about the allocated bytes, not file or directory size
+// This is not currently supported on Windows, but at least other lotus can components can build on Windows now
+func FileSize(path string) (SizeInfo, error) {
+	return SizeInfo{0}, fmt.Errorf("unsupported")
+}


### PR DESCRIPTION
## Proposed Changes
Mocking out the FileSize function call in the sealer when built on Windows so that lotus library components can be used on Windows.

## Additional Info
Would also be great to test that Windows library usage (e.g. of the state tree and actors) can continue to work on Windows even though running lotus and doing things like sealing isn't going to happen.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
