### PR TITLE
Dual execution

### DIFF
--- a/chain/types/execresult.go
+++ b/chain/types/execresult.go
@@ -30,7 +30,7 @@ type GasTrace struct {
 	VirtualComputeGas int64 `json:"vcg,omitempty"`
 	VirtualStorageGas int64 `json:"vsg,omitempty"`
 
-	TimeTaken time.Duration `json:"tt"`
+	TimeTaken time.Duration `json:"tt,omitempty"`
 	Extra     interface{}   `json:"ex,omitempty"`
 
 	Callers []uintptr `json:"-"`

--- a/chain/types/execresult.go
+++ b/chain/types/execresult.go
@@ -22,13 +22,13 @@ type ExecutionTrace struct {
 type GasTrace struct {
 	Name string
 
-	Location          []Loc `json:"loc"`
+	Location          []Loc `json:"loc,omitempty"`
 	TotalGas          int64 `json:"tg"`
 	ComputeGas        int64 `json:"cg"`
 	StorageGas        int64 `json:"sg"`
-	TotalVirtualGas   int64 `json:"vtg"`
-	VirtualComputeGas int64 `json:"vcg"`
-	VirtualStorageGas int64 `json:"vsg"`
+	TotalVirtualGas   int64 `json:"vtg,omitempty"`
+	VirtualComputeGas int64 `json:"vcg,omitempty"`
+	VirtualStorageGas int64 `json:"vsg,omitempty"`
 
 	TimeTaken time.Duration `json:"tt"`
 	Extra     interface{}   `json:"ex,omitempty"`

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -707,7 +707,7 @@ func (vm *dualExecutionFVM) ApplyImplicitMessage(ctx context.Context, msg *types
 	var err2 error
 	go func() {
 		defer wg.Done()
-		ret2, err2 = vm.debug.ApplyMessage(ctx, msg)
+		ret2, err2 = vm.debug.ApplyImplicitMessage(ctx, msg)
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
How to use:
 - Download or build V10 actor bundle
 - Set env variables: `env LOTUS_FVM_DEBUG_BUNDLE_V10=$PATH_TO_V10_BUNDLE LOTUS_FVM_DEVELOPER_DEBUG=1 LOTUS_FVM_DEVELOPER_DEBUG_FORWARD=1`
 - run lotus, either sync blocks or call `lotus state compute-state $BLOCK_CID`
 - results are appended to `dual_execution_results.ndjson` in working directory of lotus daemon
 - possible entries are `type: "dualExec"` with value of `{active: ActorRet, debug: ActorRet}` and `type: "executionError"` with value of the error string.