### PR TITLE
feat: Make execution trace configurable via env variable

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -80,9 +80,9 @@ func init() {
 		letc, err := strconv.Atoi(s)
 		if err != nil {
 			log.Errorf("failed to parse 'LOTUS_EXEC_TRACE_CACHE' env var: %s", err)
+		} else {
+			defaultExecTraceCacheSize = letc
 		}
-
-		defaultExecTraceCacheSize = letc
 	}
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -3,6 +3,8 @@ package stmgr
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -40,8 +42,7 @@ import (
 const LookbackNoLimit = api.LookbackNoLimit
 const ReceiptAmtBitwidth = 3
 
-const execTraceCacheSize = 16
-
+var defaultExecTraceCacheSize = 16
 var log = logging.Logger("statemgr")
 
 type StateManagerAPI interface {
@@ -72,6 +73,17 @@ type migrationResultCache struct {
 func (m *migrationResultCache) keyForMigration(root cid.Cid) dstore.Key {
 	kStr := fmt.Sprintf("%s/%s", m.keyPrefix, root)
 	return dstore.NewKey(kStr)
+}
+
+func init() {
+	if s := os.Getenv("LOTUS_EXEC_TRACE_CACHE"); s != "" {
+		letc, err := strconv.Atoi(s)
+		if err != nil {
+			log.Errorf("failed to parse 'LOTUS_EXEC_TRACE_CACHE' env var: %s", err)
+		}
+
+		defaultExecTraceCacheSize = letc
+	}
 }
 
 func (m *migrationResultCache) Get(ctx context.Context, root cid.Cid) (cid.Cid, bool, error) {
@@ -200,9 +212,14 @@ func NewStateManager(cs *store.ChainStore, exec Executor, sys vm.SyscallBuilder,
 		}
 	}
 
-	execTraceCache, err := lru.NewARC[types.TipSetKey, tipSetCacheEntry](execTraceCacheSize)
-	if err != nil {
-		return nil, err
+	log.Debugf("execTraceCache size: %d", defaultExecTraceCacheSize)
+	var execTraceCache *lru.ARCCache[types.TipSetKey, tipSetCacheEntry]
+	var err error
+	if defaultExecTraceCacheSize > 0 {
+		execTraceCache, err = lru.NewARC[types.TipSetKey, tipSetCacheEntry](defaultExecTraceCacheSize)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &StateManager{


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10584
https://github.com/filecoin-project/lotus/issues/10504

## Proposed Changes
We want to make the execution trace cache size configurable as SPs may want to disable it while exchanges may want to crank it up.

We were also are going with intuition for this value, so having ability to change it without a new build would help.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
