### PR TITLE
fix: shed remove datacap not working with ledger

### DIFF
--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -474,7 +474,7 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 
 		st, err := multisig.Load(store, vrkState)
 		if err != nil {
-			return err
+			return fmt.Errorf("load vrk failed: %w ", err)
 		}
 
 		signers, err := st.Signers()
@@ -508,14 +508,13 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 			return err
 		}
 
-		sm, _, err := srv.PublishMessage(ctx, proto, false)
+		sm, err := lcli.InteractiveSend(ctx, cctx, srv, proto)
 		if err != nil {
 			return err
 		}
 
 		msgCid := sm.Cid()
-
-		fmt.Printf("message sent, now waiting on cid: %s\n", msgCid)
+		fmt.Println("sending msg: ", msgCid)
 
 		mwait, err := api.StateWaitMsg(ctx, msgCid, uint64(cctx.Int("confidence")), build.Finality, true)
 		if err != nil {


### PR DESCRIPTION
reported [here](https://filecoinproject.slack.com/archives/CPFTWMY7N/p1682613089521759 ) publish message will hit `Filecoin.MpoolPushMessage': failed to sign message: Unexpected number of items`

use interactive send instead 

tested by using ledger and was able to successfully sign the desired message 