### PR TITLE
perf: use sqlite/msgindex.db as `epoch=>tipsetkey` index to speed up `eth_getBlockByNumber` queries

### DIFF
--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -33,6 +33,14 @@ type MsgIndex interface {
 	Close() error
 }
 
+// TipsetIndex is the interface to the tipset index
+type TipsetIndex interface {
+	// GetTipsetCID returns the tipset cid for the given epoch
+	GetTipsetCID(ctx context.Context, epoch abi.ChainEpoch) (*cid.Cid, error)
+	// Close closes the index
+	Close() error
+}
+
 type dummyMsgIndex struct{}
 
 func (dummyMsgIndex) GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error) {
@@ -44,3 +52,15 @@ func (dummyMsgIndex) Close() error {
 }
 
 var DummyMsgIndex MsgIndex = dummyMsgIndex{}
+
+type dummyTipsetIndex struct{}
+
+func (dummyTipsetIndex) GetTipsetCID(ctx context.Context, epoch abi.ChainEpoch) (*cid.Cid, error) {
+	return nil, ErrNotFound
+}
+
+func (dummyTipsetIndex) Close() error {
+	return nil
+}
+
+var DummyTipsetIndex TipsetIndex = dummyTipsetIndex{}

--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -24,18 +24,19 @@ type MsgInfo struct {
 
 // MsgIndex is the interface to the message index
 type MsgIndex interface {
-	// GetMsgInfo retrieves the message metadata through the index.
+	// GetMsgInfo looks up the message in index and retrieves its metadata and execution
+	// tipset cid.
 	// The lookup is done using the onchain message Cid; that is the signed message Cid
 	// for SECP messages and unsigned message Cid for BLS messages.
-	GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error)
+	GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error)
 	// Close closes the index
 	Close() error
 }
 
 type dummyMsgIndex struct{}
 
-func (dummyMsgIndex) GetMsgInfo(ctx context.Context, m cid.Cid) (MsgInfo, error) {
-	return MsgInfo{}, ErrNotFound
+func (dummyMsgIndex) GetMsgInfo(ctx context.Context, mCid cid.Cid) (MsgInfo, cid.Cid, error) {
+	return MsgInfo{}, cid.Undef, ErrNotFound
 }
 
 func (dummyMsgIndex) Close() error {

--- a/chain/index/msgindex_test.go
+++ b/chain/index/msgindex_test.go
@@ -157,7 +157,7 @@ func verifyIndex(t *testing.T, cs *mockChainStore, msgIndex MsgIndex) {
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			minfo, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			minfo, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.NoError(t, err)
 			require.Equal(t, tsCid, minfo.TipSet)
 			require.Equal(t, ts.Height(), minfo.Epoch)
@@ -174,7 +174,7 @@ func verifyMissing(t *testing.T, cs *mockChainStore, msgIndex MsgIndex, missing 
 		msgs, err := cs.MessagesForTipset(context.Background(), ts)
 		require.NoError(t, err)
 		for _, m := range msgs {
-			_, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
+			_, _, err := msgIndex.GetMsgInfo(context.Background(), m.Cid())
 			require.Equal(t, ErrNotFound, err)
 		}
 	}

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -161,7 +161,8 @@ func NewChainStore(chainBs bstore.Blockstore, stateBs bstore.Blockstore, ds dsto
 		evtTypeHeadChange: j.RegisterEventType("sync", "head_change"),
 	}
 
-	ci := NewChainIndex(cs.LoadTipSet)
+	// TODO: what's the best way to get the message (tipset) index loaded into here?
+	ci := NewChainIndex(cs.LoadTipSet, nil)
 
 	cs.cindex = ci
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Builds on-top of https://github.com/filecoin-project/lotus/pull/10632
https://github.com/filecoin-project/lotus/issues/10663
https://github.com/vulcanize/filecoin-indexing/issues/20

## Proposed Changes
<!-- A clear list of the changes being made -->
in sqlite/msgindex.db we have a table which maps message_cids to epochs and tipset cids for the tipset in which these messages appear. We could also leverage this table as an index for looking up the tipset corresponding to a specific epoch when proceeding down the `eth_getBlockByNumber` search path described in https://github.com/vulcanize/filecoin-indexing/issues/20#issue-1724539676 (assuming my understanding there is correct).

## Additional Info
<!-- Callouts, links to documentation, and etc -->
Opening this as a draft hoping to spur some discussion/feedback, I am not entirely confident in my line of thinking for this. Additionally, if the reasoning is sound, I would appreciate maintainer's opinion on how to best access this index from the `ChainStore`/`ChainIndex` (i.e. https://github.com/filecoin-project/lotus/pull/10922/files#diff-6032ffd931dc723fcaa5d9b7926dae0b7fa6bea74763d8e0a0693d2b45992976R164).

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
