### PR TITLE
fix: cli: send with InvokeEVM when sending from an eth account

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -295,6 +295,19 @@ func EthAddressFromPubKey(pubk []byte) ([]byte, error) {
 	return ethAddr, nil
 }
 
+func IsEthAddress(addr address.Address) bool {
+	if addr.Protocol() != address.Delegated {
+		return false
+	}
+	payload := addr.Payload()
+	namespace, _, err := varint.FromUvarint(payload)
+	if err != nil {
+		return false
+	}
+
+	return namespace == builtintypes.EthereumAddressManagerActorID
+}
+
 func EthAddressFromFilecoinAddress(addr address.Address) (EthAddress, error) {
 	switch addr.Protocol() {
 	case address.ID:

--- a/cli/send.go
+++ b/cli/send.go
@@ -1,15 +1,18 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/urfave/cli/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -117,15 +120,51 @@ var sendCmd = &cli.Command{
 			params.From = faddr
 		}
 
-		if params.From.Protocol() == address.Delegated {
+		if cctx.IsSet("params-hex") {
+			decparams, err := hex.DecodeString(cctx.String("params-hex"))
+			if err != nil {
+				return fmt.Errorf("failed to decode hex params: %w", err)
+			}
+			params.Params = decparams
+		}
+
+		if ethtypes.IsEthAddress(params.From) {
+			// Method numbers don't make sense from eth accounts.
+			if cctx.IsSet("method") {
+				return xerrors.Errorf("messages from f410f addresses may not specify a method number")
+			}
+
+			// Now, figure out the correct method number from the recipient.
+			if params.To == builtintypes.EthereumAddressManagerActorAddr {
+				params.Method = builtintypes.MethodsEAM.CreateExternal
+			} else {
+				params.Method = builtintypes.MethodsEVM.InvokeContract
+			}
+
+			if cctx.IsSet("params-json") {
+				return xerrors.Errorf("may not call with json parameters from an eth account")
+			}
+
+			// And format the parameters, if present.
+			if len(params.Params) > 0 {
+				var buf bytes.Buffer
+				if err := cbg.WriteByteArray(&buf, params.Params); err != nil {
+					return xerrors.Errorf("failed to marshal EVM parameters")
+				}
+				params.Params = buf.Bytes()
+			}
+
+			// We can only send to an f410f or f0 address.
 			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
 				api := srv.FullNodeAPI()
 				// Resolve id addr if possible.
 				params.To, err = api.StateLookupID(ctx, params.To, types.EmptyTSK)
 				if err != nil {
-					return xerrors.Errorf("f4 addresses can only send to other f4 or id addresses. could not find id address for %s", params.To.String())
+					return xerrors.Errorf("addresses starting with f410f can only send to other addresses starting with f410f, or id addresses. could not find id address for %s", params.To.String())
 				}
 			}
+		} else {
+			params.Method = abi.MethodNum(cctx.Uint64("method"))
 		}
 
 		if cctx.IsSet("gas-premium") {
@@ -149,22 +188,13 @@ var sendCmd = &cli.Command{
 			params.GasLimit = &limit
 		}
 
-		params.Method = abi.MethodNum(cctx.Uint64("method"))
-
 		if cctx.IsSet("params-json") {
-			decparams, err := srv.DecodeTypedParamsFromJSON(ctx, params.To, params.Method, cctx.String("params-json"))
-			if err != nil {
-				return fmt.Errorf("failed to decode json params: %w", err)
-			}
-			params.Params = decparams
-		}
-		if cctx.IsSet("params-hex") {
 			if params.Params != nil {
 				return fmt.Errorf("can only specify one of 'params-json' and 'params-hex'")
 			}
-			decparams, err := hex.DecodeString(cctx.String("params-hex"))
+			decparams, err := srv.DecodeTypedParamsFromJSON(ctx, params.To, params.Method, cctx.String("params-json"))
 			if err != nil {
-				return fmt.Errorf("failed to decode hex params: %w", err)
+				return fmt.Errorf("failed to decode json params: %w", err)
 			}
 			params.Params = decparams
 		}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

In the `lotus send` cli, replace method 0 with InvokeEVM when the sender is an ethereum-style account.

This will make `lotus send` "work", mostly. However, there are some
caveats:

1. Sending to, e.g., a storage provider will still fail (doesn't implement InvokeEVM).
2. We're changing the method number specified by the user.
3. This will end up running code.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green