### PR TITLE
feat: eth: cache fee history percentiles

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -337,6 +337,9 @@
   # env var: LOTUS_FEVM_ETHTXHASHMAPPINGLIFETIMEDAYS
   #EthTxHashMappingLifetimeDays = 0
 
+  # env var: LOTUS_FEVM_ETHFEEHISTORYCACHECAPACITY
+  #EthFeeHistoryCacheCapacity = 1024
+
   [Fevm.Events]
     # EnableEthRPC enables APIs that
     # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -104,6 +104,7 @@ func DefaultFullNode() *FullNode {
 		Fevm: FevmConfig{
 			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
+			EthFeeHistoryCacheCapacity:   1024,
 			Events: Events{
 				DisableRealTimeFilterAPI: false,
 				DisableHistoricFilterAPI: false,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -418,6 +418,12 @@ This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, bu
 Set to 0 to keep all mappings`,
 		},
 		{
+			Name: "EthFeeHistoryCacheCapacity",
+			Type: "int",
+
+			Comment: `EthFeeHistoryCacheCapacity is the maximum size of the fee history cache (in tipsets).`,
+		},
+		{
 			Name: "Events",
 			Type: "Events",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -687,6 +687,9 @@ type FevmConfig struct {
 	// Set to 0 to keep all mappings
 	EthTxHashMappingLifetimeDays int
 
+	// EthFeeHistoryCacheCapacity is the maximum size of the fee history cache (in tipsets).
+	EthFeeHistoryCacheCapacity int
+
 	Events Events
 }
 

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"go.uber.org/fx"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/chain/ethhashlookup"
 	"github.com/filecoin-project/lotus/chain/events"
@@ -78,6 +79,11 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 			},
 		})
 
+		feeHistoryCache, err := full.NewEthFeeHistoryCache(cfg.EthFeeHistoryCacheCapacity)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to construct the fee history cache: %w", err)
+		}
+
 		return &full.EthModule{
 			Chain:        cs,
 			Mpool:        mp,
@@ -87,7 +93,8 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 			MpoolAPI: mpoolapi,
 			StateAPI: stateapi,
 
-			EthTxHashManager: &ethTxHashManager,
+			EthTxHashManager:   &ethTxHashManager,
+			EthFeeHistoryCache: feeHistoryCache,
 		}, nil
 	}
 }


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Instead of re-computing these every time, cache (approximately) a set of recent tipsets. This works by:

1. Caching 5% percentiles.
2. Approximating the requested percentile to 5%, rounding up.
  - 0% -> 5%
  - 5% -> 5%
  - 5.1% -> 10%
  - ...
  - 96% -> 100%

## Additional Info
<!-- Callouts, links to documentation, and etc -->

The implementation is ugly and this definitely needs a test or two, but it gets the idea across.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green