### PR TITLE
VM Execution Lanes Part II: Hide the lock

### DIFF
--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -496,7 +496,6 @@ func VerifyPreSealedData(ctx context.Context, cs *store.ChainStore, sys vm.Sysca
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to create VM: %w", err)
 	}
-	defer vm.Done()
 
 	for mi, m := range template.Miners {
 		for si, s := range m.Sectors {

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -88,7 +88,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 		return big.Zero(), nil
 	}
 
-	newVM := func(base cid.Cid) (vm.Executor, error) {
+	newVM := func(base cid.Cid) (vm.Interface, error) {
 		vmopt := &vm.VMOpts{
 			StateBase:      base,
 			Epoch:          0,
@@ -108,8 +108,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 	if err != nil {
 		return cid.Undef, fmt.Errorf("creating vm: %w", err)
 	}
-	// Note: genesisVm is mutated, so this has to happen in a deferred func; go horror show.
-	defer func() { genesisVm.Done() }()
 
 	if len(miners) == 0 {
 		return cid.Undef, xerrors.New("no genesis miners")
@@ -340,7 +338,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 			return cid.Undef, xerrors.Errorf("flushing state tree: %w", err)
 		}
 
-		genesisVm.Done()
 		genesisVm, err = newVM(nh)
 		if err != nil {
 			return cid.Undef, fmt.Errorf("creating new vm: %w", err)
@@ -413,7 +410,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 					return cid.Undef, xerrors.Errorf("flushing state tree: %w", err)
 				}
 
-				genesisVm.Done()
 				genesisVm, err = newVM(nh)
 				if err != nil {
 					return cid.Undef, fmt.Errorf("creating new vm: %w", err)
@@ -521,7 +517,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 						return cid.Undef, xerrors.Errorf("flushing state tree: %w", err)
 					}
 
-					genesisVm.Done()
 					genesisVm, err = newVM(nh)
 					if err != nil {
 						return cid.Undef, fmt.Errorf("creating new vm: %w", err)

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -159,8 +159,6 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 	if err != nil {
 		return nil, xerrors.Errorf("failed to set up vm: %w", err)
 	}
-	// Note: vmi is mutated, so this has to happen in a deferred func; go horror show.
-	defer func() { vmi.Done() }()
 
 	for i, m := range priorMsgs {
 		_, err = vmi.ApplyMessage(ctx, m)
@@ -194,7 +192,6 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 		vmopt.BaseFee = big.Zero()
 		vmopt.StateBase = stateCid
 
-		vmi.Done()
 		vmi, err = sm.newVM(ctx, vmopt)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to set up estimation vm: %w", err)

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -56,12 +56,6 @@ const testForkHeight = 40
 type testActor struct {
 }
 
-type mockExecutor struct {
-	vm.Interface
-}
-
-func (*mockExecutor) Done() {}
-
 // must use existing actor that an account is allowed to exec.
 func (testActor) Code() cid.Cid  { return builtin0.PaymentChannelActorCodeID }
 func (testActor) State() cbor.Er { return new(testActorState) }
@@ -184,13 +178,13 @@ func TestForkHeightTriggers(t *testing.T) {
 	registry := builtin.MakeRegistryLegacy([]rtt.VMActor{testActor{}})
 	inv.Register(actorstypes.Version0, nil, registry)
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		nvm, err := vm.NewLegacyVM(ctx, vmopt)
 		if err != nil {
 			return nil, err
 		}
 		nvm.SetInvoker(inv)
-		return &mockExecutor{nvm}, nil
+		return nvm, nil
 	})
 
 	cg.SetStateManager(sm)
@@ -302,13 +296,13 @@ func testForkRefuseCall(t *testing.T, nullsBefore, nullsAfter int) {
 	registry := builtin.MakeRegistryLegacy([]rtt.VMActor{testActor{}})
 	inv.Register(actorstypes.Version0, nil, registry)
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		nvm, err := vm.NewLegacyVM(ctx, vmopt)
 		if err != nil {
 			return nil, err
 		}
 		nvm.SetInvoker(inv)
-		return &mockExecutor{nvm}, nil
+		return nvm, nil
 	})
 
 	cg.SetStateManager(sm)
@@ -524,13 +518,13 @@ func TestForkPreMigration(t *testing.T) {
 	registry := builtin.MakeRegistryLegacy([]rtt.VMActor{testActor{}})
 	inv.Register(actorstypes.Version0, nil, registry)
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		nvm, err := vm.NewLegacyVM(ctx, vmopt)
 		if err != nil {
 			return nil, err
 		}
 		nvm.SetInvoker(inv)
-		return &mockExecutor{nvm}, nil
+		return nvm, nil
 	})
 
 	cg.SetStateManager(sm)
@@ -598,11 +592,11 @@ func TestDisablePreMigration(t *testing.T) {
 	registry := builtin.MakeRegistryLegacy([]rtt.VMActor{testActor{}})
 	inv.Register(actorstypes.Version0, nil, registry)
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		nvm, err := vm.NewLegacyVM(ctx, vmopt)
 		require.NoError(t, err)
 		nvm.SetInvoker(inv)
-		return &mockExecutor{nvm}, nil
+		return nvm, nil
 	})
 
 	cg.SetStateManager(sm)
@@ -653,11 +647,11 @@ func TestMigrtionCache(t *testing.T) {
 	registry := builtin.MakeRegistryLegacy([]rtt.VMActor{testActor{}})
 	inv.Register(actorstypes.Version0, nil, registry)
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		nvm, err := vm.NewLegacyVM(ctx, vmopt)
 		require.NoError(t, err)
 		nvm.SetInvoker(inv)
-		return &mockExecutor{nvm}, nil
+		return nvm, nil
 	})
 
 	cg.SetStateManager(sm)
@@ -697,11 +691,11 @@ func TestMigrtionCache(t *testing.T) {
 			index.DummyMsgIndex,
 		)
 		require.NoError(t, err)
-		sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+		sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 			nvm, err := vm.NewLegacyVM(ctx, vmopt)
 			require.NoError(t, err)
 			nvm.SetInvoker(inv)
-			return &mockExecutor{nvm}, nil
+			return nvm, nil
 		})
 
 		ctx := context.Background()

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -125,7 +125,7 @@ type StateManager struct {
 	compWait            map[string]chan struct{}
 	stlk                sync.Mutex
 	genesisMsigLk       sync.Mutex
-	newVM               func(context.Context, *vm.VMOpts) (vm.Executor, error)
+	newVM               func(context.Context, *vm.VMOpts) (vm.Interface, error)
 	Syscalls            vm.SyscallBuilder
 	preIgnitionVesting  []msig0.State
 	postIgnitionVesting []msig0.State
@@ -439,12 +439,12 @@ func (sm *StateManager) ValidateChain(ctx context.Context, ts *types.TipSet) err
 	return nil
 }
 
