### PR TITLE
feat: Events API enabled by default if EnableEthRPC is true

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -293,59 +293,6 @@
   #Tracing = false
 
 
-[Events]
-  # EnableEthRPC enables APIs that
-  # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
-  # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
-  #
-  # type: bool
-  # env var: LOTUS_EVENTS_DISABLEREALTIMEFILTERAPI
-  #DisableRealTimeFilterAPI = false
-
-  # DisableHistoricFilterAPI will disable the HistoricFilterAPI that can create and query filters for actor events
-  # that occurred in the past. HistoricFilterAPI maintains a queryable index of events.
-  # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
-  #
-  # type: bool
-  # env var: LOTUS_EVENTS_DISABLEHISTORICFILTERAPI
-  #DisableHistoricFilterAPI = false
-
-  # FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
-  # this time become eligible for automatic deletion.
-  #
-  # type: Duration
-  # env var: LOTUS_EVENTS_FILTERTTL
-  #FilterTTL = "0s"
-
-  # MaxFilters specifies the maximum number of filters that may exist at any one time.
-  #
-  # type: int
-  # env var: LOTUS_EVENTS_MAXFILTERS
-  #MaxFilters = 0
-
-  # MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.
-  #
-  # type: int
-  # env var: LOTUS_EVENTS_MAXFILTERRESULTS
-  #MaxFilterResults = 0
-
-  # MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
-  # the entire chain)
-  #
-  # type: uint64
-  # env var: LOTUS_EVENTS_MAXFILTERHEIGHTRANGE
-  #MaxFilterHeightRange = 0
-
-  # DatabasePath is the full path to a sqlite database that will be used to index actor events to
-  # support the historic filter APIs. If the database does not exist it will be created. The directory containing
-  # the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
-  # relative to the CWD (current working directory).
-  #
-  # type: string
-  # env var: LOTUS_EVENTS_DATABASEPATH
-  #DatabasePath = ""
-
-
 [Fevm]
   # EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
   # This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be disabled by config options above.

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -293,58 +293,62 @@
   #Tracing = false
 
 
-[ActorEvent]
-  # EnableRealTimeFilterAPI enables APIs that can create and query filters for actor events as they are emitted.
+[Events]
+  # EnableEthRPC enables APIs that
+  # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
+  # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
   #
   # type: bool
-  # env var: LOTUS_ACTOREVENT_ENABLEREALTIMEFILTERAPI
-  #EnableRealTimeFilterAPI = false
+  # env var: LOTUS_EVENTS_DISABLEREALTIMEFILTERAPI
+  #DisableRealTimeFilterAPI = false
 
-  # EnableHistoricFilterAPI enables APIs that can create and query filters for actor events that occurred in the past.
-  # A queryable index of events will be maintained.
+  # DisableHistoricFilterAPI will disable the HistoricFilterAPI that can create and query filters for actor events
+  # that occurred in the past. HistoricFilterAPI maintains a queryable index of events.
+  # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
   #
   # type: bool
-  # env var: LOTUS_ACTOREVENT_ENABLEHISTORICFILTERAPI
-  #EnableHistoricFilterAPI = false
+  # env var: LOTUS_EVENTS_DISABLEHISTORICFILTERAPI
+  #DisableHistoricFilterAPI = false
 
   # FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
   # this time become eligible for automatic deletion.
   #
   # type: Duration
-  # env var: LOTUS_ACTOREVENT_FILTERTTL
-  #FilterTTL = "24h0m0s"
+  # env var: LOTUS_EVENTS_FILTERTTL
+  #FilterTTL = "0s"
 
   # MaxFilters specifies the maximum number of filters that may exist at any one time.
   #
   # type: int
-  # env var: LOTUS_ACTOREVENT_MAXFILTERS
-  #MaxFilters = 100
+  # env var: LOTUS_EVENTS_MAXFILTERS
+  #MaxFilters = 0
 
   # MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.
   #
   # type: int
-  # env var: LOTUS_ACTOREVENT_MAXFILTERRESULTS
-  #MaxFilterResults = 10000
+  # env var: LOTUS_EVENTS_MAXFILTERRESULTS
+  #MaxFilterResults = 0
 
   # MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
   # the entire chain)
   #
   # type: uint64
