### PR TITLE
feat: eth: Add support for blockHash param in eth_getLogs

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1209,7 +1209,7 @@ func (e *EthEvent) installEthFilterSpec(ctx context.Context, filterSpec *ethtype
 			return nil, xerrors.Errorf("must not specify block hash and from/to block")
 		}
 
-		// TODO: derive a tipset hash from eth hash - might need to push this down into the EventFilterManager
+		tipsetCid = filterSpec.BlockHash.ToCid()
 	} else {
 		if filterSpec.FromBlock == nil || *filterSpec.FromBlock == "latest" {
 			ts := e.Chain.GetHeaviestTipSet()


### PR DESCRIPTION
Fixes: #10781 

**Context**
When working on https://github.com/filecoin-project/lotus/pull/10780 I noticed we currently did not support the `blockHash` param for the `eth_getLogs` rpc method. If it was specified by user he got confusing results (fromBlock/toBlock were both 0). This PR therefore adds this feature as described in the [eth docs](https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_getlogs)

**Test plan**

Lets consider the tipset 2848101 (hex: 0x2B7565) and get the logs for only that tipset (using fromBlock/toBlock). Since the log output it long lets just count the lines and compute the sha1sum:
```
curl -s http://localhost:1234/rpc/v1 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"fromBlock": "0x2B7565", "toBlock": "0x2B7565"}],"id":1,"jsonrpc":"2.0"}'|jq|wc -l
231

curl -s http://localhost:1234/rpc/v1 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"fromBlock": "0x2B7565", "toBlock": "0x2B7565"}],"id":1,"jsonrpc":"2.0"}'|jq|sha1sum
50cbd75fd8e9059441d91173c53372237f5f3600  -
```

Now lets get the same tipset by specifying its blockHash and observe that we get the same results (since using blockHash is the same as specifying fromBlock=toBlock of the tipset):

```
curl -s http://localhost:1234/rpc/v1 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"blockHash": "0xe8179500429f4c485015a9253e9ee7270a1d3f773fc33ea21d2f007e14623980"}],"id":1,"jsonrpc":"2.0"}'|jq|wc -l
231

curl -s http://localhost:1234/rpc/v1 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getLogs","params":[{"blockHash": "0xe8179500429f4c485015a9253e9ee7270a1d3f773fc33ea21d2f007e14623980"}],"id":1,"jsonrpc":"2.0"}'|jq|sha1sum 
50cbd75fd8e9059441d91173c53372237f5f3600  -
```