### PR TITLE
feat: eth API: reject masked ID addresses embedded in f410f payloads

### DIFF
--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
 )
 
 type TestCase struct {
@@ -176,6 +177,20 @@ func TestParseEthAddr(t *testing.T) {
 
 		require.Equal(t, addr, faddr)
 	}
+}
+
+func TestMaskedIDInF4(t *testing.T) {
+	addr, err := address.NewIDAddress(100)
+	require.NoError(t, err)
+
+	eaddr, err := EthAddressFromFilecoinAddress(addr)
+	require.NoError(t, err)
+
+	badaddr, err := address.NewDelegatedAddress(builtin.EthereumAddressManagerActorID, eaddr[:])
+	require.NoError(t, err)
+
+	_, err = EthAddressFromFilecoinAddress(badaddr)
+	require.Error(t, err)
 }
 
 func TestUnmarshalEthCall(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

We'll never get an actor/account deployed to one of these addresses (although we might get a placeholder). However, converting such an address to an f4 address is definitely wrong.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green