### PR TITLE
ci: build: add race detector build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,6 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
-
   test:
     description: |
       Run tests with gotestsum.
@@ -149,6 +148,63 @@ jobs:
       go-test-flags:
         type: string
         default: "-timeout 20m"
+        description: Flags passed to go test.
+      target:
+        type: string
+        default: "./..."
+        description: Import paths of packages to be tested.
+      proofs-log-test:
+        type: string
+        default: "0"
+      get-params:
+        type: boolean
+        default: false
+      suite:
+        type: string
+        default: unit
+        description: Test suite name to report to CircleCI.
+    executor: << parameters.executor >>
+    steps:
+      - install-ubuntu-deps
+      - attach_workspace:
+          at: ~/
+      - when:
+          condition: << parameters.get-params >>
+          steps:
+            - download-params
+      - run:
+          name: go test
+          environment:
+            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
+            SKIP_CONFORMANCE: "1"
+            LOTUS_SRC_DIR: /home/circleci/project
+          command: |
+            mkdir -p /tmp/test-reports/<< parameters.suite >>
+            mkdir -p /tmp/test-artifacts
+            gotestsum \
+              --format standard-verbose \
+              --junitfile /tmp/test-reports/<< parameters.suite >>/junit.xml \
+              --jsonfile /tmp/test-artifacts/<< parameters.suite >>.json \
+              --packages="<< parameters.target >>" \
+              -- << parameters.go-test-flags >>
+          no_output_timeout: 30m
+      - store_test_results:
+          path: /tmp/test-reports
+      - store_artifacts:
+          path: /tmp/test-artifacts/<< parameters.suite >>.json
+
+
+  test-race:
+    description: |
+      Run tests with the go race detector
+    working_directory: ~/lotus
+    parameters: &test-params
+      executor:
+        type: executor
+        default: golang
+      go-test-flags:
+        type: string
+        default: "-race -timeout 30m"
         description: Flags passed to go test.
       target:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,63 @@ jobs:
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
 
+  test-race:
+    description: |
+      Run tests with go race detector.
+    working_directory: ~/lotus
+    parameters: &test-params
+      executor:
+        type: executor
+        default: golang
+      go-test-flags:
+        type: string
+        default: "-race -timeout 40m"
+        description: Flags passed to go test.
+      target:
+        type: string
+        default: "./..."
+        description: Import paths of packages to be tested.
+      proofs-log-test:
+        type: string
+        default: "0"
+      get-params:
+        type: boolean
+        default: false
+      suite:
+        type: string
+        default: unit
+        description: Test suite name to report to CircleCI.
+    executor: << parameters.executor >>
+    steps:
+      - install-ubuntu-deps
+      - attach_workspace:
+          at: ~/
+      - when:
+          condition: << parameters.get-params >>
+          steps:
+            - download-params
+      - run:
+          name: go test
+          environment:
+            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
+            SKIP_CONFORMANCE: "1"
+            LOTUS_SRC_DIR: /home/circleci/project
+          command: |
+            mkdir -p /tmp/test-reports/<< parameters.suite >>
+            mkdir -p /tmp/test-artifacts
+            gotestsum \
+              --format standard-verbose \
+              --junitfile /tmp/test-reports/<< parameters.suite >>/junit.xml \
+              --jsonfile /tmp/test-artifacts/<< parameters.suite >>.json \
+              --packages="<< parameters.target >>" \
+              -- << parameters.go-test-flags >>
+          no_output_timeout: 30m
+      - store_test_results:
+          path: /tmp/test-reports
+      - store_artifacts:
+          path: /tmp/test-artifacts/<< parameters.suite >>.json
+
+
   build-linux-amd64:
     executor: golang
     steps:
@@ -1272,3 +1329,9 @@ workflows:
           channel: nightly
           network: debug
           push: true
+      - test-race:
+          name: "Test with race detector"
+          requires:
+            - build
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
           command: |
             git --no-pager diff go.mod go.sum
             git --no-pager diff --quiet go.mod go.sum
+
   test:
     description: |
       Run tests with gotestsum.
@@ -148,63 +149,6 @@ jobs:
       go-test-flags:
         type: string
         default: "-timeout 20m"
