### PR TITLE
fix: gas: update ffi & correct the message inclusion cost in nv18

### DIFF
--- a/chain/vm/gas.go
+++ b/chain/vm/gas.go
@@ -213,6 +213,16 @@ var Prices = map[abi.ChainEpoch]Pricelist{
 
 		verifyReplicaUpdate: 36316136,
 	},
+	build.UpgradeHyggeHeight: &pricelistV0{
+		computeGasMulti: 1,
+		storageGasMulti: 1300, // only applies to messages/return values.
+
+		onChainMessageComputeBase:    38863 + 475000, // includes the actor update cost
+		onChainMessageStorageBase:    36,
+		onChainMessageStoragePerByte: 1,
+
+		onChainReturnValuePerByte: 1,
+	},
 }
 
 // PricelistByEpoch finds the latest prices for the given epoch

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -58,7 +58,7 @@ func buildInputFromuint64(number uint64) []byte {
 // recursive delegate calls that fail due to gas limits are currently getting to 229 iterations
 // before running out of gas
 func recursiveDelegatecallFail(ctx context.Context, t *testing.T, client *kit.TestFullNode, filename string, count uint64) {
-	expectedIterationsBeforeFailing := int(229)
+	expectedIterationsBeforeFailing := int(220)
 	fromAddr, idAddr := client.EVM().DeployContractFromFilename(ctx, filename)
 	t.Log("recursion count - ", count)
 	inputData := buildInputFromuint64(count)
@@ -158,7 +158,7 @@ func TestFEVMRecursiveDelegatecallCount(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	highestSuccessCount := uint64(235)
+	highestSuccessCount := uint64(225)
 
 	filename := "contracts/RecursiveDelegeatecall.hex"
 	recursiveDelegatecallSuccess(ctx, t, client, filename, uint64(1))

--- a/itests/gas_estimation_test.go
+++ b/itests/gas_estimation_test.go
@@ -2,16 +2,19 @@ package itests
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/account"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/itests/kit"
 )
 
@@ -37,8 +40,9 @@ func TestEstimateGasNoFunds(t *testing.T) {
 	sm, err := client.MpoolPushMessage(ctx, msg, nil)
 	require.NoError(t, err)
 
-	_, err = client.StateWaitMsg(ctx, sm.Cid(), 3, api.LookbackNoLimit, true)
+	ret, err := client.StateWaitMsg(ctx, sm.Cid(), 3, api.LookbackNoLimit, true)
 	require.NoError(t, err)
+	require.True(t, ret.Receipt.ExitCode.IsSuccess())
 
 	// Make sure we can estimate gas even if we have no funds.
 	msg2 := &types.Message{
@@ -51,4 +55,43 @@ func TestEstimateGasNoFunds(t *testing.T) {
 	limit, err := client.GasEstimateGasLimit(ctx, msg2, types.EmptyTSK)
 	require.NoError(t, err)
 	require.NotZero(t, limit)
+}
+
+func TestEstimateNoop(t *testing.T) {
+	ctx := context.Background()
+
+	kit.QuietMiningLogs()
+
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs())
+	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
+	msg := &types.Message{
+		From:       client.DefaultKey.Address,
+		To:         client.DefaultKey.Address,
+		Value:      big.Zero(),
+		GasLimit:   0,
+		GasFeeCap:  abi.NewTokenAmount(10000),
+		GasPremium: abi.NewTokenAmount(10000),
+	}
+
+	// Sign the message and compute the correct inclusion cost.
+	var smsg *types.SignedMessage
+	for i := 0; ; i++ {
+		var err error
+		smsg, err = client.WalletSignMessage(ctx, client.DefaultKey.Address, msg)
+		require.NoError(t, err)
+		estimatedGas := vm.PricelistByEpoch(math.MaxInt).OnChainMessage(smsg.ChainLength()).Total()
+		if estimatedGas == msg.GasLimit {
+			break
+		}
+		// Try 10 times to get the right gas value.
+		require.Less(t, i, 10, "unable to estimate gas: %s != %s", estimatedGas, msg.GasLimit)
+		msg.GasLimit = estimatedGas
+	}
+
+	cid, err := client.MpoolPush(ctx, smsg)
+	require.NoError(t, err)
+	ret, err := client.StateWaitMsg(ctx, cid, 3, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.True(t, ret.Receipt.ExitCode.IsSuccess())
+	require.Equal(t, msg.GasLimit, ret.Receipt.GasUsed)
 }

--- a/itests/gas_estimation_test.go
+++ b/itests/gas_estimation_test.go
@@ -125,7 +125,7 @@ func TestEstimateInclusion(t *testing.T) {
 
 	// Mutate the last byte to get a new address of the same length.
 	toBytes := msg.To.Bytes()
-	toBytes[len(toBytes)-1] += 1
+	toBytes[len(toBytes)-1] += 1 //nolint:golint
 	newAddr, err := address.NewFromBytes(toBytes)
 	require.NoError(t, err)
 
@@ -158,7 +158,7 @@ func TestEstimateInclusion(t *testing.T) {
 
 	msg.Nonce = 2
 	msg.To = msg.From
-	msg.GasLimit -= 1
+	msg.GasLimit -= 1 //nolint:golint
 
 	smsg, err = client.WalletSignMessage(ctx, client.DefaultKey.Address, msg)
 	require.NoError(t, err)

--- a/itests/gas_estimation_test.go
+++ b/itests/gas_estimation_test.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/account"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
@@ -57,21 +61,42 @@ func TestEstimateGasNoFunds(t *testing.T) {
 	require.NotZero(t, limit)
 }
 
-func TestEstimateNoop(t *testing.T) {
+// Make sure that we correctly calculate the inclusion cost. Especially, make sure the FVM and Lotus
+// agree and that:
+//  1. The FVM will never charge _less_ than the inclusion cost.
+//  2. The FVM will never fine a storage provider for including a message that costs exactly the
+//     inclusion cost.
+func TestEstimateInclusion(t *testing.T) {
 	ctx := context.Background()
 
 	kit.QuietMiningLogs()
 
+	// We need this to be "correct" in this test so that lotus can get the correct gas value
+	// (which, unfortunately, looks at the height and not the current network version).
+	oldPrices := vm.Prices
+	vm.Prices = map[abi.ChainEpoch]vm.Pricelist{
+		0: oldPrices[build.UpgradeHyggeHeight],
+	}
+	t.Cleanup(func() { vm.Prices = oldPrices })
+
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs())
 	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
+
+	// First, try sending a message that should have no fees beyond the inclusion cost. I.e., it
+	// does absolutely nothing:
 	msg := &types.Message{
 		From:       client.DefaultKey.Address,
 		To:         client.DefaultKey.Address,
 		Value:      big.Zero(),
 		GasLimit:   0,
 		GasFeeCap:  abi.NewTokenAmount(10000),
-		GasPremium: abi.NewTokenAmount(10000),
+		GasPremium: big.Zero(),
 	}
+
+	burntBefore, err := client.WalletBalance(ctx, builtin.BurntFundsActorAddr)
+	require.NoError(t, err)
+	balanceBefore, err := client.WalletBalance(ctx, client.DefaultKey.Address)
+	require.NoError(t, err)
 
 	// Sign the message and compute the correct inclusion cost.
 	var smsg *types.SignedMessage
@@ -94,4 +119,51 @@ func TestEstimateNoop(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ret.Receipt.ExitCode.IsSuccess())
 	require.Equal(t, msg.GasLimit, ret.Receipt.GasUsed)
+
+	// Then try sending a message of the same size that tries to create an actor. This should
+	// get successfully included, but fail with out of gas:
+
+	// Mutate the last byte to get a new address of the same length.
+	toBytes := msg.To.Bytes()
+	toBytes[len(toBytes)-1] += 1
+	newAddr, err := address.NewFromBytes(toBytes)
+	require.NoError(t, err)
+
+	msg.Nonce = 1
+	msg.To = newAddr
+	smsg, err = client.WalletSignMessage(ctx, client.DefaultKey.Address, msg)
+	require.NoError(t, err)
+
+	cid, err = client.MpoolPush(ctx, smsg)
+	require.NoError(t, err)
+	ret, err = client.StateWaitMsg(ctx, cid, 3, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.Equal(t, ret.Receipt.ExitCode, exitcode.SysErrOutOfGas)
+	require.Equal(t, msg.GasLimit, ret.Receipt.GasUsed)
+
+	// Now make sure that the client is the only contributor to the burnt funds actor (the
+	// miners should not have been fined for either message).
+
+	burntAfter, err := client.WalletBalance(ctx, builtin.BurntFundsActorAddr)
+	require.NoError(t, err)
+	balanceAfter, err := client.WalletBalance(ctx, client.DefaultKey.Address)
+	require.NoError(t, err)
+
+	burnt := big.Sub(burntAfter, burntBefore)
+	spent := big.Sub(balanceBefore, balanceAfter)
+
+	require.Equal(t, burnt, spent)
+
+	// Finally, try to submit a message with too little gas. This should fail.
+
+	msg.Nonce = 2
+	msg.To = msg.From
+	msg.GasLimit -= 1
+
+	smsg, err = client.WalletSignMessage(ctx, client.DefaultKey.Address, msg)
+	require.NoError(t, err)
+
+	_, err = client.MpoolPush(ctx, smsg)
+	require.ErrorContains(t, err, "will not be included in a block")
+	require.ErrorContains(t, err, "cannot be less than the cost of storing a message")
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

https://github.com/filecoin-project/lotus/issues/10226

## Proposed Changes
<!-- A clear list of the changes being made -->

This fixes two issues:

1. We need to charge an additional 475,000 gas to update the sending actor.
2. We needed to update the FVM as it was miscalculating the inclusion cost.

I've also removed all the other fees from the price list as they don't make sense anymore.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green