### PR TITLE
feat: Use MessageIndex in WaitForMessage

### DIFF
--- a/chain/stmgr/searchwait.go
+++ b/chain/stmgr/searchwait.go
@@ -57,10 +57,15 @@ func (sm *StateManager) WaitForMessage(ctx context.Context, mcid cid.Cid, confid
 	var backFm cid.Cid
 	backSearchWait := make(chan struct{})
 	go func() {
-		fts, r, foundMsg, err := sm.searchBackForMsg(ctx, head[0].Val, msg, lookbackLimit, allowReplaced)
-		if err != nil {
-			log.Warnf("failed to look back through chain for message: %v", err)
-			return
+		fts, r, foundMsg, err := sm.searchForIndexedMsg(ctx, mcid, msg)
+
+		found := (err == nil && r != nil && foundMsg.Defined())
+		if !found {
+			fts, r, foundMsg, err = sm.searchBackForMsg(ctx, head[0].Val, msg, lookbackLimit, allowReplaced)
+			if err != nil {
+				log.Warnf("failed to look back through chain for message: %v", err)
+				return
+			}
 		}
 
 		backTs = fts


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10583

## Proposed Changes
This commit enables the use for MessageIndex in StateWaitForMessage 

## Test plan

Start lotus node using calibration net

```
make clean calibnet
lotus daemon --import-snapshot /Users/fridrik/Downloads/calibnet/425760_2023_03_29T14_13_00Z.car --halt-after-import
lotus daemon
```

Printed out some messages in sqlite/messageindx.db

```
sqlite3 ~/.lotus/sqlite/msgindex.db
select * from messages order by epoch desc limit 10;
bafy2bzacedqe7fiaxloruetqxf2kfqsorvuhf27llu73vcwolfzfxtotmn2fk|bafy2bzacedioozngzfwlm6qojrqmrbke4evwrsvemeompjttl24gasclvkeqw|425855
bafy2bzacedjhywgkxclwvpbsn7alabrdrhif46bpdvzjyq3yywg7hk3rinfww|bafy2bzacea553srf777sxkkm4vl7fatmsvay3mftw734kxlygem2gsr4jhx2o|425854
bafy2bzacebmbn7syj65duanfehangmj2me6oi2h4fdv6353sg2fs5t5zzyq3g|bafy2bzaced2ztyqrwrew2sxl23plnnjx3nb5st5uhvjsyl3nvdaro2j5ryduc|425853
```
Picked a message `bafy2bzacedjhywgkxclwvpbsn7alabrdrhif46bpdvzjyq3yywg7hk3rinfww`  and called the RPC endpoint:

```
> curl -X POST -H "Content-Type: application/json"  --data '{ "jsonrpc": "2.0", "method":"Filecoin.StateWaitMsg", "params": [{"/": "bafy2bzacedjhywgkxclwvpbsn7alabrdrhif46bpdvzjyq3yywg7hk3rinfww"}, 12], "id": 0 }' 'http://127.0.0.1:1234/rpc/v0'
{"jsonrpc":"2.0","result":{"Message":{"/":"bafy2bzacedjhywgkxclwvpbsn7alabrdrhif46bpdvzjyq3yywg7hk3rinfww"},"Receipt":{"ExitCode":0,"Return":null,"GasUsed":1269163,"EventsRoot":null},"ReturnDec":null,"TipSet":[{"/":"bafy2bzacecv3khxqf3kukjzhytqapeuimybi3btgwupvmpnrjrjjzjrxxjehq"},{"/":"bafy2bzacebpgvtikjuy3u7zyupsbqiiqbiljbbwwvajzctlzfsfik4nd7dt4e"},{"/":"bafy2bzacecrcvz3eti6vdvexv6kmbz3hownjwegv7ymc5teac3cidsnm3bmc2"},{"/":"bafy2bzacedij66kwxewue7hrqe3sud4zhh3d44cvvdt6btac6fvuombigwgri"},{"/":"bafy2bzaceddr5jqddtuexe6omesgici55mlji4iztv45euoiiqrkz5xbqdkze"}],"Height":425855},"id":0}
```
Observed (using debug logs not part of this PR) that we retrieved the message from MessageIndex
 
## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
