### PR TITLE
fix: eth: cleanup error cases

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -895,7 +895,7 @@ func (a *EthModule) EthEstimateGas(ctx context.Context, tx ethtypes.EthCall) (et
 
 	expectedGas, err := ethGasSearch(ctx, a.Chain, a.Stmgr, a.Mpool, msg, ts)
 	if err != nil {
-		log.Errorw("expected gas", "err", err)
+		return 0, xerrors.Errorf("gas search failed: %w", err)
 	}
 
 	return ethtypes.EthUint64(expectedGas), nil
@@ -2157,11 +2157,13 @@ func (m *EthTxHashManager) ProcessSignedMessage(ctx context.Context, msg *types.
 	ethTx, err := newEthTxFromSignedMessage(ctx, msg, m.StateAPI)
 	if err != nil {
 		log.Errorf("error converting filecoin message to eth tx: %s", err)
+		return
 	}
 
 	err = m.TransactionHashLookup.UpsertHash(ethTx.Hash, msg.Cid())
 	if err != nil {
 		log.Errorf("error inserting tx mapping to db: %s", err)
+		return
 	}
 }
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

Cleanup some error cases:

1. Return an error on gas estimation failure instead of logging.
2. Return early when processing signed messages on failure instead of
continuing.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

@travisperson any reason to not return an error when `ethGasSearch` fails?

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] CI is green