### PR TITLE
feat: sync: harden chain sync

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1188,7 +1188,7 @@ func (syncer *Syncer) collectChain(ctx context.Context, ts *types.TipSet, hts *t
 	ss.SetStage(api.StagePersistHeaders)
 
 	// Write tipsets from oldest to newest.
-	for i := len(headers) - 1; i >= 0; i++ {
+	for i := len(headers) - 1; i >= 0; i-- {
 		ts := headers[i]
 		if err := syncer.store.PersistTipset(ctx, ts); err != nil {
 			err = xerrors.Errorf("failed to persist synced tipset to the chainstore: %w", err)

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1187,7 +1187,9 @@ func (syncer *Syncer) collectChain(ctx context.Context, ts *types.TipSet, hts *t
 
 	ss.SetStage(api.StagePersistHeaders)
 
-	for _, ts := range headers {
+	// Write tipsets from oldest to newest.
+	for i := len(headers) - 1; i >= 0; i++ {
+		ts := headers[i]
 		if err := syncer.store.PersistTipset(ctx, ts); err != nil {
 			err = xerrors.Errorf("failed to persist synced tipset to the chainstore: %w", err)
 			ss.Error(err)


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

This makes two changes:

1. Write headers in chain order, not reverse order. This shouldn't matter, but it may help if badger crashes.
2. Force `collectChain` to collect the correct chain. This shouldn't matter, but we might as well (as long as it's safe).

WRT 1, I'm worried about the following:

1. Attempt to sync a chain from epochs 3-7.
2. Write tipsets 7, 6, 5.
3. Badger realizes that the current vlog is "full", so it creates a new one.
4. Write tipsets 4, 3.

My concern is that, while badger will write _synchronously_, it doesn't call `fsync `on the file itself, and the directory containing the file. That means, if the machine crashes, the new vlog might just disappear.

Of course, the _right_ solution would be to fix badger to sync the file/directory metadata, but that's not likely to happen, ever.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green