### PR TITLE
fix: tests: Use mutex-wrapped datastore in storage tests

### DIFF
--- a/storage/sealer/manager_test.go
+++ b/storage/sealer/manager_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-datastore"
+	syncds "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,7 +144,7 @@ func TestSimple(t *testing.T) {
 	logging.SetAllLoggers(logging.LevelDebug)
 
 	ctx := context.Background()
-	m, lstor, _, _, cleanup := newTestMgr(ctx, t, datastore.NewMapDatastore())
+	m, lstor, _, _, cleanup := newTestMgr(ctx, t, syncds.MutexWrap(datastore.NewMapDatastore()))
 	defer cleanup()
 
 	localTasks := []sealtasks.TaskType{
@@ -200,7 +201,7 @@ func (m NullReader) NullBytes() int64 {
 func TestSnapDeals(t *testing.T) {
 	logging.SetAllLoggers(logging.LevelWarn)
 	ctx := context.Background()
-	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, datastore.NewMapDatastore())
+	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, syncds.MutexWrap(datastore.NewMapDatastore()))
 	defer cleanup()
 
 	localTasks := []sealtasks.TaskType{
@@ -208,7 +209,7 @@ func TestSnapDeals(t *testing.T) {
 		sealtasks.TTFetch, sealtasks.TTReplicaUpdate, sealtasks.TTProveReplicaUpdate1, sealtasks.TTProveReplicaUpdate2, sealtasks.TTUnseal,
 		sealtasks.TTRegenSectorKey, sealtasks.TTFinalizeUnsealed,
 	}
-	wds := datastore.NewMapDatastore()
+	wds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	w := NewLocalWorker(WorkerConfig{TaskTypes: localTasks}, stor, lstor, idx, m, statestore.New(wds))
 	err := m.AddWorker(ctx, w)
@@ -329,7 +330,7 @@ func TestSnapDeals(t *testing.T) {
 func TestSnarkPackV2(t *testing.T) {
 	logging.SetAllLoggers(logging.LevelWarn)
 	ctx := context.Background()
-	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, datastore.NewMapDatastore())
+	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, syncds.MutexWrap(datastore.NewMapDatastore()))
 	defer cleanup()
 
 	localTasks := []sealtasks.TaskType{
@@ -337,7 +338,7 @@ func TestSnarkPackV2(t *testing.T) {
 		sealtasks.TTFetch, sealtasks.TTReplicaUpdate, sealtasks.TTProveReplicaUpdate1, sealtasks.TTProveReplicaUpdate2, sealtasks.TTUnseal,
 		sealtasks.TTRegenSectorKey, sealtasks.TTFinalizeUnsealed,
 	}
-	wds := datastore.NewMapDatastore()
+	wds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	w := NewLocalWorker(WorkerConfig{TaskTypes: localTasks}, stor, lstor, idx, m, statestore.New(wds))
 	err := m.AddWorker(ctx, w)
@@ -471,7 +472,7 @@ func TestRedoPC1(t *testing.T) {
 	logging.SetAllLoggers(logging.LevelDebug)
 
 	ctx := context.Background()
-	m, lstor, _, _, cleanup := newTestMgr(ctx, t, datastore.NewMapDatastore())
+	m, lstor, _, _, cleanup := newTestMgr(ctx, t, syncds.MutexWrap(datastore.NewMapDatastore()))
 	defer cleanup()
 
 	localTasks := []sealtasks.TaskType{
@@ -524,7 +525,7 @@ func TestRestartManager(t *testing.T) {
 			ctx, done := context.WithCancel(context.Background())
 			defer done()
 
-			ds := datastore.NewMapDatastore()
+			ds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 			m, lstor, _, _, cleanup := newTestMgr(ctx, t, ds)
 			defer cleanup()
@@ -622,7 +623,7 @@ func TestRestartWorker(t *testing.T) {
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
 
-	ds := datastore.NewMapDatastore()
+	ds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, ds)
 	defer cleanup()
@@ -631,7 +632,7 @@ func TestRestartWorker(t *testing.T) {
 		sealtasks.TTAddPiece, sealtasks.TTFetch,
 	}
 
-	wds := datastore.NewMapDatastore()
+	wds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	arch := make(chan chan apres)
 	w := newLocalWorker(func() (storiface.Storage, error) {
@@ -695,7 +696,7 @@ func TestReenableWorker(t *testing.T) {
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
 
-	ds := datastore.NewMapDatastore()
+	ds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, ds)
 	defer cleanup()
@@ -768,7 +769,7 @@ func TestResUse(t *testing.T) {
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
 
-	ds := datastore.NewMapDatastore()
+	ds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, ds)
 	defer cleanup()
@@ -777,7 +778,7 @@ func TestResUse(t *testing.T) {
 		sealtasks.TTAddPiece, sealtasks.TTFetch,
 	}
 
-	wds := datastore.NewMapDatastore()
+	wds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	arch := make(chan chan apres)
 	w := newLocalWorker(func() (storiface.Storage, error) {
@@ -826,7 +827,7 @@ func TestResOverride(t *testing.T) {
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
 
-	ds := datastore.NewMapDatastore()
+	ds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	m, lstor, stor, idx, cleanup := newTestMgr(ctx, t, ds)
 	defer cleanup()
@@ -835,7 +836,7 @@ func TestResOverride(t *testing.T) {
 		sealtasks.TTAddPiece, sealtasks.TTFetch,
 	}
 
-	wds := datastore.NewMapDatastore()
+	wds := syncds.MutexWrap(datastore.NewMapDatastore())
 
 	arch := make(chan chan apres)
 	w := newLocalWorker(func() (storiface.Storage, error) {


### PR DESCRIPTION
## Related Issues
Should fix a flake from https://app.circleci.com/pipelines/github/filecoin-project/lotus/28667/workflows/ae7a8156-78d0-48c2-852f-e203ea10e251/jobs/966677

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
```
fatal error: concurrent map read and map write

goroutine 103 [running]:
github.com/ipfs/go-datastore.(*MapDatastore).Has(0xc000046420?, {0x37e6f28?, 0xc00054be20?}, {{0xc00003a420?, 0x2c?}})
	/home/circleci/go/pkg/mod/github.com/ipfs/go-datastore@v0.6.0/basic_ds.go:51 +0x2e
github.com/filecoin-project/go-statestore.(*StoredState).End(0xc00054be68)
	/home/circleci/go/pkg/mod/github.com/filecoin-project/go-statestore@v0.2.0/state.go:20 +0x43
github.com/filecoin-project/lotus/storage/sealer.(*workerCallTracker).onReturned(0x37d9f58?, {{0x3e8, 0x1}, {0xce, 0xc, 0x8, 0x2b, 0x5a, 0x7a, 0x4c, ...}})
	/home/circleci/lotus/storage/sealer/worker_calltracker.go:55 +0x8a
github.com/filecoin-project/lotus/storage/sealer.(*LocalWorker).asyncCall.func1()
	/home/circleci/lotus/storage/sealer/worker_local.go:300 +0x3f7
created by github.com/filecoin-project/lotus/storage/sealer.(*LocalWorker).asyncCall
	/home/circleci/lotus/storage/sealer/worker_local.go:275 +0x34f
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
