### PR TITLE
feat:chain:export-range:configurable output dir and name

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -404,4 +404,6 @@ type ChainExportConfig struct {
 	IncludeMessages   bool
 	IncludeReceipts   bool
 	IncludeStateRoots bool
+	FileName          string
+	ExportDir         string
 }

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -1193,6 +1193,16 @@ var ChainExportRangeCmd = &cli.Command{
 			Value:  true,
 			Hidden: true, // currently, non-internal export is not implemented.
 		},
+		&cli.StringFlag{
+			Name:   "filename",
+			Usage:  "name of exported CAR file for internal chain export",
+			Hidden: true, // currently, non-internal export is not implemented.
+		},
+		&cli.StringFlag{
+			Name:   "export-dir",
+			Usage:  "directory where to save the exported CAR file",
+			Hidden: true, // currently, non-internal export is not implemented.
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := GetFullNodeAPIV1(cctx)
@@ -1242,6 +1252,8 @@ var ChainExportRangeCmd = &cli.Command{
 			IncludeMessages:   cctx.Bool("messages"),
 			IncludeReceipts:   cctx.Bool("receipts"),
 			IncludeStateRoots: cctx.Bool("stateroots"),
+			FileName:          cctx.String("filename"),
+			ExportDir:         cctx.String("export-dir"),
 		})
 		if err != nil {
 			return err

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -598,9 +598,19 @@ func (a ChainAPI) ChainExportRangeInternal(ctx context.Context, head, tail types
 		return xerrors.Errorf("Height of head-tipset (%d) must be greater or equal to the height of the tail-tipset (%d)", headTs.Height(), tailTs.Height())
 	}
 
-	fileName := filepath.Join(a.Repo.Path(), fmt.Sprintf("snapshot_%d_%d_%d.car", tailTs.Height(), headTs.Height(), time.Now().Unix()))
-	if err != nil {
-		return err
+	var fileName string
+	defaultFileName := fmt.Sprintf("snapshot_%d_%d_%d.car", tailTs.Height(), headTs.Height(), time.Now().Unix())
+	defaultFileDir := a.Repo.Path()
+	if cfg.FileName != "" {
+		if cfg.ExportDir != "" {
+			fileName = filepath.Join(cfg.ExportDir, cfg.FileName)
+		} else {
+			fileName = filepath.Join(defaultFileDir, cfg.FileName)
+		}
+	} else if cfg.ExportDir != "" {
+		fileName = filepath.Join(cfg.ExportDir, defaultFileName)
+	} else {
+		fileName = filepath.Join(defaultFileDir, defaultFileName)
 	}
 
 	f, err := os.Create(fileName)


### PR DESCRIPTION
## Related Issues
as a snapshot operator, I would like to set the snapshot car filename and output directory.

## Proposed Changes
adds two new configuration parameters, and maintains default behavior if unset

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
