### PR TITLE
feat: eth: return revert data on failed gas estimation

### DIFF
--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -901,14 +901,23 @@ func TestFEVMErrorParsing(t *testing.T) {
 		"failCustom()":       customError,
 	} {
 		sig := sig
-		expected := expected
+		expected := fmt.Sprintf("exit 33, revert reason: %s, vm error", expected)
 		t.Run(sig, func(t *testing.T) {
 			entryPoint := kit.CalcFuncSignature(sig)
-			_, err := e.EthCall(ctx, ethtypes.EthCall{
-				To:   &contractAddrEth,
-				Data: entryPoint,
-			}, "latest")
-			require.ErrorContains(t, err, fmt.Sprintf("exit 33, revert reason: %s, vm error", expected))
+			t.Run("EthCall", func(t *testing.T) {
+				_, err := e.EthCall(ctx, ethtypes.EthCall{
+					To:   &contractAddrEth,
+					Data: entryPoint,
+				}, "latest")
+				require.ErrorContains(t, err, expected)
+			})
+			t.Run("EthEstimateGas", func(t *testing.T) {
+				_, err := e.EthEstimateGas(ctx, ethtypes.EthCall{
+					To:   &contractAddrEth,
+					Data: entryPoint,
+				})
+				require.ErrorContains(t, err, expected)
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Return revert data on failed gas estimation.

Unfortunately, we need to execute the message twice to get this (unless we want to change some APIs). But it's unlikely to be a performance issue and will definitely help people debug failures.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green