### PR TITLE
itests: Test FEVM recursive calls

### DIFF
--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -151,21 +151,21 @@ func TestFEVMRecursiveFuncCall(t *testing.T) {
 	filenameActor := "contracts/StackFunc.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
-	testN := func(n int) func(t *testing.T) {
+	testN := func(n int, ex exitcode.ExitCode) func(t *testing.T) {
 		return func(t *testing.T) {
 			inputData := make([]byte, 32)
 			binary.BigEndian.PutUint64(inputData[24:], uint64(n))
 
-			result := client.EVM().InvokeContractByFuncName(ctx, fromAddr, actorAddr, "exec1(uint256)", inputData)
-			require.Equal(t, result, []byte{})
+			client.EVM().InvokeContractByFuncNameExpectExit(ctx, fromAddr, actorAddr, "exec1(uint256)", inputData, ex)
 		}
 	}
 
-	t.Run("n=0", testN(0))
-	t.Run("n=1", testN(1))
-	t.Run("n=20", testN(20))
-	t.Run("n=200", testN(200))
-	t.Run("n=293", testN(293))
+	t.Run("n=0", testN(0, exitcode.Ok))
+	t.Run("n=1", testN(1, exitcode.Ok))
+	t.Run("n=20", testN(20, exitcode.Ok))
+	t.Run("n=200", testN(200, exitcode.Ok))
+	t.Run("n=507", testN(507, exitcode.Ok))
+	t.Run("n=508", testN(508, exitcode.ExitCode(23))) // 23 means stack overflow
 }
 
 // TestFEVMRecursiveActorCall deploys a contract and makes a recursive actor calls


### PR DESCRIPTION
## Related Issues
On top of https://github.com/filecoin-project/lotus/pull/10010
Closes https://github.com/filecoin-project/ref-fvm/issues/1322

## Proposed Changes
Add 2 itests:
* One with a function which calls itself recursively
* One with a function which calls itself recursively, then calls the contract recursively

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