-  # env var: LOTUS_ACTOREVENT_MAXFILTERHEIGHTRANGE
-  #MaxFilterHeightRange = 2880
+  # env var: LOTUS_EVENTS_MAXFILTERHEIGHTRANGE
+  #MaxFilterHeightRange = 0
 
-  # ActorEventDatabasePath is the full path to a sqlite database that will be used to index actor events to
+  # DatabasePath is the full path to a sqlite database that will be used to index actor events to
   # support the historic filter APIs. If the database does not exist it will be created. The directory containing
   # the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
   # relative to the CWD (current working directory).
   #
   # type: string
-  # env var: LOTUS_ACTOREVENT_ACTOREVENTDATABASEPATH
-  #ActorEventDatabasePath = ""
+  # env var: LOTUS_EVENTS_DATABASEPATH
+  #DatabasePath = ""
 
 
 [Fevm]
   # EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
+  # This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be disabled by config options above.
   #
   # type: bool
   # env var: LOTUS_FEVM_ENABLEETHRPC
@@ -356,5 +360,57 @@
   # type: int
   # env var: LOTUS_FEVM_ETHTXHASHMAPPINGLIFETIMEDAYS
   #EthTxHashMappingLifetimeDays = 0
+
+  [Fevm.Events]
+    # EnableEthRPC enables APIs that
+    # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
+    # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
+    #
+    # type: bool
+    # env var: LOTUS_FEVM_EVENTS_DISABLEREALTIMEFILTERAPI
+    #DisableRealTimeFilterAPI = false
+
+    # DisableHistoricFilterAPI will disable the HistoricFilterAPI that can create and query filters for actor events
+    # that occurred in the past. HistoricFilterAPI maintains a queryable index of events.
+    # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
+    #
+    # type: bool
+    # env var: LOTUS_FEVM_EVENTS_DISABLEHISTORICFILTERAPI
+    #DisableHistoricFilterAPI = false
+
+    # FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
+    # this time become eligible for automatic deletion.
+    #
+    # type: Duration
+    # env var: LOTUS_FEVM_EVENTS_FILTERTTL
+    #FilterTTL = "24h0m0s"
+
+    # MaxFilters specifies the maximum number of filters that may exist at any one time.
+    #
+    # type: int
+    # env var: LOTUS_FEVM_EVENTS_MAXFILTERS
+    #MaxFilters = 100
+
+    # MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.
+    #
+    # type: int
+    # env var: LOTUS_FEVM_EVENTS_MAXFILTERRESULTS
+    #MaxFilterResults = 10000
+
+    # MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
+    # the entire chain)
+    #
+    # type: uint64
+    # env var: LOTUS_FEVM_EVENTS_MAXFILTERHEIGHTRANGE
+    #MaxFilterHeightRange = 2880
+
+    # DatabasePath is the full path to a sqlite database that will be used to index actor events to
+    # support the historic filter APIs. If the database does not exist it will be created. The directory containing
+    # the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
+    # relative to the CWD (current working directory).
+    #
+    # type: string
+    # env var: LOTUS_FEVM_EVENTS_DATABASEPATH
+    #DatabasePath = ""
 
 

--- a/itests/eth_deploy_test.go
+++ b/itests/eth_deploy_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/itests/kit"
-	"github.com/filecoin-project/lotus/node/config"
 )
 
 // TestDeployment smoke tests the deployment of a contract via the
@@ -36,11 +35,7 @@ func TestDeployment(t *testing.T) {
 	client, _, ens := kit.EnsembleMinimal(
 		t,
 		kit.MockProofs(),
-		kit.ThroughRPC(),
-		kit.WithCfgOpt(func(cfg *config.FullNode) error {
-			cfg.ActorEvent.EnableRealTimeFilterAPI = true
-			return nil
-		}))
+		kit.ThroughRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,7 +29,7 @@ func TestEthNewPendingTransactionFilter(t *testing.T) {
 
 	kit.QuietMiningLogs()
 
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.RealTimeFilterAPI())
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
 
 	// create a new address where to send funds.
@@ -124,7 +123,7 @@ func TestEthNewBlockFilter(t *testing.T) {
 
 	kit.QuietMiningLogs()
 
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.RealTimeFilterAPI())
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
 
 	// create a new address where to send funds.
@@ -204,7 +203,7 @@ func TestEthNewFilterCatchAll(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	blockTime := 100 * time.Millisecond
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.RealTimeFilterAPI())
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -569,9 +568,8 @@ func TestEthGetLogsAll(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	blockTime := 100 * time.Millisecond
-	dbpath := filepath.Join(t.TempDir(), "actorevents.db")
 
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.HistoricFilterAPI(dbpath))
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
 
 	ethContractAddr, received := invokeContractAndWaitUntilAllOnChain(t, client, 10)
@@ -632,9 +630,8 @@ func TestEthGetLogsByTopic(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	blockTime := 100 * time.Millisecond
-	dbpath := filepath.Join(t.TempDir(), "actorevents.db")
 
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.HistoricFilterAPI(dbpath))
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
 
 	invocations := 1
@@ -696,7 +693,7 @@ func TestEthSubscribeLogs(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	blockTime := 100 * time.Millisecond
-	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.RealTimeFilterAPI())
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -290,18 +290,9 @@ func SplitstoreMessges() NodeOpt {
 	})
 }
 
