### PR TITLE
feat: vm: Assert empty object CID when dumping state

### DIFF
--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -291,7 +291,10 @@ func DumpActorState(i *ActorRegistry, act *types.Actor, b []byte) (interface{}, 
 
 	um := actInfo.vmActor.State()
 	if um == nil {
-		// TODO::FVM @arajasek I would like to assert that we have the empty object here
+		if act.Code != EmptyObjectCid {
+			return nil, xerrors.Errorf("actor with code %s should only have empty object (%s) as its Head, instead has %s", act.Code, EmptyObjectCid, act.Head)
+		}
+
 		return nil, nil
 	}
 	if err := um.UnmarshalCBOR(bytes.NewReader(b)); err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Resolves a TODO in code.

## Proposed Changes
<!-- A clear list of the changes being made -->

We have certain actors that have no state. We register these actors as having `nil` states in the actor registry. When dumping an actor's state, we currently just skip these actors (return nil).

In Filecoin today, however, the Head for these actors must always be the EmptyObjectCID. This PR changes DumpActorState behaviour to actually assert that and fail if the Head is something else -- this is only a UX change, but is still correcter.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
