### PR TITLE
Add back <<network>> parameter for docker push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,7 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [[ ! -z $CIRCLE_SHA ]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -496,7 +496,7 @@ jobs:
                   - run:
                       name: Docker push
                       command: |
-                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>
+                        docker push filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>>
                         if [["[[ ! -z $CIRCLE_SHA ]]"]]; then
                           docker image tag filecoin/<<parameters.image>>:<<parameters.channel>>-<<parameters.network>> filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>
                           docker push filecoin/<<parameters.image>>:"${CIRCLE_SHA:0:7}"-<<parameters.network>>


### PR DESCRIPTION
This commit reverts a change with the previous fix for this flow:
- https://github.com/filecoin-project/lotus/pull/10088

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
