### PR TITLE
feat: cli(compute-state) default to the tipset at the given epoch

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -1065,12 +1065,19 @@ var StateComputeStateCmd = &cli.Command{
 
 		ctx := ReqContext(cctx)
 
-		ts, err := LoadTipSet(ctx, cctx, api)
+		h := abi.ChainEpoch(cctx.Uint64("vm-height"))
+		var ts *types.TipSet
+		if tss := cctx.String("tipset"); tss != "" {
+			ts, err = ParseTipSetRef(ctx, api, tss)
+		} else if h > 0 {
+			ts, err = api.ChainGetTipSetByHeight(ctx, h, types.EmptyTSK)
+		} else {
+			ts, err = api.ChainHead(ctx)
+		}
 		if err != nil {
 			return err
 		}
 
-		h := abi.ChainEpoch(cctx.Uint64("vm-height"))
 		if h == 0 {
 			h = ts.Height()
 		}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Default to the using tipset at the specified epoch. Otherwise, specifying an epoch without a tipset would lead to computing the _latest_ tipset with at the specified epoch.

Previously, we'd use the current head if not otherwise specified, even when the user specified a epoch. Now:

1. If the user specifies nothing, we use head head's epoch.
2. If the user specifies a tipset and no epoch, we use that tipset and the epoch of that tipset.
3. If the user specifies an epoch and no tipset, use the tipset at that epoch (based on the current head).
4. Finally, if the user species both, use both (allowing the epoch/tipset to disagree).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

This is a significant breaking change that should, in most cases, simply fix buggy code. _Most_ of the time, the user _doesn't_ want to execute a tipset at a different logical epoch.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green