### PR TITLE
feat: daemon: improvemens to the consensus slasher

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -406,7 +406,7 @@ var DaemonCmd = &cli.Command{
 			go func() {
 				err := slashConsensus(api, cctx.String("slashdb-dir"), cctx.String("slasher-sender"))
 				if err != nil {
-					panic("slashConsensus error")
+					panic("slashConsensus error: " + err.Error())
 				}
 			}()
 		}
@@ -697,15 +697,19 @@ func slashFilterMinedBlock(ctx context.Context, sf *slashfilter.SlashFilter, a l
 	if err != nil {
 		return nil, nil, xerrors.Errorf("chain get block error:%s", err)
 	}
+
 	otherCid, err := sf.MinedBlock(ctx, blockB, blockC.Height)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("slash filter check block error:%s", err)
 	}
+
 	if otherCid != cid.Undef {
 		otherHeader, err := a.ChainGetBlock(ctx, otherCid)
 		return otherHeader, nil, xerrors.Errorf("chain get other block error:%s", err)
 	}
+
 	blockA, err := a.ChainGetBlock(ctx, otherCid)
+	if 
 
 	// (c) parent-grinding fault
 	// Here extra is the "witness", a third block that shows the connection between A and B as

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/zstd"
-	"github.com/ipfs/go-cid"
 	levelds "github.com/ipfs/go-ds-leveldb"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
 	"github.com/mitchellh/go-homedir"
