### PR TITLE
perf: Return the execution tipset in GetMsgInfo

### DIFF
--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -20,23 +20,24 @@ type MsgInfo struct {
 	TipSet cid.Cid
 	// the epoch where this message was included
 	Epoch abi.ChainEpoch
+	// the execution tipset of the message (if it exists)
+	ExTsCid cid.Cid
 }
 
 // MsgIndex is the interface to the message index
 type MsgIndex interface {
-	// GetMsgInfo looks up the message in index and retrieves its metadata and execution
-	// tipset cid.
+	// GetMsgInfo looks up the message in index and retrieves its metadata.
 	// The lookup is done using the onchain message Cid; that is the signed message Cid
 	// for SECP messages and unsigned message Cid for BLS messages.
-	GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error)
+	GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error)
 	// Close closes the index
 	Close() error
 }
 
 type dummyMsgIndex struct{}
 
-func (dummyMsgIndex) GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error) {
-	return MsgInfo{}, cid.Undef, ErrNotFound
+func (dummyMsgIndex) GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error) {
+	return MsgInfo{}, ErrNotFound
 }
 
 func (dummyMsgIndex) Close() error {

--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -24,18 +24,19 @@ type MsgInfo struct {
 
 // MsgIndex is the interface to the message index
 type MsgIndex interface {
-	// GetMsgInfo retrieves the message metadata through the index.
+	// GetMsgInfo looks up the message in index and retrieves its metadata and execution
+	// tipset cid.
 	// The lookup is done using the onchain message Cid; that is the signed message Cid
 	// for SECP messages and unsigned message Cid for BLS messages.
-	GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error)
+	GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error)
 	// Close closes the index
 	Close() error
 }
 
 type dummyMsgIndex struct{}
 
