### PR TITLE
test: events: fix race when recording tipsets

### DIFF
--- a/chain/events/events_test.go
+++ b/chain/events/events_test.go
@@ -174,12 +174,15 @@ func (fcs *fakeCS) makeTs(t *testing.T, parents []cid.Cid, h abi.ChainEpoch, msg
 		},
 	})
 
+	require.NoError(t, err)
+
+	fcs.mu.Lock()
+	defer fcs.mu.Unlock()
+
 	if fcs.tipsets == nil {
 		fcs.tipsets = map[types.TipSetKey]*types.TipSet{}
 	}
 	fcs.tipsets[ts.Key()] = ts
-
-	require.NoError(t, err)
 
 	return ts
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes #10664

## Proposed Changes
<!-- A clear list of the changes being made -->

Fix a race when recording tipsets in the mock chainstore.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green