### PR TITLE
fix: eth: eth_subscribe tag

### DIFF
--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -117,7 +117,7 @@ type EthSubscriberStruct struct {
 }
 
 type EthSubscriberMethods struct {
-	EthSubscription func(p0 context.Context, p1 jsonrpc.RawParams) error `notify:"true"rpc_method:"eth_subscription"`
+	EthSubscription func(p0 context.Context, p1 jsonrpc.RawParams) error `notify:"true" rpc_method:"eth_subscription"`
 }
 
 type EthSubscriberStub struct {

--- a/gen/api/proxygen.go
+++ b/gen/api/proxygen.go
@@ -307,7 +307,8 @@ type {{.Num}}Struct struct {
 
 type {{.Num}}Methods struct {
 {{range .Methods}}
-		{{.Num}} func({{.NamedParams}}) ({{.Results}}) `+"`"+`{{range .Tags}}{{index . 0}}:"{{index . 1}}"{{end}}`+"`"+`
+	{{.Num}} func({{.NamedParams}}) ({{.Results}}) `+"`"+`{{$first := true}}{{range .Tags}}{{if $first}}{{$first = false}}{{else}} {{end}}{{index . 0}}:"{{index . 1}}"{{end}}`+"`"+`
+
 {{end}}
 	}
 

--- a/itests/deals_partial_retrieval_dm-level_test.go
+++ b/itests/deals_partial_retrieval_dm-level_test.go
@@ -166,7 +166,7 @@ func testDMExportAsFile(ctx context.Context, client *kit.TestFullNode, expDirect
 func testV0RetrievalAsFile(ctx context.Context, client *kit.TestFullNode, retOrder api0.RetrievalOrder, tempDir string) error {
 	out := tempDir + string(os.PathSeparator) + "exp-test" + retOrder.Root.String()
 
-	cv0 := &api0.WrapperV1Full{client.FullNode} //nolint:govet
+	cv0 := &api0.WrapperV1Full{FullNode: client.FullNode}
 	err := cv0.ClientRetrieve(ctx, retOrder, &api.FileRef{
 		Path: out,
 	})
@@ -220,7 +220,7 @@ func tesV0RetrievalAsCar(ctx context.Context, client *kit.TestFullNode, retOrder
 	}
 	defer out.Close() //nolint:errcheck
 
-	cv0 := &api0.WrapperV1Full{client.FullNode} //nolint:govet
+	cv0 := &api0.WrapperV1Full{FullNode: client.FullNode}
 	err = cv0.ClientRetrieve(ctx, retOrder, &api.FileRef{
 		Path:  out.Name(),
 		IsCAR: true,


### PR DESCRIPTION
This fixes some errors caught by `go vet`.

1. Fixes some lints that were previously being ignored (because `go vet` doesn't actually have a built-in way to ignore errors).
2. Fixes the formatting of multiple JSON-RPC API struct tags.

However, I'm not sure why this matters and/or why we even have this tag.