### PR TITLE
fix: Don't call WalletExport in msg signing flows

### DIFF
--- a/chain/messagesigner/messagesigner.go
+++ b/chain/messagesigner/messagesigner.go
@@ -13,13 +13,11 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-state-types/crypto"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
-	"github.com/filecoin-project/lotus/chain/wallet/key"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
@@ -69,11 +67,7 @@ func (ms *MessageSigner) SignMessage(ctx context.Context, msg *types.Message, sp
 	// Sign the message with the nonce
 	msg.Nonce = nonce
 
-	keyInfo, err := ms.wallet.WalletExport(ctx, msg.From)
-	if err != nil {
-		return nil, err
-	}
-	sb, err := SigningBytes(msg, key.ActSigType(keyInfo.Type))
+	sb, err := SigningBytes(msg, msg.From.Protocol())
 	if err != nil {
 		return nil, err
 	}
@@ -200,8 +194,8 @@ func (ms *MessageSigner) dstoreKey(addr address.Address) datastore.Key {
 	return datastore.KeyWithNamespaces([]string{dsKeyActorNonce, addr.String()})
 }
 
-func SigningBytes(msg *types.Message, sigType crypto.SigType) ([]byte, error) {
-	if sigType == crypto.SigTypeDelegated {
+func SigningBytes(msg *types.Message, sigType address.Protocol) ([]byte, error) {
+	if sigType == address.Delegated {
 		txArgs, err := ethtypes.EthTxArgsFromUnsignedEthMessage(msg)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to reconstruct eth transaction: %w", err)

--- a/node/impl/full/wallet.go
+++ b/node/impl/full/wallet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
-	"github.com/filecoin-project/lotus/chain/wallet/key"
 	"github.com/filecoin-project/lotus/lib/sigs"
 )
 
@@ -53,11 +52,7 @@ func (a *WalletAPI) WalletSignMessage(ctx context.Context, k address.Address, ms
 		return nil, xerrors.Errorf("failed to resolve ID address: %w", keyAddr)
 	}
 
-	keyInfo, err := a.Wallet.WalletExport(ctx, k)
-	if err != nil {
-		return nil, err
-	}
-	sb, err := messagesigner.SigningBytes(msg, key.ActSigType(keyInfo.Type))
+	sb, err := messagesigner.SigningBytes(msg, keyAddr.Protocol())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Don't call WalletExport just to get key type

## Additional Info
Calls to WalletExport breaks remote wallets, looks really bad in interactive wallets, and probably also breaks ledger wallet.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
