### PR TITLE
feat: eth cli: Strip out empty spaces around contract bytes

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -413,6 +413,10 @@ func DecodeHexString(s string) ([]byte, error) {
 	return b, nil
 }
 
+func DecodeHexStringTrimSpace(s string) ([]byte, error) {
+	return DecodeHexString(strings.TrimSpace(s))
+}
+
 func handleHexStringPrefix(s string) string {
 	// Strip the leading 0x or 0X prefix since hex.DecodeString does not support it.
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {

--- a/cli/evm.go
+++ b/cli/evm.go
@@ -107,7 +107,7 @@ var EvmCallSimulateCmd = &cli.Command{
 			return err
 		}
 
-		params, err := ethtypes.DecodeHexString(cctx.Args().Get(2))
+		params, err := ethtypes.DecodeHexStringTrimSpace(cctx.Args().Get(2))
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ var EvmGetContractAddress = &cli.Command{
 			return err
 		}
 
-		salt, err := ethtypes.DecodeHexString(cctx.Args().Get(1))
+		salt, err := ethtypes.DecodeHexStringTrimSpace(cctx.Args().Get(1))
 		if err != nil {
 			return xerrors.Errorf("Could not decode salt: %w", err)
 		}
@@ -170,7 +170,7 @@ var EvmGetContractAddress = &cli.Command{
 
 			return err
 		}
-		contract, err := ethtypes.DecodeHexString(string(contractHex))
+		contract, err := ethtypes.DecodeHexStringTrimSpace(string(contractHex))
 		if err != nil {
 			return xerrors.Errorf("Could not decode contract file: %w", err)
 		}
@@ -219,7 +219,7 @@ var EvmDeployCmd = &cli.Command{
 			return xerrors.Errorf("failed to read contract: %w", err)
 		}
 		if cctx.Bool("hex") {
-			contract, err = ethtypes.DecodeHexString(string(contract))
+			contract, err = ethtypes.DecodeHexStringTrimSpace(string(contract))
 			if err != nil {
 				return xerrors.Errorf("failed to decode contract: %w", err)
 			}
@@ -341,7 +341,7 @@ var EvmInvokeCmd = &cli.Command{
 		}
 
 		var calldata []byte
-		calldata, err = ethtypes.DecodeHexString(cctx.Args().Get(1))
+		calldata, err = ethtypes.DecodeHexStringTrimSpace(cctx.Args().Get(1))
 		if err != nil {
 			return xerrors.Errorf("decoding hex input data: %w", err)
 		}


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/9803

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
