### PR TITLE
chore: market: disable lotus market by default as the service is EOL by Jan 31, 2023.

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -143,7 +143,7 @@
 
   # type: bool
   # env var: LOTUS_SUBSYSTEMS_ENABLEMARKETS
-  #EnableMarkets = true
+  #EnableMarkets = false
 
   # type: string
   # env var: LOTUS_SUBSYSTEMS_SEALERAPIINFO
@@ -159,37 +159,37 @@
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDERONLINESTORAGEDEALS
-  #ConsiderOnlineStorageDeals = true
+  #ConsiderOnlineStorageDeals = false
 
   # When enabled, the miner can accept offline deals
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDEROFFLINESTORAGEDEALS
-  #ConsiderOfflineStorageDeals = true
+  #ConsiderOfflineStorageDeals = false
 
   # When enabled, the miner can accept retrieval deals
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDERONLINERETRIEVALDEALS
-  #ConsiderOnlineRetrievalDeals = true
+  #ConsiderOnlineRetrievalDeals = false
 
   # When enabled, the miner can accept offline retrieval deals
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDEROFFLINERETRIEVALDEALS
-  #ConsiderOfflineRetrievalDeals = true
+  #ConsiderOfflineRetrievalDeals = false
 
   # When enabled, the miner can accept verified deals
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDERVERIFIEDSTORAGEDEALS
-  #ConsiderVerifiedStorageDeals = true
+  #ConsiderVerifiedStorageDeals = false
 
   # When enabled, the miner can accept unverified deals
   #
   # type: bool
   # env var: LOTUS_DEALMAKING_CONSIDERUNVERIFIEDSTORAGEDEALS
-  #ConsiderUnverifiedStorageDeals = true
+  #ConsiderUnverifiedStorageDeals = false
 
   # A list of Data CIDs to reject when making deals
   #
@@ -288,7 +288,7 @@
 
     [Dealmaking.RetrievalPricing.Default]
       # env var: LOTUS_DEALMAKING_RETRIEVALPRICING_DEFAULT_VERIFIEDDEALSFREETRANSFER
-      #VerifiedDealsFreeTransfer = true
+      #VerifiedDealsFreeTransfer = false
 
     [Dealmaking.RetrievalPricing.External]
       # env var: LOTUS_DEALMAKING_RETRIEVALPRICING_EXTERNAL_PATH
@@ -301,7 +301,7 @@
   #
   # type: bool
   # env var: LOTUS_INDEXPROVIDER_ENABLE
-  #Enable = true
+  #Enable = false
 
   # EntriesCacheCapacity sets the maximum capacity to use for caching the indexing advertisement
   # entries. Defaults to 1024 if not specified. The cache is evicted using LRU policy. The

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -181,12 +181,12 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		Dealmaking: DealmakingConfig{
-			ConsiderOnlineStorageDeals:     true,
-			ConsiderOfflineStorageDeals:    true,
-			ConsiderOnlineRetrievalDeals:   true,
-			ConsiderOfflineRetrievalDeals:  true,
-			ConsiderVerifiedStorageDeals:   true,
-			ConsiderUnverifiedStorageDeals: true,
+			ConsiderOnlineStorageDeals:     false,
+			ConsiderOfflineStorageDeals:    false,
+			ConsiderOnlineRetrievalDeals:   false,
+			ConsiderOfflineRetrievalDeals:  false,
+			ConsiderVerifiedStorageDeals:   false,
+			ConsiderUnverifiedStorageDeals: false,
 			PieceCidBlocklist:              []cid.Cid{},
 			// TODO: It'd be nice to set this based on sector size
 			MaxDealStartDelay:               Duration(time.Hour * 24 * 14),
@@ -204,7 +204,7 @@ func DefaultStorageMiner() *StorageMiner {
 			RetrievalPricing: &RetrievalPricing{
 				Strategy: RetrievalPricingDefaultMode,
 				Default: &RetrievalPricingDefault{
-					VerifiedDealsFreeTransfer: true,
+					VerifiedDealsFreeTransfer: false,
 				},
 				External: &RetrievalPricingExternal{
 					Path: "",
@@ -213,7 +213,7 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		IndexProvider: IndexProviderConfig{
-			Enable:               true,
+			Enable:               false,
 			EntriesCacheCapacity: 1024,
 			EntriesChunkSize:     16384,
 			// The default empty TopicName means it is inferred from network name, in the following
@@ -226,7 +226,7 @@ func DefaultStorageMiner() *StorageMiner {
 			EnableMining:        true,
 			EnableSealing:       true,
 			EnableSectorStorage: true,
-			EnableMarkets:       true,
+			EnableMarkets:       false,
 		},
 
 		Fees: MinerFeeConfig{


### PR DESCRIPTION
As announced in 2022 November, we are deprecating lotus market support by Jan 31, 2023, and users are encouraged to migrate to lotus miner compatible deal-making focused software like boost.