### PR TITLE
feat: alerts: Add lotus-miner legacy-markets alert

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -89,6 +89,7 @@ const (
 
 	// health checks
 	CheckFDLimit
+	LegacyMarketsEOL
 
 	// libp2p
 	PstoreAddSelfKeysKey

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -147,6 +147,10 @@ func ConfigStorageMiner(c interface{}) Option {
 		),
 
 		If(cfg.Subsystems.EnableMarkets,
+
+			// Alert that legacy-markets is being deprecated
+			Override(LegacyMarketsEOL, modules.LegacyMarketsEOL),
+
 			// Markets
 			Override(new(dtypes.StagingBlockstore), modules.StagingBlockstore),
 			Override(new(dtypes.StagingGraphsync), modules.StagingGraphsync(cfg.Dealmaking.SimultaneousTransfersForStorage, cfg.Dealmaking.SimultaneousTransfersForStoragePerClient, cfg.Dealmaking.SimultaneousTransfersForRetrieval)),

--- a/node/modules/alerts.go
+++ b/node/modules/alerts.go
@@ -32,6 +32,16 @@ func CheckFdLimit(min uint64) func(al *alerting.Alerting) {
 	}
 }
 
+func LegacyMarketsEOL(al *alerting.Alerting) {
+	// Add alert if lotus-miner legacy markets subsystem is still in use
+	alert := al.AddAlertType("system", "EOL")
+
+	// Alert with a message to migrate to Boost or similar markets subsystems
+	al.Raise(alert, map[string]string{
+		"message": "The lotus-miner legacy markets subsystem is deprecated and will be removed in a future release. Please migrate to [Boost](https://boost.filecoin.io) or similar markets subsystems.",
+	})
+}
+
 // TODO: More things:
 //  * Space in repo dirs (taking into account mounts)
 //  * Miner


### PR DESCRIPTION
## Proposed Changes
Add alert if a storage provider is still using the lotus-miner legacy-markets.

**Lotus-miner info:**
```
Enabled subsystems: [Mining Sealing SectorStorage Markets]
StartTime: 48s (started at 2023-05-15 06:59:10 -0400 EDT)
Chain: [sync ok] [basefee 100 aFIL]
⚠ 2 Active alerts (check lotus-miner log alerts)
```

And checking the alert with `lotus-miner log alerts`:

```
active   system:EOL
         last raised at 2023-05-15 06:59:10.141 -0400 EDT; reason: {"message":"The lotus-miner legacy markets subsystem is deprecated and will be removed in a future release. Please migrate to [Boost](https://boost.filecoin.io) or similar markets subsystems."}
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
