### PR TITLE
feat:config:force existing users to opt into new defaults

### DIFF
--- a/cmd/lotus-miner/config.go
+++ b/cmd/lotus-miner/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultStorageMiner()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"))
+		cb, err := config.ConfigUpdate(c, nil, config.Commented(!cctx.Bool("no-comment")))
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultStorageMiner()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"))
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, config.Commented(!cctx.Bool("no-comment")))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-miner/config.go
+++ b/cmd/lotus-miner/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultStorageMiner()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"))
+		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.CommentFilterNone())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultStorageMiner()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"))
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.CommentFilterNone())
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-miner/config.go
+++ b/cmd/lotus-miner/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultStorageMiner()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.CommentFilterNone())
+		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"))
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultStorageMiner()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.CommentFilterNone())
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-miner/init_restore.go
+++ b/cmd/lotus-miner/init_restore.go
@@ -189,7 +189,7 @@ func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfi
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg)
+			ff, err := config.FromFile(cf, config.SetDefault(func() (interface{}, error) { return rcfg, nil }))
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus-miner/init_restore.go
+++ b/cmd/lotus-miner/init_restore.go
@@ -189,7 +189,7 @@ func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfi
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg)
+			ff, err := config.FromFile(cf, rcfg, config.LoadabilityCheckNone())
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus-miner/init_restore.go
+++ b/cmd/lotus-miner/init_restore.go
@@ -189,7 +189,7 @@ func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfi
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg, config.LoadabilityCheckNone())
+			ff, err := config.FromFile(cf, rcfg)
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus/backup.go
+++ b/cmd/lotus/backup.go
@@ -66,7 +66,7 @@ func restore(cctx *cli.Context, r repo.Repo) error {
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg)
+			ff, err := config.FromFile(cf, config.SetDefault(func() (interface{}, error) { return rcfg, nil }))
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus/backup.go
+++ b/cmd/lotus/backup.go
@@ -66,7 +66,7 @@ func restore(cctx *cli.Context, r repo.Repo) error {
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg, config.LoadabilityCheckNone())
+			ff, err := config.FromFile(cf, rcfg)
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus/backup.go
+++ b/cmd/lotus/backup.go
@@ -66,7 +66,7 @@ func restore(cctx *cli.Context, r repo.Repo) error {
 				return
 			}
 
-			ff, err := config.FromFile(cf, rcfg)
+			ff, err := config.FromFile(cf, rcfg, config.LoadabilityCheckNone())
 			if err != nil {
 				cerr = xerrors.Errorf("loading config: %w", err)
 				return

--- a/cmd/lotus/config.go
+++ b/cmd/lotus/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultFullNode()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.DefaultFullNodeCommentFilter())
+		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.KeepUncommented(config.MatchEnableSplitstoreField))
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultFullNode()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.DefaultFullNodeCommentFilter())
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.KeepUncommented(config.MatchEnableSplitstoreField))
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus/config.go
+++ b/cmd/lotus/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultFullNode()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.KeepUncommented(config.MatchEnableSplitstoreField))
+		cb, err := config.ConfigUpdate(c, nil, config.Commented(!cctx.Bool("no-comment")), config.DefaultKeepUncommented())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultFullNode()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.KeepUncommented(config.MatchEnableSplitstoreField))
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, config.Commented(!cctx.Bool("no-comment")), config.DefaultKeepUncommented())
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus/config.go
+++ b/cmd/lotus/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultFullNode()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"))
+		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.CommentFilterDefault())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultFullNode()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"))
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.CommentFilterDefault())
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus/config.go
+++ b/cmd/lotus/config.go
@@ -31,7 +31,7 @@ var configDefaultCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		c := config.DefaultFullNode()
 
-		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.CommentFilterDefault())
+		cb, err := config.ConfigUpdate(c, nil, !cctx.Bool("no-comment"), config.DefaultFullNodeCommentFilter())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var configUpdateCmd = &cli.Command{
 
 		cfgDef := config.DefaultFullNode()
 
-		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.CommentFilterDefault())
+		updated, err := config.ConfigUpdate(cfgNode, cfgDef, !cctx.Bool("no-comment"), config.DefaultFullNodeCommentFilter())
 		if err != nil {
 			return err
 		}

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -191,7 +191,7 @@
 [Chainstore]
   # type: bool
   # env var: LOTUS_CHAINSTORE_ENABLESPLITSTORE
