### PR TITLE
fix: rpcenc: deflake TestReaderRedirectDrop

### DIFF
--- a/lib/rpcenc/reader.go
+++ b/lib/rpcenc/reader.go
@@ -221,7 +221,7 @@ type RpcReader struct {
 
 	res       chan readRes
 	beginOnce *sync.Once
-	closeOnce sync.Once
+	closeOnce *sync.Once
 }
 
 var ErrHasBody = errors.New("RPCReader has body, either already read from or from a client with no redirect support")
@@ -265,6 +265,7 @@ func (w *RpcReader) beginPost() {
 		w.postBody = nr.postBody
 		w.res = nr.res
 		w.beginOnce = nr.beginOnce
+		w.closeOnce = nr.closeOnce
 	}
 }
 
@@ -355,6 +356,7 @@ func ReaderParamDecoder() (http.HandlerFunc, jsonrpc.ServerOption) {
 			res:       make(chan readRes),
 			next:      ch,
 			beginOnce: &sync.Once{},
+			closeOnce: &sync.Once{},
 		}
 
 		switch req.Method {

--- a/lib/rpcenc/reader_test.go
+++ b/lib/rpcenc/reader_test.go
@@ -3,8 +3,8 @@ package rpcenc
 
 import (
 	"context"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -77,7 +77,12 @@ func (h *ReaderHandler) CloseReader(ctx context.Context, r io.Reader) error {
 }
 
 func (h *ReaderHandler) ReadAll(ctx context.Context, r io.Reader) ([]byte, error) {
-	return ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, xerrors.Errorf("readall: %w", err)
+	}
+
+	return b, nil
 }
 
 func (h *ReaderHandler) ReadNullLen(ctx context.Context, r io.Reader) (int64, error) {
@@ -219,9 +224,15 @@ func TestReaderRedirect(t *testing.T) {
 }
 
 func TestReaderRedirectDrop(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("test %d", i), testReaderRedirectDrop)
+	}
+}
+
+func testReaderRedirectDrop(t *testing.T) {
 	// lower timeout so that the dangling connection between client and reader is dropped quickly
 	// after the test. Otherwise httptest.Close is blocked.
-	Timeout = 200 * time.Millisecond
+	Timeout = 90 * time.Millisecond
 
 	var allClient struct {
 		ReadAll func(ctx context.Context, r io.Reader) ([]byte, error)
@@ -294,6 +305,8 @@ func TestReaderRedirectDrop(t *testing.T) {
 
 	done.Wait()
 
+	fmt.Println("---------------------")
+
 	// Redir client drops before subcall
 	done.Add(1)
 
@@ -313,6 +326,8 @@ func TestReaderRedirectDrop(t *testing.T) {
 	// kill redirecting server connection
 	testServ.CloseClientConnections()
 
+	//time.Sleep(200 * time.Millisecond)
+
 	// ReadAllWaiting should fail
 	done.Wait()
 
@@ -322,5 +337,9 @@ func TestReaderRedirectDrop(t *testing.T) {
 	// wait for subcall to finish
 	<-contCh
 
-	require.ErrorContains(t, allServerHandler.subErr, "decoding params for 'ReaderHandler.ReadAll' (param: 0; custom decoder): context canceled")
+	estr := allServerHandler.subErr.Error()
+
+	require.True(t,
+		strings.Contains(estr, "decoding params for 'ReaderHandler.ReadAll' (param: 0; custom decoder): context canceled") ||
+			strings.Contains(estr, "readall: unexpected EOF"), "unexpected error: %s", estr)
 }

--- a/lib/rpcenc/reader_test.go
+++ b/lib/rpcenc/reader_test.go
@@ -326,8 +326,6 @@ func testReaderRedirectDrop(t *testing.T) {
 	// kill redirecting server connection
 	testServ.CloseClientConnections()
 
-	//time.Sleep(200 * time.Millisecond)
-
 	// ReadAllWaiting should fail
 	done.Wait()
 


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/10201

## Proposed Changes
* Make the test reproduce the original issue with near ~100% reliability
* Fix the edge-case
* Update the test to deal with racy behavior correctly

## Additional Info
* `beginPost` "transforms" the virtual reader into a real one after the first call to Read
* `TestReaderRedirectDrop` tests what happens when the connection from the client to the redirecting node drops juuust before the redirecting node attempts to call a target node with a redirected reader
  * There appears to be a race between the redirected stream being accepted/consumed on the decoding end, and the redirect logic noticing that the stream that we have just tried to redirect was closed.
  * Fixing that would require a lot of hacky instrumentation, so for now the test accepts both, entirely correct, outcomes from the closed to-be-redirected head request.
* `closeOnce` needs to be propagated because it's what's guarding nr.res from double-close

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
