### PR TITLE
update: builtin to builtin11 in wdpost worker

### DIFF
--- a/storage/sealer/manager_post.go
+++ b/storage/sealer/manager_post.go
@@ -11,7 +11,7 @@ import (
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/v6/actors/builtin"
+	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/specs-actors/v7/actors/runtime/proof"
 
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"


### PR DESCRIPTION
## Related Issues
none

## Proposed Changes
storage/sealer/manager_post.go:
"github.com/filecoin-project/specs-actors/v6/actors/builtin"        -> 
"github.com/filecoin-project/go-state-types/builtin"     

## Additional Info
This is the log about wd post worker on calibnet

Apr 21 03:49:30 node lotus-miner[54989]: 2023-04-21T03:49:30.121+0800        INFO        wdpost        wdpost/wdpost_run.go:411        running window post        {"cycle": "2023-04-21T03:49:29.754+0800", "chain-random": "u9W8Rko1E2nQs8Qzc59u44V6h3AX1xteF0B7zK0VWVg=", "deadline": {"CurrentEpoch":489793,"PeriodStart":489812,"Index":0,"Open":489812,"Close":489872,"Challenge":489792,"FaultCutoff":489742,"WPoStPeriodDeadlines":48,"WPoStProvingPeriod":2880,"WPoStChallengeWindow":60,"WPoStChallengeLookback":20,"FaultDeclarationCutoff":70}, "height": "489793", "skipped": 0}
Apr 21 03:49:30 node lotus-miner[54989]: 2023-04-21T03:49:30.121+0800        INFO        wdpost        wdpost/wdpost_run.go:431        computing window post        {"cycle": "2023-04-21T03:49:29.754+0800", "batch": 0, "elapsed": 0.000042143, "skip": 0, "err": "get sectors count of partition failed:unsupported proof type: 13:\n    github.com/filecoin-project/specs-actors/v6/actors/builtin.PoStProofWindowPoStPartitionSectors\n        /home/sirius/go/pkg/mod/github.com/filecoin-project/specs-actors/v6@v6.0.2/actors/builtin/sector.go:127", "errVerbose": "get sectors count of partition failed:unsupported proof type: 13:\n        github.com/filecoin-project/specs-actors/v6/actors/builtin.PoStProofWindowPoStPartitionSectors\n            /home/sirius/go/pkg/mod/github.com/filecoin-project/specs-actors/v6@v6.0.2/actors/builtin/sector.go:127:\n    github.com/filecoin-project/lotus/storage/sealer.(*Manager).generateWindowPoSt\n        /home/sirius/go/src/github.com/siriusyim/lotus/storage/sealer/manager_post.go:118"}
Apr 21 03:49:30 node lotus-miner[54989]: 2023-04-21T03:49:30.121+0800        ERROR        wdpost        wdpost/wdpost_run.go:433        error generating window post: get sectors count of partition failed:unsupported proof type: 13:
Apr 21 03:49:30 node lotus-miner[54989]: 2023-04-21T03:49:30.121+0800        ERROR        wdpost        wdpost/wdpost_run.go:98        runPoStCycle failed: running window post failed:
Apr 21 03:49:30 node lotus-miner[54989]:   - get sectors count of partition failed:unsupported proof type: 13:
Apr 21 03:49:30 node lotus-miner[54989]: 2023-04-21T03:49:30.122+0800        WARN        wdpost        wdpost/wdpost_changehandler.go:254        Aborted window post Proving (Deadline: &{CurrentEpoch:489793 PeriodStart:489812 Index:0 Open:489812 Close:489872 Challenge:489792 FaultCutoff:489742 WPoStPeriodDeadlines:48 WPoStProvingPeriod:2880 WPoStChallengeWindow:60 WPoStChallengeLookback:20 FaultDeclarationCutoff:70})

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
