### PR TITLE
feat: sync: validate (early) that blocks fall within range

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -208,7 +208,7 @@ func (syncer *Syncer) InformNewHead(from peer.ID, fts *store.FullTipSet) bool {
 		return false
 	}
 
-	if syncer.consensus.IsEpochBeyondCurrMax(fts.TipSet().Height()) {
+	if !syncer.consensus.IsEpochInConsensusRange(fts.TipSet().Height()) {
 		log.Errorf("Received block with impossibly large height %d", fts.TipSet().Height())
 		return false
 	}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

This will reject blocks in pubsub validation if they're either:

1. Too far into the future (5 blocks beyond the expected head).
2. Too far into the past (before finality).

Specifically:

1. We were previously rejecting future blocks in the sync logic, but not in pubsub itself.
2. We never used to check if a block was too _old_.

Motivation: Blocks that are too new/too old can cause us to perform quite a bit of unnecessary work.

We should carefully consider that second check as we may need to tweak it (e.g., to handle network issues?). We may want to base this check on the latest synced head, not the _expected_ epoch.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green