### PR TITLE
fix: stmgr: check message validity before invoking vm

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -107,6 +107,14 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 		}
 	}
 
+	// This isn't strictly necessary, but the underlying VM will assume that the message is
+	// valid and may not return helpful debugging information. Checking here makes message
+	// validity issues easier to debug.
+	nv := sm.GetNetworkVersion(ctx, ts.Height())
+	if err := msg.ValidForBlockInclusion(0, nv); err != nil {
+		return nil, xerrors.Errorf("message not valid for network version %d: %w", nv, err)
+	}
+
 	// Unless executing on a specific state cid, apply all the messages from the current tipset
 	// first. Unfortunately, we can't just execute the tipset, because that will run cron. We
 	// don't want to apply miner messages after cron runs in a given epoch.


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Otherwise we may, e.g., try to estimate gas on a message to an f4 address before the nv18 migration.

I'm _not_ checking the "prior messages" here as this is just a sanity check.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green