### PR TITLE
feat: Allow libp2p user agent to be overriden

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -66,9 +66,10 @@ var (
 	ConnectionManagerKey = special{9}  // Libp2p option
 	AutoNATSvcKey        = special{10} // Libp2p option
 	BandwidthReporterKey = special{11} // Libp2p option
-	ConnGaterKey         = special{12} // libp2p option
+	ConnGaterKey         = special{12} // Libp2p option
 	DAGStoreKey          = special{13} // constructor returns multiple values
 	ResourceManagerKey   = special{14} // Libp2p option
+	UserAgentKey         = special{15} // Libp2p option
 )
 
 type invoke int

--- a/node/modules/lp2p/host.go
+++ b/node/modules/lp2p/host.go
@@ -69,6 +69,13 @@ func Host(mctx helpers.MetricsCtx, lc fx.Lifecycle, params P2PHostIn) (RawHost, 
 	return h, nil
 }
 
+func UserAgentOption(agent string) func() (opts Libp2pOpts, err error) {
+	return func() (opts Libp2pOpts, err error) {
+		opts.Opts = append(opts.Opts, libp2p.UserAgent(agent))
+		return
+	}
+}
+
 func MockHost(mn mocknet.Mocknet, id peer.ID, ps peerstore.Peerstore) (RawHost, error) {
 	return mn.AddPeerWithPeerstore(id, ps)
 }
@@ -113,11 +120,4 @@ func NilRouting(mctx helpers.MetricsCtx) (BaseIpfsRouting, error) {
 
 func RoutedHost(rh RawHost, r BaseIpfsRouting) host.Host {
 	return routedhost.Wrap(rh, r)
-}
-
-func UserAgentOption(agent string) func() (opts Libp2pOpts, err error) {
-	return func() (opts Libp2pOpts, err error) {
-		opts.Opts = append(opts.Opts, libp2p.UserAgent(agent))
-		return
-	}
 }

--- a/node/modules/lp2p/host.go
+++ b/node/modules/lp2p/host.go
@@ -114,3 +114,10 @@ func NilRouting(mctx helpers.MetricsCtx) (BaseIpfsRouting, error) {
 func RoutedHost(rh RawHost, r BaseIpfsRouting) host.Host {
 	return routedhost.Wrap(rh, r)
 }
+
+func UserAgentOption(agent string) func() (opts Libp2pOpts, err error) {
+	return func() (opts Libp2pOpts, err error) {
+		opts.Opts = append(opts.Opts, libp2p.UserAgent(agent))
+		return
+	}
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Partially addresses: https://github.com/filecoin-project/lily/issues/692

## Proposed Changes
<!-- A clear list of the changes being made -->
1. Adding a special option for configuring the UserAgent
2. Adding a function callable by 3rd parties to override the user agent

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
