### PR TITLE
mpool: fix: data race when adding messages

### DIFF
--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -765,7 +765,6 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 	}()
 
 	mp.curTsLk.Lock()
-	tmpCurTs := mp.curTs
 	defer mp.curTsLk.Unlock()
 	_, err = mp.addTs(ctx, m, mp.curTs, false, false)
 	return err

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -764,28 +764,9 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 		<-mp.addSema
 	}()
 
-	mp.curTsLk.RLock()
-	tmpCurTs := mp.curTs
-	mp.curTsLk.RUnlock()
-
-	//ensures computations are cached without holding lock
-	_, _ = mp.api.GetActorAfter(m.Message.From, tmpCurTs)
-
 	mp.curTsLk.Lock()
-	if tmpCurTs == mp.curTs {
-		//with the lock enabled, mp.curTs is the same Ts as we just had, so we know that our computations are cached
-	} else {
-		//curTs has been updated so we want to cache the new one:
-		tmpCurTs = mp.curTs
-		//we want to release the lock, cache the computations then grab it again
-		mp.curTsLk.Unlock()
-		_, _ = mp.api.GetActorAfter(m.Message.From, tmpCurTs)
-		mp.curTsLk.Lock()
-		//now that we have the lock, we continue, we could do this as a loop forever, but that's bad to loop forever, and this was added as an optimization and it seems once is enough because the computation < block time
-	}
-
+	tmpCurTs := mp.curTs
 	defer mp.curTsLk.Unlock()
-
 	_, err = mp.addTs(ctx, m, mp.curTs, false, false)
 	return err
 }
@@ -872,7 +853,7 @@ func (mp *MessagePool) addTs(ctx context.Context, m *types.SignedMessage, curTs 
 		return false, xerrors.Errorf("minimum expected nonce is %d: %w", snonce, ErrNonceTooLow)
 	}
 
-	senderAct, err := mp.api.GetActorAfter(m.Message.From, curTs)
+	senderAct, err := mp.api.GetActorBefore(m.Message.From, curTs)
 	if err != nil {
 		return false, xerrors.Errorf("failed to get sender actor: %w", err)
 	}

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -770,7 +770,6 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 
 	//ensures computations are cached without holding lock
 	_, _ = mp.api.GetActorAfter(m.Message.From, tmpCurTs)
-	_, _ = mp.getStateNonce(ctx, m.Message.From, tmpCurTs)
 
 	mp.curTsLk.Lock()
 	if tmpCurTs == mp.curTs {
@@ -781,7 +780,6 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 		//we want to release the lock, cache the computations then grab it again
 		mp.curTsLk.Unlock()
 		_, _ = mp.api.GetActorAfter(m.Message.From, tmpCurTs)
-		_, _ = mp.getStateNonce(ctx, m.Message.From, tmpCurTs)
 		mp.curTsLk.Lock()
 		//now that we have the lock, we continue, we could do this as a loop forever, but that's bad to loop forever, and this was added as an optimization and it seems once is enough because the computation < block time
 	}


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10755

## Proposed Changes
Remove cache hacks and change actor look up from GetActorAfter to GetActorBefore

## Additional Info
This drop support for sending messages from an account immediately after creating it

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
