### PR TITLE
Fixed incorrect words that could not be compiled

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -143,4 +143,4 @@ var WhitelistedBlock = cid.Undef
 
 // Reducing the delivery delay for equivocation of
 // consistent broadcast to just half a second.
-var CBDeliveryDelay = 500 * time.Milisecond
+var CBDeliveryDelay = 500 * time.Millisecond


### PR DESCRIPTION
Milisecond is incorrect,resulting in failure to compile.

## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
