### PR TITLE
Validate that FromBlock/ToBlock epoch is indeed a hex value

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -548,12 +548,12 @@ func (h EthSubscriptionID) String() string {
 }
 
 type EthFilterSpec struct {
-	// Interpreted as an epoch or one of "latest" for last mined block, "earliest" for first,
+	// Interpreted as an epoch (in hex) or one of "latest" for last mined block, "earliest" for first,
 	// "pending" for not yet committed messages.
 	// Optional, default: "latest".
 	FromBlock *string `json:"fromBlock,omitempty"`
 
-	// Interpreted as an epoch or one of "latest" for last mined block, "earliest" for first,
+	// Interpreted as an epoch (in hex) or one of "latest" for last mined block, "earliest" for first,
 	// "pending" for not yet committed messages.
 	// Optional, default: "latest".
 	ToBlock *string `json:"toBlock,omitempty"`

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -425,6 +425,11 @@ func TestEthNewFilterDefaultSpec(t *testing.T) {
 	elogs, err := parseEthLogsFromFilterResult(res)
 	require.NoError(err)
 	AssertEthLogs(t, elogs, expected, received)
+
+	// giving a number to fromBlock/toBlock needs to be in hex format, so make sure passing in decimal fails
+	blockNrInDecimal := "2812200"
+	_, err = client.EthNewFilter(ctx, &ethtypes.EthFilterSpec{FromBlock: &blockNrInDecimal, ToBlock: &blockNrInDecimal})
+	require.Error(err, "expected error when fromBlock/toBlock is not in hex format")
 }
 
 func TestEthGetLogsBasic(t *testing.T) {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1180,6 +1181,9 @@ func (e *EthEvent) installEthFilterSpec(ctx context.Context, filterSpec *ethtype
 		} else if *filterSpec.FromBlock == "pending" {
 			return nil, api.ErrNotSupported
 		} else {
+			if !strings.HasPrefix(*filterSpec.FromBlock, "0x") {
+				return nil, xerrors.Errorf("FromBlock is not a hex")
+			}
 			epoch, err := ethtypes.EthUint64FromHex(*filterSpec.FromBlock)
 			if err != nil {
 				return nil, xerrors.Errorf("invalid epoch")
@@ -1195,6 +1199,9 @@ func (e *EthEvent) installEthFilterSpec(ctx context.Context, filterSpec *ethtype
 		} else if *filterSpec.ToBlock == "pending" {
 			return nil, api.ErrNotSupported
 		} else {
+			if !strings.HasPrefix(*filterSpec.ToBlock, "0x") {
+				return nil, xerrors.Errorf("ToBlock is not a hex")
+			}
 			epoch, err := ethtypes.EthUint64FromHex(*filterSpec.ToBlock)
 			if err != nil {
 				return nil, xerrors.Errorf("invalid epoch")


### PR DESCRIPTION
**Context**
When calling ETH rpc method `eth_getLogs` and giving it a `fromBlock`/`toBlock` as epoch then return an error if its not in a hexadecimal format (instead of silently passing through and returning nothing or even worse potentially giving incorrect results)

**Test plan**

Verify that giving epoch ("2812200") as decimal returns a nice error:
```
curl -s http://localhost:1234/rpc/v1  -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"fromBlock": "2812200"}],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"error":{"code":1,"message":"FromBlock is not a hex"}}
```

And that giving the same epoch in hex ("0x2AE928") works:
```
curl -s http://localhost:1234/rpc/v1  -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"fromBlock": "0x2AE928"}],"id":1,"jsonrpc":"2.0"}'|jq|head -n 15
{
  "jsonrpc": "2.0",
  "result": [
    {
      "address": "0xa35bf7ef23b09fb099e6e75a078727dff14b7576",
      "data": "0x0000000000000000000000000000000000000000000000000429d069189e0000",
      "topics": [
        "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c",
        "0x0000000000000000000000006c29c4366a2f9ac5f083ef3394d9849b02a690c0"
      ],
      "removed": false,
      "logIndex": "0x0",
      "transactionIndex": "0x3f",
      "transactionHash": "0xce8a0e185d8e64ea5a9aeae51fde7f46aaa57239d1e3ce351759ccd9fb604c69",
      "blockHash": "0x3aa8d8603c95936cc964c64951bc75af118c5f79a8e81c8130281ec62ef98130",
```

