### PR TITLE
feat: eth: optimize eth block loading + eth_feeHistory

### DIFF
--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -237,6 +237,26 @@ func (cs *ChainStore) ReadMsgMetaCids(ctx context.Context, mmc cid.Cid) ([]cid.C
 	return blscids, secpkcids, nil
 }
 
+func (cs *ChainStore) ReadReceipts(ctx context.Context, root cid.Cid) ([]types.MessageReceipt, error) {
+	a, err := blockadt.AsArray(cs.ActorStore(ctx), root)
+	if err != nil {
+		return nil, err
+	}
+
+	receipts := make([]types.MessageReceipt, 0, a.Length())
+	var rcpt types.MessageReceipt
+	if err := a.ForEach(&rcpt, func(i int64) error {
+		if int64(len(receipts)) != i {
+			return xerrors.Errorf("missing receipt %d", i)
+		}
+		receipts = append(receipts, rcpt)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return receipts, nil
+}
+
 func (cs *ChainStore) MessagesForBlock(ctx context.Context, b *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {
 	blscids, secpkcids, err := cs.ReadMsgMetaCids(ctx, b.Messages)
 	if err != nil {

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -44,14 +44,6 @@ type EthTx struct {
 	S                    EthBigInt   `json:"s"`
 }
 
-func (tx *EthTx) Reward(blkBaseFee big.Int) EthBigInt {
-	availablePriorityFee := big.Sub(big.Int(tx.MaxFeePerGas), blkBaseFee)
-	if big.Cmp(big.Int(tx.MaxPriorityFeePerGas), availablePriorityFee) <= 0 {
-		return tx.MaxPriorityFeePerGas
-	}
-	return EthBigInt(availablePriorityFee)
-}
-
 type EthTxArgs struct {
 	ChainID              int         `json:"chainId"`
 	Nonce                int         `json:"nonce"`

--- a/chain/types/message.go
+++ b/chain/types/message.go
@@ -219,4 +219,17 @@ func (m *Message) ValidForBlockInclusion(minGas int64, version network.Version) 
 	return nil
 }
 
+// EffectiveGasPremium returns the effective gas premium claimable by the miner
+// given the supplied base fee.
+//
+// Filecoin clamps the gas premium at GasFeeCap - BaseFee, if lower than the
+// specified premium.
+func (m *Message) EffectiveGasPremium(baseFee abi.TokenAmount) abi.TokenAmount {
+	available := big.Sub(m.GasFeeCap, baseFee)
+	if big.Cmp(m.GasPremium, available) <= 0 {
+		return m.GasPremium
+	}
+	return available
+}
+
 const TestGasLimit = 100e6

--- a/itests/eth_block_hash_test.go
+++ b/itests/eth_block_hash_test.go
@@ -49,9 +49,6 @@ func TestEthBlockHashesCorrect_MultiBlockTipset(t *testing.T) {
 	// let the chain run a little bit longer to minimise the chance of reorgs
 	n2.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+50))
 
-	head, err = n2.ChainHead(context.Background())
-	require.NoError(t, err)
-
 	for i := 1; i <= int(head.Height()); i++ {
 		hex := fmt.Sprintf("0x%x", i)
 

--- a/itests/eth_conformance_test.go
+++ b/itests/eth_conformance_test.go
@@ -237,14 +237,6 @@ func TestEthOpenRPCConformance(t *testing.T) {
 		},
 
 		{
-			method:  "eth_getBlockByNumber",
-			variant: "pending",
-			call: func(a *ethAPIRaw) (json.RawMessage, error) {
-				return ethapi.EthGetBlockByNumber(context.Background(), "pending", true)
-			},
-		},
-
-		{
 			method: "eth_getBlockByNumber",
 			call: func(a *ethAPIRaw) (json.RawMessage, error) {
 				return ethapi.EthGetBlockByNumber(context.Background(), blockNumberWithMessage.Hex(), true)

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -193,25 +193,14 @@ func (a *ChainAPI) ChainGetParentReceipts(ctx context.Context, bcid cid.Cid) ([]
 		return nil, nil
 	}
 
-	// TODO: need to get the number of messages better than this
-	pts, err := a.Chain.LoadTipSet(ctx, types.NewTipSetKey(b.Parents...))
+	receipts, err := a.Chain.ReadReceipts(ctx, b.ParentMessageReceipts)
 	if err != nil {
 		return nil, err
 	}
 
-	cm, err := a.Chain.MessagesForTipset(ctx, pts)
-	if err != nil {
-		return nil, err
-	}
-
-	var out []*types.MessageReceipt
-	for i := 0; i < len(cm); i++ {
-		r, err := a.Chain.GetParentReceipt(ctx, b, i)
-		if err != nil {
-			return nil, err
-		}
-
-		out = append(out, r)
+	out := make([]*types.MessageReceipt, len(receipts))
+	for i := range receipts {
+		out[i] = &receipts[i]
 	}
 
 	return out, nil

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -710,10 +710,6 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 
 		txGasRewards := gasRewardSorter{}
 		for i, msg := range msgs {
-			if msg.VMMessage().From == builtintypes.SystemActorAddr {
-				continue
-			}
-
 			effectivePremium := msg.VMMessage().EffectiveGasPremium(basefee)
 			txGasRewards = append(txGasRewards, gasRewardTuple{
 				premium: effectivePremium,

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -234,14 +234,13 @@ func (a *EthModule) EthGetBlockByHash(ctx context.Context, blkHash ethtypes.EthH
 }
 
 func (a *EthModule) parseBlkParam(ctx context.Context, blkParam string, strict bool) (tipset *types.TipSet, err error) {
-	if blkParam == "earliest" {
-		return nil, fmt.Errorf("block param \"earliest\" is not supported")
+	switch blkParam {
+	case "earliest", "pending":
+		return nil, fmt.Errorf("block param %q is not supported", blkParam)
 	}
 
 	head := a.Chain.GetHeaviestTipSet()
 	switch blkParam {
-	case "pending":
-		return head, nil
 	case "latest":
 		parent, err := a.Chain.GetTipSetFromKey(ctx, head.Parents())
 		if err != nil {


### PR DESCRIPTION
## Related Issues

The current implementations of eth_getBlock* and eth_feeHistory have proven computationally expensive due to their usage of full tipset computations (`StateCompute`). This PR replaces the expensive logic with receipt lookups.

## Proposed Changes

For eth_getBlock* and eth_feeHistory, instead of replaying the tipset:

1. Lookup the tipset receipts.
2. Load the receipts.
3. Calculate everything from there (we have the gas used, etc.)

This also removes support for the `pending` block parameter as it's impossible to handle it without forcing state computes, which are prohibitively expensive. The Eth community is evaluating a proposal to also remove it in their next fork, given its limited applications due to MEV and other reasons.

## Additional Info

We've gone down from 10 seconds to various minutes (depending on the method and amount of data request) to almost instantaneous responses.

### After

```
⟩ time curl --silent --url http://localhost:1234/rpc/v1 \
      -X POST \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","method":"eth_feeHistory","params":[ "0x08", "latest", [10, 50, 90] ],"id":1}'
{"jsonrpc":"2.0","result":{"oldestBlock":"0x28d39e","baseFeePerGas":["0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b","0x56ceb9b"],"gasUsedRatio":[1.1866695961,2.0196181532,2.5688713134,1.6794295302,1.7004244153,1.2444834388,1.736932316,2.2669179384],"reward":[["0x2de55df","0x2e29630","0x2e8e694"],["0x2d92b3b","0x2e665f8","0x5a874a8"],["0x294d17d","0x2e5547e","0x2eb2dbb"],["0x11c1e0d","0x2e35135","0x38a8b8f"],["0x11b8225","0x2e4b13e","0x39fb27c"],["0x2e18bb6","0x2e7c695","0x5d51c6a"],["0x2e0836d","0x2e70add","0x2ec2445"],["0x2e18763","0x2e429c9","0x2ebcc8a"]]},"id":1}

________________________________________________________
Executed in  345.14 millis    fish           external
   usr time    3.56 millis    0.12 millis    3.44 millis
   sys time    7.72 millis    3.36 millis    4.36 millis

~/W/pl/lotus · (steb/optimize-eth-block±)
⟩ time curl --silent --url http://localhost:1234/rpc/v1 \
      -X POST \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":[ "latest", false ],"id":1}'
...

________________________________________________________
Executed in  366.47 millis    fish           external
   usr time    4.64 millis    0.12 millis    4.52 millis
   sys time   11.66 millis    4.58 millis    7.08 millis
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
