### PR TITLE
feat: Update FFI, test disputing nv20 window posts fails 

### DIFF
--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -8,19 +8,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-state-types/builtin"
-	"github.com/filecoin-project/lotus/chain/actors"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
 	miner11 "github.com/filecoin-project/go-state-types/builtin/v11/miner"
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/node/impl"

--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/lotus/chain/actors"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
@@ -484,4 +487,40 @@ waitForProof:
 	// Simulate call on inclTs's parents, so that the partition isn't already proven
 	_, err = client.StateCall(ctx, slmsg, inclTs.Parents())
 	require.ErrorContains(t, err, "expected proof of type StackedDRGWindow2KiBV1P1, got StackedDRGWindow2KiBV1")
+
+	for {
+		//stm: @CHAIN_STATE_MINER_CALCULATE_DEADLINE_001
+		di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
+		require.NoError(t, err)
+		// wait until the deadline finishes.
+		if di.Index == ((params.Deadline + 1) % di.WPoStPeriodDeadlines) {
+			break
+		}
+
+		build.Clock.Sleep(blocktime)
+	}
+
+	// Try to object to the proof. This should fail.
+
+	disputeParams := &miner11.DisputeWindowedPoStParams{
+		Deadline:  params.Deadline,
+		PoStIndex: 0,
+	}
+
+	enc, aerr := actors.SerializeParams(disputeParams)
+	require.NoError(t, aerr)
+
+	disputeMsg := &types.Message{
+		To:     maddr,
+		Method: builtin.MethodsMiner.DisputeWindowedPoSt,
+		Params: enc,
+		Value:  types.NewInt(0),
+		From:   client.DefaultKey.Address,
+	}
+
+	_, err = client.MpoolPushMessage(ctx, disputeMsg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to dispute valid post")
+	require.Contains(t, err.Error(), "(RetCode=16)")
+
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#10735, but on 1.22.1

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
