### PR TITLE
feat: consensus: log ApplyBlock timing/gas stats

### DIFF
--- a/chain/consensus/compute_state.go
+++ b/chain/consensus/compute_state.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -113,6 +114,8 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		return sm.VMConstructor()(ctx, vmopt)
 	}
 
+	var cronGas int64
+
 	runCron := func(vmCron vm.Interface, epoch abi.ChainEpoch) error {
 		cronMsg := &types.Message{
 			To:         cron.Address,
@@ -129,6 +132,8 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		if err != nil {
 			return xerrors.Errorf("running cron: %w", err)
 		}
+
+		cronGas += ret.GasUsed
 
 		if em != nil {
 			if err := em.MessageApplied(ctx, ts, cronMsg.Cid(), cronMsg, ret, true); err != nil {
@@ -181,7 +186,9 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		}
 	}
 
-	partDone()
+	vmEarly := partDone()
+	earlyCronGas := cronGas
+	cronGas = 0
 	partDone = metrics.Timer(ctx, metrics.VMApplyMessages)
 
 	vmi, err := makeVm(pstate, epoch, ts.MinTimestamp())
@@ -196,6 +203,8 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		processedMsgs = make(map[cid.Cid]struct{})
 	)
 
+	var msgGas int64
+
 	for _, b := range bms {
 		penalty := types.NewInt(0)
 		gasReward := big.Zero()
@@ -209,6 +218,8 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 			if err != nil {
 				return cid.Undef, cid.Undef, err
 			}
+
+			msgGas += r.GasUsed
 
 			receipts = append(receipts, &r.MessageReceipt)
 			gasReward = big.Add(gasReward, r.GasCosts.MinerTip)
@@ -239,14 +250,14 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 		}
 	}
 
-	partDone()
+	vmMsg := partDone()
 	partDone = metrics.Timer(ctx, metrics.VMApplyCron)
 
 	if err := runCron(vmi, epoch); err != nil {
 		return cid.Cid{}, cid.Cid{}, err
 	}
 
-	partDone()
+	vmCron := partDone()
 	partDone = metrics.Timer(ctx, metrics.VMApplyFlush)
 
 	rectarr := blockadt.MakeEmptyArray(sm.ChainStore().ActorStore(ctx))
@@ -281,6 +292,11 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 	if err != nil {
 		return cid.Undef, cid.Undef, xerrors.Errorf("vm flush failed: %w", err)
 	}
+
+	vmFlush := partDone()
+	partDone = func() time.Duration { return time.Duration(0) }
+
+	log.Infow("ApplyBlocks stats", "early", vmEarly, "earlyCronGas", earlyCronGas, "vmMsg", vmMsg, "msgGas", msgGas, "vmCron", vmCron, "cronGas", cronGas, "vmFlush", vmFlush, "epoch", epoch, "tsk", ts.Key())
 
 	stats.Record(ctx, metrics.VMSends.M(int64(atomic.LoadUint64(&vm.StatSends))),
 		metrics.VMApplied.M(int64(atomic.LoadUint64(&vm.StatApplied))))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -775,9 +775,10 @@ func SinceInMilliseconds(startTime time.Time) float64 {
 
 // Timer is a function stopwatch, calling it starts the timer,
 // calling the returned function will record the duration.
-func Timer(ctx context.Context, m *stats.Float64Measure) func() {
+func Timer(ctx context.Context, m *stats.Float64Measure) func() time.Duration {
 	start := time.Now()
-	return func() {
+	return func() time.Duration {
 		stats.Record(ctx, m.M(SinceInMilliseconds(start)))
+		return time.Since(start)
 	}
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Log applyblock stats

## Additional Info
Those metrics can be very useful for more detailed gas / block time analysis. Today we only have prometheus metrics, which are bucketed, and not too accurate due to that, and the "block validation" log, which usually doesn't include state compute, which most of the time is pre-computed.

Example output:
```
2023-03-14T10:16:59.748+0100    INFO    consensus-common        consensus/compute_state.go:496  ApplyBlocks stats       {"early": 0.00008036, "earlyCronGas": 0, "vmMsg": 2.428463637, "msgGas": 18247427215, "vmCron": 6.90146274, "cronGas": 126278836788, "vmFlush": 0.472160843, "epoch": "2682071", "tsk": "{bafy2bzacebyx3aten2gih4rokwrzg5qocalnllqslyu4xqvyqbu33hskjknos,bafy2bzacedvjoqkoj2utw3d5cyhb4bw4csrrkftdaf5mc3my54g3j77ots6oe,bafy2bzacedvr6fw3ctyiwrfdt65l65s3ybqf6tiiastqipdyt6rvb7ivj5k7u,bafy2bzaceaqfnv4jezbpsv54g3t7a5jcimbqk7b7h3lsncwmzh47smoofhw46}"}
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
