### PR TITLE
fix: post: Tune down default post-parallel-reads

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -257,7 +257,7 @@ var runCmd = &cli.Command{
 		&cli.IntFlag{
 			Name:    "post-parallel-reads",
 			Usage:   "maximum number of parallel challenge reads (0 = no limit)",
-			Value:   128,
+			Value:   32,
 			EnvVars: []string{"LOTUS_WORKER_POST_PARALLEL_READS"},
 		},
 		&cli.DurationFlag{

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -47,7 +47,7 @@ OPTIONS:
    --no-local-storage            don't use storageminer repo for sector storage (default: false) [$LOTUS_WORKER_NO_LOCAL_STORAGE]
    --no-swap                     don't use swap (default: false) [$LOTUS_WORKER_NO_SWAP]
    --parallel-fetch-limit value  maximum fetch operations to run in parallel (default: 5) [$LOTUS_WORKER_PARALLEL_FETCH_LIMIT]
-   --post-parallel-reads value   maximum number of parallel challenge reads (0 = no limit) (default: 128) [$LOTUS_WORKER_POST_PARALLEL_READS]
+   --post-parallel-reads value   maximum number of parallel challenge reads (0 = no limit) (default: 32) [$LOTUS_WORKER_POST_PARALLEL_READS]
    --post-read-timeout value     time limit for reading PoSt challenges (0 = no limit) (default: 0s) [$LOTUS_WORKER_POST_READ_TIMEOUT]
    --precommit1                  enable precommit1 (default: true) [$LOTUS_WORKER_PRECOMMIT1]
    --precommit2                  enable precommit2 (default: true) [$LOTUS_WORKER_PRECOMMIT2]

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -352,7 +352,7 @@
   #
   # type: int
   # env var: LOTUS_PROVING_PARALLELCHECKLIMIT
-  #ParallelCheckLimit = 128
+  #ParallelCheckLimit = 32
 
   # Maximum amount of time a proving pre-check can take for a sector. If the check times out the sector will be skipped
   # 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -154,7 +154,7 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		Proving: ProvingConfig{
-			ParallelCheckLimit:    128,
+			ParallelCheckLimit:    32,
 			PartitionCheckTimeout: Duration(20 * time.Minute),
 			SingleCheckTimeout:    Duration(10 * time.Minute),
 		},


### PR DESCRIPTION
## Related Issues
fixes #9074

## Proposed Changes
Tuning down the default post-parallel-reads to a conservative number. Seems more beneficial to be conservative here, and not cause any network timeouts, ending up in sectors being skipped. SPs can fine tune this value higher if their architectures can handle it.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
