### PR TITLE
fix: deflake: use 2 miners for flaky tests

### DIFF
--- a/itests/sector_finalize_early_test.go
+++ b/itests/sector_finalize_early_test.go
@@ -30,7 +30,8 @@ func TestDealsWithFinalizeEarly(t *testing.T) {
 
 	var blockTime = 50 * time.Millisecond
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) { sc.FinalizeEarly = true })) // no mock proofs.
+	// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
+	client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) { sc.FinalizeEarly = true })) // no mock proofs.
 	ens.InterconnectAll().BeginMining(blockTime)
 	dh := kit.NewDealHarness(t, client, miner, miner)
 

--- a/itests/sector_import_full_test.go
+++ b/itests/sector_import_full_test.go
@@ -65,7 +65,8 @@ func TestSectorImport(t *testing.T) {
 			////////
 			// Start a miner node
 
-			client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC())
+			// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
+			client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC())
 			ens.InterconnectAll().BeginMining(blockTime)
 
 			ctx := context.Background()


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

These tests fail quite often, and it's always because the PoSt process doesn't kick off, causing the network to halt eventually (because no blocks can be produced).

## Proposed Changes
<!-- A clear list of the changes being made -->

Run the network with two miners, in the hope that the second miner (that isn't being actively tested) will keep the blockchain going. If that doesn't work, we can try using the `BeginMiningMustPoSt` mode.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
