### PR TITLE
Add support to backfill actor events + resuming when left off

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -389,6 +389,14 @@
     # env var: LOTUS_FEVM_EVENTS_DATABASEPATH
     #DatabasePath = ""
 
+    # EnableEventBackfillOnStartup will run a backfill of all actor events from the current head up to the genesis
+    # block (while we have state) and populate the events.db. The DisableHistoricFilterAPI must be set to false
+    # for this to have any effect.
+    #
+    # type: bool
+    # env var: LOTUS_FEVM_EVENTS_ENABLEEVENTBACKFILLONSTARTUP
+    #EnableEventBackfillOnStartup = false
+
 
 [Index]
   # EXPERIMENTAL FEATURE. USE WITH CAUTION

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -393,6 +393,14 @@ support the historic filter APIs. If the database does not exist it will be crea
 the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as
 relative to the CWD (current working directory).`,
 		},
+		{
+			Name: "EnableEventBackfillOnStartup",
+			Type: "bool",
+
+			Comment: `EnableEventBackfillOnStartup will run a backfill of all actor events from the current head up to the genesis
+block (while we have state) and populate the events.db. The DisableHistoricFilterAPI must be set to false
+for this to have any effect.`,
+		},
 	},
 	"FeeConfig": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -721,6 +721,11 @@ type Events struct {
 	// relative to the CWD (current working directory).
 	DatabasePath string
 
+	// EnableEventBackfillOnStartup will run a backfill of all actor events from the current head up to the genesis
+	// block (while we have state) and populate the events.db. The DisableHistoricFilterAPI must be set to false
+	// for this to have any effect.
+	EnableEventBackfillOnStartup bool
+
 	// Others, not implemented yet:
 	// Set a limit on the number of active websocket subscriptions (may be zero)
 	// Set a timeout for subscription clients

--- a/node/impl/full/backfill.go
+++ b/node/impl/full/backfill.go
@@ -1,0 +1,278 @@
+package full
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	"github.com/multiformats/go-varint"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	builtintypes "github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/exitcode"
+
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+func isIndexedValue(b uint8) bool {
+	// currently we mark the full entry as indexed if either the key
+	// or the value are indexed; in the future we will need finer-grained
+	// management of indices
+	return b&(types.EventFlagIndexedKey|types.EventFlagIndexedValue) > 0
+}
+
+// BackfillEvents walks up the chain from the current head and backfills all actor events that were not stored in
+// the event.db database.
+func BackfillEvents(ctx context.Context, chainapi ChainAPI, stateApi StateAPI, stateManager *stmgr.StateManager) error {
+	resolveFn := func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool) {
+		// we only want to match using f4 addresses
+		idAddr, err := address.NewIDAddress(uint64(emitter))
+		if err != nil {
+			return address.Undef, false
+		}
+
+		actor, err := stateManager.LoadActor(ctx, idAddr, ts)
+		if err != nil || actor.Address == nil {
+			return address.Undef, false
+		}
+
+		// if robust address is not f4 then we won't match against it so bail early
+		if actor.Address.Protocol() != address.Delegated {
+			return address.Undef, false
+		}
+		// we have an f4 address, make sure it's assigned by the EAM
+		if namespace, _, err := varint.FromUvarint(actor.Address.Payload()); err != nil || namespace != builtintypes.EthereumAddressManagerActorID {
+			return address.Undef, false
+		}
+		return *actor.Address, true
+	}
+
+	dbPath := filepath.Join(chainapi.Repo.Path(), "sqlite", "events.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			fmt.Printf("ERROR: closing db: %s", err)
+		}
+	}()
+
+	stmtSelectEvent, err := db.Prepare("SELECT MAX(id) from event WHERE height=? AND tipset_key=? and tipset_key_cid=? and emitter_addr=? and event_index=? and message_cid=? and message_index=? and reverted=false")
+	if err != nil {
+		return err
+	}
+	stmtSelectEntry, err := db.Prepare("SELECT EXISTS(SELECT 1 from event_entry WHERE event_id=? and indexed=? and flags=? and key=? and codec=? and value=?)")
+	if err != nil {
+		return err
+	}
+	stmtEvent, err := db.Prepare("INSERT INTO event (height, tipset_key, tipset_key_cid, emitter_addr, event_index, message_cid, message_index, reverted) VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	stmtEntry, err := db.Prepare("INSERT INTO event_entry(event_id, indexed, flags, key, codec, value) VALUES(?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+
+	checkTs := chainapi.Chain.GetHeaviestTipSet()
+
+	// look into the event_backfilled table to see where we left off
+	var height sql.NullInt32
+	err = db.QueryRow("SELECT MIN(height) FROM event_backfilled").Scan(&height)
+	if err != nil {
+		return err
+	}
+	if !height.Valid {
+		// no backfilling has been done yet, so we need to start from the beginning (current head)
+		_, err := db.Exec("INSERT INTO event_backfilled(height) VALUES(?)", checkTs.Height())
+		if err != nil {
+			return err
+		}
+		log.Infof("Starting backfill from current head %d", checkTs.Height())
+	} else {
+		checkTs, err = chainapi.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height.Int32), checkTs.Key())
+		if err != nil {
+			return err
+		}
+		log.Infof("Starting backfill from epoch %d", checkTs.Height())
+	}
+
+	addressLookups := make(map[abi.ActorID]address.Address)
+
+	var eventsAffected int64
+	var entriesAffected int64
+	for i := 0; i < int(checkTs.Height()); i++ {
+		select {
+		case <-ctx.Done():
+			log.Infoln("request cancelled")
+			return nil
+		default:
+		}
+
+		execTsk := checkTs.Parents()
+		execTs, err := chainapi.Chain.GetTipSetFromKey(ctx, execTsk)
+		if err != nil {
+			return fmt.Errorf("failed to load tipset %s: %w", execTsk, err)
+		}
+
+		if i%100 == 0 {
+			log.Infof("[%d] backfilling actor events epoch:%d, eventsAffected:%d, entriesAffected:%d", i, execTs.Height(), eventsAffected, entriesAffected)
+		}
+
+		_, rcptRoot, err := stateManager.TipSetState(ctx, execTs)
+		if err != nil {
+			return fmt.Errorf("failed to load tipset state %s: %w", execTsk, err)
+		}
+
+		msgs, err := chainapi.Chain.MessagesForTipset(ctx, execTs)
+		if err != nil {
+			return fmt.Errorf("failed to load messages for tipset %s: %w", execTsk, err)
+		}
+
+		rcpts, err := chainapi.Chain.ReadReceipts(ctx, rcptRoot)
+		if err != nil {
+			return fmt.Errorf("failed to load receipts for tipset %s: %w", execTsk, err)
+		}
+
+		if len(msgs) != len(rcpts) {
+			return fmt.Errorf("mismatched message and receipt count %d vs %d", len(msgs), len(rcpts))
+		}
+
+		for idx, rcpt := range rcpts {
+			msg := msgs[idx]
+
+			if rcpt.ExitCode != exitcode.Ok {
+				continue
+			}
+			if rcpt.EventsRoot == nil {
+				continue
+			}
+
+			events, err := chainapi.ChainGetEvents(ctx, *rcpt.EventsRoot)
+			if err != nil {
+				return fmt.Errorf("failed to load events for tipset %s: %w", execTsk, err)
+			}
+
+			for eventIdx, event := range events {
+				addr, found := addressLookups[event.Emitter]
+				if !found {
+					var ok bool
+					addr, ok = resolveFn(ctx, event.Emitter, execTs)
+					if !ok {
+						// not an address we will be able to match against
+						continue
+					}
+					addressLookups[event.Emitter] = addr
+				}
+
+				//log.Infof("[BackfillEvents] %d %d: event:%+v", eventIdx, execTs.Height(), event)
+				tsKeyCid, err := execTs.Key().Cid()
+				if err != nil {
+					return fmt.Errorf("failed to get tipset key cid: %w", err)
+				}
+
+				// select the highest event id that exists in database, or null if none exists
+				var entryID sql.NullInt64
+				err = stmtSelectEvent.QueryRow(
+					execTs.Height(),
+					execTs.Key().Bytes(),
+					tsKeyCid.Bytes(),
+					addr.Bytes(),
+					eventIdx,
+					msg.Cid().Bytes(),
+					idx,
+				).Scan(&entryID)
+				if err != nil {
+					return fmt.Errorf("error checking if event exists: %w", err)
+				}
+
+				if !entryID.Valid {
+					// event does not exist, lets backfill it
+					res, err := stmtEvent.Exec(
+						execTs.Height(),      // height
+						execTs.Key().Bytes(), // tipset_key
+						tsKeyCid.Bytes(),     // tipset_key_cid
+						addr.Bytes(),         // emitter_addr
+						eventIdx,             // event_index
+						msg.Cid().Bytes(),    // message_cid
+						idx,                  // message_index
+						false,                // reverted
+					)
+
+					if err != nil {
+						return fmt.Errorf("error inserting event: %w", err)
+					}
+
+					entryID.Int64, err = res.LastInsertId()
+					if err != nil {
+						return fmt.Errorf("could not get last insert id: %w", err)
+					}
+
+					rowsAffected, err := res.RowsAffected()
+					if err != nil {
+						return fmt.Errorf("error getting rows affected: %s", err)
+					}
+
+					eventsAffected += rowsAffected
+				}
+
+				//log.Infof("[BackfillEvents] entryID:%d", entryID.Int64)
+				for _, entry := range event.Entries {
+					//log.Infof("    [BackfillEvents] entry:%+v", entry)
+
+					// check if entry exists
+					var exists bool
+					err = stmtSelectEntry.QueryRow(
+						entryID.Int64,
+						isIndexedValue(entry.Flags),
+						[]byte{entry.Flags},
+						entry.Key,
+						entry.Codec,
+						entry.Value,
+					).Scan(&exists)
+					if err != nil {
+						return fmt.Errorf("error checking if entry exists: %w", err)
+					}
+
+					if !exists {
+						// entry does not exist, lets backfill it
+						res, err := stmtEntry.Exec(
+							entryID.Int64,               // event_id
+							isIndexedValue(entry.Flags), // indexed
+							[]byte{entry.Flags},         // flags
+							entry.Key,                   // key
+							entry.Codec,                 // codec
+							entry.Value,                 // value
+						)
+						if err != nil {
+							return fmt.Errorf("error inserting entry: %w", err)
+						}
+
+						rowsAffected, err := res.RowsAffected()
+						if err != nil {
+							return fmt.Errorf("error getting rows affected: %s", err)
+						}
+						entriesAffected += rowsAffected
+					}
+				}
+			}
+		}
+
+		_, err = db.Exec("UPDATE event_backfilled set height =?", execTs.Height())
+		if err != nil {
+			return fmt.Errorf("error updating backfill at height %d: %w", execTs.Height(), err)
+		}
+
+		checkTs = execTs
+	}
+
+	log.Infof("backfilling events complete, eventsAffected:%d, entriesAffected:%d", eventsAffected, entriesAffected)
+
+	return nil
+}


### PR DESCRIPTION
Related: https://github.com/filecoin-project/lotus/issues/10807

## Context
When lotus is configured to enable indexing of actor events (when `EnableEthRPC=true` and `DisableHistoricFilterAPI=false`) then Lotus will observe for new tipset and store all the actor events in a sqlite table stored at `sqlite/events.db`. We however, don't have any way to backfill this table which is what this PR is about

I tried first to implement this backfilling using lotus-shed (as we have for backfilling [msgindex](https://github.com/filecoin-project/lotus/pull/10941) and [eth txhahses](https://github.com/filecoin-project/lotus/pull/10932)) but I had some issues getting the required dependencies to work there, so I ended up integrating this into the lotus node directy.

This backfill is guarded behind a new lotus config `EnableEventBackfillOnStartup` which now defaults to false. When set to true, then Lotus will start a background go routine which walks up the chain to collect the actor events. It then checks the sqlite database if that actor event are missing from the database and inserts them if that is the case.

To gracefully handle restarts when backfilling, we mark the current process in a new table `event_backfilled` so we will resume from where we left of if the backfill process was interrupted for any reason.


## Test plan

**Backfill active node that is already storing events**

As expected, backfilling should not have any side effects on a node that is already saving actor events.

```
2023-06-23T09:21:05.444Z        INFO    modules modules/actorevent.go:89        EnableEventBackfillOnStartup was set, starting backfill of actor events in the background...
2023-06-23T09:21:05.444Z        INFO    fullnode        full/backfill.go:97     Starting backfill from current head 2973519
2023-06-23T09:21:05.444Z        INFO    fullnode        full/backfill.go:125    [0] backfilling actor events epoch:2973518, eventsAffected:0, entriesAffected:0
2023-06-23T09:21:09.426Z        INFO    fullnode        full/backfill.go:125    [100] backfilling actor events epoch:2973418, eventsAffected:0, entriesAffected:0
2023-06-23T09:21:21.288Z        INFO    fullnode        full/backfill.go:125    [200] backfilling actor events epoch:2973318, eventsAffected:0, entriesAffected:0
2023-06-23T09:21:25.873Z        INFO    fullnode        full/backfill.go:125    [300] backfilling actor events epoch:2973216, eventsAffected:0, entriesAffected:0
2023-06-23T09:25:34.964Z        INFO    fullnode        full/backfill.go:125    [5400] backfilling actor events epoch:2968086, eventsAffected:0, entriesAffected:0
2023-06-23T09:25:40.108Z        INFO    modules modules/actorevent.go:93        backfill events error: failed to load messages for tipset {bafy2bzacecowakd744tlnuueezixti5icjmb4dle52q5veevsfpsspbpqpafa,bafy2bzacecxl3ianxpwpymxunvs3o5uyesjfykua5qfbw4w5u6twjlpfkkgc4,bafy2bzacebbopm24ikoeu2lu6xyt53obm6s53ctyvit3lyean44vafyhs5alu,bafy2bzaceaw4jy56uhwbkjfo4zrvzt354x6adwhzwbc7jdjuff3ivawdqvnpm,bafy2bzacedqsm46ndmh55q4a2vll3ntpaivo2qqse65erd3kpe6xrslmkgd7g}: failed to load state tree at tipset [bafy2bzacecowakd744tlnuueezixti5icjmb4dle52q5veevsfpsspbpqpafa bafy2bzacecxl3ianxpwpymxunvs3o5uyesjfykua5qfbw4w5u6twjlpfkkgc4 bafy2bzacebbopm24ikoeu2lu6xyt53obm6s53ctyvit3lyean44vafyhs5alu bafy2bzaceaw4jy56uhwbkjfo4zrvzt354x6adwhzwbc7jdjuff3ivawdqvnpm bafy2bzacedqsm46ndmh55q4a2vll3ntpaivo2qqse65erd3kpe6xrslmkgd7g]: failed to load state tree bafy2bzacedaiycnoxohubm6btfyu6vl3ydolbpm5aiwuo62lydt75guebc2oo: failed to load hamt node: ipld: could not find bafy2bzacedaiycnoxohubm6btfyu6vl3ydolbpm5aiwuo62lydt75guebc2oo
2023-06-23T09:25:40.108Z        INFO    modules modules/actorevent.go:95        backfill of actor events done in: 4m34.664418745s
```

**Backfill a node that had never stored any events**

```
2023-06-23T10:34:33.773Z        INFO    modules modules/actorevent.go:89        EnableEventBackfillOnStartup was set, starting backfill of actor events in the background...
2023-06-23T10:34:33.774Z        INFO    fullnode        full/backfill.go:97     Starting backfill from current head 2973668
2023-06-23T10:34:33.774Z        INFO    fullnode        full/backfill.go:125    [0] backfilling actor events epoch:2973667, eventsAffected:0, entriesAffected:0
2023-06-23T10:34:34.220Z        INFO    fullnode        full/backfill.go:125    [100] backfilling actor events epoch:2973567, eventsAffected:168, entriesAffected:596
2023-06-23T10:34:34.538Z        INFO    fullnode        full/backfill.go:125    [200] backfilling actor events epoch:2973467, eventsAffected:273, entriesAffected:967
2023-06-23T10:34:34.792Z        INFO    fullnode        full/backfill.go:125    [300] backfilling actor events epoch:2973367, eventsAffected:443, entriesAffected:1578
2023-06-23T10:34:35.052Z        INFO    fullnode        full/backfill.go:125    [400] backfilling actor events epoch:2973267, eventsAffected:697, entriesAffected:2483
2023-06-23T10:34:35.300Z        INFO    fullnode        full/backfill.go:125    [500] backfilling actor events epoch:2973165, eventsAffected:829, entriesAffected:2946
2023-06-23T10:34:35.596Z        INFO    fullnode        full/backfill.go:125    [600] backfilling actor events epoch:2973064, eventsAffected:1025, entriesAffected:3642
...
2023-06-23T10:35:20.307Z        INFO    fullnode        full/backfill.go:125    [5500] backfilling actor events epoch:2968135, eventsAffected:8119, entriesAffected:28682
2023-06-23T10:35:22.937Z        INFO    fullnode        full/backfill.go:125    [5600] backfilling actor events epoch:2968034, eventsAffected:8369, entriesAffected:29586
2023-06-23T10:35:23.542Z        INFO    modules modules/actorevent.go:93        backfill events error: failed to load messages for tipset {bafy2bzacecowakd744tlnuueezixti5icjmb4dle52q5veevsfpsspbpqpafa,bafy2bzacecxl3ianxpwpymxunvs3o5uyesjfykua5qfbw4w5u6twjlpfkkgc4,bafy2bzacebbopm24ikoeu2lu6xyt53obm6s53ctyvit3lyean44vafyhs5alu,bafy2bzaceaw4jy56uhwbkjfo4zrvzt354x6adwhzwbc7jdjuff3ivawdqvnpm,bafy2bzacedqsm46ndmh55q4a2vll3ntpaivo2qqse65erd3kpe6xrslmkgd7g}: failed to load state tree at tipset [bafy2bzacecowakd744tlnuueezixti5icjmb4dle52q5veevsfpsspbpqpafa bafy2bzacecxl3ianxpwpymxunvs3o5uyesjfykua5qfbw4w5u6twjlpfkkgc4 bafy2bzacebbopm24ikoeu2lu6xyt53obm6s53ctyvit3lyean44vafyhs5alu bafy2bzaceaw4jy56uhwbkjfo4zrvzt354x6adwhzwbc7jdjuff3ivawdqvnpm bafy2bzacedqsm46ndmh55q4a2vll3ntpaivo2qqse65erd3kpe6xrslmkgd7g]: failed to load state tree bafy2bzacedaiycnoxohubm6btfyu6vl3ydolbpm5aiwuo62lydt75guebc2oo: failed to load hamt node: ipld: could not find bafy2bzacedaiycnoxohubm6btfyu6vl3ydolbpm5aiwuo62lydt75guebc2oo
2023-06-23T10:35:23.542Z        INFO    modules modules/actorevent.go:95        backfill of actor events done in: 49.768782713s
```

**Verify backfill results**

I compared the `events.db` that was generated from scratch via backfill to another `events.db` which was generated from by an active lotus node. I attached the second database as `events2` and used the following sql to verify there are no missing events:

```sql
SELECT * FROM (
  SELECT e.height, e.tipset_key, e.emitter_addr, e.event_index, e.message_cid, e.message_index, e.reverted, ee.indexed, ee.flags, ee.key, ee.codec, ee.value 
  FROM event e, event_entry ee
  WHERE ee.event_id = e.id AND e.height > 2971667 AND e.height < 2973667
  EXCEPT
  SELECT e.height, e.tipset_key, e.emitter_addr, e.event_index, e.message_cid, e.message_index, e.reverted, ee.indexed, ee.flags, ee.key, ee.codec, ee.value 
  FROM events2.event e, events2.event_entry ee
  WHERE ee.event_id = e.id AND e.height > 2971667 AND e.height < 2973667
) WHERE reverted = 0

Result: 0 rows returned in 168ms
```

The nice thing is that the backfilled actor events naturally do not contain any duplicates as is generated during a live node as there are no reverts

```sql
SELECT COUNT(*) FROM event e, event_entry ee WHERE ee.event_id = e.id AND e.height > 2971667 AND e.height < 2973667
7975

SELECT COUNT(*) FROM events2.event e, events2.event_entry ee WHERE ee.event_id = e.id AND e.height > 2971667 AND e.height < 2973667
17633
```