-func RealTimeFilterAPI() NodeOpt {
+func WithEthRPC() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
-		cfg.ActorEvent.EnableRealTimeFilterAPI = true
-		return nil
-	})
-}
-
-func HistoricFilterAPI(dbpath string) NodeOpt {
-	return WithCfgOpt(func(cfg *config.FullNode) error {
-		cfg.ActorEvent.EnableRealTimeFilterAPI = true
-		cfg.ActorEvent.EnableHistoricFilterAPI = true
-		cfg.ActorEvent.ActorEventDatabasePath = dbpath
+		cfg.Fevm.EnableEthRPC = true
 		return nil
 	})
 }

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -259,7 +259,7 @@ func ConfigFullNode(c interface{}) Option {
 		// Actor event filtering support
 		Override(new(events.EventAPI), From(new(modules.EventAPI))),
 		// in lite-mode Eth event api is provided by gateway
-		ApplyIf(isFullNode, Override(new(full.EthEventAPI), modules.EthEventAPI(cfg.ActorEvent))),
+		ApplyIf(isFullNode, Override(new(full.EthEventAPI), modules.EthEventAPI(cfg.Fevm))),
 
 		If(cfg.Fevm.EnableEthRPC, Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm))),
 		If(!cfg.Fevm.EnableEthRPC, Override(new(full.EthModuleAPI), &full.EthModuleDummy{})),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -102,7 +102,7 @@ func DefaultFullNode() *FullNode {
 		Fevm: FevmConfig{
 			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
-			Events: EventsConfig{
+			Events: Events{
 				DisableRealTimeFilterAPI: false,
 				DisableHistoricFilterAPI: false,
 				FilterTTL:                Duration(time.Hour * 24),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -99,17 +99,17 @@ func DefaultFullNode() *FullNode {
 			},
 		},
 		Cluster: *DefaultUserRaftConfig(),
-		ActorEvent: ActorEventConfig{
-			EnableRealTimeFilterAPI: false,
-			EnableHistoricFilterAPI: false,
-			FilterTTL:               Duration(time.Hour * 24),
-			MaxFilters:              100,
-			MaxFilterResults:        10000,
-			MaxFilterHeightRange:    2880, // conservative limit of one day
-		},
 		Fevm: FevmConfig{
 			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
+			Events: EventsConfig{
+				DisableRealTimeFilterAPI: false,
+				DisableHistoricFilterAPI: false,
+				FilterTTL:                Duration(time.Hour * 24),
+				MaxFilters:               100,
+				MaxFilterResults:         10000,
+				MaxFilterHeightRange:     2880, // conservative limit of one day
+			},
 		},
 	}
 }

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -29,56 +29,6 @@ var Doc = map[string][]DocField{
 			Comment: ``,
 		},
 	},
