### PR TITLE
feat: run lotus-shed commands in context that is cancelled on sigterm

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -127,7 +127,7 @@ func main() {
 	go func() {
 		<-c
 		cancel()
-		fmt.Println("Received interrupt, stopping... Press CTRL+C again to force stop")
+		fmt.Println("Received interrupt, shutting down... Press CTRL+C again to force shutdown")
 		<-c
 		fmt.Println("Forcing stop")
 		os.Exit(1)


### PR DESCRIPTION
**Context**
Currently, `lotus-shed` runs all commands with `app.Run`. This makes handling  handle interrupts difficult or even impossible from the client side (https://github.com/urfave/cli/issues/945). We would like to be able to interrupt (CTRL+C) all our commands such that they can gracefully exit, or if that fails force them to stop (right now we need to do a manual SIGKILL)

**This diff**
Updates  `lotus-shed` to run all commands with `app.RunContext()` and pass it a context that we cancel on interrupt from `main()`. This allows each command to simply check for `ctx.Done()` and gracefully exit (we can add that incrementally later).

Implementation notes:
- Calling `cancel()` does not in all cases gracefully exit as it seems that we not thoroughly check for Done in all codepaths. Therefore, added a second forced stop.
- I left out other lotus tools from this initial PR, but I can update them as well if this looks good