### PR TITLE
chore: github: Update bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,15 +9,9 @@ body:
     options:
       - label: This is **not** a security-related bug/issue. If it is, please follow please follow the [security policy](https://github.com/filecoin-project/lotus/security/policy).
         required: true
-      - label: This is **not** a question or a support request. If you have any lotus related questions, please ask in the [lotus forum](https://github.com/filecoin-project/lotus/discussions).
-        required: true
-      - label: This is **not** a new feature request. If it is, please file a [feature request](https://github.com/filecoin-project/lotus/issues/new?assignees=&labels=need%2Ftriage%2Ckind%2Ffeature&template=feature_request.yml) instead.
-        required: true
-      - label: This is **not** an enhancement request. If it is, please file a [improvement suggestion](https://github.com/filecoin-project/lotus/issues/new?assignees=&labels=need%2Ftriage%2Ckind%2Fenhancement&template=enhancement.yml) instead.
-        required: true
       - label: I **have** searched on the [issue tracker](https://github.com/filecoin-project/lotus/issues) and the [lotus forum](https://github.com/filecoin-project/lotus/discussions), and there is no existing related issue or discussion.
         required: true
-      - label: I am running the [`Latest release`](https://github.com/filecoin-project/lotus/releases), or the most recent RC(release canadiate) for the upcoming release or the dev branch(master), or have an issue updating to any of these.
+      - label: I am running the [`Latest release`](https://github.com/filecoin-project/lotus/releases), the most recent RC(release canadiate) for the upcoming release or the dev branch(master), or have an issue updating to any of these.
         required: true
       - label: I did not make any code changes to lotus.
         required: false
@@ -28,19 +22,11 @@ body:
     options:
       - label: lotus daemon - chain sync
         required: false
-      - label: lotus miner - mining and block production
+      - label: lotus fvm/fevm - Lotus FVM and FEVM interactions
         required: false
       - label: lotus miner/worker - sealing
         required: false
-      - label: lotus miner - proving(WindowPoSt)
-        required: false
-      - label: lotus miner/market - storage deal
-        required: false
-      - label: lotus miner/market - retrieval deal
-        required: false
-      - label: lotus miner/market - data transfer
-        required: false
-      - label: lotus client
+      - label: lotus miner - proving(WindowPoSt/WinningPoSt)
         required: false
       - label: lotus JSON-RPC API
         required: false
@@ -56,22 +42,33 @@ body:
     description: Enter the output of `lotus version` and `lotus-miner version` if applicable.
     placeholder: |
       e.g. 
-      Daemon:1.11.0-rc2+debug+git.0519cd371.dirty+api1.3.0 
-      Local: lotus version 1.11.0-rc2+debug+git.0519cd371.dirty
+      Daemon:  1.19.0+mainnet+git.64059ca87+api1.5.0
+      Local: lotus-miner version 1.19.0+mainnet+git.64059ca87
   validations:
     required: true
+- type: textarea
+  id: ReproSteps
+  attributes:
+    label: Repro Steps
+    description: "Steps to reproduce the behavior"
+    value: |
+      1. Run '...'
+      2. Do '...'
+      3. See error '...'
+      ...
+  validations:
+    required: false
 - type: textarea
   id: Description
   attributes:
     label: Describe the Bug
     description: |
       This is where you get to tell us what went wrong, when doing so, please try to provide a clear and concise description of the bug with all related information:
-      * What you were doding when you experienced the bug?
+      * What you were doing when you experienced the bug?
       * Any *error* messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
       * What is the expected behaviour?
       * For sealing issues, include the output of `lotus-miner sectors status --log <sectorId>` for the failed sector(s).
       * For proving issues, include the output of `lotus-miner proving` info.
-      * For deal making issues, include the output of `lotus client list-deals -v` and/or `lotus-miner storage-deals|retrieval-deals|data-transfers list [-v]` commands for the deal(s) in question.
   validations:
     required: true
 - type: textarea
@@ -83,18 +80,6 @@ body:
       Please provide debug logs of the problem, remember you can get set log level control for:
       * lotus: use `lotus log list` to get all log systems available and set level by `lotus log set-level`. An example can be found [here](https://lotus.filecoin.io/lotus/configure/defaults/#log-level-control).
       * lotus-miner:`lotus-miner log list` to get all log systems available and set level by `lotus-miner log set-level
-      If you don't provide detailed logs when you raise the issue it will almost certainly be the first request I make before furthur diagnosing the problem.
+      If you don't provide detailed logs when you raise the issue it will almost certainly be the first request we make before furthur diagnosing the problem.
   validations:
     required: true
-- type: textarea
-  id: RepoSteps
-  attributes:
-    label: Repo Steps
-    description: "Steps to reproduce the behavior"
-    value: |
-      1. Run '...'
-      2. Do '...'
-      3. See error '...'
-      ...
-  validations:
-    required: false


### PR DESCRIPTION
## Related Issues
Part of #10242 

## Proposed Changes
Update bug_report template:

- Removing unnecessary checklist options.
   - These have been move to the Github `New Issue` UI to reduce text overhead #10268 
- Remove deprecated components options
- Add FVM/FEVM component

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
