### PR TITLE
fix: cli: make redeclare cmd work properly

### DIFF
--- a/cmd/lotus-miner/storage.go
+++ b/cmd/lotus-miner/storage.go
@@ -225,6 +225,7 @@ var storageRedeclareCmd = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "drop-missing",
 			Usage: "Drop index entries with missing files",
+			Value: true,
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -264,13 +265,17 @@ var storageRedeclareCmd = &cli.Command{
 		var meta storiface.LocalStorageMeta
 		metaFile, err := os.Open(metaFilePath)
 		if err != nil {
-			return xerrors.Errorf("Failed to open meta file: %w", err)
+			return xerrors.Errorf("Failed to open file: %w", err)
 		}
-		defer metaFile.Close()
+		defer func() {
+			if closeErr := metaFile.Close(); closeErr != nil {
+				log.Error("Failed to close the file: %v", closeErr)
+			}
+		}()
 
 		err = json.NewDecoder(metaFile).Decode(&meta)
 		if err != nil {
-			return xerrors.Errorf("Failed to decode meta file: %w", err)
+			return xerrors.Errorf("Failed to decode file: %w", err)
 		}
 
 		id := meta.ID

--- a/cmd/lotus-miner/storage.go
+++ b/cmd/lotus-miner/storage.go
@@ -235,12 +235,17 @@ var storageRedeclareCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
-		if cctx.NArg() != 1 {
-			return lcli.IncorrectNumArgs(cctx)
+		// check if no argument and no --id or --all flag is provided
+		if cctx.NArg() == 0 && !cctx.IsSet("id") && !cctx.Bool("all") {
+			return xerrors.Errorf("You must specify a storage path, or --id, or --all")
 		}
 
 		if cctx.IsSet("id") && cctx.Bool("all") {
 			return xerrors.Errorf("--id and --all can't be passed at the same time")
+		}
+
+		if cctx.Bool("all") && cctx.NArg() > 0 {
+			return xerrors.Errorf("No additional arguments are expected when --all is set")
 		}
 
 		if cctx.IsSet("id") {
@@ -252,7 +257,24 @@ var storageRedeclareCmd = &cli.Command{
 			return minerApi.StorageRedeclareLocal(ctx, nil, cctx.Bool("drop-missing"))
 		}
 
-		return xerrors.Errorf("either --all or --id must be specified")
+		// As no --id or --all flag is set, we can assume the argument is a path.
+		path := cctx.Args().First()
+		metaFilePath := filepath.Join(path, "sectorstore.json")
+
+		var meta storiface.LocalStorageMeta
+		metaFile, err := os.Open(metaFilePath)
+		if err != nil {
+			return xerrors.Errorf("Failed to open meta file: %w", err)
+		}
+		defer metaFile.Close()
+
+		err = json.NewDecoder(metaFile).Decode(&meta)
+		if err != nil {
+			return xerrors.Errorf("Failed to decode meta file: %w", err)
+		}
+
+		id := meta.ID
+		return minerApi.StorageRedeclareLocal(ctx, &id, cctx.Bool("drop-missing"))
 	},
 }
 

--- a/cmd/lotus-worker/storage.go
+++ b/cmd/lotus-worker/storage.go
@@ -178,6 +178,7 @@ var storageRedeclareCmd = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "drop-missing",
 			Usage: "Drop index entries with missing files",
+			Value: true,
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -188,8 +189,17 @@ var storageRedeclareCmd = &cli.Command{
 		defer closer()
 		ctx := lcli.ReqContext(cctx)
 
+		// check if no argument and no --id or --all flag is provided
+		if cctx.NArg() == 0 && !cctx.IsSet("id") && !cctx.Bool("all") {
+			return xerrors.Errorf("You must specify a storage path, or --id, or --all")
+		}
+
 		if cctx.IsSet("id") && cctx.Bool("all") {
 			return xerrors.Errorf("--id and --all can't be passed at the same time")
+		}
+
+		if cctx.Bool("all") && cctx.NArg() > 0 {
+			return xerrors.Errorf("No additional arguments are expected when --all is set")
 		}
 
 		if cctx.IsSet("id") {
@@ -201,6 +211,27 @@ var storageRedeclareCmd = &cli.Command{
 			return nodeApi.StorageRedeclareLocal(ctx, nil, cctx.Bool("drop-missing"))
 		}
 
-		return xerrors.Errorf("either --all or --id must be specified")
+		// As no --id or --all flag is set, we can assume the argument is a path.
+		path := cctx.Args().First()
+		metaFilePath := filepath.Join(path, "sectorstore.json")
+
+		var meta storiface.LocalStorageMeta
+		metaFile, err := os.Open(metaFilePath)
+		if err != nil {
+			return xerrors.Errorf("Failed to open file: %w", err)
+		}
+		defer func() {
+			if closeErr := metaFile.Close(); closeErr != nil {
+				log.Error("Failed to close the file: %v", closeErr)
+			}
+		}()
+
+		err = json.NewDecoder(metaFile).Decode(&meta)
+		if err != nil {
+			return xerrors.Errorf("Failed to decode file: %w", err)
+		}
+
+		id := meta.ID
+		return nodeApi.StorageRedeclareLocal(ctx, &id, cctx.Bool("drop-missing"))
 	},
 }

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -1285,7 +1285,7 @@ USAGE:
 
 OPTIONS:
    --all           redeclare all storage paths (default: false)
-   --drop-missing  Drop index entries with missing files (default: false)
+   --drop-missing  Drop index entries with missing files (default: true)
    --id value      storage path ID
    
 ```

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -148,7 +148,7 @@ USAGE:
 
 OPTIONS:
    --all           redeclare all storage paths (default: false)
-   --drop-missing  Drop index entries with missing files (default: false)
+   --drop-missing  Drop index entries with missing files (default: true)
    --id value      storage path ID
    
 ```


### PR DESCRIPTION
## Related Issues
Fix: #10859

## Proposed Changes
- Fix issue where `lotus-miner storage redeclare --all` required an argument
- Set value of --drop-missing to `true`
- Implement the logic to redeclare sectors in a single storage path.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
