### PR TITLE
fix: cli: add ArgsUsage

### DIFF
--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -55,9 +55,10 @@ var actorCmd = &cli.Command{
 }
 
 var actorSetAddrsCmd = &cli.Command{
-	Name:    "set-addresses",
-	Aliases: []string{"set-addrs"},
-	Usage:   "set addresses that your miner can be publicly dialed on",
+	Name:      "set-addresses",
+	Aliases:   []string{"set-addrs"},
+	Usage:     "set addresses that your miner can be publicly dialed on",
+	ArgsUsage: "<multiaddrs>",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "from",
@@ -170,8 +171,9 @@ var actorSetAddrsCmd = &cli.Command{
 }
 
 var actorSetPeeridCmd = &cli.Command{
-	Name:  "set-peer-id",
-	Usage: "set the peer id of your miner",
+	Name:      "set-peer-id",
+	Usage:     "set the peer id of your miner",
+	ArgsUsage: "<peer id>",
 	Flags: []cli.Flag{
 		&cli.Int64Flag{
 			Name:  "gas-limit",
@@ -193,6 +195,10 @@ var actorSetPeeridCmd = &cli.Command{
 		defer acloser()
 
 		ctx := lcli.ReqContext(cctx)
+
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
+		}
 
 		pid, err := peer.Decode(cctx.Args().Get(0))
 		if err != nil {
@@ -720,13 +726,13 @@ var actorSetOwnerCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		if cctx.NArg() != 2 {
+			return lcli.IncorrectNumArgs(cctx)
+		}
+
 		if !cctx.Bool("really-do-it") {
 			fmt.Println("Pass --really-do-it to actually execute this action")
 			return nil
-		}
-
-		if cctx.NArg() != 2 {
-			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		api, acloser, err := lcli.GetFullNodeAPI(cctx)

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -120,8 +120,8 @@ var sectorsStatusCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if !cctx.Args().Present() {
-			return fmt.Errorf("must specify sector number to get status of")
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().First(), 10, 64)
@@ -1145,9 +1145,6 @@ var sectorsTerminateCmd = &cli.Command{
 		sectorsTerminatePendingCmd,
 	},
 	Action: func(cctx *cli.Context) error {
-		if !cctx.Bool("really-do-it") {
-			return xerrors.Errorf("pass --really-do-it to confirm this action")
-		}
 		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
 			return err
@@ -1156,6 +1153,10 @@ var sectorsTerminateCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
+		}
+
+		if !cctx.Bool("really-do-it") {
+			return xerrors.Errorf("pass --really-do-it to confirm this action")
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)
@@ -1490,8 +1491,8 @@ var sectorsUpdateCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
-		if cctx.NArg() < 2 {
-			return lcli.ShowHelp(cctx, xerrors.Errorf("must pass sector number and new state"))
+		if cctx.NArg() != 2 {
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		id, err := strconv.ParseUint(cctx.Args().Get(0), 10, 64)

--- a/cmd/lotus-miner/storage.go
+++ b/cmd/lotus-miner/storage.go
@@ -55,8 +55,9 @@ stored while moving through the sealing pipeline (references as 'seal').`,
 }
 
 var storageAttachCmd = &cli.Command{
-	Name:  "attach",
-	Usage: "attach local storage path",
+	Name:      "attach",
+	Usage:     "attach local storage path",
+	ArgsUsage: "[path]",
 	Description: `Storage can be attached to the miner using this command. The storage volume
 list is stored local to the miner in $LOTUS_MINER_PATH/storage.json. We do not
 recommend manually modifying this value without further understanding of the
@@ -115,8 +116,8 @@ over time
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if !cctx.Args().Present() {
-			return xerrors.Errorf("must specify storage path to attach")
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		p, err := homedir.Expand(cctx.Args().First())
@@ -192,8 +193,8 @@ var storageDetachCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if !cctx.Args().Present() {
-			return xerrors.Errorf("must specify storage path")
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
 		}
 
 		p, err := homedir.Expand(cctx.Args().First())
@@ -210,8 +211,9 @@ var storageDetachCmd = &cli.Command{
 }
 
 var storageRedeclareCmd = &cli.Command{
-	Name:  "redeclare",
-	Usage: "redeclare sectors in a local storage path",
+	Name:      "redeclare",
+	Usage:     "redeclare sectors in a local storage path",
+	ArgsUsage: "[path]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "id",
@@ -233,6 +235,10 @@ var storageRedeclareCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
+
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
+		}
 
 		if cctx.IsSet("id") && cctx.Bool("all") {
 			return xerrors.Errorf("--id and --all can't be passed at the same time")
@@ -465,6 +471,10 @@ var storageFindCmd = &cli.Command{
 		}
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
+
+		if cctx.NArg() != 1 {
+			return lcli.IncorrectNumArgs(cctx)
+		}
 
 		ma, err := minerApi.ActorAddress(ctx)
 		if err != nil {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -286,7 +286,7 @@ NAME:
    lotus-miner actor set-peer-id - set the peer id of your miner
 
 USAGE:
-   lotus-miner actor set-peer-id [command options] [arguments...]
+   lotus-miner actor set-peer-id [command options] <peer id>
 
 OPTIONS:
    --gas-limit value  set gas limit (default: 0)
@@ -2273,7 +2273,7 @@ NAME:
    lotus-miner storage attach - attach local storage path
 
 USAGE:
-   lotus-miner storage attach [command options] [arguments...]
+   lotus-miner storage attach [command options] [path]
 
 DESCRIPTION:
    Storage can be attached to the miner using this command. The storage volume
@@ -2326,7 +2326,7 @@ NAME:
    lotus-miner storage redeclare - redeclare sectors in a local storage path
 
 USAGE:
-   lotus-miner storage redeclare [command options] [arguments...]
+   lotus-miner storage redeclare [command options] [path]
 
 OPTIONS:
    --all           redeclare all storage paths (default: false)


### PR DESCRIPTION
## Proposed Changes
- Add ArgsUsage to commands that where missing it
- Move check for bool flag after NArgs check on `actorSetPeeridCmd` and `sectorsTerminateCmd`
- Change to cctx.NArg() instead of cctx.Args().xxx in a couple of places

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
