### PR TITLE
fix: worker: Hide `wait-quiet` cmd

### DIFF
--- a/cmd/lotus-worker/cli.go
+++ b/cmd/lotus-worker/cli.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
@@ -35,9 +37,11 @@ var setCmd = &cli.Command{
 }
 
 var waitQuietCmd = &cli.Command{
-	Name:  "wait-quiet",
-	Usage: "Block until all running tasks exit",
+	Name:   "wait-quiet",
+	Usage:  "Block until all running tasks exit",
+	Hidden: true,
 	Action: func(cctx *cli.Context) error {
+		fmt.Println("DEPRECATED: This command will be removed in the future")
 		api, closer, err := lcli.GetWorkerAPI(cctx)
 		if err != nil {
 			return err

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -10,15 +10,14 @@ VERSION:
    1.21.0-dev
 
 COMMANDS:
-   run         Start lotus worker
-   stop        Stop a running lotus worker
-   info        Print worker info
-   storage     manage sector storage
-   set         Manage worker settings
-   wait-quiet  Block until all running tasks exit
-   resources   Manage resource table overrides
-   tasks       Manage task processing
-   help, h     Shows a list of commands or help for one command
+   run        Start lotus worker
+   stop       Stop a running lotus worker
+   info       Print worker info
+   storage    manage sector storage
+   set        Manage worker settings
+   resources  Manage resource table overrides
+   tasks      Manage task processing
+   help, h    Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --enable-gpu-proving                     enable use of GPU for mining operations (default: true) [$LOTUS_WORKER_ENABLE_GPU_PROVING]
@@ -164,19 +163,6 @@ USAGE:
 
 OPTIONS:
    --enabled  enable/disable new task processing (default: true)
-   
-```
-
-## lotus-worker wait-quiet
-```
-NAME:
-   lotus-worker wait-quiet - Block until all running tasks exit
-
-USAGE:
-   lotus-worker wait-quiet [command options] [arguments...]
-
-OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 


### PR DESCRIPTION
## Related Issues
Based on the discussion in #10210

## Proposed Changes
Hide the `lotus-worker wait-quiet` cmd from the lotus-worker cli to prevent user confusion around its functionality, and print that the cmd will be deprecated in the future.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
