### PR TITLE
fix: cli: error if backup file already exists

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -61,6 +61,10 @@ func BackupCmd(repoFlag string, rt repo.RepoType, getApi BackupApiFn) *cli.Comma
 			return xerrors.Errorf("expanding file path: %w", err)
 		}
 
+		if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+			return xerrors.Errorf("backup file %s already exists. Overwriting it will corrupt the file, please specify another file name", fpath)
+		}
+
 		out, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return xerrors.Errorf("opening backup file %s: %w", fpath, err)
@@ -87,7 +91,12 @@ func BackupCmd(repoFlag string, rt repo.RepoType, getApi BackupApiFn) *cli.Comma
 		}
 		defer closer()
 
-		err = api.CreateBackup(ReqContext(cctx), cctx.Args().First())
+		backupPath := cctx.Args().First()
+		if _, err := os.Stat(backupPath); err == nil {
+			return xerrors.Errorf("backup file %s already exists. Overwriting it will corrupt the file, please specify another file name", backupPath)
+		}
+
+		err = api.CreateBackup(ReqContext(cctx), backupPath)
 		if err != nil {
 			return err
 		}

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -92,7 +92,7 @@ func BackupCmd(repoFlag string, rt repo.RepoType, getApi BackupApiFn) *cli.Comma
 		defer closer()
 
 		backupPath := cctx.Args().First()
-		if _, err := os.Stat(backupPath); err == nil {
+		if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
 			return xerrors.Errorf("backup file %s already exists. Overwriting it will corrupt the file, please specify another file name", backupPath)
 		}
 


### PR DESCRIPTION
## Related Issues
fix https://github.com/filecoin-project/lotus/issues/7028

## Proposed Changes
Calling `lotus-miner backup` or `lotus backup` on a backup file which already exists corrupts the file.
Added check to see if a file with the same name already exists, and if it does error out explaining that another file name should be used. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