-  #EnableSplitstore = true
+  EnableSplitstore = true
 
   [Chainstore.Splitstore]
     # ColdStoreType specifies the type of the coldstore.

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -80,9 +80,9 @@ type loadabilityCheck struct {
 
 func DefaultFullNodeLoadabilityCheck() loadabilityCheck {
 	configOk := func(cfgRaw string) error {
-		poisonStr := "#EnableSplitstore =" // splitstore must be set explicitly
-		if strings.Contains(cfgRaw, poisonStr) {
-			return xerrors.Errorf("Config contains disallowed string %s, refusing to load. Please explicitly set EnableSplitstore. Set it to false to keep chain management unchanged from March 2023 set it to true if you want to discard old state by default", poisonStr)
+		explicitSplitstoreRx := regexp.MustCompile("\n[\t\n\f\r ]*EnableSplitstore =")
+		if match := explicitSplitstoreRx.FindString(cfgRaw); match == "" {
+			return xerrors.Errorf("Config does not contain explicit set of EnableSplitstore field, refusing to load. Please explicitly set EnableSplitstore. Set it to false to keep chain management unchanged from March 2023 set it to true if you want to discard old state by default")
 		}
 		return nil
 	}

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -82,12 +82,12 @@ func DefaultFullNodeLoadabilityCheck() loadabilityCheck {
 	configOk := func(cfgRaw string) error {
 		explicitSplitstoreRx := regexp.MustCompile("\n[\t\n\f\r ]*EnableSplitstore =")
 		if match := explicitSplitstoreRx.FindString(cfgRaw); match == "" {
-			return xerrors.Errorf("Config does not contain explicit set of EnableSplitstore field, refusing to load. Please explicitly set EnableSplitstore. Set it to false to keep chain management unchanged from March 2023 set it to true if you want to discard old state by default")
+			return xerrors.Errorf("Config does not contain explicit set of EnableSplitstore field, refusing to load. Please explicitly set EnableSplitstore. Set it to false if you are running a full archival node")
 		}
 		return nil
 	}
 	configNotFound := func() error {
-		return xerrors.Errorf("FullNode config not found and fallback to default disallowed.  Set up config and explicitly set EnableSplitstore.  Set it to false to keep chain management unchanged from March 2023 set it to true if you want to discard old state by default ")
+		return xerrors.Errorf("FullNode config not found and fallback to default disallowed while we transition to splitstore discard default.  Use `lotus config default` to set this repo up with a default config.  Be sure to set `EnableSplitstore` to `false` if you are running a full archive node")
 	}
 	return loadabilityCheck{
 		configOk:       configOk,

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -106,7 +106,9 @@ type keepUncommented func(string) bool
 
 func DefaultFullNodeCommentFilter() keepUncommented {
 	return func(s string) bool {
-		return strings.Contains(s, "EnableSplitstore")
+		enableSplitstoreRx := regexp.MustCompile("^[\t\n\f\r ]*EnableSplitstore =")
+		match := enableSplitstoreRx.FindString(s)
+		return match != ""
 	}
 }
 

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -55,8 +55,10 @@ func FromFile(path string, opts ...LoadCfgOpt) (interface{}, error) {
 		return nil, xerrors.Errorf("failed to read config for validation checks %w", err)
 	}
 	buf := bytes.NewBuffer(cfgBs)
-	if err := loadOpts.validate(buf.String()); err != nil {
-		return nil, xerrors.Errorf("config failed validation: %w", err)
+	if loadOpts.validate != nil {
+		if err := loadOpts.validate(buf.String()); err != nil {
+			return nil, xerrors.Errorf("config failed validation: %w", err)
+		}
 	}
 	return FromReader(buf, def)
 }

--- a/node/config/load_test.go
+++ b/node/config/load_test.go
@@ -16,14 +16,14 @@ func TestDecodeNothing(t *testing.T) {
 	assert := assert.New(t)
 
 	{
-		cfg, err := FromFile(os.DevNull, DefaultFullNode())
+		cfg, err := FromFile(os.DevNull, DefaultFullNode(), LoadabilityCheckNone())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from empty file should be the same as default")
 	}
 
 	{
-		cfg, err := FromFile("./does-not-exist.toml", DefaultFullNode())
+		cfg, err := FromFile("./does-not-exist.toml", DefaultFullNode(), LoadabilityCheckNone())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from not exisiting file should be the same as default")
@@ -58,7 +58,7 @@ func TestParitalConfig(t *testing.T) {
 		assert.NoError(err, "closing tmp file should not error")
 		defer os.Remove(fname) //nolint:errcheck
 
-		cfg, err := FromFile(fname, DefaultFullNode())
+		cfg, err := FromFile(fname, DefaultFullNode(), LoadabilityCheckNone())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")

--- a/node/config/load_test.go
+++ b/node/config/load_test.go
@@ -111,7 +111,7 @@ func TestKeepEnableSplitstoreUncommented(t *testing.T) {
 func TestValidateConfigSetsEnableSplitstore(t *testing.T) {
 	cfgCommentedOutEnableSS, err := ConfigUpdate(DefaultFullNode(), DefaultFullNode(), Commented(true))
 	assert.NoError(t, err)
-	// this comments out EnableSplitstore
+	// assert that this config comments out EnableSplitstore
 	assert.False(t, MatchEnableSplitstoreField(string(cfgCommentedOutEnableSS)))
 
 	// write config with commented out EnableSplitstore to file

--- a/node/config/load_test.go
+++ b/node/config/load_test.go
@@ -16,14 +16,14 @@ func TestDecodeNothing(t *testing.T) {
 	assert := assert.New(t)
 
 	{
-		cfg, err := FromFile(os.DevNull, DefaultFullNode())
+		cfg, err := FromFile(os.DevNull, SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from empty file should be the same as default")
 	}
 
 	{
-		cfg, err := FromFile("./does-not-exist.toml", DefaultFullNode())
+		cfg, err := FromFile("./does-not-exist.toml", SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from not exisiting file should be the same as default")
@@ -41,7 +41,7 @@ func TestParitalConfig(t *testing.T) {
 	expected.API.Timeout = Duration(10 * time.Second)
 
 	{
-		cfg, err := FromReader(bytes.NewReader([]byte(cfgString)), DefaultFullNode())
+		cfg, err := FromReader(bytes.NewReader([]byte(cfgString)), SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
 		assert.NoError(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")
@@ -58,7 +58,7 @@ func TestParitalConfig(t *testing.T) {
 		assert.NoError(err, "closing tmp file should not error")
 		defer os.Remove(fname) //nolint:errcheck
 
-		cfg, err := FromFile(fname, DefaultFullNode())
+		cfg, err := FromFile(fname, SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")

--- a/node/config/load_test.go
+++ b/node/config/load_test.go
@@ -16,14 +16,14 @@ func TestDecodeNothing(t *testing.T) {
 	assert := assert.New(t)
 
 	{
-		cfg, err := FromFile(os.DevNull, DefaultFullNode(), LoadabilityCheckNone())
+		cfg, err := FromFile(os.DevNull, DefaultFullNode())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from empty file should be the same as default")
 	}
 
 	{
-		cfg, err := FromFile("./does-not-exist.toml", DefaultFullNode(), LoadabilityCheckNone())
+		cfg, err := FromFile("./does-not-exist.toml", DefaultFullNode())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from not exisiting file should be the same as default")
@@ -58,7 +58,7 @@ func TestParitalConfig(t *testing.T) {
 		assert.NoError(err, "closing tmp file should not error")
 		defer os.Remove(fname) //nolint:errcheck
 
-		cfg, err := FromFile(fname, DefaultFullNode(), LoadabilityCheckNone())
+		cfg, err := FromFile(fname, DefaultFullNode())
 		assert.Nil(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")

--- a/node/config/load_test.go
+++ b/node/config/load_test.go
@@ -11,19 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func fullNodeDefault() (interface{}, error) { return DefaultFullNode(), nil }
+
 func TestDecodeNothing(t *testing.T) {
 	//stm: @NODE_CONFIG_LOAD_FILE_002
 	assert := assert.New(t)
 
 	{
-		cfg, err := FromFile(os.DevNull, SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
+		cfg, err := FromFile(os.DevNull, SetDefault(fullNodeDefault))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from empty file should be the same as default")
 	}
 
 	{
-		cfg, err := FromFile("./does-not-exist.toml", SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
+		cfg, err := FromFile("./does-not-exist.toml", SetDefault(fullNodeDefault))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(DefaultFullNode(), cfg,
 			"config from not exisiting file should be the same as default")
@@ -41,7 +43,7 @@ func TestParitalConfig(t *testing.T) {
 	expected.API.Timeout = Duration(10 * time.Second)
 
 	{
-		cfg, err := FromReader(bytes.NewReader([]byte(cfgString)), SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
+		cfg, err := FromReader(bytes.NewReader([]byte(cfgString)), DefaultFullNode())
 		assert.NoError(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")
@@ -58,9 +60,82 @@ func TestParitalConfig(t *testing.T) {
 		assert.NoError(err, "closing tmp file should not error")
 		defer os.Remove(fname) //nolint:errcheck
 
-		cfg, err := FromFile(fname, SetDefault(func() (interface{}, error) { return DefaultFullNode(), nil }))
+		cfg, err := FromFile(fname, SetDefault(fullNodeDefault))
 		assert.Nil(err, "error should be nil")
 		assert.Equal(expected, cfg,
 			"config from reader should contain changes")
 	}
+}
+
+func TestValidateSplitstoreSet(t *testing.T) {
+	cfgSet := ` 
+		EnableSplitstore = false
+		`
+	assert.NoError(t, ValidateSplitstoreSet(cfgSet))
+	cfgSloppySet := `
+		           	EnableSplitstore          =   	true	
+	`
+	assert.NoError(t, ValidateSplitstoreSet(cfgSloppySet))
+
+	// Missing altogether
+	cfgMissing := ` 
+	[Chainstore]
+	  # type: bool                                                                         
+	  # env var: LOTUS_CHAINSTORE_ENABLESPLITSTORE                                         
+	  # oops its mising
+
+	[Chainstore.Splitstore]
+    	ColdStoreType = "discard"
+	`
+	err := ValidateSplitstoreSet(cfgMissing)
+	assert.Error(t, err)
+	cfgCommentedOut := `
+				#    EnableSplitstore = false
+	`
+	err = ValidateSplitstoreSet(cfgCommentedOut)
+	assert.Error(t, err)
+}
+
+// Default config keeps EnableSplitstore field uncommented
+func TestKeepEnableSplitstoreUncommented(t *testing.T) {
+	cfgStr, err := ConfigComment(DefaultFullNode())
+	assert.NoError(t, err)
+	assert.True(t, MatchEnableSplitstoreField(string(cfgStr)))
+
+	cfgStrFromDef, err := ConfigUpdate(DefaultFullNode(), DefaultFullNode(), Commented(true), DefaultKeepUncommented())
+	assert.NoError(t, err)
+	assert.True(t, MatchEnableSplitstoreField(string(cfgStrFromDef)))
+}
+
+// Loading a config with commented EnableSplitstore fails when setting validator
+func TestValidateConfigSetsEnableSplitstore(t *testing.T) {
+	cfgCommentedOutEnableSS, err := ConfigUpdate(DefaultFullNode(), DefaultFullNode(), Commented(true))
+	assert.NoError(t, err)
+	// this comments out EnableSplitstore
+	assert.False(t, MatchEnableSplitstoreField(string(cfgCommentedOutEnableSS)))
+
+	// write config with commented out EnableSplitstore to file
+	f, err := ioutil.TempFile("", "config.toml")
+	fname := f.Name()
+	assert.NoError(t, err)
+	defer func() {
+		err = f.Close()
+		assert.NoError(t, err)
+		os.Remove(fname) //nolint:errcheck
+	}()
+	_, err = f.WriteString(string(cfgCommentedOutEnableSS))
+	assert.NoError(t, err)
+
+	_, err = FromFile(fname, SetDefault(fullNodeDefault), SetValidate(ValidateSplitstoreSet))
+	assert.Error(t, err)
+}
+
+// Loading without a config file and a default fails if the default fallback is disabled
+func TestFailToFallbackToDefault(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dirWithNoFiles")
+	assert.NoError(t, err)
+	defer assert.NoError(t, os.RemoveAll(dir))
+	nonExistantFileName := dir + "/notarealfile"
+	_, err = FromFile(nonExistantFileName, SetDefault(fullNodeDefault), SetCanFallbackOnDefault(NoDefaultForSplitstoreTransition))
+	assert.Error(t, err)
 }

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -550,7 +550,10 @@ func (fsr *fsLockedRepo) loadConfigFromDisk() (interface{}, error) {
 		opts = append(opts, config.SetCanFallbackOnDefault(config.NoDefaultForSplitstoreTransition))
 		opts = append(opts, config.SetValidate(config.ValidateSplitstoreSet))
 	}
-	return config.FromFile(fsr.configPath, fsr.repoType.Config(), opts...)
+	opts = append(opts, config.SetDefault(func() (interface{}, error) {
+		return fsr.repoType.Config(), nil
+	}))
+	return config.FromFile(fsr.configPath, opts...)
 }
 
 func (fsr *fsLockedRepo) SetConfig(c func(interface{})) error {

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -545,11 +545,12 @@ func (fsr *fsLockedRepo) Config() (interface{}, error) {
 }
 
 func (fsr *fsLockedRepo) loadConfigFromDisk() (interface{}, error) {
-	loadabilityCheck := config.LoadabilityCheckNone()
+	var opts []config.LoadCfgOpt
 	if fsr.repoType == FullNode {
-		loadabilityCheck = config.DefaultFullNodeLoadabilityCheck()
+		opts = append(opts, config.SetCanFallbackOnDefault(config.NoDefaultForSplitstoreTransition))
+		opts = append(opts, config.SetValidate(config.ValidateSplitstoreSet))
 	}
-	return config.FromFile(fsr.configPath, fsr.repoType.Config(), loadabilityCheck)
+	return config.FromFile(fsr.configPath, fsr.repoType.Config(), opts...)
 }
 
 func (fsr *fsLockedRepo) SetConfig(c func(interface{})) error {

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -545,7 +545,11 @@ func (fsr *fsLockedRepo) Config() (interface{}, error) {
 }
 
 func (fsr *fsLockedRepo) loadConfigFromDisk() (interface{}, error) {
-	return config.FromFile(fsr.configPath, fsr.repoType.Config())
+	loadabilityCheck := config.LoadabilityCheckNone()
+	if fsr.repoType == FullNode {
+		loadabilityCheck = config.DefaultFullNodeLoadabilityCheck()
+	}
+	return config.FromFile(fsr.configPath, fsr.repoType.Config(), loadabilityCheck)
 }
 
 func (fsr *fsLockedRepo) SetConfig(c func(interface{})) error {

--- a/node/repo/fsrepo_test.go
+++ b/node/repo/fsrepo_test.go
@@ -2,12 +2,7 @@
 package repo
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/filecoin-project/lotus/node/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func genFsRepo(t *testing.T) *FsRepo {
@@ -33,19 +28,4 @@ func TestFsBasic(t *testing.T) {
 	//stm: @NODE_FS_REPO_GET_KEY_001, NODE_FS_REPO_DELETE_KEY_001
 	repo := genFsRepo(t)
 	basicTest(t, repo)
-}
-
-func TestConfig(t *testing.T) {
-	repo := genFsRepo(t)
-	lrepo, err := repo.Lock(FullNode)
-	require.NoError(t, err)
-	c1, err := lrepo.Config()
-	assert.Equal(t, config.DefaultFullNode(), c1, "there should be a default config")
-	assert.NoError(t, err, "config should not error")
-	cfg := c1.(*config.FullNode)
-	fmt.Printf("%t\n", cfg.Chainstore.EnableSplitstore)
-
-	err = lrepo.Close()
-	assert.NoError(t, err, "should be able to close")
-
 }

--- a/node/repo/fsrepo_test.go
+++ b/node/repo/fsrepo_test.go
@@ -2,7 +2,12 @@
 package repo
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/filecoin-project/lotus/node/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func genFsRepo(t *testing.T) *FsRepo {
@@ -28,4 +33,19 @@ func TestFsBasic(t *testing.T) {
 	//stm: @NODE_FS_REPO_GET_KEY_001, NODE_FS_REPO_DELETE_KEY_001
 	repo := genFsRepo(t)
 	basicTest(t, repo)
+}
+
+func TestConfig(t *testing.T) {
+	repo := genFsRepo(t)
+	lrepo, err := repo.Lock(FullNode)
+	require.NoError(t, err)
+	c1, err := lrepo.Config()
+	assert.Equal(t, config.DefaultFullNode(), c1, "there should be a default config")
+	assert.NoError(t, err, "config should not error")
+	cfg := c1.(*config.FullNode)
+	fmt.Printf("%t\n", cfg.Chainstore.EnableSplitstore)
+
+	err = lrepo.Close()
+	assert.NoError(t, err, "should be able to close")
+
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
This is the change to 1) force users to explicitly set splitstore config by uncommenting the default, 2) for new nodes do the uncommenting automatically so they will opt into the default automatically 

## Proposed Changes
<!-- A clear list of the changes being made -->
- Add a notion of uncommenting filters to config update.  Then apply a filter on EnableSplitstore in the default full node config
- Add a notion of loadability checks to the lotus config.  Then apply a check ensuring `#EnableSplitstore =` is not in the config to ensure that users with old configs will reset their config explicity.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
- The patterns introduced here can hopefully be used in other sensative default change situations
- We can probably revert the splitstore specific filters and loadability checks in a few months when the community is adjusted to the new defaults 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
