### PR TITLE
Eth JSON-RPC: populate reward in eth_feeHistory

### DIFF
--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -44,6 +44,15 @@ type EthTx struct {
 	S                    EthBigInt   `json:"s"`
 }
 
+func (tx *EthTx) Reward(blkBaseFee big.Int) EthBigInt {
+	effectivePriorityFee := big.NewInt(0)
+	effectivePriorityFee.Sub(tx.MaxFeePerGas.Int, blkBaseFee.Int)
+	if tx.MaxPriorityFeePerGas.Int.Cmp(effectivePriorityFee.Int) <= 0 {
+		return tx.MaxPriorityFeePerGas
+	}
+	return EthBigInt(effectivePriorityFee)
+}
+
 type EthTxArgs struct {
 	ChainID              int         `json:"chainId"`
 	Nonce                int         `json:"nonce"`

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -45,12 +45,11 @@ type EthTx struct {
 }
 
 func (tx *EthTx) Reward(blkBaseFee big.Int) EthBigInt {
-	effectivePriorityFee := big.NewInt(0)
-	effectivePriorityFee.Sub(tx.MaxFeePerGas.Int, blkBaseFee.Int)
-	if tx.MaxPriorityFeePerGas.Int.Cmp(effectivePriorityFee.Int) <= 0 {
+	availablePriorityFee := big.Sub(big.Int(tx.MaxFeePerGas), blkBaseFee)
+	if big.Cmp(big.Int(tx.MaxPriorityFeePerGas), availablePriorityFee) <= 0 {
 		return tx.MaxPriorityFeePerGas
 	}
-	return EthBigInt(effectivePriorityFee)
+	return EthBigInt(availablePriorityFee)
 }
 
 type EthTxArgs struct {

--- a/itests/eth_fee_history_test.go
+++ b/itests/eth_fee_history_test.go
@@ -37,6 +37,7 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(16-5+1), history.OldestBlock)
+	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{"5", "0x10"}),
@@ -45,6 +46,7 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(16-5+1), history.OldestBlock)
+	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{"0x10", "0x12"}),
@@ -53,6 +55,7 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(17, len(history.BaseFeePerGas))
 	require.Equal(16, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(18-16+1), history.OldestBlock)
+	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{5, "0x10"}),
@@ -61,6 +64,7 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(16-5+1), history.OldestBlock)
+	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{5, "10"}),
@@ -69,19 +73,28 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(10-5+1), history.OldestBlock)
+	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
-		json.Marshal([]interface{}{5, "10", &[]float64{0.25, 0.50, 0.75}}),
+		json.Marshal([]interface{}{5, "10", &[]float64{25, 50, 75}}),
 	).Assert(require.NoError))
 	require.NoError(err)
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(10-5+1), history.OldestBlock)
 	require.NotNil(history.Reward)
-	require.Equal(0, len(*history.Reward))
+	require.Equal(5, len(*history.Reward))
+	for _, arr := range *history.Reward {
+		require.Equal(3, len(arr))
+	}
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
-		json.Marshal([]interface{}{1025, "10", &[]float64{0.25, 0.50, 0.75}}),
+		json.Marshal([]interface{}{1025, "10", &[]float64{25, 50, 75}}),
 	).Assert(require.NoError))
 	require.Error(err)
+
+	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
+		json.Marshal([]interface{}{5, "10", &[]float64{}}),
+	).Assert(require.NoError))
+	require.NoError(err)
 }

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -2176,7 +2176,7 @@ func calculateRewardsAndGasUsed(rewardPercentiles []float64, txGasRewards gasRew
 		return rewards, totalGasUsed
 	}
 
