### PR TITLE
fix: proving: Initialize slice with with same length as partition

### DIFF
--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -658,6 +658,10 @@ It will not send any messages to the chain.`,
 		for _, i := range res {
 			var postParam SubmitWindowedPoStParams
 			postParam.Deadline = i.Deadline
+
+			// Initialize the postParam.Partitions slice with the same length as i.Partitions
+			postParam.Partitions = make([]PoStPartition, len(i.Partitions))
+
 			for id, part := range i.Partitions {
 				postParam.Partitions[id].Index = part.Index
 				count, err := part.Skipped.Count()


### PR DESCRIPTION
## Related Issues
Fixes #10564

## Proposed Changes
Initialize the postParam.Partitions slice with the same length as i.Partitions before iterating over it in the loop.

## Additional Info
Tested on a local net, and now it does not panic:

```
lotus-miner proving compute window-post 0
Took 1.781950251s
[
  {
    "Deadline": 0,
    "Partitions": [
      {
        "Index": 0,
        "Skipped": []
      }
    ],
    "Proofs": [
      {
        "PoStProof": 5,
        "ProofBytes": "jTEZNQZRWjBRcpnOjyae10RtXnN0k8ALGYeenRLVpzdtBKTQiC+BdVlWdk1qehfarXYYWNE+ib9arhYRj4bmVnyA1xAOlLTzs81lEgW64g1tUOxTVaoBWj0sTPBQGEgbFsMB1vKrVkzBRkTUZU9ZWgaZYb59znxB7/ZrARVJw93hLwd3NRjZQvWNhj/JxfyVgaTuW9Uid2Hc2qIpoDrgKY9HRIQmmKTR9sSjYA3seX6B/6uBDI+/BoqaGJkOcOJc"
      }
    ],
    "ChainCommitEpoch": 0,
    "ChainCommitRand": null
  }
]
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
