### PR TITLE
feat: Add small cache to execution traces

### DIFF
--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -128,10 +128,17 @@ func (sm *StateManager) ExecutionTraceWithMonitor(ctx context.Context, ts *types
 }
 
 func (sm *StateManager) ExecutionTrace(ctx context.Context, ts *types.TipSet) (cid.Cid, []*api.InvocResult, error) {
+	if entry, ok := sm.execTraceCache.Get(ts); ok {
+		return entry.cid, entry.invocTrace, nil
+	}
+
 	var invocTrace []*api.InvocResult
 	st, err := sm.ExecutionTraceWithMonitor(ctx, ts, &InvocationTracer{trace: &invocTrace})
 	if err != nil {
 		return cid.Undef, nil, err
 	}
+
+	sm.execTraceCache.Add(ts, tipSetCacheEntry{st, invocTrace})
+
 	return st, invocTrace, nil
 }

--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -130,15 +130,16 @@ func (sm *StateManager) ExecutionTraceWithMonitor(ctx context.Context, ts *types
 func (sm *StateManager) ExecutionTrace(ctx context.Context, ts *types.TipSet) (cid.Cid, []*api.InvocResult, error) {
 	tsKey := ts.Key()
 
-	{
-		// check if we have the trace for this tipset in the cache
-		sm.execTraceCacheLock.Lock()
-		defer sm.execTraceCacheLock.Unlock()
-		if entry, ok := sm.execTraceCache.Get(tsKey); ok {
-			// we have to make a deep copy since caller can modify the invocTrace
-			return entry.postStateRoot, makeDeepCopy(entry.invocTrace), nil
-		}
+	// check if we have the trace for this tipset in the cache
+	sm.execTraceCacheLock.Lock()
+	if entry, ok := sm.execTraceCache.Get(tsKey); ok {
+		// we have to make a deep copy since caller can modify the invocTrace
+		// and we don't want that to change what we store in cache
+		invocTraceCopy := makeDeepCopy(entry.invocTrace)
+		sm.execTraceCacheLock.Unlock()
+		return entry.postStateRoot, invocTraceCopy, nil
 	}
+	sm.execTraceCacheLock.Unlock()
 
 	var invocTrace []*api.InvocResult
 	st, err := sm.ExecutionTraceWithMonitor(ctx, ts, &InvocationTracer{trace: &invocTrace})
@@ -146,7 +147,11 @@ func (sm *StateManager) ExecutionTrace(ctx context.Context, ts *types.TipSet) (c
 		return cid.Undef, nil, err
 	}
 
-	sm.execTraceCache.Add(tsKey, tipSetCacheEntry{st, makeDeepCopy(invocTrace)})
+	invocTraceCopy := makeDeepCopy(invocTrace)
+
+	sm.execTraceCacheLock.Lock()
+	sm.execTraceCache.Add(tsKey, tipSetCacheEntry{st, invocTraceCopy})
+	sm.execTraceCacheLock.Unlock()
 
 	return st, invocTrace, nil
 }

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-cid"
 	dstore "github.com/ipfs/go-datastore"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -38,6 +39,8 @@ import (
 
 const LookbackNoLimit = api.LookbackNoLimit
 const ReceiptAmtBitwidth = 3
+
+const execTraceCacheSize = 16
 
 var log = logging.Logger("statemgr")
 
@@ -138,12 +141,21 @@ type StateManager struct {
 	beacon        beacon.Schedule
 
 	msgIndex index.MsgIndex
+
+	// We keep a small cache for calls to ExecutionTrace which helps improve
+	// performance for node operators like exchanges and block explorers
+	execTraceCache *lru.ARCCache[*types.TipSet, tipSetCacheEntry]
 }
 
 // Caches a single state tree
 type treeCache struct {
 	root cid.Cid
 	tree *state.StateTree
+}
+
+type tipSetCacheEntry struct {
+	cid        cid.Cid
+	invocTrace []*api.InvocResult
 }
 
 func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder, us UpgradeSchedule, beacon beacon.Schedule, metadataDs dstore.Batching, msgIndex index.MsgIndex) (*StateManager, error) {
@@ -185,6 +197,11 @@ func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder,
 		}
 	}
 
+	execTraceCache, err := lru.NewARC[*types.TipSet, tipSetCacheEntry](execTraceCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
 	return &StateManager{
 		networkVersions:   networkVersions,
 		latestVersion:     lastVersion,
@@ -200,8 +217,9 @@ func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder,
 			root: cid.Undef,
 			tree: nil,
 		},
-		compWait: make(map[string]chan struct{}),
-		msgIndex: msgIndex,
+		compWait:       make(map[string]chan struct{}),
+		msgIndex:       msgIndex,
+		execTraceCache: execTraceCache,
 	}, nil
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -144,7 +144,9 @@ type StateManager struct {
 
 	// We keep a small cache for calls to ExecutionTrace which helps improve
 	// performance for node operators like exchanges and block explorers
-	execTraceCache     *lru.ARCCache[types.TipSetKey, tipSetCacheEntry]
+	execTraceCache *lru.ARCCache[types.TipSetKey, tipSetCacheEntry]
+	// We need a lock while making the copy as to prevent other callers
+	// overwrite the cache while making the copy
 	execTraceCacheLock sync.Mutex
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -144,7 +144,8 @@ type StateManager struct {
 
 	// We keep a small cache for calls to ExecutionTrace which helps improve
 	// performance for node operators like exchanges and block explorers
-	execTraceCache *lru.ARCCache[*types.TipSet, tipSetCacheEntry]
+	execTraceCache     *lru.ARCCache[types.TipSetKey, tipSetCacheEntry]
+	execTraceCacheLock sync.Mutex
 }
 
 // Caches a single state tree
@@ -154,8 +155,8 @@ type treeCache struct {
 }
 
 type tipSetCacheEntry struct {
-	cid        cid.Cid
-	invocTrace []*api.InvocResult
+	postStateRoot cid.Cid
+	invocTrace    []*api.InvocResult
 }
 
 func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder, us UpgradeSchedule, beacon beacon.Schedule, metadataDs dstore.Batching, msgIndex index.MsgIndex) (*StateManager, error) {
@@ -197,7 +198,7 @@ func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder,
 		}
 	}
 
-	execTraceCache, err := lru.NewARC[*types.TipSet, tipSetCacheEntry](execTraceCacheSize)
+	execTraceCache, err := lru.NewARC[types.TipSetKey, tipSetCacheEntry](execTraceCacheSize)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10504

## Proposed Changes
This PR adds a small cache to calls to `ExecutionTrace` which helps improve performance for node operators like exchanges and block explorers.

If items is in cache calls to this function will be 2-3x faster. 

## Additional Info
I ran a local test for 30minutes where I called `lotus state compute-state --json` in a loop from two threads. 
- Before this cache, each query took close to 8-10 seconds to run, but with this change it goes down to under 3 seconds.
- Cache hit rate was 82% (671/816)

NOTE: Stress testing this over an hour resulted in Lotus process residual memory taking almost 30GB, I am kind concerned that it grew this large and GC didn't kick in, so will continue to stress test this for longer. 

EDIT: Ran longer stress test, memory stayed flat so should be good

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
