### PR TITLE
fix: events: put the _signed_ message through the pipeline.

### DIFF
--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -266,13 +266,13 @@ func (te *TipSetEvents) messages(ctx context.Context) ([]executedMessage, error)
 }
 
 type executedMessage struct {
-	msg *types.Message
+	msg types.ChainMsg
 	rct *types.MessageReceipt
 	// events extracted from receipt
 	evs []*types.Event
 }
 
-func (e *executedMessage) Message() *types.Message {
+func (e *executedMessage) Message() types.ChainMsg {
 	return e.msg
 }
 
@@ -428,7 +428,7 @@ func (m *EventFilterManager) loadExecutedMessages(ctx context.Context, msgTs, rc
 	ems := make([]executedMessage, len(msgs))
 
 	for i := 0; i < len(msgs); i++ {
-		ems[i].msg = msgs[i].VMMessage()
+		ems[i].msg = msgs[i]
 
 		var rct types.MessageReceipt
 		found, err := arr.Get(uint64(i), &rct)


### PR DESCRIPTION
## Related Issues

We were putting the unsigned/VM message through the pipeline. The events index was storing the _unsigned_ message CID.

However, the Eth tx hash index maps signed Delegated-signature message CIDs to transaction hashes, i.e. it uses the _signed_ message CID.

As a result, eth_getLogs and other log-related methods were unable to resolve the transaction hash from the index properly, and would end up returning 0x00..00 in the transactionHash field.

## Proposed Changes

Use the correct message.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
