### PR TITLE
feat: populate the index on snapshot import

### DIFF
--- a/chain/index/msgindex.go
+++ b/chain/index/msgindex.go
@@ -176,8 +176,12 @@ func PopulateAfterSnapshot(lctx context.Context, basePath string, cs ChainStore)
 	}
 
 	dbPath := path.Join(basePath, dbName)
+
+	// if a database already exists, we try to delete it and create a new one
 	if _, err := os.Stat(dbPath); err == nil {
-		return xerrors.Errorf("msgindex already exists at %s", dbPath)
+		if err = os.Remove(dbPath); err != nil {
+			return xerrors.Errorf("msgindex already exists at %s and can't be deleted", dbPath)
+		}
 	}
 
 	db, err := sql.Open("sqlite3", dbPath)

--- a/chain/index/msgindex.go
+++ b/chain/index/msgindex.go
@@ -211,13 +211,9 @@ func PopulateAfterSnapshot(lctx context.Context, basePath string, cs ChainStore)
 
 	insertStmt, err := tx.Prepare(dbqInsertMessage)
 	if err != nil {
+		rollback()
 		return xerrors.Errorf("error preparing insertStmt: %w", err)
 	}
-	defer func() {
-		if err := insertStmt.Close(); err != nil {
-			log.Errorf("error closing insert statement: %s", err)
-		}
-	}()
 
 	curTs := cs.GetHeaviestTipSet()
 	startHeight := curTs.Height()

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"runtime/pprof"
 	"strings"
 
@@ -557,6 +558,12 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 	if err := cst.ForceHeadSilent(ctx, ts); err != nil {
 		return err
 	}
+
+	log.Info("populating message index...")
+	if err := index.PopulateAfterSnapshot(ctx, path.Join(lr.Path(), "sqlite"), cst); err != nil {
+		return err
+	}
+	log.Info("populating message index done")
 
 	return nil
 }


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/filecoin-project/lotus/issues/10537

## Proposed Changes
After importing from snapshot this PR creates and populates the sqlite message index introduced in https://github.com/filecoin-project/lotus/pull/10452 from the 2k tipsets in the snapshot.

## Additional Info
When loading from snapshot from mainnet, populating the message index takex approx 30 seconds. We should be able to lower this somewhat with bulk inserts (though doing it inside a transaction is at least an order of magnitude faster than not).

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
