### PR TITLE
fix: cli: Change arg wording in change-beneficiary cmd

### DIFF
--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -1166,7 +1166,7 @@ var actorConfirmChangeWorker = &cli.Command{
 var actorConfirmChangeBeneficiary = &cli.Command{
 	Name:      "confirm-change-beneficiary",
 	Usage:     "Confirm a beneficiary address change",
-	ArgsUsage: "[minerAddress]",
+	ArgsUsage: "[minerID]",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "really-do-it",

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -968,7 +968,7 @@ var actorProposeChangeBeneficiary = &cli.Command{
 var actorConfirmChangeBeneficiary = &cli.Command{
 	Name:      "confirm-change-beneficiary",
 	Usage:     "Confirm a beneficiary address change",
-	ArgsUsage: "[minerAddress]",
+	ArgsUsage: "[minerID]",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "really-do-it",

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -412,7 +412,7 @@ NAME:
    lotus-miner actor confirm-change-beneficiary - Confirm a beneficiary address change
 
 USAGE:
-   lotus-miner actor confirm-change-beneficiary [command options] [minerAddress]
+   lotus-miner actor confirm-change-beneficiary [command options] [minerID]
 
 OPTIONS:
    --existing-beneficiary  send confirmation from the existing beneficiary address (default: false)


### PR DESCRIPTION
## Proposed Changes
Change arg wording from `minerAddress` to `minerID` in the `lotus-miner actor confirm-change-beneficiary` and `lotus-shed actor confirm-change-beneficiary` cmds.

## Additional Info
A user encountered some confusion when using the `lotus-miner actor confirm-change-beneficiary` cmd, as the args (minerAddress) input in the helptext can easily be confused with the owner address/key/.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
