### PR TITLE
fix: stmgr: don't attempt to lookup genesis state

### DIFF
--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -74,6 +74,11 @@ func (sm *StateManager) TipSetState(ctx context.Context, ts *types.TipSet) (st c
 // NOTE: This _won't_ recursively walk the receipt/state trees. It assumes that having the root
 // implies having the rest of the tree. However, lotus generally makes that assumption anyways.
 func tryLookupTipsetState(ctx context.Context, cs *store.ChainStore, ts *types.TipSet) (cid.Cid, cid.Cid, bool) {
+	if ts.Height() == 0 {
+		// Genesis state is cheaper to compute than to look up.
+		return cid.Undef, cid.Undef, false
+	}
+
 	nextTs, err := cs.GetTipsetByHeight(ctx, ts.Height()+1, nil, false)
 	if err != nil {
 		// Nothing to see here. The requested height may be beyond the current head.


### PR DESCRIPTION
## Related Issues
Fixes a regression introduced in https://github.com/filecoin-project/lotus/pull/10445

## Proposed Changes
Don't attempt to get genesis state by walking back to it.

## Additional Info
I've noticed that with latest master my mainnet nodes are taking a really long time to start syncing after startup. One splitstore node took 2 hours (!) to begin the process.

This appears to have been caused by trying to get genesis state for the vesting schedule:
```
goroutine 13001085 [semacquire]:
sync.runtime_Semacquire(0xc0164e8680?)
	/usr/lib/go/src/runtime/sema.go:62 +0x25
sync.(*WaitGroup).Wait(0xc015ed0501?)
	/usr/lib/go/src/sync/waitgroup.go:139 +0x52
golang.org/x/sync/errgroup.(*Group).Wait(0xc01bee3e40)
	/home/magik6k/.opt/go/pkg/mod/golang.org/x/sync@v0.0.0-20220907140024-f12130a52804/errgroup/errgroup.go:53 +0x27
github.com/filecoin-project/lotus/chain/store.(*ChainStore).LoadTipSet(0xc000672240, {0x64bafa0?, 0xc005b39da0}, {{0xc046797ef0?, 0xe4?}})
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/store/store.go:842 +0x125
github.com/filecoin-project/lotus/chain/store.(*ChainIndex).walkBack(0xc0339ca390, {0x64bafa0, 0xc005b39da0}, 0xc000616720?, 0x25fbac)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/store/index.go:165 +0xed
github.com/filecoin-project/lotus/chain/store.(*ChainIndex).fillCache(0xc0339ca390, {0x64bafa0, 0xc005b39da0}, {{0xc045471ec0?, 0x96b8cbe4fcef58c4?}})
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/store/index.go:120 +0x178
github.com/filecoin-project/lotus/chain/store.(*ChainIndex).GetTipsetByHeight(0xc0339ca390, {0x64bafa0, 0xc005b39da0}, 0xc015ed0898?, 0x1)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/store/index.go:68 +0x113
github.com/filecoin-project/lotus/chain/store.(*ChainStore).GetTipsetByHeight(0xc000672240, {0x64bafa0, 0xc005b39da0}, 0x1, 0x7dcd86?, 0x0)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/store/store.go:1165 +0xac
github.com/filecoin-project/lotus/chain/stmgr.tryLookupTipsetState({0x64bafa0, 0xc005b39da0}, 0xc000672240, 0xc0194aa700)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/execute.go:77 +0x6c
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).TipSetState(0xc00093bd40, {0x64bafa0?, 0xc013733710?}, 0xc0194aa700)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/execute.go:58 +0x6e5
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).setupGenesisVestingSchedule(0xc00093bd40, {0x64bafa0, 0xc013733710})
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/supply.go:43 +0x155
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).GetFilVested(0xc00093bd40, {0x64bafa0, 0xc013733710}, 0x28ec90)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/supply.go:206 +0x15d
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).GetVMCirculatingSupplyDetailed(0x0?, {0x64bafa0, 0xc013733710}, 0x28ec90, 0x26?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/supply.go:342 +0x65
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).GetVMCirculatingSupply(0xc015ed10f0?, {0x64bafa0?, 0xc013733710?}, 0x46956c0?, 0xc049ebe701?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/supply.go:333 +0x3b
github.com/filecoin-project/lotus/chain/vm.defaultFVMOpts({0x64bafa0, 0xc013733710}, 0xc019b21c80)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/vm/fvm.go:250 +0x163
github.com/filecoin-project/lotus/chain/vm.NewFVM({0x64bafa0?, 0xc013733710?}, 0xc019b21c80)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/vm/fvm.go:279 +0x2c
github.com/filecoin-project/lotus/chain/vm.NewVM({0x64bafa0?, 0xc013733710?}, 0x9dbb001?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/vm/vmi.go:41 +0x45
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).VMConstructor.func1({0x64bafa0?, 0xc013733710?}, 0xc001680c00?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/stmgr.go:444 +0x2e
github.com/filecoin-project/lotus/chain/consensus.(*TipSetExecutor).ApplyBlocks.func2({{0xc00ff81170?, 0xc013733710?}}, 0x28ec90, 0x640ff140)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/consensus/compute_state.go:291 +0x302
github.com/filecoin-project/lotus/chain/consensus.(*TipSetExecutor).ApplyBlocks(0xc0000143a8, {0x64bafa0, 0xc038220480}, 0xc00093bd40, 0x28ec8f, {{0xc00ff81170?, 0x28ec91?}}, {0xc00fc8b5e0, 0x3, 0x3}, ...)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/consensus/compute_state.go:365 +0xc7c
github.com/filecoin-project/lotus/chain/consensus.(*TipSetExecutor).ExecuteTipSet(0x64bafa0?, {0x64bafa0?, 0xc038220450?}, 0xc00093bd40, 0xc01327e980, {0x0, 0x0}, 0x0?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/consensus/compute_state.go:548 +0x7ef
github.com/filecoin-project/lotus/chain/stmgr.(*StateManager).TipSetState(0xc00093bd40, {0x64baf30?, 0xc000226008?}, 0xc01327e980)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/stmgr/execute.go:62 +0x733
github.com/filecoin-project/lotus/chain/messagepool.(*mpoolProvider).GetActorAfter(0xc000496300, {{0xc019b241c0?, 0xc002022360?}}, 0xc038220240?)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/provider.go:94 +0x21b
github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).getStateNonce(0xc0164e8340, {0x64baef8?, 0xc0161b36c0?}, {{0xc019b241c0?, 0x0?}}, 0xc01327e980)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/messagepool.go:1209 +0x1c6
github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).addLoaded(0xc0164e8340, {0x64baef8, 0xc0161b36c0}, 0xc019b22090)
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/messagepool.go:1058 +0x73
github.com/filecoin-project/lotus/chain/messagepool.(*MessagePool).loadLocal(0xc0164e8340, {0x64baef8, 0xc0161b36c0})
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/messagepool.go:1687 +0x28e
github.com/filecoin-project/lotus/chain/messagepool.New.func2()
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/messagepool.go:448 +0x6b
created by github.com/filecoin-project/lotus/chain/messagepool.New
	/home/magik6k/github.com/filecoin-project/go-lotus/chain/messagepool/messagepool.go:446 +0xc25
```

Previously this would be very fast as before #10445 we'd just compute that state, and because genesis is mostly empty, it was very fast.

This PR special-cases genesis state compute to avoid this very long walk in the main sync code path.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
