### PR TITLE
fix: config: Fix eth rpc typo

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -344,11 +344,11 @@
 
 
 [Fevm]
-  # EnableEthPRC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
+  # EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
   #
   # type: bool
-  # env var: LOTUS_FEVM_ENABLEETHPRC
-  #EnableEthPRC = false
+  # env var: LOTUS_FEVM_ENABLEETHRPC
+  #EnableEthRPC = false
 
   # EthTxHashMappingLifetimeDays the transaction hash lookup database will delete mappings that have been stored for more than x days
   # Set to 0 to keep all mappings

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -137,5 +137,5 @@ func TestEVMRpcDisable(t *testing.T) {
 	client, _, _ := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.DisableEthRPC())
 
 	_, err := client.EthBlockNumber(context.Background())
-	require.ErrorContains(t, err, "module disabled, enable with Fevm.EnableEthPRC")
+	require.ErrorContains(t, err, "module disabled, enable with Fevm.EnableEthRPC")
 }

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -62,7 +62,7 @@ var DefaultNodeOpts = nodeOpts{
 		func(cfg *config.FullNode) error {
 			// test defaults
 
-			cfg.Fevm.EnableEthPRC = true
+			cfg.Fevm.EnableEthRPC = true
 			return nil
 		},
 	},
@@ -308,7 +308,7 @@ func HistoricFilterAPI(dbpath string) NodeOpt {
 
 func DisableEthRPC() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		cfg.Fevm.EnableEthPRC = false
+		cfg.Fevm.EnableEthRPC = false
 		return nil
 	})
 }

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -261,8 +261,8 @@ func ConfigFullNode(c interface{}) Option {
 		// in lite-mode Eth event api is provided by gateway
 		ApplyIf(isFullNode, Override(new(full.EthEventAPI), modules.EthEventAPI(cfg.ActorEvent))),
 
-		If(cfg.Fevm.EnableEthPRC, Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm))),
-		If(!cfg.Fevm.EnableEthPRC, Override(new(full.EthModuleAPI), &full.EthModuleDummy{})),
+		If(cfg.Fevm.EnableEthRPC, Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm))),
+		If(!cfg.Fevm.EnableEthRPC, Override(new(full.EthModuleAPI), &full.EthModuleDummy{})),
 	)
 }
 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -108,7 +108,7 @@ func DefaultFullNode() *FullNode {
 			MaxFilterHeightRange:    2880, // conservative limit of one day
 		},
 		Fevm: FevmConfig{
-			EnableEthPRC:                 false,
+			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
 		},
 	}

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -401,10 +401,10 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 	},
 	"FevmConfig": []DocField{
 		{
-			Name: "EnableEthPRC",
+			Name: "EnableEthRPC",
 			Type: "bool",
 
-			Comment: `EnableEthPRC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.`,
+			Comment: `EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.`,
 		},
 		{
 			Name: "EthTxHashMappingLifetimeDays",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -695,8 +695,8 @@ type ActorEventConfig struct {
 }
 
 type FevmConfig struct {
-	// EnableEthPRC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
-	EnableEthPRC bool
+	// EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
+	EnableEthRPC bool
 
 	// EthTxHashMappingLifetimeDays the transaction hash lookup database will delete mappings that have been stored for more than x days
 	// Set to 0 to keep all mappings

--- a/node/impl/full/dummy.go
+++ b/node/impl/full/dummy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
 
-var ErrModuleDisabled = errors.New("module disabled, enable with Fevm.EnableEthPRC / LOTUS_FEVM_ENABLEETHPRC")
+var ErrModuleDisabled = errors.New("module disabled, enable with Fevm.EnableEthRPC / LOTUS_FEVM_ENABLEETHPRC")
 
 type EthModuleDummy struct{}
 


### PR DESCRIPTION
## Related Issues
Fixes a typo in https://github.com/filecoin-project/lotus/pull/10072

## Proposed Changes
```
[Fevm]
  # EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
  #
  # type: bool
  # env var: LOTUS_FEVM_ENABLEETHRPC
  EnableEthRPC = false
```

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
