### PR TITLE
fix: sync: reduce log from error to info

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -209,7 +209,7 @@ func (syncer *Syncer) InformNewHead(from peer.ID, fts *store.FullTipSet) bool {
 	}
 
 	if !syncer.consensus.IsEpochInConsensusRange(fts.TipSet().Height()) {
-		log.Errorf("Received block with impossibly large height %d", fts.TipSet().Height())
+		log.Infof("received block outside of consensus range at height %d", fts.TipSet().Height())
 		return false
 	}
 


### PR DESCRIPTION
And fix the message to account for the fact that we now reject _old_ blocks along with new ones.

We frequently receive "out of date" blocks in hello messages from syncing and/or out of sync nodes. This isn't an error.