### PR TITLE
sealing: Use only non-assigned deals when selecting snap sectors

### DIFF
--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -630,6 +630,10 @@ func (m *Sealing) pendingPieceEpochBounds() []pieceBound {
 	boundsByEpoch := map[abi.ChainEpoch]*pieceBound{}
 
 	for ppi, piece := range m.pendingPieces {
+		if piece.assigned {
+			continue
+		}
+
 		// start bound on deal end
 		if boundsByEpoch[piece.deal.DealProposal.EndEpoch] == nil {
 			boundsByEpoch[piece.deal.DealProposal.EndEpoch] = &pieceBound{


### PR DESCRIPTION
## Related Issues
Likely fixes https://github.com/filecoin-project/lotus/issues/10914
Thanks to added logging in https://github.com/filecoin-project/lotus/pull/10915

## Proposed Changes
The sealing pipeline keeps pending piece references for a while after deals are assigned/added to sectors. When selecting what sector to upgrade, we calculate a list which says "at Y epoch there are X deals waiting to be inserted into a sector". That logic only cares about deals/pieces which weren't added/assigned to any sector, which we didn't check, causing us to potentially select sectors which couldn't accept any deals, which would cause the pipeline to fill up with waiting sectors, just waiting for a timeout..

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
