### PR TITLE
gateway: fix: drop overzealous guard on MsigGetVested

### DIFF
--- a/gateway/proxy_fil.go
+++ b/gateway/proxy_fil.go
@@ -217,9 +217,6 @@ func (gw *Node) MsigGetVested(ctx context.Context, addr address.Address, start t
 	if err := gw.limit(ctx, walletRateLimitTokens); err != nil {
 		return types.BigInt{}, err
 	}
-	if err := gw.checkTipsetKey(ctx, start); err != nil {
-		return types.NewInt(0), err
-	}
 	if err := gw.checkTipsetKey(ctx, end); err != nil {
 		return types.NewInt(0), err
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Folks were trying to use the chain.love gateway to get info about a msig's vesting funds, starting from genesis. This didn't work, because we guard on the start tipset (making sure it's within the last 24 hours).

## Proposed Changes
<!-- A clear list of the changes being made -->

There's no actual reason to guard on the start tipset, though -- we're not actually loading its state, just its height. We could honestly change this API to take a start height, it'd be better.

But the quick solution is just to drop the guard on the start tipset for the gateway.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
