### PR TITLE
[WIP] feat: Add nv21 skeleton

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -339,6 +339,7 @@ type ForkUpgradeParams struct {
 	UpgradeHyggeHeight       abi.ChainEpoch
 	UpgradeLightningHeight   abi.ChainEpoch
 	UpgradeThunderHeight     abi.ChainEpoch
+	UpgradeSummerHeight      abi.ChainEpoch
 }
 
 type NonceMapType map[address.Address]uint64

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -61,9 +61,11 @@ var UpgradeSharkHeight = abi.ChainEpoch(-20)
 
 var UpgradeHyggeHeight = abi.ChainEpoch(-21)
 
-var UpgradeLightningHeight = abi.ChainEpoch(30)
+var UpgradeLightningHeight = abi.ChainEpoch(-22)
 
-var UpgradeThunderHeight = abi.ChainEpoch(1000)
+var UpgradeThunderHeight = abi.ChainEpoch(-23)
+
+var UpgradeSummerHeight = abi.ChainEpoch(1000)
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandMainnet,
@@ -120,6 +122,7 @@ func init() {
 	UpgradeHyggeHeight = getUpgradeHeight("LOTUS_HYGGE_HEIGHT", UpgradeHyggeHeight)
 	UpgradeLightningHeight = getUpgradeHeight("LOTUS_LIGHTNING_HEIGHT", UpgradeLightningHeight)
 	UpgradeThunderHeight = getUpgradeHeight("LOTUS_THUNDER_HEIGHT", UpgradeThunderHeight)
+	UpgradeSummerHeight = getUpgradeHeight("LOTUS_SUMMER_HEIGHT", UpgradeSummerHeight)
 
 	BuildType |= Build2k
 

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -57,6 +57,9 @@ const UpgradeLightningHeight = 50
 
 const UpgradeThunderHeight = UpgradeLightningHeight + 360
 
+// ???????
+const UpgradeSummerHeight = 999999999999999
+
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg512MiBV1,
 	abi.RegisteredSealProof_StackedDrg32GiBV1,

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -79,6 +79,9 @@ const UpgradeLightningHeight = 489094
 // 2023-04-21T16:00:00Z
 const UpgradeThunderHeight = UpgradeLightningHeight + 3120
 
+// ???????
+const UpgradeSummerHeight = 999999999999999
+
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,
 	abi.RegisteredSealProof_StackedDrg64GiBV1,

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -52,8 +52,9 @@ var UpgradeSkyrHeight = abi.ChainEpoch(-19)
 var UpgradeSharkHeight = abi.ChainEpoch(-20)
 var UpgradeHyggeHeight = abi.ChainEpoch(-21)
 var UpgradeLightningHeight = abi.ChainEpoch(-22)
+var UpgradeThunderHeight = abi.ChainEpoch(-23)
 
-const UpgradeThunderHeight = 50
+const UpgradeSummerHeight = 50
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandMainnet,

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -95,6 +95,9 @@ var UpgradeLightningHeight = abi.ChainEpoch(2809800)
 // 2023-05-18T13:00:00Z
 var UpgradeThunderHeight = UpgradeLightningHeight + 2880*21
 
+// ???????
+var UpgradeSummerHeight = abi.ChainEpoch(9999999999)
+
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,
 	abi.RegisteredSealProof_StackedDrg64GiBV1,
@@ -108,12 +111,8 @@ func init() {
 		SetAddressNetwork(address.Mainnet)
 	}
 
-	if os.Getenv("LOTUS_DISABLE_LIGHTNING") == "1" {
-		UpgradeLightningHeight = math.MaxInt64
-	}
-
-	if os.Getenv("LOTUS_DISABLE_THUNDER") == "1" {
-		UpgradeThunderHeight = math.MaxInt64
+	if os.Getenv("LOTUS_DISABLE_SUMMER") == "1" {
+		UpgradeSummerHeight = math.MaxInt64
 	}
 
 	// NOTE: DO NOT change this unless you REALLY know what you're doing. This is not consensus critical, however,

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -30,7 +30,7 @@ const AllowableClockDriftSecs = uint64(1)
 /* inline-gen template
 const TestNetworkVersion = network.Version{{.latestNetworkVersion}}
 /* inline-gen start */
-const TestNetworkVersion = network.Version20
+const TestNetworkVersion = network.Version21
 
 /* inline-gen end */
 

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -109,6 +109,7 @@ var (
 	UpgradeHyggeHeight      abi.ChainEpoch = -20
 	UpgradeLightningHeight  abi.ChainEpoch = -21
 	UpgradeThunderHeight    abi.ChainEpoch = -22
+	UpgradeSummerHeight     abi.ChainEpoch = -23
 
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 		0: DrandMainnet,

--- a/chain/actors/builtin/account/account.go
+++ b/chain/actors/builtin/account/account.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -22,7 +22,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-var Methods = builtin11.MethodsAccount
+var Methods = builtin12.MethodsAccount
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	if name, av, ok := actors.GetActorMetaByCode(act.Code); ok {
@@ -43,6 +43,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -111,6 +114,9 @@ func MakeState(store adt.Store, av actorstypes.Version, addr address.Address) (S
 	case actorstypes.Version11:
 		return make11(store, addr)
 
+	case actorstypes.Version12:
+		return make12(store, addr)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -139,5 +145,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/account/v12.go
+++ b/chain/actors/builtin/account/v12.go
@@ -1,0 +1,62 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-address"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	account12 "github.com/filecoin-project/go-state-types/builtin/v12/account"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, addr address.Address) (State, error) {
+	out := state12{store: store}
+	out.State = account12.State{Address: addr}
+	return &out, nil
+}
+
+type state12 struct {
+	account12.State
+	store adt.Store
+}
+
+func (s *state12) PubkeyAddress() (address.Address, error) {
+	return s.Address, nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.AccountKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/cron/cron.go
+++ b/chain/actors/builtin/cron/cron.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/xerrors"
 
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -39,6 +39,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -107,13 +110,16 @@ func MakeState(store adt.Store, av actorstypes.Version) (State, error) {
 	case actorstypes.Version11:
 		return make11(store)
 
+	case actorstypes.Version12:
+		return make12(store)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
 
 var (
-	Address = builtin11.CronActorAddr
-	Methods = builtin11.MethodsCron
+	Address = builtin12.CronActorAddr
+	Methods = builtin12.MethodsCron
 )
 
 type State interface {
@@ -137,5 +143,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/cron/v12.go
+++ b/chain/actors/builtin/cron/v12.go
@@ -1,0 +1,57 @@
+package cron
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	cron12 "github.com/filecoin-project/go-state-types/builtin/v12/cron"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store) (State, error) {
+	out := state12{store: store}
+	out.State = *cron12.ConstructState(cron12.BuiltInEntries())
+	return &out, nil
+}
+
+type state12 struct {
+	cron12.State
+	store adt.Store
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.CronKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/datacap/datacap.go
+++ b/chain/actors/builtin/datacap/datacap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	Address = builtin11.DatacapActorAddr
-	Methods = builtin11.MethodsDatacap
+	Address = builtin12.DatacapActorAddr
+	Methods = builtin12.MethodsDatacap
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -38,6 +38,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 		case actorstypes.Version11:
 			return load11(store, act.Head)
 
+		case actorstypes.Version12:
+			return load12(store, act.Head)
+
 		}
 	}
 
@@ -55,6 +58,9 @@ func MakeState(store adt.Store, av actorstypes.Version, governor address.Address
 
 	case actorstypes.Version11:
 		return make11(store, governor, bitwidth)
+
+	case actorstypes.Version12:
+		return make12(store, governor, bitwidth)
 
 	default:
 		return nil, xerrors.Errorf("datacap actor only valid for actors v9 and above, got %d", av)
@@ -79,5 +85,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/datacap/v12.go
+++ b/chain/actors/builtin/datacap/v12.go
@@ -1,0 +1,82 @@
+package datacap
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	datacap12 "github.com/filecoin-project/go-state-types/builtin/v12/datacap"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, governor address.Address, bitwidth uint64) (State, error) {
+	out := state12{store: store}
+	s, err := datacap12.ConstructState(store, governor, bitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	datacap12.State
+	store adt.Store
+}
+
+func (s *state12) Governor() (address.Address, error) {
+	return s.State.Governor, nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ForEachClient(cb func(addr address.Address, dcap abi.StoragePower) error) error {
+	return forEachClient(s.store, actors.Version12, s.verifiedClients, cb)
+}
+
+func (s *state12) verifiedClients() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.Token.Balances, int(s.Token.HamtBitWidth))
+}
+
+func (s *state12) VerifiedClientDataCap(addr address.Address) (bool, abi.StoragePower, error) {
+	return getDataCap(s.store, actors.Version12, s.verifiedClients, addr)
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.DatacapKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/evm/evm.go
+++ b/chain/actors/builtin/evm/evm.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/xerrors"
 
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 
@@ -14,7 +14,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-var Methods = builtin11.MethodsEVM
+var Methods = builtin12.MethodsEVM
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	if name, av, ok := actors.GetActorMetaByCode(act.Code); ok {
@@ -30,6 +30,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 		case actorstypes.Version11:
 			return load11(store, act.Head)
 
+		case actorstypes.Version12:
+			return load12(store, act.Head)
+
 		}
 	}
 
@@ -44,6 +47,9 @@ func MakeState(store adt.Store, av actorstypes.Version, bytecode cid.Cid) (State
 
 	case actorstypes.Version11:
 		return make11(store, bytecode)
+
+	case actorstypes.Version12:
+		return make12(store, bytecode)
 
 	default:
 		return nil, xerrors.Errorf("evm actor only valid for actors v10 and above, got %d", av)

--- a/chain/actors/builtin/evm/v12.go
+++ b/chain/actors/builtin/evm/v12.go
@@ -1,0 +1,72 @@
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	evm12 "github.com/filecoin-project/go-state-types/builtin/v12/evm"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, bytecode cid.Cid) (State, error) {
+	out := state12{store: store}
+	s, err := evm12.ConstructState(store, bytecode)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	evm12.State
+	store adt.Store
+}
+
+func (s *state12) Nonce() (uint64, error) {
+	return s.State.Nonce, nil
+}
+
+func (s *state12) IsAlive() (bool, error) {
+	return s.State.Tombstone == nil, nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) GetBytecodeCID() (cid.Cid, error) {
+	return s.State.Bytecode, nil
+}
+
+func (s *state12) GetBytecodeHash() ([32]byte, error) {
+	return s.State.BytecodeHash, nil
+}
+
+func (s *state12) GetBytecode() ([]byte, error) {
+	bc, err := s.GetBytecodeCID()
+	if err != nil {
+		return nil, err
+	}
+
+	var byteCode abi.CborBytesTransparent
+	if err := s.store.Get(s.store.Context(), bc, &byteCode); err != nil {
+		return nil, err
+	}
+
+	return byteCode, nil
+}

--- a/chain/actors/builtin/init/init.go
+++ b/chain/actors/builtin/init/init.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	Address = builtin11.InitActorAddr
-	Methods = builtin11.MethodsInit
+	Address = builtin12.InitActorAddr
+	Methods = builtin12.MethodsInit
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -48,6 +48,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -116,6 +119,9 @@ func MakeState(store adt.Store, av actorstypes.Version, networkName string) (Sta
 	case actorstypes.Version11:
 		return make11(store, networkName)
 
+	case actorstypes.Version12:
+		return make12(store, networkName)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -167,5 +173,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/init/v12.go
+++ b/chain/actors/builtin/init/v12.go
@@ -1,0 +1,147 @@
+package init
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, networkName string) (State, error) {
+	out := state12{store: store}
+
+	s, err := init12.ConstructState(store, networkName)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	init12.State
+	store adt.Store
+}
+
+func (s *state12) ResolveAddress(address address.Address) (address.Address, bool, error) {
+	return s.State.ResolveAddress(s.store, address)
+}
+
+func (s *state12) MapAddressToNewID(address address.Address) (address.Address, error) {
+	return s.State.MapAddressToNewID(s.store, address)
+}
+
+func (s *state12) ForEachActor(cb func(id abi.ActorID, address address.Address) error) error {
+	addrs, err := adt12.AsMap(s.store, s.State.AddressMap, builtin12.DefaultHamtBitwidth)
+	if err != nil {
+		return err
+	}
+	var actorID cbg.CborInt
+	return addrs.ForEach(&actorID, func(key string) error {
+		addr, err := address.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		return cb(abi.ActorID(actorID), addr)
+	})
+}
+
+func (s *state12) NetworkName() (dtypes.NetworkName, error) {
+	return dtypes.NetworkName(s.State.NetworkName), nil
+}
+
+func (s *state12) SetNetworkName(name string) error {
+	s.State.NetworkName = name
+	return nil
+}
+
+func (s *state12) SetNextID(id abi.ActorID) error {
+	s.State.NextID = id
+	return nil
+}
+
+func (s *state12) Remove(addrs ...address.Address) (err error) {
+	m, err := adt12.AsMap(s.store, s.State.AddressMap, builtin12.DefaultHamtBitwidth)
+	if err != nil {
+		return err
+	}
+	for _, addr := range addrs {
+		if err = m.Delete(abi.AddrKey(addr)); err != nil {
+			return xerrors.Errorf("failed to delete entry for address: %s; err: %w", addr, err)
+		}
+	}
+	amr, err := m.Root()
+	if err != nil {
+		return xerrors.Errorf("failed to get address map root: %w", err)
+	}
+	s.State.AddressMap = amr
+	return nil
+}
+
+func (s *state12) SetAddressMap(mcid cid.Cid) error {
+	s.State.AddressMap = mcid
+	return nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) AddressMap() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.State.AddressMap, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) AddressMapBitWidth() int {
+	return builtin12.DefaultHamtBitwidth
+}
+
+func (s *state12) AddressMapHashFunction() func(input []byte) []byte {
+	return func(input []byte) []byte {
+		res := sha256.Sum256(input)
+		return res[:]
+	}
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.InitKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -55,6 +55,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 		case actorstypes.Version11:
 			return load11(store, act.Head)
 
+		case actorstypes.Version12:
+			return load12(store, act.Head)
+
 		}
 	}
 
@@ -121,6 +124,9 @@ func MakeState(store adt.Store, av actorstypes.Version) (State, error) {
 
 	case actorstypes.Version11:
 		return make11(store)
+
+	case actorstypes.Version12:
+		return make12(store)
 
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
@@ -217,6 +223,9 @@ func DecodePublishStorageDealsReturn(b []byte, nv network.Version) (PublishStora
 	case actorstypes.Version11:
 		return decodePublishStorageDealsReturn11(b)
 
+	case actorstypes.Version12:
+		return decodePublishStorageDealsReturn12(b)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -303,5 +312,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/market/v12.go
+++ b/chain/actors/builtin/market/v12.go
@@ -1,0 +1,377 @@
+package market
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
+	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/builtin"
+	market12 "github.com/filecoin-project/go-state-types/builtin/v12/market"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"
+	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store) (State, error) {
+	out := state12{store: store}
+
+	s, err := market12.ConstructState(store)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	market12.State
+	store adt.Store
+}
+
+func (s *state12) TotalLocked() (abi.TokenAmount, error) {
+	fml := types.BigAdd(s.TotalClientLockedCollateral, s.TotalProviderLockedCollateral)
+	fml = types.BigAdd(fml, s.TotalClientStorageFee)
+	return fml, nil
+}
+
+func (s *state12) BalancesChanged(otherState State) (bool, error) {
+	otherState12, ok := otherState.(*state12)
+	if !ok {
+		// there's no way to compare different versions of the state, so let's
+		// just say that means the state of balances has changed
+		return true, nil
+	}
+	return !s.State.EscrowTable.Equals(otherState12.State.EscrowTable) || !s.State.LockedTable.Equals(otherState12.State.LockedTable), nil
+}
+
+func (s *state12) StatesChanged(otherState State) (bool, error) {
+	otherState12, ok := otherState.(*state12)
+	if !ok {
+		// there's no way to compare different versions of the state, so let's
+		// just say that means the state of balances has changed
+		return true, nil
+	}
+	return !s.State.States.Equals(otherState12.State.States), nil
+}
+
+func (s *state12) States() (DealStates, error) {
+	stateArray, err := adt12.AsArray(s.store, s.State.States, market12.StatesAmtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &dealStates12{stateArray}, nil
+}
+
+func (s *state12) ProposalsChanged(otherState State) (bool, error) {
+	otherState12, ok := otherState.(*state12)
+	if !ok {
+		// there's no way to compare different versions of the state, so let's
+		// just say that means the state of balances has changed
+		return true, nil
+	}
+	return !s.State.Proposals.Equals(otherState12.State.Proposals), nil
+}
+
+func (s *state12) Proposals() (DealProposals, error) {
+	proposalArray, err := adt12.AsArray(s.store, s.State.Proposals, market12.ProposalsAmtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &dealProposals12{proposalArray}, nil
+}
+
+func (s *state12) EscrowTable() (BalanceTable, error) {
+	bt, err := adt12.AsBalanceTable(s.store, s.State.EscrowTable)
+	if err != nil {
+		return nil, err
+	}
+	return &balanceTable12{bt}, nil
+}
+
+func (s *state12) LockedTable() (BalanceTable, error) {
+	bt, err := adt12.AsBalanceTable(s.store, s.State.LockedTable)
+	if err != nil {
+		return nil, err
+	}
+	return &balanceTable12{bt}, nil
+}
+
+func (s *state12) VerifyDealsForActivation(
+	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
+) (weight, verifiedWeight abi.DealWeight, err error) {
+	w, vw, _, err := market12.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return w, vw, err
+}
+
+func (s *state12) NextID() (abi.DealID, error) {
+	return s.State.NextID, nil
+}
+
+type balanceTable12 struct {
+	*adt12.BalanceTable
+}
+
+func (bt *balanceTable12) ForEach(cb func(address.Address, abi.TokenAmount) error) error {
+	asMap := (*adt12.Map)(bt.BalanceTable)
+	var ta abi.TokenAmount
+	return asMap.ForEach(&ta, func(key string) error {
+		a, err := address.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+		return cb(a, ta)
+	})
+}
+
+type dealStates12 struct {
+	adt.Array
+}
+
+func (s *dealStates12) Get(dealID abi.DealID) (*DealState, bool, error) {
+	var deal12 market12.DealState
+	found, err := s.Array.Get(uint64(dealID), &deal12)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+	deal := fromV12DealState(deal12)
+	return &deal, true, nil
+}
+
+func (s *dealStates12) ForEach(cb func(dealID abi.DealID, ds DealState) error) error {
+	var ds12 market12.DealState
+	return s.Array.ForEach(&ds12, func(idx int64) error {
+		return cb(abi.DealID(idx), fromV12DealState(ds12))
+	})
+}
+
+func (s *dealStates12) decode(val *cbg.Deferred) (*DealState, error) {
+	var ds12 market12.DealState
+	if err := ds12.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
+		return nil, err
+	}
+	ds := fromV12DealState(ds12)
+	return &ds, nil
+}
+
+func (s *dealStates12) array() adt.Array {
+	return s.Array
+}
+
+func fromV12DealState(v12 market12.DealState) DealState {
+	ret := DealState{
+		SectorStartEpoch: v12.SectorStartEpoch,
+		LastUpdatedEpoch: v12.LastUpdatedEpoch,
+		SlashEpoch:       v12.SlashEpoch,
+		VerifiedClaim:    0,
+	}
+
+	ret.VerifiedClaim = verifregtypes.AllocationId(v12.VerifiedClaim)
+
+	return ret
+}
+
+type dealProposals12 struct {
+	adt.Array
+}
+
+func (s *dealProposals12) Get(dealID abi.DealID) (*DealProposal, bool, error) {
+	var proposal12 market12.DealProposal
+	found, err := s.Array.Get(uint64(dealID), &proposal12)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+
+	proposal, err := fromV12DealProposal(proposal12)
+	if err != nil {
+		return nil, true, xerrors.Errorf("decoding proposal: %w", err)
+	}
+
+	return &proposal, true, nil
+}
+
+func (s *dealProposals12) ForEach(cb func(dealID abi.DealID, dp DealProposal) error) error {
+	var dp12 market12.DealProposal
+	return s.Array.ForEach(&dp12, func(idx int64) error {
+		dp, err := fromV12DealProposal(dp12)
+		if err != nil {
+			return xerrors.Errorf("decoding proposal: %w", err)
+		}
+
+		return cb(abi.DealID(idx), dp)
+	})
+}
+
+func (s *dealProposals12) decode(val *cbg.Deferred) (*DealProposal, error) {
+	var dp12 market12.DealProposal
+	if err := dp12.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
+		return nil, err
+	}
+
+	dp, err := fromV12DealProposal(dp12)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dp, nil
+}
+
+func (s *dealProposals12) array() adt.Array {
+	return s.Array
+}
+
+func fromV12DealProposal(v12 market12.DealProposal) (DealProposal, error) {
+
+	label, err := fromV12Label(v12.Label)
+
+	if err != nil {
+		return DealProposal{}, xerrors.Errorf("error setting deal label: %w", err)
+	}
+
+	return DealProposal{
+		PieceCID:     v12.PieceCID,
+		PieceSize:    v12.PieceSize,
+		VerifiedDeal: v12.VerifiedDeal,
+		Client:       v12.Client,
+		Provider:     v12.Provider,
+
+		Label: label,
+
+		StartEpoch:           v12.StartEpoch,
+		EndEpoch:             v12.EndEpoch,
+		StoragePricePerEpoch: v12.StoragePricePerEpoch,
+
+		ProviderCollateral: v12.ProviderCollateral,
+		ClientCollateral:   v12.ClientCollateral,
+	}, nil
+}
+
+func fromV12Label(v12 market12.DealLabel) (DealLabel, error) {
+	if v12.IsString() {
+		str, err := v12.ToString()
+		if err != nil {
+			return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert string label to string: %w", err)
+		}
+		return markettypes.NewLabelFromString(str)
+	}
+
+	bs, err := v12.ToBytes()
+	if err != nil {
+		return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert bytes label to bytes: %w", err)
+	}
+	return markettypes.NewLabelFromBytes(bs)
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+var _ PublishStorageDealsReturn = (*publishStorageDealsReturn12)(nil)
+
+func decodePublishStorageDealsReturn12(b []byte) (PublishStorageDealsReturn, error) {
+	var retval market12.PublishStorageDealsReturn
+	if err := retval.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal PublishStorageDealsReturn: %w", err)
+	}
+
+	return &publishStorageDealsReturn12{retval}, nil
+}
+
+type publishStorageDealsReturn12 struct {
+	market12.PublishStorageDealsReturn
+}
+
+func (r *publishStorageDealsReturn12) IsDealValid(index uint64) (bool, int, error) {
+
+	set, err := r.ValidDeals.IsSet(index)
+	if err != nil || !set {
+		return false, -1, err
+	}
+	maskBf, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{
+		Runs: []rlepluslazy.Run{rlepluslazy.Run{Val: true, Len: index}}})
+	if err != nil {
+		return false, -1, err
+	}
+	before, err := bitfield.IntersectBitField(maskBf, r.ValidDeals)
+	if err != nil {
+		return false, -1, err
+	}
+	outIdx, err := before.Count()
+	if err != nil {
+		return false, -1, err
+	}
+	return set, int(outIdx), nil
+
+}
+
+func (r *publishStorageDealsReturn12) DealIDs() ([]abi.DealID, error) {
+	return r.IDs, nil
+}
+
+func (s *state12) GetAllocationIdForPendingDeal(dealId abi.DealID) (verifregtypes.AllocationId, error) {
+
+	allocations, err := adt12.AsMap(s.store, s.PendingDealAllocationIds, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return verifregtypes.NoAllocationID, xerrors.Errorf("failed to load allocation id for %d: %w", dealId, err)
+	}
+
+	var allocationId cbg.CborInt
+	found, err := allocations.Get(abi.UIntKey(uint64(dealId)), &allocationId)
+	if err != nil {
+		return verifregtypes.NoAllocationID, xerrors.Errorf("failed to load allocation id for %d: %w", dealId, err)
+	}
+	if !found {
+		return verifregtypes.NoAllocationID, nil
+	}
+
+	return verifregtypes.AllocationId(allocationId), nil
+
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.MarketKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -48,6 +48,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 		case actorstypes.Version11:
 			return load11(store, act.Head)
 
+		case actorstypes.Version12:
+			return load12(store, act.Head)
+
 		}
 	}
 
@@ -114,6 +117,9 @@ func MakeState(store adt.Store, av actors.Version) (State, error) {
 
 	case actors.Version11:
 		return make11(store)
+
+	case actors.Version12:
+		return make12(store)
 
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
@@ -321,5 +327,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/miner/v12.go
+++ b/chain/actors/builtin/miner/v12.go
@@ -1,0 +1,591 @@
+package miner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-bitfield"
+	rle "github.com/filecoin-project/go-bitfield/rle"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	miner12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/dline"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store) (State, error) {
+	out := state12{store: store}
+	out.State = miner12.State{}
+	return &out, nil
+}
+
+type state12 struct {
+	miner12.State
+	store adt.Store
+}
+
+type deadline12 struct {
+	miner12.Deadline
+	store adt.Store
+}
+
+type partition12 struct {
+	miner12.Partition
+	store adt.Store
+}
+
+func (s *state12) AvailableBalance(bal abi.TokenAmount) (available abi.TokenAmount, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = xerrors.Errorf("failed to get available balance: %w", r)
+			available = abi.NewTokenAmount(0)
+		}
+	}()
+	// this panics if the miner doesnt have enough funds to cover their locked pledge
+	available, err = s.GetAvailableBalance(bal)
+	return available, err
+}
+
+func (s *state12) VestedFunds(epoch abi.ChainEpoch) (abi.TokenAmount, error) {
+	return s.CheckVestedFunds(s.store, epoch)
+}
+
+func (s *state12) LockedFunds() (LockedFunds, error) {
+	return LockedFunds{
+		VestingFunds:             s.State.LockedFunds,
+		InitialPledgeRequirement: s.State.InitialPledge,
+		PreCommitDeposits:        s.State.PreCommitDeposits,
+	}, nil
+}
+
+func (s *state12) FeeDebt() (abi.TokenAmount, error) {
+	return s.State.FeeDebt, nil
+}
+
+func (s *state12) InitialPledge() (abi.TokenAmount, error) {
+	return s.State.InitialPledge, nil
+}
+
+func (s *state12) PreCommitDeposits() (abi.TokenAmount, error) {
+	return s.State.PreCommitDeposits, nil
+}
+
+// Returns nil, nil if sector is not found
+func (s *state12) GetSector(num abi.SectorNumber) (*SectorOnChainInfo, error) {
+	info, ok, err := s.State.GetSector(s.store, num)
+	if !ok || err != nil {
+		return nil, err
+	}
+
+	ret := fromV12SectorOnChainInfo(*info)
+	return &ret, nil
+}
+
+func (s *state12) FindSector(num abi.SectorNumber) (*SectorLocation, error) {
+	dlIdx, partIdx, err := s.State.FindSector(s.store, num)
+	if err != nil {
+		return nil, err
+	}
+	return &SectorLocation{
+		Deadline:  dlIdx,
+		Partition: partIdx,
+	}, nil
+}
+
+func (s *state12) NumLiveSectors() (uint64, error) {
+	dls, err := s.State.LoadDeadlines(s.store)
+	if err != nil {
+		return 0, err
+	}
+	var total uint64
+	if err := dls.ForEach(s.store, func(dlIdx uint64, dl *miner12.Deadline) error {
+		total += dl.LiveSectors
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// GetSectorExpiration returns the effective expiration of the given sector.
+//
+// If the sector does not expire early, the Early expiration field is 0.
+func (s *state12) GetSectorExpiration(num abi.SectorNumber) (*SectorExpiration, error) {
+	dls, err := s.State.LoadDeadlines(s.store)
+	if err != nil {
+		return nil, err
+	}
+	// NOTE: this can be optimized significantly.
+	// 1. If the sector is non-faulty, it will expire on-time (can be
+	// learned from the sector info).
+	// 2. If it's faulty, it will expire early within the first 42 entries
+	// of the expiration queue.
+
+	stopErr := errors.New("stop")
+	out := SectorExpiration{}
+	err = dls.ForEach(s.store, func(dlIdx uint64, dl *miner12.Deadline) error {
+		partitions, err := dl.PartitionsArray(s.store)
+		if err != nil {
+			return err
+		}
+		quant := s.State.QuantSpecForDeadline(dlIdx)
+		var part miner12.Partition
+		return partitions.ForEach(&part, func(partIdx int64) error {
+			if found, err := part.Sectors.IsSet(uint64(num)); err != nil {
+				return err
+			} else if !found {
+				return nil
+			}
+			if found, err := part.Terminated.IsSet(uint64(num)); err != nil {
+				return err
+			} else if found {
+				// already terminated
+				return stopErr
+			}
+
+			q, err := miner12.LoadExpirationQueue(s.store, part.ExpirationsEpochs, quant, miner12.PartitionExpirationAmtBitwidth)
+			if err != nil {
+				return err
+			}
+			var exp miner12.ExpirationSet
+			return q.ForEach(&exp, func(epoch int64) error {
+				if early, err := exp.EarlySectors.IsSet(uint64(num)); err != nil {
+					return err
+				} else if early {
+					out.Early = abi.ChainEpoch(epoch)
+					return nil
+				}
+				if onTime, err := exp.OnTimeSectors.IsSet(uint64(num)); err != nil {
+					return err
+				} else if onTime {
+					out.OnTime = abi.ChainEpoch(epoch)
+					return stopErr
+				}
+				return nil
+			})
+		})
+	})
+	if err == stopErr {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if out.Early == 0 && out.OnTime == 0 {
+		return nil, xerrors.Errorf("failed to find sector %d", num)
+	}
+	return &out, nil
+}
+
+func (s *state12) GetPrecommittedSector(num abi.SectorNumber) (*SectorPreCommitOnChainInfo, error) {
+	info, ok, err := s.State.GetPrecommittedSector(s.store, num)
+	if !ok || err != nil {
+		return nil, err
+	}
+
+	ret := fromV12SectorPreCommitOnChainInfo(*info)
+
+	return &ret, nil
+}
+
+func (s *state12) ForEachPrecommittedSector(cb func(SectorPreCommitOnChainInfo) error) error {
+	precommitted, err := adt12.AsMap(s.store, s.State.PreCommittedSectors, builtin12.DefaultHamtBitwidth)
+	if err != nil {
+		return err
+	}
+
+	var info miner12.SectorPreCommitOnChainInfo
+	if err := precommitted.ForEach(&info, func(_ string) error {
+		return cb(fromV12SectorPreCommitOnChainInfo(info))
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *state12) LoadSectors(snos *bitfield.BitField) ([]*SectorOnChainInfo, error) {
+	sectors, err := miner12.LoadSectors(s.store, s.State.Sectors)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no sector numbers are specified, load all.
+	if snos == nil {
+		infos := make([]*SectorOnChainInfo, 0, sectors.Length())
+		var info12 miner12.SectorOnChainInfo
+		if err := sectors.ForEach(&info12, func(_ int64) error {
+			info := fromV12SectorOnChainInfo(info12)
+			infos = append(infos, &info)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return infos, nil
+	}
+
+	// Otherwise, load selected.
+	infos12, err := sectors.Load(*snos)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]*SectorOnChainInfo, len(infos12))
+	for i, info12 := range infos12 {
+		info := fromV12SectorOnChainInfo(*info12)
+		infos[i] = &info
+	}
+	return infos, nil
+}
+
+func (s *state12) loadAllocatedSectorNumbers() (bitfield.BitField, error) {
+	var allocatedSectors bitfield.BitField
+	err := s.store.Get(s.store.Context(), s.State.AllocatedSectors, &allocatedSectors)
+	return allocatedSectors, err
+}
+
+func (s *state12) IsAllocated(num abi.SectorNumber) (bool, error) {
+	allocatedSectors, err := s.loadAllocatedSectorNumbers()
+	if err != nil {
+		return false, err
+	}
+
+	return allocatedSectors.IsSet(uint64(num))
+}
+
+func (s *state12) GetProvingPeriodStart() (abi.ChainEpoch, error) {
+	return s.State.ProvingPeriodStart, nil
+}
+
+func (s *state12) UnallocatedSectorNumbers(count int) ([]abi.SectorNumber, error) {
+	allocatedSectors, err := s.loadAllocatedSectorNumbers()
+	if err != nil {
+		return nil, err
+	}
+
+	allocatedRuns, err := allocatedSectors.RunIterator()
+	if err != nil {
+		return nil, err
+	}
+
+	unallocatedRuns, err := rle.Subtract(
+		&rle.RunSliceIterator{Runs: []rle.Run{{Val: true, Len: abi.MaxSectorNumber}}},
+		allocatedRuns,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	iter, err := rle.BitsFromRuns(unallocatedRuns)
+	if err != nil {
+		return nil, err
+	}
+
+	sectors := make([]abi.SectorNumber, 0, count)
+	for iter.HasNext() && len(sectors) < count {
+		nextNo, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+		sectors = append(sectors, abi.SectorNumber(nextNo))
+	}
+
+	return sectors, nil
+}
+
+func (s *state12) GetAllocatedSectors() (*bitfield.BitField, error) {
+	var allocatedSectors bitfield.BitField
+	if err := s.store.Get(s.store.Context(), s.State.AllocatedSectors, &allocatedSectors); err != nil {
+		return nil, err
+	}
+
+	return &allocatedSectors, nil
+}
+
+func (s *state12) LoadDeadline(idx uint64) (Deadline, error) {
+	dls, err := s.State.LoadDeadlines(s.store)
+	if err != nil {
+		return nil, err
+	}
+	dl, err := dls.LoadDeadline(s.store, idx)
+	if err != nil {
+		return nil, err
+	}
+	return &deadline12{*dl, s.store}, nil
+}
+
+func (s *state12) ForEachDeadline(cb func(uint64, Deadline) error) error {
+	dls, err := s.State.LoadDeadlines(s.store)
+	if err != nil {
+		return err
+	}
+	return dls.ForEach(s.store, func(i uint64, dl *miner12.Deadline) error {
+		return cb(i, &deadline12{*dl, s.store})
+	})
+}
+
+func (s *state12) NumDeadlines() (uint64, error) {
+	return miner12.WPoStPeriodDeadlines, nil
+}
+
+func (s *state12) DeadlinesChanged(other State) (bool, error) {
+	other12, ok := other.(*state12)
+	if !ok {
+		// treat an upgrade as a change, always
+		return true, nil
+	}
+
+	return !s.State.Deadlines.Equals(other12.Deadlines), nil
+}
+
+func (s *state12) MinerInfoChanged(other State) (bool, error) {
+	other0, ok := other.(*state12)
+	if !ok {
+		// treat an upgrade as a change, always
+		return true, nil
+	}
+	return !s.State.Info.Equals(other0.State.Info), nil
+}
+
+func (s *state12) Info() (MinerInfo, error) {
+	info, err := s.State.GetInfo(s.store)
+	if err != nil {
+		return MinerInfo{}, err
+	}
+
+	mi := MinerInfo{
+		Owner:            info.Owner,
+		Worker:           info.Worker,
+		ControlAddresses: info.ControlAddresses,
+
+		PendingWorkerKey: (*WorkerKeyChange)(info.PendingWorkerKey),
+
+		PeerId:                     info.PeerId,
+		Multiaddrs:                 info.Multiaddrs,
+		WindowPoStProofType:        info.WindowPoStProofType,
+		SectorSize:                 info.SectorSize,
+		WindowPoStPartitionSectors: info.WindowPoStPartitionSectors,
+		ConsensusFaultElapsed:      info.ConsensusFaultElapsed,
+
+		Beneficiary:            info.Beneficiary,
+		BeneficiaryTerm:        BeneficiaryTerm(info.BeneficiaryTerm),
+		PendingBeneficiaryTerm: (*PendingBeneficiaryChange)(info.PendingBeneficiaryTerm),
+	}
+
+	return mi, nil
+}
+
+func (s *state12) DeadlineInfo(epoch abi.ChainEpoch) (*dline.Info, error) {
+	return s.State.RecordedDeadlineInfo(epoch), nil
+}
+
+func (s *state12) DeadlineCronActive() (bool, error) {
+	return s.State.DeadlineCronActive, nil
+}
+
+func (s *state12) sectors() (adt.Array, error) {
+	return adt12.AsArray(s.store, s.Sectors, miner12.SectorsAmtBitwidth)
+}
+
+func (s *state12) decodeSectorOnChainInfo(val *cbg.Deferred) (SectorOnChainInfo, error) {
+	var si miner12.SectorOnChainInfo
+	err := si.UnmarshalCBOR(bytes.NewReader(val.Raw))
+	if err != nil {
+		return SectorOnChainInfo{}, err
+	}
+
+	return fromV12SectorOnChainInfo(si), nil
+}
+
+func (s *state12) precommits() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.PreCommittedSectors, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) decodeSectorPreCommitOnChainInfo(val *cbg.Deferred) (SectorPreCommitOnChainInfo, error) {
+	var sp miner12.SectorPreCommitOnChainInfo
+	err := sp.UnmarshalCBOR(bytes.NewReader(val.Raw))
+	if err != nil {
+		return SectorPreCommitOnChainInfo{}, err
+	}
+
+	return fromV12SectorPreCommitOnChainInfo(sp), nil
+}
+
+func (s *state12) EraseAllUnproven() error {
+
+	dls, err := s.State.LoadDeadlines(s.store)
+	if err != nil {
+		return err
+	}
+
+	err = dls.ForEach(s.store, func(dindx uint64, dl *miner12.Deadline) error {
+		ps, err := dl.PartitionsArray(s.store)
+		if err != nil {
+			return err
+		}
+
+		var part miner12.Partition
+		err = ps.ForEach(&part, func(pindx int64) error {
+			_ = part.ActivateUnproven()
+			err = ps.Set(uint64(pindx), &part)
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		dl.Partitions, err = ps.Root()
+		if err != nil {
+			return err
+		}
+
+		return dls.UpdateDeadline(s.store, dindx, dl)
+	})
+	if err != nil {
+		return err
+	}
+
+	return s.State.SaveDeadlines(s.store, dls)
+
+}
+
+func (d *deadline12) LoadPartition(idx uint64) (Partition, error) {
+	p, err := d.Deadline.LoadPartition(d.store, idx)
+	if err != nil {
+		return nil, err
+	}
+	return &partition12{*p, d.store}, nil
+}
+
+func (d *deadline12) ForEachPartition(cb func(uint64, Partition) error) error {
+	ps, err := d.Deadline.PartitionsArray(d.store)
+	if err != nil {
+		return err
+	}
+	var part miner12.Partition
+	return ps.ForEach(&part, func(i int64) error {
+		return cb(uint64(i), &partition12{part, d.store})
+	})
+}
+
+func (d *deadline12) PartitionsChanged(other Deadline) (bool, error) {
+	other12, ok := other.(*deadline12)
+	if !ok {
+		// treat an upgrade as a change, always
+		return true, nil
+	}
+
+	return !d.Deadline.Partitions.Equals(other12.Deadline.Partitions), nil
+}
+
+func (d *deadline12) PartitionsPoSted() (bitfield.BitField, error) {
+	return d.Deadline.PartitionsPoSted, nil
+}
+
+func (d *deadline12) DisputableProofCount() (uint64, error) {
+
+	ops, err := d.OptimisticProofsSnapshotArray(d.store)
+	if err != nil {
+		return 0, err
+	}
+
+	return ops.Length(), nil
+
+}
+
+func (p *partition12) AllSectors() (bitfield.BitField, error) {
+	return p.Partition.Sectors, nil
+}
+
+func (p *partition12) FaultySectors() (bitfield.BitField, error) {
+	return p.Partition.Faults, nil
+}
+
+func (p *partition12) RecoveringSectors() (bitfield.BitField, error) {
+	return p.Partition.Recoveries, nil
+}
+
+func (p *partition12) UnprovenSectors() (bitfield.BitField, error) {
+	return p.Partition.Unproven, nil
+}
+
+func fromV12SectorOnChainInfo(v12 miner12.SectorOnChainInfo) SectorOnChainInfo {
+	info := SectorOnChainInfo{
+		SectorNumber:          v12.SectorNumber,
+		SealProof:             v12.SealProof,
+		SealedCID:             v12.SealedCID,
+		DealIDs:               v12.DealIDs,
+		Activation:            v12.Activation,
+		Expiration:            v12.Expiration,
+		DealWeight:            v12.DealWeight,
+		VerifiedDealWeight:    v12.VerifiedDealWeight,
+		InitialPledge:         v12.InitialPledge,
+		ExpectedDayReward:     v12.ExpectedDayReward,
+		ExpectedStoragePledge: v12.ExpectedStoragePledge,
+
+		SectorKeyCID: v12.SectorKeyCID,
+	}
+	return info
+}
+
+func fromV12SectorPreCommitOnChainInfo(v12 miner12.SectorPreCommitOnChainInfo) SectorPreCommitOnChainInfo {
+	ret := SectorPreCommitOnChainInfo{
+		Info: SectorPreCommitInfo{
+			SealProof:     v12.Info.SealProof,
+			SectorNumber:  v12.Info.SectorNumber,
+			SealedCID:     v12.Info.SealedCID,
+			SealRandEpoch: v12.Info.SealRandEpoch,
+			DealIDs:       v12.Info.DealIDs,
+			Expiration:    v12.Info.Expiration,
+			UnsealedCid:   nil,
+		},
+		PreCommitDeposit: v12.PreCommitDeposit,
+		PreCommitEpoch:   v12.PreCommitEpoch,
+	}
+
+	ret.Info.UnsealedCid = v12.Info.UnsealedCid
+
+	return ret
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.MinerKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/multisig/message10.go
+++ b/chain/actors/builtin/multisig/message10.go
@@ -8,7 +8,7 @@ import (
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 	multisig10 "github.com/filecoin-project/go-state-types/builtin/v10/multisig"
-	init11 "github.com/filecoin-project/go-state-types/builtin/v11/init"
+	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
 	"github.com/filecoin-project/go-state-types/manifest"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -57,7 +57,7 @@ func (m message10) Create(
 	}
 
 	// new actors are created by invoking 'exec' on the init actor with the constructor params
-	execParams := &init11.ExecParams{
+	execParams := &init12.ExecParams{
 		CodeCID:           code,
 		ConstructorParams: enc,
 	}

--- a/chain/actors/builtin/multisig/message11.go
+++ b/chain/actors/builtin/multisig/message11.go
@@ -7,8 +7,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
-	init11 "github.com/filecoin-project/go-state-types/builtin/v11/init"
 	multisig11 "github.com/filecoin-project/go-state-types/builtin/v11/multisig"
+	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
 	"github.com/filecoin-project/go-state-types/manifest"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -57,7 +57,7 @@ func (m message11) Create(
 	}
 
 	// new actors are created by invoking 'exec' on the init actor with the constructor params
-	execParams := &init11.ExecParams{
+	execParams := &init12.ExecParams{
 		CodeCID:           code,
 		ConstructorParams: enc,
 	}

--- a/chain/actors/builtin/multisig/message12.go
+++ b/chain/actors/builtin/multisig/message12.go
@@ -8,7 +8,7 @@ import (
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
-	multisig8 "github.com/filecoin-project/go-state-types/builtin/v8/multisig"
+	multisig12 "github.com/filecoin-project/go-state-types/builtin/v12/multisig"
 	"github.com/filecoin-project/go-state-types/manifest"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -16,9 +16,9 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-type message8 struct{ message0 }
+type message12 struct{ message0 }
 
-func (m message8) Create(
+func (m message12) Create(
 	signers []address.Address, threshold uint64,
 	unlockStart, unlockDuration abi.ChainEpoch,
 	initialAmount abi.TokenAmount,
@@ -39,7 +39,7 @@ func (m message8) Create(
 	}
 
 	// Set up constructor parameters for multisig
-	msigParams := &multisig8.ConstructorParams{
+	msigParams := &multisig12.ConstructorParams{
 		Signers:               signers,
 		NumApprovalsThreshold: threshold,
 		UnlockDuration:        unlockDuration,
@@ -51,7 +51,7 @@ func (m message8) Create(
 		return nil, actErr
 	}
 
-	code, ok := actors.GetActorCodeID(actorstypes.Version8, manifest.MultisigKey)
+	code, ok := actors.GetActorCodeID(actorstypes.Version12, manifest.MultisigKey)
 	if !ok {
 		return nil, xerrors.Errorf("failed to get multisig code ID")
 	}

--- a/chain/actors/builtin/multisig/message9.go
+++ b/chain/actors/builtin/multisig/message9.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
-	init11 "github.com/filecoin-project/go-state-types/builtin/v11/init"
+	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
 	multisig9 "github.com/filecoin-project/go-state-types/builtin/v9/multisig"
 	"github.com/filecoin-project/go-state-types/manifest"
 
@@ -57,7 +57,7 @@ func (m message9) Create(
 	}
 
 	// new actors are created by invoking 'exec' on the init actor with the constructor params
-	execParams := &init11.ExecParams{
+	execParams := &init12.ExecParams{
 		CodeCID:           code,
 		ConstructorParams: enc,
 	}

--- a/chain/actors/builtin/multisig/v12.go
+++ b/chain/actors/builtin/multisig/v12.go
@@ -1,0 +1,138 @@
+package multisig
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	msig12 "github.com/filecoin-project/go-state-types/builtin/v12/multisig"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, signers []address.Address, threshold uint64, startEpoch abi.ChainEpoch, unlockDuration abi.ChainEpoch, initialBalance abi.TokenAmount) (State, error) {
+	out := state12{store: store}
+	out.State = msig12.State{}
+	out.State.Signers = signers
+	out.State.NumApprovalsThreshold = threshold
+	out.State.StartEpoch = startEpoch
+	out.State.UnlockDuration = unlockDuration
+	out.State.InitialBalance = initialBalance
+
+	em, err := adt12.StoreEmptyMap(store, builtin12.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State.PendingTxns = em
+
+	return &out, nil
+}
+
+type state12 struct {
+	msig12.State
+	store adt.Store
+}
+
+func (s *state12) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
+	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+}
+
+func (s *state12) StartEpoch() (abi.ChainEpoch, error) {
+	return s.State.StartEpoch, nil
+}
+
+func (s *state12) UnlockDuration() (abi.ChainEpoch, error) {
+	return s.State.UnlockDuration, nil
+}
+
+func (s *state12) InitialBalance() (abi.TokenAmount, error) {
+	return s.State.InitialBalance, nil
+}
+
+func (s *state12) Threshold() (uint64, error) {
+	return s.State.NumApprovalsThreshold, nil
+}
+
+func (s *state12) Signers() ([]address.Address, error) {
+	return s.State.Signers, nil
+}
+
+func (s *state12) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
+	arr, err := adt12.AsMap(s.store, s.State.PendingTxns, builtin12.DefaultHamtBitwidth)
+	if err != nil {
+		return err
+	}
+	var out msig12.Transaction
+	return arr.ForEach(&out, func(key string) error {
+		txid, n := binary.Varint([]byte(key))
+		if n <= 0 {
+			return xerrors.Errorf("invalid pending transaction key: %v", key)
+		}
+		return cb(txid, (Transaction)(out)) //nolint:unconvert
+	})
+}
+
+func (s *state12) PendingTxnChanged(other State) (bool, error) {
+	other12, ok := other.(*state12)
+	if !ok {
+		// treat an upgrade as a change, always
+		return true, nil
+	}
+	return !s.State.PendingTxns.Equals(other12.PendingTxns), nil
+}
+
+func (s *state12) transactions() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.PendingTxns, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) decodeTransaction(val *cbg.Deferred) (Transaction, error) {
+	var tx msig12.Transaction
+	if err := tx.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
+		return Transaction{}, err
+	}
+	return Transaction(tx), nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.MultisigKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/paych/message12.go
+++ b/chain/actors/builtin/paych/message12.go
@@ -1,0 +1,109 @@
+package paych
+
+import (
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
+	paych12 "github.com/filecoin-project/go-state-types/builtin/v12/paych"
+	paychtypes "github.com/filecoin-project/go-state-types/builtin/v8/paych"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+type message12 struct{ from address.Address }
+
+func (m message12) Create(to address.Address, initialAmount abi.TokenAmount) (*types.Message, error) {
+
+	actorCodeID, ok := actors.GetActorCodeID(actorstypes.Version12, "paymentchannel")
+	if !ok {
+		return nil, xerrors.Errorf("error getting actor paymentchannel code id for actor version %d", 12)
+	}
+
+	params, aerr := actors.SerializeParams(&paych12.ConstructorParams{From: m.from, To: to})
+	if aerr != nil {
+		return nil, aerr
+	}
+	enc, aerr := actors.SerializeParams(&init12.ExecParams{
+		CodeCID:           actorCodeID,
+		ConstructorParams: params,
+	})
+	if aerr != nil {
+		return nil, aerr
+	}
+
+	return &types.Message{
+		To:     init_.Address,
+		From:   m.from,
+		Value:  initialAmount,
+		Method: builtin12.MethodsInit.Exec,
+		Params: enc,
+	}, nil
+}
+
+func (m message12) Update(paych address.Address, sv *paychtypes.SignedVoucher, secret []byte) (*types.Message, error) {
+	params, aerr := actors.SerializeParams(&paych12.UpdateChannelStateParams{
+
+		Sv: toV12SignedVoucher(*sv),
+
+		Secret: secret,
+	})
+	if aerr != nil {
+		return nil, aerr
+	}
+
+	return &types.Message{
+		To:     paych,
+		From:   m.from,
+		Value:  abi.NewTokenAmount(0),
+		Method: builtin12.MethodsPaych.UpdateChannelState,
+		Params: params,
+	}, nil
+}
+
+func toV12SignedVoucher(sv paychtypes.SignedVoucher) paych12.SignedVoucher {
+	merges := make([]paych12.Merge, len(sv.Merges))
+	for i := range sv.Merges {
+		merges[i] = paych12.Merge{
+			Lane:  sv.Merges[i].Lane,
+			Nonce: sv.Merges[i].Nonce,
+		}
+	}
+
+	return paych12.SignedVoucher{
+		ChannelAddr:     sv.ChannelAddr,
+		TimeLockMin:     sv.TimeLockMin,
+		TimeLockMax:     sv.TimeLockMax,
+		SecretHash:      sv.SecretHash,
+		Extra:           (*paych12.ModVerifyParams)(sv.Extra),
+		Lane:            sv.Lane,
+		Nonce:           sv.Nonce,
+		Amount:          sv.Amount,
+		MinSettleHeight: sv.MinSettleHeight,
+		Merges:          merges,
+		Signature:       sv.Signature,
+	}
+}
+
+func (m message12) Settle(paych address.Address) (*types.Message, error) {
+	return &types.Message{
+		To:     paych,
+		From:   m.from,
+		Value:  abi.NewTokenAmount(0),
+		Method: builtin12.MethodsPaych.Settle,
+	}, nil
+}
+
+func (m message12) Collect(paych address.Address) (*types.Message, error) {
+	return &types.Message{
+		To:     paych,
+		From:   m.from,
+		Value:  abi.NewTokenAmount(0),
+		Method: builtin12.MethodsPaych.Collect,
+	}, nil
+}

--- a/chain/actors/builtin/paych/paych.go
+++ b/chain/actors/builtin/paych/paych.go
@@ -50,6 +50,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 		case actorstypes.Version11:
 			return load11(store, act.Head)
 
+		case actorstypes.Version12:
+			return load12(store, act.Head)
+
 		}
 	}
 
@@ -167,6 +170,9 @@ func Message(version actorstypes.Version, from address.Address) MessageBuilder {
 	case actorstypes.Version11:
 		return message11{from}
 
+	case actorstypes.Version12:
+		return message12{from}
+
 	default:
 		panic(fmt.Sprintf("unsupported actors version: %d", version))
 	}
@@ -208,5 +214,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/paych/v12.go
+++ b/chain/actors/builtin/paych/v12.go
@@ -1,0 +1,135 @@
+package paych
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/big"
+	paych12 "github.com/filecoin-project/go-state-types/builtin/v12/paych"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store) (State, error) {
+	out := state12{store: store}
+	out.State = paych12.State{}
+	return &out, nil
+}
+
+type state12 struct {
+	paych12.State
+	store adt.Store
+	lsAmt *adt12.Array
+}
+
+// Channel owner, who has funded the actor
+func (s *state12) From() (address.Address, error) {
+	return s.State.From, nil
+}
+
+// Recipient of payouts from channel
+func (s *state12) To() (address.Address, error) {
+	return s.State.To, nil
+}
+
+// Height at which the channel can be `Collected`
+func (s *state12) SettlingAt() (abi.ChainEpoch, error) {
+	return s.State.SettlingAt, nil
+}
+
+// Amount successfully redeemed through the payment channel, paid out on `Collect()`
+func (s *state12) ToSend() (abi.TokenAmount, error) {
+	return s.State.ToSend, nil
+}
+
+func (s *state12) getOrLoadLsAmt() (*adt12.Array, error) {
+	if s.lsAmt != nil {
+		return s.lsAmt, nil
+	}
+
+	// Get the lane state from the chain
+	lsamt, err := adt12.AsArray(s.store, s.State.LaneStates, paych12.LaneStatesAmtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	s.lsAmt = lsamt
+	return lsamt, nil
+}
+
+// Get total number of lanes
+func (s *state12) LaneCount() (uint64, error) {
+	lsamt, err := s.getOrLoadLsAmt()
+	if err != nil {
+		return 0, err
+	}
+	return lsamt.Length(), nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+// Iterate lane states
+func (s *state12) ForEachLaneState(cb func(idx uint64, dl LaneState) error) error {
+	// Get the lane state from the chain
+	lsamt, err := s.getOrLoadLsAmt()
+	if err != nil {
+		return err
+	}
+
+	// Note: we use a map instead of an array to store laneStates because the
+	// client sets the lane ID (the index) and potentially they could use a
+	// very large index.
+	var ls paych12.LaneState
+	return lsamt.ForEach(&ls, func(i int64) error {
+		return cb(uint64(i), &laneState12{ls})
+	})
+}
+
+type laneState12 struct {
+	paych12.LaneState
+}
+
+func (ls *laneState12) Redeemed() (big.Int, error) {
+	return ls.LaneState.Redeemed, nil
+}
+
+func (ls *laneState12) Nonce() (uint64, error) {
+	return ls.LaneState.Nonce, nil
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.PaychKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/power/power.go
+++ b/chain/actors/builtin/power/power.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/big"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	Address = builtin11.StoragePowerActorAddr
-	Methods = builtin11.MethodsPower
+	Address = builtin12.StoragePowerActorAddr
+	Methods = builtin12.MethodsPower
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -50,6 +50,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -118,6 +121,9 @@ func MakeState(store adt.Store, av actorstypes.Version) (State, error) {
 	case actorstypes.Version11:
 		return make11(store)
 
+	case actorstypes.Version12:
+		return make12(store)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -183,5 +189,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/power/v12.go
+++ b/chain/actors/builtin/power/v12.go
@@ -1,0 +1,207 @@
+package power
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	power12 "github.com/filecoin-project/go-state-types/builtin/v12/power"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store) (State, error) {
+	out := state12{store: store}
+
+	s, err := power12.ConstructState(store)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	power12.State
+	store adt.Store
+}
+
+func (s *state12) TotalLocked() (abi.TokenAmount, error) {
+	return s.TotalPledgeCollateral, nil
+}
+
+func (s *state12) TotalPower() (Claim, error) {
+	return Claim{
+		RawBytePower:    s.TotalRawBytePower,
+		QualityAdjPower: s.TotalQualityAdjPower,
+	}, nil
+}
+
+// Committed power to the network. Includes miners below the minimum threshold.
+func (s *state12) TotalCommitted() (Claim, error) {
+	return Claim{
+		RawBytePower:    s.TotalBytesCommitted,
+		QualityAdjPower: s.TotalQABytesCommitted,
+	}, nil
+}
+
+func (s *state12) MinerPower(addr address.Address) (Claim, bool, error) {
+	claims, err := s.claims()
+	if err != nil {
+		return Claim{}, false, err
+	}
+	var claim power12.Claim
+	ok, err := claims.Get(abi.AddrKey(addr), &claim)
+	if err != nil {
+		return Claim{}, false, err
+	}
+	return Claim{
+		RawBytePower:    claim.RawBytePower,
+		QualityAdjPower: claim.QualityAdjPower,
+	}, ok, nil
+}
+
+func (s *state12) MinerNominalPowerMeetsConsensusMinimum(a address.Address) (bool, error) {
+	return s.State.MinerNominalPowerMeetsConsensusMinimum(s.store, a)
+}
+
+func (s *state12) TotalPowerSmoothed() (builtin.FilterEstimate, error) {
+	return builtin.FilterEstimate(s.State.ThisEpochQAPowerSmoothed), nil
+}
+
+func (s *state12) MinerCounts() (uint64, uint64, error) {
+	return uint64(s.State.MinerAboveMinPowerCount), uint64(s.State.MinerCount), nil
+}
+
+func (s *state12) ListAllMiners() ([]address.Address, error) {
+	claims, err := s.claims()
+	if err != nil {
+		return nil, err
+	}
+
+	var miners []address.Address
+	err = claims.ForEach(nil, func(k string) error {
+		a, err := address.NewFromBytes([]byte(k))
+		if err != nil {
+			return err
+		}
+		miners = append(miners, a)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return miners, nil
+}
+
+func (s *state12) ForEachClaim(cb func(miner address.Address, claim Claim) error) error {
+	claims, err := s.claims()
+	if err != nil {
+		return err
+	}
+
+	var claim power12.Claim
+	return claims.ForEach(&claim, func(k string) error {
+		a, err := address.NewFromBytes([]byte(k))
+		if err != nil {
+			return err
+		}
+		return cb(a, Claim{
+			RawBytePower:    claim.RawBytePower,
+			QualityAdjPower: claim.QualityAdjPower,
+		})
+	})
+}
+
+func (s *state12) ClaimsChanged(other State) (bool, error) {
+	other12, ok := other.(*state12)
+	if !ok {
+		// treat an upgrade as a change, always
+		return true, nil
+	}
+	return !s.State.Claims.Equals(other12.State.Claims), nil
+}
+
+func (s *state12) SetTotalQualityAdjPower(p abi.StoragePower) error {
+	s.State.TotalQualityAdjPower = p
+	return nil
+}
+
+func (s *state12) SetTotalRawBytePower(p abi.StoragePower) error {
+	s.State.TotalRawBytePower = p
+	return nil
+}
+
+func (s *state12) SetThisEpochQualityAdjPower(p abi.StoragePower) error {
+	s.State.ThisEpochQualityAdjPower = p
+	return nil
+}
+
+func (s *state12) SetThisEpochRawBytePower(p abi.StoragePower) error {
+	s.State.ThisEpochRawBytePower = p
+	return nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) claims() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.Claims, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) decodeClaim(val *cbg.Deferred) (Claim, error) {
+	var ci power12.Claim
+	if err := ci.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
+		return Claim{}, err
+	}
+	return fromV12Claim(ci), nil
+}
+
+func fromV12Claim(v12 power12.Claim) Claim {
+	return Claim{
+		RawBytePower:    v12.RawBytePower,
+		QualityAdjPower: v12.QualityAdjPower,
+	}
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.PowerKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/registry.go
+++ b/chain/actors/builtin/registry.go
@@ -42,6 +42,22 @@ import (
 	reward11 "github.com/filecoin-project/go-state-types/builtin/v11/reward"
 	system11 "github.com/filecoin-project/go-state-types/builtin/v11/system"
 	verifreg11 "github.com/filecoin-project/go-state-types/builtin/v11/verifreg"
+	account12 "github.com/filecoin-project/go-state-types/builtin/v12/account"
+	cron12 "github.com/filecoin-project/go-state-types/builtin/v12/cron"
+	datacap12 "github.com/filecoin-project/go-state-types/builtin/v12/datacap"
+	eam12 "github.com/filecoin-project/go-state-types/builtin/v12/eam"
+	ethaccount12 "github.com/filecoin-project/go-state-types/builtin/v12/ethaccount"
+	evm12 "github.com/filecoin-project/go-state-types/builtin/v12/evm"
+	_init12 "github.com/filecoin-project/go-state-types/builtin/v12/init"
+	market12 "github.com/filecoin-project/go-state-types/builtin/v12/market"
+	miner12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
+	multisig12 "github.com/filecoin-project/go-state-types/builtin/v12/multisig"
+	paych12 "github.com/filecoin-project/go-state-types/builtin/v12/paych"
+	placeholder12 "github.com/filecoin-project/go-state-types/builtin/v12/placeholder"
+	power12 "github.com/filecoin-project/go-state-types/builtin/v12/power"
+	reward12 "github.com/filecoin-project/go-state-types/builtin/v12/reward"
+	system12 "github.com/filecoin-project/go-state-types/builtin/v12/system"
+	verifreg12 "github.com/filecoin-project/go-state-types/builtin/v12/verifreg"
 	account8 "github.com/filecoin-project/go-state-types/builtin/v8/account"
 	cron8 "github.com/filecoin-project/go-state-types/builtin/v8/cron"
 	_init8 "github.com/filecoin-project/go-state-types/builtin/v8/init"
@@ -491,6 +507,110 @@ func MakeRegistry(av actorstypes.Version) []RegistryEntry {
 				registry = append(registry, RegistryEntry{
 					code:    codeID,
 					methods: ethaccount11.Methods,
+					state:   nil,
+				})
+
+			}
+		}
+
+	case actorstypes.Version12:
+		for key, codeID := range codeIDs {
+			switch key {
+			case manifest.AccountKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: account12.Methods,
+					state:   new(account12.State),
+				})
+			case manifest.CronKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: cron12.Methods,
+					state:   new(cron12.State),
+				})
+			case manifest.InitKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: _init12.Methods,
+					state:   new(_init12.State),
+				})
+			case manifest.MarketKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: market12.Methods,
+					state:   new(market12.State),
+				})
+			case manifest.MinerKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: miner12.Methods,
+					state:   new(miner12.State),
+				})
+			case manifest.MultisigKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: multisig12.Methods,
+					state:   new(multisig12.State),
+				})
+			case manifest.PaychKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: paych12.Methods,
+					state:   new(paych12.State),
+				})
+			case manifest.PowerKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: power12.Methods,
+					state:   new(power12.State),
+				})
+			case manifest.RewardKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: reward12.Methods,
+					state:   new(reward12.State),
+				})
+			case manifest.SystemKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: system12.Methods,
+					state:   new(system12.State),
+				})
+			case manifest.VerifregKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: verifreg12.Methods,
+					state:   new(verifreg12.State),
+				})
+			case manifest.DatacapKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: datacap12.Methods,
+					state:   new(datacap12.State),
+				})
+
+			case manifest.EvmKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: evm12.Methods,
+					state:   new(evm12.State),
+				})
+			case manifest.EamKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: eam12.Methods,
+					state:   nil,
+				})
+			case manifest.PlaceholderKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: placeholder12.Methods,
+					state:   nil,
+				})
+			case manifest.EthAccountKey:
+				registry = append(registry, RegistryEntry{
+					code:    codeID,
+					methods: ethaccount12.Methods,
 					state:   nil,
 				})
 

