### PR TITLE
_build_ Add checked in file to dockerignore ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ dist/
 # The following files are checked into git and result
 # in dirty git state if removed from the docker context
 !extern/filecoin-ffi/rust/filecoin.pc
+!extern/test-vectors


### PR DESCRIPTION
## Related Issues
The Dockerfile would not build on my local machine 

## Proposed Changes
By adding this submodule to the !gitignore list (which is symlinked to dockerignore), it ensures it is still copied from the local machine into the Docker context before building. Without this, the Docker build will fail in order to prevent the dirty git state from ending up in the go version tag.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [X] New features have usage guidelines and / or documentation updates in
  - [X] [Lotus Documentation](https://lotus.filecoin.io)
  - [X] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [X] Tests exist for new functionality or change in behavior
- [X] CI is green
