### PR TITLE
fix: EthAPI: use StateCompute for feeHistory; apply minimum gas premium

### DIFF
--- a/itests/eth_fee_history_test.go
+++ b/itests/eth_fee_history_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/filecoin-project/go-jsonrpc"
 
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/lib/result"
+	"github.com/filecoin-project/lotus/node/impl/full"
 )
 
 func TestEthFeeHistory(t *testing.T) {
@@ -22,13 +24,16 @@ func TestEthFeeHistory(t *testing.T) {
 
 	blockTime := 100 * time.Millisecond
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
-	ens.InterconnectAll().BeginMining(blockTime)
+	miner := ens.InterconnectAll().BeginMining(blockTime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	// Wait for the network to create 20 blocks
 	client.WaitTillChain(ctx, kit.HeightAtLeast(20))
+	for _, m := range miner {
+		m.Pause()
+	}
 
 	history, err := client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{5, "0x10"}),
@@ -46,6 +51,17 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(6, len(history.BaseFeePerGas))
 	require.Equal(5, len(history.GasUsedRatio))
 	require.Equal(ethtypes.EthUint64(16-5+1), history.OldestBlock)
+	require.Nil(history.Reward)
+
+	latestBlk, err := client.EthGetBlockByNumber(ctx, "latest", false)
+	require.NoError(err)
+	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
+		json.Marshal([]interface{}{5, "latest"}),
+	).Assert(require.NoError))
+	require.NoError(err)
+	require.Equal(6, len(history.BaseFeePerGas))
+	require.Equal(5, len(history.GasUsedRatio))
+	require.Equal(latestBlk.Number-5+1, history.OldestBlock)
 	require.Nil(history.Reward)
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
@@ -75,6 +91,26 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(ethtypes.EthUint64(10-5+1), history.OldestBlock)
 	require.Nil(history.Reward)
 
+	// test when the requested number of blocks is longer than chain length
+	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
+		json.Marshal([]interface{}{"0x30", "latest"}),
+	).Assert(require.NoError))
+	require.NoError(err)
+	require.Equal(int(latestBlk.Number)+1, len(history.BaseFeePerGas))
+	require.Equal(int(latestBlk.Number), len(history.GasUsedRatio))
+	require.Equal(ethtypes.EthUint64(1), history.OldestBlock)
+	require.Nil(history.Reward)
+
+	// test when the requested number of blocks is longer than chain length
+	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
+		json.Marshal([]interface{}{"0x30", "10"}),
+	).Assert(require.NoError))
+	require.NoError(err)
+	require.Equal(10+1, len(history.BaseFeePerGas))
+	require.Equal(10, len(history.GasUsedRatio))
+	require.Equal(ethtypes.EthUint64(1), history.OldestBlock)
+	require.Nil(history.Reward)
+
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{5, "10", &[]float64{25, 50, 75}}),
 	).Assert(require.NoError))
@@ -86,10 +122,18 @@ func TestEthFeeHistory(t *testing.T) {
 	require.Equal(5, len(*history.Reward))
 	for _, arr := range *history.Reward {
 		require.Equal(3, len(arr))
+		for _, item := range arr {
+			require.Equal(ethtypes.EthBigInt(types.NewInt(full.MinGasPremium)), item)
+		}
 	}
 
 	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
 		json.Marshal([]interface{}{1025, "10", &[]float64{25, 50, 75}}),
+	).Assert(require.NoError))
+	require.Error(err)
+
+	history, err = client.EthFeeHistory(ctx, result.Wrap[jsonrpc.RawParams](
+		json.Marshal([]interface{}{5, "10", &[]float64{75, 50}}),
 	).Assert(require.NoError))
 	require.Error(err)
 

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -691,8 +691,8 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	gasUsedRatioArray := []float64{}
 	rewardsArray := make([][]ethtypes.EthBigInt, 0)
 
