### PR TITLE
fix: EthAPI: Correctly get parent hash

### DIFF
--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -87,3 +87,25 @@ func TestFilecoinAddressToEthAddress(t *testing.T) {
 
 	require.ErrorContains(t, err, ethtypes.ErrInvalidAddress.Error())
 }
+
+func TestEthGetGenesis(t *testing.T) {
+	blockTime := 100 * time.Millisecond
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
+	ens.InterconnectAll().BeginMining(blockTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	ethBlk, err := client.EVM().EthGetBlockByNumber(ctx, "0x0", true)
+	require.NoError(t, err)
+
+	genesis, err := client.ChainGetGenesis(ctx)
+	require.NoError(t, err)
+
+	genesisCid, err := genesis.Key().Cid()
+	require.NoError(t, err)
+
+	genesisHash, err := ethtypes.EthHashFromCid(genesisCid)
+	require.NoError(t, err)
+	require.Equal(t, ethBlk.Hash, genesisHash)
+}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1763,11 +1763,7 @@ func (e *ethSubscription) stop() {
 }
 
 func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTxInfo bool, cs *store.ChainStore, sa StateAPI) (ethtypes.EthBlock, error) {
-	parent, err := cs.LoadTipSet(ctx, ts.Parents())
-	if err != nil {
-		return ethtypes.EthBlock{}, err
-	}
-	parentKeyCid, err := parent.Key().Cid()
+	parentKeyCid, err := ts.Parents().Cid()
 	if err != nil {
 		return ethtypes.EthBlock{}, err
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#10385 

## Proposed Changes
<!-- A clear list of the changes being made -->

The previous implementation was trying to _load_ the tipset that is the genesis's parents, which is both wrong and unnecessary. Simplifing fixes #10385.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
