### PR TITLE
feat: Synthetic-porep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "extern/filecoin-ffi"]
 	path = extern/filecoin-ffi
 	url = https://github.com/filecoin-project/filecoin-ffi.git
+	branch = .
 [submodule "extern/serialization-vectors"]
 	path = extern/serialization-vectors
 	url = https://github.com/filecoin-project/serialization-vectors.git

--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -154,7 +154,7 @@ type Partition interface {
 
 type SectorOnChainInfo = minertypes.SectorOnChainInfo
 
-func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof) (abi.RegisteredSealProof, error) {
+func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof, configWantSynthetic bool) (abi.RegisteredSealProof, error) {
 	// We added support for the new proofs in network version 7, and removed support for the old
 	// ones in network version 8.
 	if nver < network.Version7 {
@@ -174,17 +174,34 @@ func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.Re
 		}
 	}
 
+	if nver < network.SyntheticVersion || !configWantSynthetic {
+		switch proof {
+		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1, abi.RegisteredPoStProof_StackedDrgWindow8MiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg8MiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1, abi.RegisteredPoStProof_StackedDrgWindow512MiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg512MiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg32GiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1, abi.RegisteredPoStProof_StackedDrgWindow64GiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg64GiBV1_1, nil
+		default:
+			return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
+		}
+	}
+
 	switch proof {
 	case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1, abi.RegisteredPoStProof_StackedDrgWindow8MiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg8MiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1, abi.RegisteredPoStProof_StackedDrgWindow512MiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg512MiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg32GiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1, abi.RegisteredPoStProof_StackedDrgWindow64GiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg64GiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep, nil
 	default:
 		return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
 	}

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -208,7 +208,7 @@ type Partition interface {
 
 type SectorOnChainInfo = minertypes.SectorOnChainInfo
 
-func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof) (abi.RegisteredSealProof, error) {
+func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof, configWantSynthetic bool) (abi.RegisteredSealProof, error) {
 	// We added support for the new proofs in network version 7, and removed support for the old
 	// ones in network version 8.
 	if nver < network.Version7 {
@@ -228,17 +228,33 @@ func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.Re
 		}
 	}
 
+	if !configWantSynthetic {
+		switch proof {
+		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1, abi.RegisteredPoStProof_StackedDrgWindow8MiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg8MiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1, abi.RegisteredPoStProof_StackedDrgWindow512MiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg512MiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg32GiBV1_1, nil
+		case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1, abi.RegisteredPoStProof_StackedDrgWindow64GiBV1_1:
+			return abi.RegisteredSealProof_StackedDrg64GiBV1_1, nil
+		default:
+			return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
+		}
+	}
 	switch proof {
 	case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1, abi.RegisteredPoStProof_StackedDrgWindow8MiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg8MiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1, abi.RegisteredPoStProof_StackedDrgWindow512MiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg512MiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1, abi.RegisteredPoStProof_StackedDrgWindow32GiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg32GiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep, nil
 	case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1, abi.RegisteredPoStProof_StackedDrgWindow64GiBV1_1:
-		return abi.RegisteredSealProof_StackedDrg64GiBV1_1, nil
+		return abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep, nil
 	default:
 		return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
 	}

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -228,7 +228,7 @@ func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.Re
 		}
 	}
 
