### PR TITLE
libp2p: add QUIC and WebTransport to default listen addresses

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -38,7 +38,7 @@
   #
   # type: []string
   # env var: LOTUS_LIBP2P_LISTENADDRESSES
-  #ListenAddresses = ["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0"]
+  #ListenAddresses = ["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0", "/ip4/0.0.0.0/udp/0/quic-v1", "/ip6/::/udp/0/quic-v1", "/ip4/0.0.0.0/udp/0/quic-v1/webtransport", "/ip6/::/udp/0/quic-v1/webtransport"]
 
   # Addresses to explicitally announce to other peers. If not specified,
   # all interface addresses are announced

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -38,7 +38,7 @@
   #
   # type: []string
   # env var: LOTUS_LIBP2P_LISTENADDRESSES
-  #ListenAddresses = ["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0"]
+  #ListenAddresses = ["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0", "/ip4/0.0.0.0/udp/0/quic-v1", "/ip6/::/udp/0/quic-v1", "/ip4/0.0.0.0/udp/0/quic-v1/webtransport", "/ip6/::/udp/0/quic-v1/webtransport"]
 
   # Addresses to explicitally announce to other peers. If not specified,
   # all interface addresses are announced

--- a/itests/net_test.go
+++ b/itests/net_test.go
@@ -220,14 +220,17 @@ func TestNetBlockIPAddr(t *testing.T) {
 	firstAddrInfo, _ := firstNode.NetAddrsListen(ctx)
 	secondAddrInfo, _ := secondNode.NetAddrsListen(ctx)
 
-	var secondNodeIPs []string
-
+	secondNodeIPsMap := map[string]struct{}{} // so we can deduplicate
 	for _, addr := range secondAddrInfo.Addrs {
 		ip, err := manet.ToIP(addr)
 		if err != nil {
 			continue
 		}
-		secondNodeIPs = append(secondNodeIPs, ip.String())
+		secondNodeIPsMap[ip.String()] = struct{}{}
+	}
+	var secondNodeIPs []string
+	for s := range secondNodeIPsMap {
+		secondNodeIPs = append(secondNodeIPs, s)
 	}
 
 	// Sanity check that we're not already connected somehow
@@ -243,6 +246,8 @@ func TestNetBlockIPAddr(t *testing.T) {
 	list, err := firstNode.NetBlockList(ctx)
 	require.NoError(t, err)
 
+	fmt.Println(list.IPAddrs)
+	fmt.Println(secondNodeIPs)
 	require.Equal(t, len(list.IPAddrs), len(secondNodeIPs), "expected %d blocked IPs", len(secondNodeIPs))
 	for _, blockedIP := range list.IPAddrs {
 		found := false
@@ -256,7 +261,8 @@ func TestNetBlockIPAddr(t *testing.T) {
 		require.True(t, found, "blocked IP %s is not one of secondNodeIPs", blockedIP)
 	}
 
-	require.Error(t, secondNode.NetConnect(ctx, firstAddrInfo), "shouldn't be able to connect to second node")
+	// a QUIC connection might still succeed when gated, but will be killed right after the handshake
+	_ = secondNode.NetConnect(ctx, firstAddrInfo)
 	connectedness, err = secondNode.NetConnectedness(ctx, firstAddrInfo.ID)
 	require.NoError(t, err, "failed to determine connectedness")
 	require.NotEqual(t, connectedness, network.Connected)

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -57,6 +57,10 @@ func defCommon() Common {
 			ListenAddresses: []string{
 				"/ip4/0.0.0.0/tcp/0",
 				"/ip6/::/tcp/0",
+				"/ip4/0.0.0.0/udp/0/quic-v1",
+				"/ip6/::/udp/0/quic-v1",
+				"/ip4/0.0.0.0/udp/0/quic-v1/webtransport",
+				"/ip6/::/udp/0/quic-v1/webtransport",
 			},
 			AnnounceAddresses:   []string{},
 			NoAnnounceAddresses: []string{},


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
