### PR TITLE
fix: types: error out on decoding BlockMsg with extraneous data

### DIFF
--- a/chain/types/blockmsg.go
+++ b/chain/types/blockmsg.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/ipfs/go-cid"
 )
@@ -14,10 +15,13 @@ type BlockMsg struct {
 
 func DecodeBlockMsg(b []byte) (*BlockMsg, error) {
 	var bm BlockMsg
-	if err := bm.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
+	data := bytes.NewReader(b)
+	if err := bm.UnmarshalCBOR(data); err != nil {
 		return nil, err
 	}
-
+	if l := data.Len(); l != 0 {
+		return nil, fmt.Errorf("extraneous data in BlockMsg CBOR encoding: got %d unexpected bytes", l)
+	}
 	return &bm, nil
 }
 

--- a/chain/types/blockmsg_test.go
+++ b/chain/types/blockmsg_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeBlockMsg(t *testing.T) {
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name    string
+		data    []byte
+		want    *BlockMsg
+		wantErr bool
+	}{
+		{"decode empty BlockMsg with extra data at the end", []byte{0x83, 0xf6, 0x80, 0x80, 0x20}, new(BlockMsg), true},
+		{"decode valid empty BlockMsg", []byte{0x83, 0xf6, 0x80, 0x80}, new(BlockMsg), false},
+		{"decode invalid cbor", []byte{0x83, 0xf6, 0x80}, nil, true},
+	}
+	for _, tt := range tests {
+		data := tt.data
+		want := tt.want
+		wantErr := tt.wantErr
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeBlockMsg(data)
+			if wantErr {
+				assert.Errorf(t, err, "DecodeBlockMsg(%v)", data)
+				return
+			}
+			assert.NoErrorf(t, err, "DecodeBlockMsg(%v)", data)
+			assert.Equalf(t, want, got, "DecodeBlockMsg(%v)", data)
+			serialized, err := got.Serialize()
+			assert.NoErrorf(t, err, "DecodeBlockMsg(%v)", data)
+			assert.Equalf(t, serialized, data, "DecodeBlockMsg(%v)", data)
+		})
+	}
+}

--- a/chain/types/blockmsg_test.go
+++ b/chain/types/blockmsg_test.go
@@ -16,7 +16,7 @@ func TestDecodeBlockMsg(t *testing.T) {
 		want    *BlockMsg
 		wantErr bool
 	}{
-		{"decode empty BlockMsg with extra data at the end", []byte{0x83, 0xf6, 0x80, 0x80, 0x20}, new(BlockMsg), true},
+		{"decode empty BlockMsg with extra data at the end", []byte{0x83, 0xf6, 0x80, 0x80, 0x20}, nil, true},
 		{"decode valid empty BlockMsg", []byte{0x83, 0xf6, 0x80, 0x80}, new(BlockMsg), false},
 		{"decode invalid cbor", []byte{0x83, 0xf6, 0x80}, nil, true},
 	}
@@ -27,14 +27,14 @@ func TestDecodeBlockMsg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := DecodeBlockMsg(data)
 			if wantErr {
-				assert.Errorf(t, err, "DecodeBlockMsg(%v)", data)
+				assert.Errorf(t, err, "DecodeBlockMsg(%x)", data)
 				return
 			}
-			assert.NoErrorf(t, err, "DecodeBlockMsg(%v)", data)
-			assert.Equalf(t, want, got, "DecodeBlockMsg(%v)", data)
+			assert.NoErrorf(t, err, "DecodeBlockMsg(%x)", data)
+			assert.Equalf(t, want, got, "DecodeBlockMsg(%x)", data)
 			serialized, err := got.Serialize()
-			assert.NoErrorf(t, err, "DecodeBlockMsg(%v)", data)
-			assert.Equalf(t, serialized, data, "DecodeBlockMsg(%v)", data)
+			assert.NoErrorf(t, err, "DecodeBlockMsg(%x)", data)
+			assert.Equalf(t, serialized, data, "DecodeBlockMsg(%x)", data)
 		})
 	}
 }


### PR DESCRIPTION
This fixes the OSS-fuzz finding [48208: lotus:fuzz_block_msg](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=48208).

The error being that invalid CBOR encoding of BlockMsg can lead to decoded values that do not re-serialize as is. Not necessarily a security issue, but making sure we're not decoding invalid representations shouldn't hurt and prevents us from having to worry about having multiple CBOR representation of the same thing (our CBOR decoder requires canonical CBOR).

## Related Issues
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=48208

## Proposed Changes
This reads the remaining bytes in the reader provided to `UnmarshalCBOR` and if it still contains data, errors out. 

## Additional Info
The oss-fuzz testcase boils down to:
`0x83F6808020`
which contains an extra byte after the data items: https://cbor.me/?bytes=83(F6-80-80((20


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