-	if !configWantSynthetic {
+	if nver < network.SyntheticVersion || !configWantSynthetic {
 		switch proof {
 		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
 			return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
@@ -244,6 +244,7 @@ func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.Re
 			return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
 		}
 	}
+
 	switch proof {
 	case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:
 		return abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep, nil

--- a/chain/actors/builtin/miner/utils.go
+++ b/chain/actors/builtin/miner/utils.go
@@ -65,7 +65,7 @@ func SealProofTypeFromSectorSize(ssize abi.SectorSize, nv network.Version, synth
 			return 0, xerrors.Errorf("unsupported sector size for miner: %v", ssize)
 		}
 
-		if synthetic {
+		if nv >= network.SyntheticVersion && synthetic {
 			return toSynthetic(v)
 		} else {
 			return v, nil

--- a/chain/actors/builtin/miner/utils.go
+++ b/chain/actors/builtin/miner/utils.go
@@ -31,7 +31,7 @@ func AllPartSectors(mas State, sget func(Partition) (bitfield.BitField, error)) 
 
 // SealProofTypeFromSectorSize returns preferred seal proof type for creating
 // new miner actors and new sectors
-func SealProofTypeFromSectorSize(ssize abi.SectorSize, nv network.Version) (abi.RegisteredSealProof, error) {
+func SealProofTypeFromSectorSize(ssize abi.SectorSize, nv network.Version, synthetic bool) (abi.RegisteredSealProof, error) {
 	switch {
 	case nv < network.Version7:
 		switch ssize {

--- a/chain/actors/builtin/miner/utils.go
+++ b/chain/actors/builtin/miner/utils.go
@@ -49,23 +49,47 @@ func SealProofTypeFromSectorSize(ssize abi.SectorSize, nv network.Version, synth
 			return 0, xerrors.Errorf("unsupported sector size for miner: %v", ssize)
 		}
 	case nv >= network.Version7:
+		var v abi.RegisteredSealProof
 		switch ssize {
 		case 2 << 10:
-			return abi.RegisteredSealProof_StackedDrg2KiBV1_1, nil
+			v = abi.RegisteredSealProof_StackedDrg2KiBV1_1
 		case 8 << 20:
-			return abi.RegisteredSealProof_StackedDrg8MiBV1_1, nil
+			v = abi.RegisteredSealProof_StackedDrg8MiBV1_1
 		case 512 << 20:
-			return abi.RegisteredSealProof_StackedDrg512MiBV1_1, nil
+			v = abi.RegisteredSealProof_StackedDrg512MiBV1_1
 		case 32 << 30:
-			return abi.RegisteredSealProof_StackedDrg32GiBV1_1, nil
+			v = abi.RegisteredSealProof_StackedDrg32GiBV1_1
 		case 64 << 30:
-			return abi.RegisteredSealProof_StackedDrg64GiBV1_1, nil
+			v = abi.RegisteredSealProof_StackedDrg64GiBV1_1
 		default:
 			return 0, xerrors.Errorf("unsupported sector size for miner: %v", ssize)
+		}
+
+		if synthetic {
+			return toSynthetic(v)
+		} else {
+			return v, nil
 		}
 	}
 
 	return 0, xerrors.Errorf("unsupported network version")
+}
+
+func toSynthetic(in abi.RegisteredSealProof) (abi.RegisteredSealProof, error) {
+	switch in {
+	case abi.RegisteredSealProof_StackedDrg2KiBV1_1:
+		return abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep, nil
+	case abi.RegisteredSealProof_StackedDrg8MiBV1_1:
+		return abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep, nil
+	case abi.RegisteredSealProof_StackedDrg512MiBV1_1:
+		return abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep, nil
+	case abi.RegisteredSealProof_StackedDrg32GiBV1_1:
+		return abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep, nil
+	case abi.RegisteredSealProof_StackedDrg64GiBV1_1:
+		return abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep, nil
+	default:
+		return 0, xerrors.Errorf("unsupported conversion to synthetic: %v", in)
+	}
 }
 
 // WindowPoStProofTypeFromSectorSize returns preferred post proof type for creating

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -578,7 +578,7 @@ func MakeGenesisBlock(ctx context.Context, j journal.Journal, bs bstore.Blocksto
 	}
 
 	// setup Storage Miners
-	stateroot, err = SetupStorageMiners(ctx, cs, sys, stateroot, template.Miners, template.NetworkVersion)
+	stateroot, err = SetupStorageMiners(ctx, cs, sys, stateroot, template.Miners, template.NetworkVersion, false)
 	if err != nil {
 		return nil, xerrors.Errorf("setup miners failed: %w", err)
 	}

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -78,7 +78,7 @@ func mkFakedSigSyscalls(base vm.SyscallBuilder) vm.SyscallBuilder {
 }
 
 // Note: Much of this is brittle, if the methodNum / param / return changes, it will break things
-func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.SyscallBuilder, sroot cid.Cid, miners []genesis.Miner, nv network.Version) (cid.Cid, error) {
+func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.SyscallBuilder, sroot cid.Cid, miners []genesis.Miner, nv network.Version, synthetic bool) (cid.Cid, error) {
 
 	cst := cbor.NewCborStore(cs.StateBlockstore())
 	av, err := actorstypes.VersionForNetwork(nv)
@@ -131,7 +131,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 		i := i
 		m := m
 
-		spt, err := miner.SealProofTypeFromSectorSize(m.SectorSize, nv)
+		spt, err := miner.SealProofTypeFromSectorSize(m.SectorSize, nv, synthetic)
 		if err != nil {
 			return cid.Undef, err
 		}

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -825,7 +825,7 @@ func bps(sectorSize abi.SectorSize, sectorNum int, d time.Duration) string {
 }
 
 func spt(ssize abi.SectorSize) abi.RegisteredSealProof {
-	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion)
+	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion, false)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1573,7 +1573,7 @@ var sectorsCapacityCollateralCmd = &cli.Command{
 			return err
 		}
 
-		spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(nv, mi.WindowPoStProofType)
+		spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(nv, mi.WindowPoStProofType, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -137,7 +137,9 @@ var preSealCmd = &cli.Command{
 			nv = network.Version(c.Uint64("network-version"))
 		}
 
-		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, nv)
+		var synthetic = false // there's little reason to have this for a seed.
+
+		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, nv, synthetic)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-sim/simulation/stages/precommit_stage.go
+++ b/cmd/lotus-sim/simulation/stages/precommit_stage.go
@@ -165,7 +165,7 @@ func (stage *PreCommitStage) packMiner(
 
 	// Generate pre-commits.
 	sealType, err := miner.PreferredSealProofTypeFromWindowPoStType(
-		nv, minerInfo.WindowPoStProofType,
+		nv, minerInfo.WindowPoStProofType, false
 	)
 	if err != nil {
 		return 0, false, err

--- a/cmd/lotus-sim/simulation/stages/precommit_stage.go
+++ b/cmd/lotus-sim/simulation/stages/precommit_stage.go
@@ -165,7 +165,7 @@ func (stage *PreCommitStage) packMiner(
 
 	// Generate pre-commits.
 	sealType, err := miner.PreferredSealProofTypeFromWindowPoStType(
-		nv, minerInfo.WindowPoStProofType, false
+		nv, minerInfo.WindowPoStProofType, false,
 	)
 	if err != nil {
 		return 0, false, err

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -679,6 +679,14 @@
   # env var: LOTUS_SEALING_TERMINATEBATCHWAIT
   #TerminateBatchWait = "5m0s"
 
+  # SealWithSyntheticPoRep will reduce data holdings after PC1 by storing the precomputed responses
+  # to any challenge. This proof's PC1 step uses a cheaper-to-compute algorithm for the responses,
+  # but still must do more computation during PC1 in order to create this oracle.
+  #
+  # type: bool
+  # env var: LOTUS_SEALING_SEALWITHSYNTHETICPOREP
+  #SealWithSyntheticPoRep = false
+
 
 [Storage]
   # type: int

--- a/go.mod
+++ b/go.mod
@@ -341,6 +341,8 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
+replace github.com/filecoin-project/go-state-types => ./extern/go-state-types
+
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
 
 replace github.com/filecoin-project/test-vectors => ./extern/test-vectors

--- a/go.sum
+++ b/go.sum
@@ -339,14 +339,6 @@ github.com/filecoin-project/go-padreader v0.0.1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MU
 github.com/filecoin-project/go-paramfetch v0.0.4 h1:H+Me8EL8T5+79z/KHYQQcT8NVOzYVqXIi7nhb48tdm8=
 github.com/filecoin-project/go-paramfetch v0.0.4/go.mod h1:1FH85P8U+DUEmWk1Jkw3Bw7FrwTVUNHk/95PSPG+dts=
 github.com/filecoin-project/go-retrieval-types v1.2.0 h1:fz6DauLVP3GRg7UuW7HZ6sE+GTmaUW70DTXBF1r9cK0=
-github.com/filecoin-project/go-state-types v0.0.0-20200903145444-247639ffa6ad/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
-github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
-github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.1.10/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.11.1 h1:GDtCN9V18bYVwXDZe+vJXc6Ck+qY9OUaQqpoVlp1FAk=
-github.com/filecoin-project/go-state-types v0.11.1/go.mod h1:SyNPwTsU7I22gL2r0OAPcImvLoTVfgRwdK/Y5rR1zz8=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.3 h1:N07o6alys+V1tNoSTi4WuuoeNC4erS/6jE74+NsgQuk=
 github.com/filecoin-project/go-statemachine v1.0.3/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -258,7 +258,7 @@ func (n *Ensemble) MinerEnroll(minerNode *TestMiner, full *TestFullNode, opts ..
 		)
 
 		// Will use 2KiB sectors by default (default value of sectorSize).
-		proofType, err := miner.SealProofTypeFromSectorSize(options.sectorSize, n.genesis.version)
+		proofType, err := miner.SealProofTypeFromSectorSize(options.sectorSize, n.genesis.version, false)
 		require.NoError(n.t, err)
 
 		// Create the preseal commitment.

--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -301,7 +301,7 @@ func TestMigrationNV17(t *testing.T) {
 	minerInfo, err := testClient.StateMinerInfo(ctx, testMiner.ActorAddr, types.EmptyTSK)
 	require.NoError(t, err)
 
-	spt, err := miner.SealProofTypeFromSectorSize(minerInfo.SectorSize, network.Version17)
+	spt, err := miner.SealProofTypeFromSectorSize(minerInfo.SectorSize, network.Version17, false)
 	require.NoError(t, err)
 
 	preCommitParams := miner9.PreCommitSectorParams{

--- a/itests/sector_import_full_test.go
+++ b/itests/sector_import_full_test.go
@@ -88,7 +88,7 @@ func TestSectorImport(t *testing.T) {
 			require.NoError(t, err)
 			ver, err := client.StateNetworkVersion(ctx, types.EmptyTSK)
 			require.NoError(t, err)
-			spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType)
+			spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType, false)
 			require.NoError(t, err)
 
 			ssize, err := spt.SectorSize()

--- a/itests/sector_import_simple_test.go
+++ b/itests/sector_import_simple_test.go
@@ -61,7 +61,7 @@ func TestSectorImportAfterPC2(t *testing.T) {
 	require.NoError(t, err)
 	ver, err := client.StateNetworkVersion(ctx, types.EmptyTSK)
 	require.NoError(t, err)
-	spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType)
+	spt, err := lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType, false)
 	require.NoError(t, err)
 
 	ssize, err := spt.SectorSize()

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
-	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -168,25 +167,6 @@ func (n *ProviderNodeAdapter) GetMinerWorkerAddress(ctx context.Context, maddr a
 		return address.Address{}, err
 	}
 	return mi.Worker, nil
-}
-
-func (n *ProviderNodeAdapter) GetProofType(ctx context.Context, maddr address.Address, tok shared.TipSetToken) (abi.RegisteredSealProof, error) {
-	tsk, err := types.TipSetKeyFromBytes(tok)
-	if err != nil {
-		return 0, err
-	}
-
-	mi, err := n.StateMinerInfo(ctx, maddr, tsk)
-	if err != nil {
-		return 0, err
-	}
-
-	nver, err := n.StateNetworkVersion(ctx, tsk)
-	if err != nil {
-		return 0, err
-	}
-
-	return miner.PreferredSealProofTypeFromWindowPoStType(nver, mi.WindowPoStProofType)
 }
 
 func (n *ProviderNodeAdapter) SignBytes(ctx context.Context, signer address.Address, b []byte) (*crypto.Signature, error) {

--- a/markets/storageadapter/provider.go
+++ b/markets/storageadapter/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/state"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -167,6 +168,28 @@ func (n *ProviderNodeAdapter) GetMinerWorkerAddress(ctx context.Context, maddr a
 		return address.Address{}, err
 	}
 	return mi.Worker, nil
+}
+
+func (n *ProviderNodeAdapter) GetProofType(ctx context.Context, maddr address.Address, tok shared.TipSetToken) (abi.RegisteredSealProof, error) {
+	tsk, err := types.TipSetKeyFromBytes(tok)
+	if err != nil {
+		return 0, err
+	}
+
+	mi, err := n.StateMinerInfo(ctx, maddr, tsk)
+	if err != nil {
+		return 0, err
+	}
+
+	nver, err := n.StateNetworkVersion(ctx, tsk)
+	if err != nil {
+		return 0, err
+	}
+
+	// false because this variance is not consumed.
+	const configWantSynthetic = false
+
+	return miner.PreferredSealProofTypeFromWindowPoStType(nver, mi.WindowPoStProofType, configWantSynthetic)
 }
 
 func (n *ProviderNodeAdapter) SignBytes(ctx context.Context, signer address.Address, b []byte) (*crypto.Signature, error) {

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -155,6 +155,7 @@ func DefaultStorageMiner() *StorageMiner {
 			TerminateBatchMax:                      100,
 			TerminateBatchWait:                     Duration(5 * time.Minute),
 			MaxSectorProveCommitsSubmittedPerEpoch: 20,
+			SealWithSyntheticPoRep:                 false,
 		},
 
 		Proving: ProvingConfig{

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1272,6 +1272,14 @@ Submitting a smaller number of prove commits per epoch would reduce the possibil
 
 			Comment: ``,
 		},
+		{
+			Name: "SealWithSyntheticPoRep",
+			Type: "bool",
+
+			Comment: `SealWithSyntheticPoRep will reduce data holdings after PC1 by storing the precomputed responses
+to any challenge. This proof's PC1 step uses a cheaper-to-compute algorithm for the responses,
+but still must do more computation during PC1 in order to create this oracle.`,
+		},
 	},
 	"Splitstore": []DocField{
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -437,6 +437,11 @@ type SealingConfig struct {
 	// todo TargetSealingSectors uint64
 
 	// todo TargetSectors - stop auto-pleding new sectors after this many sectors are sealed, default CC upgrade for deals sectors if above
+
+	// SealWithSyntheticPoRep will reduce data holdings after PC1 by storing the precomputed responses
+	// to any challenge. This proof's PC1 step uses a cheaper-to-compute algorithm for the responses,
+	// but still must do more computation during PC1 in order to create this oracle.
+	SealWithSyntheticPoRep bool
 }
 
 type SealerConfig struct {

--- a/node/impl/client/client.go
+++ b/node/impl/client/client.go
@@ -197,7 +197,7 @@ func (a *API) dealStarter(ctx context.Context, params *api.StartDealParams, isSt
 		return nil, xerrors.Errorf("failed to get network version: %w", err)
 	}
 
-	st, err := miner.PreferredSealProofTypeFromWindowPoStType(networkVersion, mi.WindowPoStProofType)
+	st, err := miner.PreferredSealProofTypeFromWindowPoStType(networkVersion, mi.WindowPoStProofType, false)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get seal proof type: %w", err)
 	}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -147,7 +147,7 @@ func StorageNetworkName(ctx helpers.MetricsCtx, a v1api.FullNode) (dtypes.Networ
 	return a.StateNetworkName(ctx)
 }
 
-func SealProofType(maddr dtypes.MinerAddress, fnapi v1api.FullNode) (abi.RegisteredSealProof, error) {
+func SealProofType(maddr dtypes.MinerAddress, fnapi v1api.FullNode, configSyntheticPoRep bool) (abi.RegisteredSealProof, error) {
 	mi, err := fnapi.StateMinerInfo(context.TODO(), address.Address(maddr), types.EmptyTSK)
 	if err != nil {
 		return 0, err
@@ -157,7 +157,7 @@ func SealProofType(maddr dtypes.MinerAddress, fnapi v1api.FullNode) (abi.Registe
 		return 0, err
 	}
 
-	return miner.PreferredSealProofTypeFromWindowPoStType(networkVersion, mi.WindowPoStProofType)
+	return miner.PreferredSealProofTypeFromWindowPoStType(networkVersion, mi.WindowPoStProofType, configSyntheticPoRep)
 }
 
 func AddressSelector(addrConf *config.MinerAddressConfig) func() (*ctladdr.AddressSelector, error) {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -1018,6 +1018,7 @@ func NewSetSealConfigFunc(r repo.LockedRepo) (dtypes.SetSealingConfigFunc, error
 				TerminateBatchMin:                      cfg.TerminateBatchMin,
 				TerminateBatchWait:                     config.Duration(cfg.TerminateBatchWait),
 				MaxSectorProveCommitsSubmittedPerEpoch: cfg.MaxSectorProveCommitsSubmittedPerEpoch,
+				SealWithSyntheticPoRep:                 cfg.SealWithSyntheticPoRep,
 			}
 			c.SetSealingConfig(newCfg)
 		})
@@ -1061,9 +1062,10 @@ func ToSealingConfig(dealmakingCfg config.DealmakingConfig, sealingCfg config.Se
 		BatchPreCommitAboveBaseFee:             types.BigInt(sealingCfg.BatchPreCommitAboveBaseFee),
 		MaxSectorProveCommitsSubmittedPerEpoch: sealingCfg.MaxSectorProveCommitsSubmittedPerEpoch,
 
-		TerminateBatchMax:  sealingCfg.TerminateBatchMax,
-		TerminateBatchMin:  sealingCfg.TerminateBatchMin,
-		TerminateBatchWait: time.Duration(sealingCfg.TerminateBatchWait),
+		TerminateBatchMax:      sealingCfg.TerminateBatchMax,
+		TerminateBatchMin:      sealingCfg.TerminateBatchMin,
+		TerminateBatchWait:     time.Duration(sealingCfg.TerminateBatchWait),
+		SealWithSyntheticPoRep: sealingCfg.SealWithSyntheticPoRep,
 	}
 }
 

--- a/storage/pipeline/sealiface/config.go
+++ b/storage/pipeline/sealiface/config.go
@@ -63,4 +63,6 @@ type Config struct {
 	TerminateBatchMax  uint64
 	TerminateBatchMin  uint64
 	TerminateBatchWait time.Duration
+
+	SealWithSyntheticPoRep bool
 }

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -339,7 +339,12 @@ func (m *Sealing) currentSealProof(ctx context.Context) (abi.RegisteredSealProof
 		return 0, err
 	}
 
-	return lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType)
+	c, err := m.getConfig()
+	if err != nil {
+		return 0, err
+	}
+
+	return lminer.PreferredSealProofTypeFromWindowPoStType(ver, mi.WindowPoStProofType, c.SealWithSyntheticPoRep)
 }
 
 func (m *Sealing) minerSector(spt abi.RegisteredSealProof, num abi.SectorNumber) storiface.SectorRef {

--- a/storage/sealer/ffiwrapper/sealer_cgo.go
+++ b/storage/sealer/ffiwrapper/sealer_cgo.go
@@ -923,7 +923,7 @@ func (sb *Sealer) SealCommit1(ctx context.Context, sector storiface.SectorRef, t
 		return output, nil // Non-fatal error.
 	}
 
-	ffi.ClearCache(uint64(ssize), paths.Cache)
+	ffi.ClearSyntheticProofs(uint64(ssize), paths.Cache)
 	if err != nil {
 		log.Warn("Unable to delete Synth cache:", err)
 		return output, nil // Non-fatal error.


### PR DESCRIPTION
## Related Issues
Synthetic PoRep Sealing Implementation for considerable reduction in disk usage by sealing machines during the network proof epochs. 

## Proposed Changes
This including Rust Proofs, FFI, and Lotus Sealing Scheduler but lacks Network/Protocol code.

## Additional Info
https://docs.google.com/document/d/1Ug4uC89Kkwhn3vcbiHETxToIUQ4zXEPa4QcQMPcvRxI/edit#heading=h.277tjch7w86w

https://www.notion.so/pl-strflt/FIP-0059-Synthetic-PoRep-180d995a027647198f6bffebc3eca932

https://www.notion.so/pl-strflt/Synthetic-PoRep-c15c9005f6284a9b9b3adeb6a3cecff1

https://github.com/filecoin-project/FIPs/discussions/245

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
