### PR TITLE
fix: stmgr: Add nv18-actors to CircSupply

### DIFF
--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -26,6 +26,7 @@ import (
 var SystemActorAddr = builtin.SystemActorAddr
 var BurntFundsActorAddr = builtin.BurntFundsActorAddr
 var CronActorAddr = builtin.CronActorAddr
+var EthereumAddressManager = builtin.EthereumAddressManagerActorAddr
 var SaftAddress = makeAddress("t0122")
 var ReserveAddress = makeAddress("t090")
 var RootVerifierAddress = makeAddress("t080")

--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -26,7 +26,7 @@ import (
 var SystemActorAddr = builtin.SystemActorAddr
 var BurntFundsActorAddr = builtin.BurntFundsActorAddr
 var CronActorAddr = builtin.CronActorAddr
-var EthereumAddressManager = builtin.EthereumAddressManagerActorAddr
+var EthereumAddressManagerActorAddr = builtin.EthereumAddressManagerActorAddr
 var SaftAddress = makeAddress("t0122")
 var ReserveAddress = makeAddress("t090")
 var RootVerifierAddress = makeAddress("t080")

--- a/chain/actors/builtin/builtin.go.template
+++ b/chain/actors/builtin/builtin.go.template
@@ -26,6 +26,7 @@ import (
 var SystemActorAddr = builtin.SystemActorAddr
 var BurntFundsActorAddr = builtin.BurntFundsActorAddr
 var CronActorAddr = builtin.CronActorAddr
+var EthereumAddressManagerActorAddr = builtin.EthereumAddressManagerActorAddr
 var SaftAddress = makeAddress("t0122")
 var ReserveAddress = makeAddress("t090")
 var RootVerifierAddress = makeAddress("t080")

--- a/chain/stmgr/supply.go
+++ b/chain/stmgr/supply.go
@@ -403,7 +403,8 @@ func (sm *StateManager) GetCirculatingSupply(ctx context.Context, height abi.Cha
 			a == builtin.CronActorAddr ||
 			a == builtin.BurntFundsActorAddr ||
 			a == builtin.SaftAddress ||
-			a == builtin.ReserveAddress:
+			a == builtin.ReserveAddress ||
+			a == builtin.EthereumAddressManager:
 
 			unCirc = big.Add(unCirc, actor.Balance)
 
@@ -421,7 +422,12 @@ func (sm *StateManager) GetCirculatingSupply(ctx context.Context, height abi.Cha
 			circ = big.Add(circ, big.Sub(actor.Balance, lb))
 			unCirc = big.Add(unCirc, lb)
 
-		case builtin.IsAccountActor(actor.Code) || builtin.IsPaymentChannelActor(actor.Code):
+		case builtin.IsAccountActor(actor.Code) ||
+			builtin.IsPaymentChannelActor(actor.Code) ||
+			builtin.IsEthAccountActor(actor.Code) ||
+			builtin.IsEvmActor(actor.Code) ||
+			builtin.IsPlaceholderActor(actor.Code):
+
 			circ = big.Add(circ, actor.Balance)
 
 		case builtin.IsStorageMinerActor(actor.Code):

--- a/chain/stmgr/supply.go
+++ b/chain/stmgr/supply.go
@@ -404,7 +404,7 @@ func (sm *StateManager) GetCirculatingSupply(ctx context.Context, height abi.Cha
 			a == builtin.BurntFundsActorAddr ||
 			a == builtin.SaftAddress ||
 			a == builtin.ReserveAddress ||
-			a == builtin.EthereumAddressManager:
+			a == builtin.EthereumAddressManagerActorAddr:
 
 			unCirc = big.Add(unCirc, actor.Balance)
 


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/10103

## Proposed Changes
- Consider funds to EAM as locked
- Add evm, placeholder and ethaccount actors to circ supply

## Additional Info
On Hyperspace you currently encounter:
```
lotus state circulating-supply 
ERROR: unexpected actor: t02188
```
With this fix you should not encounter any errors
```
lotus state circulating-supply
Exact circulating supply:  100277222.576725446405532536 FIL
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
