### PR TITLE
fix: Eth API: make net_version return the chain ID.

### DIFF
--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/lotus/build"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/builtin"
 
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/chain/wallet/key"

--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -2,9 +2,11 @@ package itests
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/lotus/build"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/builtin"
@@ -108,4 +110,17 @@ func TestEthGetGenesis(t *testing.T) {
 	genesisHash, err := ethtypes.EthHashFromCid(genesisCid)
 	require.NoError(t, err)
 	require.Equal(t, ethBlk.Hash, genesisHash)
+}
+
+func TestNetVersion(t *testing.T) {
+	blockTime := 100 * time.Millisecond
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
+	ens.InterconnectAll().BeginMining(blockTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	version, err := client.NetVersion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(build.Eip155ChainId), version)
 }

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -766,13 +766,8 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	return ret, nil
 }
 
-func (a *EthModule) NetVersion(ctx context.Context) (string, error) {
-	// Note that networkId is not encoded in hex
-	nv, err := a.StateNetworkVersion(ctx, types.EmptyTSK)
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatUint(uint64(nv), 10), nil
+func (a *EthModule) NetVersion(_ context.Context) (string, error) {
+	return strconv.FormatInt(build.Eip155ChainId, 10), nil
 }
 
 func (a *EthModule) NetListening(ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Related Issues

Fixes #10408.

## Proposed Changes

Makes `net_version` return the chain ID in decimal string. Also, sdds a test.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
