### PR TITLE
feat: worker: Ensure tempdir exists on startup

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -296,6 +296,13 @@ var runCmd = &cli.Command{
 			}
 		}
 
+		// ensure tmpdir exists
+		td := os.TempDir()
+		if err := os.MkdirAll(td, 0755); err != nil {
+			return xerrors.Errorf("ensuring temp dir %s exists: %w", td, err)
+		}
+
+		// Check file descriptor limit
 		limit, _, err := ulimit.GetLimit()
 		switch {
 		case err == ulimit.ErrUnsupported:


### PR DESCRIPTION
## Related Issues
This is something I occasionally run into in my setup when starting workers with custom TMPDIR, which on some of my systems disappears after reboot.

If not caught this would cause tasks like AddPiece to fail with a somewhat crypic error like
```
Caused by:
    0: failed to create data store
    1: No such file or directory (os error 2)
``` 

## Proposed Changes
Make UX slightly better when the tempdir doesn't exist.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
