### PR TITLE
hyperspace: event index v1=>v2 speed up migration.

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -417,13 +417,15 @@ func (ei *EventIndex) RunMigration(from, to int) error {
 		return nil
 	}
 
+	log.Warnw("[migration v1=>v2] beginning transaction")
+
 	tx, err := ei.db.Begin()
 	if err != nil {
-		return err
+		return xerrors.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback() //nolint
 
-	if _, err = tx.Exec(`ALTER TABLE event_entry ADD COLUMN codec INTEGER`); err != nil {
+	if _, err := tx.Exec(`ALTER TABLE event_entry ADD COLUMN codec INTEGER`); err != nil {
 		return xerrors.Errorf("failed to alter table event_entry to add codec column: %w", err)
 	}
 
@@ -434,7 +436,7 @@ func (ei *EventIndex) RunMigration(from, to int) error {
 		return xerrors.Errorf("failed to update table event_entry to set codec 0x55: %w", err)
 	}
 	n, _ := res.RowsAffected()
-	log.Warnw("[migration v1=>v2] updated %d event entries with codec=0x55", "affected", n)
+	log.Warnw("[migration v1=>v2] updated event entries with codec=0x55", "affected", n)
 
 	var keyRewrites = [][]string{
 		{"topic1", "t1"},
@@ -454,7 +456,38 @@ func (ei *EventIndex) RunMigration(from, to int) error {
 		log.Warnw("[migration v1=>v2] rewrote entry keys", "from", from, "to", to, "affected", n)
 	}
 
-	update, err := tx.Prepare(`UPDATE event_entry SET value = ? WHERE value = ?`)
+	if _, err := tx.Exec(`DROP TABLE IF EXISTS event_entry_tmp`); err != nil {
+		return xerrors.Errorf("failed to drop old event_entry_tmp temporary table: %w", err)
+	}
+
+	if _, err := tx.Exec(`CREATE TABLE event_entry_tmp (
+		event_id INTEGER,
+		indexed INTEGER NOT NULL,
+		flags BLOB NOT NULL,
+		key TEXT NOT NULL,
+		codec INTEGER,
+		value BLOB NOT NULL
+	)`); err != nil {
+		return xerrors.Errorf("failed to create temporary table: %w", err)
+	}
+
+	// Copy over all data. We will run the iterator from this table.
+	if _, err := tx.Exec(`INSERT INTO event_entry_tmp SELECT * FROM event_entry`); err != nil {
+		return xerrors.Errorf("failed to copy over data: %w", err)
+	}
+
+	// Add an index on value.
+	if _, err := tx.Exec(`CREATE INDEX event_entry_value ON event_entry(value)`); err != nil {
+		return xerrors.Errorf("failed to create index on event_entry: %w", err)
+	}
+
+	// Add an index on event_id.
+	if _, err := tx.Exec(`CREATE INDEX event_entry_event_id ON event_entry(event_id)`); err != nil {
+		return xerrors.Errorf("failed to create index on event_entry: %w", err)
+	}
+
+	// Match by value to be extra safe.
+	update, err := tx.Prepare(`UPDATE event_entry SET value = ? WHERE event_id = ? and key = ?`)
 	if err != nil {
 		return xerrors.Errorf("failed to prepare update statement: %w", err)
 	}
@@ -468,21 +501,19 @@ func (ei *EventIndex) RunMigration(from, to int) error {
 		"t4": {},
 	}
 
-	if _, err = tx.Exec(`CREATE TABLE tmp AS SELECT key, value FROM event_entry`); err != nil {
-		return xerrors.Errorf("failed to create temporary table: %w", err)
-	}
-
-	// Pull the values out and process them in Go land before updating.
-	rows, err := tx.Query(`SELECT key, value FROM tmp`)
+	// Pull the values out out of the original table, process them in Go land before updating, and the update the v2 table.
+	rows, err := tx.Query(`SELECT event_id, key, value FROM event_entry_tmp`)
 	if err != nil {
 		return xerrors.Errorf("failed to select values: %w", err)
 	}
 
 	var i int
 	for rows.Next() {
+		var eventId int
 		var key string
 		var before []byte
-		if err := rows.Scan(&key, &before); err != nil {
+		if err := rows.Scan(&eventId, &key, &before); err != nil {
+			_ = rows.Close()
 			return xerrors.Errorf("failed to scan from query: %w", err)
 		}
 		reader := bytes.NewReader(before)
@@ -499,22 +530,29 @@ func (ei *EventIndex) RunMigration(from, to int) error {
 			copy(pvalue[32-len(after):], after)
 			after = pvalue
 		}
-		if _, err := update.Exec(after, before); err != nil {
-			return xerrors.Errorf("failed to scan from query: %w", err)
+		if _, err := update.Exec(after, eventId, key); err != nil {
+			log.Warnw("failed to update entry", "value_before", before, "value_after", after)
 		}
 
 		if i++; i%500 == 0 {
 			log.Warnw("[migration v1=>v2] processed values", "count", i)
 		}
 	}
+	_ = rows.Close()
 
 	log.Warnw("[migration v1=>v2] processed all values", "count", i)
 
-	if _, err = tx.Exec(`DROP TABLE tmp`); err != nil {
-		return xerrors.Errorf("failed to drop temporary table: %w", err)
+	if _, err := tx.Exec(`DROP INDEX event_entry_value`); err != nil {
+		log.Warnw("[migration v1=>v2] failed to drop index event_entry_value; ignoring")
 	}
 
-	log.Warnw("[migration v1=>v2] dropped temporary table")
+	if _, err := tx.Exec(`DROP INDEX event_entry_event_id`); err != nil {
+		log.Warnw("[migration v1=>v2] failed to drop index event_entry_event_id; ignoring")
+	}
+
+	if _, err = tx.Exec(`DROP TABLE event_entry_tmp`); err != nil {
+		return xerrors.Errorf("failed to drop original table: %w", err)
+	}
 
 	if _, err = tx.Exec(`INSERT INTO _meta (version) VALUES (2)`); err != nil {
 		return xerrors.Errorf("failed to update schema version: %w", err)


### PR DESCRIPTION
This fixes the slow event index v1=>v2 migration by:

* Adding temporary indices on the value and the event_id.
* Matching on value, event_id, and key when updating entries.

It also warns and moves on when we fail to update an entry.

## Speed on Macbook M1 Max

~5 seconds to migrate 230k entries from an event database that has accumulated events since genesis over various network versions.

```
2023-02-15T13:03:40.585Z	WARN	event_index	filter/index.go:495	[migration v1=>v2] processing values
2023-02-15T13:03:40.597Z	WARN	event_index	filter/index.go:538	[migration v1=>v2] processed values	{"count": 500}
2023-02-15T13:03:40.607Z	WARN	event_index	filter/index.go:538	[migration v1=>v2] processed values	{"count": 1000}
2023-02-15T13:03:40.618Z	WARN	event_index	filter/index.go:538	[migration v1=>v2] processed values	{"count": 1500}
2023-02-15T13:03:40.629Z	WARN	event_index	filter/index.go:538	[migration v1=>v2] processed values	{"count": 2000}
...
2023-02-15T13:03:45.547Z	WARN	event_index	filter/index.go:538	[migration v1=>v2] processed values	{"count": 238000}
2023-02-15T13:03:45.554Z	WARN	event_index	filter/index.go:543	[migration v1=>v2] processed all values	{"count": 238310}
2023-02-15T13:03:45.565Z	WARN	event_index	filter/index.go:561	[migration v1=>v2] schema version updated to v2
2023-02-15T13:03:45.626Z	WARN	event_index	filter/index.go:567	[migration v1=>v2] transaction committed; ALL DONE
```

## Tests

After loosening the event filter limits:

```
curl --location --request POST 'localhost:1234/rpc/v1' \
      --header 'Content-Type: application/json' \
      --data-raw '{
  "jsonrpc":"2.0",
  "method":"eth_getLogs",
  "params":[ { "fromBlock": "0x124F8" } ],
  "id":1
  }'

{"jsonrpc":"2.0","result":[{"address":"0xa526253ae512a6ce7586dc602e50a71b3fc2f56b","data":"0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b333434353435732e66696c000000000000000000000000000000000000000000","topics":["0xb7d29e911041e8d9b843369e890bcb72c9388692ba48b65ac54e7214c4c348f7","0x48e403c93f2fbf2c5c7c3a878a737d6aee2204963fe68dded825eae37ac1dea6"],"removed":false,"logIndex":"0x6","transactionIndex":"0x0","transactionHash":"0xf6433e1880e7b756aa1bcba2b4c3caeeb87a10bd87c3df0a90635b6589e899a7","blockHash":"0x0bcc8988ec3d08e61847ad48147b044facd637b3b813460270d931722fadf91f","blockNumber":"0x12511"},{"address":"0xc5c9fba1b420f4ad6d0662d08306551391c857bb","data":"0x0000000000000000000000008d5335accb417436c299f903d594f82ae3329f88","topics":["0xce0457fe73731f824cc272376169235128c118b49d344817417c6d108d155e82","0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2","0x3584ed15a91a84cde77798dfceea2e247e03b1adfa5ed0151d008c493e2dfca7"],"removed":false,"logIndex":"0x5","transactionIndex":"0x0","transactionHash":"0xf6433e1880e7b756aa1bcba2b4c3caeeb87a10bd87c3df0a90635b6589e899a7","blockHash":"0x0bcc8988ec3d08e61847ad48147b044facd637b3b813460270d931722fadf91f","blockNumber":"0x12511"},{"address":"0xc5c9fba1b420f4ad6d0662d08306551391c857bb","data":"0x000000000000000000000000a526253ae512a6ce7586dc602e50a71b3fc2f56b","topics":["0x335721b01866dc23fbee8b6b2c7b1e14d6f05c28cd35a2c934239f94095602a0","0x6a02c28edda64fa23c420e5bcb29fb33ba73714d8fca1f01d5f74ba189f08d5d"],"removed":false,"logIndex":"0x2","transactionIndex":"0x0","transactionHash":"0xf6433e1880e7b756aa1bcba2b4c3caeeb87a10bd87c3df0a90635b6589e899a7","blockHash":"0x0bcc8988ec3d08e61847ad48147b044facd637b3b813460270d931722fadf91f","blockNumber":"0x12511"},{"address":"0xc5c9fba1b420f4ad6d0662d08306551391c857bb","data":"0x0000000000000000000000008d5335accb417436c299f903d594f82ae3329f88","topics":["0xce0457fe73731f824cc272376169235128c118b49d344817417c6d108d155e82","0x78f6b1389af563cc5c91f234ea46b055e49658d8b999eeb9e0baef7dbbc93fdb","0xe5ab962b4999d8b0ab65167ad4bf98c9758b6b18f13a46a45a5a93029125a8be"],"removed":false,"logIndex":"0x1","transactionIndex":"0x0","transactionHash":"0xf6433e1880e7b756aa1bcba2b4c3caeeb87a10bd87c3df0a90635b6589e899a7","blockHash":"0x0bcc8988ec3d08e61847ad48147b044facd637b3b813460270d931722fadf91f","blockNumber":"0x12511"},{"address":"0xc9cf92750d731c5b278af0873302a8b58be17bea","data":"0x00000000000000000000000025cb30acd1786e49177429318f26959681f9aabd000000000000000000000000c9cf92750d731c5b278af0873302a8b58be17bea0000000000000000000000000000000000000000000000000000000000000000"...
```

## SQL checks

```
sqlite> select count(*) from event_entry where key in ('t1', 't2', 't3', 't4') and length(value) != 32;
0
sqlite> select count(*) from event_entry where key not in ('t1', 't2', 't3', 't4', 'd');
0
```