### PR TITLE
chore: deps: update to FVM 3.3.1

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -86,6 +86,7 @@ func main() {
 		replayOfflineCmd,
 		msgindexCmd,
 		FevmAnalyticsCmd,
+		mismatchesCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/mismatches.go
+++ b/cmd/lotus-shed/mismatches.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 
-	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
+
+	lcli "github.com/filecoin-project/lotus/cli"
 )
 
 var mismatchesCmd = &cli.Command{

--- a/cmd/lotus-shed/mismatches.go
+++ b/cmd/lotus-shed/mismatches.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+)
+
+var mismatchesCmd = &cli.Command{
+	Name:        "mismatches",
+	Description: "Walk up the chain, recomputing state, and reporting any mismatches",
+	Action: func(cctx *cli.Context) error {
+		srv, err := lcli.GetFullNodeServices(cctx)
+		if err != nil {
+			return err
+		}
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
+		ctx := lcli.ReqContext(cctx)
+
+		checkTs, err := api.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+
+		for checkTs.Height() != 0 {
+			if checkTs.Height()%10000 == 0 {
+				fmt.Println("Reached height ", checkTs.Height())
+			}
+
+			execTsk := checkTs.Parents()
+			execTs, err := api.ChainGetTipSet(ctx, execTsk)
+			if err != nil {
+				return err
+			}
+
+			st, err := api.StateCompute(ctx, execTs.Height(), nil, execTsk)
+			if err != nil {
+				return err
+			}
+
+			if st.Root != checkTs.ParentState() {
+				fmt.Println("consensus mismatch found at height ", execTs.Height())
+			}
+
+			checkTs = execTs
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This allows nodes to sync the entirety of calibnet again.

## Proposed Changes
<!-- A clear list of the changes being made -->
 - Update to FVM 3.3.1
 - Add a shed command that reports on recent consensus breaks over the API

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
