### PR TITLE
fix: tracer: emit raw peer ids for compatibility with libp2p tracer

### DIFF
--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -31,7 +31,7 @@ const (
 
 type LotusTraceEvent struct {
 	Type       pubsub_pb.TraceEvent_Type `json:"type,omitempty"`
-	PeerID     string                    `json:"peerID,omitempty"`
+	PeerID     []byte                    `json:"peerID,omitempty"`
 	Timestamp  *int64                    `json:"timestamp,omitempty"`
 	PeerScore  TraceEventPeerScore       `json:"peerScore,omitempty"`
 	SourceAuth string                    `json:"sourceAuth,omitempty"`
@@ -46,7 +46,7 @@ type TopicScore struct {
 }
 
 type TraceEventPeerScore struct {
-	PeerID             string       `json:"peerID"`
+	PeerID             []byte       `json:"peerID"`
 	Score              float64      `json:"score"`
 	AppSpecificScore   float64      `json:"appSpecificScore"`
 	IPColocationFactor float64      `json:"ipColocationFactor"`
@@ -77,11 +77,11 @@ func (lt *lotusTracer) PeerScores(scores map[peer.ID]*pubsub.PeerScoreSnapshot) 
 
 		evt := &LotusTraceEvent{
 			Type:       *TraceEventPeerScores.Enum(),
-			PeerID:     lt.pid.Pretty(),
+			PeerID:     []byte(lt.pid),
 			Timestamp:  &now,
 			SourceAuth: lt.sa,
 			PeerScore: TraceEventPeerScore{
-				PeerID:             pid.Pretty(),
+				PeerID:             []byte(pid),
 				Score:              score.Score,
 				AppSpecificScore:   score.AppSpecificScore,
 				IPColocationFactor: score.IPColocationFactor,
@@ -104,7 +104,6 @@ func (lt *lotusTracer) TraceLotusEvent(evt *LotusTraceEvent) {
 			log.Errorf("error while transporting peer scores: %s", err)
 		}
 	}
-
 }
 
 func (lt *lotusTracer) Trace(evt *pubsub_pb.TraceEvent) {

--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -77,8 +77,8 @@ func (lt *lotusTracer) PeerScores(scores map[peer.ID]*pubsub.PeerScoreSnapshot) 
 
 		evt := &LotusTraceEvent{
 			Type:       *TraceEventPeerScores.Enum(),
-			PeerID:     []byte(lt.pid),
 			Timestamp:  &now,
+			PeerID:     []byte(lt.pid),
 			SourceAuth: lt.sa,
 			PeerScore: TraceEventPeerScore{
 				PeerID:             []byte(pid),

--- a/node/modules/tracer/tracer_test.go
+++ b/node/modules/tracer/tracer_test.go
@@ -30,16 +30,15 @@ func (ttt *testTracerTransport) Transport(evt TracerTransportEvent) error {
 }
 
 func TestTracer_PeerScores(t *testing.T) {
-
 	testTransport := NewTestTraceTransport(t, func(t *testing.T, evt TracerTransportEvent) {
-		require.Equal(t, peerIDA.Pretty(), evt.lotusTraceEvent.PeerID)
+		require.Equal(t, []byte(peerIDA), evt.lotusTraceEvent.PeerID)
 		require.Equal(t, "source-auth-token-test", evt.lotusTraceEvent.SourceAuth)
 		require.Equal(t, float64(32), evt.lotusTraceEvent.PeerScore.Score)
 
 		n := time.Now().UnixNano()
 		require.LessOrEqual(t, *evt.lotusTraceEvent.Timestamp, n)
 
-		require.Equal(t, peerIDA.Pretty(), evt.lotusTraceEvent.PeerScore.PeerID)
+		require.Equal(t, []byte(peerIDA), evt.lotusTraceEvent.PeerScore.PeerID)
 		require.Equal(t, 1, len(evt.lotusTraceEvent.PeerScore.Topics))
 
 		topic := evt.lotusTraceEvent.PeerScore.Topics[0]
@@ -85,7 +84,6 @@ func TestTracer_PubSubTrace(t *testing.T) {
 		PeerID:    []byte(peerIDA),
 		Timestamp: &n,
 	})
-
 }
 
 func TestTracer_MultipleTransports(t *testing.T) {


### PR DESCRIPTION
## Related Issues
The pubsub tracer emits traces in JSON format or posts JSON documents to an opensearch endpoint. The traces are a combination of libp2p-pubsub traces and a custom LotusTraceEvent, intermixed in the JSON stream. The libp2p traces use `[]byte` as the type for peer IDs which, in JSON, is base64 encoded. 

The LotusTraceEvent type uses a `string` for peer IDs (prettified) which is emitted as-is in the JSON.

However clients have no sensible way to distinguish the two encodings, the stream consists of a mix of the two representations:

```
{"type":11,"peerID":"ACQIARIgTM4a29NqIGdalfumxVWLOB6hZ4xm0ybAT4giXOe8/G4=","timestamp":1676302327478329014,"graft": ... 
{"type":100,"peerID":"12D3KooWEzBS8UbFGKaHGcksuteyq363zdfHCNB9ZrEzuHbWTyQy","timestamp":1676302331378019221,"peerScore ...
```

If a client attempts to decode into a struct using a `[]byte` field they will get the base64 decoded bytes of the libp2p peer IDs and the garbled base64 decoding of the pretty peer ID emitted in LotusTraceEvent

If they use a string field, they get the pretty peer ID from LotusTraceEvent and a base64 encoded string for the libp2p traces. 

Since one supported client is ElasticSearch, there is not much scope for the user to decode the peer IDs properly.

Fix this by using `[]byte` and raw peer IDs in the LotusTraceEvent to retain compatibility the [pre-existing libp2p trace field type](https://github.com/libp2p/go-libp2p-pubsub/blob/master/pb/trace.pb.go#L100) 


## Proposed Changes
Change `LotusTraceEvent.PeerID` and `TraceEventPeerScore.PeerID` types to `[]byte`

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ x PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
