### PR TITLE
add a lotus-shed eth check-tipsets command.

### DIFF
--- a/cmd/lotus-shed/eth.go
+++ b/cmd/lotus-shed/eth.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
-	"github.com/urfave/cli/v2"
 )
 
 var ethCmd = &cli.Command{

--- a/cmd/lotus-shed/eth.go
+++ b/cmd/lotus-shed/eth.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/types"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+)
+
+var ethCmd = &cli.Command{
+	Name:        "eth",
+	Description: "Ethereum compatibility related commands",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo",
+			Value: "~/.lotus",
+		},
+	},
+	Subcommands: []*cli.Command{
+		checkTipsetsCmd,
+	},
+}
+
+var checkTipsetsCmd = &cli.Command{
+	Name:        "check-tipsets",
+	Description: "Check that eth_getBlockByNumber and eth_getBlockByHash consistently return tipsets",
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetFullNodeAPIV1(cctx)
+		if err != nil {
+			return err
+		}
+
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+
+		head, err := api.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+
+		height := head.Height()
+		fmt.Println("Current height:", height)
+		for i := int64(height); i > 0; i-- {
+			if _, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(i), types.EmptyTSK); err != nil {
+				fmt.Printf("[FAIL] failed to get tipset @%d from Lotus: %s\n", i, err)
+				continue
+			}
+			hex := fmt.Sprintf("0x%x", i)
+			ethBlockA, err := api.EthGetBlockByNumber(ctx, hex, false)
+			if err != nil {
+				fmt.Printf("[FAIL] failed to get tipset @%d via eth_getBlockByNumber: %s\n", i, err)
+				continue
+			}
+			ethBlockB, err := api.EthGetBlockByHash(ctx, ethBlockA.Hash, false)
+			if err != nil {
+				fmt.Printf("[FAIL] failed to get tipset @%d via eth_getBlockByHash: %s\n", i, err)
+				continue
+			}
+			if equal := reflect.DeepEqual(ethBlockA, ethBlockB); equal {
+				fmt.Printf("[OK] blocks received via eth_getBlockByNumber and eth_getBlockByHash for tipset @%d are identical\n", i)
+			} else {
+				fmt.Printf("[FAIL] blocks received via eth_getBlockByNumber and eth_getBlockByHash for tipset @%d are NOT identical\n", i)
+			}
+		}
+		return nil
+	},
+}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -49,6 +49,7 @@ func main() {
 		minerCmd,
 		mpoolStatsCmd,
 		exportChainCmd,
+		ethCmd,
 		exportCarCmd,
 		consensusCmd,
 		syncCmd,


### PR DESCRIPTION
This checks Eth API consistency by walking the chain backwards from HEAD and verifying that all data returned from eth_getBlockByNumber is consistent with eth_getBlockByHash. This helps us debug Eth JSON-RPC endpoint inconsistencies re: tipset CID.

## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
