### PR TITLE
fix: devnets: default to starting from nv17

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -23,7 +23,7 @@ var NetworkBundle = "devnet"
 var BundleOverrides map[actorstypes.Version]string
 var ActorDebugging = true
 
-const GenesisNetworkVersion = network.Version18
+const GenesisNetworkVersion = network.Version17
 
 var UpgradeBreezeHeight = abi.ChainEpoch(-1)
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@maciejwitowski reported that devnets were failing with

```
failed to create block: failed to load tipset state: error handling state forks: migrating actors v10 state: expected state root version 4 for actors v9 upgrade, got 5
```

This makes sense because the current default is to start from nv18, but also include the nv17 -> nv18 upgrade at epoch 30, which obviously doesn't work.

## Proposed Changes
<!-- A clear list of the changes being made -->

Start from v17, upgrade to v18 at epoch 30.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
