### PR TITLE
fix: Eth RPC: do not occlude block param errors.

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -386,7 +386,7 @@ func (a *EthModule) EthGetTransactionCount(ctx context.Context, sender ethtypes.
 
 	ts, err := a.parseBlkParam(ctx, blkParam, false)
 	if err != nil {
-		return ethtypes.EthUint64(0), xerrors.Errorf("cannot parse block param: %s", blkParam)
+		return ethtypes.EthUint64(0), xerrors.Errorf("failed to process block param: %s; %w", blkParam, err)
 	}
 
 	// First, handle the case where the "sender" is an EVM actor.
@@ -474,7 +474,7 @@ func (a *EthModule) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 
 	ts, err := a.parseBlkParam(ctx, blkParam, false)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot parse block param: %s", blkParam)
+		return nil, xerrors.Errorf("failed to process block param: %s; %w", blkParam, err)
 	}
 
 	// StateManager.Call will panic if there is no parent
@@ -553,7 +553,7 @@ func (a *EthModule) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 func (a *EthModule) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAddress, position ethtypes.EthBytes, blkParam string) (ethtypes.EthBytes, error) {
 	ts, err := a.parseBlkParam(ctx, blkParam, false)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot parse block param: %s", blkParam)
+		return nil, xerrors.Errorf("failed to process block param: %s; %w", blkParam, err)
 	}
 
 	l := len(position)
@@ -649,7 +649,7 @@ func (a *EthModule) EthGetBalance(ctx context.Context, address ethtypes.EthAddre
 
 	ts, err := a.parseBlkParam(ctx, blkParam, false)
 	if err != nil {
-		return ethtypes.EthBigInt{}, xerrors.Errorf("cannot parse block param: %s", blkParam)
+		return ethtypes.EthBigInt{}, xerrors.Errorf("failed to process block param: %s; %w", blkParam, err)
 	}
 
 	st, _, err := a.StateManager.TipSetState(ctx, ts)
@@ -1070,7 +1070,7 @@ func (a *EthModule) EthCall(ctx context.Context, tx ethtypes.EthCall, blkParam s
 
 	ts, err := a.parseBlkParam(ctx, blkParam, false)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot parse block param: %s", blkParam)
+		return nil, xerrors.Errorf("failed to process block param: %s; %w", blkParam, err)
 	}
 
 	invokeResult, err := a.applyMessage(ctx, msg, ts.Key())


### PR DESCRIPTION
## Related Issues

RPC methods do not relay the error returned from `parseBlkParam`. This behaviour loses information and complicates debugging.

## Proposed Changes

Wrap the error and make the error string more general since the problem may not be caused by parsing only.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
