### PR TITLE
fix: state: short-circuit genesis state computation

### DIFF
--- a/chain/consensus/compute_state.go
+++ b/chain/consensus/compute_state.go
@@ -235,7 +235,7 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		}
 		rErr := t.reward(ctx, vmi, em, epoch, ts, params)
 		if rErr != nil {
-			return cid.Undef, cid.Undef, xerrors.Errorf("error applying reward: %w", err)
+			return cid.Undef, cid.Undef, xerrors.Errorf("error applying reward: %w", rErr)
 		}
 	}
 
@@ -306,6 +306,14 @@ func (t *TipSetExecutor) ExecuteTipSet(ctx context.Context,
 						blks[i].Miner, blks[j].Miner)
 			}
 		}
+	}
+
+	if ts.Height() == 0 {
+		// NB: This is here because the process that executes blocks requires that the
+		// block miner reference a valid miner in the state tree. Unless we create some
+		// magical genesis miner, this won't work properly, so we short circuit here
+		// This avoids the question of 'who gets paid the genesis block reward'
+		return blks[0].ParentStateRoot, blks[0].ParentMessageReceipts, nil
 	}
 
 	var parentEpoch abi.ChainEpoch

--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -52,14 +52,6 @@ func (sm *StateManager) TipSetState(ctx context.Context, ts *types.TipSet) (st c
 
 	sm.stlk.Unlock()
 
-	if ts.Height() == 0 {
-		// NB: This is here because the process that executes blocks requires that the
-		// block miner reference a valid miner in the state tree. Unless we create some
-		// magical genesis miner, this won't work properly, so we short circuit here
-		// This avoids the question of 'who gets paid the genesis block reward'
-		return ts.Blocks()[0].ParentStateRoot, ts.Blocks()[0].ParentMessageReceipts, nil
-	}
-
 	st, rec, err = sm.tsExec.ExecuteTipSet(ctx, sm, ts, sm.tsExecMonitor, false)
 	if err != nil {
 		return cid.Undef, cid.Undef, err


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@magik6k observed that the recently added TestEthGetGenesis is flaky. The cause is that our state computation of the first epoch needs short-circuiting to handle certain special-casing (eg. a WinCount of 0).

## Proposed Changes
<!-- A clear list of the changes being made -->

This special-casing already exists, but lived one level too high for tooling like `StateCompute`. Moving it down one level fixes the issue.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
