### PR TITLE
Backport #10605 to v1.21.0

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -242,7 +242,7 @@
     #
     # type: uint64
     # env var: LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREMAXSPACETARGET
-    #HotStoreMaxSpaceTarget = 0
+    #HotStoreMaxSpaceTarget = 650000000000
 
     # When HotStoreMaxSpaceTarget is set Moving GC will be triggered when total moving size
     # exceeds HotstoreMaxSpaceTarget - HotstoreMaxSpaceThreshold

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -96,6 +96,7 @@ func DefaultFullNode() *FullNode {
 				MarkSetType:   "badger",
 
 				HotStoreFullGCFrequency:      20,
+				HotStoreMaxSpaceTarget:       650_000_000_000,
 				HotStoreMaxSpaceThreshold:    150_000_000_000,
 				HotstoreMaxSpaceSafetyBuffer: 50_000_000_000,
 			},


### PR DESCRIPTION
## Proposed Changes
Backports https://github.com/filecoin-project/lotus/pull/10605 to v1.21.0

## Additional Info
Set splitstore max space config as default

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
