### PR TITLE
[WIP] feat: worker: add graceful stop cmd

### DIFF
--- a/cmd/lotus-worker/gracefulstop.go
+++ b/cmd/lotus-worker/gracefulstop.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/lotus/api"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/storage/sealer/sealtasks"
+	"github.com/urfave/cli/v2"
+)
+
+var gracefulStopCmd = &cli.Command{
+	Name:  "gracefully",
+	Usage: "Gracefully stop a running lotus worker",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "checks",
+			Usage: "Number of consecutive checks (every second without a running tasks) we wait before stopping the worker (default: 30))",
+			Value: 30,
+		},
+	},
+	Action: gracefulStopCmdAct,
+}
+
+func gracefulStopCmdAct(cctx *cli.Context) error {
+	//Disable all tasks
+	tasksDisableAction := taskDisableAll(api.Worker.TaskDisable)
+	err := tasksDisableAction(cctx)
+	if err != nil {
+		return err
+	}
+
+	// Wait for current tasks to finish
+	fmt.Println("Waiting for tasks to finish...")
+	api, closer, err := lcli.GetWorkerAPI(cctx)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	ctx := lcli.ReqContext(cctx)
+
+	consecutiveChecks := cctx.Int("checks")
+	checks := 0
+	for {
+		start := time.Now()
+		err := api.WaitQuiet(ctx)
+		if err != nil {
+			return err
+		}
+
+		elapsed := time.Since(start)
+		if elapsed < time.Second {
+			checks++
+			if checks >= consecutiveChecks {
+				break
+			}
+		} else {
+			// Reset if we encounter a slow check
+			checks = 0
+		}
+	}
+
+	//Stop the worker
+	fmt.Println("Stopping the worker...")
+	err = api.StorageDetachAll(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = api.Shutdown(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Worker has been stopped gracefully.")
+	return nil
+}
+
+func taskDisableAll(tf func(a api.Worker, ctx context.Context, tt sealtasks.TaskType) error) func(cctx *cli.Context) error {
+	return func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetWorkerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Disable all tasks
+		for taskType := range allowSetting {
+			if err := tf(api, ctx, taskType); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -119,13 +119,19 @@ func main() {
 var stopCmd = &cli.Command{
 	Name:  "stop",
 	Usage: "Stop a running lotus worker",
-	Flags: []cli.Flag{},
-	Action: func(cctx *cli.Context) error {
-		api, closer, err := lcli.GetWorkerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
+	Subcommands: []*cli.Command{
+		gracefulStopCmd,
+	},
+	Flags:  []cli.Flag{},
+	Action: stopCmdAct,
+}
+
+func stopCmdAct(cctx *cli.Context) error {
+	api, closer, err := lcli.GetWorkerAPI(cctx)
+	if err != nil {
+		return err
+	}
+	defer closer()
 
 		ctx := lcli.ReqContext(cctx)
 


### PR DESCRIPTION
## Related Issues
#10942 

## Proposed Changes
Add `lotus-worker stop graceful` cmd that:

1. Disables all sealing tasks
2. Waits to see if there is still any running sealing tasks
3. Stops the lotus-worker

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
