### PR TITLE
chore: github: Service-provider/dev bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
@@ -1,0 +1,82 @@
+name: "Bug Report - developer/service provider"
+description: "File a bug report related to FEVM/FVM to help us improve"
+labels: [need/triage, kind/bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Checklist
+    description: Please check off the following boxes before continuing to file a bug report!
+    options:
+      - label: This is **not** a security-related bug/issue. If it is, please follow please follow the [security policy](https://github.com/filecoin-project/lotus/security/policy).
+        required: true
+      - label: I **have** searched on the [issue tracker](https://github.com/filecoin-project/lotus/issues) and the [lotus forum](https://github.com/filecoin-project/lotus/discussions), and there is no existing related issue or discussion.
+        required: true
+      - label: I did not make any code changes to lotus.
+        required: false
+- type: checkboxes
+  attributes:
+    label: Lotus component
+    description: Please select the lotus component you are filing a bug for
+    options:
+      - label: lotus Ethereum RPC
+        required: false
+      - label: lotus evm - Lotus EVM interactions
+        required: false
+      - label:  Other
+        required: false
+- type: textarea
+  id: version
+  attributes:
+    label: Lotus Version
+    render: text
+    description: Enter the output of `lotus version` if applicable.
+    placeholder: |
+      e.g. 
+      Daemon:  1.19.0+mainnet+git.64059ca87+api1.5.0
+      Local: lotus-miner version 1.19.0+mainnet+git.64059ca87
+  validations:
+    required: true
+- type: textarea
+  id: Repro Steps
+  attributes:
+    label: Repro Steps
+    description: "Steps to reproduce the behavior"
+    value: |
+      1. Run '...'
+      2. Do '...'
+      3. See error '...'
+      ...
+  validations:
+    required: false
+- type: textarea
+  id: Description
+  attributes:
+    label: Describe the Bug
+    description: |
+      This is where you get to tell us what went wrong, when doing so, please try to provide a clear and concise description of the bug with all related information:
+      * What you were doing when you experienced the bug?
+      * Any *error* messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
+      * What is the expected behaviour?
+  validations:
+    required: true
+- type: textarea
+  id: extraInfo
+  attributes:
+    label: Logging Information
+    render: text
+    description: |
+      Please provide debug logs of the problem, remember you can get set log level control for:
+      * lotus: use `lotus log list` to get all log systems available and set level by `lotus log set-level`. An example can be found [here](https://lotus.filecoin.io/lotus/configure/defaults/#log-level-control).
+      If you don't provide detailed logs when you raise the issue it will almost certainly be the first request I make before furthur diagnosing the problem.
+  validations:
+    required: true
+- type: textarea
+  id: extraInfo
+  attributes:
+    label: Configuration Options
+    render: text
+    description: |
+      Please provide your updated FEVM related configuration options, or custome enviroment variables related to Lotus FEVM
+      * lotus: use `lotus config updated` to get your configuration options, and copy the [FEVM] section
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
@@ -22,6 +22,8 @@ body:
         required: false
       - label: lotus FVM - Lotus FVM interactions
         required: false
+      - label: FEVM tooling
+        required: false
       - label:  Other
         required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
@@ -56,7 +56,7 @@ body:
     label: Describe the Bug
     description: |
       This is where you get to tell us what went wrong, when doing so, please try to provide a clear and concise description of the bug with all related information:
-      * What you were doing when you experienced the bug?
+      * What you were doing when you experienced the bug? What are you trying to build?
       * Any *error* messages and logs you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
       * What is the expected behaviour? Links to the actual code?
   validations:

--- a/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
@@ -20,7 +20,7 @@ body:
     options:
       - label: lotus Ethereum RPC
         required: false
-      - label: lotus evm - Lotus EVM interactions
+      - label: lotus FVM - Lotus FVM interactions
         required: false
       - label:  Other
         required: false

--- a/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/service_developer_bug_report.yml
@@ -1,6 +1,6 @@
 name: "Bug Report - developer/service provider"
-description: "File a bug report related to FEVM/FVM to help us improve"
-labels: [need/triage, kind/bug]
+description: "Bug report template about FEVM/FVM for developers/service providers"
+labels: [need/triage, kind/bug, area/fevm]
 body:
 - type: checkboxes
   attributes:
@@ -55,19 +55,18 @@ body:
     description: |
       This is where you get to tell us what went wrong, when doing so, please try to provide a clear and concise description of the bug with all related information:
       * What you were doing when you experienced the bug?
-      * Any *error* messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
-      * What is the expected behaviour?
+      * Any *error* messages and logs you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
+      * What is the expected behaviour? Links to the actual code?
   validations:
     required: true
 - type: textarea
   id: extraInfo
   attributes:
-    label: Logging Information
+    label: Tooling
     render: text
     description: |
-      Please provide debug logs of the problem, remember you can get set log level control for:
-      * lotus: use `lotus log list` to get all log systems available and set level by `lotus log set-level`. An example can be found [here](https://lotus.filecoin.io/lotus/configure/defaults/#log-level-control).
-      If you don't provide detailed logs when you raise the issue it will almost certainly be the first request I make before furthur diagnosing the problem.
+      What kind of tooling are you using:
+      * Are you using ether.js, Alchemy, Hardhat, etc.
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
## Related Issues
Closes #10242 

## Proposed Changes
Adds a service provider / FEVM-developer bug report template in preperation for network version 18. The template is requesting more relevant information regarding their tooling, etc, compared to the general bug report.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
