### PR TITLE
Fix: export-range: Ignore ipld Blocks not found in Receipts.

### DIFF
--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -425,7 +425,7 @@ func (s *walkScheduler) processTask(t walkTask, workerN int) error {
 
 	blk, err := s.store.Get(s.ctx, t.c)
 	if errors.Is(err, format.ErrNotFound{}) && t.topLevelTaskType == receiptTask {
-		log.Warnw("ignoring not-found block in Receipts",
+		log.Debugw("ignoring not-found block in Receipts",
 			"block", t.blockCid,
 			"epoch", t.epoch,
 			"cid", t.c)


### PR DESCRIPTION
## Related Issues

#10492 

## Proposed Changes

These commits improve error reporting during export-range so that users can easily pinpoint in which epoch and in which part of the export an error happens (particularly getting an error when reading a block to export).

Additionally, given there are references to never-written CIDs in Receipts (see linked issue), rather than aborting the export, it will just print a warning when these are found.  This is less strict than decoding receipts and only skipping EventRoot CIDs, but possibly achieves the same result without the complexity.


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
