### PR TITLE
fix: worker: add all tasks flag

### DIFF
--- a/cmd/lotus-worker/tasks.go
+++ b/cmd/lotus-worker/tasks.go
@@ -45,32 +45,52 @@ var tasksEnableCmd = &cli.Command{
 	Name:      "enable",
 	Usage:     "Enable a task type",
 	ArgsUsage: "[" + settableStr + "]",
-	Action:    taskAction(api.Worker.TaskEnable),
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "all",
+			Usage: "Enable all task types",
+		},
+	},
+	Action: taskAction(api.Worker.TaskEnable),
 }
 
 var tasksDisableCmd = &cli.Command{
 	Name:      "disable",
 	Usage:     "Disable a task type",
 	ArgsUsage: "[" + settableStr + "]",
-	Action:    taskAction(api.Worker.TaskDisable),
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "all",
+			Usage: "Disable all task types",
+		},
+	},
+	Action: taskAction(api.Worker.TaskDisable),
 }
 
 func taskAction(tf func(a api.Worker, ctx context.Context, tt sealtasks.TaskType) error) func(cctx *cli.Context) error {
 	return func(cctx *cli.Context) error {
-		if cctx.NArg() != 1 {
-			return xerrors.Errorf("expected 1 argument")
+		allFlag := cctx.Bool("all")
+
+		if cctx.NArg() == 1 && allFlag {
+			return xerrors.Errorf("Cannot use --all flag with task type argument")
+		}
+
+		if cctx.NArg() == 0 && !allFlag {
+			return xerrors.Errorf("Expected 1 argument or use --all flag")
 		}
 
 		var tt sealtasks.TaskType
-		for taskType := range allowSetting {
-			if taskType.Short() == cctx.Args().First() {
-				tt = taskType
-				break
+		if cctx.NArg() == 1 {
+			for taskType := range allowSetting {
+				if taskType.Short() == cctx.Args().First() {
+					tt = taskType
+					break
+				}
 			}
-		}
 
-		if tt == "" {
-			return xerrors.Errorf("unknown task type '%s'", cctx.Args().First())
+			if tt == "" {
+				return xerrors.Errorf("unknown task type '%s'", cctx.Args().First())
+			}
 		}
 
 		api, closer, err := lcli.GetWorkerAPI(cctx)
@@ -80,6 +100,15 @@ func taskAction(tf func(a api.Worker, ctx context.Context, tt sealtasks.TaskType
 		defer closer()
 
 		ctx := lcli.ReqContext(cctx)
+
+		if allFlag {
+			for taskType := range allowSetting {
+				if err := tf(api, ctx, taskType); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 
 		return tf(api, ctx, tt)
 	}

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -221,7 +221,7 @@ USAGE:
    lotus-worker tasks enable [command options] [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --all  Enable all task types (default: false)
    
 ```
 
@@ -234,6 +234,6 @@ USAGE:
    lotus-worker tasks disable [command options] [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --all  Disable all task types (default: false)
    
 ```

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -218,7 +218,7 @@ NAME:
    lotus-worker tasks enable - Enable a task type
 
 USAGE:
-   lotus-worker tasks enable [command options] [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
+   lotus-worker tasks enable [command options] --all | [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
    --all  Enable all task types (default: false)
@@ -231,7 +231,7 @@ NAME:
    lotus-worker tasks disable - Disable a task type
 
 USAGE:
-   lotus-worker tasks disable [command options] [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
+   lotus-worker tasks disable [command options] --all | [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
    --all  Disable all task types (default: false)


### PR DESCRIPTION
## Proposed Changes
Add a `all` flag for the `lotus-worker tasks enable/disable` cmds. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
