### PR TITLE
test: ethtypes: hex leading zeros

### DIFF
--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -20,8 +20,10 @@ func TestEthIntMarshalJSON(t *testing.T) {
 	// https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding
 	testcases := []TestCase{
 		{EthUint64(0), []byte("\"0x0\"")},
+		{EthUint64(1), []byte("\"0x1\"")},
 		{EthUint64(65), []byte("\"0x41\"")},
 		{EthUint64(1024), []byte("\"0x400\"")},
+		{EthUint64(2685060795998787), []byte("\"0x98a0c6ef22243\"")},
 	}
 
 	for _, tc := range testcases {
@@ -36,6 +38,7 @@ func TestEthIntUnmarshalJSON(t *testing.T) {
 		{[]byte("\"0x0\""), EthUint64(0)},
 		{[]byte("\"0x41\""), EthUint64(65)},
 		{[]byte("\"0x400\""), EthUint64(1024)},
+		{[]byte("\"0x0400\""), EthUint64(1024)},
 	}
 
 	for _, tc := range testcases {
@@ -52,6 +55,7 @@ func TestEthBigIntMarshalJSON(t *testing.T) {
 		{EthBigInt(big.NewInt(65)), []byte("\"0x41\"")},
 		{EthBigInt(big.NewInt(1024)), []byte("\"0x400\"")},
 		{EthBigInt(big.Int{}), []byte("\"0x0\"")},
+		{EthBigInt(big.MustFromString("4314726344238778862224669783019953265742676409691641697694925658285796229120")), []byte("\"0x98a0c6ef2224342b2a8727ae5111fd000000000000000000000000000000000\"")},
 	}
 	for _, tc := range testcases {
 		j, err := tc.Input.(EthBigInt).MarshalJSON()
@@ -66,6 +70,8 @@ func TestEthBigIntUnmarshalJSON(t *testing.T) {
 		{[]byte("\"0x41\""), EthBigInt(big.MustFromString("65"))},
 		{[]byte("\"0x400\""), EthBigInt(big.MustFromString("1024"))},
 		{[]byte("\"0xff1000000000000000000000000\""), EthBigInt(big.MustFromString("323330131220712761719252861321216"))},
+		{[]byte("\"0x98a0c6ef2224342b2a8727ae5111fd000000000000000000000000000000000\""), EthBigInt(big.MustFromString("4314726344238778862224669783019953265742676409691641697694925658285796229120"))},
+		{[]byte("\"0x098a0c6ef2224342b2a8727ae5111fd000000000000000000000000000000000\""), EthBigInt(big.MustFromString("4314726344238778862224669783019953265742676409691641697694925658285796229120"))},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10170

## Proposed Changes
add tests that probe the ideas in the issue around Ethereum JSON-RPC responses should not include leading zero in hex
## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
