### PR TITLE
feat: EthApiTest: Confirm EthAddressToFilecoinAddress works without E…

### DIFF
--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 func TestEthAddressToFilecoinAddress(t *testing.T) {
-	client, _, _ := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
+	// Disable EthRPC to confirm that this method does NOT need the EthEnableRPC config set to true
+	client, _, _ := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.DisableEthRPC())
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@jennijuju was concerned the EthAddressToFilecoinAddress would only work if the EthRPC was enabled.

## Proposed Changes
<!-- A clear list of the changes being made -->

Disable the EthRPC API for the test that tests this method.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
