### PR TITLE
wip feat: Ability to back universal blockstore by CQL servers

### DIFF
--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -2,7 +2,6 @@ package blockstore
 
 import (
 	"context"
-
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"

--- a/blockstore/cached.go
+++ b/blockstore/cached.go
@@ -5,11 +5,15 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-cid"
 	block "github.com/ipfs/go-libipfs/blocks"
+	"sync"
 )
 
 type CachedBlockstore struct {
 	write Blockstore
 	cache *lru.ARCCache[cid.Cid, block.Block]
+
+	writeLk       sync.Mutex
+	pendingWrites map[cid.Cid]block.Block
 }
 
 var CacheBstoreSize = (4 << 30) / 16000 // 4GB with average block size of 16KB
@@ -20,7 +24,8 @@ func WithCache(base Blockstore) *CachedBlockstore {
 	bs := &CachedBlockstore{
 		write: base,
 
-		cache: c,
+		cache:         c,
+		pendingWrites: make(map[cid.Cid]block.Block),
 	}
 	return bs
 }
@@ -30,7 +35,9 @@ var (
 	_ Viewer     = (*CachedBlockstore)(nil)
 )
 
-func (bs *CachedBlockstore) Flush(ctx context.Context) error { return bs.write.Flush(ctx) }
+func (bs *CachedBlockstore) Flush(ctx context.Context) error {
+	return bs.write.Flush(ctx)
+}
 
 func (bs *CachedBlockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return bs.write.AllKeysChan(ctx)
@@ -53,6 +60,13 @@ func (bs *CachedBlockstore) View(ctx context.Context, c cid.Cid, callback func([
 		return callback(blk.RawData())
 	}
 
+	bs.writeLk.Lock()
+	if blk, ok := bs.pendingWrites[c]; ok {
+		bs.writeLk.Unlock()
+		return callback(blk.RawData())
+	}
+	bs.writeLk.Unlock()
+
 	return bs.write.View(ctx, c, func(bytes []byte) error {
 		blk, err := block.NewBlockWithCid(bytes, c)
 		if err != nil {
@@ -68,6 +82,13 @@ func (bs *CachedBlockstore) Get(ctx context.Context, c cid.Cid) (block.Block, er
 	if blk, ok := bs.cache.Get(c); ok {
 		return blk, nil
 	}
+
+	bs.writeLk.Lock()
+	if blk, ok := bs.pendingWrites[c]; ok {
+		bs.writeLk.Unlock()
+		return blk, nil
+	}
+	bs.writeLk.Unlock()
 
 	return bs.write.Get(ctx, c)
 }
@@ -92,6 +113,13 @@ func (bs *CachedBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 		return true, nil
 	}
 
+	bs.writeLk.Lock()
+	if _, ok := bs.pendingWrites[c]; ok {
+		bs.writeLk.Unlock()
+		return true, nil
+	}
+	bs.writeLk.Unlock()
+
 	return bs.write.Has(ctx, c)
 }
 
@@ -100,8 +128,44 @@ func (bs *CachedBlockstore) HashOnRead(hor bool) {
 }
 
 func (bs *CachedBlockstore) PutMany(ctx context.Context, blks []block.Block) error {
+	toPut := make([]block.Block, 0, len(blks))
+
 	for _, blk := range blks {
+		if bs.cache.Contains(blk.Cid()) {
+			continue
+		}
+
 		bs.cache.Add(blk.Cid(), blk)
+		toPut = append(toPut, blk)
 	}
-	return bs.write.PutMany(ctx, blks)
+
+	if len(toPut) == 0 {
+		return nil
+	}
+
+	//return bs.write.PutMany(ctx, toPut)
+
+	// this part is EXTREMELY aggresive
+
+	bs.writeLk.Lock()
+	for i, blk := range blks {
+		bs.pendingWrites[blk.Cid()] = blks[i]
+	}
+	bs.writeLk.Unlock()
+
+	go func() {
+		err := bs.write.PutMany(context.TODO(), toPut)
+
+		bs.writeLk.Lock()
+		for _, blk := range toPut {
+			delete(bs.pendingWrites, blk.Cid())
+		}
+		bs.writeLk.Unlock()
+
+		if err != nil {
+			log.Error("failed to write to disk", err)
+		}
+	}()
+
+	return nil
 }

--- a/blockstore/cached.go
+++ b/blockstore/cached.go
@@ -1,0 +1,107 @@
+package blockstore
+
+import (
+	"context"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/ipfs/go-cid"
+	block "github.com/ipfs/go-libipfs/blocks"
+)
+
+type CachedBlockstore struct {
+	write Blockstore
+	cache *lru.ARCCache[cid.Cid, block.Block]
+}
+
+var CacheBstoreSize = (4 << 30) / 16000 // 4GB with average block size of 16KB
+
+func WithCache(base Blockstore) *CachedBlockstore {
+	c, _ := lru.NewARC[cid.Cid, block.Block](CacheBstoreSize)
+
+	bs := &CachedBlockstore{
+		write: base,
+
+		cache: c,
+	}
+	return bs
+}
+
+var (
+	_ Blockstore = (*CachedBlockstore)(nil)
+	_ Viewer     = (*CachedBlockstore)(nil)
+)
+
+func (bs *CachedBlockstore) Flush(ctx context.Context) error { return bs.write.Flush(ctx) }
+
+func (bs *CachedBlockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return bs.write.AllKeysChan(ctx)
+}
+
+func (bs *CachedBlockstore) DeleteBlock(ctx context.Context, c cid.Cid) error {
+	bs.cache.Remove(c)
+	return bs.write.DeleteBlock(ctx, c)
+}
+
+func (bs *CachedBlockstore) DeleteMany(ctx context.Context, cids []cid.Cid) error {
+	for _, c := range cids {
+		bs.cache.Remove(c)
+	}
+	return bs.write.DeleteMany(ctx, cids)
+}
+
+func (bs *CachedBlockstore) View(ctx context.Context, c cid.Cid, callback func([]byte) error) error {
+	if blk, ok := bs.cache.Get(c); ok {
+		return callback(blk.RawData())
+	}
+
+	return bs.write.View(ctx, c, func(bytes []byte) error {
+		blk, err := block.NewBlockWithCid(bytes, c)
+		if err != nil {
+			return err
+		}
+		bs.cache.Add(c, blk)
+
+		return callback(bytes)
+	})
+}
+
+func (bs *CachedBlockstore) Get(ctx context.Context, c cid.Cid) (block.Block, error) {
+	if blk, ok := bs.cache.Get(c); ok {
+		return blk, nil
+	}
+
+	return bs.write.Get(ctx, c)
+}
+
+func (bs *CachedBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
+	b, err := bs.Get(ctx, c)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(b.RawData()), nil
+}
+
+func (bs *CachedBlockstore) Put(ctx context.Context, blk block.Block) error {
+	bs.cache.Add(blk.Cid(), blk)
+
+	return bs.write.Put(ctx, blk)
+}
+
+func (bs *CachedBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	if bs.cache.Contains(c) {
+		return true, nil
+	}
+
+	return bs.write.Has(ctx, c)
+}
+
+func (bs *CachedBlockstore) HashOnRead(hor bool) {
+	bs.write.HashOnRead(hor)
+}
+
+func (bs *CachedBlockstore) PutMany(ctx context.Context, blks []block.Block) error {
+	for _, blk := range blks {
+		bs.cache.Add(blk.Cid(), blk)
+	}
+	return bs.write.PutMany(ctx, blks)
+}

--- a/blockstore/cassbs/cassandra_ds.go
+++ b/blockstore/cassbs/cassandra_ds.go
@@ -26,6 +26,9 @@ func NewCassandraDS(connectString string) (*CassandraDatastore, error) {
 	cluster := gocql.NewCluster(connectString)
 	cluster.Consistency = gocql.Quorum
 	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 30}
+	cluster.Timeout = 30 * time.Second
+	cluster.ConnectTimeout = 30 * time.Second
+
 	session, err := cluster.CreateSession()
 	if err != nil {
 		return nil, fmt.Errorf("creating new Cassandra session: %w", err)

--- a/blockstore/cassbs/cassandra_ds.go
+++ b/blockstore/cassbs/cassandra_ds.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"sort"
+	"time"
+
 	"github.com/gocql/gocql"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
-	"os"
-	"sort"
-	"time"
 )
 
 var log = logging.Logger("casbs")

--- a/blockstore/cassbs/cassandra_ds.go
+++ b/blockstore/cassbs/cassandra_ds.go
@@ -1,0 +1,200 @@
+package cassbs
+
+import (
+	"context"
+	"fmt"
+	"github.com/gocql/gocql"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	"golang.org/x/xerrors"
+	"os"
+	"sort"
+)
+
+type CassandraDatastore struct {
+	session *gocql.Session
+}
+
+var ReplicationFactor = 2
+
+func NewCassandraDS(connectString string) (*CassandraDatastore, error) {
+	cluster := gocql.NewCluster(connectString)
+	cluster.Consistency = gocql.LocalQuorum
+	session, err := cluster.CreateSession()
+	if err != nil {
+		return nil, fmt.Errorf("creating new Cassandra session: %w", err)
+	}
+	if err := setupSchema(session, ReplicationFactor); err != nil {
+		return nil, xerrors.Errorf("setup schema: %w", err)
+	}
+	return &CassandraDatastore{session: session}, nil
+}
+
+func setupSchema(session *gocql.Session, replicationFactor int) error {
+	if os.Getenv("LOTUS_DROP_CAS") == "1" {
+		// drop lotus.chain table
+		if err := session.Query(`DROP TABLE IF EXISTS lotus.chain`).WithContext(context.Background()).Exec(); err != nil {
+			return fmt.Errorf("dropping table: %w", err)
+		}
+
+		// drop keyspace
+		if err := session.Query(`DROP KEYSPACE IF EXISTS lotus`).WithContext(context.Background()).Exec(); err != nil {
+			return fmt.Errorf("dropping keyspace: %w", err)
+		}
+	}
+
+	// Set up keyspace if needed
+	keyspaceQuery := fmt.Sprintf(`
+		CREATE KEYSPACE IF NOT EXISTS lotus
+		WITH REPLICATION = {
+			'class': 'SimpleStrategy',
+			'replication_factor': %d
+		}
+	`, replicationFactor)
+	if err := session.Query(keyspaceQuery).WithContext(context.Background()).Exec(); err != nil {
+		return fmt.Errorf("creating keyspace: %w", err)
+	}
+
+	// Set up table schema if needed
+	tableSchemaQuery := `
+		CREATE TABLE IF NOT EXISTS lotus.chain (
+			key text PRIMARY KEY,
+			value blob
+		)
+	`
+	if err := session.Query(tableSchemaQuery).WithContext(context.Background()).Exec(); err != nil {
+		return fmt.Errorf("creating table schema: %w", err)
+	}
+
+	return nil
+}
+
+func (cds *CassandraDatastore) Put(ctx context.Context, key datastore.Key, value []byte) error {
+	keyStr := key.String()
+	qry := `UPDATE lotus.chain SET value = ? WHERE key = ?`
+	if err := cds.session.Query(qry, value, keyStr).WithContext(ctx).Exec(); err != nil {
+		return fmt.Errorf("upserting key-value pair: %w", err)
+	}
+	return nil
+}
+
+func (cds *CassandraDatastore) Delete(ctx context.Context, key datastore.Key) error {
+	keyStr := key.String()
+	qry := `DELETE FROM lotus.chain WHERE key = ?`
+	if err := cds.session.Query(qry, keyStr).WithContext(ctx).Exec(); err != nil {
+		return fmt.Errorf("deleting key: %w", err)
+	}
+	return nil
+}
+
+var _ datastore.Write = (*CassandraDatastore)(nil)
+
+func (cds *CassandraDatastore) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
+	var value []byte
+	err := cds.session.Query("SELECT value FROM lotus.chain WHERE key = ?", key.String()).WithContext(ctx).Scan(&value)
+	if err != nil {
+		if err == gocql.ErrNotFound {
+			return nil, datastore.ErrNotFound
+		}
+		return nil, err
+	}
+	return value, nil
+}
+
+func (cds *CassandraDatastore) Has(ctx context.Context, key datastore.Key) (bool, error) {
+	var count int
+	err := cds.session.Query("SELECT COUNT(*) FROM lotus.chain WHERE key = ?", key.String()).WithContext(ctx).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (cds *CassandraDatastore) GetSize(ctx context.Context, key datastore.Key) (int, error) {
+	value, err := cds.Get(ctx, key) // todo this is not great, but getting blob len is not that easy. Hopefully we don't call this much
+	if err != nil {
+		return -1, err
+	}
+	return len(value), nil
+}
+
+func (cds *CassandraDatastore) Query(ctx context.Context, q query.Query) (query.Results, error) {
+	// Basic implementation assumes all filters, orders and limits are applied client-side
+	// todo do more fancy things if needed
+	iter := cds.session.Query("SELECT key, value FROM lotus.chain").WithContext(ctx).Iter()
+
+	var (
+		k       string
+		v       []byte
+		entries []query.Entry
+	)
+
+	for iter.Scan(&k, &v) {
+		vs := string(v) // copy
+		v := []byte(vs)
+
+		entry := query.Entry{Key: k, Value: v}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { // todo eww
+		return entries[i].Key < entries[j].Key
+	})
+
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+
+	// Apply filters, orders and limits client-side
+	qr := query.ResultsWithEntries(q, entries)
+	for _, filter := range q.Filters {
+		qr = query.NaiveFilter(qr, filter)
+	}
+	qr = query.NaiveOrder(qr, q.Orders...)
+	qr = query.NaiveLimit(qr, q.Limit)
+	qr = query.NaiveOffset(qr, q.Offset)
+
+	return qr, nil
+}
+
+var _ datastore.Read = (*CassandraDatastore)(nil)
+
+func (cds *CassandraDatastore) Sync(ctx context.Context, prefix datastore.Key) error {
+	return nil
+}
+
+func (cds *CassandraDatastore) Close() error {
+	cds.session.Close()
+	return nil
+}
+
+var _ datastore.Datastore = (*CassandraDatastore)(nil)
+
+type cassandraBatch struct {
+	session *gocql.Session
+	batch   *gocql.Batch
+}
+
+func (c *cassandraBatch) Put(ctx context.Context, key datastore.Key, value []byte) error {
+	statement := "UPDATE lotus.chain SET value = ? WHERE key = ?"
+	c.batch.Query(statement, value, key.String())
+	return nil
+}
+
+func (c *cassandraBatch) Delete(ctx context.Context, key datastore.Key) error {
+	statement := "DELETE FROM lotus.chain WHERE key = ?"
+	c.batch.Query(statement, key.String())
+	return nil
+}
+
+func (c *cassandraBatch) Commit(ctx context.Context) error {
+	return c.session.ExecuteBatch(c.batch.WithContext(ctx))
+}
+
+func (cds *CassandraDatastore) Batch(ctx context.Context) (datastore.Batch, error) {
+	return &cassandraBatch{
+		session: cds.session,
+		batch:   cds.session.NewBatch(gocql.UnloggedBatch),
+	}, nil
+}
+
+var _ datastore.Batching = (*CassandraDatastore)(nil)

--- a/blockstore/cassbs/cassandra_ds.go
+++ b/blockstore/cassbs/cassandra_ds.go
@@ -21,7 +21,7 @@ type CassandraDatastore struct {
 	session *gocql.Session
 }
 
-var ReplicationFactor = 1
+var ReplicationFactor = 2
 
 func NewCassandraDS(connectString string) (*CassandraDatastore, error) {
 	cluster := gocql.NewCluster(connectString)

--- a/blockstore/cassbs/cassandra_ds_test.go
+++ b/blockstore/cassbs/cassandra_ds_test.go
@@ -1,0 +1,22 @@
+package cassbs
+
+import (
+	"os"
+	"testing"
+	
+	dstest "github.com/ipfs/go-datastore/test"
+)
+
+func TestCassandraDS(t *testing.T) {
+	casConn, ok := os.LookupEnv("CASSANDRA_TEST_CONNECTION")
+	if !ok {
+		t.Skip("CASSANDRA_TEST_CONNECTION not set")
+	}
+
+	ds, err := NewCassandraDS(casConn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstest.SubtestAll(t, ds)
+}

--- a/blockstore/cassbs/cassandra_ds_test.go
+++ b/blockstore/cassbs/cassandra_ds_test.go
@@ -3,7 +3,7 @@ package cassbs
 import (
 	"os"
 	"testing"
-	
+
 	dstest "github.com/ipfs/go-datastore/test"
 )
 

--- a/chain/store/index_test.go
+++ b/chain/store/index_test.go
@@ -41,7 +41,7 @@ func TestIndexSeeks(t *testing.T) {
 	cs := store.NewChainStore(nbs, nbs, syncds.MutexWrap(datastore.NewMapDatastore()), filcns.Weight, nil)
 	defer cs.Close() //nolint:errcheck
 
-	_, err = cs.Import(ctx, bytes.NewReader(gencar))
+	_, _, err = cs.Import(ctx, bytes.NewReader(gencar))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -60,7 +60,7 @@ func (cs *ChainStore) Export(ctx context.Context, ts *types.TipSet, inclRecentRo
 	})
 }
 
-func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, error) {
+func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (head *types.TipSet, tail *types.BlockHeader, err error) {
 	// TODO: writing only to the state blockstore is incorrect.
 	//  At this time, both the state and chain blockstores are backed by the
 	//  universal store. When we physically segregate the stores, we will need
@@ -69,7 +69,7 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 
 	br, err := carv2.NewBlockReader(r)
 	if err != nil {
-		return nil, xerrors.Errorf("loadcar failed: %w", err)
+		return nil, nil, xerrors.Errorf("loadcar failed: %w", err)
 	}
 
 	s := cs.StateBlockstore()
@@ -80,27 +80,44 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 		putThrottle <- nil
 	}
 
+	nextTailCid := br.Roots[0]
+	var tailBlock types.BlockHeader
+	tailBlock.Height = abi.ChainEpoch(-1)
+
 	var buf []blocks.Block
 	for {
 		blk, err := br.Next()
 		if err != nil {
+
+			// we're at the end
 			if err == io.EOF {
 				if len(buf) > 0 {
 					if err := s.PutMany(ctx, buf); err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
 
 				break
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
+		// check for header block, looking for genesis
+		if blk.Cid() == nextTailCid && tailBlock.Height != 0 {
+			if err := tailBlock.UnmarshalCBOR(bytes.NewReader(blk.RawData())); err != nil {
+				return nil, nil, xerrors.Errorf("failed to unmarshal tail block: %w", err)
+			}
+			if len(tailBlock.Parents) > 0 {
+				nextTailCid = tailBlock.Parents[0]
+			}
+		}
+
+		// append to batch
 		buf = append(buf, blk)
 
 		if len(buf) > 1000 {
 			if lastErr := <-putThrottle; lastErr != nil { // consume one error to have the right to add one
-				return nil, lastErr
+				return nil, nil, lastErr
 			}
 
 			go func(buf []blocks.Block) {
@@ -113,20 +130,24 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 	// check errors
 	for i := 0; i < parallelPuts; i++ {
 		if lastErr := <-putThrottle; lastErr != nil {
-			return nil, lastErr
+			return nil, nil, lastErr
 		}
+	}
+
+	if tailBlock.Height != 0 {
+		return nil, nil, xerrors.Errorf("expected tail block to have height 0 (genesis), got %d: %s", tailBlock.Height, tailBlock.Cid())
 	}
 
 	root, err := cs.LoadTipSet(ctx, types.NewTipSetKey(br.Roots...))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to load root tipset from chainfile: %w", err)
+		return nil, nil, xerrors.Errorf("failed to load root tipset from chainfile: %w", err)
 	}
 
 	ts := root
 	for i := 0; i < int(TipsetkeyBackfillRange); i++ {
 		err = cs.PersistTipset(ctx, ts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		parentTsKey := ts.Parents()
 		ts, err = cs.LoadTipSet(ctx, parentTsKey)
@@ -136,7 +157,7 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 		}
 	}
 
-	return root, nil
+	return root, &tailBlock, nil
 }
 
 type walkSchedTaskType int

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -74,7 +74,7 @@ func (cs *ChainStore) Import(ctx context.Context, r io.Reader) (*types.TipSet, e
 
 	s := cs.StateBlockstore()
 
-	parallelPuts := 5
+	parallelPuts := 50
 	putThrottle := make(chan error, parallelPuts)
 	for i := 0; i < parallelPuts; i++ {
 		putThrottle <- nil

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -117,7 +117,7 @@ func TestChainExportImport(t *testing.T) {
 	cs := store.NewChainStore(nbs, nbs, datastore.NewMapDatastore(), filcns.Weight, nil)
 	defer cs.Close() //nolint:errcheck
 
-	root, err := cs.Import(context.TODO(), buf)
+	root, _, err := cs.Import(context.TODO(), buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestChainImportTipsetKeyCid(t *testing.T) {
 	cs := store.NewChainStore(nbs, nbs, datastore.NewMapDatastore(), filcns.Weight, nil)
 	defer cs.Close() //nolint:errcheck
 
-	root, err := cs.Import(ctx, buf)
+	root, _, err := cs.Import(ctx, buf)
 	require.NoError(t, err)
 
 	require.Truef(t, root.Equals(last), "imported chain differed from exported chain")
@@ -201,7 +201,7 @@ func TestChainExportImportFull(t *testing.T) {
 	cs := store.NewChainStore(nbs, nbs, ds, filcns.Weight, nil)
 	defer cs.Close() //nolint:errcheck
 
-	root, err := cs.Import(context.TODO(), buf)
+	root, _, err := cs.Import(context.TODO(), buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -304,7 +304,7 @@ var importBenchCmd = &cli.Command{
 				return fmt.Errorf("no CAR file provided for import")
 			}
 
-			head, err = cs.Import(cctx.Context, carFile)
+			head, _, err = cs.Import(cctx.Context, carFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/lotus-shed/genesis-verify.go
+++ b/cmd/lotus-shed/genesis-verify.go
@@ -62,7 +62,7 @@ var genesisVerifyCmd = &cli.Command{
 			return xerrors.Errorf("opening the car file: %w", err)
 		}
 
-		ts, err := cs.Import(cctx.Context, f)
+		ts, _, err := cs.Import(cctx.Context, f)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -9,9 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/filecoin-project/lotus/blockstore"
-	"github.com/filecoin-project/lotus/blockstore/cassbs"
-	bstore "github.com/ipfs/go-ipfs-blockstore"
 	"io"
 	"net/http"
 	"os"
@@ -20,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/zstd"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
@@ -35,6 +33,8 @@ import (
 	"github.com/filecoin-project/go-paramfetch"
 
 	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/blockstore/cassbs"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -534,7 +534,7 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 	}
 
 	bar.Start()
-	ts, err := cst.Import(ctx, ir)
+	ts, gen, err := cst.Import(ctx, ir)
 	bar.Finish()
 
 	if err != nil {
@@ -545,12 +545,8 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 		return xerrors.Errorf("flushing validation cache failed: %w", err)
 	}
 
-	gb, err := cst.GetTipsetByHeight(ctx, 0, ts, true)
-	if err != nil {
-		return err
-	}
-
-	err = cst.SetGenesis(ctx, gb.Blocks()[0])
+	log.Infof("setting genesis")
+	err = cst.SetGenesis(ctx, gen)
 	if err != nil {
 		return err
 	}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -486,18 +486,10 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 		if err != nil {
 			return xerrors.Errorf("open cassandra store: %w", err)
 		}
-		copt := bstore.DefaultCacheOpts()
-		copt.HasARCCacheSize = 1 << 20
 
 		rbs := bstore.NewBlockstoreNoPrefix(cds)
 
-		// only metadata cache
-		cbs, err := bstore.CachedBlockstore(context.TODO(), rbs, copt)
-		if err != nil {
-			return err
-		}
-
-		bs = blockstore.Adapt(cbs)
+		bs = blockstore.Adapt(rbs)
 	}
 
 	mds, err := lr.Datastore(ctx, "/metadata")

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/gbrlsnchs/jwt/v3 v3.0.1
 	github.com/gdamore/tcell/v2 v2.2.0
 	github.com/go-openapi/spec v0.19.11
+	github.com/gocql/gocql v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -77,6 +78,7 @@ require (
 	github.com/icza/backscanner v0.0.0-20210726202459-ac2ffc679f94
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/ipfs/bbloom v0.0.4
+	github.com/ipfs/go-block-format v0.1.1
 	github.com/ipfs/go-blockservice v0.5.0
 	github.com/ipfs/go-cid v0.4.0
 	github.com/ipfs/go-cidutil v0.1.0
@@ -226,6 +228,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20221203041831-ce31453925ec // indirect
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20230214144701-5d17c9d5243c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
@@ -234,7 +237,7 @@ require (
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/iancoleman/orderedmap v0.1.0 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
-	github.com/ipfs/go-block-format v0.1.1 // indirect
+	github.com/ipfs/go-detect-race v0.0.1 // indirect
 	github.com/ipfs/go-filestore v1.2.0 // indirect
 	github.com/ipfs/go-ipfs-cmds v0.8.2 // indirect
 	github.com/ipfs/go-ipfs-delay v0.0.1 // indirect
@@ -333,6 +336,7 @@ require (
 	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4 // indirect
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,10 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
+github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
@@ -468,6 +472,8 @@ github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2 h1:CoAavW/wd/kulfZmSIBt6p24n4j7tHgNVCjsfHVNUbo=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gocql/gocql v1.3.2 h1:ox3T+R7VFibHSIGxRkuUi1uIvAv8jBHCWxc+9aFQ/LA=
+github.com/gocql/gocql v1.3.2/go.mod h1:3gM2c4D3AnkISwBxGnMMsS8Oy4y2lhbPRsH4xnJrHG8=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -597,6 +603,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 h1:BpJ2o0OR5FV7vrkDYfXYVJQeMNWa8RhklZOpW2ITAIQ=
 github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20230214144701-5d17c9d5243c h1:iiD+p+U0M6n/FsO6XIZuOgobnNa48FxtyYFfWwLttUQ=
@@ -2262,6 +2270,7 @@ gopkg.in/cheggaaa/pb.v1 v1.0.28/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"context"
-	"github.com/filecoin-project/lotus/blockstore/cassbs"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/filecoin-project/lotus/blockstore"
 	badgerbs "github.com/filecoin-project/lotus/blockstore/badger"
+	"github.com/filecoin-project/lotus/blockstore/cassbs"
 	"github.com/filecoin-project/lotus/blockstore/splitstore"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -42,7 +42,7 @@ func UniversalBlockstore(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.Locked
 			return nil, err
 		}
 
-		return blockstore.Adapt(cbs), nil
+		return blockstore.WithCache(blockstore.Adapt(cbs)), nil
 	}
 
 	bs, err := r.Blockstore(helpers.LifecycleCtx(mctx, lc), repo.UniversalBlockstore)

--- a/node/modules/blockstore.go
+++ b/node/modules/blockstore.go
@@ -31,6 +31,8 @@ func UniversalBlockstore(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.Locked
 		}
 		copt := bstore.DefaultCacheOpts()
 		copt.HasARCCacheSize = 1 << 20
+		copt.HasBloomFilterSize = 0
+		copt.HasBloomFilterHashes = 0
 
 		rbs := bstore.NewBlockstoreNoPrefix(cds)
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Experiment to see if this can work

## Additional Info
* Set `LOTUS_PATH` to a new dir, or move .lotus somewhere else
* Set `LOTUS_CASSANDRA_UNIVERSAL_STORE=[connect string (usually just ip)]`
* Import snapshot / start daemon as usual

Didn't test at all yet

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
