### PR TITLE
fix: unseal: check if sealed/update sector exists

### DIFF
--- a/storage/sealer/manager.go
+++ b/storage/sealer/manager.go
@@ -319,6 +319,15 @@ func (m *Manager) SectorsUnsealPiece(ctx context.Context, sector storiface.Secto
 		return xerrors.Errorf("acquiring unseal sector lock: %w", err)
 	}
 
+	// Check if sealed or update sector file exists
+	s, err := m.index.StorageFindSector(ctx, sector.ID, storiface.FTSealed|storiface.FTUpdate, 0, false)
+	if err != nil {
+		return xerrors.Errorf("finding sealed or updated sector: %w", err)
+	}
+	if len(s) == 0 {
+		return xerrors.Errorf("sealed or updated sector file not found for sector %d", sector.ID)
+	}
+
 	// if the selected worker does NOT have the sealed files for the sector, instruct it to fetch it from a worker that has them and
 	// put it in the sealing scratch space.
 	sealFetch := PrepareAction{


### PR DESCRIPTION
## Related Issues
fixes: #10222 

## Proposed Changes
Check if `storiface.FTSealed` or `storiface.FTUpdate` sector exists when `SectorsUnsealPiece` is called, and fail if they are not present.

## Additional Info

```
lotus-miner storage find 111
In 94f8a49e-1208-442d-b960-9c6fca5ec2a0 (Cache)
        Sealing: true; Storage: true
        Local (/root/.lotus-miner-local-net)
        URL: http://127.0.0.1:2345/remote/cache/s-t01000-111
```

```
lotus-miner sectors unseal 111
ERROR: sealed or updated sector file not found for sector {1000 111}
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
