### PR TITLE
feat: cli: allow value send from f4 to any address type

### DIFF
--- a/cli/send.go
+++ b/cli/send.go
@@ -117,6 +117,17 @@ var sendCmd = &cli.Command{
 			params.From = faddr
 		}
 
+		if params.From.Protocol() == address.Delegated {
+			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
+				api := srv.FullNodeAPI()
+				// Resolve id addr if possible.
+				params.To, err = api.StateLookupID(ctx, params.To, types.EmptyTSK)
+				if err != nil {
+					return xerrors.Errorf("f4 addresses can only send to other f4 or id addresses. could not find id address for %s", params.To.String())
+				}
+			}
+		}
+
 		if cctx.IsSet("gas-premium") {
 			gp, err := types.BigFromString(cctx.String("gas-premium"))
 			if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
If f4 address is not sending to f4 or f0, tries to resolve the `to` address to and ID address. Otherwise the call will fail, because a message coming from an f4 address will get converted to an eth transaction, and f1, f2, f3 will not fit in 20 bytes.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
