### PR TITLE
fix: shed: Standardize use of path flag

### DIFF
--- a/cmd/lotus-shed/balances.go
+++ b/cmd/lotus-shed/balances.go
@@ -454,8 +454,9 @@ var chainBalanceStateCmd = &cli.Command{
 	Description: "Produces a csv file of all account balances from a given stateroot",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.BoolFlag{
 			Name: "miner-info",
@@ -677,8 +678,9 @@ var chainPledgeCmd = &cli.Command{
 	Description: "Calculate sector pledge numbers",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	ArgsUsage: "[stateroot epoch]",

--- a/cmd/lotus-shed/datastore.go
+++ b/cmd/lotus-shed/datastore.go
@@ -42,6 +42,11 @@ var datastoreListCmd = &cli.Command{
 	Description: "list datastore keys",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
+		},
+		&cli.StringFlag{
 			Name:  "repo-type",
 			Usage: "node type (FullNode, StorageMiner, Worker, Wallet)",
 			Value: "FullNode",
@@ -111,6 +116,11 @@ var datastoreGetCmd = &cli.Command{
 	Description: "list datastore keys",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
+		},
+		&cli.StringFlag{
 			Name:  "repo-type",
 			Usage: "node type (FullNode, StorageMiner, Worker, Wallet)",
 			Value: "FullNode",
@@ -123,7 +133,7 @@ var datastoreGetCmd = &cli.Command{
 	},
 	ArgsUsage: "[namespace key]",
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		r, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {

--- a/cmd/lotus-shed/deal-label.go
+++ b/cmd/lotus-shed/deal-label.go
@@ -24,8 +24,9 @@ var dealLabelCmd = &cli.Command{
 	Usage: "Scrape state to report on how many deals have non UTF-8 labels",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/diff.go
+++ b/cmd/lotus-shed/diff.go
@@ -33,8 +33,9 @@ var diffMinerStates = &cli.Command{
 	ArgsUsage: "<stateCidA> <stateCidB>",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/export-car.go
+++ b/cmd/lotus-shed/export-car.go
@@ -35,8 +35,9 @@ var exportCarCmd = &cli.Command{
 	Description: "Export a car from repo",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	ArgsUsage: "[outfile] [root cid]",

--- a/cmd/lotus-shed/export.go
+++ b/cmd/lotus-shed/export.go
@@ -42,8 +42,9 @@ var exportChainCmd = &cli.Command{
 	Description: "Export chain from repo (requires node to be offline)",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.StringFlag{
 			Name:  "tipset",
@@ -146,8 +147,9 @@ var exportRawCmd = &cli.Command{
 	Description: "Export raw blocks from repo (requires node to be offline)",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.StringFlag{
 			Name:  "car-size",

--- a/cmd/lotus-shed/fip-0036.go
+++ b/cmd/lotus-shed/fip-0036.go
@@ -58,12 +58,6 @@ var fip36PollCmd = &cli.Command{
 	Name:      "fip36poll",
 	Usage:     "Process the FIP0036 FilPoll result",
 	ArgsUsage: "[state root, votes]",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
-		},
-	},
 	Subcommands: []*cli.Command{
 		finalResultCmd,
 	},
@@ -75,8 +69,9 @@ var finalResultCmd = &cli.Command{
 	ArgsUsage: "[state root] [height] [votes json]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 

--- a/cmd/lotus-shed/gas-estimation.go
+++ b/cmd/lotus-shed/gas-estimation.go
@@ -42,8 +42,9 @@ var gasTraceCmd = &cli.Command{
 	ArgsUsage:   "[migratedStateRootCid networkVersion messageCid]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -146,8 +147,9 @@ var replayOfflineCmd = &cli.Command{
 	ArgsUsage:   "[messageCid]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.Int64Flag{
 			Name:  "lookback-limit",

--- a/cmd/lotus-shed/import-car.go
+++ b/cmd/lotus-shed/import-car.go
@@ -19,6 +19,13 @@ import (
 var importCarCmd = &cli.Command{
 	Name:        "import-car",
 	Description: "Import a car file into node chain blockstore",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		r, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {
@@ -96,6 +103,13 @@ var importCarCmd = &cli.Command{
 var importObjectCmd = &cli.Command{
 	Name:  "import-obj",
 	Usage: "import a raw ipld object into your datastore",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		r, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {

--- a/cmd/lotus-shed/invariants.go
+++ b/cmd/lotus-shed/invariants.go
@@ -35,8 +35,9 @@ var invariantsCmd = &cli.Command{
 	ArgsUsage:   "[StateRootCid, height]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/keyinfo.go
+++ b/cmd/lotus-shed/keyinfo.go
@@ -146,9 +146,14 @@ var keyinfoImportCmd = &cli.Command{
    Examples
 
    env LOTUS_PATH=/var/lib/lotus lotus-shed keyinfo import libp2p-host.keyinfo`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
+		},
+	},
 	Action: func(cctx *cli.Context) error {
-		flagRepo := cctx.String("repo")
-
 		var input io.Reader
 		if cctx.NArg() == 0 {
 			input = os.Stdin
@@ -177,7 +182,7 @@ var keyinfoImportCmd = &cli.Command{
 			return err
 		}
 
-		fsrepo, err := repo.NewFS(flagRepo)
+		fsrepo, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -88,19 +87,6 @@ func main() {
 		Version:  build.UserVersion(),
 		Commands: local,
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "repo",
-				EnvVars: []string{"LOTUS_PATH"},
-				Hidden:  true,
-				Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
-			},
-			&cli.StringFlag{
-				Name:    "miner-repo",
-				Aliases: []string{"storagerepo"},
-				EnvVars: []string{"LOTUS_MINER_PATH", "LOTUS_STORAGE_PATH"},
-				Value:   "~/.lotusminer", // TODO: Consider XDG_DATA_HOME
-				Usage:   fmt.Sprintf("Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON"),
-			},
 			&cli.StringFlag{
 				Name:  "log-level",
 				Value: "info",

--- a/cmd/lotus-shed/market.go
+++ b/cmd/lotus-shed/market.go
@@ -124,8 +124,9 @@ var marketExportDatastoreCmd = &cli.Command{
 	Description: "export markets datastore key/values to a file",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "path to the repo",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.StringFlag{
 			Name:  "backup-dir",
@@ -241,8 +242,9 @@ var marketImportDatastoreCmd = &cli.Command{
 	Description: "import markets datastore key/values from a backup file",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Usage: "path to the repo",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.StringFlag{
 			Name:     "backup-path",

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -54,8 +54,9 @@ var migrationsCmd = &cli.Command{
 	ArgsUsage:   "[new network version, block to look back from]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.BoolFlag{
 			Name: "skip-pre-migration",

--- a/cmd/lotus-shed/miner-peerid.go
+++ b/cmd/lotus-shed/miner-peerid.go
@@ -26,10 +26,12 @@ import (
 
 var minerPeeridCmd = &cli.Command{
 	Name:  "miner-peerid",
-	Usage: "Scrape state to find a miner based on peerid", Flags: []cli.Flag{
+	Usage: "Scrape state to find a miner based on peerid",
+	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/miner-types.go
+++ b/cmd/lotus-shed/miner-types.go
@@ -28,10 +28,12 @@ import (
 
 var minerTypesCmd = &cli.Command{
 	Name:  "miner-types",
-	Usage: "Scrape state to report on how many miners of each WindowPoStProofType exist", Flags: []cli.Flag{
+	Usage: "Scrape state to report on how many miners of each WindowPoStProofType exist",
+	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/msig.go
+++ b/cmd/lotus-shed/msig.go
@@ -43,8 +43,9 @@ var multisigGetAllCmd = &cli.Command{
 	ArgsUsage: "[state root]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/cmd/lotus-shed/nonce-fix.go
+++ b/cmd/lotus-shed/nonce-fix.go
@@ -17,12 +17,6 @@ import (
 var noncefix = &cli.Command{
 	Name: "noncefix",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "repo",
-			EnvVars: []string{"LOTUS_PATH"},
-			Hidden:  true,
-			Value:   "~/.lotus", // TODO: Consider XDG_DATA_HOME
-		},
 		&cli.Uint64Flag{
 			Name: "start",
 		},

--- a/cmd/lotus-shed/pruning.go
+++ b/cmd/lotus-shed/pruning.go
@@ -86,8 +86,9 @@ var stateTreePruneCmd = &cli.Command{
 	Description: "Deletes old state root data from local chainstore",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.Int64Flag{
 			Name:  "keep-from-lookback",

--- a/cmd/lotus-shed/splitstore.go
+++ b/cmd/lotus-shed/splitstore.go
@@ -39,8 +39,9 @@ var splitstoreRollbackCmd = &cli.Command{
 	Description: "rollbacks a splitstore installation",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.BoolFlag{
 			Name:  "gc-coldstore",
@@ -129,8 +130,9 @@ var splitstoreClearCmd = &cli.Command{
 	Description: "clears a splitstore installation for restart from snapshot",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 		&cli.BoolFlag{
 			Name:  "keys-only",

--- a/cmd/lotus-shed/terminations.go
+++ b/cmd/lotus-shed/terminations.go
@@ -33,8 +33,9 @@ var terminationsCmd = &cli.Command{
 	ArgsUsage:   "[block to look back from] [lookback period (epochs)]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "repo",
-			Value: "~/.lotus",
+			Name:    "repo",
+			Value:   "~/.lotus",
+			EnvVars: []string{"LOTUS_PATH"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Standardize how we pass in "path". Removes top-level env var, which could be overwritten by the default in the path variable declared in the individual functions. 

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
