### PR TITLE
make StateCompute not write the output state to the blockstore.

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	blocks "github.com/ipfs/go-libipfs/blocks"
+	"github.com/ipfs/go-libipfs/blocks"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/filecoin-project/go-address"
@@ -606,6 +606,9 @@ type FullNode interface {
 	//
 	// Messages in the `apply` parameter must have the correct nonces, and gas
 	// values set.
+	//
+	// This method does not write the resulting state to the blockstore. Usually
+	// that state will already exist.
 	StateCompute(context.Context, abi.ChainEpoch, []*types.Message, types.TipSetKey) (*ComputeStateOutput, error) //perm:read
 	// StateVerifierStatus returns the data cap for the given address.
 	// Returns nil if there is no entry in the data cap table for the

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -17,6 +17,7 @@ import (
 	gstStore "github.com/filecoin-project/go-state-types/store"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/blockstore"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/system"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -86,13 +87,14 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		// future. It's not guaranteed to be accurate... but that's fine.
 	}
 
+	buf := blockstore.NewBuffered(sm.cs.StateBlockstore())
 	r := rand.NewStateRand(sm.cs, ts.Cids(), sm.beacon, sm.GetNetworkVersion)
 	vmopt := &vm.VMOpts{
 		StateBase:      base,
 		Epoch:          height,
 		Timestamp:      ts.MinTimestamp(),
 		Rand:           r,
-		Bstore:         sm.cs.StateBlockstore(),
+		Bstore:         buf,
 		Actors:         sm.tsExec.NewActorRegistry(),
 		Syscalls:       sm.Syscalls,
 		CircSupplyCalc: sm.GetVMCirculatingSupply,

--- a/cmd/lotus-shed/chain.go
+++ b/cmd/lotus-shed/chain.go
@@ -77,6 +77,10 @@ var computeStateRangeCmd = &cli.Command{
 			return err
 		}
 
+		// StateCompute doesn't write the resulting state to the blockstore,
+		// hence state write overheads that would otherwise apply during block
+		// validation will not be observed here.
+
 		fmt.Printf("computing tipset at height %d (start)\n", startTs.Height())
 		if _, err := api.StateCompute(ctx, startTs.Height(), nil, startTs.Key()); err != nil {
 			return err


### PR DESCRIPTION
## Related Issues

v1.20.3 began using `StateCompute` in the Eth API. Unfortunately, node operators reported a sharp increase in blockstore size. This was traced to `StateCompute` writing the output state to the blockstore. Badger is an LSM-tree + value log store, and will happily take the redundant write. The sharp increase was reported by the Glif team — the API endpoint that most wallets use, as well as the Codefi gas oracle, which pings it constantly with eth_feeHistory calls. These calls are special offenders since they call `StateCompute` over a sequence of tipsets.

## Proposed Changes

Make `StateCompute` discard its output state. This won't have any effects since all state should already be present in the blockstore anyway. Also, it's only used by CLI and Shed tooling (beyond the Eth API). I've left a note in the relevant places.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