-	sort.Sort(txGasRewards)
+	sort.Stable(txGasRewards)
 
 	var idx int
 	var sum uint64

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-state-types/big"
+
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
@@ -99,4 +101,66 @@ func TestEthLogFromEvent(t *testing.T) {
 	require.Nil(t, data)
 	require.Len(t, topics, 1)
 	require.Equal(t, topics[0], ethtypes.EthHash{})
+}
+
+func TestReward(t *testing.T) {
+	baseFee := big.NewInt(100)
+	testcases := []struct {
+		maxFeePerGas, maxPriorityFeePerGas big.Int
+		answer                             big.Int
+	}{
+		{maxFeePerGas: big.NewInt(600), maxPriorityFeePerGas: big.NewInt(200), answer: big.NewInt(200)},
+		{maxFeePerGas: big.NewInt(600), maxPriorityFeePerGas: big.NewInt(300), answer: big.NewInt(300)},
+		{maxFeePerGas: big.NewInt(600), maxPriorityFeePerGas: big.NewInt(500), answer: big.NewInt(500)},
+		{maxFeePerGas: big.NewInt(600), maxPriorityFeePerGas: big.NewInt(600), answer: big.NewInt(500)},
+		{maxFeePerGas: big.NewInt(600), maxPriorityFeePerGas: big.NewInt(1000), answer: big.NewInt(500)},
+		{maxFeePerGas: big.NewInt(50), maxPriorityFeePerGas: big.NewInt(200), answer: big.NewInt(-50)},
+	}
+	for _, tc := range testcases {
+		tx := ethtypes.EthTx{
+			MaxFeePerGas:         ethtypes.EthBigInt(tc.maxFeePerGas),
+			MaxPriorityFeePerGas: ethtypes.EthBigInt(tc.maxPriorityFeePerGas),
+		}
+		reward := tx.Reward(baseFee)
+		require.Equal(t, 0, reward.Int.Cmp(tc.answer.Int), reward, tc.answer)
+	}
+}
+
+func TestRewardPercentiles(t *testing.T) {
+	testcases := []struct {
+		percentiles  []float64
+		txGasRewards gasRewardSorter
+		answer       []int64
+	}{
+		{
+			percentiles:  []float64{25, 50, 75},
+			txGasRewards: []gasRewardTuple{},
+			answer:       []int64{0, 0, 0},
+		},
+		{
+			percentiles: []float64{25, 50, 75},
+			txGasRewards: []gasRewardTuple{
+				{gas: uint64(0), reward: ethtypes.EthBigInt(big.NewInt(300))},
+				{gas: uint64(100), reward: ethtypes.EthBigInt(big.NewInt(200))},
+				{gas: uint64(350), reward: ethtypes.EthBigInt(big.NewInt(100))},
+				{gas: uint64(500), reward: ethtypes.EthBigInt(big.NewInt(600))},
+				{gas: uint64(300), reward: ethtypes.EthBigInt(big.NewInt(700))},
+			},
+			answer: []int64{200, 700, 700},
+		},
+	}
+	for _, tc := range testcases {
+		rewards, totalGasUsed := calRewardPercentiles(tc.percentiles, tc.txGasRewards)
+		gasUsed := uint64(0)
+		for _, tx := range tc.txGasRewards {
+			gasUsed += tx.gas
+		}
+		ans := []ethtypes.EthBigInt{}
+		for _, bi := range tc.answer {
+			ans = append(ans, ethtypes.EthBigInt(big.NewInt(bi)))
+		}
+		require.Equal(t, totalGasUsed, gasUsed)
+		require.Equal(t, len(ans), len(tc.percentiles))
+		require.Equal(t, ans, rewards)
+	}
 }

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -150,7 +150,7 @@ func TestRewardPercentiles(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		rewards, totalGasUsed := calRewardPercentiles(tc.percentiles, tc.txGasRewards)
+		rewards, totalGasUsed := calculateRewardsAndGasUsed(tc.percentiles, tc.txGasRewards)
 		gasUsed := uint64(0)
 		for _, tx := range tc.txGasRewards {
 			gasUsed += tx.gas

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -138,7 +138,7 @@ func TestRewardPercentiles(t *testing.T) {
 			answer:       []int64{0, 0, 0},
 		},
 		{
-			percentiles: []float64{25, 50, 75},
+			percentiles: []float64{25, 50, 75, 100},
 			txGasRewards: []gasRewardTuple{
 				{gas: uint64(0), reward: ethtypes.EthBigInt(big.NewInt(300))},
 				{gas: uint64(100), reward: ethtypes.EthBigInt(big.NewInt(200))},
@@ -146,7 +146,7 @@ func TestRewardPercentiles(t *testing.T) {
 				{gas: uint64(500), reward: ethtypes.EthBigInt(big.NewInt(600))},
 				{gas: uint64(300), reward: ethtypes.EthBigInt(big.NewInt(700))},
 			},
-			answer: []int64{200, 700, 700},
+			answer: []int64{200, 700, 700, 700},
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10236

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
