### PR TITLE
Upgrade urfave dependency which now supports DisableSliceFlagSeparato…

### DIFF
--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -98,9 +98,10 @@ func main() {
 	log.Info("Starting lotus-bench")
 
 	app := &cli.App{
-		Name:    "lotus-bench",
-		Usage:   "Benchmark performance of lotus on your hardware",
-		Version: build.UserVersion(),
+		Name:                      "lotus-bench",
+		Usage:                     "Benchmark performance of lotus on your hardware",
+		Version:                   build.UserVersion(),
+		DisableSliceFlagSeparator: true,
 		Commands: []*cli.Command{
 			proveCmd,
 			sealBenchCmd,

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -34,11 +34,10 @@ COMMANDS:
 GLOBAL OPTIONS:
    --actor value, -a value                  specify other actor to query / manipulate
    --color                                  use color in display output (default: depends on output being a TTY)
-   --help, -h                               show help (default: false)
    --miner-repo value, --storagerepo value  Specify miner repo path. flag(storagerepo) and env(LOTUS_STORAGE_PATH) are DEPRECATION, will REMOVE SOON (default: "~/.lotusminer") [$LOTUS_MINER_PATH, $LOTUS_STORAGE_PATH]
-   --version, -v                            print the version (default: false)
    --vv                                     enables very verbose mode, useful for debugging the CLI (default: false)
-   
+   --help, -h                               show help
+   --version, -v                            print the version
 ```
 
 ## lotus-miner init
@@ -50,9 +49,9 @@ USAGE:
    lotus-miner init command [command options] [arguments...]
 
 COMMANDS:
-     restore  Initialize a lotus miner repo from a backup
-     service  Initialize a lotus miner sub-service
-     help, h  Shows a list of commands or help for one command
+   restore  Initialize a lotus miner repo from a backup
+   service  Initialize a lotus miner sub-service
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --actor value                                              specify the address of an already created miner actor
@@ -67,8 +66,7 @@ OPTIONS:
    --no-local-storage                                         don't use storageminer repo for sector storage (default: false)
    --gas-premium value                                        set gas premium for initialization messages in AttoFIL (default: "0")
    --from value                                               select which address to send actor creation message from
-   --help, -h                                                 show help (default: false)
-   
+   --help, -h                                                 show help
 ```
 
 ### lotus-miner init restore
@@ -80,10 +78,10 @@ USAGE:
    lotus-miner init restore [command options] [backupFile]
 
 OPTIONS:
-   --config value          config file (config.toml)
    --nosync                don't check full-node sync status (default: false)
+   --config value          config file (config.toml)
    --storage-config value  storage paths config (storage.json)
-   
+   --help, -h              show help
 ```
 
 ### lotus-miner init service
@@ -95,12 +93,12 @@ USAGE:
    lotus-miner init service [command options] [backupFile]
 
 OPTIONS:
-   --api-sealer value             sealer API info (lotus-miner auth api-info --perm=admin)
-   --api-sector-index value       sector Index API info (lotus-miner auth api-info --perm=admin)
    --config value                 config file (config.toml)
    --nosync                       don't check full-node sync status (default: false)
    --type value [ --type value ]  type of service to be enabled
-   
+   --api-sealer value             sealer API info (lotus-miner auth api-info --perm=admin)
+   --api-sector-index value       sector Index API info (lotus-miner auth api-info --perm=admin)
+   --help, -h                     show help
 ```
 
 ## lotus-miner run
@@ -112,11 +110,11 @@ USAGE:
    lotus-miner run [command options] [arguments...]
 
 OPTIONS:
-   --enable-gpu-proving  enable use of GPU for mining operations (default: true)
-   --manage-fdlimit      manage open file limit (default: true)
    --miner-api value     2345
+   --enable-gpu-proving  enable use of GPU for mining operations (default: true)
    --nosync              don't check full-node sync status (default: false)
-   
+   --manage-fdlimit      manage open file limit (default: true)
+   --help, -h            show help
 ```
 
 ## lotus-miner stop
@@ -128,8 +126,7 @@ USAGE:
    lotus-miner stop [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner config
@@ -141,13 +138,12 @@ USAGE:
    lotus-miner config command [command options] [arguments...]
 
 COMMANDS:
-     default  Print default node config
-     updated  Print updated node config
-     help, h  Shows a list of commands or help for one command
+   default  Print default node config
+   updated  Print updated node config
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner config default
@@ -160,7 +156,7 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   
+   --help, -h    show help
 ```
 
 ### lotus-miner config updated
@@ -173,7 +169,7 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   
+   --help, -h    show help
 ```
 
 ## lotus-miner backup
@@ -186,15 +182,15 @@ USAGE:
 
 DESCRIPTION:
    The backup command writes a copy of node metadata under the specified path
-   
+
    Online backups:
    For security reasons, the daemon must be have LOTUS_BACKUP_BASE_PATH env var set
    to a path where backup files are supposed to be saved, and the path specified in
    this command must be within this base path
 
 OPTIONS:
-   --offline  create backup without the node running (default: false)
-   
+   --offline   create backup without the node running (default: false)
+   --help, -h  show help
 ```
 
 ## lotus-miner version
@@ -206,8 +202,7 @@ USAGE:
    lotus-miner version [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner actor
@@ -219,22 +214,21 @@ USAGE:
    lotus-miner actor command [command options] [arguments...]
 
 COMMANDS:
-     set-addresses, set-addrs    set addresses that your miner can be publicly dialed on
-     withdraw                    withdraw available balance to beneficiary
-     repay-debt                  pay down a miner's debt
-     set-peer-id                 set the peer id of your miner
-     set-owner                   Set owner address (this command should be invoked twice, first with the old owner as the senderAddress, and then with the new owner)
-     control                     Manage control addresses
-     propose-change-worker       Propose a worker address change
-     confirm-change-worker       Confirm a worker address change
-     compact-allocated           compact allocated sectors bitfield
-     propose-change-beneficiary  Propose a beneficiary address change
-     confirm-change-beneficiary  Confirm a beneficiary address change
-     help, h                     Shows a list of commands or help for one command
+   set-addresses, set-addrs    set addresses that your miner can be publicly dialed on
+   withdraw                    withdraw available balance to beneficiary
+   repay-debt                  pay down a miner's debt
+   set-peer-id                 set the peer id of your miner
+   set-owner                   Set owner address (this command should be invoked twice, first with the old owner as the senderAddress, and then with the new owner)
+   control                     Manage control addresses
+   propose-change-worker       Propose a worker address change
+   confirm-change-worker       Confirm a worker address change
+   compact-allocated           compact allocated sectors bitfield
+   propose-change-beneficiary  Propose a beneficiary address change
+   confirm-change-beneficiary  Confirm a beneficiary address change
+   help, h                     Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner actor set-addresses, set-addrs
@@ -250,9 +244,9 @@ USAGE:
    lotus-miner actor withdraw [command options] [amount (FIL)]
 
 OPTIONS:
-   --beneficiary       send withdraw message from the beneficiary address (default: false)
    --confidence value  number of block confirmations to wait for (default: 5)
-   
+   --beneficiary       send withdraw message from the beneficiary address (default: false)
+   --help, -h          show help
 ```
 
 ### lotus-miner actor repay-debt
@@ -265,7 +259,7 @@ USAGE:
 
 OPTIONS:
    --from value  optionally specify the account to send funds from
-   
+   --help, -h    show help
 ```
 
 ### lotus-miner actor set-peer-id
@@ -278,7 +272,7 @@ USAGE:
 
 OPTIONS:
    --gas-limit value  set gas limit (default: 0)
-   
+   --help, -h         show help
 ```
 
 ### lotus-miner actor set-owner
@@ -291,7 +285,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner actor control
@@ -303,13 +297,12 @@ USAGE:
    lotus-miner actor control command [command options] [arguments...]
 
 COMMANDS:
-     list     Get currently set control addresses
-     set      Set control address(-es)
-     help, h  Shows a list of commands or help for one command
+   list     Get currently set control addresses
+   set      Set control address(-es)
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner actor control list
@@ -321,8 +314,8 @@ USAGE:
    lotus-miner actor control list [command options] [arguments...]
 
 OPTIONS:
-   --verbose  (default: false)
-   
+   --verbose   (default: false)
+   --help, -h  show help
 ```
 
 #### lotus-miner actor control set
@@ -335,7 +328,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner actor propose-change-worker
@@ -348,7 +341,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner actor confirm-change-worker
@@ -361,7 +354,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner actor compact-allocated
@@ -376,7 +369,7 @@ OPTIONS:
    --mask-last-offset value  Mask sector IDs from 0 to 'higest_allocated - offset' (default: 0)
    --mask-upto-n value       Mask sector IDs from 0 to 'n' (default: 0)
    --really-do-it            Actually send transaction performing the action (default: false)
-   
+   --help, -h                show help
 ```
 
 ### lotus-miner actor propose-change-beneficiary
@@ -388,10 +381,10 @@ USAGE:
    lotus-miner actor propose-change-beneficiary [command options] [beneficiaryAddress quota expiration]
 
 OPTIONS:
-   --actor value               specify the address of miner actor
-   --overwrite-pending-change  Overwrite the current beneficiary change proposal (default: false)
    --really-do-it              Actually send transaction performing the action (default: false)
-   
+   --overwrite-pending-change  Overwrite the current beneficiary change proposal (default: false)
+   --actor value               specify the address of miner actor
+   --help, -h                  show help
 ```
 
 ### lotus-miner actor confirm-change-beneficiary
@@ -403,10 +396,10 @@ USAGE:
    lotus-miner actor confirm-change-beneficiary [command options] [minerID]
 
 OPTIONS:
+   --really-do-it          Actually send transaction performing the action (default: false)
    --existing-beneficiary  send confirmation from the existing beneficiary address (default: false)
    --new-beneficiary       send confirmation from the new beneficiary address (default: false)
-   --really-do-it          Actually send transaction performing the action (default: false)
-   
+   --help, -h              show help
 ```
 
 ## lotus-miner info
@@ -418,14 +411,13 @@ USAGE:
    lotus-miner info command [command options] [arguments...]
 
 COMMANDS:
-     all      dump all related miner info
-     help, h  Shows a list of commands or help for one command
+   all      dump all related miner info
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --hide-sectors-info  hide sectors info (default: false)
    --blocks value       Log of produced <blocks> newest blocks and rewards(Miner Fee excluded) (default: 0)
-   --help, -h           show help (default: false)
-   
+   --help, -h           show help
 ```
 
 ### lotus-miner info all
@@ -437,8 +429,7 @@ USAGE:
    lotus-miner info all [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner auth
@@ -450,13 +441,12 @@ USAGE:
    lotus-miner auth command [command options] [arguments...]
 
 COMMANDS:
-     create-token  Create token
-     api-info      Get token with API info required to connect to this node
-     help, h       Shows a list of commands or help for one command
+   create-token  Create token
+   api-info      Get token with API info required to connect to this node
+   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner auth create-token
@@ -469,7 +459,7 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   
+   --help, -h    show help
 ```
 
 ### lotus-miner auth api-info
@@ -482,7 +472,7 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   
+   --help, -h    show help
 ```
 
 ## lotus-miner log
@@ -494,14 +484,13 @@ USAGE:
    lotus-miner log command [command options] [arguments...]
 
 COMMANDS:
-     list       List log systems
-     set-level  Set log level
-     alerts     Get alert states
-     help, h    Shows a list of commands or help for one command
+   list       List log systems
+   set-level  Set log level
+   alerts     Get alert states
+   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner log list
@@ -513,8 +502,7 @@ USAGE:
    lotus-miner log list [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner log set-level
@@ -527,27 +515,27 @@ USAGE:
 
 DESCRIPTION:
    Set the log level for logging systems:
-   
+
       The system flag can be specified multiple times.
-   
+
       eg) log set-level --system chain --system chainxchg debug
-   
+
       Available Levels:
       debug
       info
       warn
       error
-   
+
       Environment Variables:
       GOLOG_LOG_LEVEL - Default log level for all log systems
       GOLOG_LOG_FMT   - Change output log format (json, nocolor)
       GOLOG_FILE      - Write logs to file
       GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr
-   
+
 
 OPTIONS:
    --system value [ --system value ]  limit to log system
-   
+   --help, -h                         show help
 ```
 
 ### lotus-miner log alerts
@@ -559,8 +547,8 @@ USAGE:
    lotus-miner log alerts [command options] [arguments...]
 
 OPTIONS:
-   --all  get all (active and inactive) alerts (default: false)
-   
+   --all       get all (active and inactive) alerts (default: false)
+   --help, -h  show help
 ```
 
 ## lotus-miner wait-api
@@ -576,7 +564,7 @@ CATEGORY:
 
 OPTIONS:
    --timeout value  duration to wait till fail (default: 30s)
-   
+   --help, -h       show help
 ```
 
 ## lotus-miner fetch-params
@@ -591,8 +579,7 @@ CATEGORY:
    DEVELOPER
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner sectors
@@ -604,32 +591,31 @@ USAGE:
    lotus-miner sectors command [command options] [arguments...]
 
 COMMANDS:
-     status                Get the seal status of a sector by its number
-     list                  List sectors
-     refs                  List References to sectors
-     update-state          ADVANCED: manually update the state of a sector, this may aid in error recovery
-     pledge                store random data in a sector
-     numbers               manage sector number assignments
-     precommits            Print on-chain precommit info
-     check-expire          Inspect expiring sectors
-     expired               Get or cleanup expired sectors
-     extend                Extend expiring sectors while not exceeding each sector's max life
-     terminate             Terminate sector on-chain then remove (WARNING: This means losing power and collateral for the removed sector)
-     remove                Forcefully remove a sector (WARNING: This means losing power and collateral for the removed sector (use 'terminate' for lower penalty))
-     snap-up               Mark a committed capacity sector to be filled with deals
-     abort-upgrade         Abort the attempted (SnapDeals) upgrade of a CC sector, reverting it to as before
-     seal                  Manually start sealing a sector (filling any unused space with junk)
-     set-seal-delay        Set the time (in minutes) that a new sector waits for deals before sealing starts
-     get-cc-collateral     Get the collateral required to pledge a committed capacity sector
-     batching              manage batch sector operations
-     match-pending-pieces  force a refreshed match of pending pieces to open sectors without manually waiting for more deals
-     compact-partitions    removes dead sectors from partitions and reduces the number of partitions used if possible
-     unseal                unseal a sector
-     help, h               Shows a list of commands or help for one command
+   status                Get the seal status of a sector by its number
+   list                  List sectors
+   refs                  List References to sectors
+   update-state          ADVANCED: manually update the state of a sector, this may aid in error recovery
+   pledge                store random data in a sector
+   numbers               manage sector number assignments
+   precommits            Print on-chain precommit info
+   check-expire          Inspect expiring sectors
+   expired               Get or cleanup expired sectors
+   extend                Extend expiring sectors while not exceeding each sector's max life
+   terminate             Terminate sector on-chain then remove (WARNING: This means losing power and collateral for the removed sector)
+   remove                Forcefully remove a sector (WARNING: This means losing power and collateral for the removed sector (use 'terminate' for lower penalty))
+   snap-up               Mark a committed capacity sector to be filled with deals
+   abort-upgrade         Abort the attempted (SnapDeals) upgrade of a CC sector, reverting it to as before
+   seal                  Manually start sealing a sector (filling any unused space with junk)
+   set-seal-delay        Set the time (in minutes) that a new sector waits for deals before sealing starts
+   get-cc-collateral     Get the collateral required to pledge a committed capacity sector
+   batching              manage batch sector operations
+   match-pending-pieces  force a refreshed match of pending pieces to open sectors without manually waiting for more deals
+   compact-partitions    removes dead sectors from partitions and reduces the number of partitions used if possible
+   unseal                unseal a sector
+   help, h               Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors status
@@ -645,7 +631,7 @@ OPTIONS:
    --on-chain-info, -c   show sector on chain info (default: false)
    --partition-info, -p  show partition related info (default: false)
    --proof               print snark proof bytes as hex (default: false)
-   
+   --help, -h            show help
 ```
 
 ### lotus-miner sectors list
@@ -657,8 +643,8 @@ USAGE:
    lotus-miner sectors list command [command options] [arguments...]
 
 COMMANDS:
-     upgrade-bounds  Output upgrade bounds for available sectors
-     help, h         Shows a list of commands or help for one command
+   upgrade-bounds  Output upgrade bounds for available sectors
+   help, h         Shows a list of commands or help for one command
 
 OPTIONS:
    --show-removed, -r         show removed sectors (default: false)
@@ -669,8 +655,7 @@ OPTIONS:
    --states value             filter sectors by a comma-separated list of states
    --unproven, -u             only show sectors which aren't in the 'Proving' state (default: false)
    --check-parallelism value  number of parallel requests to make for checking sector states (default: 300)
-   --help, -h                 show help (default: false)
-   
+   --help, -h                 show help
 ```
 
 #### lotus-miner sectors list upgrade-bounds
@@ -685,7 +670,7 @@ OPTIONS:
    --buckets value  (default: 25)
    --csv            output machine-readable values (default: false)
    --deal-terms     bucket by how many deal-sectors can start at a given expiration (default: false)
-   
+   --help, -h       show help
 ```
 
 ### lotus-miner sectors refs
@@ -697,8 +682,7 @@ USAGE:
    lotus-miner sectors refs [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors update-state
@@ -711,7 +695,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner sectors pledge
@@ -723,8 +707,7 @@ USAGE:
    lotus-miner sectors pledge [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors numbers
@@ -736,15 +719,14 @@ USAGE:
    lotus-miner sectors numbers command [command options] [arguments...]
 
 COMMANDS:
-     info          view sector assigner state
-     reservations  list sector number reservations
-     reserve       create sector number reservations
-     free          remove sector number reservations
-     help, h       Shows a list of commands or help for one command
+   info          view sector assigner state
+   reservations  list sector number reservations
+   reserve       create sector number reservations
+   free          remove sector number reservations
+   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors numbers info
@@ -756,8 +738,7 @@ USAGE:
    lotus-miner sectors numbers info [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors numbers reservations
@@ -769,8 +750,7 @@ USAGE:
    lotus-miner sectors numbers reservations [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors numbers reserve
@@ -782,8 +762,8 @@ USAGE:
    lotus-miner sectors numbers reserve [command options] [reservation name] [reserved ranges]
 
 OPTIONS:
-   --force  skip duplicate reservation checks (note: can lead to damaging other reservations on free) (default: false)
-   
+   --force     skip duplicate reservation checks (note: can lead to damaging other reservations on free) (default: false)
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors numbers free
@@ -795,8 +775,7 @@ USAGE:
    lotus-miner sectors numbers free [command options] [reservation name]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors precommits
@@ -808,8 +787,7 @@ USAGE:
    lotus-miner sectors precommits [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors check-expire
@@ -822,7 +800,7 @@ USAGE:
 
 OPTIONS:
    --cutoff value  skip sectors whose current expiration is more than <cutoff> epochs from now, defaults to 60 days (default: 172800)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner sectors expired
@@ -834,10 +812,10 @@ USAGE:
    lotus-miner sectors expired [command options] [arguments...]
 
 OPTIONS:
-   --expired-epoch value  epoch at which to check sector expirations (default: WinningPoSt lookback epoch)
-   --remove-expired       remove expired sectors (default: false)
    --show-removed         show removed sectors (default: false)
-   
+   --remove-expired       remove expired sectors (default: false)
+   --expired-epoch value  epoch at which to check sector expirations (default: WinningPoSt lookback epoch)
+   --help, -h             show help
 ```
 
 ### lotus-miner sectors extend
@@ -849,19 +827,19 @@ USAGE:
    lotus-miner sectors extend [command options] <sectorNumbers...(optional)>
 
 OPTIONS:
-   --drop-claims           drop claims for sectors that can be extended, but only by dropping some of their verified power claims (default: false)
+   --from value            only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120 (1 hour) (default: 0)
+   --to value              only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 92160 (32 days) (default: 0)
+   --sector-file value     provide a file containing one sector number in each line, ignoring above selecting criteria
    --exclude value         optionally provide a file containing excluding sectors
    --extension value       try to extend selected sectors by this number of epochs, defaults to 540 days (default: 1555200)
-   --from value            only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120 (1 hour) (default: 0)
-   --max-fee value         use up to this amount of FIL for one message. pass this flag to avoid message congestion. (default: "0")
-   --max-sectors value     the maximum number of sectors contained in each message (default: 0)
    --new-expiration value  try to extend selected sectors to this epoch, ignoring extension (default: 0)
    --only-cc               only extend CC sectors (useful for making sector ready for snap upgrade) (default: false)
-   --really-do-it          pass this flag to really extend sectors, otherwise will only print out json representation of parameters (default: false)
-   --sector-file value     provide a file containing one sector number in each line, ignoring above selecting criteria
-   --to value              only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 92160 (32 days) (default: 0)
+   --drop-claims           drop claims for sectors that can be extended, but only by dropping some of their verified power claims (default: false)
    --tolerance value       don't try to extend sectors by fewer than this number of epochs, defaults to 7 days (default: 20160)
-   
+   --max-fee value         use up to this amount of FIL for one message. pass this flag to avoid message congestion. (default: "0")
+   --max-sectors value     the maximum number of sectors contained in each message (default: 0)
+   --really-do-it          pass this flag to really extend sectors, otherwise will only print out json representation of parameters (default: false)
+   --help, -h              show help
 ```
 
 ### lotus-miner sectors terminate
@@ -873,14 +851,13 @@ USAGE:
    lotus-miner sectors terminate command [command options] <sectorNum>
 
 COMMANDS:
-     flush    Send a terminate message if there are sectors queued for termination
-     pending  List sector numbers of sectors pending termination
-     help, h  Shows a list of commands or help for one command
+   flush    Send a terminate message if there are sectors queued for termination
+   pending  List sector numbers of sectors pending termination
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   --help, -h      show help (default: false)
-   
+   --help, -h      show help
 ```
 
 #### lotus-miner sectors terminate flush
@@ -892,8 +869,7 @@ USAGE:
    lotus-miner sectors terminate flush [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors terminate pending
@@ -905,8 +881,7 @@ USAGE:
    lotus-miner sectors terminate pending [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors remove
@@ -919,7 +894,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner sectors snap-up
@@ -931,8 +906,7 @@ USAGE:
    lotus-miner sectors snap-up [command options] <sectorNum>
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors abort-upgrade
@@ -945,7 +919,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner sectors seal
@@ -957,8 +931,7 @@ USAGE:
    lotus-miner sectors seal [command options] <sectorNum>
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors set-seal-delay
@@ -970,8 +943,8 @@ USAGE:
    lotus-miner sectors set-seal-delay [command options] <time>
 
 OPTIONS:
-   --seconds  Specifies that the time argument should be in seconds (default: false)
-   
+   --seconds   Specifies that the time argument should be in seconds (default: false)
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors get-cc-collateral
@@ -984,7 +957,7 @@ USAGE:
 
 OPTIONS:
    --expiration value  the epoch when the sector will expire (default: 0)
-   
+   --help, -h          show help
 ```
 
 ### lotus-miner sectors batching
@@ -996,13 +969,12 @@ USAGE:
    lotus-miner sectors batching command [command options] [arguments...]
 
 COMMANDS:
-     commit     list sectors waiting in commit batch queue
-     precommit  list sectors waiting in precommit batch queue
-     help, h    Shows a list of commands or help for one command
+   commit     list sectors waiting in commit batch queue
+   precommit  list sectors waiting in precommit batch queue
+   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner sectors batching commit
@@ -1015,7 +987,7 @@ USAGE:
 
 OPTIONS:
    --publish-now  send a batch now (default: false)
-   
+   --help, -h     show help
 ```
 
 #### lotus-miner sectors batching precommit
@@ -1028,7 +1000,7 @@ USAGE:
 
 OPTIONS:
    --publish-now  send a batch now (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus-miner sectors match-pending-pieces
@@ -1040,8 +1012,7 @@ USAGE:
    lotus-miner sectors match-pending-pieces [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sectors compact-partitions
@@ -1053,11 +1024,11 @@ USAGE:
    lotus-miner sectors compact-partitions [command options] [arguments...]
 
 OPTIONS:
-   --actor value                              Specify the address of the miner to run this command
    --deadline value                           the deadline to compact the partitions in (default: 0)
    --partitions value [ --partitions value ]  list of partitions to compact sectors in
    --really-do-it                             Actually send transaction performing the action (default: false)
-   
+   --actor value                              Specify the address of the miner to run this command
+   --help, -h                                 show help
 ```
 
 ### lotus-miner sectors unseal
@@ -1069,8 +1040,7 @@ USAGE:
    lotus-miner sectors unseal [command options] [sector number]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner proving
@@ -1082,19 +1052,18 @@ USAGE:
    lotus-miner proving command [command options] [arguments...]
 
 COMMANDS:
-     info            View current state information
-     deadlines       View the current proving period deadlines information
-     deadline        View the current proving period deadline information by its index
-     faults          View the currently known proving faulty sectors information
-     check           Check sectors provable
-     workers         list workers
-     compute         Compute simulated proving tasks
-     recover-faults  Manually recovers faulty sectors on chain
-     help, h         Shows a list of commands or help for one command
+   info            View current state information
+   deadlines       View the current proving period deadlines information
+   deadline        View the current proving period deadline information by its index
+   faults          View the currently known proving faulty sectors information
+   check           Check sectors provable
+   workers         list workers
+   compute         Compute simulated proving tasks
+   recover-faults  Manually recovers faulty sectors on chain
+   help, h         Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner proving info
@@ -1106,8 +1075,7 @@ USAGE:
    lotus-miner proving info [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner proving deadlines
@@ -1119,8 +1087,8 @@ USAGE:
    lotus-miner proving deadlines [command options] [arguments...]
 
 OPTIONS:
-   --all, -a  Count all sectors (only live sectors are counted by default) (default: false)
-   
+   --all, -a   Count all sectors (only live sectors are counted by default) (default: false)
+   --help, -h  show help
 ```
 
 ### lotus-miner proving deadline
@@ -1132,9 +1100,9 @@ USAGE:
    lotus-miner proving deadline [command options] <deadlineIdx>
 
 OPTIONS:
-   --bitfield, -b     Print partition bitfield stats (default: false)
    --sector-nums, -n  Print sector/fault numbers belonging to this deadline (default: false)
-   
+   --bitfield, -b     Print partition bitfield stats (default: false)
+   --help, -h         show help
 ```
 
 ### lotus-miner proving faults
@@ -1146,8 +1114,7 @@ USAGE:
    lotus-miner proving faults [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner proving check
@@ -1159,11 +1126,11 @@ USAGE:
    lotus-miner proving check [command options] <deadlineIdx>
 
 OPTIONS:
-   --faulty            only check faulty sectors (default: false)
    --only-bad          print only bad sectors (default: false)
    --slow              run slower checks (default: false)
    --storage-id value  filter sectors by storage path (path id)
-   
+   --faulty            only check faulty sectors (default: false)
+   --help, -h          show help
 ```
 
 ### lotus-miner proving workers
@@ -1175,8 +1142,7 @@ USAGE:
    lotus-miner proving workers [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner proving compute
@@ -1188,12 +1154,11 @@ USAGE:
    lotus-miner proving compute command [command options] [arguments...]
 
 COMMANDS:
-     windowed-post, window-post  Compute WindowPoSt for a specific deadline
-     help, h                     Shows a list of commands or help for one command
+   windowed-post, window-post  Compute WindowPoSt for a specific deadline
+   help, h                     Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus-miner proving compute windowed-post, window-post
@@ -1210,7 +1175,7 @@ USAGE:
 
 OPTIONS:
    --confidence value  number of block confirmations to wait for (default: 5)
-   
+   --help, -h          show help
 ```
 
 ## lotus-miner storage
@@ -1228,18 +1193,17 @@ DESCRIPTION:
    stored while moving through the sealing pipeline (references as 'seal').
 
 COMMANDS:
-     attach     attach local storage path
-     detach     detach local storage path
-     redeclare  redeclare sectors in a local storage path
-     list       list local storage paths
-     find       find sector in the storage system
-     cleanup    trigger cleanup actions
-     locks      show active sector locks
-     help, h    Shows a list of commands or help for one command
+   attach     attach local storage path
+   detach     detach local storage path
+   redeclare  redeclare sectors in a local storage path
+   list       list local storage paths
+   find       find sector in the storage system
+   cleanup    trigger cleanup actions
+   locks      show active sector locks
+   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner storage attach
@@ -1255,31 +1219,31 @@ DESCRIPTION:
    list is stored local to the miner in $LOTUS_MINER_PATH/storage.json. We do not
    recommend manually modifying this value without further understanding of the
    storage system.
-   
+
    Each storage volume contains a configuration file which describes the
    capabilities of the volume. When the '--init' flag is provided, this file will
    be created using the additional flags.
-   
+
    Weight
    A high weight value means data will be more likely to be stored in this path
-   
+
    Seal
    Data for the sealing process will be stored here
-   
+
    Store
    Finalized sectors that will be moved here for long term storage and be proven
    over time
       
 
 OPTIONS:
-   --allow-to value [ --allow-to value ]  path groups allowed to pull data from this path (allow all if not specified)
-   --groups value [ --groups value ]      path group names
    --init                                 initialize the path first (default: false)
-   --max-storage value                    (for init) limit storage space for sectors (expensive for very large paths!)
+   --weight value                         (for init) path weight (default: 10)
    --seal                                 (for init) use path for sealing (default: false)
    --store                                (for init) use path for long-term storage (default: false)
-   --weight value                         (for init) path weight (default: 10)
-   
+   --max-storage value                    (for init) limit storage space for sectors (expensive for very large paths!)
+   --groups value [ --groups value ]      path group names
+   --allow-to value [ --allow-to value ]  path groups allowed to pull data from this path (allow all if not specified)
+   --help, -h                             show help
 ```
 
 ### lotus-miner storage detach
@@ -1292,7 +1256,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner storage redeclare
@@ -1304,10 +1268,10 @@ USAGE:
    lotus-miner storage redeclare [command options] [path]
 
 OPTIONS:
+   --id value      storage path ID
    --all           redeclare all storage paths (default: false)
    --drop-missing  Drop index entries with missing files (default: true)
-   --id value      storage path ID
-   
+   --help, -h      show help
 ```
 
 ### lotus-miner storage list
@@ -1319,12 +1283,11 @@ USAGE:
    lotus-miner storage list command [command options] [arguments...]
 
 COMMANDS:
-     sectors  get list of all sector files
-     help, h  Shows a list of commands or help for one command
+   sectors  get list of all sector files
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus-miner storage list sectors
@@ -1336,8 +1299,7 @@ USAGE:
    lotus-miner storage list sectors [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner storage find
@@ -1349,8 +1311,7 @@ USAGE:
    lotus-miner storage find [command options] [sector number]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner storage cleanup
@@ -1362,8 +1323,8 @@ USAGE:
    lotus-miner storage cleanup [command options] [arguments...]
 
 OPTIONS:
-   --removed  cleanup remaining files from removed sectors (default: true)
-   
+   --removed   cleanup remaining files from removed sectors (default: true)
+   --help, -h  show help
 ```
 
 ### lotus-miner storage locks
@@ -1375,8 +1336,7 @@ USAGE:
    lotus-miner storage locks [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-miner sealing
@@ -1388,16 +1348,15 @@ USAGE:
    lotus-miner sealing command [command options] [arguments...]
 
 COMMANDS:
-     jobs        list running jobs
-     workers     list workers
-     sched-diag  Dump internal scheduler state
-     abort       Abort a running job
-     data-cid    Compute data CID using workers
-     help, h     Shows a list of commands or help for one command
+   jobs        list running jobs
+   workers     list workers
+   sched-diag  Dump internal scheduler state
+   abort       Abort a running job
+   data-cid    Compute data CID using workers
+   help, h     Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sealing jobs
@@ -1410,7 +1369,7 @@ USAGE:
 
 OPTIONS:
    --show-ret-done  show returned but not consumed calls (default: false)
-   
+   --help, -h       show help
 ```
 
 ### lotus-miner sealing workers
@@ -1422,8 +1381,7 @@ USAGE:
    lotus-miner sealing workers [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-miner sealing sched-diag
@@ -1436,7 +1394,7 @@ USAGE:
 
 OPTIONS:
    --force-sched  (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus-miner sealing abort
@@ -1448,8 +1406,8 @@ USAGE:
    lotus-miner sealing abort [command options] [callid]
 
 OPTIONS:
-   --sched  Specifies that the argument is UUID of the request to be removed from scheduler (default: false)
-   
+   --sched     Specifies that the argument is UUID of the request to be removed from scheduler (default: false)
+   --help, -h  show help
 ```
 
 ### lotus-miner sealing data-cid
@@ -1462,5 +1420,5 @@ USAGE:
 
 OPTIONS:
    --file-size value  real file size (default: 0)
-   
+   --help, -h         show help
 ```

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -19,12 +19,11 @@ COMMANDS:
    help, h    Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --enable-gpu-proving                     enable use of GPU for mining operations (default: true) [$LOTUS_WORKER_ENABLE_GPU_PROVING]
-   --help, -h                               show help (default: false)
-   --miner-repo value, --storagerepo value  Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON (default: "~/.lotusminer") [$LOTUS_MINER_PATH, $LOTUS_STORAGE_PATH]
-   --version, -v                            print the version (default: false)
    --worker-repo value, --workerrepo value  Specify worker repo path. flag workerrepo and env WORKER_PATH are DEPRECATION, will REMOVE SOON (default: "~/.lotusworker") [$LOTUS_WORKER_PATH, $WORKER_PATH]
-   
+   --miner-repo value, --storagerepo value  Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON (default: "~/.lotusminer") [$LOTUS_MINER_PATH, $LOTUS_STORAGE_PATH]
+   --enable-gpu-proving                     enable use of GPU for mining operations (default: true) [$LOTUS_WORKER_ENABLE_GPU_PROVING]
+   --help, -h                               show help
+   --version, -v                            print the version
 ```
 
 ## lotus-worker run
@@ -36,29 +35,29 @@ USAGE:
    lotus-worker run [command options] [arguments...]
 
 OPTIONS:
-   --addpiece                    enable addpiece (default: true) [$LOTUS_WORKER_ADDPIECE]
-   --commit                      enable commit (default: true) [$LOTUS_WORKER_COMMIT]
-   --data-cid                    Run the data-cid task. true|false (default: inherits --addpiece)
-   --http-server-timeout value   (default: "30s")
    --listen value                host address and port the worker api will listen on (default: "0.0.0.0:3456") [$LOTUS_WORKER_LISTEN]
-   --name value                  custom worker name (default: hostname) [$LOTUS_WORKER_NAME]
-   --no-default                  disable all default compute tasks, use the worker for storage/fetching only (default: false) [$LOTUS_WORKER_NO_DEFAULT]
    --no-local-storage            don't use storageminer repo for sector storage (default: false) [$LOTUS_WORKER_NO_LOCAL_STORAGE]
    --no-swap                     don't use swap (default: false) [$LOTUS_WORKER_NO_SWAP]
+   --name value                  custom worker name (default: hostname) [$LOTUS_WORKER_NAME]
+   --addpiece                    enable addpiece (default: true) [$LOTUS_WORKER_ADDPIECE]
+   --precommit1                  enable precommit1 (default: true) [$LOTUS_WORKER_PRECOMMIT1]
+   --unseal                      enable unsealing (default: true) [$LOTUS_WORKER_UNSEAL]
+   --precommit2                  enable precommit2 (default: true) [$LOTUS_WORKER_PRECOMMIT2]
+   --commit                      enable commit (default: true) [$LOTUS_WORKER_COMMIT]
+   --replica-update              enable replica update (default: true) [$LOTUS_WORKER_REPLICA_UPDATE]
+   --prove-replica-update2       enable prove replica update 2 (default: true) [$LOTUS_WORKER_PROVE_REPLICA_UPDATE2]
+   --regen-sector-key            enable regen sector key (default: true) [$LOTUS_WORKER_REGEN_SECTOR_KEY]
+   --sector-download             enable external sector data download (default: false) [$LOTUS_WORKER_SECTOR_DOWNLOAD]
+   --windowpost                  enable window post (default: false) [$LOTUS_WORKER_WINDOWPOST]
+   --winningpost                 enable winning post (default: false) [$LOTUS_WORKER_WINNINGPOST]
+   --no-default                  disable all default compute tasks, use the worker for storage/fetching only (default: false) [$LOTUS_WORKER_NO_DEFAULT]
    --parallel-fetch-limit value  maximum fetch operations to run in parallel (default: 5) [$LOTUS_WORKER_PARALLEL_FETCH_LIMIT]
    --post-parallel-reads value   maximum number of parallel challenge reads (0 = no limit) (default: 32) [$LOTUS_WORKER_POST_PARALLEL_READS]
    --post-read-timeout value     time limit for reading PoSt challenges (0 = no limit) (default: 0s) [$LOTUS_WORKER_POST_READ_TIMEOUT]
-   --precommit1                  enable precommit1 (default: true) [$LOTUS_WORKER_PRECOMMIT1]
-   --precommit2                  enable precommit2 (default: true) [$LOTUS_WORKER_PRECOMMIT2]
-   --prove-replica-update2       enable prove replica update 2 (default: true) [$LOTUS_WORKER_PROVE_REPLICA_UPDATE2]
-   --regen-sector-key            enable regen sector key (default: true) [$LOTUS_WORKER_REGEN_SECTOR_KEY]
-   --replica-update              enable replica update (default: true) [$LOTUS_WORKER_REPLICA_UPDATE]
-   --sector-download             enable external sector data download (default: false) [$LOTUS_WORKER_SECTOR_DOWNLOAD]
    --timeout value               used when 'listen' is unspecified. must be a valid duration recognized by golang's time.ParseDuration function (default: "30m") [$LOTUS_WORKER_TIMEOUT]
-   --unseal                      enable unsealing (default: true) [$LOTUS_WORKER_UNSEAL]
-   --windowpost                  enable window post (default: false) [$LOTUS_WORKER_WINDOWPOST]
-   --winningpost                 enable winning post (default: false) [$LOTUS_WORKER_WINNINGPOST]
-   
+   --http-server-timeout value   (default: "30s")
+   --data-cid                    Run the data-cid task. true|false (default: inherits --addpiece)
+   --help, -h                    show help
 ```
 
 ## lotus-worker stop
@@ -70,8 +69,7 @@ USAGE:
    lotus-worker stop [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-worker info
@@ -83,8 +81,7 @@ USAGE:
    lotus-worker info [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus-worker storage
@@ -96,14 +93,13 @@ USAGE:
    lotus-worker storage command [command options] [arguments...]
 
 COMMANDS:
-     attach     attach local storage path
-     detach     detach local storage path
-     redeclare  redeclare sectors in a local storage path
-     help, h    Shows a list of commands or help for one command
+   attach     attach local storage path
+   detach     detach local storage path
+   redeclare  redeclare sectors in a local storage path
+   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-worker storage attach
@@ -115,14 +111,14 @@ USAGE:
    lotus-worker storage attach [command options] [arguments...]
 
 OPTIONS:
-   --allow-to value [ --allow-to value ]  path groups allowed to pull data from this path (allow all if not specified)
-   --groups value [ --groups value ]      path group names
    --init                                 initialize the path first (default: false)
-   --max-storage value                    (for init) limit storage space for sectors (expensive for very large paths!)
+   --weight value                         (for init) path weight (default: 10)
    --seal                                 (for init) use path for sealing (default: false)
    --store                                (for init) use path for long-term storage (default: false)
-   --weight value                         (for init) path weight (default: 10)
-   
+   --max-storage value                    (for init) limit storage space for sectors (expensive for very large paths!)
+   --groups value [ --groups value ]      path group names
+   --allow-to value [ --allow-to value ]  path groups allowed to pull data from this path (allow all if not specified)
+   --help, -h                             show help
 ```
 
 ### lotus-worker storage detach
@@ -135,7 +131,7 @@ USAGE:
 
 OPTIONS:
    --really-do-it  (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus-worker storage redeclare
@@ -147,10 +143,10 @@ USAGE:
    lotus-worker storage redeclare [command options] [arguments...]
 
 OPTIONS:
+   --id value      storage path ID
    --all           redeclare all storage paths (default: false)
    --drop-missing  Drop index entries with missing files (default: true)
-   --id value      storage path ID
-   
+   --help, -h      show help
 ```
 
 ## lotus-worker resources
@@ -162,9 +158,9 @@ USAGE:
    lotus-worker resources [command options] [arguments...]
 
 OPTIONS:
-   --all      print all resource envvars (default: false)
-   --default  print default resource envvars (default: false)
-   
+   --all       print all resource envvars (default: false)
+   --default   print default resource envvars (default: false)
+   --help, -h  show help
 ```
 
 ## lotus-worker tasks
@@ -176,13 +172,12 @@ USAGE:
    lotus-worker tasks command [command options] [arguments...]
 
 COMMANDS:
-     enable   Enable a task type
-     disable  Disable a task type
-     help, h  Shows a list of commands or help for one command
+   enable   Enable a task type
+   disable  Disable a task type
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus-worker tasks enable
@@ -194,8 +189,8 @@ USAGE:
    lotus-worker tasks enable [command options] --all | [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
-   --all  Enable all task types (default: false)
-   
+   --all       Enable all task types (default: false)
+   --help, -h  show help
 ```
 
 ### lotus-worker tasks disable
@@ -207,6 +202,6 @@ USAGE:
    lotus-worker tasks disable [command options] --all | [UNS|C2|PC2|PC1|PR2|RU|AP|DC|GSK]
 
 OPTIONS:
-   --all  Disable all task types (default: false)
-   
+   --all       Disable all task types (default: false)
+   --help, -h  show help
 ```

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -40,12 +40,11 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --color        use color in display output (default: depends on output being a TTY)
-   --force-send   if true, will ignore pre-send checks (default: false)
-   --help, -h     show help (default: false)
    --interactive  setting to false will disable interactive functionality of commands (default: false)
-   --version, -v  print the version (default: false)
+   --force-send   if true, will ignore pre-send checks (default: false)
    --vv           enables very verbose mode, useful for debugging the CLI (default: false)
-   
+   --help, -h     show help
+   --version, -v  print the version
 ```
 
 ## lotus daemon
@@ -57,8 +56,8 @@ USAGE:
    lotus daemon command [command options] [arguments...]
 
 COMMANDS:
-     stop     Stop a running lotus daemon
-     help, h  Shows a list of commands or help for one command
+   stop     Stop a running lotus daemon
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --api value               (default: "1234")
@@ -75,8 +74,7 @@ OPTIONS:
    --api-max-req-size value  maximum API request size accepted by the JSON RPC server (default: 0)
    --restore value           restore from backup file
    --restore-config value    config file to use when restoring from backup
-   --help, -h                show help (default: false)
-   
+   --help, -h                show help
 ```
 
 ### lotus daemon stop
@@ -88,8 +86,7 @@ USAGE:
    lotus daemon stop [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus backup
@@ -102,15 +99,15 @@ USAGE:
 
 DESCRIPTION:
    The backup command writes a copy of node metadata under the specified path
-   
+
    Online backups:
    For security reasons, the daemon must be have LOTUS_BACKUP_BASE_PATH env var set
    to a path where backup files are supposed to be saved, and the path specified in
    this command must be within this base path
 
 OPTIONS:
-   --offline  create backup without the node running (default: false)
-   
+   --offline   create backup without the node running (default: false)
+   --help, -h  show help
 ```
 
 ## lotus config
@@ -122,13 +119,12 @@ USAGE:
    lotus config command [command options] [arguments...]
 
 COMMANDS:
-     default  Print default node config
-     updated  Print updated node config
-     help, h  Shows a list of commands or help for one command
+   default  Print default node config
+   updated  Print updated node config
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus config default
@@ -141,7 +137,7 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   
+   --help, -h    show help
 ```
 
 ### lotus config updated
@@ -154,7 +150,7 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   
+   --help, -h    show help
 ```
 
 ## lotus version
@@ -166,8 +162,7 @@ USAGE:
    lotus version [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus send
@@ -182,17 +177,17 @@ CATEGORY:
    BASIC
 
 OPTIONS:
-   --force                Deprecated: use global 'force-send' (default: false)
    --from value           optionally specify the account to send funds from
    --from-eth-addr value  optionally specify the eth addr to send funds from
+   --gas-premium value    specify gas price to use in AttoFIL (default: "0")
    --gas-feecap value     specify gas fee cap to use in AttoFIL (default: "0")
    --gas-limit value      specify gas limit (default: 0)
-   --gas-premium value    specify gas price to use in AttoFIL (default: "0")
-   --method value         specify method to invoke (default: 0)
    --nonce value          specify the nonce to use (default: 0)
-   --params-hex value     specify invocation parameters in hex
+   --method value         specify method to invoke (default: 0)
    --params-json value    specify invocation parameters in json
-   
+   --params-hex value     specify invocation parameters in hex
+   --force                Deprecated: use global 'force-send' (default: false)
+   --help, -h             show help
 ```
 
 ## lotus wallet
@@ -204,22 +199,21 @@ USAGE:
    lotus wallet command [command options] [arguments...]
 
 COMMANDS:
-     new          Generate a new key of the given type
-     list         List wallet address
-     balance      Get account balance
-     export       export keys
-     import       import keys
-     default      Get default wallet address
-     set-default  Set default wallet address
-     sign         sign a message
-     verify       verify the signature of a message
-     delete       Soft delete an address from the wallet - hard deletion needed for permanent removal
-     market       Interact with market balances
-     help, h      Shows a list of commands or help for one command
+   new          Generate a new key of the given type
+   list         List wallet address
+   balance      Get account balance
+   export       export keys
+   import       import keys
+   default      Get default wallet address
+   set-default  Set default wallet address
+   sign         sign a message
+   verify       verify the signature of a message
+   delete       Soft delete an address from the wallet - hard deletion needed for permanent removal
+   market       Interact with market balances
+   help, h      Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet new
@@ -231,8 +225,7 @@ USAGE:
    lotus wallet new [command options] [bls|secp256k1 (default secp256k1)]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet list
@@ -247,7 +240,7 @@ OPTIONS:
    --addr-only, -a  Only print addresses (default: false)
    --id, -i         Output ID addresses (default: false)
    --market, -m     Output market balances (default: false)
-   
+   --help, -h       show help
 ```
 
 ### lotus wallet balance
@@ -259,8 +252,7 @@ USAGE:
    lotus wallet balance [command options] [address]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet export
@@ -272,8 +264,7 @@ USAGE:
    lotus wallet export [command options] [address]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet import
@@ -285,9 +276,9 @@ USAGE:
    lotus wallet import [command options] [<path> (optional, will read from stdin if omitted)]
 
 OPTIONS:
-   --as-default    import the given key as your new default key (default: false)
    --format value  specify input format for key (default: "hex-lotus")
-   
+   --as-default    import the given key as your new default key (default: false)
+   --help, -h      show help
 ```
 
 ### lotus wallet default
@@ -299,8 +290,7 @@ USAGE:
    lotus wallet default [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet set-default
@@ -312,8 +302,7 @@ USAGE:
    lotus wallet set-default [command options] [address]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet sign
@@ -325,8 +314,7 @@ USAGE:
    lotus wallet sign [command options] <signing address> <hexMessage>
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet verify
@@ -338,8 +326,7 @@ USAGE:
    lotus wallet verify [command options] <signing address> <hexMessage> <signature>
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet delete
@@ -351,8 +338,7 @@ USAGE:
    lotus wallet delete [command options] <address> 
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus wallet market
@@ -364,13 +350,12 @@ USAGE:
    lotus wallet market command [command options] [arguments...]
 
 COMMANDS:
-     withdraw  Withdraw funds from the Storage Market Actor
-     add       Add funds to the Storage Market Actor
-     help, h   Shows a list of commands or help for one command
+   withdraw  Withdraw funds from the Storage Market Actor
+   add       Add funds to the Storage Market Actor
+   help, h   Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus wallet market withdraw
@@ -382,10 +367,10 @@ USAGE:
    lotus wallet market withdraw [command options] [amount (FIL) optional, otherwise will withdraw max available]
 
 OPTIONS:
+   --wallet value, -w value   Specify address to withdraw funds to, otherwise it will use the default wallet address
    --address value, -a value  Market address to withdraw from (account or miner actor address, defaults to --wallet address)
    --confidence value         number of block confirmations to wait for (default: 5)
-   --wallet value, -w value   Specify address to withdraw funds to, otherwise it will use the default wallet address
-   
+   --help, -h                 show help
 ```
 
 #### lotus wallet market add
@@ -397,9 +382,9 @@ USAGE:
    lotus wallet market add [command options] <amount>
 
 OPTIONS:
-   --address value, -a value  Market address to move funds to (account or miner actor address, defaults to --from address)
    --from value, -f value     Specify address to move funds from, otherwise it will use the default wallet address
-   
+   --address value, -a value  Market address to move funds to (account or miner actor address, defaults to --from address)
+   --help, -h                 show help
 ```
 
 ## lotus info
@@ -414,8 +399,7 @@ CATEGORY:
    BASIC
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus client
@@ -427,7 +411,7 @@ USAGE:
    lotus client command [command options] [arguments...]
 
 COMMANDS:
-     help, h  Shows a list of commands or help for one command
+   help, h  Shows a list of commands or help for one command
    DATA:
      import  Import data
      drop    Remove import
@@ -458,8 +442,7 @@ COMMANDS:
      cancel-transfer   Force cancel a data transfer
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus client import
@@ -476,7 +459,7 @@ CATEGORY:
 OPTIONS:
    --car        import from a car file instead of a regular file (default: false)
    --quiet, -q  Output root CID only (default: false)
-   
+   --help, -h   show help
 ```
 
 ### lotus client drop
@@ -491,8 +474,7 @@ CATEGORY:
    DATA
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus client local
@@ -507,7 +489,7 @@ CATEGORY:
    DATA
 
 OPTIONS:
-   
+   --help, -h  show help
 ```
 
 ### lotus client stat
@@ -522,8 +504,7 @@ CATEGORY:
    DATA
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus client find
@@ -539,7 +520,7 @@ CATEGORY:
 
 OPTIONS:
    --pieceCid value  require data to be retrieved from a specific Piece CID
-   
+   --help, -h        show help
 ```
 
 ### lotus client retrieval-ask
@@ -555,7 +536,7 @@ CATEGORY:
 
 OPTIONS:
    --size value  data size in bytes (default: 0)
-   
+   --help, -h    show help
 ```
 
 ### lotus client retrieve
@@ -571,48 +552,48 @@ CATEGORY:
 
 DESCRIPTION:
    Retrieve data from the Filecoin network.
-   
+
    The retrieve command will attempt to find a provider make a retrieval deal with
    them. In case a provider can't be found, it can be specified with the --provider
    flag.
-   
+
    By default the data will be interpreted as DAG-PB UnixFSv1 File. Alternatively
    a CAR file containing the raw IPLD graph can be exported by setting the --car
    flag.
-   
+
    Partial Retrieval:
-   
+
    The --data-selector flag can be used to specify a sub-graph to fetch. The
    selector can be specified as either IPLD datamodel text-path selector, or IPLD
    json selector.
-   
+
    In case of unixfs retrieval, the selector must point at a single root node, and
    match the entire graph under that node.
-   
+
    In case of CAR retrieval, the selector must have one common "sub-root" node.
-   
+
    Examples:
-   
+
    - Retrieve a file by CID
      $ lotus client retrieve Qm... my-file.txt
-   
+
    - Retrieve a file by CID from f0123
      $ lotus client retrieve --provider f0123 Qm... my-file.txt
-   
+
    - Retrieve a first file from a specified directory
      $ lotus client retrieve --data-selector /Links/0/Hash Qm... my-file.txt
-   
+
 
 OPTIONS:
-   --allow-local                                           (default: false)
    --car                                                   Export to a car file instead of a regular file (default: false)
-   --car-export-merkle-proof                               (requires --data-selector and --car) Export data-selector merkle proof (default: false)
    --data-selector value, --datamodel-path-selector value  IPLD datamodel text-path selector, or IPLD json selector
+   --car-export-merkle-proof                               (requires --data-selector and --car) Export data-selector merkle proof (default: false)
    --from value                                            address to send transactions from
+   --provider value, --miner value                         provider to use for retrieval, if not present it'll use local discovery
    --maxPrice value                                        maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                                        require data to be retrieved from a specific Piece CID
-   --provider value, --miner value                         provider to use for retrieval, if not present it'll use local discovery
-   
+   --allow-local                                           (default: false)
+   --help, -h                                              show help
 ```
 
 ### lotus client cat
@@ -627,14 +608,14 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --allow-local                    (default: false)
+   --ipld                           list IPLD datamodel links (default: false)
    --data-selector value            IPLD datamodel text-path selector, or IPLD json selector
    --from value                     address to send transactions from
-   --ipld                           list IPLD datamodel links (default: false)
+   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
    --maxPrice value                 maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                 require data to be retrieved from a specific Piece CID
-   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
-   
+   --allow-local                    (default: false)
+   --help, -h                       show help
 ```
 
 ### lotus client ls
@@ -649,15 +630,15 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --allow-local                    (default: false)
-   --data-selector value            IPLD datamodel text-path selector, or IPLD json selector
-   --depth value                    list links recursively up to the specified depth (default: 1)
-   --from value                     address to send transactions from
    --ipld                           list IPLD datamodel links (default: false)
+   --depth value                    list links recursively up to the specified depth (default: 1)
+   --data-selector value            IPLD datamodel text-path selector, or IPLD json selector
+   --from value                     address to send transactions from
+   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
    --maxPrice value                 maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                 require data to be retrieved from a specific Piece CID
-   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
-   
+   --allow-local                    (default: false)
+   --help, -h                       show help
 ```
 
 ### lotus client cancel-retrieval
@@ -673,7 +654,7 @@ CATEGORY:
 
 OPTIONS:
    --deal-id value  specify retrieval deal by deal ID (default: 0)
-   
+   --help, -h       show help
 ```
 
 ### lotus client list-retrievals
@@ -688,11 +669,11 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --completed    show completed retrievals (default: false)
-   --show-failed  show failed/failing deals (default: true)
    --verbose, -v  print verbose deal details (default: false)
+   --show-failed  show failed/failing deals (default: true)
+   --completed    show completed retrievals (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus client deal
@@ -717,15 +698,15 @@ DESCRIPTION:
    The minimum value is 518400 (6 months).
 
 OPTIONS:
-   --fast-retrieval             indicates that data should be available for fast retrieval (default: true)
-   --from value                 specify address to fund the deal with
    --manual-piece-cid value     manually specify piece commitment for data (dataCid must be to a car file)
    --manual-piece-size value    if manually specifying piece cid, used to specify size (dataCid must be to a car file) (default: 0)
    --manual-stateless-deal      instructs the node to send an offline deal without registering it with the deallist/fsm (default: false)
-   --provider-collateral value  specify the requested provider collateral the miner should put up
+   --from value                 specify address to fund the deal with
    --start-epoch value          specify the epoch that the deal should start at (default: -1)
+   --fast-retrieval             indicates that data should be available for fast retrieval (default: true)
    --verified-deal              indicate that the deal counts towards verified client total (default: true if client is verified, false otherwise)
-   
+   --provider-collateral value  specify the requested provider collateral the miner should put up
+   --help, -h                   show help
 ```
 
 ### lotus client query-ask
@@ -740,10 +721,10 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
-   --duration value  deal duration (default: 0)
    --peerid value    specify peer ID of node to make query against
    --size value      data size in bytes (default: 0)
-   
+   --duration value  deal duration (default: 0)
+   --help, -h        show help
 ```
 
 ### lotus client list-deals
@@ -758,10 +739,10 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
-   --show-failed  show failed/failing deals (default: false)
    --verbose, -v  print verbose deal details (default: false)
+   --show-failed  show failed/failing deals (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus client get-deal
@@ -776,8 +757,7 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus client list-asks
@@ -795,7 +775,7 @@ OPTIONS:
    --by-ping              sort by ping (default: false)
    --output-format value  Either 'text' or 'csv' (default: "text")
    --protocols            Output supported deal protocols (default: false)
-   
+   --help, -h             show help
 ```
 
 ### lotus client deal-stats
@@ -811,7 +791,7 @@ CATEGORY:
 
 OPTIONS:
    --newer-than value  (default: 0s)
-   
+   --help, -h          show help
 ```
 
 ### lotus client inspect-deal
@@ -828,7 +808,7 @@ CATEGORY:
 OPTIONS:
    --deal-id value       (default: 0)
    --proposal-cid value  
-   
+   --help, -h            show help
 ```
 
 ### lotus client commP
@@ -843,7 +823,7 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   
+   --help, -h  show help
 ```
 
 ### lotus client generate-car
@@ -858,8 +838,7 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus client balances
@@ -875,7 +854,7 @@ CATEGORY:
 
 OPTIONS:
    --client value  specify storage client address
-   
+   --help, -h      show help
 ```
 
 ### lotus client list-transfers
@@ -890,11 +869,11 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --completed    show completed data transfers (default: false)
-   --show-failed  show failed/cancelled transfers (default: false)
    --verbose, -v  print verbose transfer details (default: false)
+   --completed    show completed data transfers (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   
+   --show-failed  show failed/cancelled transfers (default: false)
+   --help, -h     show help
 ```
 
 ### lotus client restart-transfer
@@ -909,9 +888,9 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --initiator     specify only transfers where peer is/is not initiator (default: true)
    --peerid value  narrow to transfer with specific peer
-   
+   --initiator     specify only transfers where peer is/is not initiator (default: true)
+   --help, -h      show help
 ```
 
 ### lotus client cancel-transfer
@@ -926,10 +905,10 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --cancel-timeout value  time to wait for cancel to be sent to storage provider (default: 5s)
-   --initiator             specify only transfers where peer is/is not initiator (default: true)
    --peerid value          narrow to transfer with specific peer
-   
+   --initiator             specify only transfers where peer is/is not initiator (default: true)
+   --cancel-timeout value  time to wait for cancel to be sent to storage provider (default: 5s)
+   --help, -h              show help
 ```
 
 ## lotus msig
@@ -941,29 +920,28 @@ USAGE:
    lotus msig command [command options] [arguments...]
 
 COMMANDS:
-     create             Create a new multisig wallet
-     inspect            Inspect a multisig wallet
-     propose            Propose a multisig transaction
-     propose-remove     Propose to remove a signer
-     approve            Approve a multisig message
-     cancel             Cancel a multisig message
-     add-propose        Propose to add a signer
-     add-approve        Approve a message to add a signer
-     add-cancel         Cancel a message to add a signer
-     swap-propose       Propose to swap signers
-     swap-approve       Approve a message to swap signers
-     swap-cancel        Cancel a message to swap signers
-     lock-propose       Propose to lock up some balance
-     lock-approve       Approve a message to lock up some balance
-     lock-cancel        Cancel a message to lock up some balance
-     vested             Gets the amount vested in an msig between two epochs
-     propose-threshold  Propose setting a different signing threshold on the account
-     help, h            Shows a list of commands or help for one command
+   create             Create a new multisig wallet
+   inspect            Inspect a multisig wallet
+   propose            Propose a multisig transaction
+   propose-remove     Propose to remove a signer
+   approve            Approve a multisig message
+   cancel             Cancel a multisig message
+   add-propose        Propose to add a signer
+   add-approve        Approve a message to add a signer
+   add-cancel         Cancel a message to add a signer
+   swap-propose       Propose to swap signers
+   swap-approve       Approve a message to swap signers
+   swap-cancel        Cancel a message to swap signers
+   lock-propose       Propose to lock up some balance
+   lock-approve       Approve a message to lock up some balance
+   lock-cancel        Cancel a message to lock up some balance
+   vested             Gets the amount vested in an msig between two epochs
+   propose-threshold  Propose setting a different signing threshold on the account
+   help, h            Shows a list of commands or help for one command
 
 OPTIONS:
    --confidence value  number of block confirmations to wait for (default: 5)
-   --help, -h          show help (default: false)
-   
+   --help, -h          show help
 ```
 
 ### lotus msig create
@@ -975,11 +953,11 @@ USAGE:
    lotus msig create [command options] [address1 address2 ...]
 
 OPTIONS:
-   --duration value  length of the period over which funds unlock (default: "0")
-   --from value      account to send the create message from
    --required value  number of required approvals (uses number of signers provided if omitted) (default: 0)
    --value value     initial funds to give to multisig (default: "0")
-   
+   --duration value  length of the period over which funds unlock (default: "0")
+   --from value      account to send the create message from
+   --help, -h        show help
 ```
 
 ### lotus msig inspect
@@ -991,9 +969,9 @@ USAGE:
    lotus msig inspect [command options] [address]
 
 OPTIONS:
-   --decode-params  Decode parameters of transaction proposals (default: false)
    --vesting        Include vesting details (default: false)
-   
+   --decode-params  Decode parameters of transaction proposals (default: false)
+   --help, -h       show help
 ```
 
 ### lotus msig propose
@@ -1006,7 +984,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the propose message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig propose-remove
@@ -1020,7 +998,7 @@ USAGE:
 OPTIONS:
    --decrease-threshold  whether the number of required signers should be decreased (default: false)
    --from value          account to send the propose message from
-   
+   --help, -h            show help
 ```
 
 ### lotus msig approve
@@ -1033,7 +1011,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig cancel
@@ -1046,7 +1024,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the cancel message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig add-propose
@@ -1058,9 +1036,9 @@ USAGE:
    lotus msig add-propose [command options] [multisigAddress signer]
 
 OPTIONS:
-   --from value          account to send the propose message from
    --increase-threshold  whether the number of required signers should be increased (default: false)
-   
+   --from value          account to send the propose message from
+   --help, -h            show help
 ```
 
 ### lotus msig add-approve
@@ -1073,7 +1051,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig add-cancel
@@ -1086,7 +1064,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig swap-propose
@@ -1099,7 +1077,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig swap-approve
@@ -1112,7 +1090,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig swap-cancel
@@ -1125,7 +1103,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig lock-propose
@@ -1138,7 +1116,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the propose message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig lock-approve
@@ -1151,7 +1129,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig lock-cancel
@@ -1164,7 +1142,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the cancel message from
-   
+   --help, -h    show help
 ```
 
 ### lotus msig vested
@@ -1176,9 +1154,9 @@ USAGE:
    lotus msig vested [command options] [multisigAddress]
 
 OPTIONS:
-   --end-epoch value    end epoch to stop measure vesting at (default: -1)
    --start-epoch value  start epoch to measure vesting from (default: 0)
-   
+   --end-epoch value    end epoch to stop measure vesting at (default: -1)
+   --help, -h           show help
 ```
 
 ### lotus msig propose-threshold
@@ -1191,7 +1169,7 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the proposal from
-   
+   --help, -h    show help
 ```
 
 ## lotus filplus
@@ -1203,21 +1181,20 @@ USAGE:
    lotus filplus command [command options] [arguments...]
 
 COMMANDS:
-     grant-datacap                  give allowance to the specified verified client address
-     list-notaries                  list all notaries
-     list-clients                   list all verified clients
-     check-client-datacap           check verified client remaining bytes
-     check-notary-datacap           check a notary's remaining bytes
-     sign-remove-data-cap-proposal  allows a notary to sign a Remove Data Cap Proposal
-     list-allocations               List allocations made by client
-     list-claims                    List claims made by provider
-     remove-expired-allocations     remove expired allocations (if no allocations are specified all eligible allocations are removed)
-     remove-expired-claims          remove expired claims (if no claims are specified all eligible claims are removed)
-     help, h                        Shows a list of commands or help for one command
+   grant-datacap                  give allowance to the specified verified client address
+   list-notaries                  list all notaries
+   list-clients                   list all verified clients
+   check-client-datacap           check verified client remaining bytes
+   check-notary-datacap           check a notary's remaining bytes
+   sign-remove-data-cap-proposal  allows a notary to sign a Remove Data Cap Proposal
+   list-allocations               List allocations made by client
+   list-claims                    List claims made by provider
+   remove-expired-allocations     remove expired allocations (if no allocations are specified all eligible allocations are removed)
+   remove-expired-claims          remove expired claims (if no claims are specified all eligible claims are removed)
+   help, h                        Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus grant-datacap
@@ -1230,7 +1207,7 @@ USAGE:
 
 OPTIONS:
    --from value  specify your notary address to send the message from
-   
+   --help, -h    show help
 ```
 
 ### lotus filplus list-notaries
@@ -1242,8 +1219,7 @@ USAGE:
    lotus filplus list-notaries [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus list-clients
@@ -1255,8 +1231,7 @@ USAGE:
    lotus filplus list-clients [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus check-client-datacap
@@ -1268,8 +1243,7 @@ USAGE:
    lotus filplus check-client-datacap [command options] clientAddress
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus check-notary-datacap
@@ -1281,8 +1255,7 @@ USAGE:
    lotus filplus check-notary-datacap [command options] notaryAddress
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus sign-remove-data-cap-proposal
@@ -1295,7 +1268,7 @@ USAGE:
 
 OPTIONS:
    --id value  specify the RemoveDataCapProposal ID (will look up on chain if unspecified) (default: 0)
-   
+   --help, -h  show help
 ```
 
 ### lotus filplus list-allocations
@@ -1307,8 +1280,8 @@ USAGE:
    lotus filplus list-allocations [command options] clientAddress
 
 OPTIONS:
-   --expired  list only expired allocations (default: false)
-   
+   --expired   list only expired allocations (default: false)
+   --help, -h  show help
 ```
 
 ### lotus filplus list-claims
@@ -1320,8 +1293,8 @@ USAGE:
    lotus filplus list-claims [command options] providerAddress
 
 OPTIONS:
-   --expired  list only expired claims (default: false)
-   
+   --expired   list only expired claims (default: false)
+   --help, -h  show help
 ```
 
 ### lotus filplus remove-expired-allocations
@@ -1334,7 +1307,7 @@ USAGE:
 
 OPTIONS:
    --from value  optionally specify the account to send the message from
-   
+   --help, -h    show help
 ```
 
 ### lotus filplus remove-expired-claims
@@ -1347,7 +1320,7 @@ USAGE:
 
 OPTIONS:
    --from value  optionally specify the account to send the message from
-   
+   --help, -h    show help
 ```
 
 ## lotus paych
@@ -1359,18 +1332,17 @@ USAGE:
    lotus paych command [command options] [arguments...]
 
 COMMANDS:
-     add-funds          Add funds to the payment channel between fromAddress and toAddress. Creates the payment channel if it doesn't already exist.
-     list               List all locally registered payment channels
-     voucher            Interact with payment channel vouchers
-     settle             Settle a payment channel
-     status             Show the status of an outbound payment channel
-     status-by-from-to  Show the status of an active outbound payment channel by from/to addresses
-     collect            Collect funds for a payment channel
-     help, h            Shows a list of commands or help for one command
+   add-funds          Add funds to the payment channel between fromAddress and toAddress. Creates the payment channel if it doesn't already exist.
+   list               List all locally registered payment channels
+   voucher            Interact with payment channel vouchers
+   settle             Settle a payment channel
+   status             Show the status of an outbound payment channel
+   status-by-from-to  Show the status of an active outbound payment channel by from/to addresses
+   collect            Collect funds for a payment channel
+   help, h            Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych add-funds
@@ -1382,9 +1354,9 @@ USAGE:
    lotus paych add-funds [command options] [fromAddress toAddress amount]
 
 OPTIONS:
-   --reserve             mark funds as reserved (default: false)
    --restart-retrievals  restart stalled retrieval deals on this payment channel (default: true)
-   
+   --reserve             mark funds as reserved (default: false)
+   --help, -h            show help
 ```
 
 ### lotus paych list
@@ -1396,8 +1368,7 @@ USAGE:
    lotus paych list [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych voucher
@@ -1409,17 +1380,16 @@ USAGE:
    lotus paych voucher command [command options] [arguments...]
 
 COMMANDS:
-     create          Create a signed payment channel voucher
-     check           Check validity of payment channel voucher
-     add             Add payment channel voucher to local datastore
-     list            List stored vouchers for a given payment channel
-     best-spendable  Print vouchers with highest value that is currently spendable for each lane
-     submit          Submit voucher to chain to update payment channel state
-     help, h         Shows a list of commands or help for one command
+   create          Create a signed payment channel voucher
+   check           Check validity of payment channel voucher
+   add             Add payment channel voucher to local datastore
+   list            List stored vouchers for a given payment channel
+   best-spendable  Print vouchers with highest value that is currently spendable for each lane
+   submit          Submit voucher to chain to update payment channel state
+   help, h         Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus paych voucher create
@@ -1432,7 +1402,7 @@ USAGE:
 
 OPTIONS:
    --lane value  specify payment channel lane to use (default: 0)
-   
+   --help, -h    show help
 ```
 
 #### lotus paych voucher check
@@ -1444,8 +1414,7 @@ USAGE:
    lotus paych voucher check [command options] [channelAddress voucher]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus paych voucher add
@@ -1457,8 +1426,7 @@ USAGE:
    lotus paych voucher add [command options] [channelAddress voucher]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus paych voucher list
@@ -1470,8 +1438,8 @@ USAGE:
    lotus paych voucher list [command options] [channelAddress]
 
 OPTIONS:
-   --export  Print voucher as serialized string (default: false)
-   
+   --export    Print voucher as serialized string (default: false)
+   --help, -h  show help
 ```
 
 #### lotus paych voucher best-spendable
@@ -1483,8 +1451,8 @@ USAGE:
    lotus paych voucher best-spendable [command options] [channelAddress]
 
 OPTIONS:
-   --export  Print voucher as serialized string (default: false)
-   
+   --export    Print voucher as serialized string (default: false)
+   --help, -h  show help
 ```
 
 #### lotus paych voucher submit
@@ -1496,8 +1464,7 @@ USAGE:
    lotus paych voucher submit [command options] [channelAddress voucher]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych settle
@@ -1509,8 +1476,7 @@ USAGE:
    lotus paych settle [command options] [channelAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych status
@@ -1522,8 +1488,7 @@ USAGE:
    lotus paych status [command options] [channelAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych status-by-from-to
@@ -1535,8 +1500,7 @@ USAGE:
    lotus paych status-by-from-to [command options] [fromAddress toAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus paych collect
@@ -1548,8 +1512,7 @@ USAGE:
    lotus paych collect [command options] [channelAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus auth
@@ -1561,13 +1524,12 @@ USAGE:
    lotus auth command [command options] [arguments...]
 
 COMMANDS:
-     create-token  Create token
-     api-info      Get token with API info required to connect to this node
-     help, h       Shows a list of commands or help for one command
+   create-token  Create token
+   api-info      Get token with API info required to connect to this node
+   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus auth create-token
@@ -1580,7 +1542,7 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   
+   --help, -h    show help
 ```
 
 ### lotus auth api-info
@@ -1593,7 +1555,7 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   
+   --help, -h    show help
 ```
 
 ## lotus mpool
@@ -1605,19 +1567,18 @@ USAGE:
    lotus mpool command [command options] [arguments...]
 
 COMMANDS:
-     pending   Get pending messages
-     sub       Subscribe to mpool changes
-     stat      print mempool stats
-     replace   replace a message in the mempool
-     find      find a message in the mempool
-     config    get or set current mpool configuration
-     gas-perf  Check gas performance of messages in mempool
-     manage    
-     help, h   Shows a list of commands or help for one command
+   pending   Get pending messages
+   sub       Subscribe to mpool changes
+   stat      print mempool stats
+   replace   replace a message in the mempool
+   find      find a message in the mempool
+   config    get or set current mpool configuration
+   gas-perf  Check gas performance of messages in mempool
+   manage    
+   help, h   Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus mpool pending
@@ -1629,11 +1590,11 @@ USAGE:
    lotus mpool pending [command options] [arguments...]
 
 OPTIONS:
-   --cids        only print cids of messages in output (default: false)
-   --from value  return messages from a given address
    --local       print pending messages for addresses in local wallet only (default: false)
+   --cids        only print cids of messages in output (default: false)
    --to value    return messages to a given address
-   
+   --from value  return messages from a given address
+   --help, -h    show help
 ```
 
 ### lotus mpool sub
@@ -1645,8 +1606,7 @@ USAGE:
    lotus mpool sub [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus mpool stat
@@ -1658,9 +1618,9 @@ USAGE:
    lotus mpool stat [command options] [arguments...]
 
 OPTIONS:
-   --basefee-lookback value  number of blocks to look back for minimum basefee (default: 60)
    --local                   print stats for addresses in local wallet only (default: false)
-   
+   --basefee-lookback value  number of blocks to look back for minimum basefee (default: 60)
+   --help, -h                show help
 ```
 
 ### lotus mpool replace
@@ -1672,12 +1632,12 @@ USAGE:
    lotus mpool replace [command options] <from> <nonce> | <message-cid>
 
 OPTIONS:
+   --gas-feecap value   gas feecap for new message (burn and pay to miner, attoFIL/GasUnit)
+   --gas-premium value  gas price for new message (pay to miner, attoFIL/GasUnit)
+   --gas-limit value    gas limit for new message (GasUnit) (default: 0)
    --auto               automatically reprice the specified message (default: false)
    --fee-limit max-fee  Spend up to X FIL for this message in units of FIL. Previously when flag was max-fee units were in attoFIL. Applicable for auto mode
-   --gas-feecap value   gas feecap for new message (burn and pay to miner, attoFIL/GasUnit)
-   --gas-limit value    gas limit for new message (GasUnit) (default: 0)
-   --gas-premium value  gas price for new message (pay to miner, attoFIL/GasUnit)
-   
+   --help, -h           show help
 ```
 
 ### lotus mpool find
@@ -1690,9 +1650,9 @@ USAGE:
 
 OPTIONS:
    --from value    search for messages with given 'from' address
-   --method value  search for messages with given method (default: 0)
    --to value      search for messages with given 'to' address
-   
+   --method value  search for messages with given method (default: 0)
+   --help, -h      show help
 ```
 
 ### lotus mpool config
@@ -1704,8 +1664,7 @@ USAGE:
    lotus mpool config [command options] [new-config]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus mpool gas-perf
@@ -1717,8 +1676,8 @@ USAGE:
    lotus mpool gas-perf [command options] [arguments...]
 
 OPTIONS:
-   --all  print gas performance for all mempool messages (default only prints for local) (default: false)
-   
+   --all       print gas performance for all mempool messages (default only prints for local) (default: false)
+   --help, -h  show help
 ```
 
 ### lotus mpool manage
@@ -1730,8 +1689,7 @@ USAGE:
    lotus mpool manage [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus state
@@ -1743,36 +1701,35 @@ USAGE:
    lotus state command [command options] [arguments...]
 
 COMMANDS:
-     power                       Query network or miner power
-     sectors                     Query the sector set of a miner
-     active-sectors              Query the active sector set of a miner
-     list-actors                 list all actors in the network
-     list-miners                 list all miners in the network
-     circulating-supply          Get the exact current circulating supply of Filecoin
-     sector, sector-info         Get miner sector info
-     get-actor                   Print actor information
-     lookup                      Find corresponding ID address
-     replay                      Replay a particular message
-     sector-size                 Look up miners sector size
-     read-state                  View a json representation of an actors state
-     list-messages               list messages on chain matching given criteria
-     compute-state               Perform state computations
-     call                        Invoke a method on an actor locally
-     get-deal                    View on-chain deal info
-     wait-msg, wait-message      Wait for a message to appear on chain
-     search-msg, search-message  Search to see whether a message has appeared on chain
-     miner-info                  Retrieve miner information
-     market                      Inspect the storage market actor
-     exec-trace                  Get the execution trace of a given message
-     network-version             Returns the network version
-     miner-proving-deadline      Retrieve information about a given miner's proving deadline
-     actor-cids                  Returns the built-in actor bundle manifest ID & system actor cids
-     help, h                     Shows a list of commands or help for one command
+   power                       Query network or miner power
+   sectors                     Query the sector set of a miner
+   active-sectors              Query the active sector set of a miner
+   list-actors                 list all actors in the network
+   list-miners                 list all miners in the network
+   circulating-supply          Get the exact current circulating supply of Filecoin
+   sector, sector-info         Get miner sector info
+   get-actor                   Print actor information
+   lookup                      Find corresponding ID address
+   replay                      Replay a particular message
+   sector-size                 Look up miners sector size
+   read-state                  View a json representation of an actors state
+   list-messages               list messages on chain matching given criteria
+   compute-state               Perform state computations
+   call                        Invoke a method on an actor locally
+   get-deal                    View on-chain deal info
+   wait-msg, wait-message      Wait for a message to appear on chain
+   search-msg, search-message  Search to see whether a message has appeared on chain
+   miner-info                  Retrieve miner information
+   market                      Inspect the storage market actor
+   exec-trace                  Get the execution trace of a given message
+   network-version             Returns the network version
+   miner-proving-deadline      Retrieve information about a given miner's proving deadline
+   actor-cids                  Returns the built-in actor bundle manifest ID & system actor cids
+   help, h                     Shows a list of commands or help for one command
 
 OPTIONS:
    --tipset value  specify tipset to call method on (pass comma separated array of cids)
-   --help, -h      show help (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus state power
@@ -1784,8 +1741,7 @@ USAGE:
    lotus state power [command options] [<minerAddress> (optional)]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state sectors
@@ -1797,8 +1753,7 @@ USAGE:
    lotus state sectors [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state active-sectors
@@ -1810,8 +1765,7 @@ USAGE:
    lotus state active-sectors [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state list-actors
@@ -1823,8 +1777,7 @@ USAGE:
    lotus state list-actors [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state list-miners
@@ -1837,7 +1790,7 @@ USAGE:
 
 OPTIONS:
    --sort-by value  criteria to sort miners by (none, num-deals)
-   
+   --help, -h       show help
 ```
 
 ### lotus state circulating-supply
@@ -1850,7 +1803,7 @@ USAGE:
 
 OPTIONS:
    --vm-supply  calculates the approximation of the circulating supply used internally by the VM (instead of the exact amount) (default: false)
-   
+   --help, -h   show help
 ```
 
 #### lotus state sector, sector-info
@@ -1866,8 +1819,7 @@ USAGE:
    lotus state get-actor [command options] [actorAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state lookup
@@ -1880,7 +1832,7 @@ USAGE:
 
 OPTIONS:
    --reverse, -r  Perform reverse lookup (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus state replay
@@ -1892,9 +1844,9 @@ USAGE:
    lotus state replay [command options] <messageCid>
 
 OPTIONS:
-   --detailed-gas  print out detailed gas costs for given message (default: false)
    --show-trace    print out full execution trace for given message (default: false)
-   
+   --detailed-gas  print out detailed gas costs for given message (default: false)
+   --help, -h      show help
 ```
 
 ### lotus state sector-size
@@ -1906,8 +1858,7 @@ USAGE:
    lotus state sector-size [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state read-state
@@ -1919,8 +1870,7 @@ USAGE:
    lotus state read-state [command options] [actorAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state list-messages
@@ -1932,11 +1882,11 @@ USAGE:
    lotus state list-messages [command options] [arguments...]
 
 OPTIONS:
-   --cids            print message CIDs instead of messages (default: false)
-   --from value      return messages from a given address
    --to value        return messages to a given address
+   --from value      return messages from a given address
    --toheight value  don't look before given block height (default: 0)
-   
+   --cids            print message CIDs instead of messages (default: false)
+   --help, -h        show help
 ```
 
 ### lotus state compute-state
@@ -1948,14 +1898,14 @@ USAGE:
    lotus state compute-state [command options] [arguments...]
 
 OPTIONS:
+   --vm-height value             set the height that the vm will see (default: 0)
    --apply-mpool-messages        apply messages from the mempool to the computed state (default: false)
-   --compute-state-output value  a json file containing pre-existing compute-state output, to generate html reports without rerunning state changes
+   --show-trace                  print out full execution trace for given tipset (default: false)
    --html                        generate html report (default: false)
    --json                        generate json output (default: false)
+   --compute-state-output value  a json file containing pre-existing compute-state output, to generate html reports without rerunning state changes
    --no-timing                   don't show timing information in html traces (default: false)
-   --show-trace                  print out full execution trace for given tipset (default: false)
-   --vm-height value             set the height that the vm will see (default: 0)
-   
+   --help, -h                    show help
 ```
 
 ### lotus state call
@@ -1967,11 +1917,11 @@ USAGE:
    lotus state call [command options] [toAddress methodId params (optional)]
 
 OPTIONS:
-   --encoding value  specify params encoding to parse (base64, hex) (default: "base64")
    --from value      (default: "f00")
-   --ret value       specify how to parse output (raw, decoded, base64, hex) (default: "decoded")
    --value value     specify value field for invocation (default: "0")
-   
+   --ret value       specify how to parse output (raw, decoded, base64, hex) (default: "decoded")
+   --encoding value  specify params encoding to parse (base64, hex) (default: "base64")
+   --help, -h        show help
 ```
 
 ### lotus state get-deal
@@ -1983,8 +1933,7 @@ USAGE:
    lotus state get-deal [command options] [dealId]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus state wait-msg, wait-message
@@ -2004,8 +1953,7 @@ USAGE:
    lotus state miner-info [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state market
@@ -2017,12 +1965,11 @@ USAGE:
    lotus state market command [command options] [arguments...]
 
 COMMANDS:
-     balance  Get the market balance (locked and escrowed) for a given account
-     help, h  Shows a list of commands or help for one command
+   balance  Get the market balance (locked and escrowed) for a given account
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus state market balance
@@ -2034,8 +1981,7 @@ USAGE:
    lotus state market balance [command options] [address]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state exec-trace
@@ -2047,8 +1993,7 @@ USAGE:
    lotus state exec-trace [command options] <messageCid>
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state network-version
@@ -2060,8 +2005,7 @@ USAGE:
    lotus state network-version [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state miner-proving-deadline
@@ -2073,8 +2017,7 @@ USAGE:
    lotus state miner-proving-deadline [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus state actor-cids
@@ -2087,7 +2030,7 @@ USAGE:
 
 OPTIONS:
    --network-version value  specify network version (default: 0)
-   
+   --help, -h               show help
 ```
 
 ## lotus chain
@@ -2099,30 +2042,29 @@ USAGE:
    lotus chain command [command options] [arguments...]
 
 COMMANDS:
-     head                              Print chain head
-     get-block, getblock               Get a block and print its details
-     read-obj                          Read the raw bytes of an object
-     delete-obj                        Delete an object from the chain blockstore
-     stat-obj                          Collect size and ipld link counts for objs
-     getmessage, get-message, get-msg  Get and print a message by its cid
-     sethead, set-head                 manually set the local nodes head tipset (Caution: normally only used for recovery)
-     list, love                        View a segment of the chain
-     get                               Get chain DAG node by path
-     bisect                            bisect chain for an event
-     export                            export chain to a car file
-     export-range                      export chain to a car file
-     slash-consensus                   Report consensus fault
-     gas-price                         Estimate gas prices
-     inspect-usage                     Inspect block space usage of a given tipset
-     decode                            decode various types
-     encode                            encode various types
-     disputer                          interact with the window post disputer
-     prune                             splitstore gc
-     help, h                           Shows a list of commands or help for one command
+   head                              Print chain head
+   get-block, getblock               Get a block and print its details
+   read-obj                          Read the raw bytes of an object
+   delete-obj                        Delete an object from the chain blockstore
+   stat-obj                          Collect size and ipld link counts for objs
+   getmessage, get-message, get-msg  Get and print a message by its cid
+   sethead, set-head                 manually set the local nodes head tipset (Caution: normally only used for recovery)
+   list, love                        View a segment of the chain
+   get                               Get chain DAG node by path
+   bisect                            bisect chain for an event
+   export                            export chain to a car file
+   export-range                      export chain to a car file
+   slash-consensus                   Report consensus fault
+   gas-price                         Estimate gas prices
+   inspect-usage                     Inspect block space usage of a given tipset
+   decode                            decode various types
+   encode                            encode various types
+   disputer                          interact with the window post disputer
+   prune                             splitstore gc
+   help, h                           Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus chain head
@@ -2134,8 +2076,7 @@ USAGE:
    lotus chain head [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus chain get-block, getblock
@@ -2151,8 +2092,7 @@ USAGE:
    lotus chain read-obj [command options] [objectCid]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus chain delete-obj
@@ -2168,7 +2108,7 @@ DESCRIPTION:
 
 OPTIONS:
    --really-do-it  (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus chain stat-obj
@@ -2181,14 +2121,14 @@ USAGE:
 
 DESCRIPTION:
    Collect object size and ipld link count for an object.
-   
+
       When a base is provided it will be walked first, and all links visisted
       will be ignored when the passed in object is walked.
-   
+
 
 OPTIONS:
    --base value  ignore links found in this obj
-   
+   --help, -h    show help
 ```
 
 ##### lotus chain getmessage, get-message, get-msg
@@ -2213,13 +2153,13 @@ USAGE:
 
 DESCRIPTION:
    Get ipld node under a specified path:
-   
+
       lotus chain get /ipfs/[cid]/some/path
-   
+
       Path prefixes:
       - /ipfs/[cid], /ipld/[cid] - traverse IPLD path
       - /pstate - traverse from head.ParentStateRoot
-   
+
       Note:
       You can use special path elements to traverse through some data structures:
       - /ipfs/[cid]/@H:elem - get 'elem' from hamt
@@ -2228,7 +2168,7 @@ DESCRIPTION:
       - /ipfs/[cid]/@Ha:t01 - get element under Addr(t01).Bytes
       - /ipfs/[cid]/@A:10   - get 10th amt element
       - .../@Ha:t01/@state  - get pretty map-based actor state
-   
+
       List of --as-type types:
       - raw
       - block
@@ -2240,13 +2180,13 @@ DESCRIPTION:
       - hamt-address
       - cronevent
       - account-state
-   
+
 
 OPTIONS:
    --as-type value  specify type to interpret output as
-   --tipset value   specify tipset for /pstate (pass comma separated array of cids)
    --verbose        (default: false)
-   
+   --tipset value   specify tipset for /pstate (pass comma separated array of cids)
+   --help, -h       show help
 ```
 
 ### lotus chain bisect
@@ -2259,22 +2199,21 @@ USAGE:
 
 DESCRIPTION:
    Bisect the chain state tree:
-   
+
       lotus chain bisect [min height] [max height] '1/2/3/state/path' 'shell command' 'args'
-   
+
       Returns the first tipset in which condition is true
                      v
       [start] FFFFFFFTTT [end]
-   
+
       Example: find height at which deal ID 100 000 appeared
        - lotus chain bisect 1 32000 '@Ha:t03/1' jq -e '.[2] > 100000'
-   
+
       For special path elements see 'chain get' help
-   
+
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus chain export
@@ -2286,10 +2225,10 @@ USAGE:
    lotus chain export [command options] [outputPath]
 
 OPTIONS:
+   --tipset value             specify tipset to start the export from (default: "@head")
    --recent-stateroots value  specify the number of recent state roots to include in the export (default: 0)
    --skip-old-msgs            (default: false)
-   --tipset value             specify tipset to start the export from (default: "@head")
-   
+   --help, -h                 show help
 ```
 
 ### lotus chain export-range
@@ -2302,13 +2241,13 @@ USAGE:
 
 OPTIONS:
    --head value          specify tipset to start the export from (higher epoch) (default: "@head")
+   --tail value          specify tipset to end the export at (lower epoch) (default: "@tail")
    --messages            specify if messages should be include (default: false)
    --receipts            specify if receipts should be include (default: false)
    --stateroots          specify if stateroots should be include (default: false)
-   --tail value          specify tipset to end the export at (lower epoch) (default: "@tail")
    --workers value       specify the number of workers (default: 1)
    --write-buffer value  specify write buffer size (default: 1048576)
-   
+   --help, -h            show help
 ```
 
 ### lotus chain slash-consensus
@@ -2320,9 +2259,9 @@ USAGE:
    lotus chain slash-consensus [command options] [blockCid1 blockCid2]
 
 OPTIONS:
-   --extra value  Extra block cid
    --from value   optionally specify the account to report consensus from
-   
+   --extra value  Extra block cid
+   --help, -h     show help
 ```
 
 ### lotus chain gas-price
@@ -2334,8 +2273,7 @@ USAGE:
    lotus chain gas-price [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus chain inspect-usage
@@ -2347,10 +2285,10 @@ USAGE:
    lotus chain inspect-usage [command options] [arguments...]
 
 OPTIONS:
+   --tipset value       specify tipset to view block space usage of (default: "@head")
    --length value       length of chain to inspect block space usage for (default: 1)
    --num-results value  number of results to print per category (default: 10)
-   --tipset value       specify tipset to view block space usage of (default: "@head")
-   
+   --help, -h           show help
 ```
 
 ### lotus chain decode
@@ -2362,12 +2300,11 @@ USAGE:
    lotus chain decode command [command options] [arguments...]
 
 COMMANDS:
-     params   Decode message params
-     help, h  Shows a list of commands or help for one command
+   params   Decode message params
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus chain decode params
@@ -2379,9 +2316,9 @@ USAGE:
    lotus chain decode params [command options] [toAddr method params]
 
 OPTIONS:
-   --encoding value  specify input encoding to parse (default: "base64")
    --tipset value    
-   
+   --encoding value  specify input encoding to parse (default: "base64")
+   --help, -h        show help
 ```
 
 ### lotus chain encode
@@ -2393,12 +2330,11 @@ USAGE:
    lotus chain encode command [command options] [arguments...]
 
 COMMANDS:
-     params   Encodes the given JSON params
-     help, h  Shows a list of commands or help for one command
+   params   Encodes the given JSON params
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus chain encode params
@@ -2410,10 +2346,10 @@ USAGE:
    lotus chain encode params [command options] [dest method params]
 
 OPTIONS:
-   --encoding value  specify input encoding to parse (default: "base64")
    --tipset value    
+   --encoding value  specify input encoding to parse (default: "base64")
    --to-code         interpret dest as code CID instead of as address (default: false)
-   
+   --help, -h        show help
 ```
 
 ### lotus chain disputer
@@ -2425,15 +2361,14 @@ USAGE:
    lotus chain disputer command [command options] [arguments...]
 
 COMMANDS:
-     start    Start the window post disputer
-     dispute  Send a specific DisputeWindowedPoSt message
-     help, h  Shows a list of commands or help for one command
+   start    Start the window post disputer
+   dispute  Send a specific DisputeWindowedPoSt message
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
    --max-fee value  Spend up to X FIL per DisputeWindowedPoSt message
    --from value     optionally specify the account to send messages from
-   --help, -h       show help (default: false)
-   
+   --help, -h       show help
 ```
 
 #### lotus chain disputer start
@@ -2446,7 +2381,7 @@ USAGE:
 
 OPTIONS:
    --start-epoch value  only start disputing PoSts after this epoch  (default: 0)
-   
+   --help, -h           show help
 ```
 
 #### lotus chain disputer dispute
@@ -2458,8 +2393,7 @@ USAGE:
    lotus chain disputer dispute [command options] [minerAddress index postIndex]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus chain prune
@@ -2471,14 +2405,13 @@ USAGE:
    lotus chain prune command [command options] [arguments...]
 
 COMMANDS:
-     compact-cold  force splitstore compaction on cold store state and run gc
-     hot           run online (badger vlog) garbage collection on hotstore
-     hot-moving    run moving gc on hotstore
-     help, h       Shows a list of commands or help for one command
+   compact-cold  force splitstore compaction on cold store state and run gc
+   hot           run online (badger vlog) garbage collection on hotstore
+   hot-moving    run moving gc on hotstore
+   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus chain prune compact-cold
@@ -2490,10 +2423,10 @@ USAGE:
    lotus chain prune compact-cold [command options] [arguments...]
 
 OPTIONS:
-   --moving-gc        use moving gc for garbage collecting the coldstore (default: false)
    --online-gc        use online gc for garbage collecting the coldstore (default: false)
+   --moving-gc        use moving gc for garbage collecting the coldstore (default: false)
    --retention value  specify state retention policy (default: -1)
-   
+   --help, -h         show help
 ```
 
 #### lotus chain prune hot
@@ -2505,9 +2438,9 @@ USAGE:
    lotus chain prune hot [command options] [arguments...]
 
 OPTIONS:
-   --periodic         Run periodic gc over multiple vlogs. Otherwise run gc once (default: false)
    --threshold value  Threshold of vlog garbage for gc (default: 0.01)
-   
+   --periodic         Run periodic gc over multiple vlogs. Otherwise run gc once (default: false)
+   --help, -h         show help
 ```
 
 #### lotus chain prune hot-moving
@@ -2519,8 +2452,7 @@ USAGE:
    lotus chain prune hot-moving [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus log
@@ -2532,14 +2464,13 @@ USAGE:
    lotus log command [command options] [arguments...]
 
 COMMANDS:
-     list       List log systems
-     set-level  Set log level
-     alerts     Get alert states
-     help, h    Shows a list of commands or help for one command
+   list       List log systems
+   set-level  Set log level
+   alerts     Get alert states
+   help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus log list
@@ -2551,8 +2482,7 @@ USAGE:
    lotus log list [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus log set-level
@@ -2565,27 +2495,27 @@ USAGE:
 
 DESCRIPTION:
    Set the log level for logging systems:
-   
+
       The system flag can be specified multiple times.
-   
+
       eg) log set-level --system chain --system chainxchg debug
-   
+
       Available Levels:
       debug
       info
       warn
       error
-   
+
       Environment Variables:
       GOLOG_LOG_LEVEL - Default log level for all log systems
       GOLOG_LOG_FMT   - Change output log format (json, nocolor)
       GOLOG_FILE      - Write logs to file
       GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr
-   
+
 
 OPTIONS:
    --system value [ --system value ]  limit to log system
-   
+   --help, -h                         show help
 ```
 
 ### lotus log alerts
@@ -2597,8 +2527,8 @@ USAGE:
    lotus log alerts [command options] [arguments...]
 
 OPTIONS:
-   --all  get all (active and inactive) alerts (default: false)
-   
+   --all       get all (active and inactive) alerts (default: false)
+   --help, -h  show help
 ```
 
 ## lotus wait-api
@@ -2614,7 +2544,7 @@ CATEGORY:
 
 OPTIONS:
    --timeout value  duration to wait till fail (default: 30s)
-   
+   --help, -h       show help
 ```
 
 ## lotus fetch-params
@@ -2629,8 +2559,7 @@ CATEGORY:
    DEVELOPER
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus evm
@@ -2642,17 +2571,16 @@ USAGE:
    lotus evm command [command options] [arguments...]
 
 COMMANDS:
-     deploy            Deploy an EVM smart contract and return its address
-     invoke            Invoke an EVM smart contract using the specified CALLDATA
-     stat              Print eth/filecoin addrs and code cid
-     call              Simulate an eth contract call
-     contract-address  Generate contract address from smart contract code
-     bytecode          Write the bytecode of a smart contract to a file
-     help, h           Shows a list of commands or help for one command
+   deploy            Deploy an EVM smart contract and return its address
+   invoke            Invoke an EVM smart contract using the specified CALLDATA
+   stat              Print eth/filecoin addrs and code cid
+   call              Simulate an eth contract call
+   contract-address  Generate contract address from smart contract code
+   bytecode          Write the bytecode of a smart contract to a file
+   help, h           Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus evm deploy
@@ -2666,7 +2594,7 @@ USAGE:
 OPTIONS:
    --from value  optionally specify the account to use for sending the creation message
    --hex         use when input contract is in hex (default: false)
-   
+   --help, -h    show help
 ```
 
 ### lotus evm invoke
@@ -2680,7 +2608,7 @@ USAGE:
 OPTIONS:
    --from value   optionally specify the account to use for sending the exec message
    --value value  optionally specify the value to be sent with the invokation message (default: 0)
-   
+   --help, -h     show help
 ```
 
 ### lotus evm stat
@@ -2692,8 +2620,7 @@ USAGE:
    lotus evm stat [command options] address
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus evm call
@@ -2705,8 +2632,7 @@ USAGE:
    lotus evm call [command options] [from] [to] [params]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus evm contract-address
@@ -2718,8 +2644,7 @@ USAGE:
    lotus evm contract-address [command options] [senderEthAddr] [salt] [contractHexPath]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus evm bytecode
@@ -2731,8 +2656,8 @@ USAGE:
    lotus evm bytecode [command options] [contract-address] [file-name]
 
 OPTIONS:
-   --bin  write the bytecode as raw binary and don't hex-encode (default: false)
-   
+   --bin       write the bytecode as raw binary and don't hex-encode (default: false)
+   --help, -h  show help
 ```
 
 ## lotus net
@@ -2744,27 +2669,26 @@ USAGE:
    lotus net command [command options] [arguments...]
 
 COMMANDS:
-     peers                Print peers
-     ping                 Ping peers
-     connect              Connect to a peer
-     disconnect           Disconnect from a peer
-     listen               List listen addresses
-     id                   Get node identity
-     find-peer, findpeer  Find the addresses of a given peerID
-     scores               Print peers' pubsub scores
-     reachability         Print information about reachability from the internet
-     bandwidth            Print bandwidth usage information
-     block                Manage network connection gating rules
-     stat                 Report resource usage for a scope
-     limit                Get or set resource limits for a scope
-     protect              Add one or more peer IDs to the list of protected peer connections
-     unprotect            Remove one or more peer IDs from the list of protected peer connections.
-     list-protected       List the peer IDs with protected connection.
-     help, h              Shows a list of commands or help for one command
+   peers                Print peers
+   ping                 Ping peers
+   connect              Connect to a peer
+   disconnect           Disconnect from a peer
+   listen               List listen addresses
+   id                   Get node identity
+   find-peer, findpeer  Find the addresses of a given peerID
+   scores               Print peers' pubsub scores
+   reachability         Print information about reachability from the internet
+   bandwidth            Print bandwidth usage information
+   block                Manage network connection gating rules
+   stat                 Report resource usage for a scope
+   limit                Get or set resource limits for a scope
+   protect              Add one or more peer IDs to the list of protected peer connections
+   unprotect            Remove one or more peer IDs from the list of protected peer connections.
+   list-protected       List the peer IDs with protected connection.
+   help, h              Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net peers
@@ -2778,7 +2702,7 @@ USAGE:
 OPTIONS:
    --agent, -a     Print agent name (default: false)
    --extended, -x  Print extended peer information in json (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus net ping
@@ -2792,7 +2716,7 @@ USAGE:
 OPTIONS:
    --count value, -c value     specify the number of times it should ping (default: 10)
    --interval value, -i value  minimum time between pings (default: 1s)
-   
+   --help, -h                  show help
 ```
 
 ### lotus net connect
@@ -2804,8 +2728,7 @@ USAGE:
    lotus net connect [command options] [peerMultiaddr|minerActorAddress]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net disconnect
@@ -2817,8 +2740,7 @@ USAGE:
    lotus net disconnect [command options] [peerID]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net listen
@@ -2830,8 +2752,7 @@ USAGE:
    lotus net listen [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net id
@@ -2843,8 +2764,7 @@ USAGE:
    lotus net id [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus net find-peer, findpeer
@@ -2861,7 +2781,7 @@ USAGE:
 
 OPTIONS:
    --extended, -x  print extended peer scores in json (default: false)
-   
+   --help, -h      show help
 ```
 
 ### lotus net reachability
@@ -2873,8 +2793,7 @@ USAGE:
    lotus net reachability [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net bandwidth
@@ -2888,7 +2807,7 @@ USAGE:
 OPTIONS:
    --by-peer      list bandwidth usage by peer (default: false)
    --by-protocol  list bandwidth usage by protocol (default: false)
-   
+   --help, -h     show help
 ```
 
 ### lotus net block
@@ -2900,14 +2819,13 @@ USAGE:
    lotus net block command [command options] [arguments...]
 
 COMMANDS:
-     add      Add connection gating rules
-     remove   Remove connection gating rules
-     list     list connection gating rules
-     help, h  Shows a list of commands or help for one command
+   add      Add connection gating rules
+   remove   Remove connection gating rules
+   list     list connection gating rules
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus net block add
@@ -2919,14 +2837,13 @@ USAGE:
    lotus net block add command [command options] [arguments...]
 
 COMMANDS:
-     peer     Block a peer
-     ip       Block an IP address
-     subnet   Block an IP subnet
-     help, h  Shows a list of commands or help for one command
+   peer     Block a peer
+   ip       Block an IP address
+   subnet   Block an IP subnet
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block add peer
@@ -2938,8 +2855,7 @@ USAGE:
    lotus net block add peer [command options] <Peer> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block add ip
@@ -2951,8 +2867,7 @@ USAGE:
    lotus net block add ip [command options] <IP> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block add subnet
@@ -2964,8 +2879,7 @@ USAGE:
    lotus net block add subnet [command options] <CIDR> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus net block remove
@@ -2977,14 +2891,13 @@ USAGE:
    lotus net block remove command [command options] [arguments...]
 
 COMMANDS:
-     peer     Unblock a peer
-     ip       Unblock an IP address
-     subnet   Unblock an IP subnet
-     help, h  Shows a list of commands or help for one command
+   peer     Unblock a peer
+   ip       Unblock an IP address
+   subnet   Unblock an IP subnet
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block remove peer
@@ -2996,8 +2909,7 @@ USAGE:
    lotus net block remove peer [command options] <Peer> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block remove ip
@@ -3009,8 +2921,7 @@ USAGE:
    lotus net block remove ip [command options] <IP> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ##### lotus net block remove subnet
@@ -3022,8 +2933,7 @@ USAGE:
    lotus net block remove subnet [command options] <CIDR> ...
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 #### lotus net block list
@@ -3035,8 +2945,7 @@ USAGE:
    lotus net block list [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net stat
@@ -3049,7 +2958,7 @@ USAGE:
 
 DESCRIPTION:
    Report resource usage for a scope.
-   
+
      The scope can be one of the following:
      - system        -- reports the system aggregate resource usage.
      - transient     -- reports the transient resource usage.
@@ -3057,11 +2966,11 @@ DESCRIPTION:
      - proto:<proto> -- reports the resource usage of a specific protocol.
      - peer:<peer>   -- reports the resource usage of a specific peer.
      - all           -- reports the resource usage for all currently active scopes.
-   
+
 
 OPTIONS:
-   --json  (default: false)
-   
+   --json      (default: false)
+   --help, -h  show help
 ```
 
 ### lotus net limit
@@ -3074,20 +2983,20 @@ USAGE:
 
 DESCRIPTION:
    Get or set resource limits for a scope.
-   
+
      The scope can be one of the following:
      - system        -- reports the system aggregate resource usage.
      - transient     -- reports the transient resource usage.
      - svc:<service> -- reports the resource usage of a specific service.
      - proto:<proto> -- reports the resource usage of a specific protocol.
      - peer:<peer>   -- reports the resource usage of a specific peer.
-   
+
     The limit is json-formatted, with the same structure as the limits file.
-   
+
 
 OPTIONS:
-   --set  set the limit for a scope (default: false)
-   
+   --set       set the limit for a scope (default: false)
+   --help, -h  show help
 ```
 
 ### lotus net protect
@@ -3099,8 +3008,7 @@ USAGE:
    lotus net protect [command options] <peer-id> [<peer-id>...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net unprotect
@@ -3112,8 +3020,7 @@ USAGE:
    lotus net unprotect [command options] <peer-id> [<peer-id>...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus net list-protected
@@ -3125,8 +3032,7 @@ USAGE:
    lotus net list-protected [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ## lotus sync
@@ -3138,17 +3044,16 @@ USAGE:
    lotus sync command [command options] [arguments...]
 
 COMMANDS:
-     status      check sync status
-     wait        Wait for sync to be complete
-     mark-bad    Mark the given block as bad, will prevent syncing to a chain that contains it
-     unmark-bad  Unmark the given block as bad, makes it possible to sync to a chain containing it
-     check-bad   check if the given block was marked bad, and for what reason
-     checkpoint  mark a certain tipset as checkpointed; the node will never fork away from this tipset
-     help, h     Shows a list of commands or help for one command
+   status      check sync status
+   wait        Wait for sync to be complete
+   mark-bad    Mark the given block as bad, will prevent syncing to a chain that contains it
+   unmark-bad  Unmark the given block as bad, makes it possible to sync to a chain containing it
+   check-bad   check if the given block was marked bad, and for what reason
+   checkpoint  mark a certain tipset as checkpointed; the node will never fork away from this tipset
+   help, h     Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus sync status
@@ -3160,8 +3065,7 @@ USAGE:
    lotus sync status [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus sync wait
@@ -3173,8 +3077,8 @@ USAGE:
    lotus sync wait [command options] [arguments...]
 
 OPTIONS:
-   --watch  don't exit after node is synced (default: false)
-   
+   --watch     don't exit after node is synced (default: false)
+   --help, -h  show help
 ```
 
 ### lotus sync mark-bad
@@ -3186,8 +3090,7 @@ USAGE:
    lotus sync mark-bad [command options] [blockCid]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus sync unmark-bad
@@ -3199,8 +3102,8 @@ USAGE:
    lotus sync unmark-bad [command options] [blockCid]
 
 OPTIONS:
-   --all  drop the entire bad block cache (default: false)
-   
+   --all       drop the entire bad block cache (default: false)
+   --help, -h  show help
 ```
 
 ### lotus sync check-bad
@@ -3212,8 +3115,7 @@ USAGE:
    lotus sync check-bad [command options] [blockCid]
 
 OPTIONS:
-   --help, -h  show help (default: false)
-   
+   --help, -h  show help
 ```
 
 ### lotus sync checkpoint
@@ -3226,7 +3128,7 @@ USAGE:
 
 OPTIONS:
    --epoch value  checkpoint the tipset at the given epoch (default: 0)
-   
+   --help, -h     show help
 ```
 
 ## lotus status
@@ -3241,6 +3143,6 @@ CATEGORY:
    STATUS
 
 OPTIONS:
-   --chain  include chain health status (default: false)
-   
+   --chain     include chain health status (default: false)
+   --help, -h  show help
 ```

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/raulk/go-watchdog v1.3.0
 	github.com/stretchr/testify v1.8.2
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/urfave/cli/v2 v2.16.3
+	github.com/urfave/cli/v2 v2.25.5
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba
 	github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa
 	github.com/whyrusleeping/ledger-filecoin-go v0.9.1-0.20201010031517-c3dcc1bddce4

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,7 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/corpix/uarand v0.1.1/go.mod h1:SFKZvkcRoLqVRFZ4u25xPmp6m9ktANfbpXZ7SJ0/FNU=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -1632,6 +1633,8 @@ github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60Nt
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.16.3 h1:gHoFIwpPjoyIMbJp/VFd+/vuD0dAgFK4B6DpEMFJfQk=
 github.com/urfave/cli/v2 v2.16.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/urfave/cli/v2 v2.25.5 h1:d0NIAyhh5shGscroL7ek/Ya9QYQE0KNabJgiUinIQkc=
+github.com/urfave/cli/v2 v2.25.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=

--- a/go.sum
+++ b/go.sum
@@ -192,7 +192,6 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/corpix/uarand v0.1.1/go.mod h1:SFKZvkcRoLqVRFZ4u25xPmp6m9ktANfbpXZ7SJ0/FNU=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -1631,8 +1630,6 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/urfave/cli/v2 v2.16.3 h1:gHoFIwpPjoyIMbJp/VFd+/vuD0dAgFK4B6DpEMFJfQk=
-github.com/urfave/cli/v2 v2.16.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/urfave/cli/v2 v2.25.5 h1:d0NIAyhh5shGscroL7ek/Ya9QYQE0KNabJgiUinIQkc=
 github.com/urfave/cli/v2 v2.25.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
**Context**
In https://github.com/filecoin-project/lotus/pull/10761 we added a new RPC benchmarking tool which parses options from terminal to build up RPC requests. However, our current urfave version does not support parsing cli options if they have a comma (`,`) in them. This was however added by urfave a few months ago by introducing a new flag `DisableSliceFlagSeparator`.

Unfortunately, upgrading the urfave dependency introduced regressions in how it generated --help output, especially for commands with subcategories, where the subcategory was not included in the help output.

- I created a new urfave issue that reported this as bug (https://github.com/urfave/cli/issues/1734)
- Urfave fixed the bug (https://github.com/urfave/cli/pull/1735)
- Urfave merged the fix in 2.25.4 (https://github.com/urfave/cli/releases/tag/v2.25.4)

NOTE that are have been some changes still in how urfave generates --help output from our previous version (2.16.3) but these look ok to me 

**Test plan**
Observed that lotus-bench rpc now works when passing it options with comma:

```
lotus-bench rpc --duration=3s --method='eth_getTransactionCount:10:2000:["0xd4c70007F3F502f212c7e6794b94C06F36173B36", "latest"]
[eth_getTransactionCount]:
- Options:
  - concurrency: 10
  - params: ["0xd4c70007F3F502f212c7e6794b94C06F36173B36", "latest"]
  - qps: 2000
- Total Requests: 5987
- Total Duration: 3004ms
- Requests/sec: 1992.487708
- Avg latency: 0ms
- Median latency: 0ms
- Latency distribution:
    10.00% in 0ms
    50.00% in 0ms
    90.00% in 0ms
    95.00% in 0ms
    99.00% in 0ms
    99.90% in 11ms
- Histogram:
     0-1ms|  5958|################################################################################################### (99.52%)
     1-2ms|     3| (0.05%)
     2-3ms|     3| (0.05%)
     3-4ms|     5| (0.08%)
     4-5ms|     5| (0.08%)
     5-6ms|     3| (0.05%)
     6-7ms|     0| (0.00%)
     7-8ms|     0| (0.00%)
     8-9ms|     1| (0.02%)
    9-13ms|     9| (0.15%)
- Status codes:
    [200]: 5987
- Errors (top 10):
    [nil]: 5987
```
