### PR TITLE
feat: discard state writes in StateCompute and StateReplay.

### DIFF
--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -263,7 +263,11 @@ func (sm *StateManager) Replay(ctx context.Context, ts *types.TipSet, mcid cid.C
 	// message to find
 	finder.mcid = mcid
 
-	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &finder, true)
+	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &ExecutorOpts{
+		ExecMonitor:  &finder,
+		VmTracing:    true,
+		DiscardState: true, // safe to skip the write since this is throwaway state.
+	})
 	if err != nil && !xerrors.Is(err, errHaltExecution) {
 		return nil, nil, xerrors.Errorf("unexpected error during execution: %w", err)
 	}

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -97,9 +97,19 @@ func (m *migrationResultCache) Store(ctx context.Context, root cid.Cid, resultCi
 	return nil
 }
 
+// ExecutorOpts defines options for the execution.
+type ExecutorOpts struct {
+	ExecMonitor ExecMonitor
+	VmTracing   bool
+	// DiscardState, when enabled, skips writing the output state tree into the
+	// blockstore. This is useful when requesting execution traces for tipsets
+	// already in the chain, or for speculative executions.
+	DiscardState bool
+}
+
 type Executor interface {
 	NewActorRegistry() *vm.ActorRegistry
-	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor, vmTracing bool) (stateroot cid.Cid, rectsroot cid.Cid, err error)
+	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, opts *ExecutorOpts) (stateroot cid.Cid, rectsroot cid.Cid, err error)
 }
 
 type StateManager struct {

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -17,6 +17,7 @@ import (
 	gstStore "github.com/filecoin-project/go-state-types/store"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/blockstore"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/system"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -86,13 +87,14 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 		// future. It's not guaranteed to be accurate... but that's fine.
 	}
 
+	bs := blockstore.NewBuffered(sm.cs.StateBlockstore())
 	r := rand.NewStateRand(sm.cs, ts.Cids(), sm.beacon, sm.GetNetworkVersion)
 	vmopt := &vm.VMOpts{
 		StateBase:      base,
 		Epoch:          height,
 		Timestamp:      ts.MinTimestamp(),
 		Rand:           r,
-		Bstore:         sm.cs.StateBlockstore(),
+		Bstore:         bs,
 		Actors:         sm.tsExec.NewActorRegistry(),
 		Syscalls:       sm.Syscalls,
 		CircSupplyCalc: sm.GetVMCirculatingSupply,

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -172,8 +172,10 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 		blocks,
 		params.ExecEpoch,
 		params.Rand,
-		recordOutputs,
-		true,
+		&stmgr.ExecutorOpts{
+			ExecMonitor: recordOutputs,
+			VmTracing:   true,
+		},
 		params.BaseFee,
 		nil,
 	)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1843,7 +1843,7 @@ func messagesAndReceipts(ctx context.Context, ts *types.TipSet, cs *store.ChainS
 		return nil, nil, xerrors.Errorf("error loading messages for tipset: %v: %w", ts, err)
 	}
 
-	_, rcptRoot, err := sa.StateManager.TipSetState(ctx, ts)
+	_, rcptRoot, err := sa.StateManager.TipSetStateWithOpts(ctx, ts, &stmgr.TipSetStateOpts{DiscardState: true})
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to compute state: %w", err)
 	}


### PR DESCRIPTION
## Related Issues

This originally started because Glif and other operators begun having blockstore ballooning issues starting with v1.20.3. The issue was the usage of `StateCompute` in the Eth API. That method finishes by flushing the new state to the blockstore. Badger is an LSM + value log store, and it happily accepts every write.

![image](https://user-images.githubusercontent.com/1101242/224517310-f04f5bc9-d615-42ae-8b1c-b9ffb1325af0.png)

## Proposed Changes

The fix is to add a flag to skip writing the state tree when executing a tipset. By default we write, except when the caller requests us not to. Instead of polluting APIs with yet another option, I decided to add an option struct (`ExecutorOpts`). Unfortunately, `TipSetState` is used a many places, so to avoid breakage I introduced a `TipSetWithOpts` method. We _could_ also use the functional options pattern, but those are generally used in more public/user-facing APIs.

This change is no longer necessary for the Eth API, since we no longer need to compute state after https://github.com/filecoin-project/lotus/pull/10446. However, they will be very beneficial to users of `StateCompute` (e.g. exchanges) and `StateReplay`.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
