### PR TITLE
fix: events: don't set GC confidence to 1

### DIFF
--- a/chain/events/events.go
+++ b/chain/events/events.go
@@ -47,7 +47,7 @@ type Events struct {
 	*hcEvents
 }
 
-func NewEventsWithConfidence(ctx context.Context, api EventAPI, gcConfidence abi.ChainEpoch) (*Events, error) {
+func newEventsWithGCConfidence(ctx context.Context, api EventAPI, gcConfidence abi.ChainEpoch) (*Events, error) {
 	cache := newCache(api, gcConfidence)
 
 	ob := newObserver(cache, gcConfidence)
@@ -63,5 +63,5 @@ func NewEventsWithConfidence(ctx context.Context, api EventAPI, gcConfidence abi
 
 func NewEvents(ctx context.Context, api EventAPI) (*Events, error) {
 	gcConfidence := 2 * build.ForkLengthThreshold
-	return NewEventsWithConfidence(ctx, api, gcConfidence)
+	return newEventsWithGCConfidence(ctx, api, gcConfidence)
 }

--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -130,7 +130,7 @@ func EthEventAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo
 
 		lc.Append(fx.Hook{
 			OnStart: func(context.Context) error {
-				ev, err := events.NewEventsWithConfidence(ctx, &evapi, ChainHeadConfidence)
+				ev, err := events.NewEvents(ctx, &evapi)
 				if err != nil {
 					return err
 				}

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -54,12 +54,10 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 			}
 		}
 
-		const ChainHeadConfidence = 1
-
 		ctx := helpers.LifecycleCtx(mctx, lc)
 		lc.Append(fx.Hook{
 			OnStart: func(context.Context) error {
-				ev, err := events.NewEventsWithConfidence(ctx, &evapi, ChainHeadConfidence)
+				ev, err := events.NewEvents(ctx, &evapi)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

- Make `NewEventsWithConfidence` private, and rename to `newEventsWithGCConfidence`.
- Use the default GC confidence everywhere.

The function/parameter were poorly named and should never have been exposed. "GC" confidence should always be the same, this parameter doesn't let us actually set the _confidence_, just the point before which we no longer support reverts.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

fixes #10706

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ x PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green