### PR TITLE
refactor: update cache to the new generic version

### DIFF
--- a/chain/badtscache.go
+++ b/chain/badtscache.go
@@ -3,14 +3,14 @@ package chain
 import (
 	"fmt"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/build"
 )
 
 type BadBlockCache struct {
-	badBlocks *lru.ARCCache
+	badBlocks *lru.ARCCache[cid.Cid, BadBlockReason]
 }
 
 type BadBlockReason struct {
@@ -43,7 +43,7 @@ func (bbr BadBlockReason) String() string {
 }
 
 func NewBadBlockCache() *BadBlockCache {
-	cache, err := lru.NewARC(build.BadBlockCacheSize)
+	cache, err := lru.NewARC[cid.Cid, BadBlockReason](build.BadBlockCacheSize)
 	if err != nil {
 		panic(err) // ok
 	}
@@ -66,10 +66,5 @@ func (bts *BadBlockCache) Purge() {
 }
 
 func (bts *BadBlockCache) Has(c cid.Cid) (BadBlockReason, bool) {
-	rval, ok := bts.badBlocks.Get(c)
-	if !ok {
-		return BadBlockReason{}, false
-	}
-
-	return rval.(BadBlockReason), true
+	return bts.badBlocks.Get(c)
 }

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -159,7 +159,7 @@ type MessagePool struct {
 	// pruneCooldown is a channel used to allow a cooldown time between prunes
 	pruneCooldown chan struct{}
 
-	blsSigCache *lru.TwoQueueCache
+	blsSigCache *lru.TwoQueueCache[cid.Cid, crypto.Signature]
 
 	changes *lps.PubSub
 
@@ -167,9 +167,9 @@ type MessagePool struct {
 
 	netName dtypes.NetworkName
 
-	sigValCache *lru.TwoQueueCache
+	sigValCache *lru.TwoQueueCache[string, struct{}]
 
-	nonceCache *lru.Cache
+	nonceCache *lru.Cache[nonceCacheKey, uint64]
 
 	evtTypes [3]journal.EventType
 	journal  journal.Journal
@@ -369,9 +369,9 @@ func (ms *msgSet) toSlice() []*types.SignedMessage {
 }
 
 func New(ctx context.Context, api Provider, ds dtypes.MetadataDS, us stmgr.UpgradeSchedule, netName dtypes.NetworkName, j journal.Journal) (*MessagePool, error) {
-	cache, _ := lru.New2Q(build.BlsSignatureCacheSize)
-	verifcache, _ := lru.New2Q(build.VerifSigCacheSize)
-	noncecache, _ := lru.New(256)
+	cache, _ := lru.New2Q[cid.Cid, crypto.Signature](build.BlsSignatureCacheSize)
+	verifcache, _ := lru.New2Q[string, struct{}](build.VerifSigCacheSize)
+	noncecache, _ := lru.New[nonceCacheKey, uint64](256)
 
 	cfg, err := loadConfig(ctx, ds)
 	if err != nil {
@@ -1053,7 +1053,7 @@ func (mp *MessagePool) getStateNonce(ctx context.Context, addr address.Address, 
 
 	n, ok := mp.nonceCache.Get(nk)
 	if ok {
-		return n.(uint64), nil
+		return n, nil
 	}
 
 	act, err := mp.api.GetActorAfter(addr, ts)
@@ -1473,13 +1473,8 @@ func (mp *MessagePool) MessagesForBlocks(ctx context.Context, blks []*types.Bloc
 }
 
 func (mp *MessagePool) RecoverSig(msg *types.Message) *types.SignedMessage {
-	val, ok := mp.blsSigCache.Get(msg.Cid())
+	sig, ok := mp.blsSigCache.Get(msg.Cid())
 	if !ok {
-		return nil
-	}
-	sig, ok := val.(crypto.Signature)
-	if !ok {
-		log.Errorf("value in signature cache was not a signature (got %T)", val)
 		return nil
 	}
 

--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -207,9 +207,7 @@ type mmCids struct {
 }
 
 func (cs *ChainStore) ReadMsgMetaCids(ctx context.Context, mmc cid.Cid) ([]cid.Cid, []cid.Cid, error) {
-	o, ok := cs.mmCache.Get(mmc)
-	if ok {
-		mmcids := o.(*mmCids)
+	if mmcids, ok := cs.mmCache.Get(mmc); ok {
 		return mmcids.bls, mmcids.secpk, nil
 	}
 
@@ -229,7 +227,7 @@ func (cs *ChainStore) ReadMsgMetaCids(ctx context.Context, mmc cid.Cid) ([]cid.C
 		return nil, nil, xerrors.Errorf("loading secpk message cids for block: %w", err)
 	}
 
-	cs.mmCache.Add(mmc, &mmCids{
+	cs.mmCache.Add(mmc, mmCids{
 		bls:   blscids,
 		secpk: secpkcids,
 	})

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	blocks "github.com/ipfs/go-libipfs/blocks"
@@ -217,7 +217,7 @@ func fetchCids(
 type BlockValidator struct {
 	self peer.ID
 
-	peers *lru.TwoQueueCache
+	peers *lru.TwoQueueCache[peer.ID, int]
 
 	killThresh int
 
@@ -231,7 +231,7 @@ type BlockValidator struct {
 }
 
 func NewBlockValidator(self peer.ID, chain *store.ChainStore, cns consensus.Consensus, blacklist func(peer.ID)) *BlockValidator {
-	p, _ := lru.New2Q(4096)
+	p, _ := lru.New2Q[peer.ID, int](4096)
 	return &BlockValidator{
 		self:       self,
 		peers:      p,
@@ -244,13 +244,11 @@ func NewBlockValidator(self peer.ID, chain *store.ChainStore, cns consensus.Cons
 }
 
 func (bv *BlockValidator) flagPeer(p peer.ID) {
-	v, ok := bv.peers.Get(p)
+	val, ok := bv.peers.Get(p)
 	if !ok {
-		bv.peers.Add(p, int(1))
+		bv.peers.Add(p, 1)
 		return
 	}
-
-	val := v.(int)
 
 	if val >= bv.killThresh {
 		log.Warnf("blacklisting peer %s", p)
@@ -258,7 +256,7 @@ func (bv *BlockValidator) flagPeer(p peer.ID) {
 		return
 	}
 
-	bv.peers.Add(p, v.(int)+1)
+	bv.peers.Add(p, val+1)
 }
 
 func (bv *BlockValidator) Validate(ctx context.Context, pid peer.ID, msg *pubsub.Message) (res pubsub.ValidationResult) {
@@ -293,11 +291,11 @@ func (bv *BlockValidator) Validate(ctx context.Context, pid peer.ID, msg *pubsub
 }
 
 type blockReceiptCache struct {
-	blocks *lru.TwoQueueCache
+	blocks *lru.TwoQueueCache[cid.Cid, int]
 }
 
 func newBlockReceiptCache() *blockReceiptCache {
-	c, _ := lru.New2Q(8192)
+	c, _ := lru.New2Q[cid.Cid, int](8192)
 
 	return &blockReceiptCache{
 		blocks: c,
@@ -307,12 +305,12 @@ func newBlockReceiptCache() *blockReceiptCache {
 func (brc *blockReceiptCache) add(bcid cid.Cid) int {
 	val, ok := brc.blocks.Get(bcid)
 	if !ok {
-		brc.blocks.Add(bcid, int(1))
+		brc.blocks.Add(bcid, 1)
 		return 0
 	}
 
-	brc.blocks.Add(bcid, val.(int)+1)
-	return val.(int)
+	brc.blocks.Add(bcid, val+1)
+	return val
 }
 
 type MessageValidator struct {
@@ -466,13 +464,13 @@ type peerMsgInfo struct {
 type IndexerMessageValidator struct {
 	self peer.ID
 
-	peerCache *lru.TwoQueueCache
+	peerCache *lru.TwoQueueCache[address.Address, *peerMsgInfo]
 	chainApi  full.ChainModuleAPI
 	stateApi  full.StateModuleAPI
 }
 
 func NewIndexerMessageValidator(self peer.ID, chainApi full.ChainModuleAPI, stateApi full.StateModuleAPI) *IndexerMessageValidator {
-	peerCache, _ := lru.New2Q(8192)
+	peerCache, _ := lru.New2Q[address.Address, *peerMsgInfo](8192)
 
 	return &IndexerMessageValidator{
 		self:      self,
@@ -515,15 +513,12 @@ func (v *IndexerMessageValidator) Validate(ctx context.Context, pid peer.ID, msg
 		return pubsub.ValidationReject
 	}
 
-	minerID := minerAddr.String()
 	msgCid := idxrMsg.Cid
 
 	var msgInfo *peerMsgInfo
-	val, ok := v.peerCache.Get(minerID)
+	msgInfo, ok := v.peerCache.Get(minerAddr)
 	if !ok {
 		msgInfo = &peerMsgInfo{}
-	} else {
-		msgInfo = val.(*peerMsgInfo)
 	}
 
 	// Lock this peer's message info.
@@ -544,7 +539,7 @@ func (v *IndexerMessageValidator) Validate(ctx context.Context, pid peer.ID, msg
 		// Check that the miner ID maps to the peer that sent the message.
 		err = v.authenticateMessage(ctx, minerAddr, originPeer)
 		if err != nil {
-			log.Warnw("cannot authenticate messsage", "err", err, "peer", originPeer, "minerID", minerID)
+			log.Warnw("cannot authenticate messsage", "err", err, "peer", originPeer, "minerID", minerAddr)
 			stats.Record(ctx, metrics.IndexerMessageValidationFailure.M(1))
 			return pubsub.ValidationReject
 		}
@@ -554,7 +549,7 @@ func (v *IndexerMessageValidator) Validate(ctx context.Context, pid peer.ID, msg
 			// messages from the same peer are handled concurrently, there is a
 			// small chance that one msgInfo could replace the other here when
 			// the info is first cached.  This is OK, so no need to prevent it.
-			v.peerCache.Add(minerID, msgInfo)
+			v.peerCache.Add(minerAddr, msgInfo)
 		}
 	}
 

--- a/cmd/lotus-shed/state-stats.go
+++ b/cmd/lotus-shed/state-stats.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/docker/go-units"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
@@ -50,13 +50,13 @@ type fieldItem struct {
 
 type cacheNodeGetter struct {
 	ds    format.NodeGetter
-	cache *lru.TwoQueueCache
+	cache *lru.TwoQueueCache[cid.Cid, format.Node]
 }
 
 func newCacheNodeGetter(d format.NodeGetter, size int) (*cacheNodeGetter, error) {
 	cng := &cacheNodeGetter{ds: d}
 
-	cache, err := lru.New2Q(size)
+	cache, err := lru.New2Q[cid.Cid, format.Node](size)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func newCacheNodeGetter(d format.NodeGetter, size int) (*cacheNodeGetter, error)
 
 func (cng *cacheNodeGetter) Get(ctx context.Context, c cid.Cid) (format.Node, error) {
 	if n, ok := cng.cache.Get(c); ok {
-		return n.(format.Node), nil
+		return n, nil
 	}
 
 	n, err := cng.ds.Get(ctx, c)

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hashicorp/raft v1.1.1
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/icza/backscanner v0.0.0-20210726202459-ac2ffc679f94
@@ -230,6 +230,7 @@ require (
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/iancoleman/orderedmap v0.1.0 // indirect
 	github.com/ipfs/go-bitfield v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,11 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
+github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
+github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	logging "github.com/ipfs/go-log/v2"
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
@@ -61,7 +61,7 @@ func randTimeOffset(width time.Duration) time.Duration {
 // NewMiner instantiates a miner with a concrete WinningPoStProver and a miner
 // address (which can be different from the worker's address).
 func NewMiner(api v1api.FullNode, epp gen.WinningPoStProver, addr address.Address, sf *slashfilter.SlashFilter, j journal.Journal) *Miner {
-	arc, err := lru.NewARC(10000)
+	arc, err := lru.NewARC[abi.ChainEpoch, bool](10000)
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +122,7 @@ type Miner struct {
 	// minedBlockHeights is a safeguard that caches the last heights we mined.
 	// It is consulted before publishing a newly mined block, for a sanity check
 	// intended to avoid slashings in case of a bug.
-	minedBlockHeights *lru.ARCCache
+	minedBlockHeights *lru.ARCCache[abi.ChainEpoch, bool]
 
 	evtTypes [1]journal.EventType
 	journal  journal.Journal
@@ -331,13 +331,12 @@ minerLoop:
 				}
 			}
 
-			blkKey := fmt.Sprintf("%d", b.Header.Height)
-			if _, ok := m.minedBlockHeights.Get(blkKey); ok {
+			if _, ok := m.minedBlockHeights.Get(b.Header.Height); ok {
 				log.Warnw("Created a block at the same height as another block we've created", "height", b.Header.Height, "miner", b.Header.Miner, "parents", b.Header.Parents)
 				continue
 			}
 
-			m.minedBlockHeights.Add(blkKey, true)
+			m.minedBlockHeights.Add(b.Header.Height, true)
 
 			if err := m.api.SyncSubmitBlock(ctx, b); err != nil {
 				log.Errorf("failed to submit newly mined block: %+v", err)

--- a/miner/testminer.go
+++ b/miner/testminer.go
@@ -3,7 +3,7 @@ package miner
 import (
 	"context"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/filecoin-project/go-address"
@@ -22,7 +22,7 @@ type MineReq struct {
 
 func NewTestMiner(nextCh <-chan MineReq, addr address.Address) func(v1api.FullNode, gen.WinningPoStProver) *Miner {
 	return func(api v1api.FullNode, epp gen.WinningPoStProver) *Miner {
-		arc, err := lru.NewARC(10000)
+		arc, err := lru.NewARC[abi.ChainEpoch, bool](10000)
 		if err != nil {
 			panic(err)
 		}

--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"sort"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
@@ -61,7 +61,7 @@ type GasAPI struct {
 
 func NewGasPriceCache() *GasPriceCache {
 	// 50 because we usually won't access more than 40
-	c, err := lru.New2Q(50)
+	c, err := lru.New2Q[types.TipSetKey, []GasMeta](50)
 	if err != nil {
 		// err only if parameter is bad
 		panic(err)
@@ -73,7 +73,7 @@ func NewGasPriceCache() *GasPriceCache {
 }
 
 type GasPriceCache struct {
-	c *lru.TwoQueueCache
+	c *lru.TwoQueueCache[types.TipSetKey, []GasMeta]
 }
 
 type GasMeta struct {
@@ -84,7 +84,7 @@ type GasMeta struct {
 func (g *GasPriceCache) GetTSGasStats(ctx context.Context, cstore *store.ChainStore, ts *types.TipSet) ([]GasMeta, error) {
 	i, has := g.c.Get(ts.Key())
 	if has {
-		return i.([]GasMeta), nil
+		return i, nil
 	}
 
 	var prices []GasMeta


### PR DESCRIPTION
- Adds type safety.
- Reduces allocations.
- ~Fixes the drand cache (was storing by value, but retrieving by pointer)~ (steven can't read)