### PR TITLE
feat: UX-friendly `lotus-miner sectors extend` cmd

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1403,7 +1403,9 @@ var sectorsExtendCmd = &cli.Command{
 					Value:  big.Zero(),
 					Params: sp,
 				}, nil, types.EmptyTSK)
-				if err != nil {
+				if err != nil && xerrors.Is(err, &api.ErrOutOfGas{}) {
+					return xerrors.Errorf("out of gas, please use --max-sectors to reduce the number of single message sectors")
+				} else if err != nil {
 					return err
 				}
 				gasTotal.Add(gasTotal.Int, estMsg.RequiredFunds().Int)

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1404,11 +1404,11 @@ var sectorsExtendCmd = &cli.Command{
 					Params: sp,
 				}, nil, types.EmptyTSK)
 				if err != nil && xerrors.Is(err, &api.ErrOutOfGas{}) {
-					return xerrors.Errorf("out of gas, please use --max-sectors to reduce the number of single message sectors")
+					return xerrors.Errorf("out of gas, please use --max-sectors and reduce the amount of sectors you extend in each message")
 				} else if err != nil {
 					return err
 				}
-				gasTotal.Add(gasTotal.Int, estMsg.RequiredFunds().Int)
+				gasTotal = big.Add(gasTotal, estMsg.RequiredFunds())
 				continue
 			}
 
@@ -1431,9 +1431,9 @@ var sectorsExtendCmd = &cli.Command{
 			fmt.Println(smsg.Cid())
 		}
 
-		fmt.Printf("Simulating extending %d sector - estimated costs %s\n", stotal, types.FIL(gasTotal))
+		fmt.Printf("Simulating extending %d sector(s) - estimated costs %s\n", stotal, types.FIL(gasTotal))
 		if !cctx.Bool("really-do-it") {
-			fmt.Println("You need to pass the --really-do-it flag to actully send the message")
+			fmt.Println("You need to pass the --really-do-it flag to actually send the message")
 		}
 
 		return nil


### PR DESCRIPTION
## Related Issues

Closes: https://github.com/filecoin-project/lotus/issues/10967

## Proposed Changes

- [x] Simulates how much the message will cost
- [x] Adds that the --really-do-it flag needs to be added to actually send the message

Example:

```
lotus-miner sectors extend --from=786831 --to=786832
Extending 5 sectors: 
 {
  "Extensions": [
    {
      "Deadline": 5,
      "Partition": 0,
      "Sectors": "5,8",
      "NewExpiration": 1570600
    },
    {
      "Deadline": 2,
      "Partition": 0,
      "Sectors": "6",
      "NewExpiration": 1570600
    },
    {
      "Deadline": 3,
      "Partition": 0,
      "Sectors": "7,10",
      "NewExpiration": 1570600
    }
  ]
}
Simulating extending 5 sector(s) - estimated costs 0.000008576090848024 FIL
You need to pass the --really-do-it flag to actually send the message
```

With the --really-do-it flag:
```
lotus-miner sectors extend --really-do-it --from=786831 --to=786832
Extending 9 sectors: bafy2bzacedputunig7mqmldbfwm2dr3xahc6m26ln7sm5e3hd5jnm7qu4aovc
Simulating extending 9 sector(s) - estimated costs 0 FIL
```

## Additional Info

Manual testing covered (tested by phi-rjan)

- [x] Extend sectors with the `--from` and `--to` flag
- [x] Extend a sector by just adding the sector number after `lotus-miner sectors extend`
- [x] Extend sectors with the `--sectorfile` option

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
