### PR TITLE
feat: shed: add a command that spams StateWaitMsg on pending messages

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -89,6 +89,7 @@ func main() {
 		msgindexCmd,
 		FevmAnalyticsCmd,
 		mismatchesCmd,
+		rpcStressCmd,
 	}
 
 	app := &cli.App{

--- a/cmd/lotus-shed/rpc-stress.go
+++ b/cmd/lotus-shed/rpc-stress.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/lotus/chain/types"
+
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/ipfs/go-cid"
+	"github.com/urfave/cli/v2"
+)
+
+var rpcStressCmd = &cli.Command{
+	Name:  "rpc-stress",
+	Usage: "stress out a Lotus node's RPC service by StateWaitMsging for every message in the mempool, FOREVER",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "workers",
+			Usage: "number of workers spamming StateWaitMsg",
+			Value: 20,
+		},
+	}, Action: func(cctx *cli.Context) error {
+		if cctx.Args().Present() {
+			return lcli.IncorrectNumArgs(cctx)
+		}
+
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+
+		pendingMsgCh := make(chan cid.Cid)
+		count := 0
+		go func() {
+			for {
+				pendingMsgs, err := api.MpoolPending(ctx, types.EmptyTSK)
+				if err != nil {
+					panic(err)
+				}
+
+				for _, pendingMsg := range pendingMsgs {
+					count++
+					if count%50 == 0 {
+						fmt.Println("waited for ", count, "messages")
+					}
+					pendingMsgCh <- pendingMsg.Cid()
+				}
+			}
+		}()
+
+		waitMsgFunc := func() {
+			for msg := range pendingMsgCh {
+				_, err := api.StateWaitMsg(ctx, msg, 5)
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+
+		for i := 0; i < cctx.Int("workers"); i++ {
+			go waitMsgFunc()
+		}
+		select {
+		case <-ctx.Done():
+			fmt.Println("all done, all done!")
+			return nil
+		}
+
+	},
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@shrenujbansal and @TippyFlitsUK are testing node perf under stress from a large number of StateWaitMsg requests.

## Proposed Changes
<!-- A clear list of the changes being made -->

Add a shed command that spams these requests for perf testing.

`lotus-shed rpc-stress --workers=100` will keep 100 StateWaitMsg requests going in perpetuity, assuming there are messages in your mempool (usually needs node to be fully synced).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
