### PR TITLE
fix: test: change Filter rpc type from uint to hash to match fevm implementation

### DIFF
--- a/itests/specs/eth_openrpc.json
+++ b/itests/specs/eth_openrpc.json
@@ -1794,9 +1794,9 @@
 			"result": {
 				"name": "Filter Identifier",
 				"schema": {
-					"title": "hex encoded unsigned integer",
+					"title": "32 byte hex value",
 					"type": "string",
-					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					"pattern": "^0x[0-9a-f]{64}$"
 				}
 			}
 		},
@@ -1807,9 +1807,9 @@
 			"result": {
 				"name": "Filter Identifier",
 				"schema": {
-					"title": "hex encoded unsigned integer",
+					"title": "32 byte hex value",
 					"type": "string",
-					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					"pattern": "^0x[0-9a-f]{64}$"
 				}
 			}
 		},
@@ -1820,9 +1820,9 @@
 			"result": {
 				"name": "Filter Identifier",
 				"schema": {
-					"title": "hex encoded unsigned integer",
+					"title": "32 byte hex value",
 					"type": "string",
-					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					"pattern": "^0x[0-9a-f]{64}$"
 				}
 			}
 		},
@@ -1833,9 +1833,9 @@
 				{
 					"name": "Filter Identifier",
 					"schema": {
-						"title": "hex encoded unsigned integer",
+						"title": "32 byte hex value",
 						"type": "string",
-						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						"pattern": "^0x[0-9a-f]{64}$"
 					}
 				}
 			],
@@ -1853,9 +1853,9 @@
 				{
 					"name": "Filter Identifier",
 					"schema": {
-						"title": "hex encoded unsigned integer",
+						"title": "32 byte hex value",
 						"type": "string",
-						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						"pattern": "^0x[0-9a-f]{64}$"
 					}
 				}
 			],
@@ -1954,9 +1954,9 @@
 				{
 					"name": "Filter Identifier",
 					"schema": {
-						"title": "hex encoded unsigned integer",
+						"title": "32 byte hex value",
 						"type": "string",
-						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						"pattern": "^0x[0-9a-f]{64}$"
 					}
 				}
 			],


### PR DESCRIPTION
## Related Issues
Ethereum JSON-RPC responses should not include leading zero in hex #10170

## Proposed Changes
change Filter in the eth json rpc spec from int to hash

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
