### PR TITLE
Properly balance <<?>> in circleci docker config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
             equal: [ mainnet, <<parameters.network>> ]
           steps:
             - when:
-                condition: <parameters.push>>
+                condition: <<parameters.push>>
                 steps:
                   - docker/build:
                       image: filecoin/<<parameters.image>>
@@ -468,7 +468,7 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                         fi
                         if [[ ! -z $CIRCLE_TAG ]]; then
@@ -496,7 +496,7 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -457,7 +457,7 @@ jobs:
             equal: [ mainnet, <<parameters.network>> ]
           steps:
             - when:
-                condition: <parameters.push>>
+                condition: <<parameters.push>>
                 steps:
                   - docker/build:
                       image: filecoin/<<parameters.image>>
@@ -468,7 +468,7 @@ jobs:
                       command: |
                         docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
-                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
+                          docker image tag filecoin/<<parameters.image>>:<<parameters.channel>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"
                         fi
                         if [["[[ ! -z $CIRCLE_TAG ]]"]]; then
@@ -496,7 +496,7 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>


### PR DESCRIPTION
## Related Issues
Builds that we're supposed to push docker images were sometimes failing during the push step, because of a bug in the circleci config. Once this is merged, the push step should be skipped when it's not needed, and we'll no longer experience errors like the following: 
https://app.circleci.com/pipelines/github/filecoin-project/lotus/25558/workflows/9b0c0540-8321-486c-b164-90fe76d5f177/jobs/759269

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
