### PR TITLE
Wire in profile logging for MpoolSelect

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -39,6 +39,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/journal"
+	"github.com/filecoin-project/lotus/lib/prof"
 	"github.com/filecoin-project/lotus/metrics"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
@@ -1403,6 +1404,8 @@ func (mp *MessagePool) HeadChange(ctx context.Context, revert []*types.TipSet, a
 }
 
 func (mp *MessagePool) runHeadChange(ctx context.Context, from *types.TipSet, to *types.TipSet, rmsgs map[address.Address]map[uint64]*types.SignedMessage) error {
+	defer prof.GetProfileLogger(ctx, "runHeadChange").Done()
+
 	add := func(m *types.SignedMessage) {
 		s, ok := rmsgs[m.Message.From]
 		if !ok {

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -120,7 +120,7 @@ func (tma *testMpoolAPI) PubSubPublish(string, []byte) error {
 	return nil
 }
 
-func (tma *testMpoolAPI) GetActorAfter(addr address.Address, ts *types.TipSet) (*types.Actor, error) {
+func (tma *testMpoolAPI) GetActorAfter(_ context.Context, addr address.Address, ts *types.TipSet) (*types.Actor, error) {
 	// regression check for load bug
 	if ts == nil {
 		panic("GetActorAfter called with nil tipset")

--- a/chain/messagepool/provider.go
+++ b/chain/messagepool/provider.go
@@ -28,7 +28,7 @@ type Provider interface {
 	SubscribeHeadChanges(func(rev, app []*types.TipSet) error) *types.TipSet
 	PutMessage(ctx context.Context, m types.ChainMsg) (cid.Cid, error)
 	PubSubPublish(string, []byte) error
-	GetActorAfter(address.Address, *types.TipSet) (*types.Actor, error)
+	GetActorAfter(context.Context, address.Address, *types.TipSet) (*types.Actor, error)
 	StateDeterministicAddressAtFinality(context.Context, address.Address, *types.TipSet) (address.Address, error)
 	StateNetworkVersion(context.Context, abi.ChainEpoch) network.Version
 	MessagesForBlock(context.Context, *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error)
@@ -78,13 +78,15 @@ func (mpp *mpoolProvider) PubSubPublish(k string, v []byte) error {
 	return mpp.ps.Publish(k, v) // nolint
 }
 
-func (mpp *mpoolProvider) GetActorAfter(addr address.Address, ts *types.TipSet) (*types.Actor, error) {
+func (mpp *mpoolProvider) GetActorAfter(ctx context.Context, addr address.Address, ts *types.TipSet) (*types.Actor, error) {
+	defer prof.GetProfileLogger(ctx, "GetActorAfter").Done()
+
 	if mpp.IsLite() {
-		n, err := mpp.lite.GetNonce(context.TODO(), addr, ts.Key())
+		n, err := mpp.lite.GetNonce(ctx, addr, ts.Key())
 		if err != nil {
 			return nil, xerrors.Errorf("getting nonce over lite: %w", err)
 		}
-		a, err := mpp.lite.GetActor(context.TODO(), addr, ts.Key())
+		a, err := mpp.lite.GetActor(ctx, addr, ts.Key())
 		if err != nil {
 			return nil, xerrors.Errorf("getting actor over lite: %w", err)
 		}
@@ -92,7 +94,7 @@ func (mpp *mpoolProvider) GetActorAfter(addr address.Address, ts *types.TipSet) 
 		return a, nil
 	}
 
-	stcid, _, err := mpp.sm.TipSetState(context.TODO(), ts)
+	stcid, _, err := mpp.sm.TipSetState(ctx, ts)
 	if err != nil {
 		return nil, xerrors.Errorf("computing tipset state for GetActor: %w", err)
 	}

--- a/chain/messagepool/provider.go
+++ b/chain/messagepool/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/prof"
 )
 
 var (
@@ -123,6 +124,8 @@ func (mpp *mpoolProvider) LoadTipSet(ctx context.Context, tsk types.TipSetKey) (
 }
 
 func (mpp *mpoolProvider) ChainComputeBaseFee(ctx context.Context, ts *types.TipSet) (types.BigInt, error) {
+	defer prof.GetProfileLogger(ctx, "ChainComputeBaseFee").Done()
+
 	baseFee, err := mpp.sm.ChainStore().ComputeBaseFee(ctx, ts)
 	if err != nil {
 		return types.NewInt(0), xerrors.Errorf("computing base fee at %s: %w", ts, err)

--- a/chain/messagepool/pruning.go
+++ b/chain/messagepool/pruning.go
@@ -89,7 +89,7 @@ func (mp *MessagePool) pruneMessages(ctx context.Context, ts *types.TipSet) erro
 		for _, m := range mset {
 			pruneMsgs[m.Message.Cid()] = m
 		}
-		actorChains := mp.createMessageChains(actor, mset, baseFeeLowerBound, ts)
+		actorChains := mp.createMessageChains(context.Background(), actor, mset, baseFeeLowerBound, ts)
 		chains = append(chains, actorChains...)
 	}
 

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -68,7 +68,7 @@ func (mp *MessagePool) republishPendingMessages(ctx context.Context) error {
 		// chains that might become profitable in the next 20 blocks.
 		// We still check the lowerBound condition for individual messages so that we don't send
 		// messages that will be rejected by the mpool spam protector, so this is safe to do.
-		next := mp.createMessageChains(actor, mset, baseFeeLowerBound, ts)
+		next := mp.createMessageChains(context.Background(), actor, mset, baseFeeLowerBound, ts)
 		chains = append(chains, next...)
 	}
 

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -239,7 +239,7 @@ func (mp *MessagePool) selectMessagesOptimal(ctx context.Context, curTs, ts *typ
 	startChains := time.Now()
 	var chains []*msgChain
 	for actor, mset := range pending {
-		next := mp.createMessageChains(actor, mset, baseFee, ts)
+		next := mp.createMessageChains(ctx, actor, mset, baseFee, ts)
 		chains = append(chains, next...)
 	}
 	if dt := time.Since(startChains); dt > time.Millisecond {
@@ -487,7 +487,7 @@ func (mp *MessagePool) selectMessagesGreedy(ctx context.Context, curTs, ts *type
 	startChains := time.Now()
 	var chains []*msgChain
 	for actor, mset := range pending {
-		next := mp.createMessageChains(actor, mset, baseFee, ts)
+		next := mp.createMessageChains(ctx, actor, mset, baseFee, ts)
 		chains = append(chains, next...)
 	}
 	if dt := time.Since(startChains); dt > time.Millisecond {
@@ -615,7 +615,7 @@ func (mp *MessagePool) selectPriorityMessages(ctx context.Context, pending map[a
 			// remove actor from pending set as we are already processed these messages
 			delete(pending, pk)
 			// create chains for the priority actor
-			next := mp.createMessageChains(actor, mset, baseFee, ts)
+			next := mp.createMessageChains(ctx, actor, mset, baseFee, ts)
 			chains = append(chains, next...)
 		}
 	}
@@ -766,7 +766,7 @@ func (*MessagePool) getGasPerf(gasReward *big.Int, gasLimit int64) float64 {
 	return r
 }
 
-func (mp *MessagePool) createMessageChains(actor address.Address, mset map[uint64]*types.SignedMessage, baseFee types.BigInt, ts *types.TipSet) []*msgChain {
+func (mp *MessagePool) createMessageChains(ctx context.Context, actor address.Address, mset map[uint64]*types.SignedMessage, baseFee types.BigInt, ts *types.TipSet) []*msgChain {
 	// collect all messages
 	msgs := make([]*types.SignedMessage, 0, len(mset))
 	for _, m := range mset {
@@ -785,7 +785,7 @@ func (mp *MessagePool) createMessageChains(actor address.Address, mset map[uint6
 	//   cannot exceed the block limit; drop all messages that exceed the limit
 	// - the total gasReward cannot exceed the actor's balance; drop all messages that exceed
 	//   the balance
-	a, err := mp.api.GetActorAfter(actor, ts)
+	a, err := mp.api.GetActorAfter(ctx, actor, ts)
 	if err != nil {
 		log.Errorf("failed to load actor state, not building chain for %s: %v", actor, err)
 		return nil

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/messagepool/gasguess"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/prof"
 )
 
 var bigBlockGasLimit = big.NewInt(build.BlockGasLimit)
@@ -40,6 +41,8 @@ type msgChain struct {
 }
 
 func (mp *MessagePool) SelectMessages(ctx context.Context, ts *types.TipSet, tq float64) ([]*types.SignedMessage, error) {
+	defer prof.GetProfileLogger(ctx, "SelectMessages").Done()
+
 	mp.curTsLk.Lock()
 	defer mp.curTsLk.Unlock()
 
@@ -450,7 +453,7 @@ tailLoop:
 func (mp *MessagePool) selectMessagesGreedy(ctx context.Context, curTs, ts *types.TipSet) (*selectedMessages, error) {
 	start := time.Now()
 
-	baseFee, err := mp.api.ChainComputeBaseFee(context.TODO(), ts)
+	baseFee, err := mp.api.ChainComputeBaseFee(ctx, ts)
 	if err != nil {
 		return nil, xerrors.Errorf("computing basefee: %w", err)
 	}
@@ -695,6 +698,8 @@ tailLoop:
 }
 
 func (mp *MessagePool) getPendingMessages(ctx context.Context, curTs, ts *types.TipSet) (map[address.Address]map[uint64]*types.SignedMessage, error) {
+	defer prof.GetProfileLogger(ctx, "getPendingMessages").Done()
+
 	start := time.Now()
 
 	result := make(map[address.Address]map[uint64]*types.SignedMessage)

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -116,7 +116,7 @@ func TestMessageChains(t *testing.T) {
 	}
 	baseFee := types.NewInt(0)
 
-	chains := mp.createMessageChains(a1, mset, baseFee, ts)
+	chains := mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 1 {
 		t.Fatal("expected a single chain")
 	}
@@ -137,7 +137,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 10 {
 		t.Fatal("expected 10 chains")
 	}
@@ -161,7 +161,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 2 {
 		t.Fatal("expected 1 chain")
 	}
@@ -192,7 +192,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 4 {
 		t.Fatal("expected 4 chains")
 	}
@@ -225,7 +225,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 1 {
 		t.Fatal("expected a single chain")
 	}
@@ -251,7 +251,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 1 {
 		t.Fatal("expected a single chain")
 	}
@@ -274,7 +274,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 1 {
 		t.Fatal("expected a single chain")
 	}
@@ -295,7 +295,7 @@ func TestMessageChains(t *testing.T) {
 		mset[uint64(i)] = makeTestMessage(w1, a1, a2, uint64(i), gasLimit, uint64(i+1))
 	}
 
-	chains = mp.createMessageChains(a1, mset, baseFee, ts)
+	chains = mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 1 {
 		t.Fatalf("expected a single chain: got %d", len(chains))
 	}
@@ -354,7 +354,7 @@ func TestMessageChainSkipping(t *testing.T) {
 		mset[uint64(i)] = m
 	}
 
-	chains := mp.createMessageChains(a1, mset, baseFee, ts)
+	chains := mp.createMessageChains(context.Background(), a1, mset, baseFee, ts)
 	if len(chains) != 4 {
 		t.Fatalf("expected 4 chains, got %d", len(chains))
 	}

--- a/lib/prof/context.go
+++ b/lib/prof/context.go
@@ -33,7 +33,7 @@ func WithProfileContext(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, profileLoggerKey, logger)
 }
 
-func UsingProfileLogger(ctx context.Context, what string) ProfileLogger {
+func GetProfileLogger(ctx context.Context, what string) ProfileLogger {
 	if v := ctx.Value(profileLoggerKey); v != nil {
 		return newProfileLogger(v.(*logging.ZapEventLogger), what)
 	}

--- a/lib/prof/context.go
+++ b/lib/prof/context.go
@@ -1,0 +1,53 @@
+package prof
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+type profileLoggerKeyType struct{}
+
+var profileLoggerKey = profileLoggerKeyType{}
+
+type ProfileLogger interface {
+	Done()
+}
+
+type profileLogger struct {
+	log   *logging.ZapEventLogger
+	start time.Time
+	what  string
+}
+
+var _ ProfileLogger = (*profileLogger)(nil)
+
+type emptyProfileLogger struct{}
+
+var _ ProfileLogger = emptyProfileLogger{}
+
+func WithProfileContext(ctx context.Context, name string) context.Context {
+	logger := logging.Logger(name)
+	return context.WithValue(ctx, profileLoggerKey, logger)
+}
+
+func UsingProfileLogger(ctx context.Context, what string) ProfileLogger {
+	if v := ctx.Value(profileLoggerKey); v != nil {
+		return newProfileLogger(v.(*logging.ZapEventLogger), what)
+	}
+
+	return emptyProfileLogger{}
+}
+
+func (emptyProfileLogger) Done() {}
+
+func newProfileLogger(log *logging.ZapEventLogger, what string) ProfileLogger {
+	start := time.Now()
+	return &profileLogger{start: start, log: log, what: what}
+}
+
+func (l *profileLogger) Done() {
+	l.log.Infow(fmt.Sprintf("%s done", l.what), "took", time.Since(l.start))
+}

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/messagesigner"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/prof"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
@@ -65,7 +66,7 @@ func (a *MpoolAPI) MpoolSelect(ctx context.Context, tsk types.TipSetKey, ticketQ
 		return nil, xerrors.Errorf("loading tipset %s: %w", tsk, err)
 	}
 
-	return a.Mpool.SelectMessages(ctx, ts, ticketQuality)
+	return a.Mpool.SelectMessages(prof.WithProfileContext(ctx, "MpoolSelect"), ts, ticketQuality)
 }
 
 func (a *MpoolAPI) MpoolPending(ctx context.Context, tsk types.TipSetKey) ([]*types.SignedMessage, error) {


### PR DESCRIPTION
adds a fancy context option to track and log timing information for profiling things, specifically mpool select.

We can add more spans that are profiled, but this should be a good enough start.