-        description: Flags passed to go test.
-      target:
-        type: string
-        default: "./..."
-        description: Import paths of packages to be tested.
-      proofs-log-test:
-        type: string
-        default: "0"
-      get-params:
-        type: boolean
-        default: false
-      suite:
-        type: string
-        default: unit
-        description: Test suite name to report to CircleCI.
-    executor: << parameters.executor >>
-    steps:
-      - install-ubuntu-deps
-      - attach_workspace:
-          at: ~/
-      - when:
-          condition: << parameters.get-params >>
-          steps:
-            - download-params
-      - run:
-          name: go test
-          environment:
-            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
-            SKIP_CONFORMANCE: "1"
-            LOTUS_SRC_DIR: /home/circleci/project
-          command: |
-            mkdir -p /tmp/test-reports/<< parameters.suite >>
-            mkdir -p /tmp/test-artifacts
-            gotestsum \
-              --format standard-verbose \
-              --junitfile /tmp/test-reports/<< parameters.suite >>/junit.xml \
-              --jsonfile /tmp/test-artifacts/<< parameters.suite >>.json \
-              --packages="<< parameters.target >>" \
-              -- << parameters.go-test-flags >>
-          no_output_timeout: 30m
-      - store_test_results:
-          path: /tmp/test-reports
-      - store_artifacts:
-          path: /tmp/test-artifacts/<< parameters.suite >>.json
-
-
-  test-race:
-    description: |
-      Run tests with the go race detector
-    working_directory: ~/lotus
-    parameters: &test-params
-      executor:
-        type: executor
-        default: golang
-      go-test-flags:
-        type: string
-        default: "-race -timeout 30m"
         description: Flags passed to go test.
       target:
         type: string

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -797,4 +797,7 @@ workflows:
       [[- end]]
       - test-race:
           name: "Test with race detector"
+          requires:
+            - build
+
 

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -253,6 +253,63 @@ jobs:
       - store_artifacts:
           path: /tmp/test-artifacts/conformance-coverage.html
 
+  test-race:
+    description: |
+      Run tests with go race detector.
+    working_directory: ~/lotus
+    parameters: &test-params
+      executor:
+        type: executor
+        default: golang
+      go-test-flags:
+        type: string
+        default: "-race -timeout 40m"
+        description: Flags passed to go test.
+      target:
+        type: string
+        default: "./..."
+        description: Import paths of packages to be tested.
+      proofs-log-test:
+        type: string
+        default: "0"
+      get-params:
+        type: boolean
+        default: false
+      suite:
+        type: string
+        default: unit
+        description: Test suite name to report to CircleCI.
+    executor: << parameters.executor >>
+    steps:
+      - install-ubuntu-deps
+      - attach_workspace:
+          at: ~/
+      - when:
+          condition: << parameters.get-params >>
+          steps:
+            - download-params
+      - run:
+          name: go test
+          environment:
+            TEST_RUSTPROOFS_LOGS: << parameters.proofs-log-test >>
+            SKIP_CONFORMANCE: "1"
+            LOTUS_SRC_DIR: /home/circleci/project
+          command: |
+            mkdir -p /tmp/test-reports/<< parameters.suite >>
+            mkdir -p /tmp/test-artifacts
+            gotestsum \
+              --format standard-verbose \
+              --junitfile /tmp/test-reports/<< parameters.suite >>/junit.xml \
+              --jsonfile /tmp/test-artifacts/<< parameters.suite >>.json \
+              --packages="<< parameters.target >>" \
+              -- << parameters.go-test-flags >>
+          no_output_timeout: 30m
+      - store_test_results:
+          path: /tmp/test-reports
+      - store_artifacts:
+          path: /tmp/test-artifacts/<< parameters.suite >>.json
+
+
   build-linux-amd64:
     executor: golang
     steps:
@@ -738,3 +795,6 @@ workflows:
           network: [[.]]
           push: true
       [[- end]]
+      - test-race:
+          name: "Test with race detector"
+


### PR DESCRIPTION
## Proposed Changes
Looking at the CI configuration, I couldn't help noticing that there's no step for testing with the built-in race detector in `go test`, as in `go test -race`. The go race detector does not generate false positives, although it may not always catch the actual races. It helps catch data races, dormant bugs and flaky tests. Maintaining a green race-detector build  contributes to a more stable pipeline that flakes less and saves time and resources.

Since this change is may be a bit controversial, as it may add more expensive minutes to the CI build (the race detector usually takes way longer to test due to instrumentation made in order to find memory safety issues), as well as just generate a lot of work which was unaccounted for, I am PR-ing it with the side-note that it should probably be worked into the `Makefile` too (`make test-race`) and the CI should run it in parallel to save on time when running build on a daily basis. This serves as an departure point as to whether this should be merged and when (but also to coordinate help from others that own certain areas of the codebase).

