### PR TITLE
feat: Add tipset -> Message lookup cache

### DIFF
--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -105,8 +105,8 @@ type BlockMessages struct {
 
 func (cs *ChainStore) BlockMsgsForTipset(ctx context.Context, ts *types.TipSet) ([]BlockMessages, error) {
 	// returned BlockMessages match block order in tipset
-
-	if entry, ok := cs.tsMsgCace.Get(ts); ok {
+	tsKey := ts.Key()
+	if entry, ok := cs.tsMsgCache.Get(tsKey); ok {
 		return entry, nil
 	}
 
@@ -182,7 +182,7 @@ func (cs *ChainStore) BlockMsgsForTipset(ctx context.Context, ts *types.TipSet) 
 		out = append(out, bm)
 	}
 
-	cs.tsMsgCace.Add(ts, out)
+	cs.tsMsgCache.Add(tsKey, out)
 
 	return out, nil
 }

--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -106,6 +106,10 @@ type BlockMessages struct {
 func (cs *ChainStore) BlockMsgsForTipset(ctx context.Context, ts *types.TipSet) ([]BlockMessages, error) {
 	// returned BlockMessages match block order in tipset
 
+	if entry, ok := cs.tsMsgCace.Get(ts); ok {
+		return entry, nil
+	}
+
 	applied := make(map[address.Address]uint64)
 
 	cst := cbor.NewCborStore(cs.stateBlockstore)
@@ -177,6 +181,8 @@ func (cs *ChainStore) BlockMsgsForTipset(ctx context.Context, ts *types.TipSet) 
 
 		out = append(out, bm)
 	}
+
+	cs.tsMsgCace.Add(ts, out)
 
 	return out, nil
 }


### PR DESCRIPTION
## Related Issues
See https://github.com/filecoin-project/lotus/issues/10519

## Proposed Changes
This commit adds a cache for looking up block messages in a tipset. This should improve performance for quite a few lotus APIs, including:

- The Eth API block accesses.
- Fee history.
- Tipset message counts
- StateListMessages
- (and likely more)

## Additional Info
I made the cache size configurable through an env variable LOTUS_CHAIN_TIPSET_MESSAGE, so we need to update the Lotus doc accortingly (https://lotus.filecoin.io/lotus/configure/defaults/#environment-variables)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x ] Commits have a clear commit message.
- [x ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
