### PR TITLE
feat: deflake eth_balance_test

### DIFF
--- a/itests/eth_balance_test.go
+++ b/itests/eth_balance_test.go
@@ -121,15 +121,24 @@ func TestEthBalanceCorrectLookup(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ml.Receipt.ExitCode.IsSuccess())
 
-	bal, err := client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height-2), 10))
+	execTs, err := client.ChainGetTipSet(ctx, ml.TipSet)
+	require.NoError(t, err)
+
+	inclTs, err := client.ChainGetTipSet(ctx, execTs.Parents())
+	require.NoError(t, err)
+
+	inclTsParents, err := client.ChainGetTipSet(ctx, inclTs.Parents())
+	require.NoError(t, err)
+
+	bal, err := client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(inclTsParents.Height()), 10))
 	require.NoError(t, err)
 	require.Equal(t, int64(0), bal.Int64())
 
-	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height-1), 10))
+	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(inclTs.Height()), 10))
 	require.NoError(t, err)
 	require.Equal(t, val, bal.Int64())
 
-	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(ml.Height), 10))
+	bal, err = client.EVM().EthGetBalance(ctx, ethAddr, strconv.FormatInt(int64(execTs.Height()), 10))
 	require.NoError(t, err)
 	require.Equal(t, val, bal.Int64())
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This test has been observed to flake, eg: https://app.circleci.com/pipelines/github/filecoin-project/lotus/28677/workflows/bf05c79a-62cf-46ee-b4f7-1aeeeeae02ed/jobs/967190

The test has a faulty assumption that the message lookup height - 2 will always get you a tipset before the relevant message has been included. This is not the case when the tipset after the inclusion tipset is null.

## Proposed Changes
<!-- A clear list of the changes being made -->

The correct way to make this assertion is to actually get heights from the blockchain itself: execution height, inclusion height, "most recent before inclusion height"


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
