### PR TITLE
fix: itests: Don't call t.Error in MineBlocks goroutine

### DIFF
--- a/itests/batch_deal_test.go
+++ b/itests/batch_deal_test.go
@@ -37,6 +37,8 @@ func TestBatchDealInput(t *testing.T) {
 
 	run := func(piece, deals, expectSectors int) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Logf("batchtest start")
+
 			ctx := context.Background()
 
 			publishPeriod := 10 * time.Second
@@ -72,6 +74,8 @@ func TestBatchDealInput(t *testing.T) {
 
 			err := miner.MarketSetAsk(ctx, big.Zero(), big.Zero(), 200, 128, 32<<30)
 			require.NoError(t, err)
+
+			t.Logf("batchtest ask set")
 
 			checkNoPadding := func() {
 				sl, err := miner.SectorsListNonGenesis(ctx)
@@ -118,16 +122,24 @@ func TestBatchDealInput(t *testing.T) {
 				}()
 			}
 
+			t.Logf("batchtest deals started")
+
 			// Wait for maxDealsPerMsg of the deals to be published
 			for i := 0; i < int(maxDealsPerMsg); i++ {
 				<-done
 			}
 
+			t.Logf("batchtest deals published")
+
 			checkNoPadding()
+
+			t.Logf("batchtest no padding")
 
 			sl, err := miner.SectorsListNonGenesis(ctx)
 			require.NoError(t, err)
 			require.Equal(t, len(sl), expectSectors)
+
+			t.Logf("batchtest done")
 		}
 	}
 

--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -245,7 +245,8 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 			case ctx.Err() != nil: // context fired.
 				return
 			default: // log error
-				bm.t.Error(err)
+				bm.t.Logf("MINEBLOCKS-post loop error: %+v", err)
+				return
 			}
 		}
 	}()

--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -291,7 +291,8 @@ func (bm *BlockMiner) MineBlocks(ctx context.Context, blocktime time.Duration) {
 			case ctx.Err() != nil: // context fired.
 				return
 			default: // log error
-				bm.t.Error(err)
+				bm.t.Logf("MINEBLOCKS loop error: %+v", err)
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
## Related Issues
This is a probable cause for <s>a lot</s> maybe some of flakiness in all itests - https://github.com/filecoin-project/lotus/issues?q=is%3Aissue+is%3Aopen+label%3Aimpact%2Ftest-flakiness

## Proposed Changes
When `miner.MineOne` returns an error, which can occasionally happen on normal test shutdown with unlucky timing (e.g. chain blockstore closed during a call to MinerGetBaseInfo while it is computing state), just log the error and quit.

## Additional Info
Previously the call to t.Error could make the failure look very random as it is called in a goroutine, and may be called after the original calling (sub)test has already finished.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
