### PR TITLE
fix: eth: ensure that the event topics are non-nil

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1537,6 +1537,8 @@ func ethLogFromEvent(entries []types.EventEntry) (data []byte, topics []ethtypes
 		topicsFoundCount int
 		dataFound        bool
 	)
+	// Topics must be non-nil, even if empty. So we might as well pre-allocate for 4 (the max).
+	topics = make([]ethtypes.EthHash, 0, 4)
 	for _, entry := range entries {
 		// Drop events with non-raw topics to avoid mistakes.
 		if entry.Codec != cid.Raw {

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -17,7 +17,8 @@ func TestEthLogFromEvent(t *testing.T) {
 	data, topics, ok := ethLogFromEvent(nil)
 	require.True(t, ok)
 	require.Nil(t, data)
-	require.Nil(t, topics)
+	require.Empty(t, topics)
+	require.NotNil(t, topics)
 
 	// basic topic
 	data, topics, ok = ethLogFromEvent([]types.EventEntry{{


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes #10910

## Proposed Changes
<!-- A clear list of the changes being made -->

Ensure event topics are non-nil, even when empty. Go treats them as equivalent, but JSON distinguishes between `null` and `[]`.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green