### PR TITLE
fix: stmgr: make the tipset and height agree when estimating gas

### DIFF
--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -113,7 +113,7 @@ func TestWindowPostDispute(t *testing.T) {
 		//stm: @CHAIN_STATE_MINER_CALCULATE_DEADLINE_001
 		di, err = client.StateMinerProvingDeadline(ctx, evilMinerAddr, types.EmptyTSK)
 		require.NoError(t, err)
-		if di.Index == evilSectorLoc.Deadline && di.CurrentEpoch-di.PeriodStart > 2 {
+		if di.Index == evilSectorLoc.Deadline && di.CurrentEpoch-di.Open > 1 {
 			break
 		}
 		build.Clock.Sleep(blocktime)
@@ -217,7 +217,8 @@ func TestWindowPostDispute(t *testing.T) {
 		//stm: @CHAIN_STATE_MINER_CALCULATE_DEADLINE_001
 		di, err = client.StateMinerProvingDeadline(ctx, evilMinerAddr, types.EmptyTSK)
 		require.NoError(t, err)
-		if di.Index == evilSectorLoc.Deadline {
+
+		if di.Index == evilSectorLoc.Deadline && di.CurrentEpoch-di.Open > 1 {
 			break
 		}
 		build.Clock.Sleep(blocktime)

--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -113,7 +113,7 @@ func TestWindowPostDispute(t *testing.T) {
 		//stm: @CHAIN_STATE_MINER_CALCULATE_DEADLINE_001
 		di, err = client.StateMinerProvingDeadline(ctx, evilMinerAddr, types.EmptyTSK)
 		require.NoError(t, err)
-		if di.Index == evilSectorLoc.Deadline && di.CurrentEpoch-di.PeriodStart > 1 {
+		if di.Index == evilSectorLoc.Deadline && di.CurrentEpoch-di.PeriodStart > 2 {
 			break
 		}
 		build.Clock.Sleep(blocktime)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Should fix https://github.com/filecoin-project/ref-fvm/issues/1648.

## Proposed Changes
<!-- A clear list of the changes being made -->

Specifically re-execute all messages in the current tipset, tacking the new message onto the end. That way, the epoch is the epoch of the current tipset.

We could try to "make" a fake block and use that, but that's unlikely to work well.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green