### PR TITLE
fix:mpool: prune excess messages before selection

### DIFF
--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -47,6 +47,16 @@ func (mp *MessagePool) SelectMessages(ctx context.Context, ts *types.TipSet, tq 
 	mp.lk.Lock()
 	defer mp.lk.Unlock()
 
+	// See if we need to prune before selection; excessive buildup can lead to slow selection,
+	// so prune if we have too many messages (ignoring the cooldown).
+	mpCfg := mp.getConfig()
+	if mp.currentSize > mpCfg.SizeLimitHigh {
+		log.Infof("too many messages; pruning before selection")
+		if err := mp.pruneMessages(ctx, ts); err != nil {
+			log.Warnf("error pruning excess messages: %s", err)
+		}
+	}
+
 	// if the ticket quality is high enough that the first block has higher probability
 	// than any other block, then we don't bother with optimal selection because the
 	// first block will always have higher effective performance


### PR DESCRIPTION
We have observed some very high buildup in the mpool, which cannot be cleared fast enough due to pruning cooldown.
This apparently results in messages selection taking too long (10-20s).

This attempts to resolve the issue by eagerly pruning (regardless of cooldown) before selecting, when we have excess messages.