### PR TITLE
perf: chain: export-range

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -172,6 +172,10 @@ type FullNode interface {
 	// If oldmsgskip is set, messages from before the requested roots are also not included.
 	ChainExport(ctx context.Context, nroots abi.ChainEpoch, oldmsgskip bool, tsk types.TipSetKey) (<-chan []byte, error) //perm:read
 
+	ChainExportRange(ctx context.Context, head, tail types.TipSetKey, cfg *ChainExportConfig) (<-chan []byte, error) //perm:read
+
+	ChainExportRangeInternal(ctx context.Context, head, tail types.TipSetKey, cfg *ChainExportConfig) error //perm:read
+
 	// ChainPrune prunes the stored chain state and garbage collects; only supported if you
 	// are using the splitstore
 	ChainPrune(ctx context.Context, opts PruneOpts) error //perm:admin

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -154,6 +154,35 @@ func (mr *MockFullNodeMockRecorder) ChainExport(arg0, arg1, arg2, arg3 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExport", reflect.TypeOf((*MockFullNode)(nil).ChainExport), arg0, arg1, arg2, arg3)
 }
 
+// ChainExportRange mocks base method.
+func (m *MockFullNode) ChainExportRange(arg0 context.Context, arg1, arg2 types.TipSetKey, arg3 *api.ChainExportConfig) (<-chan []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainExportRange", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(<-chan []byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChainExportRange indicates an expected call of ChainExportRange.
+func (mr *MockFullNodeMockRecorder) ChainExportRange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExportRange", reflect.TypeOf((*MockFullNode)(nil).ChainExportRange), arg0, arg1, arg2, arg3)
+}
+
+// ChainExportRangeInternal mocks base method.
+func (m *MockFullNode) ChainExportRangeInternal(arg0 context.Context, arg1, arg2 types.TipSetKey, arg3 *api.ChainExportConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainExportRangeInternal", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChainExportRangeInternal indicates an expected call of ChainExportRangeInternal.
+func (mr *MockFullNodeMockRecorder) ChainExportRangeInternal(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExportRangeInternal", reflect.TypeOf((*MockFullNode)(nil).ChainExportRangeInternal), arg0, arg1, arg2, arg3)
+}
+
 // ChainGetBlock mocks base method.
 func (m *MockFullNode) ChainGetBlock(arg0 context.Context, arg1 cid.Cid) (*types.BlockHeader, error) {
 	m.ctrl.T.Helper()

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -119,6 +119,10 @@ type FullNodeStruct struct {
 
 		ChainExport func(p0 context.Context, p1 abi.ChainEpoch, p2 bool, p3 types.TipSetKey) (<-chan []byte, error) `perm:"read"`
 
+		ChainExportRange func(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) (<-chan []byte, error) `perm:"read"`
+
+		ChainExportRangeInternal func(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) error `perm:"read"`
+
 		ChainGetBlock func(p0 context.Context, p1 cid.Cid) (*types.BlockHeader, error) `perm:"read"`
 
 		ChainGetBlockMessages func(p0 context.Context, p1 cid.Cid) (*BlockMessages, error) `perm:"read"`
@@ -1382,6 +1386,28 @@ func (s *FullNodeStruct) ChainExport(p0 context.Context, p1 abi.ChainEpoch, p2 b
 
 func (s *FullNodeStub) ChainExport(p0 context.Context, p1 abi.ChainEpoch, p2 bool, p3 types.TipSetKey) (<-chan []byte, error) {
 	return nil, ErrNotSupported
+}
+
+func (s *FullNodeStruct) ChainExportRange(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) (<-chan []byte, error) {
+	if s.Internal.ChainExportRange == nil {
+		return nil, ErrNotSupported
+	}
+	return s.Internal.ChainExportRange(p0, p1, p2, p3)
+}
+
+func (s *FullNodeStub) ChainExportRange(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) (<-chan []byte, error) {
+	return nil, ErrNotSupported
+}
+
+func (s *FullNodeStruct) ChainExportRangeInternal(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) error {
+	if s.Internal.ChainExportRangeInternal == nil {
+		return ErrNotSupported
+	}
+	return s.Internal.ChainExportRangeInternal(p0, p1, p2, p3)
+}
+
+func (s *FullNodeStub) ChainExportRangeInternal(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *ChainExportConfig) error {
+	return ErrNotSupported
 }
 
 func (s *FullNodeStruct) ChainGetBlock(p0 context.Context, p1 cid.Cid) (*types.BlockHeader, error) {

--- a/api/types.go
+++ b/api/types.go
@@ -398,3 +398,12 @@ func (m *MsgUuidMapType) UnmarshalJSON(b []byte) error {
 	}
 	return nil
 }
+
+type ChainExportConfig struct {
+	WriteBufferSize   int
+	Workers           int64
+	CacheSize         int
+	IncludeMessages   bool
+	IncludeReceipts   bool
+	IncludeStateRoots bool
+}

--- a/api/v0api/full.go
+++ b/api/v0api/full.go
@@ -161,6 +161,10 @@ type FullNode interface {
 	// If oldmsgskip is set, messages from before the requested roots are also not included.
 	ChainExport(ctx context.Context, nroots abi.ChainEpoch, oldmsgskip bool, tsk types.TipSetKey) (<-chan []byte, error) //perm:read
 
+	ChainExportRange(ctx context.Context, head, tail types.TipSetKey, cfg *api.ChainExportConfig) (<-chan []byte, error) //perm:read
+
+	ChainExportRangeInternal(ctx context.Context, head, tail types.TipSetKey, cfg *api.ChainExportConfig) error //perm:read
+
 	// MethodGroup: Beacon
 	// The Beacon method group contains methods for interacting with the random beacon (DRAND)
 

--- a/api/v0api/proxy_gen.go
+++ b/api/v0api/proxy_gen.go
@@ -46,6 +46,10 @@ type FullNodeStruct struct {
 
 		ChainExport func(p0 context.Context, p1 abi.ChainEpoch, p2 bool, p3 types.TipSetKey) (<-chan []byte, error) `perm:"read"`
 
+		ChainExportRange func(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) (<-chan []byte, error) `perm:"read"`
+
+		ChainExportRangeInternal func(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) error `perm:"read"`
+
 		ChainGetBlock func(p0 context.Context, p1 cid.Cid) (*types.BlockHeader, error) `perm:"read"`
 
 		ChainGetBlockMessages func(p0 context.Context, p1 cid.Cid) (*api.BlockMessages, error) `perm:"read"`
@@ -526,6 +530,28 @@ func (s *FullNodeStruct) ChainExport(p0 context.Context, p1 abi.ChainEpoch, p2 b
 
 func (s *FullNodeStub) ChainExport(p0 context.Context, p1 abi.ChainEpoch, p2 bool, p3 types.TipSetKey) (<-chan []byte, error) {
 	return nil, ErrNotSupported
+}
+
+func (s *FullNodeStruct) ChainExportRange(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) (<-chan []byte, error) {
+	if s.Internal.ChainExportRange == nil {
+		return nil, ErrNotSupported
+	}
+	return s.Internal.ChainExportRange(p0, p1, p2, p3)
+}
+
+func (s *FullNodeStub) ChainExportRange(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) (<-chan []byte, error) {
+	return nil, ErrNotSupported
+}
+
+func (s *FullNodeStruct) ChainExportRangeInternal(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) error {
+	if s.Internal.ChainExportRangeInternal == nil {
+		return ErrNotSupported
+	}
+	return s.Internal.ChainExportRangeInternal(p0, p1, p2, p3)
+}
+
+func (s *FullNodeStub) ChainExportRangeInternal(p0 context.Context, p1 types.TipSetKey, p2 types.TipSetKey, p3 *api.ChainExportConfig) error {
+	return ErrNotSupported
 }
 
 func (s *FullNodeStruct) ChainGetBlock(p0 context.Context, p1 cid.Cid) (*types.BlockHeader, error) {

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -141,6 +141,35 @@ func (mr *MockFullNodeMockRecorder) ChainExport(arg0, arg1, arg2, arg3 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExport", reflect.TypeOf((*MockFullNode)(nil).ChainExport), arg0, arg1, arg2, arg3)
 }
 
+// ChainExportRange mocks base method.
+func (m *MockFullNode) ChainExportRange(arg0 context.Context, arg1, arg2 types.TipSetKey, arg3 *api.ChainExportConfig) (<-chan []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainExportRange", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(<-chan []byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChainExportRange indicates an expected call of ChainExportRange.
+func (mr *MockFullNodeMockRecorder) ChainExportRange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExportRange", reflect.TypeOf((*MockFullNode)(nil).ChainExportRange), arg0, arg1, arg2, arg3)
+}
+
+// ChainExportRangeInternal mocks base method.
+func (m *MockFullNode) ChainExportRangeInternal(arg0 context.Context, arg1, arg2 types.TipSetKey, arg3 *api.ChainExportConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainExportRangeInternal", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChainExportRangeInternal indicates an expected call of ChainExportRangeInternal.
+func (mr *MockFullNodeMockRecorder) ChainExportRangeInternal(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainExportRangeInternal", reflect.TypeOf((*MockFullNode)(nil).ChainExportRangeInternal), arg0, arg1, arg2, arg3)
+}
+
 // ChainGetBlock mocks base method.
 func (m *MockFullNode) ChainGetBlock(arg0 context.Context, arg1 cid.Cid) (*types.BlockHeader, error) {
 	m.ctrl.T.Helper()

--- a/chain/store/cache.go
+++ b/chain/store/cache.go
@@ -1,0 +1,118 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	lru "github.com/hashicorp/golang-lru"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/lotus/blockstore"
+)
+
+type CachingBlockstore struct {
+	cache  *lru.ARCCache
+	blocks blockstore.Blockstore
+	reads  int64 // updated atomically
+	hits   int64 // updated atomically
+	bytes  int64 // updated atomically
+}
+
+func NewCachingBlockstore(blocks blockstore.Blockstore, cacheSize int) (*CachingBlockstore, error) {
+	cache, err := lru.NewARC(cacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("new arc: %w", err)
+	}
+
+	return &CachingBlockstore{
+		cache:  cache,
+		blocks: blocks,
+	}, nil
+}
+
+func (cs *CachingBlockstore) DeleteBlock(ctx context.Context, c cid.Cid) error {
+	return cs.blocks.DeleteBlock(ctx, c)
+}
+
+func (cs *CachingBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
+	return cs.blocks.GetSize(ctx, c)
+}
+
+func (cs *CachingBlockstore) Put(ctx context.Context, blk blocks.Block) error {
+	return cs.blocks.Put(ctx, blk)
+}
+
+func (cs *CachingBlockstore) PutMany(ctx context.Context, blks []blocks.Block) error {
+	return cs.blocks.PutMany(ctx, blks)
+}
+
+func (cs *CachingBlockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return cs.blocks.AllKeysChan(ctx)
+}
+
+func (cs *CachingBlockstore) HashOnRead(enabled bool) {
+	cs.blocks.HashOnRead(enabled)
+}
+
+func (cs *CachingBlockstore) DeleteMany(ctx context.Context, cids []cid.Cid) error {
+	return cs.blocks.DeleteMany(ctx, cids)
+}
+
+func (cs *CachingBlockstore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	reads := atomic.AddInt64(&cs.reads, 1)
+	if reads%100000 == 0 {
+		hits := atomic.LoadInt64(&cs.hits)
+		by := atomic.LoadInt64(&cs.bytes)
+		log.Infow("CachingBlockstore stats", "reads", reads, "cache_len", cs.cache.Len(), "hit_rate", float64(hits)/float64(reads), "bytes_read", by)
+	}
+
+	v, hit := cs.cache.Get(c)
+	if hit {
+		atomic.AddInt64(&cs.hits, 1)
+		return v.(blocks.Block), nil
+	}
+
+	blk, err := cs.blocks.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	atomic.AddInt64(&cs.bytes, int64(len(blk.RawData())))
+	cs.cache.Add(c, blk)
+	return blk, err
+}
+
+func (cs *CachingBlockstore) View(ctx context.Context, c cid.Cid, callback func([]byte) error) error {
+	reads := atomic.AddInt64(&cs.reads, 1)
+	if reads%1000000 == 0 {
+		hits := atomic.LoadInt64(&cs.hits)
+		by := atomic.LoadInt64(&cs.bytes)
+		log.Infow("CachingBlockstore stats", "reads", reads, "cache_len", cs.cache.Len(), "hit_rate", float64(hits)/float64(reads), "bytes_read", by)
+	}
+	v, hit := cs.cache.Get(c)
+	if hit {
+		atomic.AddInt64(&cs.hits, 1)
+		return callback(v.(blocks.Block).RawData())
+	}
+
+	blk, err := cs.blocks.Get(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	atomic.AddInt64(&cs.bytes, int64(len(blk.RawData())))
+	cs.cache.Add(c, blk)
+	return callback(blk.RawData())
+}
+
+func (cs *CachingBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	atomic.AddInt64(&cs.reads, 1)
+	// Safe to query cache since blockstore never deletes
+	if cs.cache.Contains(c) {
+		return true, nil
+	}
+
+	return cs.blocks.Has(ctx, c)
+}

--- a/documentation/en/api-v0-methods.md
+++ b/documentation/en/api-v0-methods.md
@@ -13,6 +13,8 @@
 * [Chain](#Chain)
   * [ChainDeleteObj](#ChainDeleteObj)
   * [ChainExport](#ChainExport)
+  * [ChainExportRange](#ChainExportRange)
+  * [ChainExportRangeInternal](#ChainExportRangeInternal)
   * [ChainGetBlock](#ChainGetBlock)
   * [ChainGetBlockMessages](#ChainGetBlockMessages)
   * [ChainGetGenesis](#ChainGetGenesis)
@@ -420,6 +422,80 @@ Inputs:
 ```
 
 Response: `"Ynl0ZSBhcnJheQ=="`
+
+### ChainExportRange
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  {
+    "WriteBufferSize": 123,
+    "Workers": 9,
+    "CacheSize": 123,
+    "IncludeMessages": true,
+    "IncludeReceipts": true,
+    "IncludeStateRoots": true
+  }
+]
+```
+
+Response: `"Ynl0ZSBhcnJheQ=="`
+
+### ChainExportRangeInternal
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  {
+    "WriteBufferSize": 123,
+    "Workers": 9,
+    "CacheSize": 123,
+    "IncludeMessages": true,
+    "IncludeReceipts": true,
+    "IncludeStateRoots": true
+  }
+]
+```
+
+Response: `{}`
 
 ### ChainGetBlock
 ChainGetBlock returns the block specified by the given CID.

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -13,6 +13,8 @@
   * [ChainCheckBlockstore](#ChainCheckBlockstore)
   * [ChainDeleteObj](#ChainDeleteObj)
   * [ChainExport](#ChainExport)
+  * [ChainExportRange](#ChainExportRange)
+  * [ChainExportRangeInternal](#ChainExportRangeInternal)
   * [ChainGetBlock](#ChainGetBlock)
   * [ChainGetBlockMessages](#ChainGetBlockMessages)
   * [ChainGetEvents](#ChainGetEvents)
@@ -469,6 +471,80 @@ Inputs:
 ```
 
 Response: `"Ynl0ZSBhcnJheQ=="`
+
+### ChainExportRange
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  {
+    "WriteBufferSize": 123,
+    "Workers": 9,
+    "CacheSize": 123,
+    "IncludeMessages": true,
+    "IncludeReceipts": true,
+    "IncludeStateRoots": true
+  }
+]
+```
+
+Response: `"Ynl0ZSBhcnJheQ=="`
+
+### ChainExportRangeInternal
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  [
+    {
+      "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+    },
+    {
+      "/": "bafy2bzacebp3shtrn43k7g3unredz7fxn4gj533d3o43tqn2p2ipxxhrvchve"
+    }
+  ],
+  {
+    "WriteBufferSize": 123,
+    "Workers": 9,
+    "CacheSize": 123,
+    "IncludeMessages": true,
+    "IncludeReceipts": true,
+    "IncludeStateRoots": true
+  }
+]
+```
+
+Response: `{}`
 
 ### ChainGetBlock
 ChainGetBlock returns the block specified by the given CID.


### PR DESCRIPTION
Taking over from #9192 .

## Related Issues
https://github.com/filecoin-project/lotus/pull/9192

## Proposed Changes
A new `chain export-range` command that can create archival-grade ranged exports of the chain as quickly as possible (letting Lotus write to disk directly).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