-	blockCount := 0
-	for blockCount < int(params.BlkCount) && ts.Height() > 0 {
+	blocksIncluded := 0
+	for blocksIncluded < int(params.BlkCount) && ts.Height() > 0 {
 		compOutput, err := a.StateCompute(ctx, ts.Height(), nil, ts.Key())
 		if err != nil {
 			return ethtypes.EthFeeHistory{}, xerrors.Errorf("cannot lookup the status of tipset: %v: %w", ts, err)
@@ -727,7 +727,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 		gasUsedRatioArray = append(gasUsedRatioArray, float64(totalGasUsed)/float64(build.BlockGasLimit))
 		rewardsArray = append(rewardsArray, rewards)
 		oldestBlkHeight = uint64(ts.Height())
-		blockCount++
+		blocksIncluded++
 
 		parentTsKey := ts.Parents()
 		ts, err = a.Chain.LoadTipSet(ctx, parentTsKey)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -681,11 +681,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 		return ethtypes.EthFeeHistory{}, fmt.Errorf("bad block parameter %s: %s", params.NewestBlkNum, err)
 	}
 
-	// Deal with the case that the chain is shorter than the number of requested blocks.
 	oldestBlkHeight := uint64(1)
-	if abi.ChainEpoch(params.BlkCount) <= ts.Height() {
-		oldestBlkHeight = uint64(ts.Height()) - uint64(params.BlkCount) + 1
-	}
 
 	// NOTE: baseFeePerGas should include the next block after the newest of the returned range,
 	//  because the next base fee can be inferred from the messages in the newest block.
@@ -695,29 +691,31 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	gasUsedRatioArray := []float64{}
 	rewardsArray := make([][]ethtypes.EthBigInt, 0)
 
-	for ts.Height() >= abi.ChainEpoch(oldestBlkHeight) {
-		// Unfortunately we need to rebuild the full message view so we can
-		// totalize gas used in the tipset.
-		msgs, err := a.Chain.MessagesForTipset(ctx, ts)
+	for len(gasUsedRatioArray) < int(params.BlkCount) && ts.Height() > 0 {
+		compOutput, err := a.StateCompute(ctx, ts.Height(), nil, ts.Key())
 		if err != nil {
-			return ethtypes.EthFeeHistory{}, xerrors.Errorf("error loading messages for tipset: %v: %w", ts, err)
+			return ethtypes.EthFeeHistory{}, xerrors.Errorf("cannot lookup the status of tipset: %v: %w", ts, err)
 		}
 
 		txGasRewards := gasRewardSorter{}
-		for txIdx, msg := range msgs {
-			msgLookup, err := a.StateAPI.StateSearchMsg(ctx, types.EmptyTSK, msg.Cid(), api.LookbackNoLimit, false)
-			if err != nil || msgLookup == nil {
-				return ethtypes.EthFeeHistory{}, nil
+		for _, msg := range compOutput.Trace {
+			if msg.Msg.From == builtintypes.SystemActorAddr {
+				continue
 			}
 
-			tx, err := newEthTxFromMessageLookup(ctx, msgLookup, txIdx, a.Chain, a.StateAPI)
+			smsgCid, err := getSignedMessage(ctx, a.Chain, msg.MsgCid)
 			if err != nil {
-				return ethtypes.EthFeeHistory{}, nil
+				return ethtypes.EthFeeHistory{}, xerrors.Errorf("failed to get signed msg %s: %w", msg.MsgCid, err)
+			}
+
+			tx, err := newEthTxFromSignedMessage(ctx, smsgCid, a.StateAPI)
+			if err != nil {
+				return ethtypes.EthFeeHistory{}, err
 			}
 
 			txGasRewards = append(txGasRewards, gasRewardTuple{
 				reward: tx.Reward(ts.Blocks()[0].ParentBaseFee),
-				gas:    uint64(msgLookup.Receipt.GasUsed),
+				gas:    uint64(msg.MsgRct.GasUsed),
 			})
 		}
 
@@ -727,6 +725,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 		baseFeeArray = append(baseFeeArray, ethtypes.EthBigInt(ts.Blocks()[0].ParentBaseFee))
 		gasUsedRatioArray = append(gasUsedRatioArray, float64(totalGasUsed)/float64(build.BlockGasLimit))
 		rewardsArray = append(rewardsArray, rewards)
+		oldestBlkHeight = uint64(ts.Height())
 
 		parentTsKey := ts.Parents()
 		ts, err = a.Chain.LoadTipSet(ctx, parentTsKey)
@@ -2343,7 +2342,7 @@ func calculateRewardsAndGasUsed(rewardPercentiles []float64, txGasRewards gasRew
 
 	rewards := make([]ethtypes.EthBigInt, len(rewardPercentiles))
 	for i := range rewards {
-		rewards[i] = ethtypes.EthBigIntZero
+		rewards[i] = ethtypes.EthBigInt(types.NewInt(MinGasPremium))
 	}
 
 	if len(txGasRewards) == 0 {

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -135,7 +135,7 @@ func TestRewardPercentiles(t *testing.T) {
 		{
 			percentiles:  []float64{25, 50, 75},
 			txGasRewards: []gasRewardTuple{},
-			answer:       []int64{0, 0, 0},
+			answer:       []int64{MinGasPremium, MinGasPremium, MinGasPremium},
 		},
 		{
 			percentiles: []float64{25, 50, 75, 100},


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10393
https://github.com/filecoin-project/lotus/issues/10414

## Proposed Changes
1. use StateCompute instead of StateSearchMsg for feeHistory
2. return MinGasPremium when there's no tx in the block

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
