### PR TITLE
feat: sched: Assigner experiments

### DIFF
--- a/storage/sealer/sched.go
+++ b/storage/sealer/sched.go
@@ -157,7 +157,15 @@ func newScheduler(ctx context.Context, assigner string) (*Scheduler, error) {
 	case "", "utilization":
 		a = NewLowestUtilizationAssigner()
 	case "spread":
-		a = NewSpreadAssigner()
+		a = NewSpreadAssigner(false)
+	case "experiment-spread-qcount":
+		a = NewSpreadAssigner(true)
+	case "experiment-spread-tasks":
+		a = NewSpreadTasksAssigner(false)
+	case "experiment-spread-tasks-qcount":
+		a = NewSpreadTasksAssigner(true)
+	case "experiment-random":
+		a = NewRandomAssigner()
 	default:
 		return nil, xerrors.Errorf("unknown assigner '%s'", assigner)
 	}

--- a/storage/sealer/sched.go
+++ b/storage/sealer/sched.go
@@ -42,6 +42,10 @@ func WithPriority(ctx context.Context, priority int) context.Context {
 const mib = 1 << 20
 
 type WorkerAction func(ctx context.Context, w Worker) error
+type PrepareAction struct {
+	Action   WorkerAction
+	PrepType sealtasks.TaskType
+}
 
 type SchedWorker interface {
 	TaskTypes(context.Context) (map[sealtasks.TaskType]struct{}, error)
@@ -130,7 +134,7 @@ type WorkerRequest struct {
 	Sel      WorkerSelector
 	SchedId  uuid.UUID
 
-	prepare WorkerAction
+	prepare PrepareAction
 	work    WorkerAction
 
 	start time.Time
@@ -197,7 +201,7 @@ func newScheduler(ctx context.Context, assigner string) (*Scheduler, error) {
 	}, nil
 }
 
-func (sh *Scheduler) Schedule(ctx context.Context, sector storiface.SectorRef, taskType sealtasks.TaskType, sel WorkerSelector, prepare WorkerAction, work WorkerAction) error {
+func (sh *Scheduler) Schedule(ctx context.Context, sector storiface.SectorRef, taskType sealtasks.TaskType, sel WorkerSelector, prepare PrepareAction, work WorkerAction) error {
 	ret := make(chan workerResponse)
 
 	select {
@@ -243,6 +247,13 @@ func (r *WorkerRequest) respond(err error) {
 func (r *WorkerRequest) SealTask() sealtasks.SealTaskType {
 	return sealtasks.SealTaskType{
 		TaskType:            r.TaskType,
+		RegisteredSealProof: r.Sector.ProofType,
+	}
+}
+
+func (r *WorkerRequest) PrepSealTask() sealtasks.SealTaskType {
+	return sealtasks.SealTaskType{
+		TaskType:            r.prepare.PrepType,
 		RegisteredSealProof: r.Sector.ProofType,
 	}
 }

--- a/storage/sealer/sched_assigner_common.go
+++ b/storage/sealer/sched_assigner_common.go
@@ -58,7 +58,7 @@ func (a *AssignerCommon) TrySched(sh *Scheduler) {
 
 	windows := make([]SchedWindow, windowsLen)
 	for i := range windows {
-		windows[i].Allocated = *NewActiveResources()
+		windows[i].Allocated = *NewActiveResources(newTaskCounter())
 	}
 	acceptableWindows := make([][]int, queueLen) // QueueIndex -> []OpenWindowIndex
 

--- a/storage/sealer/sched_assigner_darts.go
+++ b/storage/sealer/sched_assigner_darts.go
@@ -1,0 +1,88 @@
+package sealer
+
+import (
+	"math/rand"
+
+	"github.com/filecoin-project/lotus/storage/sealer/storiface"
+)
+
+func NewRandomAssigner() Assigner {
+	return &AssignerCommon{
+		WindowSel: RandomWS,
+	}
+}
+
+func RandomWS(sh *Scheduler, queueLen int, acceptableWindows [][]int, windows []SchedWindow) int {
+	scheduled := 0
+	rmQueue := make([]int, 0, queueLen)
+
+	for sqi := 0; sqi < queueLen; sqi++ {
+		task := (*sh.SchedQueue)[sqi]
+
+		//bestAssigned := math.MaxInt // smaller = better
+
+		type choice struct {
+			selectedWindow int
+			needRes        storiface.Resources
+			info           storiface.WorkerInfo
+			bestWid        storiface.WorkerID
+		}
+		choices := make([]choice, 0, len(acceptableWindows[task.IndexHeap]))
+
+		for i, wnd := range acceptableWindows[task.IndexHeap] {
+			wid := sh.OpenWindows[wnd].Worker
+			w := sh.Workers[wid]
+
+			res := w.Info.Resources.ResourceSpec(task.Sector.ProofType, task.TaskType)
+
+			log.Debugf("SCHED try assign sqi:%d sector %d to window %d (awi:%d)", sqi, task.Sector.ID.Number, wnd, i)
+
+			if !windows[wnd].Allocated.CanHandleRequest(task.SealTask(), res, wid, "schedAssign", w.Info) {
+				continue
+			}
+
+			choices = append(choices, choice{
+				selectedWindow: wnd,
+				needRes:        res,
+				info:           w.Info,
+				bestWid:        wid,
+			})
+
+		}
+
+		if len(choices) == 0 {
+			// all windows full
+			continue
+		}
+
+		// chose randomly
+		randIndex := rand.Intn(len(choices))
+		selectedWindow := choices[randIndex].selectedWindow
+		needRes := choices[randIndex].needRes
+		info := choices[randIndex].info
+		bestWid := choices[randIndex].bestWid
+
+		log.Debugw("SCHED ASSIGNED",
+			"assigner", "darts",
+			"sqi", sqi,
+			"sector", task.Sector.ID.Number,
+			"task", task.TaskType,
+			"window", selectedWindow,
+			"worker", bestWid,
+			"choices", len(choices))
+
+		windows[selectedWindow].Allocated.Add(task.SealTask(), info.Resources, needRes)
+		windows[selectedWindow].Todo = append(windows[selectedWindow].Todo, task)
+
+		rmQueue = append(rmQueue, sqi)
+		scheduled++
+	}
+
+	if len(rmQueue) > 0 {
+		for i := len(rmQueue) - 1; i >= 0; i-- {
+			sh.SchedQueue.Remove(rmQueue[i])
+		}
+	}
+
+	return scheduled
+}

--- a/storage/sealer/sched_assigner_utilization.go
+++ b/storage/sealer/sched_assigner_utilization.go
@@ -74,6 +74,7 @@ func LowestUtilizationWS(sh *Scheduler, queueLen int, acceptableWindows [][]int,
 		}
 
 		log.Debugw("SCHED ASSIGNED",
+			"assigner", "util",
 			"sqi", sqi,
 			"sector", task.Sector.ID.Number,
 			"task", task.TaskType,

--- a/storage/sealer/sched_resources.go
+++ b/storage/sealer/sched_resources.go
@@ -13,15 +13,65 @@ type ActiveResources struct {
 	gpuUsed    float64
 	cpuUse     uint64
 
-	taskCounters map[sealtasks.SealTaskType]int
+	taskCounters *taskCounter
 
 	cond    *sync.Cond
 	waiting int
 }
 
-func NewActiveResources() *ActiveResources {
-	return &ActiveResources{
+type taskCounter struct {
+	taskCounters map[sealtasks.SealTaskType]int
+
+	// this lock is technically redundant, as ActiveResources is always accessed
+	// with the worker lock, but let's not panic if we ever change that
+	lk sync.Mutex
+}
+
+func newTaskCounter() *taskCounter {
+	return &taskCounter{
 		taskCounters: map[sealtasks.SealTaskType]int{},
+	}
+}
+
+func (tc *taskCounter) Add(tt sealtasks.SealTaskType) {
+	tc.lk.Lock()
+	defer tc.lk.Unlock()
+	tc.taskCounters[tt]++
+}
+
+func (tc *taskCounter) Free(tt sealtasks.SealTaskType) {
+	tc.lk.Lock()
+	defer tc.lk.Unlock()
+	tc.taskCounters[tt]--
+}
+
+func (tc *taskCounter) Get(tt sealtasks.SealTaskType) int {
+	tc.lk.Lock()
+	defer tc.lk.Unlock()
+	return tc.taskCounters[tt]
+}
+
+func (tc *taskCounter) Sum() int {
+	tc.lk.Lock()
+	defer tc.lk.Unlock()
+	sum := 0
+	for _, v := range tc.taskCounters {
+		sum += v
+	}
+	return sum
+}
+
+func (tc *taskCounter) ForEach(cb func(tt sealtasks.SealTaskType, count int)) {
+	tc.lk.Lock()
+	defer tc.lk.Unlock()
+	for tt, count := range tc.taskCounters {
+		cb(tt, count)
+	}
+}
+
+func NewActiveResources(tc *taskCounter) *ActiveResources {
+	return &ActiveResources{
+		taskCounters: tc,
 	}
 }
 
@@ -59,7 +109,7 @@ func (a *ActiveResources) Add(tt sealtasks.SealTaskType, wr storiface.WorkerReso
 	a.cpuUse += r.Threads(wr.CPUs, len(wr.GPUs))
 	a.memUsedMin += r.MinMemory
 	a.memUsedMax += r.MaxMemory
-	a.taskCounters[tt]++
+	a.taskCounters.Add(tt)
 
 	return a.utilization(wr) - startUtil
 }
@@ -71,7 +121,7 @@ func (a *ActiveResources) Free(tt sealtasks.SealTaskType, wr storiface.WorkerRes
 	a.cpuUse -= r.Threads(wr.CPUs, len(wr.GPUs))
 	a.memUsedMin -= r.MinMemory
 	a.memUsedMax -= r.MaxMemory
-	a.taskCounters[tt]--
+	a.taskCounters.Free(tt)
 
 	if a.cond != nil {
 		a.cond.Broadcast()
@@ -82,8 +132,8 @@ func (a *ActiveResources) Free(tt sealtasks.SealTaskType, wr storiface.WorkerRes
 // handle the request.
 func (a *ActiveResources) CanHandleRequest(tt sealtasks.SealTaskType, needRes storiface.Resources, wid storiface.WorkerID, caller string, info storiface.WorkerInfo) bool {
 	if needRes.MaxConcurrent > 0 {
-		if a.taskCounters[tt] >= needRes.MaxConcurrent {
-			log.Debugf("sched: not scheduling on worker %s for %s; at task limit tt=%s, curcount=%d", wid, caller, tt, a.taskCounters[tt])
+		if a.taskCounters.Get(tt) >= needRes.MaxConcurrent {
+			log.Debugf("sched: not scheduling on worker %s for %s; at task limit tt=%s, curcount=%d", wid, caller, tt, a.taskCounters.Get(tt))
 			return false
 		}
 	}
@@ -173,14 +223,10 @@ func (a *ActiveResources) utilization(wr storiface.WorkerResources) float64 { //
 func (a *ActiveResources) taskCount(tt *sealtasks.SealTaskType) int {
 	// nil means all tasks
 	if tt == nil {
-		var count int
-		for _, c := range a.taskCounters {
-			count += c
-		}
-		return count
+		return a.taskCounters.Sum()
 	}
 
-	return a.taskCounters[*tt]
+	return a.taskCounters.Get(*tt)
 }
 
 func (wh *WorkerHandle) Utilization() float64 {

--- a/storage/sealer/sched_test.go
+++ b/storage/sealer/sched_test.go
@@ -639,8 +639,8 @@ func BenchmarkTrySched(b *testing.B) {
 						Resources: decentWorkerResources,
 					},
 					Enabled:   true,
-					preparing: NewActiveResources(),
-					active:    NewActiveResources(),
+					preparing: NewActiveResources(newTaskCounter()),
+					active:    NewActiveResources(newTaskCounter()),
 				}
 
 				for i := 0; i < windows; i++ {
@@ -685,7 +685,7 @@ func TestWindowCompact(t *testing.T) {
 
 			for _, windowTasks := range start {
 				window := &SchedWindow{
-					Allocated: *NewActiveResources(),
+					Allocated: *NewActiveResources(newTaskCounter()),
 				}
 
 				for _, task := range windowTasks {
@@ -708,7 +708,7 @@ func TestWindowCompact(t *testing.T) {
 			require.Equal(t, len(start)-len(expect), -sw.windowsRequested)
 
 			for wi, tasks := range expect {
-				expectRes := NewActiveResources()
+				expectRes := NewActiveResources(newTaskCounter())
 
 				for ti, task := range tasks {
 					require.Equal(t, task, wh.activeWindows[wi].Todo[ti].TaskType, "%d, %d", wi, ti)

--- a/storage/sealer/sched_test.go
+++ b/storage/sealer/sched_test.go
@@ -288,25 +288,30 @@ func TestSched(t *testing.T) {
 					ProofType: spt,
 				}
 
-				err := sched.Schedule(ctx, sectorRef, taskType, sel, func(ctx context.Context, w Worker) error {
-					wi, err := w.Info(ctx)
-					require.NoError(t, err)
+				prep := PrepareAction{
+					Action: func(ctx context.Context, w Worker) error {
+						wi, err := w.Info(ctx)
+						require.NoError(t, err)
 
-					require.Equal(t, expectWorker, wi.Hostname)
+						require.Equal(t, expectWorker, wi.Hostname)
 
-					log.Info("IN  ", taskName)
+						log.Info("IN  ", taskName)
 
-					for {
-						_, ok := <-done
-						if !ok {
-							break
+						for {
+							_, ok := <-done
+							if !ok {
+								break
+							}
 						}
-					}
 
-					log.Info("OUT ", taskName)
+						log.Info("OUT ", taskName)
 
-					return nil
-				}, noopAction)
+						return nil
+					},
+					PrepType: taskType,
+				}
+
+				err := sched.Schedule(ctx, sectorRef, taskType, sel, prep, noopAction)
 				if err != context.Canceled {
 					require.NoError(t, err, fmt.Sprint(l, l2))
 				}

--- a/storage/sealer/sched_worker.go
+++ b/storage/sealer/sched_worker.go
@@ -354,8 +354,8 @@ assignLoop:
 
 			worker.lk.Lock()
 			for t, todo := range firstWindow.Todo {
-				needRes := worker.Info.Resources.ResourceSpec(todo.Sector.ProofType, todo.TaskType)
-				if worker.preparing.CanHandleRequest(todo.SealTask(), needRes, sw.wid, "startPreparing", worker.Info) {
+				needResPrep := worker.Info.Resources.PrepResourceSpec(todo.Sector.ProofType, todo.TaskType, todo.prepare.PrepType)
+				if worker.preparing.CanHandleRequest(todo.PrepSealTask(), needResPrep, sw.wid, "startPreparing", worker.Info) {
 					tidx = t
 					break
 				}
@@ -454,20 +454,21 @@ func (sw *schedWorker) startProcessingTask(req *WorkerRequest) error {
 	w, sh := sw.worker, sw.sched
 
 	needRes := w.Info.Resources.ResourceSpec(req.Sector.ProofType, req.TaskType)
+	needResPrep := w.Info.Resources.PrepResourceSpec(req.Sector.ProofType, req.TaskType, req.prepare.PrepType)
 
 	w.lk.Lock()
-	w.preparing.Add(req.SealTask(), w.Info.Resources, needRes)
+	w.preparing.Add(req.PrepSealTask(), w.Info.Resources, needResPrep)
 	w.lk.Unlock()
 
 	go func() {
 		// first run the prepare step (e.g. fetching sector data from other worker)
 		tw := sh.workTracker.worker(sw.wid, w.Info, w.workerRpc)
 		tw.start()
-		err := req.prepare(req.Ctx, tw)
+		err := req.prepare.Action(req.Ctx, tw)
 		w.lk.Lock()
 
 		if err != nil {
-			w.preparing.Free(req.SealTask(), w.Info.Resources, needRes)
+			w.preparing.Free(req.PrepSealTask(), w.Info.Resources, needResPrep)
 			w.lk.Unlock()
 
 			select {
@@ -497,7 +498,7 @@ func (sw *schedWorker) startProcessingTask(req *WorkerRequest) error {
 
 		// wait (if needed) for resources in the 'active' window
 		err = w.active.withResources(sw.wid, w.Info, req.SealTask(), needRes, &w.lk, func() error {
-			w.preparing.Free(req.SealTask(), w.Info.Resources, needRes)
+			w.preparing.Free(req.PrepSealTask(), w.Info.Resources, needResPrep)
 			w.lk.Unlock()
 			defer w.lk.Lock() // we MUST return locked from this function
 

--- a/storage/sealer/sched_worker.go
+++ b/storage/sealer/sched_worker.go
@@ -30,12 +30,14 @@ func newWorkerHandle(ctx context.Context, w Worker) (*WorkerHandle, error) {
 		return nil, xerrors.Errorf("getting worker info: %w", err)
 	}
 
+	tc := newTaskCounter()
+
 	worker := &WorkerHandle{
 		workerRpc: w,
 		Info:      info,
 
-		preparing: NewActiveResources(),
-		active:    NewActiveResources(),
+		preparing: NewActiveResources(tc),
+		active:    NewActiveResources(tc),
 		Enabled:   true,
 
 		closingMgr: make(chan struct{}),

--- a/storage/sealer/sealtasks/task.go
+++ b/storage/sealer/sealtasks/task.go
@@ -36,6 +36,8 @@ const (
 
 	TTGenerateWindowPoSt  TaskType = "post/v0/windowproof"
 	TTGenerateWinningPoSt TaskType = "post/v0/winningproof"
+
+	TTNoop TaskType = ""
 )
 
 var order = map[TaskType]int{

--- a/storage/sealer/stats.go
+++ b/storage/sealer/stats.go
@@ -43,9 +43,9 @@ func (m *Manager) WorkerStats(ctx context.Context) map[uuid.UUID]storiface.Worke
 			TaskCounts: map[string]int{},
 		}
 
-		for tt, count := range handle.active.taskCounters {
+		handle.active.taskCounters.ForEach(func(tt sealtasks.SealTaskType, count int) {
 			out[uuid.UUID(id)].TaskCounts[tt.String()] = count
-		}
+		})
 
 		handle.lk.Unlock()
 	}

--- a/storage/sealer/storiface/worker.go
+++ b/storage/sealer/storiface/worker.go
@@ -65,6 +65,20 @@ func (wr WorkerResources) ResourceSpec(spt abi.RegisteredSealProof, tt sealtasks
 	return res
 }
 
+// PrepResourceSpec is like ResourceSpec, but meant for use limiting parallel preparing
+// tasks.
+func (wr WorkerResources) PrepResourceSpec(spt abi.RegisteredSealProof, tt, prepTT sealtasks.TaskType) Resources {
+	res := wr.ResourceSpec(spt, tt)
+
+	if prepTT != tt && prepTT != sealtasks.TTNoop {
+		prepRes := wr.ResourceSpec(spt, prepTT)
+		res.MaxConcurrent = prepRes.MaxConcurrent
+	}
+
+	// otherwise, use the default resource table
+	return res
+}
+
 type WorkerStats struct {
 	Info    WorkerInfo
 	Tasks   []sealtasks.TaskType


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Currently lotus-miner can be configured with one of two assigners:
* `utilization` (default) - For each task pick a worker with a lowest 'utilization factor', which is based on ratios of compute resources
* `spread` - In each assign loop try to assign to a worker with least tasks assigned so far

This PR adds a few experimental assigners:
* `experiment-spread-qcount` - Like spread, but also takes into account task counts which are running/preparing/queued
* `experiment-spread-tasks` -  Like spread, but counts running tasks on a per-task-type basis
* `experiment-spread-tasks-qcount` - The two above combined - count running tasks grouped by task type, also takes into account tasks which are running/preparing/queued
* `experiment-random` - In each schedule loop figure a set of all workers which can handle the task.. then pick a random one

## Additional Info
* [x] Would be good to try all of those and see how they behave
* [x] Interested to hear if `experiment-random` / `experiment-spread-tasks-qcount` work better for `--no-default` storage workers
* [x] Interested to hear additional ideas

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
