### PR TITLE
feat: events: make event saving configurable independent of eth api

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -338,7 +338,13 @@
   #EthTxHashMappingLifetimeDays = 0
 
   [Fevm.Events]
-    # EnableEthRPC enables APIs that
+    # Save specifies whether or not to save and index emitted events, or discard them. Events
+    # are discarded by default unless the Eth RPC is also enabled by setting EnableEthRPC.
+    #
+    # type: bool
+    # env var: LOTUS_FEVM_EVENTS_SAVE
+    #Save = false
+
     # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
     # The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
     #

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -220,10 +220,10 @@ func ConfigFullNode(c interface{}) Option {
 			Override(SetupFallbackBlockstoresKey, modules.InitFallbackBlockstores),
 		),
 
-		// If the Eth JSON-RPC is enabled, enable storing events at the ChainStore.
+		// If the event saving or the Eth JSON-RPC is enabled, enable storing events at the ChainStore.
 		// This is the case even if real-time and historic filtering are disabled,
 		// as it enables us to serve logs in eth_getTransactionReceipt.
-		If(cfg.Fevm.EnableEthRPC, Override(StoreEventsKey, modules.EnableStoringEvents)),
+		If(cfg.Fevm.Events.Save || cfg.Fevm.EnableEthRPC, Override(StoreEventsKey, modules.EnableStoringEvents)),
 
 		Override(new(dtypes.ClientImportMgr), modules.ClientImportMgr),
 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -111,6 +111,7 @@ func DefaultFullNode() *FullNode {
 			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
 			Events: Events{
+				Save:                     false,
 				DisableRealTimeFilterAPI: false,
 				DisableHistoricFilterAPI: false,
 				FilterTTL:                Duration(time.Hour * 24),

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -343,11 +343,17 @@ see https://lotus.filecoin.io/storage-providers/advanced-configurations/market/#
 	},
 	"Events": []DocField{
 		{
+			Name: "Save",
+			Type: "bool",
+
+			Comment: `Save specifies whether or not to save and index emitted events, or discard them. Events
+are discarded by default unless the Eth RPC is also enabled by setting EnableEthRPC.`,
+		},
+		{
 			Name: "DisableRealTimeFilterAPI",
 			Type: "bool",
 
-			Comment: `EnableEthRPC enables APIs that
-DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
+			Comment: `DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
 The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.`,
 		},
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -693,7 +693,10 @@ type FevmConfig struct {
 }
 
 type Events struct {
-	// EnableEthRPC enables APIs that
+	// Save specifies whether or not to save and index emitted events, or discard them. Events
+	// are discarded by default unless the Eth RPC is also enabled by setting EnableEthRPC.
+	Save bool
+
 	// DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
 	// The API is enabled when EnableEthRPC is true, but can be disabled selectively with this flag.
 	DisableRealTimeFilterAPI bool


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Related to https://github.com/filecoin-project/lotus/issues/9774

## Proposed Changes
<!-- A clear list of the changes being made -->

We can now instruct lotus to store events, even if the Eth JSON-RPC API is disabled.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Bikeshed on name?

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green