### PR TITLE
fix: event filters use cbor encoding internally

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -980,17 +980,9 @@ func (e *EthEvent) installEthFilterSpec(ctx context.Context, filterSpec *ethtype
 		addresses = append(addresses, a)
 	}
 
-	for idx, vals := range filterSpec.Topics {
-		if len(vals) == 0 {
-			continue
-		}
-		// Ethereum topics are emitted using `LOG{0..4}` opcodes resulting in topics1..4
-		key := fmt.Sprintf("topic%d", idx+1)
-		for _, v := range vals {
-			buf := make([]byte, len(v[:]))
-			copy(buf, v[:])
-			keys[key] = append(keys[key], buf)
-		}
+	keys, err := parseEthTopics(filterSpec.Topics)
+	if err != nil {
+		return nil, err
 	}
 
 	return e.EventFilterManager.Install(ctx, minHeight, maxHeight, tipsetCid, addresses, keys)
@@ -1141,17 +1133,12 @@ func (e *EthEvent) EthSubscribe(ctx context.Context, eventType string, params *e
 	case EthSubscribeEventTypeLogs:
 		keys := map[string][][]byte{}
 		if params != nil {
-			for idx, vals := range params.Topics {
-				if len(vals) == 0 {
-					continue
-				}
-				// Ethereum topics are emitted using `LOG{0..4}` opcodes resulting in topics1..4
-				key := fmt.Sprintf("topic%d", idx+1)
-				for _, v := range vals {
-					buf := make([]byte, len(v[:]))
-					copy(buf, v[:])
-					keys[key] = append(keys[key], buf)
-				}
+			var err error
+			keys, err = parseEthTopics(params.Topics)
+			if err != nil {
+				// clean up any previous filters added and stop the sub
+				_, _ = e.EthUnsubscribe(ctx, sub.id)
+				return nil, err
 			}
 		}
 
@@ -1238,7 +1225,10 @@ func ethFilterResultFromEvents(evs []*filter.CollectedEvent, sa StateAPI) (*etht
 		var err error
 
 		for _, entry := range ev.Entries {
-			value := ethtypes.EthBytes(leftpad32(entry.Value)) // value has already been cbor-decoded but see https://github.com/filecoin-project/ref-fvm/issues/1345
+			value, err := cborDecodeTopicValue(entry.Value)
+			if err != nil {
+				return nil, err
+			}
 			if entry.Key == ethtypes.EthTopic1 || entry.Key == ethtypes.EthTopic2 || entry.Key == ethtypes.EthTopic3 || entry.Key == ethtypes.EthTopic4 {
 				log.Topics = append(log.Topics, value)
 			} else {
@@ -1892,10 +1882,6 @@ func EthTxHashGC(ctx context.Context, retentionDays int, manager *EthTxHashManag
 	}
 }
 
-// TODO we could also emit full EVM words from the EVM runtime, but not doing so
-// makes the contract slightly cheaper (and saves storage bytes), at the expense
-// of having to left pad in the API, which is a pretty acceptable tradeoff at
-// face value. There may be other protocol implications to consider.
 func leftpad32(orig []byte) []byte {
 	needed := 32 - len(orig)
 	if needed <= 0 {
@@ -1904,4 +1890,52 @@ func leftpad32(orig []byte) []byte {
 	ret := make([]byte, 32)
 	copy(ret[needed:], orig)
 	return ret
+}
+
+func trimLeadingZeros(b []byte) []byte {
+	for i := range b {
+		if b[i] != 0 {
+			return b[i:]
+		}
+	}
+	return []byte{}
+}
+
+func cborEncodeTopicValue(orig []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	err := cbg.WriteByteArray(&buf, trimLeadingZeros(orig))
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func cborDecodeTopicValue(orig []byte) ([]byte, error) {
+	if len(orig) == 0 {
+		return orig, nil
+	}
+	decoded, err := cbg.ReadByteArray(bytes.NewReader(orig), uint64(len(orig)))
+	if err != nil {
+		return nil, err
+	}
+	return leftpad32(decoded), nil
+}
+
+func parseEthTopics(topics ethtypes.EthTopicSpec) (map[string][][]byte, error) {
+	keys := map[string][][]byte{}
+	for idx, vals := range topics {
+		if len(vals) == 0 {
+			continue
+		}
+		// Ethereum topics are emitted using `LOG{0..4}` opcodes resulting in topics1..4
+		key := fmt.Sprintf("topic%d", idx+1)
+		for _, v := range vals {
+			encodedVal, err := cborEncodeTopicValue(v[:])
+			if err != nil {
+				return nil, xerrors.Errorf("failed to encode topic value")
+			}
+			keys[key] = append(keys[key], encodedVal)
+		}
+	}
+	return keys, nil
 }


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/ref-fvm/issues/1345

## Proposed Changes
All cbor decoding/encoding of event log values by filters is now handled in the Eth API. Internally all values are kept as cbor encoded byte arrays.

*NOTE: this invalidates previous data stored in the event log sqlite database so events indexed before this change will not be discoverable. Advise removing the database to start indexing to a new one.*


## Additional Info
This is currently based on https://github.com/filecoin-project/lotus/pull/10083 which contains comprehensive itests for this area.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
