### PR TITLE
fix: cli: Hide `lotus-worker set` command

### DIFF
--- a/cmd/lotus-worker/cli.go
+++ b/cmd/lotus-worker/cli.go
@@ -10,8 +10,9 @@ import (
 )
 
 var setCmd = &cli.Command{
-	Name:  "set",
-	Usage: "Manage worker settings",
+	Name:   "set",
+	Usage:  "Manage worker settings",
+	Hidden: true,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "enabled",
@@ -20,6 +21,7 @@ var setCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		fmt.Println("DEPRECATED: This command will be removed in the future")
 		api, closer, err := lcli.GetWorkerAPI(cctx)
 		if err != nil {
 			return err

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -14,7 +14,6 @@ COMMANDS:
    stop       Stop a running lotus worker
    info       Print worker info
    storage    manage sector storage
-   set        Manage worker settings
    resources  Manage resource table overrides
    tasks      Manage task processing
    help, h    Shows a list of commands or help for one command
@@ -150,19 +149,6 @@ OPTIONS:
    --all           redeclare all storage paths (default: false)
    --drop-missing  Drop index entries with missing files (default: false)
    --id value      storage path ID
-   
-```
-
-## lotus-worker set
-```
-NAME:
-   lotus-worker set - Manage worker settings
-
-USAGE:
-   lotus-worker set [command options] [arguments...]
-
-OPTIONS:
-   --enabled  enable/disable new task processing (default: true)
    
 ```
 


### PR DESCRIPTION
## Related Issues
Fixes #10210, Fixes #7866

## Proposed Changes
Based on the discussion in #10210 and in #7866, I propose to hide this command and start the deprecation process of this function.

The desired feature from our users point of view will be fulfilled by the `lotus-worker tasks enable/disable`, which allows SPs to gracefully shutdown the lotus-worker even with incoming sealing tasks:

1. SP have a lot of incoming sealing tasks in the pipeline, but want/need to shut down worker nr.124 for maintainence/upgrade
2. Issue the `lotus-worker tasks disable --all`, and let the remaining sealing tasks finish and let other workers fetch the finished sectors.
3. `lotus-worker stop` to detach it and do maintenance/upgrades.

## Additional Info
A follow up here is to document how to gracefully shutdown a lotus-worker to our users: https://github.com/filecoin-project/lotus-docs/issues/511

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
