### PR TITLE
feat: alert: Add FVM_CONCURRENCY alert

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -89,6 +89,7 @@ const (
 
 	// health checks
 	CheckFDLimit
+	CheckFvmConcurrency
 	LegacyMarketsEOL
 
 	// libp2p
@@ -165,6 +166,7 @@ func defaults() []Option {
 		Override(new(dtypes.NodeStartTime), FromVal(dtypes.NodeStartTime(time.Now()))),
 
 		Override(CheckFDLimit, modules.CheckFdLimit(build.DefaultFDLimit)),
+		Override(CheckFvmConcurrency, modules.CheckFvmConcurrency()),
 
 		Override(new(system.MemoryConstraints), modules.MemoryConstraints),
 		Override(InitMemoryWatchdog, modules.MemoryWatchdog),

--- a/node/modules/alerts.go
+++ b/node/modules/alerts.go
@@ -63,12 +63,12 @@ func CheckFvmConcurrency() func(al *alerting.Alerting) {
 		}
 
 		// Raise alert if LOTUS_FVM_CONCURRENCY is set to a high value
-		if fvmConcurrencyVal >= 24 {
+		if fvmConcurrencyVal > 24 {
 			alert := al.AddAlertType("process", "fvm-concurrency")
 			al.Raise(alert, map[string]interface{}{
 				"message":     "LOTUS_FVM_CONCURRENCY is set to a high value that can cause chain sync panics on network migrations/upgrades",
 				"set_value":   fvmConcurrencyVal,
-				"recommended": "23 or less during network upgrades",
+				"recommended": "24 or less during network upgrades",
 			})
 		}
 	}

--- a/node/modules/alerts.go
+++ b/node/modules/alerts.go
@@ -1,6 +1,9 @@
 package modules
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/filecoin-project/lotus/journal/alerting"
 	"github.com/filecoin-project/lotus/lib/ulimit"
 )
@@ -40,6 +43,35 @@ func LegacyMarketsEOL(al *alerting.Alerting) {
 	al.Raise(alert, map[string]string{
 		"message": "The lotus-miner legacy markets subsystem is deprecated and will be removed in a future release. Please migrate to [Boost](https://boost.filecoin.io) or similar markets subsystems.",
 	})
+}
+
+func CheckFvmConcurrency() func(al *alerting.Alerting) {
+	return func(al *alerting.Alerting) {
+		fvmConcurrency, ok := os.LookupEnv("LOTUS_FVM_CONCURRENCY")
+		if !ok {
+			return
+		}
+
+		fvmConcurrencyVal, err := strconv.Atoi(fvmConcurrency)
+		if err != nil {
+			alert := al.AddAlertType("process", "fvm-concurrency")
+			al.Raise(alert, map[string]string{
+				"message": "LOTUS_FVM_CONCURRENCY is not an integer",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		// Raise alert if LOTUS_FVM_CONCURRENCY is set to a high value
+		if fvmConcurrencyVal >= 24 {
+			alert := al.AddAlertType("process", "fvm-concurrency")
+			al.Raise(alert, map[string]interface{}{
+				"message":     "LOTUS_FVM_CONCURRENCY is set to a high value that can cause chain sync panics on network migrations/upgrades",
+				"set_value":   fvmConcurrencyVal,
+				"recommended": "23 or less during network upgrades",
+			})
+		}
+	}
 }
 
 // TODO: More things:


### PR DESCRIPTION
## Related Issues
Inspired by #10710

## Proposed Changes
Raise an alert in the alert system if the `LOTUS_FVM_CONCURRENCY` enviroment variable is set higher then 24. Alert the user that this can cause chain sync panics when going over network upgrades/migrations.

## Additional Info
Alert will show up in **lotus info**
```
Network: localnet-3de9f2f7-de34-41cc-a5fe-0893f2b6e707
StartTime: 4m18s (started at 2023-05-31 09:41:36 -0400 EDT)
Chain: [sync ok] [basefee 100 aFIL] [epoch 328606]
Peers to: [publish messages 0] [publish blocks 0]
⚠ 1 Active alerts (check lotus log alerts)
```

**lotus log alerts**
```
active   process:fvm-concurrency
         last raised at 2023-05-31 09:41:36.969 -0400 EDT; reason: {"message":"LOTUS_FVM_CONCURRENCY is set to a high value that can cause chain sync panics on network migrations/upgrades","recommended":"23 or less during network upgrades","set_value":46}
```
## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
