### PR TITLE
feat: sealing: flag to run data_cid untied from addpiece

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -275,6 +275,11 @@ var runCmd = &cli.Command{
 			Name:  "http-server-timeout",
 			Value: "30s",
 		},
+		&cli.BoolFlag{
+			Name:  "data-cid",
+			Usage: "Run the data-cid task. --add-piece defaults this to true unless overridden",
+			Value: true,
+		},
 	},
 	Before: func(cctx *cli.Context) error {
 		if cctx.IsSet("address") {
@@ -379,8 +384,14 @@ var runCmd = &cli.Command{
 			}
 		}
 
+		ttDataCidDefault := false
 		if (workerType == sealtasks.WorkerSealing || cctx.IsSet("addpiece")) && cctx.Bool("addpiece") {
-			taskTypes = append(taskTypes, sealtasks.TTAddPiece, sealtasks.TTDataCid)
+			taskTypes = append(taskTypes, sealtasks.TTAddPiece)
+			ttDataCidDefault = true
+		}
+		if (cctx.IsSet("data-cid") && cctx.Bool("data-cid")) ||
+			(!cctx.IsSet("data-cid") && ttDataCidDefault) {
+			taskTypes = append(taskTypes, sealtasks.TTDataCid)
 		}
 		if (workerType == sealtasks.WorkerSealing || cctx.IsSet("sector-download")) && cctx.Bool("sector-download") {
 			taskTypes = append(taskTypes, sealtasks.TTDownloadSector)

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -277,7 +277,7 @@ var runCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "data-cid",
-			Usage: "Run the data-cid task. --add-piece defaults this to true unless overridden",
+			Usage: "Run the data-cid task. true|false (default: inherits --addpiece)",
 			Value: true,
 		},
 	},
@@ -389,9 +389,14 @@ var runCmd = &cli.Command{
 			taskTypes = append(taskTypes, sealtasks.TTAddPiece)
 			ttDataCidDefault = true
 		}
-		if (cctx.IsSet("data-cid") && cctx.Bool("data-cid")) ||
-			(!cctx.IsSet("data-cid") && ttDataCidDefault) {
-			taskTypes = append(taskTypes, sealtasks.TTDataCid)
+		if workerType == sealtasks.WorkerSealing {
+			if cctx.IsSet("data-cid") {
+				if cctx.Bool("data-cid") {
+					taskTypes = append(taskTypes, sealtasks.TTDataCid)
+				}
+			} else if ttDataCidDefault {
+				taskTypes = append(taskTypes, sealtasks.TTDataCid)
+			}
 		}
 		if (workerType == sealtasks.WorkerSealing || cctx.IsSet("sector-download")) && cctx.Bool("sector-download") {
 			taskTypes = append(taskTypes, sealtasks.TTDownloadSector)

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -277,7 +277,7 @@ var runCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:        "data-cid",
-			Usage:       "Run the data-cid task. true|false ",
+			Usage:       "Run the data-cid task. true|false",
 			Value:       true,
 			DefaultText: "inherits --addpiece",
 		},

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -276,9 +276,10 @@ var runCmd = &cli.Command{
 			Value: "30s",
 		},
 		&cli.BoolFlag{
-			Name:  "data-cid",
-			Usage: "Run the data-cid task. true|false (default: inherits --addpiece)",
-			Value: true,
+			Name:        "data-cid",
+			Usage:       "Run the data-cid task. true|false ",
+			Value:       true,
+			DefaultText: "inherits --addpiece",
 		},
 	},
 	Before: func(cctx *cli.Context) error {

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -38,7 +38,7 @@ USAGE:
 OPTIONS:
    --addpiece                    enable addpiece (default: true) [$LOTUS_WORKER_ADDPIECE]
    --commit                      enable commit (default: true) [$LOTUS_WORKER_COMMIT]
-   --data-cid                    Run the data-cid task. --add-piece defaults this to true unless overridden (default: true)
+   --data-cid                    Run the data-cid task. true|false (default: inherits --addpiece)
    --http-server-timeout value   (default: "30s")
    --listen value                host address and port the worker api will listen on (default: "0.0.0.0:3456") [$LOTUS_WORKER_LISTEN]
    --name value                  custom worker name (default: hostname) [$LOTUS_WORKER_NAME]

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -38,6 +38,7 @@ USAGE:
 OPTIONS:
    --addpiece                    enable addpiece (default: true) [$LOTUS_WORKER_ADDPIECE]
    --commit                      enable commit (default: true) [$LOTUS_WORKER_COMMIT]
+   --data-cid                    Run the data-cid task. --add-piece defaults this to true unless overridden (default: true)
    --http-server-timeout value   (default: "30s")
    --listen value                host address and port the worker api will listen on (default: "0.0.0.0:3456") [$LOTUS_WORKER_LISTEN]
    --name value                  custom worker name (default: hostname) [$LOTUS_WORKER_NAME]


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/10351

## Proposed Changes
data_cid flag that workers can use to enable/disable that task irrespective of addpiece. Backwards compat is maintained (addpiece starts data_cid)

## Additional Info
CLI description of usage added.
