### PR TITLE
fix: state: lotus-miner info should show deals info without admin permission

### DIFF
--- a/cmd/lotus-miner/info.go
+++ b/cmd/lotus-miner/info.go
@@ -347,14 +347,12 @@ func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v1api.Full
 		}
 	}
 
-	{
-		fmt.Println()
+	fmt.Println()
 
-		ws, err := nodeApi.WorkerStats(ctx)
-		if err != nil {
-			return xerrors.Errorf("getting worker stats: %w", err)
-		}
-
+	ws, err := nodeApi.WorkerStats(ctx)
+	if err != nil {
+		fmt.Printf("ERROR: getting worker stats: %s\n", err)
+	} else {
 		workersByType := map[string]int{
 			sealtasks.WorkerSealing:     0,
 			sealtasks.WorkerWindowPoSt:  0,


### PR DESCRIPTION
## Related Issues
`lotus-miner info` currently does not show deals info without admin permission.  This is similar issue to #8057.

## Proposed Changes
Instead of return in `infoCmdAct()` when `WorkerStats()` fails, just print error and continue.

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
