### PR TITLE
feat: cli: More ux-friendly batching cmds

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1944,7 +1944,9 @@ var sectorsBatchingPendingCommit = &cli.Command{
 				return nil
 			}
 
-		fmt.Println("No sectors queued to be committed")
+		} else {
+			fmt.Println("No sectors queued to be committed")
+		}
 		return nil
 	},
 }
@@ -2020,9 +2022,10 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
 				return nil
 			}
-		}
 
-		fmt.Println("No sectors queued to be committed")
+		} else {
+			fmt.Println("No sectors queued to be committed")
+		}
 		return nil
 	},
 }

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1922,7 +1922,24 @@ var sectorsBatchingPendingCommit = &cli.Command{
 			for _, sector := range pending {
 				fmt.Println(sector.Number)
 			}
-			return nil
+
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Do you want to publish these sectors now? (yes/no): ")
+			userInput, err := reader.ReadString('\n')
+			if err != nil {
+				return xerrors.Errorf("reading user input: %w", err)
+			}
+			userInput = strings.ToLower(strings.TrimSpace(userInput))
+
+			if userInput == "yes" {
+				cctx.Set("publish-now", "true")
+				return cctx.Command.Action(cctx)
+			} else if userInput == "no" {
+				return nil
+			} else {
+				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
+				return nil
+			}
 		}
 
 		fmt.Println("No sectors queued to be committed")
@@ -1980,7 +1997,24 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 			for _, sector := range pending {
 				fmt.Println(sector.Number)
 			}
-			return nil
+
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Do you want to publish these sectors now? (yes/no): ")
+			userInput, err := reader.ReadString('\n')
+			if err != nil {
+				return xerrors.Errorf("reading user input: %w", err)
+			}
+			userInput = strings.ToLower(strings.TrimSpace(userInput))
+
+			if userInput == "yes" {
+				cctx.Set("publish-now", "true")
+				return cctx.Command.Action(cctx)
+			} else if userInput == "no" {
+				return nil
+			} else {
+				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
+				return nil
+			}
 		}
 
 		fmt.Println("No sectors queued to be committed")

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1932,7 +1932,10 @@ var sectorsBatchingPendingCommit = &cli.Command{
 			userInput = strings.ToLower(strings.TrimSpace(userInput))
 
 			if userInput == "yes" {
-				cctx.Set("publish-now", "true")
+				err := cctx.Set("publish-now", "true")
+				if err != nil {
+					return xerrors.Errorf("setting publish-now flag: %w", err)
+				}
 				return cctx.Command.Action(cctx)
 			} else if userInput == "no" {
 				return nil
@@ -1940,7 +1943,6 @@ var sectorsBatchingPendingCommit = &cli.Command{
 				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
 				return nil
 			}
-		}
 
 		fmt.Println("No sectors queued to be committed")
 		return nil
@@ -2007,7 +2009,10 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 			userInput = strings.ToLower(strings.TrimSpace(userInput))
 
 			if userInput == "yes" {
-				cctx.Set("publish-now", "true")
+				err := cctx.Set("publish-now", "true")
+				if err != nil {
+					return xerrors.Errorf("setting publish-now flag: %w", err)
+				}
 				return cctx.Command.Action(cctx)
 			} else if userInput == "no" {
 				return nil


### PR DESCRIPTION
## Proposed Changes
Add a easier way to publish with `lotus-miner sectors batching precommit` and `lotus-miner sectors batching commit` cmd´s. Currently its not clear that you need to add the --publish-now flag to manually send the batch.

Current output with these commands:
```
lotus-miner sectors batching commit 
7
8
9
10
```

Proposed change is to prompt the user if they want to publish the sectors/messages now and automatically do it for them:
```
lotus-miner sectors batching commit
7
8
9
10
Do you want to publish these sectors? (yes/no): yes
Batch 0:
        Message: bafy2bzacedbitvc6hkp463lehfut6di3iqrbwlhn2z7fe2qmprpy7dxapuidg
        Sectors:
                9       OK
Batch 1:
        Message: bafy2bzacec7jpltlldcdv6r5n6vjd2gvmgytgs6ovj7va325ddcp37lptjhem
        Sectors:
                10      OK
Batch 2:
        Message: bafy2bzacedinziwxrb52cfdanop3xcvmk2h6obxqbbemoggvncms5naayznjc
        Sectors:
                8       OK
Batch 3:
        Message: bafy2bzacebpltzu2me2hwn4jtakrjt6viqbcfb5hobz3ljhjqswg77aqqsudc
        Sectors:
                7       OK
```

## Additional Info
A follow-up to this would be to give an estimate to how much gas it would cost.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