--- a/chain/actors/builtin/reward/reward.go
+++ b/chain/actors/builtin/reward/reward.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	Address = builtin11.RewardActorAddr
-	Methods = builtin11.MethodsReward
+	Address = builtin12.RewardActorAddr
+	Methods = builtin12.MethodsReward
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -48,6 +48,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -116,6 +119,9 @@ func MakeState(store adt.Store, av actorstypes.Version, currRealizedPower abi.St
 	case actorstypes.Version11:
 		return make11(store, currRealizedPower)
 
+	case actorstypes.Version12:
+		return make12(store, currRealizedPower)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -159,5 +165,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/reward/v12.go
+++ b/chain/actors/builtin/reward/v12.go
@@ -1,0 +1,120 @@
+package reward
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	miner12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
+	reward12 "github.com/filecoin-project/go-state-types/builtin/v12/reward"
+	smoothing12 "github.com/filecoin-project/go-state-types/builtin/v12/util/smoothing"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, currRealizedPower abi.StoragePower) (State, error) {
+	out := state12{store: store}
+	out.State = *reward12.ConstructState(currRealizedPower)
+	return &out, nil
+}
+
+type state12 struct {
+	reward12.State
+	store adt.Store
+}
+
+func (s *state12) ThisEpochReward() (abi.TokenAmount, error) {
+	return s.State.ThisEpochReward, nil
+}
+
+func (s *state12) ThisEpochRewardSmoothed() (builtin.FilterEstimate, error) {
+
+	return builtin.FilterEstimate{
+		PositionEstimate: s.State.ThisEpochRewardSmoothed.PositionEstimate,
+		VelocityEstimate: s.State.ThisEpochRewardSmoothed.VelocityEstimate,
+	}, nil
+
+}
+
+func (s *state12) ThisEpochBaselinePower() (abi.StoragePower, error) {
+	return s.State.ThisEpochBaselinePower, nil
+}
+
+func (s *state12) TotalStoragePowerReward() (abi.TokenAmount, error) {
+	return s.State.TotalStoragePowerReward, nil
+}
+
+func (s *state12) EffectiveBaselinePower() (abi.StoragePower, error) {
+	return s.State.EffectiveBaselinePower, nil
+}
+
+func (s *state12) EffectiveNetworkTime() (abi.ChainEpoch, error) {
+	return s.State.EffectiveNetworkTime, nil
+}
+
+func (s *state12) CumsumBaseline() (reward12.Spacetime, error) {
+	return s.State.CumsumBaseline, nil
+}
+
+func (s *state12) CumsumRealized() (reward12.Spacetime, error) {
+	return s.State.CumsumRealized, nil
+}
+
+func (s *state12) InitialPledgeForPower(qaPower abi.StoragePower, networkTotalPledge abi.TokenAmount, networkQAPower *builtin.FilterEstimate, circSupply abi.TokenAmount) (abi.TokenAmount, error) {
+	return miner12.InitialPledgeForPower(
+		qaPower,
+		s.State.ThisEpochBaselinePower,
+		s.State.ThisEpochRewardSmoothed,
+		smoothing12.FilterEstimate{
+			PositionEstimate: networkQAPower.PositionEstimate,
+			VelocityEstimate: networkQAPower.VelocityEstimate,
+		},
+		circSupply,
+	), nil
+}
+
+func (s *state12) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
+	return miner12.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
+		smoothing12.FilterEstimate{
+			PositionEstimate: networkQAPower.PositionEstimate,
+			VelocityEstimate: networkQAPower.VelocityEstimate,
+		},
+		sectorWeight), nil
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.RewardKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/system/system.go
+++ b/chain/actors/builtin/system/system.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/xerrors"
 
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	Address = builtin11.SystemActorAddr
+	Address = builtin12.SystemActorAddr
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -43,6 +43,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -111,6 +114,9 @@ func MakeState(store adt.Store, av actorstypes.Version, builtinActors cid.Cid) (
 	case actorstypes.Version11:
 		return make11(store, builtinActors)
 
+	case actorstypes.Version12:
+		return make12(store, builtinActors)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -138,5 +144,6 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }

