### PR TITLE
feat: badger: add a has check before writing to reduce duplicates

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -732,6 +732,20 @@ func (b *Blockstore) Put(ctx context.Context, block blocks.Block) error {
 	}
 
 	put := func(db *badger.DB) error {
+		// Check if we have it before writing it.
+		switch err := db.View(func(txn *badger.Txn) error {
+			_, err := txn.Get(k)
+			return err
+		}); err {
+		case badger.ErrKeyNotFound:
+		case nil:
+			// Already exists, skip the put.
+			return nil
+		default:
+			return err
+		}
+
+		// Then write it.
 		err := db.Update(func(txn *badger.Txn) error {
 			return txn.Set(k, block.RawData())
 		})
@@ -787,12 +801,33 @@ func (b *Blockstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 		keys = append(keys, k)
 	}
 
+	err := b.db.View(func(txn *badger.Txn) error {
+		for i, k := range keys {
+			switch _, err := txn.Get(k); err {
+			case badger.ErrKeyNotFound:
+			case nil:
+				keys[i] = nil
+			default:
+				// Something is actually wrong
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
 	put := func(db *badger.DB) error {
 		batch := db.NewWriteBatch()
 		defer batch.Cancel()
 
 		for i, block := range blocks {
 			k := keys[i]
+			if k == nil {
+				// skipped because we already have it.
+				continue
+			}
 			if err := batch.Set(k, block.RawData()); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being ade -->

fixes #10457

## Proposed Changes
<!-- A clear list of the changes being made -->

Check if we have blocks before writing them (in badger, only). By default, badger just appends the block which will grow the size of the datastore until garbage collected. Worse, badger garbage collection is expensive and not fully effective.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Downsides:

1. This code is racy. I.e., if we write the same block multiple times in parallel, we'll end up with multiple versions. We could prevent this with transactions, but that has other performance implications.
2. This adds a serial read before every write, reducing performance.

However, the average block sync time (on my machine) is 10.5s before and after this patch, so it shouldn't matter.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green