-	"ActorEventConfig": []DocField{
-		{
-			Name: "EnableRealTimeFilterAPI",
-			Type: "bool",
-
-			Comment: `EnableRealTimeFilterAPI enables APIs that can create and query filters for actor events as they are emitted.`,
-		},
-		{
-			Name: "EnableHistoricFilterAPI",
-			Type: "bool",
-
-			Comment: `EnableHistoricFilterAPI enables APIs that can create and query filters for actor events that occurred in the past.
-A queryable index of events will be maintained.`,
-		},
-		{
-			Name: "FilterTTL",
-			Type: "Duration",
-
-			Comment: `FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
-this time become eligible for automatic deletion.`,
-		},
-		{
-			Name: "MaxFilters",
-			Type: "int",
-
-			Comment: `MaxFilters specifies the maximum number of filters that may exist at any one time.`,
-		},
-		{
-			Name: "MaxFilterResults",
-			Type: "int",
-
-			Comment: `MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.`,
-		},
-		{
-			Name: "MaxFilterHeightRange",
-			Type: "uint64",
-
-			Comment: `MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
-the entire chain)`,
-		},
-		{
-			Name: "ActorEventDatabasePath",
-			Type: "string",
-
-			Comment: `ActorEventDatabasePath is the full path to a sqlite database that will be used to index actor events to
-support the historic filter APIs. If the database does not exist it will be created. The directory containing
-the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
-relative to the CWD (current working directory).`,
-		},
-	},
 	"Backup": []DocField{
 		{
 			Name: "DisableMetadataLog",
@@ -391,6 +341,59 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 			Comment: ``,
 		},
 	},
+	"EventsConfig": []DocField{
+		{
+			Name: "DisableRealTimeFilterAPI",
+			Type: "bool",
+
+			Comment: `EnableEthRPC enables APIs that
+DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
+The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.`,
+		},
+		{
+			Name: "DisableHistoricFilterAPI",
+			Type: "bool",
+
+			Comment: `DisableHistoricFilterAPI will disable the HistoricFilterAPI that can create and query filters for actor events
+that occurred in the past. HistoricFilterAPI maintains a queryable index of events.
+The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.`,
+		},
+		{
+			Name: "FilterTTL",
+			Type: "Duration",
+
+			Comment: `FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
+this time become eligible for automatic deletion.`,
+		},
+		{
+			Name: "MaxFilters",
+			Type: "int",
+
+			Comment: `MaxFilters specifies the maximum number of filters that may exist at any one time.`,
+		},
+		{
+			Name: "MaxFilterResults",
+			Type: "int",
+
+			Comment: `MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.`,
+		},
+		{
+			Name: "MaxFilterHeightRange",
+			Type: "uint64",
+
+			Comment: `MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
+the entire chain)`,
+		},
+		{
+			Name: "DatabasePath",
+			Type: "string",
+
+			Comment: `DatabasePath is the full path to a sqlite database that will be used to index actor events to
+support the historic filter APIs. If the database does not exist it will be created. The directory containing
+the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
+relative to the CWD (current working directory).`,
+		},
+	},
 	"FeeConfig": []DocField{
 		{
 			Name: "DefaultMaxFee",
@@ -404,7 +407,8 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 			Name: "EnableEthRPC",
 			Type: "bool",
 
-			Comment: `EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.`,
+			Comment: `EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
+This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be disabled by config options above.`,
 		},
 		{
 			Name: "EthTxHashMappingLifetimeDays",
@@ -412,6 +416,12 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 
 			Comment: `EthTxHashMappingLifetimeDays the transaction hash lookup database will delete mappings that have been stored for more than x days
 Set to 0 to keep all mappings`,
+		},
+		{
+			Name: "Events",
+			Type: "EventsConfig",
+
+			Comment: ``,
 		},
 	},
 	"FullNode": []DocField{
@@ -446,8 +456,8 @@ Set to 0 to keep all mappings`,
 			Comment: ``,
 		},
 		{
-			Name: "ActorEvent",
-			Type: "ActorEventConfig",
+			Name: "Events",
+			Type: "EventsConfig",
 
 			Comment: ``,
 		},

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -341,7 +341,7 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 			Comment: ``,
 		},
 	},
-	"EventsConfig": []DocField{
+	"Events": []DocField{
 		{
 			Name: "DisableRealTimeFilterAPI",
 			Type: "bool",
@@ -419,7 +419,7 @@ Set to 0 to keep all mappings`,
 		},
 		{
 			Name: "Events",
-			Type: "EventsConfig",
+			Type: "Events",
 
 			Comment: ``,
 		},