--- a/chain/actors/builtin/system/v12.go
+++ b/chain/actors/builtin/system/v12.go
@@ -1,0 +1,72 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	system12 "github.com/filecoin-project/go-state-types/builtin/v12/system"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, builtinActors cid.Cid) (State, error) {
+	out := state12{store: store}
+	out.State = system12.State{
+		BuiltinActors: builtinActors,
+	}
+	return &out, nil
+}
+
+type state12 struct {
+	system12.State
+	store adt.Store
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) GetBuiltinActors() cid.Cid {
+
+	return s.State.BuiltinActors
+
+}
+
+func (s *state12) SetBuiltinActors(c cid.Cid) error {
+
+	s.State.BuiltinActors = c
+	return nil
+
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.SystemKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/verifreg/v12.go
+++ b/chain/actors/builtin/verifreg/v12.go
@@ -1,0 +1,170 @@
+package verifreg
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/big"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
+	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
+	verifreg12 "github.com/filecoin-project/go-state-types/builtin/v12/verifreg"
+	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state12)(nil)
+
+func load12(store adt.Store, root cid.Cid) (State, error) {
+	out := state12{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make12(store adt.Store, rootKeyAddress address.Address) (State, error) {
+	out := state12{store: store}
+
+	s, err := verifreg12.ConstructState(store, rootKeyAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state12 struct {
+	verifreg12.State
+	store adt.Store
+}
+
+func (s *state12) RootKey() (address.Address, error) {
+	return s.State.RootKey, nil
+}
+
+func (s *state12) VerifiedClientDataCap(addr address.Address) (bool, abi.StoragePower, error) {
+
+	return false, big.Zero(), xerrors.Errorf("unsupported in actors v12")
+
+}
+
+func (s *state12) VerifierDataCap(addr address.Address) (bool, abi.StoragePower, error) {
+	return getDataCap(s.store, actors.Version12, s.verifiers, addr)
+}
+
+func (s *state12) RemoveDataCapProposalID(verifier address.Address, client address.Address) (bool, uint64, error) {
+	return getRemoveDataCapProposalID(s.store, actors.Version12, s.removeDataCapProposalIDs, verifier, client)
+}
+
+func (s *state12) ForEachVerifier(cb func(addr address.Address, dcap abi.StoragePower) error) error {
+	return forEachCap(s.store, actors.Version12, s.verifiers, cb)
+}
+
+func (s *state12) ForEachClient(cb func(addr address.Address, dcap abi.StoragePower) error) error {
+
+	return xerrors.Errorf("unsupported in actors v12")
+
+}
+
+func (s *state12) verifiedClients() (adt.Map, error) {
+
+	return nil, xerrors.Errorf("unsupported in actors v12")
+
+}
+
+func (s *state12) verifiers() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.Verifiers, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) removeDataCapProposalIDs() (adt.Map, error) {
+	return adt12.AsMap(s.store, s.RemoveDataCapProposalIDs, builtin12.DefaultHamtBitwidth)
+}
+
+func (s *state12) GetState() interface{} {
+	return &s.State
+}
+
+func (s *state12) GetAllocation(clientIdAddr address.Address, allocationId verifreg9.AllocationId) (*Allocation, bool, error) {
+
+	alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, verifreg12.AllocationId(allocationId))
+	return (*Allocation)(alloc), ok, err
+}
+
+func (s *state12) GetAllocations(clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
+
+	v12Map, err := s.LoadAllocationsToMap(s.store, clientIdAddr)
+
+	retMap := make(map[AllocationId]Allocation, len(v12Map))
+	for k, v := range v12Map {
+		retMap[AllocationId(k)] = Allocation(v)
+	}
+
+	return retMap, err
+
+}
+
+func (s *state12) GetClaim(providerIdAddr address.Address, claimId verifreg9.ClaimId) (*Claim, bool, error) {
+
+	claim, ok, err := s.FindClaim(s.store, providerIdAddr, verifreg12.ClaimId(claimId))
+	return (*Claim)(claim), ok, err
+
+}
+
+func (s *state12) GetClaims(providerIdAddr address.Address) (map[ClaimId]Claim, error) {
+
+	v12Map, err := s.LoadClaimsToMap(s.store, providerIdAddr)
+
+	retMap := make(map[ClaimId]Claim, len(v12Map))
+	for k, v := range v12Map {
+		retMap[ClaimId(k)] = Claim(v)
+	}
+
+	return retMap, err
+
+}
+
+func (s *state12) GetClaimIdsBySector(providerIdAddr address.Address) (map[abi.SectorNumber][]ClaimId, error) {
+
+	v12Map, err := s.LoadClaimsToMap(s.store, providerIdAddr)
+
+	retMap := make(map[abi.SectorNumber][]ClaimId)
+	for k, v := range v12Map {
+		claims, ok := retMap[v.Sector]
+		if !ok {
+			retMap[v.Sector] = []ClaimId{ClaimId(k)}
+		} else {
+			retMap[v.Sector] = append(claims, ClaimId(k))
+		}
+	}
+
+	return retMap, err
+
+}
+
+func (s *state12) ActorKey() string {
+	return manifest.VerifregKey
+}
+
+func (s *state12) ActorVersion() actorstypes.Version {
+	return actorstypes.Version12
+}
+
+func (s *state12) Code() cid.Cid {
+	code, ok := actors.GetActorCodeID(s.ActorVersion(), s.ActorKey())
+	if !ok {
+		panic(fmt.Errorf("didn't find actor %v code id for actor version %d", s.ActorKey(), s.ActorVersion()))
+	}
+
+	return code
+}

--- a/chain/actors/builtin/verifreg/verifreg.go
+++ b/chain/actors/builtin/verifreg/verifreg.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+	builtin12 "github.com/filecoin-project/go-state-types/builtin"
 	verifregtypes "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	Address = builtin11.VerifiedRegistryActorAddr
-	Methods = builtin11.MethodsVerifiedRegistry
+	Address = builtin12.VerifiedRegistryActorAddr
+	Methods = builtin12.MethodsVerifiedRegistry
 )
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
@@ -48,6 +48,9 @@ func Load(store adt.Store, act *types.Actor) (State, error) {
 
 		case actorstypes.Version11:
 			return load11(store, act.Head)
+
+		case actorstypes.Version12:
+			return load12(store, act.Head)
 
 		}
 	}
