### PR TITLE
fix: pubsub: do not treat ErrExistingNonce as Reject

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -361,6 +361,8 @@ func (mv *MessageValidator) Validate(ctx context.Context, pid peer.ID, msg *pubs
 		case xerrors.Is(err, messagepool.ErrGasFeeCapTooLow):
 			fallthrough
 		case xerrors.Is(err, messagepool.ErrNonceTooLow):
+			fallthrough
+		case xerrors.Is(err, messagepool.ErrExistingNonce):
 			return pubsub.ValidationIgnore
 		default:
 			return pubsub.ValidationReject


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This might help with #10906.

The `ErrExistingNonce` error is thrown when [we already have the exact message we're trying to add ](https://github.com/filecoin-project/lotus/blob/fb228ebbff5b2e3bbb6a51f2b2cfe232f2f16f94/chain/messagepool/messagepool.go#L284-L285)in our pending mset. It is an error to try and add this message, but it is not wrong for us to _receive_ a message multiple times, and try to add it. We should definitely not penalize peers who inform us of messages we've already added.

What's not clear to me is whether something earlier in the pipeline should be realizing that we've already processed this message. Regardless, however, I think we should be treating this case as an Ignore, not a Reject. 

## Proposed Changes
<!-- A clear list of the changes being made -->

Lower the pubsub handling of this particular failure to Ignore.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
