### PR TITLE
feat: chainstore: exit early in MaybeTakeHeavierTipset

### DIFF
--- a/chain/events/observer.go
+++ b/chain/events/observer.go
@@ -125,7 +125,7 @@ func (o *observer) listenHeadChangesOnce(ctx context.Context) error {
 
 	for changes := range notifs {
 		if err := o.applyChanges(ctx, changes); err != nil {
-			return err
+			return xerrors.Errorf("failed to apply a change notification: %w", err)
 		}
 	}
 

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -425,6 +425,11 @@ func (cs *ChainStore) MaybeTakeHeavierTipSet(ctx context.Context, ts *types.TipS
 	}
 
 	defer cs.heaviestLk.Unlock()
+
+	if ts.Equals(cs.heaviest) {
+		return nil
+	}
+
 	w, err := cs.weight(ctx, cs.StateBlockstore(), ts)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

I've noticed multiple test failures* resulting from the observer system getting confused because it's asked to "apply" the same tipset as its current head. I'm not entirely sure why this happens, and I'm pretty sure there's an underlying issue (because the tipset question later can't be found in the blockstore for some reason).

BUT, regardless, we can just shortcut if we're ever asked to `MaybeTakeHeavierTipset`, which looks possible given that sync workers as well as `SyncSubmitBlock` can lead here.

*[example 1](https://circleci.com/api/v1.1/project/github/filecoin-project/lotus/962701/output/104/0?file=true&allocation-id=6454d26c6d28d7391af7b45b-0-build%2F3DD38584), [example 2](https://circleci.com/api/v1.1/project/github/filecoin-project/lotus/963331/output/104/0?file=true&allocation-id=64550b88d9767979b84e17cd-0-build%2F69AAF7FA), [example 3](https://circleci.com/api/v1.1/project/github/filecoin-project/lotus/961692/output/104/0?file=true&allocation-id=6453ef2ede6d1e09cf34b355-0-build%2F1FB585D7)

## Proposed Changes
<!-- A clear list of the changes being made -->

Exit early.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
