### PR TITLE
feat:fountain:add grant-datacap support

### DIFF
--- a/cmd/lotus-fountain/site/datacap.html
+++ b/cmd/lotus-fountain/site/datacap.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Grant DataCap - Lotus Fountain</title>
+    <link rel="stylesheet" type="text/css" href="main.css">
+	<script src="https://www.google.com/recaptcha/api.js"></script>
+	<script>
+   		function onSubmit(token) {
+     	document.getElementById("funds-form").submit();
+   	}
+	</script>
+
+</head>
+<body>
+<div class="Index">
+    <div class="Index-nodes">
+        <div class="Index-node">
+            [GRANT DATACAP]
+        </div>
+        <div class="Index-node">
+            <form action='/datacap' method='post' id='datacap-form'>
+                <span>Enter destination address:</span>
+                <input type='text' name='address' style="width: 300px">
+                <button class="g-recaptcha"
+                        data-sitekey="{{ . }}"
+                        data-callback='onSubmit'
+                        data-action='submit'>Grant Datacap</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="Index-footer">
+        <div>
+            <a href="index.html">[Back]</a>
+            <span style="float: right">Not dispensing real Filecoin tokens</span>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/cmd/lotus-fountain/site/index.html
+++ b/cmd/lotus-fountain/site/index.html
@@ -13,6 +13,12 @@
         <div class="Index-node">
             <a href="funds.html">[Send Funds]</a>
         </div>
+        <div class="Index-node">
+            [LOTUS DEVNET GRANT DATACAP]
+        </div>
+        <div class="Index-node">
+            <a href="datacap.html">[Grant DataCap]</a>
+        </div>
     </div>
     <div class="Index-footer">
         <div>


### PR DESCRIPTION
## Related Issues
adding the support to grant datacap from fountain

## Proposed Changes
Add a new endpoint for grant datacap. 

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
