### PR TITLE
feat: snapshot: Store tipset key cids in chain store during snapshot import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,11 +926,6 @@ workflows:
           target: "./itests/self_sent_txn_test.go"
       
       - test:
-          name: test-itest-snapshot
-          suite: itest-snapshot
-          target: "./itests/snapshot_test.go"
-      
-      - test:
           name: test-itest-splitstore
           suite: itest-splitstore
           target: "./itests/splitstore_test.go"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,6 +926,11 @@ workflows:
           target: "./itests/self_sent_txn_test.go"
       
       - test:
+          name: test-itest-snapshot
+          suite: itest-snapshot
+          target: "./itests/snapshot_test.go"
+      
+      - test:
           name: test-itest-splitstore
           suite: itest-splitstore
           target: "./itests/splitstore_test.go"

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -22,7 +22,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const MAX_TIPSETS_FROM_SNAPSHOT = 2000
+const TIPSETKEY_BACKFILL_RANGE = 2 * build.Finality
 
 func (cs *ChainStore) UnionStore() bstore.Blockstore {
 	return bstore.Union(cs.stateBlockstore, cs.chainBlockstore)
@@ -116,7 +116,7 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 	}
 
 	ts := root
-	for i := 0; i < MAX_TIPSETS_FROM_SNAPSHOT; i++ {
+	for i := 0; i < int(TIPSETKEY_BACKFILL_RANGE); i++ {
 		err = cs.PersistTipset(ctx, ts)
 		if err != nil {
 			return nil, err

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -117,15 +117,16 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 
 	ts := root
 	for i := 0; i < MAX_TIPSETS_FROM_SNAPSHOT; i++ {
-		if ts == nil {
-			break
-		}
 		err = cs.PersistTipset(ctx, ts)
 		if err != nil {
 			return nil, err
 		}
 		parentTsKey := ts.Parents()
 		ts, err = cs.LoadTipSet(ctx, parentTsKey)
+		if ts == nil || err != nil {
+			log.Warnf("Only able to load the last %d tipsets", i)
+			break
+		}
 	}
 
 	return root, nil

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1097,6 +1097,10 @@ func (cs *ChainStore) StateBlockstore() bstore.Blockstore {
 	return cs.stateBlockstore
 }
 
+func (cs *ChainStore) ChainLocalBlockstore() bstore.Blockstore {
+	return cs.chainLocalBlockstore
+}
+
 func ActorStore(ctx context.Context, bs bstore.Blockstore) adt.Store {
 	return adt.WrapStore(ctx, cbor.NewCborStore(bs))
 }

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -4,11 +4,11 @@ package store_test
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -4,6 +4,7 @@ package store_test
 import (
 	"bytes"
 	"context"
+	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
 
@@ -121,6 +122,51 @@ func TestChainExportImport(t *testing.T) {
 
 	if !root.Equals(last) {
 		t.Fatal("imported chain differed from exported chain")
+	}
+}
+
+// Test to check if tipset key cids are being stored on snapshot
+func TestChainImportTipsetKeyCid(t *testing.T) {
+
+	ctx := context.Background()
+	cg, err := gen.NewGenerator()
+	require.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	var last *types.TipSet
+	var tsKeys []types.TipSetKey
+	for i := 0; i < 10; i++ {
+		ts, err := cg.NextTipSet()
+		require.NoError(t, err)
+		last = ts.TipSet.TipSet()
+		tsKeys = append(tsKeys, last.Key())
+	}
+
+	if err := cg.ChainStore().Export(ctx, last, last.Height(), false, buf); err != nil {
+		t.Fatal(err)
+	}
+
+	nbs := blockstore.NewMemorySync()
+	cs := store.NewChainStore(nbs, nbs, datastore.NewMapDatastore(), filcns.Weight, nil)
+	defer cs.Close() //nolint:errcheck
+
+	root, err := cs.Import(ctx, buf)
+	require.NoError(t, err)
+
+	err = cs.SetHead(ctx, last)
+	require.NoError(t, err)
+
+	require.Truef(t, root.Equals(last), "imported chain differed from exported chain")
+
+	for _, tsKey := range tsKeys {
+		_, err := cs.LoadTipSet(ctx, tsKey)
+		require.NoError(t, err)
+
+		tsCid, err := tsKey.Cid()
+		require.NoError(t, err)
+		_, err = cs.ChainLocalBlockstore().Get(ctx, tsCid)
+		require.NoError(t, err)
+
 	}
 }
 

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -153,10 +153,10 @@ func TestChainImportTipsetKeyCid(t *testing.T) {
 	root, err := cs.Import(ctx, buf)
 	require.NoError(t, err)
 
+	require.Truef(t, root.Equals(last), "imported chain differed from exported chain")
+
 	err = cs.SetHead(ctx, last)
 	require.NoError(t, err)
-
-	require.Truef(t, root.Equals(last), "imported chain differed from exported chain")
 
 	for _, tsKey := range tsKeys {
 		_, err := cs.LoadTipSet(ctx, tsKey)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/9977

## Proposed Changes
<!-- A clear list of the changes being made -->
On snapshot import, persist the tipset key cids in the chain blockstore

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