## Additional Info
Please see the attached [test-race-output.zip](https://github.com/filecoin-project/lotus/files/10461611/test-race-output.zip) build log I have locally in which you can search for race detector failures (look for `race detected during execution of test`). When I ran it locally it found 15 data races. There might be more that would just pop up later on sporadically. I added some examples of the output below, however the Github textbox does not compute for such long outputs.

```
==================
WARNING: DATA RACE
Write at 0x00c000005358 by goroutine 216:
  runtime.racewrite()
      <autogenerated>:1 +0x24
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Close()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:786 +0x186
  github.com/filecoin-project/lotus/blockstore/splitstore.testSplitStore.func5()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:97 +0x39
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  github.com/filecoin-project/lotus/blockstore/splitstore.TestSplitStoreCompactionWithBadger()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:241 +0x14f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x00c000005358 by goroutine 218:
  runtime.raceread()
      <autogenerated>:1 +0x24
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).reifyOrchestrator()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_reify.go:49 +0x117
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Start.func1()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:752 +0x39

Goroutine 216 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:61 +0x2e9

Goroutine 218 (running) created at:
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Start()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:752 +0x101b
  github.com/filecoin-project/lotus/blockstore/splitstore.testSplitStore()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:104 +0xcfc
  github.com/filecoin-project/lotus/blockstore/splitstore.TestSplitStoreCompactionWithBadger()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:241 +0x14f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestSplitStoreCompactionWithBadger (0.51s)
```

```
==================
WARNING: DATA RACE
Write at 0x00c0000055d8 by goroutine 304:
  runtime.racewrite()
      <autogenerated>:1 +0x24
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Close()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:786 +0x186
  github.com/filecoin-project/lotus/blockstore/splitstore.TestSplitStoreSuppressCompactionNearUpgrade.func4()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:291 +0x39
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x00c0000055d8 by goroutine 306:
  runtime.raceread()
      <autogenerated>:1 +0x24
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).reifyOrchestrator()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_reify.go:49 +0x117
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Start.func1()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:752 +0x39

Goroutine 304 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:61 +0x2e9

Goroutine 306 (running) created at:
  github.com/filecoin-project/lotus/blockstore/splitstore.(*SplitStore).Start()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore.go:752 +0x101b
  github.com/filecoin-project/lotus/blockstore/splitstore.TestSplitStoreSuppressCompactionNearUpgrade()
      /home/growlie/repos/lotus/blockstore/splitstore/splitstore_test.go:300 +0xbb6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestSplitStoreSuppressCompactionNearUpgrade (0.41s)
```
```
==================
WARNING: DATA RACE
Write at 0x0000081c12c0 by goroutine 70:
  github.com/filecoin-project/lotus/node/modules.MemoryWatchdog()
      /home/growlie/repos/lotus/node/modules/core.go:85 +0x212
  runtime.call64()
      /usr/local/go/src/runtime/asm_amd64.s:726 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  go.uber.org/dig.defaultInvoker()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:355 +0x7e
  go.uber.org/dig.(*Container).Invoke()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:510 +0x563
  go.uber.org/fx.(*App).executeInvoke()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:964 +0x4e9
  go.uber.org/fx.(*App).executeInvokes()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:929 +0x100e
  go.uber.org/fx.New()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:596 +0xbe6
  github.com/filecoin-project/lotus/node.New()
      /home/growlie/repos/lotus/node/builder.go:363 +0x617
  github.com/filecoin-project/lotus/chain_test.(*syncTestUtil).addClientNode()
      /home/growlie/repos/lotus/chain/sync_test.go:330 +0x511
  github.com/filecoin-project/lotus/chain_test.TestSyncSimple()
      /home/growlie/repos/lotus/chain/sync_test.go:479 +0x46
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x0000081c12c0 by goroutine 228:
  github.com/raulk/go-watchdog.(*watermarkPolicy).Evaluate()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watermarks.go:32 +0x109
  github.com/raulk/go-watchdog.pollingWatchdog.func1()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:315 +0x16a
  github.com/raulk/go-watchdog.pollingWatchdog()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:356 +0x30a
  github.com/raulk/go-watchdog.SystemDriven.func2()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:280 +0x71

Goroutine 70 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:91 +0x2e9
  runtime.main()
      /usr/local/go/src/runtime/proc.go:250 +0x211
  github.com/cilium/ebpf/link.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/link/syscalls.go:50 +0x109
  github.com/cilium/ebpf/link.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/link/syscalls.go:29 +0xac
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6329 +0x125
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:437 +0x4d0
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/prog.go:421 +0x470
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:419 +0x413
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:235 +0x3b6
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:217 +0x358
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6329 +0x125
  github.com/cilium/ebpf/internal/btf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/internal/btf/btf.go:720 +0x1bc

Goroutine 228 (running) created at:
  github.com/raulk/go-watchdog.SystemDriven()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:280 +0x444
  github.com/filecoin-project/lotus/node/modules.MemoryWatchdog()
      /home/growlie/repos/lotus/node/modules/core.go:128 +0x612
  runtime.call64()
      /usr/local/go/src/runtime/asm_amd64.s:726 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  go.uber.org/dig.defaultInvoker()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:355 +0x7e
  go.uber.org/dig.(*Container).Invoke()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:510 +0x563
  go.uber.org/fx.(*App).executeInvoke()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:964 +0x4e9
  go.uber.org/fx.(*App).executeInvokes()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:929 +0x100e
  go.uber.org/fx.New()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:596 +0xbe6
  github.com/filecoin-project/lotus/node.New()
      /home/growlie/repos/lotus/node/builder.go:363 +0x617
  github.com/filecoin-project/lotus/chain_test.(*syncTestUtil).addSourceNode()
      /home/growlie/repos/lotus/chain/sync_test.go:296 +0x549
  github.com/filecoin-project/lotus/chain_test.prepSyncTest()
      /home/growlie/repos/lotus/chain/sync_test.go:108 +0x3c4
  github.com/filecoin-project/lotus/chain_test.TestSyncSimple()
      /home/growlie/repos/lotus/chain/sync_test.go:477 +0x3c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
```
```
==================
WARNING: DATA RACE
Write at 0x00000949b0d8 by goroutine 5782:
  github.com/filecoin-project/lotus/node/modules.MemoryWatchdog()
      /home/growlie/repos/lotus/node/modules/core.go:84 +0x1db
  runtime.call64()
      /usr/local/go/src/runtime/asm_amd64.s:726 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  go.uber.org/dig.defaultInvoker()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:355 +0x7e
  go.uber.org/dig.(*Container).Invoke()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:510 +0x563
  go.uber.org/fx.(*App).executeInvoke()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:964 +0x4e9
  go.uber.org/fx.(*App).executeInvokes()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:929 +0x100e
  go.uber.org/fx.New()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:596 +0xbe6
  github.com/filecoin-project/lotus/node.New()
      /home/growlie/repos/lotus/node/builder.go:363 +0x617
  github.com/filecoin-project/lotus/chain_test.(*syncTestUtil).addClientNode()
      /home/growlie/repos/lotus/chain/sync_test.go:330 +0x511
  github.com/filecoin-project/lotus/chain_test.TestSyncBadTimestamp()
      /home/growlie/repos/lotus/chain/sync_test.go:521 +0x64
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x00000949b0d8 by goroutine 5937:
  github.com/raulk/go-watchdog.maybeCaptureHeapProfile()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:481 +0xdb
  github.com/raulk/go-watchdog.pollingWatchdog()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:342 +0x457
  github.com/raulk/go-watchdog.SystemDriven.func2()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:280 +0x71

Goroutine 5782 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:91 +0x2e9
  runtime.main()
      /usr/local/go/src/runtime/proc.go:250 +0x211
  github.com/cilium/ebpf/link.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/link/syscalls.go:50 +0x109
  github.com/cilium/ebpf/link.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/link/syscalls.go:29 +0xac
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6329 +0x125
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:437 +0x4d0
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/prog.go:421 +0x470
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:419 +0x413
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:235 +0x3b6
  github.com/cilium/ebpf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/syscalls.go:217 +0x358
  runtime.doInit()
      /usr/local/go/src/runtime/proc.go:6329 +0x125
  github.com/cilium/ebpf/internal/btf.init()
      /home/growlie/go/pkg/mod/github.com/cilium/ebpf@v0.4.0/internal/btf/btf.go:720 +0x1bc

Goroutine 5937 (running) created at:
  github.com/raulk/go-watchdog.SystemDriven()
      /home/growlie/go/pkg/mod/github.com/raulk/go-watchdog@v1.3.0/watchdog.go:280 +0x444
  github.com/filecoin-project/lotus/node/modules.MemoryWatchdog()
      /home/growlie/repos/lotus/node/modules/core.go:128 +0x612
  runtime.call64()
      /usr/local/go/src/runtime/asm_amd64.s:726 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  go.uber.org/dig.defaultInvoker()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:355 +0x7e
  go.uber.org/dig.(*Container).Invoke()
      /home/growlie/go/pkg/mod/go.uber.org/dig@v1.12.0/dig.go:510 +0x563
  go.uber.org/fx.(*App).executeInvoke()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:964 +0x4e9
  go.uber.org/fx.(*App).executeInvokes()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:929 +0x100e
  go.uber.org/fx.New()
      /home/growlie/go/pkg/mod/go.uber.org/fx@v1.15.0/app.go:596 +0xbe6
  github.com/filecoin-project/lotus/node.New()
      /home/growlie/repos/lotus/node/builder.go:363 +0x617
  github.com/filecoin-project/lotus/chain_test.(*syncTestUtil).addSourceNode()
      /home/growlie/repos/lotus/chain/sync_test.go:296 +0x549
  github.com/filecoin-project/lotus/chain_test.prepSyncTest()
      /home/growlie/repos/lotus/chain/sync_test.go:108 +0x3c4
  github.com/filecoin-project/lotus/chain_test.TestSyncBadTimestamp()
      /home/growlie/repos/lotus/chain/sync_test.go:519 +0x56
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
```
```
    testing.go:1319: race detected during execution of test
--- FAIL: TestSyncBadTimestamp (11.73s)
```
```
=== RUN   TestRepubMessages
2023-01-19T17:13:50.332-0300	INFO	messagepool	messagepool/messagepool.go:438	mpool ready
2023-01-19T17:13:50.365-0300	INFO	messagepool	messagepool/repub.go:139	republishing 10 messages
==================
WARNING: DATA RACE
Read at 0x00c0028820d8 by goroutine 245:
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:76 +0xa04
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous write at 0x00c0028820d8 by goroutine 247:
  github.com/filecoin-project/lotus/chain/messagepool.(*testMpoolAPI).PubSubPublish()
      /home/growlie/repos/lotus/chain/messagepool/messagepool_test.go:119 +0x54
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).republishPendingMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub.go:146 +0xa19
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).runLoop()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:590 +0x206
  github.com/filecoin-project/lotus/chain/messagepool.New.func2()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:440 +0x224

Goroutine 245 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:127 +0x2e9

Goroutine 247 (running) created at:
  github.com/filecoin-project/lotus/chain/messagepool.New()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:427 +0x1171
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:30 +0x199
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x000005217870 by goroutine 245:
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages.func1()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:24 +0x32
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x000005217870 by goroutine 247:
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).republishPendingMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub.go:156 +0xa4b
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).runLoop()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:590 +0x206
  github.com/filecoin-project/lotus/chain/messagepool.New.func2()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:440 +0x224

Goroutine 245 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:127 +0x2e9

Goroutine 247 (running) created at:
  github.com/filecoin-project/lotus/chain/messagepool.New()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:427 +0x1171
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:30 +0x199
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestRepubMessages (0.14s)
```
```
=== RUN   TestRepubMessages
2023-01-19T17:13:50.332-0300	INFO	messagepool	messagepool/messagepool.go:438	mpool ready
2023-01-19T17:13:50.365-0300	INFO	messagepool	messagepool/repub.go:139	republishing 10 messages
==================
WARNING: DATA RACE
Read at 0x00c0028820d8 by goroutine 245:
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:76 +0xa04
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous write at 0x00c0028820d8 by goroutine 247:
  github.com/filecoin-project/lotus/chain/messagepool.(*testMpoolAPI).PubSubPublish()
      /home/growlie/repos/lotus/chain/messagepool/messagepool_test.go:119 +0x54
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).republishPendingMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub.go:146 +0xa19
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).runLoop()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:590 +0x206
  github.com/filecoin-project/lotus/chain/messagepool.New.func2()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:440 +0x224

Goroutine 245 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:127 +0x2e9

Goroutine 247 (running) created at:
  github.com/filecoin-project/lotus/chain/messagepool.New()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:427 +0x1171
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:30 +0x199
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x000005217870 by goroutine 245:
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages.func1()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:24 +0x32
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Previous read at 0x000005217870 by goroutine 247:
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).republishPendingMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub.go:156 +0xa4b
  github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).runLoop()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:590 +0x206
  github.com/filecoin-project/lotus/chain/messagepool.New.func2()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:440 +0x224

Goroutine 245 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:127 +0x2e9

Goroutine 247 (running) created at:
  github.com/filecoin-project/lotus/chain/messagepool.New()
      /home/growlie/repos/lotus/chain/messagepool/messagepool.go:427 +0x1171
  github.com/filecoin-project/lotus/chain/messagepool.TestRepubMessages()
      /home/growlie/repos/lotus/chain/messagepool/repub_test.go:30 +0x199
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestRepubMessages (0.14s)
```
