### PR TITLE
fix: sealing: Make lotus-worker report GPU usage to miner during ReplicaUpdate task

### DIFF
--- a/storage/sealer/storiface/resources.go
+++ b/storage/sealer/storiface/resources.go
@@ -342,9 +342,9 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredSealProof]Resources
 			MaxMemory: 8 << 30,
 			MinMemory: 8 << 30,
 
-			MaxParallelism: 1,
+			MaxParallelism:    1,
 			MaxParallelismGPU: 6,
-			GPUUtilization: 1.0,
+			GPUUtilization:    1.0,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -352,9 +352,9 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredSealProof]Resources
 			MaxMemory: 4 << 30,
 			MinMemory: 4 << 30,
 
-			MaxParallelism: 1,
+			MaxParallelism:    1,
 			MaxParallelismGPU: 6,
-			GPUUtilization: 1.0,
+			GPUUtilization:    1.0,
 
 			BaseMinMemory: 1 << 30,
 		},


### PR DESCRIPTION
## Related Issues
Fixes #10767 

## Proposed Changes
This PR fixes a bug in which a lotus-worker never reports GPU usage status to the lotus-miner when tasked with a ReplicaUpdate task. 

`lotus-miner sealing workers` prior to this change:
```
Worker 84411102-45c2-4581-b988-a8b8e268d0c9, host worker6
TASK: RU(1/1)
CPU:  [||||||                                                          ] 6/64 core(s) in use
RAM:  [|||||||||||||||||||||||||||||                                   ] 44% 224.5 GiB/503.8 GiB
VMEM: [|||||||||||||||||||||||||||||                                   ] 44% 224.5 GiB/503.8 GiB
GPU:  [                                                                ] 0% 0.00/1 gpu(s) in use
GPU: NVIDIA GeForce RTX 3090, not used
```

After this change:
```
Worker 4ffe89c9-a31d-434a-8bf0-208aab47f0d4, host worker6
TASK: RU(1/1)
CPU:  [||||||                                                          ] 6/64 core(s) in use
RAM:  [||                                                              ] 1% 13.83 GiB/503.8 GiB
VMEM: [||                                                              ] 1% 9.83 GiB/503.8 GiB
GPU:  [||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||] 100% 1.00/1 gpu(s) in use
GPU: NVIDIA GeForce RTX 3090, used
```

This fixes a scheduling bug where lotus-miner might schedule too many GPU-based tasks to a single worker, causing CUDA out-of-memory conditions.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
