### PR TITLE
eth: FIP-0055: implement final version of transitory delegated signature.

### DIFF
--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -117,14 +117,7 @@ func EthTxArgsFromUnsignedEthMessage(msg *types.Message) (EthTxArgs, error) {
 		default:
 			return EthTxArgs{}, fmt.Errorf("unsupported EAM method")
 		}
-	} else {
-		if msg.Method != builtintypes.MethodsEVM.InvokeContract {
-			return EthTxArgs{},
-				xerrors.Errorf("invalid methodnum %d: only allowed non-send method is InvokeContract(%d)",
-					msg.Method,
-					builtintypes.MethodsEVM.InvokeContract)
-		}
-
+	} else if msg.Method == builtintypes.MethodsEVM.InvokeContract {
 		addr, err := EthAddressFromFilecoinAddress(msg.To)
 		if err != nil {
 			return EthTxArgs{}, err
@@ -137,6 +130,10 @@ func EthTxArgsFromUnsignedEthMessage(msg *types.Message) (EthTxArgs, error) {
 				return EthTxArgs{}, xerrors.Errorf("failed to read params byte array: %w", err)
 			}
 		}
+	} else {
+		return EthTxArgs{},
+			xerrors.Errorf("invalid methodnum %d: only allowed method is InvokeContract(%d)",
+				msg.Method, builtintypes.MethodsEVM.InvokeContract)
 	}
 
 	if paramsReader.Len() != 0 {

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -131,9 +131,11 @@ func EthTxArgsFromUnsignedEthMessage(msg *types.Message) (EthTxArgs, error) {
 		}
 		to = &addr
 
-		params, err = cbg.ReadByteArray(paramsReader, uint64(len(msg.Params)))
-		if err != nil {
-			return EthTxArgs{}, xerrors.Errorf("failed to read params byte array: %w", err)
+		if len(msg.Params) > 0 {
+			params, err = cbg.ReadByteArray(paramsReader, uint64(len(msg.Params)))
+			if err != nil {
+				return EthTxArgs{}, xerrors.Errorf("failed to read params byte array: %w", err)
+			}
 		}
 	}
 
@@ -181,11 +183,13 @@ func (tx *EthTxArgs) ToUnsignedMessage(from address.Address) (*types.Message, er
 		if err != nil {
 			return nil, xerrors.Errorf("failed to convert To into filecoin addr: %w", err)
 		}
-		buf := new(bytes.Buffer)
-		if err = cbg.WriteByteArray(buf, tx.Input); err != nil {
-			return nil, xerrors.Errorf("failed to write input args: %w", err)
+		if len(tx.Input) > 0 {
+			buf := new(bytes.Buffer)
+			if err = cbg.WriteByteArray(buf, tx.Input); err != nil {
+				return nil, xerrors.Errorf("failed to write input args: %w", err)
+			}
+			params = buf.Bytes()
 		}
-		params = buf.Bytes()
 	}
 
 	return &types.Message{

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -137,7 +137,7 @@ func TestPlaceholderPromotion(t *testing.T) {
 }
 
 // Tests that an placeholder turns into an EthAccout even if the message fails
-func TestEthAccountAbstractionFailure(t *testing.T) {
+func TestPlaceholderPromotionFailure(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
@@ -154,9 +154,10 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 
 	// create a placeholder actor at the target address
 	msgCreatePlaceholder := &types.Message{
-		From:  client.DefaultKey.Address,
-		To:    placeholderAddress,
-		Value: abi.TokenAmount(types.MustParseFIL("100")),
+		From:   client.DefaultKey.Address,
+		To:     placeholderAddress,
+		Value:  abi.TokenAmount(types.MustParseFIL("100")),
+		Method: builtin2.MethodsEVM.InvokeContract,
 	}
 	smCreatePlaceholder, err := client.MpoolPushMessage(ctx, msgCreatePlaceholder, nil)
 	require.NoError(t, err)
@@ -174,9 +175,10 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 
 	// send a message from the placeholder address
 	msgFromPlaceholder := &types.Message{
-		From:  placeholderAddress,
-		To:    placeholderAddress,
-		Value: abi.TokenAmount(types.MustParseFIL("20")),
+		From:   placeholderAddress,
+		To:     placeholderAddress,
+		Value:  abi.TokenAmount(types.MustParseFIL("20")),
+		Method: builtin2.MethodsEVM.InvokeContract,
 	}
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
 	require.NoError(t, err)
@@ -211,10 +213,11 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 	// Send a valid message now, it should succeed without any code CID changes
 
 	msgFromPlaceholder = &types.Message{
-		From:  placeholderAddress,
-		To:    placeholderAddress,
-		Nonce: 1,
-		Value: abi.NewTokenAmount(1),
+		From:   placeholderAddress,
+		To:     placeholderAddress,
+		Nonce:  1,
+		Value:  abi.NewTokenAmount(1),
+		Method: builtin2.MethodsEVM.InvokeContract,
 	}
 
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
@@ -247,7 +250,7 @@ func TestEthAccountAbstractionFailure(t *testing.T) {
 }
 
 // Tests that f4 addresess that aren't placeholders/ethaccounts can't be top-level senders
-func TestEthAccountAbstractionFailsFromEvmActor(t *testing.T) {
+func TestPlaceholderPromotionFailsFromEvmActor(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/filecoin-project/lotus/itests/kit"
 )
 
-// TestEthAccountAbstraction goes over the account abstraction workflow:
+// TestPlaceholderPromotion goes over the placeholder creation and promotion workflow:
 // - an placeholder is created when it receives a message
 // - the placeholder turns into an EOA when it sends a message
-func TestEthAccountAbstraction(t *testing.T) {
+func TestPlaceholderPromotion(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
@@ -67,7 +67,8 @@ func TestEthAccountAbstraction(t *testing.T) {
 	msgFromPlaceholder := &types.Message{
 		From: placeholderAddress,
 		// self-send because an "eth tx payload" can't be to a filecoin address?
-		To: placeholderAddress,
+		To:     placeholderAddress,
+		Method: builtin2.MethodsEVM.InvokeContract,
 	}
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)
 	require.NoError(t, err)
@@ -100,9 +101,10 @@ func TestEthAccountAbstraction(t *testing.T) {
 	// Send another message, it should succeed without any code CID changes
 
 	msgFromPlaceholder = &types.Message{
-		From:  placeholderAddress,
-		To:    placeholderAddress,
-		Nonce: 1,
+		From:   placeholderAddress,
+		To:     placeholderAddress,
+		Method: builtin2.MethodsEVM.InvokeContract,
+		Nonce:  1,
 	}
 
 	msgFromPlaceholder, err = client.GasEstimateMessageGas(ctx, msgFromPlaceholder, nil, types.EmptyTSK)

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/filecoin-project/lotus/itests/kit"
 )
 
-// TestPlaceholderPromotion goes over the placeholder creation and promotion workflow:
+// TestEthAccountAbstraction goes over the placeholder creation and promotion workflow:
 // - an placeholder is created when it receives a message
 // - the placeholder turns into an EOA when it sends a message
-func TestPlaceholderPromotion(t *testing.T) {
+func TestEthAccountAbstraction(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
@@ -137,7 +137,7 @@ func TestPlaceholderPromotion(t *testing.T) {
 }
 
 // Tests that an placeholder turns into an EthAccout even if the message fails
-func TestPlaceholderPromotionFailure(t *testing.T) {
+func TestEthAccountAbstractionFailure(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
@@ -250,7 +250,7 @@ func TestPlaceholderPromotionFailure(t *testing.T) {
 }
 
 // Tests that f4 addresess that aren't placeholders/ethaccounts can't be top-level senders
-func TestPlaceholderPromotionFailsFromEvmActor(t *testing.T) {
+func TestEthAccountAbstractionFailsFromEvmActor(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -806,7 +806,7 @@ func TestFEVMBareTransferTriggersSmartContractLogic(t *testing.T) {
 	gaslimit, err := client.EthEstimateGas(ctx, ethtypes.EthCall{
 		From:  &accntEth,
 		To:    &contractEth,
-		Value: ethtypes.EthBigInt(types.FromFil(1)),
+		Value: ethtypes.EthBigInt(big.NewInt(100)),
 	})
 	require.NoError(t, err)
 
@@ -833,12 +833,13 @@ func TestFEVMBareTransferTriggersSmartContractLogic(t *testing.T) {
 	var receipt *api.EthTxReceipt
 	for i := 0; i < 1000; i++ {
 		receipt, err = client.EthGetTransactionReceipt(ctx, hash)
-		if err != nil || receipt == nil {
-			time.Sleep(500 * time.Millisecond)
-			continue
+		require.NoError(t, err)
+		if receipt != nil {
+			break
 		}
-		break
+		time.Sleep(500 * time.Millisecond)
 	}
 
+	// The receive() function emits one log, that's how we know we hit it.
 	require.Len(t, receipt.Logs, 1)
 }

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -233,33 +233,33 @@ func TestFEVMDelegateCall(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/DelegatecallActor.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
-	// install contract Storage
+	//install contract Storage
 	filenameStorage := "contracts/DelegatecallStorage.hex"
 	fromAddrStorage, storageAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 	require.Equal(t, fromAddr, fromAddrStorage)
 
-	// call Contract Storage which makes a delegatecall to contract Actor
-	// this contract call sets the "counter" variable to 7, from default value 0
+	//call Contract Storage which makes a delegatecall to contract Actor
+	//this contract call sets the "counter" variable to 7, from default value 0
 	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
 	inputDataValue := inputDataFromArray([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
-	// verify that the returned value of the call to setvars is 7
+	//verify that the returned value of the call to setvars is 7
 	result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, storageAddr, "setVars(address,uint256)", inputData)
 	require.NoError(t, err)
 	expectedResult, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000007")
 	require.NoError(t, err)
 	require.Equal(t, result, expectedResult)
 
-	// test the value is 7 a second way by calling the getter
+	//test the value is 7 a second way by calling the getter
 	result, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, storageAddr, "getCounter()", []byte{})
 	require.NoError(t, err)
 	require.Equal(t, result, expectedResult)
 
-	// test the value is 0 via calling the getter on the Actor contract
+	//test the value is 0 via calling the getter on the Actor contract
 	result, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, actorAddr, "getCounter()", []byte{})
 	require.NoError(t, err)
 	expectedResultActor, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
@@ -273,34 +273,34 @@ func TestFEVMDelegateCallRevert(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/DelegatecallActor.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
-	// install contract Storage
+	//install contract Storage
 	filenameStorage := "contracts/DelegatecallStorage.hex"
 	fromAddrStorage, storageAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 	require.Equal(t, fromAddr, fromAddrStorage)
 
-	// call Contract Storage which makes a delegatecall to contract Actor
-	// this contract call sets the "counter" variable to 7, from default value 0
+	//call Contract Storage which makes a delegatecall to contract Actor
+	//this contract call sets the "counter" variable to 7, from default value 0
 
 	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
 	inputDataValue := inputDataFromArray([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
-	// verify that the returned value of the call to setvars is 7
+	//verify that the returned value of the call to setvars is 7
 	_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, storageAddr, "setVarsRevert(address,uint256)", inputData)
 	require.Error(t, err)
 	require.Equal(t, exitcode.ExitCode(33), wait.Receipt.ExitCode)
 
-	// test the value is 0 via calling the getter and was not set to 7
+	//test the value is 0 via calling the getter and was not set to 7
 	expectedResult, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(t, err)
 	result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, storageAddr, "getCounter()", []byte{})
 	require.NoError(t, err)
 	require.Equal(t, result, expectedResult)
 
-	// test the value is 0 via calling the getter on the Actor contract
+	//test the value is 0 via calling the getter on the Actor contract
 	result, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, actorAddr, "getCounter()", []byte{})
 	require.NoError(t, err)
 	require.Equal(t, result, expectedResult)
@@ -311,11 +311,11 @@ func TestFEVMSimpleRevert(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameStorage := "contracts/DelegatecallStorage.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// call revert
+	//call revert
 	_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "revert()", []byte{})
 
 	require.Equal(t, wait.Receipt.ExitCode, exitcode.ExitCode(33))
@@ -327,15 +327,15 @@ func TestFEVMSelfDestruct(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameStorage := "contracts/SelfDestruct.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// call destroy
+	//call destroy
 	_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "destroy()", []byte{})
 	require.NoError(t, err)
 
-	// call destroy a second time and also no error
+	//call destroy a second time and also no error
 	_, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "destroy()", []byte{})
 	require.NoError(t, err)
 }
@@ -345,7 +345,7 @@ func TestFEVMTestApp(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameStorage := "contracts/TestApp.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
@@ -367,11 +367,11 @@ func TestFEVMTestConstructor(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameStorage := "contracts/Constructor.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// input = uint256{7}. set value and confirm tx success
+	//input = uint256{7}. set value and confirm tx success
 	inputData, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000007")
 	require.NoError(t, err)
 	_, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "new_Test(uint256)", inputData)
@@ -384,11 +384,11 @@ func TestFEVMAutoSelfDestruct(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameStorage := "contracts/AutoSelfDestruct.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// call destroy
+	//call destroy
 	_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "destroy()", []byte{})
 	require.NoError(t, err)
 }
@@ -401,16 +401,16 @@ func TestFEVMTestSendToContract(t *testing.T) {
 	bal, err := client.WalletBalance(ctx, client.DefaultKey.Address)
 	require.NoError(t, err)
 
-	// install contract TestApp
+	//install contract TestApp
 	filenameStorage := "contracts/SelfDestruct.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// transfer half balance to contract
+	//transfer half balance to contract
 
 	sendAmount := big.Div(bal, big.NewInt(2))
 	client.EVM().TransferValueOrFail(ctx, fromAddr, contractAddr, sendAmount)
 
-	// call self destruct which should return balance
+	//call self destruct which should return balance
 	_, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "destroy()", []byte{})
 	require.NoError(t, err)
 
@@ -431,7 +431,7 @@ func TestFEVMTestNotPayable(t *testing.T) {
 	fromAddr := client.DefaultKey.Address
 	t.Log("from - ", fromAddr)
 
-	// create contract A
+	//create contract A
 	filenameStorage := "contracts/NotPayable.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 	sendAmount := big.NewInt(10_000_000)
@@ -445,7 +445,7 @@ func TestFEVMSendCall(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract
+	//install contract
 	filenameActor := "contracts/GasSendTest.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
@@ -460,12 +460,12 @@ func TestFEVMSendGasLimit(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract
+	//install contract
 	filenameActor := "contracts/GasLimitSend.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
-	// send $ to contract
-	// transfer 1 attoFIL to contract
+	//send $ to contract
+	//transfer 1 attoFIL to contract
 	sendAmount := big.MustFromString("1")
 
 	client.EVM().TransferValueOrFail(ctx, fromAddr, contractAddr, sendAmount)
@@ -476,26 +476,26 @@ func TestFEVMSendGasLimit(t *testing.T) {
 
 // TestFEVMDelegateCall deploys the two contracts in TestFEVMDelegateCall but instead of A calling B, A calls A which should cause A to cause A in an infinite loop and should give a reasonable error
 func TestFEVMDelegateCallRecursiveFail(t *testing.T) {
-	// TODO change the gas limit of this invocation and confirm that the number of errors is
+	//TODO change the gas limit of this invocation and confirm that the number of errors is
 	// different
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/DelegatecallStorage.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
-	// any data will do for this test that fails
+	//any data will do for this test that fails
 	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
 	inputDataValue := inputDataFromArray([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
-	// verify that we run out of gas then revert.
+	//verify that we run out of gas then revert.
 	_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, actorAddr, "setVarsSelf(address,uint256)", inputData)
 	require.Error(t, err)
 	require.Equal(t, exitcode.ExitCode(33), wait.Receipt.ExitCode)
 
-	// assert no fatal errors but still there are errors::
+	//assert no fatal errors but still there are errors::
 	errorAny := "fatal error"
 	require.NotContains(t, err.Error(), errorAny)
 }
@@ -510,11 +510,11 @@ func TestFEVMTestSendValueThroughContractsAndDestroy(t *testing.T) {
 	fromAddr := client.DefaultKey.Address
 	t.Log("from - ", fromAddr)
 
-	// create contract A
+	//create contract A
 	filenameStorage := "contracts/ValueSender.hex"
 	fromAddr, contractAddr := client.EVM().DeployContractFromFilename(ctx, filenameStorage)
 
-	// create contract B
+	//create contract B
 	ret, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "createB()", []byte{})
 	require.NoError(t, err)
 
@@ -524,7 +524,7 @@ func TestFEVMTestSendValueThroughContractsAndDestroy(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("contractBAddress - ", contractBAddress)
 
-	// self destruct contract B
+	//self destruct contract B
 	_, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractBAddress, "selfDestruct()", []byte{})
 	require.NoError(t, err)
 
@@ -542,7 +542,7 @@ func TestFEVMRecursiveFuncCall(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/StackFunc.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
@@ -567,7 +567,7 @@ func TestFEVMRecursiveActorCall(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/RecCall.hex"
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
@@ -616,7 +616,7 @@ func TestFEVMRecursiveActorCallEstimate(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// install contract Actor
+	//install contract Actor
 	filenameActor := "contracts/ExternalRecursiveCallSimple.hex"
 	_, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
@@ -713,8 +713,8 @@ func TestFEVMDeployWithValue(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// testValue is the amount sent when the contract is created
-	// at the end we check that the new contract has a balance of testValue
+	//testValue is the amount sent when the contract is created
+	//at the end we check that the new contract has a balance of testValue
 	testValue := big.NewInt(20)
 
 	// deploy DeployValueTest which creates NewContract
@@ -723,14 +723,14 @@ func TestFEVMDeployWithValue(t *testing.T) {
 	filenameActor := "contracts/DeployValueTest.hex"
 	fromAddr, idAddr := client.EVM().DeployContractFromFilenameWithValue(ctx, filenameActor, testValue)
 
-	// call getNewContractBalance to find the value of NewContract
+	//call getNewContractBalance to find the value of NewContract
 	ret, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "getNewContractBalance()", []byte{})
 	require.NoError(t, err)
 
 	contractBalance, err := decodeOutputToUint64(ret)
 	require.NoError(t, err)
 
-	// require balance of NewContract is testValue
+	//require balance of NewContract is testValue
 	require.Equal(t, testValue.Uint64(), contractBalance)
 }
 
@@ -738,39 +738,39 @@ func TestFEVMDestroyCreate2(t *testing.T) {
 	ctx, cancel, client := kit.SetupFEVMTest(t)
 	defer cancel()
 
-	// deploy create2 factory contract
+	//deploy create2 factory contract
 	filename := "contracts/Create2Factory.hex"
 	fromAddr, idAddr := client.EVM().DeployContractFromFilename(ctx, filename)
 
-	// construct salt for create2
+	//construct salt for create2
 	salt := make([]byte, 32)
 	_, err := rand.Read(salt)
 	require.NoError(t, err)
 
-	// deploy contract using create2 factory
+	//deploy contract using create2 factory
 	selfDestructAddress, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "deploy(bytes32)", salt)
 	require.NoError(t, err)
 
-	// convert to filecoin actor address so we can call InvokeContractByFuncName
+	//convert to filecoin actor address so we can call InvokeContractByFuncName
 	ea, err := ethtypes.CastEthAddress(selfDestructAddress[12:])
 	require.NoError(t, err)
 	selfDestructAddressActor, err := ea.ToFilecoinAddress()
 	require.NoError(t, err)
 
-	// read sender property from contract
+	//read sender property from contract
 	ret, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, selfDestructAddressActor, "sender()", []byte{})
 	require.NoError(t, err)
 
-	// assert contract has correct data
+	//assert contract has correct data
 	ethFromAddr := inputDataFromFrom(ctx, t, client, fromAddr)
 	require.Equal(t, ethFromAddr, ret)
 
-	// run test() which 1.calls sefldestruct 2. verifies sender() is the correct value 3. attempts and fails to deploy via create2
+	//run test() which 1.calls sefldestruct 2. verifies sender() is the correct value 3. attempts and fails to deploy via create2
 	testSenderAddress, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "test(address)", selfDestructAddress)
 	require.NoError(t, err)
 	require.Equal(t, testSenderAddress, ethFromAddr)
 
-	// read sender() but get response of 0x0 because of self destruct
+	//read sender() but get response of 0x0 because of self destruct
 	senderAfterDestroy, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, selfDestructAddressActor, "sender()", []byte{})
 	require.NoError(t, err)
 	require.Equal(t, []byte{}, senderAfterDestroy)
@@ -780,11 +780,11 @@ func TestFEVMDestroyCreate2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, newAddressSelfDestruct, selfDestructAddress)
 
-	// verify sender() property is correct
+	//verify sender() property is correct
 	senderSecondCall, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, selfDestructAddressActor, "sender()", []byte{})
 	require.NoError(t, err)
 
-	// assert contract has correct data
+	//assert contract has correct data
 	require.Equal(t, ethFromAddr, senderSecondCall)
 
 }

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/lotus/api"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
@@ -19,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/manifest"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"

--- a/itests/kit/evm.go
+++ b/itests/kit/evm.go
@@ -354,7 +354,7 @@ func SetupFEVMTest(t *testing.T) (context.Context, context.CancelFunc, *TestFull
 	return ctx, cancel, client
 }
 
-func (e *EVM) TransferValueOrFail(ctx context.Context, fromAddr address.Address, toAddr address.Address, sendAmount big.Int) {
+func (e *EVM) TransferValueOrFail(ctx context.Context, fromAddr address.Address, toAddr address.Address, sendAmount big.Int) *api.MsgLookup {
 	sendMsg := &types.Message{
 		From:  fromAddr,
 		To:    toAddr,
@@ -365,6 +365,7 @@ func (e *EVM) TransferValueOrFail(ctx context.Context, fromAddr address.Address,
 	mLookup, err := e.StateWaitMsg(ctx, signedMsg.Cid(), 3, api.LookbackNoLimit, true)
 	require.NoError(e.t, err)
 	require.Equal(e.t, exitcode.Ok, mLookup.Receipt.ExitCode)
+	return mLookup
 }
 
 func NewEthFilterBuilder() *EthFilterBuilder {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -755,11 +755,14 @@ func (a *EthModule) ethCallToFilecoinMessage(ctx context.Context, tx ethtypes.Et
 		}
 		to = addr
 
-		var buf bytes.Buffer
-		if err := cbg.WriteByteArray(&buf, tx.Data); err != nil {
-			return nil, fmt.Errorf("failed to encode tx input into a cbor byte-string")
+		if len(tx.Data) > 0 {
+			var buf bytes.Buffer
+			if err := cbg.WriteByteArray(&buf, tx.Data); err != nil {
+				return nil, fmt.Errorf("failed to encode tx input into a cbor byte-string")
+			}
+			params = buf.Bytes()
 		}
-		params = buf.Bytes()
+
 		method = builtintypes.MethodsEVM.InvokeContract
 	}
 

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -755,16 +755,12 @@ func (a *EthModule) ethCallToFilecoinMessage(ctx context.Context, tx ethtypes.Et
 		}
 		to = addr
 
-		if len(tx.Data) > 0 {
-			var buf bytes.Buffer
-			if err := cbg.WriteByteArray(&buf, tx.Data); err != nil {
-				return nil, fmt.Errorf("failed to encode tx input into a cbor byte-string")
-			}
-			params = buf.Bytes()
-			method = builtintypes.MethodsEVM.InvokeContract
-		} else {
-			method = builtintypes.MethodSend
+		var buf bytes.Buffer
+		if err := cbg.WriteByteArray(&buf, tx.Data); err != nil {
+			return nil, fmt.Errorf("failed to encode tx input into a cbor byte-string")
 		}
+		params = buf.Bytes()
+		method = builtintypes.MethodsEVM.InvokeContract
 	}
 
 	return &types.Message{


### PR DESCRIPTION
We now only accept two methods on delegated signatures:

- `EAM#CreateExternal` on contract deployment.
- `EVM#InvokeContract` otherwise.

Support for bare sends (method 0) via Eth messages has been dropped, so as to always trigger smart contract logic via `EVM#InvokeContract`.

This PR also adds a test to verify that's the case.

Next week, we should look at cleaning up and consolidating EVM tests. They have grown organically, many private utility functions have sprouted here and there that belong in the itests kit, and I'm not happy with how we're using time to poll for transaction receipts (even though that's how Ethereum tools do it, so in theory it's the most realistic way of testing).

## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
