### PR TITLE
fix: config: Disable lotus-miner local-sealing-worker configs

### DIFF
--- a/cmd/lotus-miner/init.go
+++ b/cmd/lotus-miner/init.go
@@ -473,14 +473,14 @@ func storageMinerInit(ctx context.Context, cctx *cli.Context, api v1api.FullNode
 
 			smgr, err := sealer.New(ctx, lstor, stor, lr, si, config.SealerConfig{
 				ParallelFetchLimit:       10,
-				AllowAddPiece:            true,
-				AllowPreCommit1:          true,
-				AllowPreCommit2:          true,
-				AllowCommit:              true,
-				AllowUnseal:              true,
-				AllowReplicaUpdate:       true,
-				AllowProveReplicaUpdate2: true,
-				AllowRegenSectorKey:      true,
+				AllowAddPiece:            false,
+				AllowPreCommit1:          false,
+				AllowPreCommit2:          false,
+				AllowCommit:              false,
+				AllowUnseal:              false,
+				AllowReplicaUpdate:       false,
+				AllowProveReplicaUpdate2: false,
+				AllowRegenSectorKey:      false,
 			}, config.ProvingConfig{}, wsts, smsts)
 			if err != nil {
 				return err

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -687,39 +687,39 @@
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWSECTORDOWNLOAD
-  #AllowSectorDownload = true
+  #AllowSectorDownload = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWADDPIECE
-  #AllowAddPiece = true
+  #AllowAddPiece = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWPRECOMMIT1
-  #AllowPreCommit1 = true
+  #AllowPreCommit1 = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWPRECOMMIT2
-  #AllowPreCommit2 = true
+  #AllowPreCommit2 = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWCOMMIT
-  #AllowCommit = true
+  #AllowCommit = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWUNSEAL
-  #AllowUnseal = true
+  #AllowUnseal = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWREPLICAUPDATE
-  #AllowReplicaUpdate = true
+  #AllowReplicaUpdate = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWPROVEREPLICAUPDATE2
-  #AllowProveReplicaUpdate2 = true
+  #AllowProveReplicaUpdate2 = false
 
   # type: bool
   # env var: LOTUS_STORAGE_ALLOWREGENSECTORKEY
-  #AllowRegenSectorKey = true
+  #AllowRegenSectorKey = false
 
   # LocalWorkerName specifies a custom name for the builtin worker.
   # If set to an empty string (default) os hostname will be used

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -164,15 +164,15 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 
 		Storage: SealerConfig{
-			AllowSectorDownload:      true,
-			AllowAddPiece:            true,
-			AllowPreCommit1:          true,
-			AllowPreCommit2:          true,
-			AllowCommit:              true,
-			AllowUnseal:              true,
-			AllowReplicaUpdate:       true,
-			AllowProveReplicaUpdate2: true,
-			AllowRegenSectorKey:      true,
+			AllowSectorDownload:      false,
+			AllowAddPiece:            false,
+			AllowPreCommit1:          false,
+			AllowPreCommit2:          false,
+			AllowCommit:              false,
+			AllowUnseal:              false,
+			AllowReplicaUpdate:       false,
+			AllowProveReplicaUpdate2: false,
+			AllowRegenSectorKey:      false,
 
 			// Default to 10 - tcp should still be able to figure this out, and
 			// it's the ratio between 10gbit / 1gbit


### PR DESCRIPTION
## Related Issues
#10870

## Proposed Changes
Disabling the builtin sealing worker configs on the lotus-miner process by default.

## Additional Info
Keeping the PR in draft for a bit to gather any feedback on the ticket in question.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
