### PR TITLE
fix: tvx: make extract-multiple support the FVM

### DIFF
--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -297,12 +297,12 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, params ExecuteMessageP
 	}
 
 	var root cid.Cid
-	if d.vmFlush {
+	if lvm, ok := vmi.(*vm.LegacyVM); ok && !d.vmFlush {
+		root, err = lvm.StateTree().(*state.StateTree).Flush(d.ctx)
+	} else {
 		// flush the VM, committing the state tree changes and forcing a
 		// recursive copy from the temporary blockstore to the real blockstore.
 		root, err = vmi.Flush(d.ctx)
-	} else {
-		root, err = vmi.(*vm.LegacyVM).StateTree().(*state.StateTree).Flush(d.ctx)
 	}
 
 	return ret, root, err


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Fix flushing to handle the case where the VM is an FVM.
2. Fix extract-multiple's code CID conversion.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] CI is green