### PR TITLE
fix: revert "Eth API: drop support for 'pending' block parameter."

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -235,13 +235,14 @@ func (a *EthModule) EthGetBlockByHash(ctx context.Context, blkHash ethtypes.EthH
 }
 
 func (a *EthModule) parseBlkParam(ctx context.Context, blkParam string, strict bool) (tipset *types.TipSet, err error) {
-	switch blkParam {
-	case "earliest", "pending":
-		return nil, fmt.Errorf("block param %q is not supported", blkParam)
+	if blkParam == "earliest" {
+		return nil, fmt.Errorf("block param \"earliest\" is not supported")
 	}
 
 	head := a.Chain.GetHeaviestTipSet()
 	switch blkParam {
+	case "pending":
+		return head, nil
 	case "latest":
 		parent, err := a.Chain.GetTipSetFromKey(ctx, head.Parents())
 		if err != nil {


### PR DESCRIPTION
This reverts commit 9412753ba33c4bba7dd5df34a1cd5f9a34464e4f.

## Related Issues

Some tools require `pending` support on some RPCs, concretely `eth_getTransactionCount`. This backs out the patch that generally dropped such support, in case we want to restore master to working condition while https://github.com/filecoin-project/lotus/pull/10462 is being reviewed.

## Proposed Changes

Re-introduce `pending` block support.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
