### PR TITLE
feat: eth: populate tx hash database on startup

### DIFF
--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -256,6 +256,20 @@ func (cs *ChainStore) MessagesForBlock(ctx context.Context, b *types.BlockHeader
 	return blsmsgs, secpkmsgs, nil
 }
 
+func (cs *ChainStore) SecpkMessagesForBlock(ctx context.Context, b *types.BlockHeader) ([]*types.SignedMessage, error) {
+	_, secpkcids, err := cs.ReadMsgMetaCids(ctx, b.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	secpkmsgs, err := cs.LoadSignedMessagesFromCids(ctx, secpkcids)
+	if err != nil {
+		return nil, xerrors.Errorf("loading secpk messages for block: %w", err)
+	}
+
+	return secpkmsgs, nil
+}
+
 func (cs *ChainStore) GetParentReceipt(ctx context.Context, b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
 	// block headers use adt0, for now.
 	a, err := blockadt.AsArray(cs.ActorStore(ctx), b.ParentMessageReceipts)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1804,6 +1804,52 @@ func (m *EthTxHashManager) Revert(ctx context.Context, from, to *types.TipSet) e
 	return nil
 }
 
+func (m *EthTxHashManager) PopulateExistingMappings(ctx context.Context, minHeight abi.ChainEpoch) error {
+	if minHeight < build.UpgradeHyggeHeight {
+		minHeight = build.UpgradeHyggeHeight
+	}
+
+	ts := m.StateAPI.Chain.GetHeaviestTipSet()
+	for ts.Height() > minHeight {
+		for _, block := range ts.Blocks() {
+			msgs, err := m.StateAPI.Chain.SecpkMessagesForBlock(ctx, block)
+			if err != nil {
+				// If we can't find the messages, we've either imported from snapshot or pruned the store
+				log.Debug("exiting message mapping population at epoch ", ts.Height())
+				return nil
+			}
+
+			for _, msg := range msgs {
+				m.ProcessSignedMessage(ctx, msg)
+			}
+		}
+
+		var err error
+		ts, err = m.StateAPI.Chain.GetTipSetFromKey(ctx, ts.Parents())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *EthTxHashManager) ProcessSignedMessage(ctx context.Context, msg *types.SignedMessage) {
+	if msg.Signature.Type != crypto.SigTypeDelegated {
+		return
+	}
+
+	ethTx, err := newEthTxFromSignedMessage(ctx, msg, m.StateAPI)
+	if err != nil {
+		log.Errorf("error converting filecoin message to eth tx: %s", err)
+	}
+
+	err = m.TransactionHashLookup.UpsertHash(ethTx.Hash, msg.Cid())
+	if err != nil {
+		log.Errorf("error inserting tx mapping to db: %s", err)
+	}
+}
+
 func WaitForMpoolUpdates(ctx context.Context, ch <-chan api.MpoolUpdate, manager *EthTxHashManager) {
 	for {
 		select {
@@ -1813,19 +1859,8 @@ func WaitForMpoolUpdates(ctx context.Context, ch <-chan api.MpoolUpdate, manager
 			if u.Type != api.MpoolAdd {
 				continue
 			}
-			if u.Message.Signature.Type != crypto.SigTypeDelegated {
-				continue
-			}
 
-			ethTx, err := newEthTxFromSignedMessage(ctx, u.Message, manager.StateAPI)
-			if err != nil {
-				log.Errorf("error converting filecoin message to eth tx: %s", err)
-			}
-
-			err = manager.TransactionHashLookup.UpsertHash(ethTx.Hash, u.Message.Cid())
-			if err != nil {
-				log.Errorf("error inserting tx mapping to db: %s", err)
-			}
+			manager.ProcessSignedMessage(ctx, u.Message)
 		}
 	}
 }


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/10044

## Proposed Changes
Checks all messages from the top of the chain down to a specified height (no lower than the v10 upgrade) and adds any relevant transaction hash mappings to the database. This will allow us to get transaction hash mappings when we import snapshots, or when users enable the feature for the first time.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
