### PR TITLE
feat:splitstore:Update config default value

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -242,7 +242,7 @@
     #
     # type: uint64
     # env var: LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREMAXSPACETARGET
-    #HotStoreMaxSpaceTarget = 0
+    #HotStoreMaxSpaceTarget = 650000000000
 
     # When HotStoreMaxSpaceTarget is set Moving GC will be triggered when total moving size
     # exceeds HotstoreMaxSpaceTarget - HotstoreMaxSpaceThreshold

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -96,6 +96,7 @@ func DefaultFullNode() *FullNode {
 				MarkSetType:   "badger",
 
 				HotStoreFullGCFrequency:      20,
+				HotStoreMaxSpaceTarget:       650_000_000_000,
 				HotStoreMaxSpaceThreshold:    150_000_000_000,
 				HotstoreMaxSpaceSafetyBuffer: 50_000_000_000,
 			},


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#10580 
## Proposed Changes
<!-- A clear list of the changes being made -->
Set splitstore max space config as default 

## Additional Info
<!-- Callouts, links to documentation, and etc -->
This config value will bound total lotus hotstore space during moves between 500 - 650 GiB by default 
Reviewers should advise if this is too small / the resources needed for frequent moves is expected to be too burdensome 
We should probably land this alongside #10392 so that more frequent moving GCs have less impact on chain sync

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
