### PR TITLE
fix: wdpost: disabled post worker handling

### DIFF
--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -336,6 +336,8 @@ func (n *Ensemble) Worker(minerNode *TestMiner, worker *TestWorker, opts ...Node
 		MinerNode:      minerNode,
 		RemoteListener: rl,
 		options:        options,
+
+		Stop: func(ctx context.Context) error { return nil },
 	}
 
 	n.inactive.workers = append(n.inactive.workers, worker)

--- a/itests/kit/rpc.go
+++ b/itests/kit/rpc.go
@@ -96,6 +96,12 @@ func workerRpc(t *testing.T, m *TestWorker) *TestWorker {
 	require.NoError(t, err)
 	t.Cleanup(stop)
 
+	m.Stop = func(ctx context.Context) error {
+		srv.Close()
+		srv.CloseClientConnections()
+		return nil
+	}
+
 	m.ListenAddr, m.Worker = maddr, cl
 	return m
 }

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -366,7 +366,7 @@ func TestWindowPostWorkerManualPoSt(t *testing.T) {
 
 	sectors := 2 * 48 * 2
 
-	client, miner, _, ens := kit.EnsembleWorker(t,
+	client, miner, _, _ := kit.EnsembleWorker(t,
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -378,16 +378,7 @@ func TestWindowPostWorkerManualPoSt(t *testing.T) {
 	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
 	require.NoError(t, err)
 
-	bm := ens.InterconnectAll().BeginMiningMustPost(2 * time.Millisecond)[0]
-
 	di = di.NextNotElapsed()
-
-	t.Log("Running one proving period")
-	waitUntil := di.Open + di.WPoStChallengeWindow*2 - 2
-	client.WaitTillChain(ctx, kit.HeightAtLeast(waitUntil))
-
-	t.Log("Waiting for post message")
-	bm.Stop()
 
 	tryDl := func(dl uint64) {
 		p, err := miner.ComputeWindowPoSt(ctx, dl, types.EmptyTSK)
@@ -398,10 +389,49 @@ func TestWindowPostWorkerManualPoSt(t *testing.T) {
 	tryDl(0)
 	tryDl(40)
 	tryDl(di.Index + 4)
+}
 
-	lastPending, err := client.MpoolPending(ctx, types.EmptyTSK)
+func TestWindowPostWorkerDisconnected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_ = logging.SetLogLevel("storageminer", "INFO")
+
+	sectors := 2 * 48 * 2
+
+	client, miner, badWorker, ens := kit.EnsembleWorker(t,
+		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
+		kit.LatestActorsAt(-1),
+		kit.ThroughRPC(),
+		kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWindowPoSt}))
+
+	var goodWorker kit.TestWorker
+	ens.Worker(miner, &goodWorker, kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWindowPoSt}), kit.ThroughRPC()).Start()
+
+	maddr, err := miner.ActorAddress(ctx)
 	require.NoError(t, err)
-	require.Len(t, lastPending, 0)
+
+	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
+	require.NoError(t, err)
+
+	di = di.NextNotElapsed()
+
+	tryDl := func(dl uint64) {
+		p, err := miner.ComputeWindowPoSt(ctx, dl, types.EmptyTSK)
+		require.NoError(t, err)
+		require.Len(t, p, 1)
+		require.Equal(t, dl, p[0].Deadline)
+	}
+	tryDl(0) // this will run on the not-yet-bad badWorker
+
+	err = badWorker.Stop(ctx)
+	require.NoError(t, err)
+
+	tryDl(10) // will fail on the badWorker, then should retry on the goodWorker
+
+	time.Sleep(15 * time.Second)
+
+	tryDl(40) // after HeartbeatInterval, the badWorker should be marked as disabled
 }
 
 func TestSchedulerRemoveRequest(t *testing.T) {

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -408,6 +408,13 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 	var goodWorker kit.TestWorker
 	ens.Worker(miner, &goodWorker, kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWindowPoSt}), kit.ThroughRPC()).Start()
 
+	// wait for all workers
+	require.Eventually(t, func() bool {
+		w, err := miner.WorkerStats(ctx)
+		require.NoError(t, err)
+		return len(w) == 3 // 2 post + 1 miner-builtin
+	}, 10*time.Second, 100*time.Millisecond)
+
 	tryDl := func(dl uint64) {
 		p, err := miner.ComputeWindowPoSt(ctx, dl, types.EmptyTSK)
 		require.NoError(t, err)

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -399,7 +399,7 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 
 	sectors := 2 * 48 * 2
 
-	client, miner, badWorker, ens := kit.EnsembleWorker(t,
+	_, miner, badWorker, ens := kit.EnsembleWorker(t,
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -407,14 +407,6 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 
 	var goodWorker kit.TestWorker
 	ens.Worker(miner, &goodWorker, kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWindowPoSt}), kit.ThroughRPC()).Start()
-
-	maddr, err := miner.ActorAddress(ctx)
-	require.NoError(t, err)
-
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
-
-	di = di.NextNotElapsed()
 
 	tryDl := func(dl uint64) {
 		p, err := miner.ComputeWindowPoSt(ctx, dl, types.EmptyTSK)
@@ -424,7 +416,7 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 	}
 	tryDl(0) // this will run on the not-yet-bad badWorker
 
-	err = badWorker.Stop(ctx)
+	err := badWorker.Stop(ctx)
 	require.NoError(t, err)
 
 	tryDl(10) // will fail on the badWorker, then should retry on the goodWorker

--- a/storage/sealer/manager_post.go
+++ b/storage/sealer/manager_post.go
@@ -196,7 +196,7 @@ func (m *Manager) generateWindowPoSt(ctx context.Context, minerID abi.ActorID, s
 				skipped = append(skipped, sk...)
 
 				if err != nil {
-					retErr = multierr.Append(retErr, xerrors.Errorf("partitionCount:%d err:%+v", partIdx, err))
+					retErr = multierr.Append(retErr, xerrors.Errorf("partitionIndex:%d err:%+v", partIdx, err))
 				}
 				flk.Unlock()
 			}

--- a/storage/sealer/sched_post.go
+++ b/storage/sealer/sched_post.go
@@ -124,6 +124,11 @@ func (ps *poStScheduler) readyWorkers(spt abi.RegisteredSealProof) (bool, []cand
 	for wid, wr := range ps.workers {
 		needRes := wr.Info.Resources.ResourceSpec(spt, ps.postType)
 
+		if !wr.Enabled {
+			log.Debugf("sched: not scheduling on PoSt-worker %s, worker disabled", wid)
+			continue
+		}
+
 		if !wr.active.CanHandleRequest(ps.postType.SealTask(spt), needRes, wid, "post-readyWorkers", wr.Info) {
 			continue
 		}

--- a/storage/sealer/sched_post.go
+++ b/storage/sealer/sched_post.go
@@ -3,14 +3,14 @@ package sealer
 import (
 	"context"
 	"errors"
-	"github.com/filecoin-project/go-jsonrpc"
-	"github.com/hashicorp/go-multierror"
 	"math/rand"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/storage/paths"


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/9854

## Proposed Changes
* Add an itest reproducing 9854
* Don't schedule PoSt on disabled workers
* If there is an RPC connection error coming from a call to a worker, retry on another worker instead of failing the whole PoSt

## Additional Info
Could use testing on a real setup

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
