### PR TITLE
fix: EthGetBalance: lookup balance at correct state

### DIFF
--- a/itests/eth_balance_test.go
+++ b/itests/eth_balance_test.go
@@ -2,6 +2,7 @@ package itests
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/itests/kit"
@@ -94,4 +96,40 @@ func TestEthGetBalanceBuiltinActor(t *testing.T) {
 	ebal, err := client.EthGetBalance(ctx, ethAddr, "latest")
 	require.NoError(t, err)
 	require.Equal(t, ethtypes.EthBigInt{Int: big.NewInt(10).Int}, ebal)
+}
+
+func TestEthBalanceCorrectLookup(t *testing.T) {
+	blockTime := 100 * time.Millisecond
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
+	ens.InterconnectAll().BeginMining(blockTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	_, ethAddr, filAddr := client.EVM().NewAccount()
+
+	val := int64(100)
+
+	smsg, err := client.MpoolPushMessage(ctx, &types.Message{
+		To:    filAddr,
+		From:  client.DefaultKey.Address,
+		Value: abi.NewTokenAmount(val),
+	}, nil)
+	require.NoError(t, err)
+
+	ml, err := client.StateWaitMsg(ctx, smsg.Cid(), 3, api.LookbackNoLimit, false)
+	require.NoError(t, err)
+	require.True(t, ml.Receipt.ExitCode.IsSuccess())
+
+	bal, err := client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height-2), 10))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), bal.Int64())
+
+	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height-1), 10))
+	require.NoError(t, err)
+	require.Equal(t, val, bal.Int64())
+
+	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height), 10))
+	require.NoError(t, err)
+	require.Equal(t, val, bal.Int64())
 }

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -636,7 +636,12 @@ func (a *EthModule) EthGetBalance(ctx context.Context, address ethtypes.EthAddre
 		return ethtypes.EthBigInt{}, xerrors.Errorf("cannot parse block param: %s", blkParam)
 	}
 
-	actor, err := a.StateGetActor(ctx, filAddr, ts.Key())
+	st, _, err := a.StateManager.TipSetState(ctx, ts)
+	if err != nil {
+		return ethtypes.EthBigInt{}, xerrors.Errorf("failed to compute tipset state: %w", err)
+	}
+
+	actor, err := a.StateManager.LoadActorRaw(ctx, filAddr, st)
 	if xerrors.Is(err, types.ErrActorNotFound) {
 		return ethtypes.EthBigIntZero, nil
 	} else if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@raulk observed that some tooling was taken longer than expected to update balance. This is because the current EthBalance implementation uses the _parent_ state of the input tipset, which is inconsistent with the Tipset <-> blockParam mapping we have.

## Proposed Changes
<!-- A clear list of the changes being made -->

- Use the `TipsetState` of the input param
  - I considered extracting this into some helper, but there isn't any other use case of it (nor is it needed anywhere else in the EthAPI), and I think it'll confuse usage with the existing `LoadActor` methods.
- Add a test

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