@@ -452,12 +452,6 @@ Set to 0 to keep all mappings`,
 		{
 			Name: "Cluster",
 			Type: "UserRaftConfig",
-
-			Comment: ``,
-		},
-		{
-			Name: "Events",
-			Type: "EventsConfig",
 
 			Comment: ``,
 		},

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -27,7 +27,7 @@ type FullNode struct {
 	Fees       FeeConfig
 	Chainstore Chainstore
 	Cluster    UserRaftConfig
-	ActorEvent ActorEventConfig
+	Events     EventsConfig
 	Fevm       FevmConfig
 }
 
@@ -660,13 +660,28 @@ type UserRaftConfig struct {
 	Tracing bool
 }
 
-type ActorEventConfig struct {
-	// EnableRealTimeFilterAPI enables APIs that can create and query filters for actor events as they are emitted.
-	EnableRealTimeFilterAPI bool
+type FevmConfig struct {
+	// EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
+	// This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be disabled by config options above.
+	EnableEthRPC bool
 
-	// EnableHistoricFilterAPI enables APIs that can create and query filters for actor events that occurred in the past.
-	// A queryable index of events will be maintained.
-	EnableHistoricFilterAPI bool
+	// EthTxHashMappingLifetimeDays the transaction hash lookup database will delete mappings that have been stored for more than x days
+	// Set to 0 to keep all mappings
+	EthTxHashMappingLifetimeDays int
+
+	Events EventsConfig
+}
+
+type EventsConfig struct {
+	// EnableEthRPC enables APIs that
+	// DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
+	// The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
+	DisableRealTimeFilterAPI bool
+
+	// DisableHistoricFilterAPI will disable the HistoricFilterAPI that can create and query filters for actor events
+	// that occurred in the past. HistoricFilterAPI maintains a queryable index of events.
+	// The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
+	DisableHistoricFilterAPI bool
 
 	// FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
 	// this time become eligible for automatic deletion.
@@ -682,23 +697,14 @@ type ActorEventConfig struct {
 	// the entire chain)
 	MaxFilterHeightRange uint64
 
-	// ActorEventDatabasePath is the full path to a sqlite database that will be used to index actor events to
+	// DatabasePath is the full path to a sqlite database that will be used to index actor events to
 	// support the historic filter APIs. If the database does not exist it will be created. The directory containing
 	// the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
 	// relative to the CWD (current working directory).
-	ActorEventDatabasePath string
+	DatabasePath string
 
 	// Others, not implemented yet:
 	// Set a limit on the number of active websocket subscriptions (may be zero)
 	// Set a timeout for subscription clients
 	// Set upper bound on index size
-}
-
-type FevmConfig struct {
-	// EnableEthRPC enables eth_ rpc, and enables storing a mapping of eth transaction hashes to filecoin message Cids.
-	EnableEthRPC bool
-
-	// EthTxHashMappingLifetimeDays the transaction hash lookup database will delete mappings that have been stored for more than x days
-	// Set to 0 to keep all mappings
-	EthTxHashMappingLifetimeDays int
 }

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -27,7 +27,6 @@ type FullNode struct {
 	Fees       FeeConfig
 	Chainstore Chainstore
 	Cluster    UserRaftConfig
-	Events     EventsConfig
 	Fevm       FevmConfig
 }
 
@@ -669,10 +668,10 @@ type FevmConfig struct {
 	// Set to 0 to keep all mappings
 	EthTxHashMappingLifetimeDays int
 
-	Events EventsConfig
+	Events Events
 }
 
-type EventsConfig struct {
+type Events struct {
 	// EnableEthRPC enables APIs that
 	// DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
 	// The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -19,12 +19,12 @@ import (
 
 func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *store.ChainStore, *stmgr.StateManager, EventAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI, full.MpoolAPI) (*full.EthModule, error) {
 	return func(mctx helpers.MetricsCtx, r repo.LockedRepo, lc fx.Lifecycle, cs *store.ChainStore, sm *stmgr.StateManager, evapi EventAPI, mp *messagepool.MessagePool, stateapi full.StateAPI, chainapi full.ChainAPI, mpoolapi full.MpoolAPI) (*full.EthModule, error) {
-		dbPath, err := r.SqlitePath()
+		sqlitePath, err := r.SqlitePath()
 		if err != nil {
 			return nil, err
 		}
 
-		transactionHashLookup, err := ethhashlookup.NewTransactionHashLookup(filepath.Join(dbPath, "txhash.db"))
+		transactionHashLookup, err := ethhashlookup.NewTransactionHashLookup(filepath.Join(sqlitePath, "txhash.db"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Sets a default path for the Events Database to be in the same directory as the tx hash database.
Enables all event API functionality if EnableEthRPC is set to true, otherwise it is always disabled.
Changes the Event Config to allow opt-out of these event APIs

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
