### PR TITLE
fix: log: Stop logging `file does not exists`

### DIFF
--- a/storage/paths/localstorage_cached.go
+++ b/storage/paths/localstorage_cached.go
@@ -1,6 +1,7 @@
 package paths
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -103,7 +104,9 @@ func (c *cachedLocalStorage) DiskUsage(path string) (int64, error) {
 		go func() {
 			du, err := c.base.DiskUsage(path)
 			if err != nil {
-				log.Errorw("error getting disk usage", "path", path, "error", err)
+				if !os.IsNotExist(err) {
+					log.Errorw("error getting disk usage", "path", path, "error", err)
+				}
 			}
 			resCh <- diskUsageResult{
 				usage: du,


### PR DESCRIPTION
## Related Issues
fixes: #9073 

## Proposed Changes
Do not log 'file does not exist' errors when retrieving disk usage information. These errors are expected, as storage can be reserved before any files are written, and they were cluttering the logs unnecessarily.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
