### PR TITLE
fix: extend LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC to the markset

### DIFF
--- a/blockstore/splitstore/markset_badger.go
+++ b/blockstore/splitstore/markset_badger.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ipfs/go-cid"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/system"
 )
 
 type BadgerMarkSetEnv struct {
@@ -349,7 +351,7 @@ func (s *BadgerMarkSet) write(seqno int) (err error) {
 	persist := s.persist
 	s.mx.RUnlock()
 
-	if persist {
+	if persist && !system.BadgerFsyncDisable {
 		return s.db.Sync()
 	}
 

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/storage/sealer/fsutil"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
+	"github.com/filecoin-project/lotus/system"
 )
 
 const (
@@ -479,19 +480,8 @@ func (fsr *fsLockedRepo) Blockstore(ctx context.Context, domain BlockstoreDomain
 			return
 		}
 
-		//
-		// Tri-state environment variable LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC
-		// - unset == the default (currently fsync enabled)
-		// - set with a false-y value == fsync enabled no matter what a future default is
-		// - set with any other value == fsync is disabled ignored defaults (recommended for day-to-day use)
-		//
-		if nosyncBs, nosyncBsSet := os.LookupEnv("LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC"); nosyncBsSet {
-			nosyncBs = strings.ToLower(nosyncBs)
-			if nosyncBs == "" || nosyncBs == "0" || nosyncBs == "false" || nosyncBs == "no" {
-				opts.SyncWrites = true
-			} else {
-				opts.SyncWrites = false
-			}
+		if system.BadgerFsyncDisable {
+			opts.SyncWrites = false
 		}
 
 		bs, err := badgerbs.Open(opts)

--- a/system/io.go
+++ b/system/io.go
@@ -1,0 +1,25 @@
+package system
+
+import (
+	"os"
+	"strings"
+)
+
+var BadgerFsyncDisable bool
+
+func init() {
+	//
+	// Tri-state environment variable LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC
+	// - unset == the default (currently fsync enabled)
+	// - set with a false-y value == fsync enabled no matter what a future default is
+	// - set with any other value == fsync is disabled ignored defaults (recommended for day-to-day use)
+	//
+	if nosyncBs, nosyncBsSet := os.LookupEnv("LOTUS_CHAIN_BADGERSTORE_DISABLE_FSYNC"); nosyncBsSet {
+		nosyncBs = strings.ToLower(nosyncBs)
+		if nosyncBs == "" || nosyncBs == "0" || nosyncBs == "false" || nosyncBs == "no" {
+			BadgerFsyncDisable = false
+		} else {
+			BadgerFsyncDisable = true
+		}
+	}
+}


### PR DESCRIPTION
## Proposed Changes
Without doing this a badger markset on a non-nvme gets into so much I/O wait that it knocks a node hopelessly out of sync.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
