### PR TITLE
fix: splitstore: remove deadlock around waiting for sync

### DIFF
--- a/blockstore/splitstore/splitstore_reify.go
+++ b/blockstore/splitstore/splitstore_reify.go
@@ -140,7 +140,7 @@ func (s *SplitStore) doReify(c cid.Cid) {
 		func(missing cid.Cid) error {
 			log.Warnf("missing reference while reifying %s: %s", c, missing)
 			return errStopWalk
-		})
+		}, true)
 
 	if err != nil {
 		if errors.Is(err, errReifyLimit) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#10788?

#10641 introduced the possibility of a deadlock, because `Put` might sleep waiting on sync to catch up while holding the all-important `txnLk`. This is definitely wrong, we also just don't want `Put`s to be yielding and sleeping.

## Proposed Changes
<!-- A clear list of the changes being made -->

Add a non-yielding version of `walkObjectIncomplete` that gets called by `Put` and `PutMany`.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

I checked thoroughly, but am still not _confident_ that other methods more directly involved in compaction don't have the same problem. This entire locking mechanism is...tricky.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