-func (dummyMsgIndex) GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error) {
-	return MsgInfo{}, ErrNotFound
+func (dummyMsgIndex) GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error) {
+	return MsgInfo{}, cid.Undef, ErrNotFound
 }
 
 func (dummyMsgIndex) Close() error {

--- a/chain/index/msgindex_test.go
+++ b/chain/index/msgindex_test.go
@@ -158,7 +158,7 @@ func verifyIndex(t *testing.T, cs *mockChainStore, msgIndex MsgIndex) {
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			minfo, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			minfo, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.NoError(t, err)
 			require.Equal(t, tsCid, minfo.TipSet)
 			require.Equal(t, ts.Height(), minfo.Epoch)
@@ -175,7 +175,7 @@ func verifyMissing(t *testing.T, cs *mockChainStore, msgIndex MsgIndex, missing 
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			_, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			_, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.Equal(t, ErrNotFound, err)
 		}
 	}

--- a/chain/index/msgindex_test.go
+++ b/chain/index/msgindex_test.go
@@ -158,7 +158,7 @@ func verifyIndex(t *testing.T, cs *mockChainStore, msgIndex MsgIndex) {
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			minfo, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			minfo, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.NoError(t, err)
 			require.Equal(t, tsCid, minfo.TipSet)
 			require.Equal(t, ts.Height(), minfo.Epoch)
@@ -175,7 +175,7 @@ func verifyMissing(t *testing.T, cs *mockChainStore, msgIndex MsgIndex, missing 
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			_, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			_, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.Equal(t, ErrNotFound, err)
 		}
 	}

--- a/chain/stmgr/searchwait.go
+++ b/chain/stmgr/searchwait.go
@@ -190,7 +190,7 @@ func (sm *StateManager) SearchForMessage(ctx context.Context, head *types.TipSet
 }
 
 func (sm *StateManager) searchForIndexedMsg(ctx context.Context, mcid cid.Cid, m types.ChainMsg) (*types.TipSet, *types.MessageReceipt, cid.Cid, error) {
-	minfo, xtsCid, err := sm.msgIndex.GetMsgInfo(ctx, mcid)
+	minfo, err := sm.msgIndex.GetMsgInfo(ctx, mcid)
 	if err != nil {
 		return nil, nil, cid.Undef, xerrors.Errorf("error looking up message in index: %w", err)
 	}
@@ -203,10 +203,10 @@ func (sm *StateManager) searchForIndexedMsg(ctx context.Context, mcid cid.Cid, m
 	}
 
 	// now get the execution tipset
-	var xts *types.TipSet = nil
-	if xtsCid != cid.Undef {
+	var xts *types.TipSet
+	if minfo.ExTsCid.Defined() {
 		// lookup by cid which is faster
-		xts, err = sm.cs.GetTipSetByCid(ctx, xtsCid)
+		xts, err = sm.cs.GetTipSetByCid(ctx, minfo.ExTsCid)
 		if err != nil {
 			return nil, nil, cid.Undef, xerrors.Errorf("error calling GetTipSetByCid: %w", err)
 		}


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10589

## Proposed Changes
This PR updates the `GetMsgInfo` to include the execution tipset of the message (if it exists). This allows us to call `GetTipSetByCid` instead of `GetTipsetByHeight` which should be considerably faster and help speed up both `StateSearcMessage` and `StateWaitForMessage` calls.  

## Additional Info
- I considered having single sql query which returned both the message info and execution tipset (if it exists) but kept it separate for now for simplicity
- Should `GetMsgInfo` have this feature disable behind a context option?

## Test plan

**Test functionality**
Start lotus node using calibration net

```
make clean calibnet
lotus daemon --import-snapshot /Users/fridrik/Downloads/calibnet/448080_2023_04_06T08_13_00Z.car --halt-after-import
lotus daemon
```

Printed out some messages in sqlite/messageindx.db

```
sqlite3 ~/.lotus/sqlite/msgindex.db
select * from messages order by epoch desc limit 10;
bafy2bzaceb5skhi6jrfyuxzyl6oe52excntshmezxyqkd67anmn63wnxdmwpq|bafy2bzacedm7socnz5gydrnldhgjtbieo7k6kxnk3plqjsrrjgp5dkirmjau2|448547
bafy2bzaceaijcqr7frffx3iaelrws4jap3rfn3bwusz5kv2oqmy22jnsafuji|bafy2bzacecve53tdw3oxlogtsazgb2h46hxynlarqqy57x3s5xadcxueycmvo|448545
bafy2bzacecs2logtqeb55rdryviveymegfyfpw6szhuz7rd6k5o7o5hyzshzo|bafy2bzacecve53tdw3oxlogtsazgb2h46hxynlarqqy57x3s5xadcxueycmvo|448545
bafy2bzacebbts5lo65s5fhuu2sfkajf7wqmh2lgogmbis44vrzkir5rsylyiu|bafy2bzacecy25lehmyilozaboilqxx7cvuaoe4plyzexxbisgtbv4x5a6nq2e|448543
bafy2bzaceccx6vyywh3k7adubdsayy7eh4mezpzz6yjvimglcngtvojn67xcg|bafy2bzacecy25lehmyilozaboilqxx7cvuaoe4plyzexxbisgtbv4x5a6nq2e|448543
bafy2bzacedu2e67ambckjqcewrbdte46f2r5obbpbxwjrswhvl72u4lsl3xj4|bafy2bzacedowm3zjmvimbyddzgozpmuxseq5njncqhaqn7v3m44xlew7bn2ce|448541
bafy2bzaceaxefz7474lvmgnsr26fr3g27knqda6dnbdospx7jxekdhyqn5kms|bafy2bzaceabqamuobnivk4eqf3yre4l2j6e7xuley7c54ryfqulnkjyjsyqi6|448540
bafy2bzacebxq5lldyyas4cftpafiztrup4zi6damircy6k2odisp6xxr4qm2k|bafy2bzacebzzhq2clrsaf2g4xryf37gefn2hfhgvsatcxp2grjanzzy4jplqa|448537
bafy2bzacecauph2ixicmj7ln2et4t3gyzmhkafdnq2zfoa6qi6gaav6brpcx4|bafy2bzacebzzhq2clrsaf2g4xryf37gefn2hfhgvsatcxp2grjanzzy4jplqa|448537
```
Picked `bafy2bzaceaxefz7474lvmgnsr26fr3g27knqda6dnbdospx7jxekdhyqn5kms` since it has a entry with epoch+1 and called the RPC endpoint:

```
> curl -X POST -H "Content-Type: application/json"  --data '{ "jsonrpc": "2.0", "method":"Filecoin.StateWaitMsg", "params": [{"/": "bafy2bzaceaxefz7474lvmgnsr26fr3g27knqda6dnbdospx7jxekdhyqn5kms"}, 12], "id": 0 }' 'http://127.0.0.1:1234/rpc/v0'
{"jsonrpc":"2.0","result":{"Message":{"/":"bafy2bzaceaxefz7474lvmgnsr26fr3g27knqda6dnbdospx7jxekdhyqn5kms"},"Receipt":{"ExitCode":0,"Return":null,"GasUsed":1840943,"EventsRoot":null},"ReturnDec":null,"TipSet":[{"/":"bafy2bzaceamo76fjsnotcbymgxkof37caiaxuur5cehchwq4wlipdl2omctqc"},{"/":"bafy2bzaced6dck4rmesmesxg4eivnbytvrow6erknetblk7jyli3qamybv5aa"}],"Height":448541},"id":0}
```

Observed (using debug logs not part of this PR) that we found the execution tipset in the message index and called `GetTipSetByCid` instead of `GetTipsetByHeight` inside `searchForIndexedMsg`. 

**test we are using sqlite index on epoch column**

Also confirmed that sqlite uses the newly created index when executing the `dbqGetTipsetInfo` prepared statement:

```
> sqlite3 ~/.lotus/sqlite/msgindex.db
EXPLAIN QUERY PLAN SELECT tipset_cid FROM messages WHERE epoch = 448541 LIMIT 1;
QUERY PLAN
`--SEARCH messages USING INDEX tipset_epochs (epoch=?)
```
## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
