### PR TITLE
sealing: Improve upgrade sector selection

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -515,15 +515,7 @@
   # env var: LOTUS_SEALING_MINUPGRADESECTOREXPIRATION
   #MinUpgradeSectorExpiration = 0
 
-  # When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
-  # be selected based on lowest initial pledge.
-  # 
-  # Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
-  # selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
-  # where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
-  # 
-  # Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
-  # initial pledge - upgrade sectors will always be chosen based on longest expiration
+  # DEPRECATED: Target expiration is no longer used
   #
   # type: uint64
   # env var: LOTUS_SEALING_MINTARGETUPGRADESECTOREXPIRATION

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1106,15 +1106,7 @@ required to have expiration of at least the soonest-ending deal`,
 			Name: "MinTargetUpgradeSectorExpiration",
 			Type: "uint64",
 
-			Comment: `When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
-be selected based on lowest initial pledge.
-
-Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
-selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
-where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
-
-Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
-initial pledge - upgrade sectors will always be chosen based on longest expiration`,
+			Comment: `DEPRECATED: Target expiration is no longer used`,
 		},
 		{
 			Name: "CommittedCapacitySectorLifetime",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -352,15 +352,7 @@ type SealingConfig struct {
 	// required to have expiration of at least the soonest-ending deal
 	MinUpgradeSectorExpiration uint64
 
-	// When set to a non-zero value, minimum number of epochs until sector expiration above which upgrade candidates will
-	// be selected based on lowest initial pledge.
-	//
-	// Target sector expiration is calculated by looking at the input deal queue, sorting it by deal expiration, and
-	// selecting N deals from the queue up to sector size. The target expiration will be Nth deal end epoch, or in case
-	// where there weren't enough deals to fill a sector, DealMaxDuration (540 days = 1555200 epochs)
-	//
-	// Setting this to a high value (for example to maximum deal duration - 1555200) will disable selection based on
-	// initial pledge - upgrade sectors will always be chosen based on longest expiration
+	// DEPRECATED: Target expiration is no longer used
 	MinTargetUpgradeSectorExpiration uint64
 
 	// CommittedCapacitySectorLifetime is the duration a Committed Capacity (CC) sector will

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -983,19 +983,18 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 	return func(cfg sealiface.Config) (err error) {
 		err = mutateSealingCfg(r, func(c config.SealingConfiger) {
 			newCfg := config.SealingConfig{
-				MaxWaitDealsSectors:              cfg.MaxWaitDealsSectors,
-				MaxSealingSectors:                cfg.MaxSealingSectors,
-				MaxSealingSectorsForDeals:        cfg.MaxSealingSectorsForDeals,
-				PreferNewSectorsForDeals:         cfg.PreferNewSectorsForDeals,
-				MaxUpgradingSectors:              cfg.MaxUpgradingSectors,
-				CommittedCapacitySectorLifetime:  config.Duration(cfg.CommittedCapacitySectorLifetime),
-				WaitDealsDelay:                   config.Duration(cfg.WaitDealsDelay),
-				MakeNewSectorForDeals:            cfg.MakeNewSectorForDeals,
-				MinUpgradeSectorExpiration:       cfg.MinUpgradeSectorExpiration,
-				MinTargetUpgradeSectorExpiration: cfg.MinTargetUpgradeSectorExpiration,
-				MakeCCSectorsAvailable:           cfg.MakeCCSectorsAvailable,
-				AlwaysKeepUnsealedCopy:           cfg.AlwaysKeepUnsealedCopy,
-				FinalizeEarly:                    cfg.FinalizeEarly,
+				MaxWaitDealsSectors:             cfg.MaxWaitDealsSectors,
+				MaxSealingSectors:               cfg.MaxSealingSectors,
+				MaxSealingSectorsForDeals:       cfg.MaxSealingSectorsForDeals,
+				PreferNewSectorsForDeals:        cfg.PreferNewSectorsForDeals,
+				MaxUpgradingSectors:             cfg.MaxUpgradingSectors,
+				CommittedCapacitySectorLifetime: config.Duration(cfg.CommittedCapacitySectorLifetime),
+				WaitDealsDelay:                  config.Duration(cfg.WaitDealsDelay),
+				MakeNewSectorForDeals:           cfg.MakeNewSectorForDeals,
+				MinUpgradeSectorExpiration:      cfg.MinUpgradeSectorExpiration,
+				MakeCCSectorsAvailable:          cfg.MakeCCSectorsAvailable,
+				AlwaysKeepUnsealedCopy:          cfg.AlwaysKeepUnsealedCopy,
+				FinalizeEarly:                   cfg.FinalizeEarly,
 
 				CollateralFromMinerBalance: cfg.CollateralFromMinerBalance,
 				AvailableBalanceBuffer:     types.FIL(cfg.AvailableBalanceBuffer),
@@ -1027,13 +1026,12 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 
 func ToSealingConfig(dealmakingCfg config.DealmakingConfig, sealingCfg config.SealingConfig) sealiface.Config {
 	return sealiface.Config{
-		MaxWaitDealsSectors:              sealingCfg.MaxWaitDealsSectors,
-		MaxSealingSectors:                sealingCfg.MaxSealingSectors,
-		MaxSealingSectorsForDeals:        sealingCfg.MaxSealingSectorsForDeals,
-		PreferNewSectorsForDeals:         sealingCfg.PreferNewSectorsForDeals,
-		MinUpgradeSectorExpiration:       sealingCfg.MinUpgradeSectorExpiration,
-		MinTargetUpgradeSectorExpiration: sealingCfg.MinTargetUpgradeSectorExpiration,
-		MaxUpgradingSectors:              sealingCfg.MaxUpgradingSectors,
+		MaxWaitDealsSectors:        sealingCfg.MaxWaitDealsSectors,
+		MaxSealingSectors:          sealingCfg.MaxSealingSectors,
+		MaxSealingSectorsForDeals:  sealingCfg.MaxSealingSectorsForDeals,
+		PreferNewSectorsForDeals:   sealingCfg.PreferNewSectorsForDeals,
+		MinUpgradeSectorExpiration: sealingCfg.MinUpgradeSectorExpiration,
+		MaxUpgradingSectors:        sealingCfg.MaxUpgradingSectors,
 
 		StartEpochSealingBuffer:         abi.ChainEpoch(dealmakingCfg.StartEpochSealingBuffer),
 		MakeNewSectorForDeals:           sealingCfg.MakeNewSectorForDeals,

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -417,6 +417,13 @@ func (m *Sealing) addPendingPiece(ctx context.Context, size abi.UnpaddedPieceSiz
 		close(pp.doneCh)
 	}
 
+	log.Debugw("new pending piece", "dealId", deal.DealID,
+		"piece", deal.DealProposal.PieceCID,
+		"size", size,
+		"dealStart", deal.DealSchedule.StartEpoch,
+		"dealEnd", deal.DealSchedule.EndEpoch,
+		"termEnd", ct.claimTermEnd)
+
 	m.pendingPieces[proposalCID(deal)] = pp
 	go func() {
 		defer m.inputLk.Unlock()
@@ -694,7 +701,6 @@ func (m *Sealing) maybeUpgradeSector(ctx context.Context, sp abi.RegisteredSealP
 		return &pieceBounds[f-1]
 	}
 
-	targetExpirationEpoch := ts.Height() + abi.ChainEpoch(cfg.MinTargetUpgradeSectorExpiration)
 	minExpirationEpoch := ts.Height() + abi.ChainEpoch(cfg.MinUpgradeSectorExpiration)
 
 	var candidate abi.SectorID
@@ -734,31 +740,18 @@ func (m *Sealing) maybeUpgradeSector(ctx context.Context, sp abi.RegisteredSealP
 
 		// if the sector has less than one sector worth of candidate deals, and
 		// the best candidate has more candidate deals, this sector isn't better
-		if pb.dealBytesInBound.Padded() < abi.PaddedPieceSize(ssize) {
-			if bestDealBytes > pb.dealBytesInBound.Padded() {
-				continue
-			}
-		}
 
-		// if best is below target, we want larger expirations
-		// if best is above target, we want lower pledge, but only if still above target
+		lessThanSectorOfData := pb.dealBytesInBound.Padded() < abi.PaddedPieceSize(ssize)
+		moreDealsThanBest := bestDealBytes > pb.dealBytesInBound.Padded()
 
-		// todo: after nv17 "target expiration" doesn't really make that much sense
-		//  (tho to be fair it doesn't make too much sense now either)
-		//  we probably want the lowest expiration that's still above the configured
-		//  minimum, and can fit most candidate deals
+		// we want lower pledge, but only if we have more than one sector worth of deals
 
-		if bestExpiration < targetExpirationEpoch {
-			if expirationEpoch > bestExpiration && slowChecks(s.Number) {
-				bestExpiration = expirationEpoch
-				bestPledge = pledge
-				bestDealBytes = pb.dealBytesInBound.Padded()
-				candidate = s
-			}
-			continue
-		}
+		preferDueToDealSize := lessThanSectorOfData && moreDealsThanBest
+		preferDueToPledge := pledge.LessThan(bestPledge) && !lessThanSectorOfData
 
-		if expirationEpoch >= targetExpirationEpoch && pledge.LessThan(bestPledge) && slowChecks(s.Number) {
+		prefer := preferDueToDealSize || preferDueToPledge
+
+		if prefer && slowChecks(s.Number) {
 			bestExpiration = expirationEpoch
 			bestPledge = pledge
 			bestDealBytes = pb.dealBytesInBound.Padded()
@@ -767,12 +760,12 @@ func (m *Sealing) maybeUpgradeSector(ctx context.Context, sp abi.RegisteredSealP
 	}
 
 	if bestExpiration < minExpirationEpoch {
-		log.Infow("Not upgrading any sectors", "available", len(m.available), "pieces", len(m.pendingPieces), "bestExp", bestExpiration, "target", targetExpirationEpoch, "min", minExpirationEpoch, "candidate", candidate)
+		log.Infow("Not upgrading any sectors", "available", len(m.available), "pieces", len(m.pendingPieces), "bestExp", bestExpiration, "min", minExpirationEpoch, "candidate", candidate)
 		// didn't find a good sector / no sectors were available
 		return false, nil
 	}
 
-	log.Infow("Upgrading sector", "number", candidate.Number, "type", "deal", "proofType", sp, "expiration", bestExpiration, "pledge", types.FIL(bestPledge))
+	log.Infow("Upgrading sector", "number", candidate.Number, "type", "deal", "proofType", sp, "expiration", bestExpiration, "pledge", types.FIL(bestPledge), "pieces", len(m.pendingPieces), "dealBytesAtExp", bestDealBytes)
 	delete(m.available, candidate)
 	m.nextDealSector = &candidate.Number
 	return true, m.sectors.Send(uint64(candidate.Number), SectorStartCCUpdate{})

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -738,11 +738,16 @@ func (m *Sealing) maybeUpgradeSector(ctx context.Context, sp abi.RegisteredSealP
 			continue
 		}
 
+		if pb.dealBytesInBound.Padded() == 0 {
+			log.Debugw("skipping available sector", "sector", s.Number, "reason", "no deals in expiration bounds", "expiration", expirationEpoch)
+			continue
+		}
+
 		// if the sector has less than one sector worth of candidate deals, and
 		// the best candidate has more candidate deals, this sector isn't better
 
 		lessThanSectorOfData := pb.dealBytesInBound.Padded() < abi.PaddedPieceSize(ssize)
-		moreDealsThanBest := bestDealBytes > pb.dealBytesInBound.Padded()
+		moreDealsThanBest := pb.dealBytesInBound.Padded() > bestDealBytes
 
 		// we want lower pledge, but only if we have more than one sector worth of deals
 

--- a/storage/pipeline/sealiface/config.go
+++ b/storage/pipeline/sealiface/config.go
@@ -22,8 +22,6 @@ type Config struct {
 
 	MinUpgradeSectorExpiration uint64
 
-	MinTargetUpgradeSectorExpiration uint64
-
 	MaxUpgradingSectors uint64
 
 	MakeNewSectorForDeals bool


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
* Attempt to improve upgrade sector selection logic
* Deprecate the MinTargetUpgradeSectorExpiration config, it makes no sense after nv17
* Add better logging about upgrade sector selection decisions

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