-func (sm *StateManager) SetVMConstructor(nvm func(context.Context, *vm.VMOpts) (vm.Executor, error)) {
+func (sm *StateManager) SetVMConstructor(nvm func(context.Context, *vm.VMOpts) (vm.Interface, error)) {
 	sm.newVM = nvm
 }
 
-func (sm *StateManager) VMConstructor() func(context.Context, *vm.VMOpts) (vm.Executor, error) {
-	return func(ctx context.Context, opts *vm.VMOpts) (vm.Executor, error) {
+func (sm *StateManager) VMConstructor() func(context.Context, *vm.VMOpts) (vm.Interface, error) {
+	return func(ctx context.Context, opts *vm.VMOpts) (vm.Interface, error) {
 		return sm.newVM(ctx, opts)
 	}
 }

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -106,7 +106,6 @@ func ComputeState(ctx context.Context, sm *StateManager, height abi.ChainEpoch, 
 	if err != nil {
 		return cid.Undef, nil, err
 	}
-	defer vmi.Done()
 
 	for i, msg := range msgs {
 		// TODO: Use the signed message length for secp messages

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -158,7 +158,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 		results:  []*vm.ApplyRet{},
 	}
 
-	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Executor, error) {
+	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
 		vmopt.CircSupplyCalc = func(context.Context, abi.ChainEpoch, *state.StateTree) (abi.TokenAmount, error) {
 			return big.Zero(), nil
 		}


### PR DESCRIPTION
On top of https://github.com/filecoin-project/lotus/pull/10551

This implements the finegrained lock suggested by @Stebalien 
Honestly, I don't think finegrained locking is actually advantageous with our usage patterns, but not having to call `Done`  is a definite improvement safety-wise.