### PR TITLE
fix:lotus-fountain:set default data-cap same as MinVerifiedDealSize

### DIFF
--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -78,7 +78,7 @@ var runCmd = &cli.Command{
 		&cli.Uint64Flag{
 			Name:    "data-cap",
 			EnvVars: []string{"LOTUS_DATACAP_AMOUNT"},
-			Value:   10240,
+			Value:   verifregtypes9.MinVerifiedDealSize.Uint64(),
 		},
 		&cli.Float64Flag{
 			Name:  "captcha-threshold",


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
set the default data-cap size same as the MinVerifiedDealSize
## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X] Commits have a clear commit message.
- [X] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
