### PR TITLE
feath: eth json rpc: enforce valid hex spec

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -45,6 +45,13 @@ func (e *EthUint64) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
+	if !startsWith0x(s) {
+		return fmt.Errorf("EthNonce UnmarshalJSON on %s failed, must start with 0x", s)
+	}
+	if hasLeadingZeroes(s) {
+		return fmt.Errorf("EthUint64 UnmarshalJSON on %s failed, must not have a leading 0x0 before the value", s)
+	}
+
 	parsedInt, err := strconv.ParseUint(strings.Replace(s, "0x", "", -1), 16, 64)
 	if err != nil {
 		return err
@@ -55,6 +62,12 @@ func (e *EthUint64) UnmarshalJSON(b []byte) error {
 }
 
 func EthUint64FromHex(s string) (EthUint64, error) {
+	if !startsWith0x(s) {
+		return EthUint64(0), fmt.Errorf("%s is not a valid input for EthUint64FromHex, must start with 0x", s)
+	}
+	if hasLeadingZeroes(s) {
+		return EthUint64(0), fmt.Errorf("%s is not a valid input for EthUint64FromHex, must not have a leading 0x0 before the value", s)
+	}
 	parsedInt, err := strconv.ParseUint(strings.Replace(s, "0x", "", -1), 16, 64)
 	if err != nil {
 		return EthUint64(0), err
@@ -81,10 +94,27 @@ func (e EthBigInt) MarshalJSON() ([]byte, error) {
 	return json.Marshal(fmt.Sprintf("0x%x", e.Int))
 }
 
+//hasLeadingZeroes returns true if s starts with 0x0 and is len 4 or longer
+func hasLeadingZeroes(s string) bool {
+	// Must be 3 or longer to start with 0x0 and 0x0 is valid
+	return strings.HasPrefix(s, "0x0") && len(s) > 3
+}
+
+//startsWith0x returns true if s starts with 0x and is valid hex
+func startsWith0x(s string) bool {
+	return strings.HasPrefix(s, "0x") && len(s) > 2
+}
+
 func (e *EthBigInt) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
+	}
+	if !startsWith0x(s) {
+		return fmt.Errorf("EthBigInt UnmarshalJSON on %s failed, must start with 0x", s)
+	}
+	if hasLeadingZeroes(s) {
+		return fmt.Errorf("EthBigInt UnmarshalJSON on %s failed, must not have a leading 0x0 before the value", s)
 	}
 
 	replaced := strings.Replace(s, "0x", "", -1)
@@ -234,6 +264,9 @@ func (n *EthNonce) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
+	}
+	if !startsWith0x(s) {
+		return fmt.Errorf("EthNonce UnmarshalJSON on %s failed, must start with 0x", s)
 	}
 
 	s = strings.Replace(s, "0x", "", -1)


### PR DESCRIPTION
 ethereum json rpc api spec in EthUint64, EthBigInt, and EthNonce that hex data  must begin with "0x" and leading zeros ie 0x0001 are invalid hex

## Related Issues
https://github.com/filecoin-project/lotus/issues/10170

## Proposed Changes
enforce hex formatting requirements in constructors and unmarshalls for eth numbers

## Additional Info


## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