@@ -639,11 +638,13 @@ func slashConsensus(a lapi.FullNode, p string, from string) error {
 	}
 	for block := range blocks {
 		log.Infof("deal with block: %d, %v, %s", block.Height, block.Miner, block.Cid())
-		if otherBlock, extraBlock, err := slashFilterMinedBlock(ctx, sf, a, block); err != nil {
-			if otherBlock == nil {
-				continue
-			}
-			log.Errorf("<!!> SLASH FILTER ERROR: %s", err)
+		otherBlock, extraBlock, fault, err := slashFilterMinedBlock(ctx, sf, a, block)
+		if err != nil {
+			log.Errorf("slash detector errored: %s", err)
+			continue
+		}
+		if fault {
+			log.Errorf("<!!> SLASH FILTER DETECTED FAULT DUE TO BLOCKS %s and %s", otherBlock.Cid(), block.Cid())
 			bh1, err := cborutil.Dump(otherBlock)
 			if err != nil {
 				log.Errorf("could not dump otherblock:%s, err:%s", otherBlock.Cid(), err)
@@ -682,7 +683,7 @@ func slashConsensus(a lapi.FullNode, p string, from string) error {
 				Params: enc,
 			}, nil)
 			if err != nil {
-				log.Errorf("ReportConsensusFault to messagepool error:%w", err)
+				log.Errorf("ReportConsensusFault to messagepool error:%s", err)
 				continue
 			}
 			log.Infof("ReportConsensusFault message CID:%s", message.Cid())
@@ -692,24 +693,35 @@ func slashConsensus(a lapi.FullNode, p string, from string) error {
 	return err
 }
 
-func slashFilterMinedBlock(ctx context.Context, sf *slashfilter.SlashFilter, a lapi.FullNode, blockB *types.BlockHeader) (*types.BlockHeader, *types.BlockHeader, error) {
+func slashFilterMinedBlock(ctx context.Context, sf *slashfilter.SlashFilter, a lapi.FullNode, blockB *types.BlockHeader) (*types.BlockHeader, *types.BlockHeader, bool, error) {
 	blockC, err := a.ChainGetBlock(ctx, blockB.Parents[0])
 	if err != nil {
-		return nil, nil, xerrors.Errorf("chain get block error:%s", err)
+		return nil, nil, false, xerrors.Errorf("chain get block error:%s", err)
 	}
 
-	otherCid, err := sf.MinedBlock(ctx, blockB, blockC.Height)
+	blockACid, fault, err := sf.MinedBlock(ctx, blockB, blockC.Height)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("slash filter check block error:%s", err)
+		return nil, nil, false, xerrors.Errorf("slash filter check block error:%s", err)
 	}
 
-	if otherCid != cid.Undef {
-		otherHeader, err := a.ChainGetBlock(ctx, otherCid)
-		return otherHeader, nil, xerrors.Errorf("chain get other block error:%s", err)
+	if !fault {
+		return nil, nil, false, nil
 	}
 
-	blockA, err := a.ChainGetBlock(ctx, otherCid)
-	if 
+	blockA, err := a.ChainGetBlock(ctx, blockACid)
+	if err != nil {
+		return nil, nil, false, xerrors.Errorf("failed to get blockA: %w", err)
+	}
+
+	// (a) double-fork mining (2 blocks at one epoch)
+	if blockA.Height == blockB.Height {
+		return blockA, nil, true, nil
+	}
+
+	// (b) time-offset mining faults (2 blocks with the same parents)
+	if types.CidArrsEqual(blockB.Parents, blockA.Parents) {
+		return blockA, nil, true, nil
+	}
 
 	// (c) parent-grinding fault
 	// Here extra is the "witness", a third block that shows the connection between A and B as
@@ -721,8 +733,9 @@ func slashFilterMinedBlock(ctx context.Context, sf *slashfilter.SlashFilter, a l
 	//  [A, C]
 	if types.CidArrsEqual(blockA.Parents, blockC.Parents) && blockA.Height == blockC.Height &&
 		types.CidArrsContains(blockB.Parents, blockC.Cid()) && !types.CidArrsContains(blockB.Parents, blockA.Cid()) {
-		return blockA, blockC, xerrors.Errorf("chain get other block error:%s", err)
+		return blockA, blockC, true, nil
 	}
 
-	return nil, nil, nil
+	log.Error("unexpectedly reached end of slashFilterMinedBlock despite fault being reported!")
+	return nil, nil, false, nil
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -333,7 +333,7 @@ minerLoop:
 				}
 
 				if fault {
-					log.Errorf("<!!> SLASH FILTER DETECTED FAULT due to witness %s", witness)
+					log.Errorf("<!!> SLASH FILTER DETECTED FAULT due to blocks %s and %s", b.Header.Cid(), witness)
 					continue
 				}
 			}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -324,9 +324,16 @@ minerLoop:
 					"block-time", btime, "time", build.Clock.Now(), "difference", build.Clock.Since(btime))
 			}
 
-			if _, err = m.sf.MinedBlock(ctx, b.Header, base.TipSet.Height()+base.NullRounds); err != nil {
-				log.Errorf("<!!> SLASH FILTER ERROR: %s", err)
-				if os.Getenv("LOTUS_MINER_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" {
+			if os.Getenv("LOTUS_MINER_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" {
+				witness, fault, err := m.sf.MinedBlock(ctx, b.Header, base.TipSet.Height()+base.NullRounds)
+				if err != nil {
+					log.Errorf("<!!> SLASH FILTER ERRORED: %s", err)
+					// Continue here, because it's _probably_ wiser to not submit this block
+					continue
+				}
+
+				if fault {
+					log.Errorf("<!!> SLASH FILTER DETECTED FAULT due to witness %s", witness)
 					continue
 				}
 			}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Improvements to the new consensus slasher that was created in #10871 

## Proposed Changes
<!-- A clear list of the changes being made -->

- Log failures
- Return a bool to indicate any faults, separate from other errors
- Perform some additional checks before reporting faults 

## Additional Info
<!-- Callouts, links to documentation, and etc -->

 Run `lotus daemon --slash-consensus=true --slashdb-dir="/mnt/data/.slasher" >> /mnt/data/slash.log 2>&1 &` to run the consensus slasher.

`--slashdb-dir` is used to supply the path to the slasher database.
`--slasher-sender` can optionally be used to specify the account to send the `ReportConsensusFault` message from.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
