### PR TITLE
fix:splitstore:revert introduced bug

### DIFF
--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -942,8 +942,8 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 		if err != nil {
 			return xerrors.Errorf("error computing cid reference to parent tipset")
 		}
-		if err := fHot(pRef); err != nil {
-			return xerrors.Errorf("error marking parent tipset cid reference")
+		if err := s.walkObjectIncomplete(pRef, visitor, fHot, stopWalk); err != nil {
+			return xerrors.Errorf("error walking parent tipset cid reference")
 		}
 
 		// message are retained if within the inclMsgs boundary
@@ -1001,8 +1001,8 @@ func (s *SplitStore) walkChain(ts *types.TipSet, inclState, inclMsgs abi.ChainEp
 	if err != nil {
 		return xerrors.Errorf("error computing cid reference to parent tipset")
 	}
-	if err := fHot(hRef); err != nil {
-		return xerrors.Errorf("error marking parent tipset cid reference")
+	if err := s.walkObjectIncomplete(hRef, visitor, fHot, stopWalk); err != nil {
+		return xerrors.Errorf("error walking parent tipset cid reference")
 	}
 
 	for len(toWalk) > 0 {


### PR DESCRIPTION
## Related Issues


## Proposed Changes
In an overzealous attempt to quash splitstore problems I introduced another bug in #10332.  I was concerned that doing walk object incomplete on the ts refs would lead to uncontrolled graph traversal which would be a huge waste of resources and overall problem.

However after opening that PR I learned that this is not actually a problem because ts refs are not serialized as ipld (cbor tags with cid tag number 42), just cbor bytes.  However by pinning these cids directly instead of using the incomplete walk I introduced a bug where warmup fails because lotus doesn't necessarily keep tsrefs around for all blocks.

This made it onto master because I went ahead and merged with red CI 😬 which was my bad.  But note to our future selves this negligence was facilitated by the state flaky tests making CI untrustworthy, this is a great example of the cost of flaky tests.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
