### PR TITLE
fix: cap the message gas limit at the block gas limit

### DIFF
--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -388,6 +388,10 @@ func (m *GasModule) GasEstimateMessageGas(ctx context.Context, msg *types.Messag
 			return nil, err
 		}
 		msg.GasLimit = int64(float64(gasLimit) * m.Mpool.GetConfig().GasLimitOverestimation)
+		// Gas overestimation can cause us to exceed the block gas limit, cap it.
+		if msg.GasLimit > build.BlockGasLimit {
+			msg.GasLimit = build.BlockGasLimit
+		}
 	}
 
 	if msg.GasPremium == types.EmptyInt || types.BigCmp(msg.GasPremium, types.NewInt(0)) == 0 {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

May fix @shrenujbansal's issue.

## Proposed Changes
<!-- A clear list of the changes being made -->

Technically, if a message is near the block gas limit, this method could over-estimate past the block gas limit. Instead, cap at the block gas limit.