### PR TITLE
fix: eth: correctly decode EthGetStorageAt output

### DIFF
--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -265,6 +265,20 @@ func TestFEVMDelegateCall(t *testing.T) {
 	expectedResultActor, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(t, err)
 	require.Equal(t, result, expectedResultActor)
+
+	// The implementation's storage should not have been updated.
+	actorAddrEth, err := ethtypes.EthAddressFromFilecoinAddress(actorAddr)
+	require.NoError(t, err)
+	value, err := client.EVM().EthGetStorageAt(ctx, actorAddrEth, nil, "latest")
+	require.NoError(t, err)
+	require.Equal(t, ethtypes.EthBytes(make([]byte, 32)), value)
+
+	// The storage actor's storage _should_ have been updated
+	storageAddrEth, err := ethtypes.EthAddressFromFilecoinAddress(storageAddr)
+	require.NoError(t, err)
+	value, err = client.EVM().EthGetStorageAt(ctx, storageAddrEth, nil, "latest")
+	require.NoError(t, err)
+	require.Equal(t, ethtypes.EthBytes(expectedResult), value)
 }
 
 // TestFEVMDelegateCallRevert makes a delegatecall action and then calls revert.

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -517,7 +517,7 @@ func (a *EthModule) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 	}
 
 	// pad with zero bytes if smaller than 32 bytes
-	position = append(make([]byte, 32-l), position...)
+	position = append(make([]byte, 32-l, 32), position...)
 
 	to, err := ethAddr.ToFilecoinAddress()
 	if err != nil {
@@ -591,7 +591,7 @@ func (a *EthModule) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 	}
 
 	// pad with zero bytes if smaller than 32 bytes
-	ret = append(make([]byte, 32-len(ret)), ret...)
+	ret = append(make([]byte, 32-len(ret), 32), ret...)
 
 	return ethtypes.EthBytes(ret), nil
 }

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -533,15 +533,13 @@ func (a *EthModule) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 	actor, err := a.StateManager.LoadActor(ctx, to, ts)
 	if err != nil {
 		if xerrors.Is(err, types.ErrActorNotFound) {
-			return nil, nil
+			return ethtypes.EthBytes(make([]byte, 32)), nil
 		}
 		return nil, xerrors.Errorf("failed to lookup contract %s: %w", ethAddr, err)
 	}
 
-	// Not a contract. Technically, we should return an empty slot... but an error is more user
-	// friendly, IMO.
 	if !builtinactors.IsEvmActor(actor.Code) {
-		return nil, xerrors.Errorf("actor is not an ethereum contract")
+		return ethtypes.EthBytes(make([]byte, 32)), nil
 	}
 
 	params, err := actors.SerializeParams(&evm.GetStorageAtParams{


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes https://github.com/filecoin-project/ref-fvm/issues/1621

(probably)

## Proposed Changes
<!-- A clear list of the changes being made -->

Correctly decode actor output in EthGetStorageAt, and test it.

Also:

1. Actually use the passed block param.
2. Check if the target actor is an EVM actor to avoid nonsense outputs.