### PR TITLE
fix:splitstore:bug fixes 

### DIFF
--- a/blockstore/splitstore/markset_badger.go
+++ b/blockstore/splitstore/markset_badger.go
@@ -351,7 +351,7 @@ func (s *BadgerMarkSet) write(seqno int) (err error) {
 	persist := s.persist
 	s.mx.RUnlock()
 
-	if persist && !system.BadgerFsyncDisable {
+	if persist && !system.BadgerFsyncDisable { // WARNING: disabling sync makes recovery from crash during critical section unsound
 		return s.db.Sync()
 	}
 

--- a/blockstore/splitstore/splitstore_prune.go
+++ b/blockstore/splitstore/splitstore_prune.go
@@ -329,9 +329,9 @@ func (s *SplitStore) doPrune(curTs *types.TipSet, retainStateP func(int64) bool,
 	}
 
 	s.pruneIndex++
-	err = s.ds.Put(s.ctx, pruneIndexKey, int64ToBytes(s.compactionIndex))
+	err = s.ds.Put(s.ctx, pruneIndexKey, int64ToBytes(s.pruneIndex))
 	if err != nil {
-		return xerrors.Errorf("error saving compaction index: %w", err)
+		return xerrors.Errorf("error saving prune index: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
- Fix 1: instead of walking tipset reference just mark it.  At first we thought this was responsible for discard instability but in retrospect it is just a nice cleanup
- Fix 2: remove discard set after compaction 
- Comments and logging improvements 

## Additional Info
<!-- Callouts, links to documentation, and etc -->


