### PR TITLE
hack: don't load prior messages when estimating gas

### DIFF
--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -262,24 +262,26 @@ func gasEstimateCallWithGas(
 	currTs *types.TipSet,
 ) (*api.InvocResult, []types.ChainMsg, *types.TipSet, error) {
 	msg := *msgIn
-	fromA, err := smgr.ResolveToDeterministicAddress(ctx, msgIn.From, currTs)
-	if err != nil {
-		return nil, []types.ChainMsg{}, nil, xerrors.Errorf("getting key address: %w", err)
-	}
+	//fromA, err := smgr.ResolveToDeterministicAddress(ctx, msgIn.From, currTs)
+	//if err != nil {
+	//	return nil, []types.ChainMsg{}, nil, xerrors.Errorf("getting key address: %w", err)
+	//}
 
-	pending, ts := mpool.PendingFor(ctx, fromA)
-	priorMsgs := make([]types.ChainMsg, 0, len(pending))
-	for _, m := range pending {
-		if m.Message.Nonce == msg.Nonce {
-			break
-		}
-		priorMsgs = append(priorMsgs, m)
-	}
+	//pending, ts := mpool.PendingFor(ctx, fromA)
+	//priorMsgs := make([]types.ChainMsg, 0, len(pending))
+	//for _, m := range pending {
+	//	if m.Message.Nonce == msg.Nonce {
+	//		break
+	//	}
+	//	priorMsgs = append(priorMsgs, m)
+	//}
 
 	// Try calling until we find a height with no migration.
+	ts := currTs
 	var res *api.InvocResult
+	var err error
 	for {
-		res, err = smgr.CallWithGas(ctx, &msg, priorMsgs, ts)
+		res, err = smgr.CallWithGas(ctx, &msg, nil, ts)
 		if err != stmgr.ErrExpensiveFork {
 			break
 		}
@@ -292,7 +294,7 @@ func gasEstimateCallWithGas(
 		return nil, []types.ChainMsg{}, nil, xerrors.Errorf("CallWithGas failed: %w", err)
 	}
 
-	return res, priorMsgs, ts, nil
+	return res, nil, ts, nil
 }
 
 func gasEstimateGasLimit(
@@ -375,14 +377,14 @@ func gasEstimateGasLimit(
 	// Special case for PaymentChannel collect, which is deleting actor
 	// We ignore errors in this special case since they CAN occur,
 	// and we just want to detect existing payment channel actors
-	st, err := smgr.ParentState(ts)
-	if err == nil {
-		act, err := st.GetActor(msg.To)
-		if err == nil && lbuiltin.IsPaymentChannelActor(act.Code) && msgIn.Method == builtin.MethodsPaych.Collect {
-			// add the refunded gas for DestroyActor back into the gas used
-			ret += 76e3
-		}
-	}
+	//st, err := smgr.ParentState(ts)
+	//if err == nil {
+	//	act, err := st.GetActor(msg.To)
+	//	if err == nil && lbuiltin.IsPaymentChannelActor(act.Code) && msgIn.Method == builtin.MethodsPaych.Collect {
+	//		// add the refunded gas for DestroyActor back into the gas used
+	//		ret += 76e3
+	//	}
+	//}
 
 	return ret, nil
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Glif nodes are experiencing performance issues. @snissn reported that contention over the message pool locks are causing these RPC calls to be slow.

## Proposed Changes
<!-- A clear list of the changes being made -->

 **This patch is "wrong", and shouldn't be applied to master, but will likely cause no issues to Glif users.**

This patch changes gas estimation to NOT load pending messages from the mempool, eliminating the slow lock contention observed by Snissn. This will make gas used estimation slightly less accurate when there are pending messages from a sender. This is an issue for SPs, and other users sending large numbers of more "complex" messages (not bare transfers), but likely will not affect most Glif users.

This is one of a few simple hacky-patches we can apply to improve overall performance.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
