### PR TITLE
feat: deflake paych_api_test

### DIFF
--- a/itests/paych_api_test.go
+++ b/itests/paych_api_test.go
@@ -10,7 +10,6 @@ import (
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	paychtypes "github.com/filecoin-project/go-state-types/builtin/v8/paych"
@@ -19,7 +18,6 @@ import (
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
-	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/events"
@@ -52,8 +50,7 @@ func TestPaymentChannelsAPI(t *testing.T) {
 		Miner(&miner, &paymentCreator, kit.WithAllSubsystems()).
 		Start().
 		InterconnectAll()
-	bms := ens.BeginMiningMustPost(blockTime)
-	bm := bms[0]
+	ens.BeginMiningMustPost(blockTime)
 
 	waitRecvInSync := func() {
 		// paymentCreator is the block miner, in some cases paymentReceiver may fall behind, so we wait for it to catch up
@@ -197,7 +194,12 @@ func TestPaymentChannelsAPI(t *testing.T) {
 	require.Errorf(t, err, "Expected shortfall error of %d", excessAmt)
 
 	// wait for the settlement period to pass before collecting
-	waitForBlocks(ctx, t, bm, paymentReceiver, receiverAddr, policy.PaychSettleDelay)
+	head, err := paymentReceiver.ChainHead(ctx)
+	require.NoError(t, err)
+
+	settleHeight := head.Height() + policy.PaychSettleDelay + 5
+	paymentReceiver.WaitTillChain(ctx, kit.HeightAtLeast(settleHeight))
+	paymentCreator.WaitTillChain(ctx, kit.HeightAtLeast(settleHeight))
 
 	creatorPreCollectBalance, err := paymentCreator.WalletBalance(ctx, createrAddr)
 	require.NoError(t, err)
@@ -224,31 +226,6 @@ func TestPaymentChannelsAPI(t *testing.T) {
 	expectedRefund := channelAmt - totalVouchers
 	delta := big.Sub(currentCreatorBalance, creatorPreCollectBalance)
 	require.EqualValues(t, abi.NewTokenAmount(expectedRefund), delta, "did not send correct funds from creator: expected %d, got %d", expectedRefund, delta)
-}
-
-func waitForBlocks(ctx context.Context, t *testing.T, bm *kit.BlockMiner, paymentReceiver kit.TestFullNode, receiverAddr address.Address, count int) {
-	// We need to add null blocks in batches, if we add too many the chain can't sync
-	batchSize := 60
-	for i := 0; i < count; i += batchSize {
-		size := batchSize
-		if i > count {
-			size = count - i
-		}
-
-		// Add a batch of null blocks to advance the chain quicker through finalities.
-		bm.InjectNulls(abi.ChainEpoch(size - 1))
-
-		// Add a real block
-		m, err := paymentReceiver.MpoolPushMessage(ctx, &types.Message{
-			To:    builtin.BurntFundsActorAddr,
-			From:  receiverAddr,
-			Value: types.NewInt(0),
-		}, nil)
-		require.NoError(t, err)
-
-		_, err = paymentReceiver.StateWaitMsg(ctx, m.Cid(), 1, api.LookbackNoLimit, true)
-		require.NoError(t, err)
-	}
 }
 
 func waitForMessage(ctx context.Context, t *testing.T, paymentCreator kit.TestFullNode, msgCid cid.Cid, duration time.Duration, desc string) *api.MsgLookup {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This test has been observed to flake a lot, example https://app.circleci.com/pipelines/github/filecoin-project/lotus/28643/workflows/32a2f145-5cac-492b-a00e-3ce566d50691/jobs/965295.

The problem is that we try to inject a lot of nulls in order to fast-forward the Paych Settle Delay (which is 12 hours on mainnet). This is nice to speed up the test, but just leads to missed PoSts, especially because we fast-forward entire deadlines at a time.

## Proposed Changes
<!-- A clear list of the changes being made -->

Just wait for the PaychSettleDelay to "normally" pass -- this is only 14 seconds, we don't need to risk flakiness. We could consider skipping fewer epochs at a time, but I honestly don't think it's worth it.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
