### PR TITLE
feat: wdpost: Emit more detailed errors

### DIFF
--- a/storage/sealer/manager_post.go
+++ b/storage/sealer/manager_post.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 
 	"go.uber.org/multierr"
 	"golang.org/x/xerrors"
@@ -82,7 +83,12 @@ func (m *Manager) GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, s
 		// if builtin PoSt isn't disabled, and there are no workers, compute the PoSt locally
 
 		log.Info("GenerateWindowPoSt run at lotus-miner")
-		return m.localProver.GenerateWindowPoSt(ctx, minerID, sectorInfo, randomness)
+		p, s, err := m.localProver.GenerateWindowPoSt(ctx, minerID, sectorInfo, randomness)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("local prover: %w", err)
+		}
+
+		return p, s, nil
 	}
 
 	return m.generateWindowPoSt(ctx, minerID, sectorInfo, randomness)
@@ -217,18 +223,20 @@ func (m *Manager) generateWindowPoSt(ctx context.Context, minerID abi.ActorID, s
 func (m *Manager) generatePartitionWindowPost(ctx context.Context, spt abi.RegisteredSealProof, ppt abi.RegisteredPoStProof, minerID abi.ActorID, partIndex int, sc []storiface.PostSectorChallenge, randomness abi.PoStRandomness) (proof.PoStProof, []abi.SectorID, error) {
 	log.Infow("generateWindowPost", "index", partIndex)
 
+	start := time.Now()
+
 	var result storiface.WindowPoStResult
 	err := m.windowPoStSched.Schedule(ctx, true, spt, func(ctx context.Context, w Worker) error {
 		out, err := w.GenerateWindowPoSt(ctx, ppt, minerID, sc, partIndex, randomness)
 		if err != nil {
-			return err
+			return xerrors.Errorf("post worker: %w", err)
 		}
 
 		result = out
 		return nil
 	})
 
-	log.Warnf("generateWindowPost partition:%d, get skip count:%d", partIndex, len(result.Skipped))
+	log.Warnw("generateWindowPost done", "index", partIndex, "skipped", len(result.Skipped), "took", time.Since(start).String(), "err", err)
 
 	return result.PoStProofs, result.Skipped, err
 }

--- a/storage/sealer/worker_local.go
+++ b/storage/sealer/worker_local.go
@@ -706,11 +706,15 @@ func (l *LocalWorker) GenerateWindowPoSt(ctx context.Context, ppt abi.Registered
 	}
 
 	res, err := sb.GenerateWindowPoStWithVanilla(ctx, ppt, mid, randomness, vproofs, partitionIdx)
-
-	return storiface.WindowPoStResult{
+	r := storiface.WindowPoStResult{
 		PoStProofs: res,
 		Skipped:    skipped,
-	}, err
+	}
+	if err != nil {
+		log.Errorw("generating window PoSt failed", "error", err)
+		return r, xerrors.Errorf("generate window PoSt with vanilla proofs: %w", err)
+	}
+	return r, nil
 }
 
 func (l *LocalWorker) TaskTypes(context.Context) (map[sealtasks.TaskType]struct{}, error) {


### PR DESCRIPTION
Should aid in debugging weird PoSt challenge reading issues which seem to cause entire PoSt to fail, without those it's hard to tell where errors are actually coming from.