### PR TITLE
feat: nv19: Make using old proofs a configurable option

### DIFF
--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -3,6 +3,7 @@ package wdpost
 import (
 	"bytes"
 	"context"
+	"os"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -424,6 +425,14 @@ func (s *WindowPoStScheduler) runPoStCycle(ctx context.Context, manual bool, di 
 			ppt, err := xsinfos[0].SealProof.RegisteredWindowPoStProofByNetworkVersion(nv)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to get window post type: %w", err)
+			}
+
+			if nv == network.Version19 && os.Getenv("LOTUS_NV19_OLD_PROOFS") == "1" {
+				ppt, err = xsinfos[0].SealProof.RegisteredWindowPoStProof()
+				if err != nil {
+					return nil, xerrors.Errorf("failed to get window post type: %w", err)
+				}
+				log.Warnw("using old V1 PoSt in nv19, this will be disallowed in nv20!")
 			}
 
 			postOut, ps, err := s.prover.GenerateWindowPoSt(ctx, abi.ActorID(mid), ppt, xsinfos, append(abi.PoStRandomness{}, rand...))


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

We extended the period between nv19 and nv20 to 3 weeks so as to allow for dependence on old (v1) proofs in the unlikely event that there are issues with new proofs. We also want to make it easy for users to opt to use old proofs during the rollover period, just in case.

## Proposed Changes
<!-- A clear list of the changes being made -->

This PR makes the proof type selection configurable behind the `LOTUS_NV19_OLD_PROOFS` envvar. If set to 1, the lotus-miner will generate "old" proofs during nv19. The default is still "new" proofs for nv19, and only new proofs will be generated for nv20.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