@@ -116,6 +119,9 @@ func MakeState(store adt.Store, av actorstypes.Version, rootKeyAddress address.A
 	case actorstypes.Version11:
 		return make11(store, rootKeyAddress)
 
+	case actorstypes.Version12:
+		return make12(store, rootKeyAddress)
+
 	}
 	return nil, xerrors.Errorf("unknown actor version %d", av)
 }
@@ -154,6 +160,7 @@ func AllCodes() []cid.Cid {
 		(&state9{}).Code(),
 		(&state10{}).Code(),
 		(&state11{}).Code(),
+		(&state12{}).Code(),
 	}
 }
 

--- a/chain/actors/version.go
+++ b/chain/actors/version.go
@@ -14,9 +14,9 @@ const ({{range .actorVersions}}
 
 /* inline-gen start */
 
-var LatestVersion = 11
+var LatestVersion = 12
 
-var Versions = []int{0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+var Versions = []int{0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
 const (
 	Version0  Version = 0
@@ -30,6 +30,7 @@ const (
 	Version9  Version = 9
 	Version10 Version = 10
 	Version11 Version = 11
+	Version12 Version = 12
 )
 
 /* inline-gen end */

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -261,6 +261,17 @@ func DefaultUpgradeSchedule() stmgr.UpgradeSchedule {
 		Height:    build.UpgradeThunderHeight,
 		Network:   network.Version20,
 		Migration: nil,
+	}, {
+		Height:    build.UpgradeSummerHeight,
+		Network:   network.Version21,
+		Migration: UpgradeActorsV12,
+		PreMigrations: []stmgr.PreMigration{{
+			PreMigration:    PreUpgradeActorsV12,
+			StartWithin:     120,
+			DontStartWithin: 15,
+			StopWithin:      10,
+		}},
+		Expensive: true,
 	},
 	}
 

--- a/chain/state/statetree.go
+++ b/chain/state/statetree.go
@@ -156,7 +156,7 @@ func VersionForNetwork(ver network.Version) (types.StateTreeVersion, error) {
 	case network.Version13, network.Version14, network.Version15, network.Version16, network.Version17:
 		return types.StateTreeVersion4, nil
 
-	case network.Version18, network.Version19, network.Version20:
+	case network.Version18, network.Version19, network.Version20, network.Version21:
 		return types.StateTreeVersion5, nil
 
 	default:

--- a/gen/inlinegen-data.json
+++ b/gen/inlinegen-data.json
@@ -1,7 +1,7 @@
 {
-  "actorVersions": [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-  "latestActorsVersion":  11,
+  "actorVersions": [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  "latestActorsVersion":  12,
 
-  "networkVersions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
-  "latestNetworkVersion":  20
+  "networkVersions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+  "latestNetworkVersion":  21
 }

--- a/itests/kit/ensemble_opts_nv.go
+++ b/itests/kit/ensemble_opts_nv.go
@@ -49,12 +49,12 @@ func LatestActorsAt(upgradeHeight abi.ChainEpoch) EnsembleOpt {
 		})
 	/* inline-gen start */
 	return UpgradeSchedule(stmgr.Upgrade{
-		Network: network.Version19,
+		Network: network.Version20,
 		Height:  -1,
 	}, stmgr.Upgrade{
-		Network:   network.Version20,
+		Network:   network.Version21,
 		Height:    upgradeHeight,
-		Migration: filcns.UpgradeActorsV11,
+		Migration: filcns.UpgradeActorsV12,
 	})
 	/* inline-gen end */
 }

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1811,6 +1811,7 @@ func (a *StateAPI) StateGetNetworkParams(ctx context.Context) (*api.NetworkParam
 			UpgradeHyggeHeight:       build.UpgradeHyggeHeight,
 			UpgradeLightningHeight:   build.UpgradeLightningHeight,
 			UpgradeThunderHeight:     build.UpgradeThunderHeight,
+			UpgradeSummerHeight:      build.UpgradeSummerHeight,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Related Issues
Closes #10993

## Proposed Changes
We need to add the skeleton for nv21 without any upgrade epochs, code / state changes / migrations. It should have no effect except on local devnets to unblock testing and tests for SynthPoRep

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
