### PR TITLE
feat: deflake splitstore_test

### DIFF
--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -502,7 +502,7 @@ func (s *SplitStore) applyProtectors() error {
 		})
 
 		if err != nil {
-			return xerrors.Errorf("error applynig protector: %w", err)
+			return xerrors.Errorf("error applying protector: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This test has been observed to flake, example [here](https://app.circleci.com/pipelines/github/filecoin-project/lotus/28582/workflows/714b74f8-2afe-4d5c-ad81-90f3d7ca1dd0/jobs/961665). In this case, the test ran forever because the Prune couldn't start at the time it was triggered, and so we just waited endlessly for a prune that was never going to happen.

## Proposed Changes
<!-- A clear list of the changes being made -->

- Do NOT mine while waiting for pruning to occur (I think by this point we don't need the chain to progress)
- Re-send the Prune request every 5 seconds if pruning doesn't start for some reason

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
