### PR TITLE
fix: cli: option to set-seal-delay in seconds

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1379,8 +1379,14 @@ var sectorsStartSealCmd = &cli.Command{
 
 var sectorsSealDelayCmd = &cli.Command{
 	Name:      "set-seal-delay",
-	Usage:     "Set the time, in minutes, that a new sector waits for deals before sealing starts",
-	ArgsUsage: "<minutes>",
+	Usage:     "Set the time (in minutes) that a new sector waits for deals before sealing starts",
+	ArgsUsage: "<time>",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "seconds",
+			Usage: "Specifies that the time argument should be in seconds",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		minerAPI, closer, err := lcli.GetStorageMinerAPI(cctx)
 		if err != nil {
@@ -1397,7 +1403,12 @@ var sectorsSealDelayCmd = &cli.Command{
 			return xerrors.Errorf("could not parse sector number: %w", err)
 		}
 
-		delay := hs * uint64(time.Minute)
+		var delay uint64
+		if cctx.Bool("seconds") {
+			delay = hs * uint64(time.Second)
+		} else {
+			delay = hs * uint64(time.Minute)
+		}
 
 		return minerAPI.SectorSetSealDelay(ctx, time.Duration(delay))
 	},

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1680,7 +1680,7 @@ COMMANDS:
      snap-up               Mark a committed capacity sector to be filled with deals
      abort-upgrade         Abort the attempted (SnapDeals) upgrade of a CC sector, reverting it to as before
      seal                  Manually start sealing a sector (filling any unused space with junk)
-     set-seal-delay        Set the time, in minutes, that a new sector waits for deals before sealing starts
+     set-seal-delay        Set the time (in minutes) that a new sector waits for deals before sealing starts
      get-cc-collateral     Get the collateral required to pledge a committed capacity sector
      batching              manage batch sector operations
      match-pending-pieces  force a refreshed match of pending pieces to open sectors without manually waiting for more deals
@@ -2002,13 +2002,13 @@ OPTIONS:
 ### lotus-miner sectors set-seal-delay
 ```
 NAME:
-   lotus-miner sectors set-seal-delay - Set the time, in minutes, that a new sector waits for deals before sealing starts
+   lotus-miner sectors set-seal-delay - Set the time (in minutes) that a new sector waits for deals before sealing starts
 
 USAGE:
-   lotus-miner sectors set-seal-delay [command options] <minutes>
+   lotus-miner sectors set-seal-delay [command options] <time>
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --seconds  Specifies that the time argument should be in seconds (default: false)
    
 ```
 


### PR DESCRIPTION
## Related Issues
Fix https://github.com/filecoin-project/lotus/issues/5349

## Proposed Changes
Add the option to specify set-seal-delay in seconds

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
