### PR TITLE
fix:must close when sqlite return sql.Rows

### DIFF
--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -76,6 +76,7 @@ func (ei *EthTxHashLookup) GetCidFromHash(txHash ethtypes.EthHash) (cid.Cid, err
 	if !q.Next() {
 		return cid.Undef, ErrNotFound
 	}
+	defer q.Close()
 	err = q.Scan(&c)
 	if err != nil {
 		return cid.Undef, err
@@ -93,6 +94,7 @@ func (ei *EthTxHashLookup) GetHashFromCid(c cid.Cid) (ethtypes.EthHash, error) {
 	if !q.Next() {
 		return ethtypes.EmptyEthHash, ErrNotFound
 	}
+	defer q.Close()
 	err = q.Scan(&hashString)
 	if err != nil {
 		return ethtypes.EmptyEthHash, err
@@ -101,7 +103,8 @@ func (ei *EthTxHashLookup) GetHashFromCid(c cid.Cid) (ethtypes.EthHash, error) {
 }
 
 func (ei *EthTxHashLookup) DeleteEntriesOlderThan(days int) (int64, error) {
-	res, err := ei.db.Exec("DELETE FROM eth_tx_hashes WHERE insertion_time < datetime('now', ?);", "-"+strconv.Itoa(days)+" day")
+	res, err := ei.db.Exec("DELETE FROM eth_tx_hashes WHERE insertion_time < datetime('now', ?);",
+		"-"+strconv.Itoa(days)+" day")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Related Issues
After the sqlite query returns `sql.Rows`, which should need to be closed, otherwise it will result in too many open files

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
