### PR TITLE
perf: mempool: lower priority optimizations

### DIFF
--- a/chain/messagepool/check.go
+++ b/chain/messagepool/check.go
@@ -35,6 +35,7 @@ func (mp *MessagePool) CheckPendingMessages(ctx context.Context, from address.Ad
 	mp.lk.RLock()
 	mset, ok := mp.pending[from]
 	if ok {
+		msgs = make([]*types.Message, 0, len(mset.msgs))
 		for _, sm := range mset.msgs {
 			msgs = append(msgs, &sm.Message)
 		}

--- a/chain/messagepool/check.go
+++ b/chain/messagepool/check.go
@@ -33,7 +33,11 @@ func (mp *MessagePool) CheckMessages(ctx context.Context, protos []*api.MessageP
 func (mp *MessagePool) CheckPendingMessages(ctx context.Context, from address.Address) ([][]api.MessageCheckStatus, error) {
 	var msgs []*types.Message
 	mp.lk.RLock()
-	mset, ok := mp.pending[from]
+	mset, ok, err := mp.getPendingMset(ctx, from)
+	if err != nil {
+		log.Warnf("errored while getting pending mset: %w", err)
+		return nil, err
+	}
 	if ok {
 		msgs = make([]*types.Message, 0, len(mset.msgs))
 		for _, sm := range mset.msgs {
@@ -65,7 +69,11 @@ func (mp *MessagePool) CheckReplaceMessages(ctx context.Context, replace []*type
 		if !ok {
 			mmap = make(map[uint64]*types.Message)
 			msgMap[m.From] = mmap
-			mset, ok := mp.pending[m.From]
+			mset, ok, err := mp.getPendingMset(ctx, m.From)
+			if err != nil {
+				log.Warnf("errored while getting pending mset: %w", err)
+				return nil, err
+			}
 			if ok {
 				count += len(mset.msgs)
 				for _, sm := range mset.msgs {
@@ -145,7 +153,11 @@ func (mp *MessagePool) checkMessages(ctx context.Context, msgs []*types.Message,
 		st, ok := state[m.From]
 		if !ok {
 			mp.lk.RLock()
-			mset, ok := mp.pending[m.From]
+			mset, ok, err := mp.getPendingMset(ctx, m.From)
+			if err != nil {
+				log.Warnf("errored while getting pending mset: %w", err)
+				return nil, err
+			}
 			if ok && !interned {
 				st = &actorState{nextNonce: mset.nextNonce, requiredFunds: mset.requiredFunds}
 				for _, m := range mset.msgs {

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -474,6 +474,15 @@ func (mp *MessagePool) TryForEachPendingMessage(f func(cid.Cid) error) error {
 }
 
 func (mp *MessagePool) resolveToKey(ctx context.Context, addr address.Address) (address.Address, error) {
+	//if addr is not an ID addr, then it is already resolved to a key
+	if addr.Protocol() != address.ID {
+		return addr, nil
+	}
+	return mp.resolveToKeyFromID(ctx, addr)
+}
+
+func (mp *MessagePool) resolveToKeyFromID(ctx context.Context, addr address.Address) (address.Address, error) {
+
 	// check the cache
 	a, ok := mp.keyCache.Get(addr)
 	if ok {
@@ -488,8 +497,6 @@ func (mp *MessagePool) resolveToKey(ctx context.Context, addr address.Address) (
 
 	// place both entries in the cache (may both be key addresses, which is fine)
 	mp.keyCache.Add(addr, ka)
-	mp.keyCache.Add(ka, ka)
-
 	return ka, nil
 }
 

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -32,14 +32,10 @@ func (mp *MessagePool) republishPendingMessages(ctx context.Context) error {
 
 	pending := make(map[address.Address]map[uint64]*types.SignedMessage)
 
-	//TODO do we need curTsLk here?
-	mp.curTsLk.Lock()
 	mp.lk.Lock()
 	mp.republished = nil // clear this to avoid races triggering an early republish
 	mp.lk.Unlock()
-	mp.curTsLk.Unlock()
 
-	//TODO is no curTsLk here acceptable?
 	mp.lk.RLock()
 	mp.forEachLocal(ctx, func(ctx context.Context, actor address.Address) {
 		mset, ok, err := mp.getPendingMset(ctx, actor)
@@ -182,8 +178,8 @@ loop:
 		republished[m.Cid()] = struct{}{}
 	}
 
-	mp.lk.Lock()
 	// update the republished set so that we can trigger early republish from head changes
+	mp.lk.Lock()
 	mp.republished = republished
 	mp.lk.Unlock()
 

--- a/chain/messagepool/repub.go
+++ b/chain/messagepool/repub.go
@@ -22,9 +22,9 @@ var RepublishBatchDelay = 100 * time.Millisecond
 func (mp *MessagePool) republishPendingMessages(ctx context.Context) error {
 	mp.curTsLk.RLock()
 	ts := mp.curTs
+	mp.curTsLk.RUnlock()
 
 	baseFee, err := mp.api.ChainComputeBaseFee(context.TODO(), ts)
-	mp.curTsLk.RUnlock()
 	if err != nil {
 		return xerrors.Errorf("computing basefee: %w", err)
 	}

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -40,12 +40,11 @@ type msgChain struct {
 }
 
 func (mp *MessagePool) SelectMessages(ctx context.Context, ts *types.TipSet, tq float64) ([]*types.SignedMessage, error) {
-	mp.curTsLk.Lock()
-	defer mp.curTsLk.Unlock()
+	mp.curTsLk.RLock()
+	defer mp.curTsLk.RUnlock()
 
-	//TODO confirm if we can switch to RLock here for performance
-	mp.lk.Lock()
-	defer mp.lk.Unlock()
+	mp.lk.RLock()
+	defer mp.lk.RUnlock()
 
 	// if the ticket quality is high enough that the first block has higher probability
 	// than any other block, then we don't bother with optimal selection because the


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10597

## Proposed Changes

 1. https://github.com/filecoin-project/lotus/pull/10561/files#r1148322934 in chain/messagepool/check.go pre-allocate the size of the array msgs array using msgs = make([]*types.Message, 0, len(mset.msgs))
 2. https://github.com/filecoin-project/lotus/pull/10561/files#r1152024072 remove the requirement of mp.keyCache.Add(ka, ka) by checking that the address is a robust address
 3. https://github.com/filecoin-project/lotus/pull/10561/files#r1150875872 chain/messagepool/repub.go - optimize the Lock timing and confirm if all tests pass with a read lock -- also ensure that mp.curTsLk.RLock() is not held during mp.api.ChainComputeBaseFee
 4. https://github.com/filecoin-project/lotus/pull/10561/files#r1150137317 chain/messagepool/selection.go change to read lock
 5. in [chain/messagepool/check.go](https://github.com/filecoin-project/lotus/pull/10561/files/41ea5a6f638ca5108a51f70a4cef85d9b98802b7#diff-ed714997f1033a2434cc1cdfd1f231667eb107c47a885b4b8761619445ea218c) pending has a giant warning saying do NOT use it directly -- we should probably be calling getPendingMset here for address resolution?


## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
