### PR TITLE
fix: explicit error in StateSearchMsg when search stops due to lookback.

### DIFF
--- a/chain/stmgr/searchwait.go
+++ b/chain/stmgr/searchwait.go
@@ -185,9 +185,15 @@ func (sm *StateManager) searchBackForMsg(ctx context.Context, from *types.TipSet
 	for {
 		// If we've reached the genesis block, or we've reached the limit of
 		// how far back to look
-		if cur.Height() == 0 || !noLimit && cur.Height() <= limitHeight {
+		if cur.Height() == 0 {
 			// it ain't here!
 			return nil, nil, cid.Undef, nil
+		}
+
+		if !noLimit && cur.Height() <= limitHeight {
+			// Explicitly report that the message was not found within the lookback, instead of silently pretending
+			// the message does not exist / could not be found at all.
+			return nil, nil, cid.Undef, xerrors.Errorf("message not found within lookback range (limit: %d epochs)", limit)
 		}
 
 		select {


### PR DESCRIPTION
## Related Issues

Currently, `StateSearchMsg` will behave identically (externally) when the message is not found at all and when the search is is halted due to the lookback limit. This prevents users from reasoning about why a method that returned a value correctly at time X, is no longer capable of returning the value at X+limit+1.

User report on Slack: https://filecoinproject.slack.com/archives/CRK2LKYHW/p1679225798632029

## Proposed Changes

Return an explicit error when the above circumstance occurs.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
