### PR TITLE
feat: snapshot: remove existing chain

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -28,7 +28,6 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"go.uber.org/multierr"
 	"golang.org/x/xerrors"
 	"gopkg.in/cheggaaa/pb.v1"
 
@@ -799,28 +798,4 @@ func deleteSplitstoreDir(lr repo.LockedRepo) error {
 	}
 
 	return os.RemoveAll(path)
-}
-
-func clearSplitstoreDir(lr repo.LockedRepo) error {
-	path, err := lr.SplitstorePath()
-	if err != nil {
-		return xerrors.Errorf("error getting splitstore path: %w", err)
-	}
-
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return xerrors.Errorf("error reading splitstore directory %s: %W", path, err)
-	}
-
-	var result error
-	for _, e := range entries {
-		target := filepath.Join(path, e.Name())
-		err = os.RemoveAll(target)
-		if err != nil {
-			log.Errorf("error removing %s: %s", target, err)
-			result = multierr.Append(result, err)
-		}
-	}
-
-	return result
 }

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -754,7 +754,11 @@ func removeExistingChain(cctx *cli.Context, lr repo.Repo) error {
 		return xerrors.Errorf("error locking repo: %w", err)
 	}
 	// Ensure that lockedRepo is closed when this function exits
-	defer lockedRepo.Close()
+	defer func() {
+		if closeErr := lockedRepo.Close(); closeErr != nil {
+			log.Errorf("Error closing the lockedRepo: %v", closeErr)
+		}
+	}()
 
 	cfg, err := lockedRepo.Config()
 	if err != nil {

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -304,52 +304,9 @@ var DaemonCmd = &cli.Command{
 				return xerrors.Errorf("lotus repo doesn't exist")
 			}
 
-			lockedRepo, err := lr.Lock(repo.FullNode)
+			err = removeExistingChain(cctx, lr)
 			if err != nil {
-				return xerrors.Errorf("error locking repo: %w", err)
-			}
-
-			cfg, err := lockedRepo.Config()
-			if err != nil {
-				lockedRepo.Close()
-				return xerrors.Errorf("error getting config: %w", err)
-			}
-
-			fullNodeConfig, ok := cfg.(*config.FullNode)
-			if !ok {
-				lockedRepo.Close()
-				return xerrors.Errorf("wrong config type: %T", cfg)
-			}
-
-			if fullNodeConfig.Chainstore.EnableSplitstore {
-				log.Info("removing splitstore directory...")
-				err = deleteSplitstoreDir(lockedRepo)
-				if err != nil {
-					lockedRepo.Close()
-					return xerrors.Errorf("error removing splitstore directory: %w", err)
-				}
-			}
-
-			// Get the base repo path
-			repoPath := lockedRepo.Path()
-
-			// Construct the path to the chain directory
-			chainPath := filepath.Join(repoPath, "datastore", "chain")
-
-			log.Info("removing chain directory:", chainPath)
-
-			err = os.RemoveAll(chainPath)
-			if err != nil {
-				lockedRepo.Close()
-				return xerrors.Errorf("error removing chain directory: %w", err)
-			}
-
-			log.Info("chain and splitstore data have been removed")
-
-			// Explicitly close the lockedRepo now that we're done with it.
-			err = lockedRepo.Close()
-			if err != nil {
-				return xerrors.Errorf("error releasing lock: %w", err)
+				return err
 			}
 		}
 
@@ -789,6 +746,49 @@ func slashFilterMinedBlock(ctx context.Context, sf *slashfilter.SlashFilter, a l
 	}
 
 	return nil, nil, nil
+}
+
+func removeExistingChain(cctx *cli.Context, lr repo.Repo) error {
+	lockedRepo, err := lr.Lock(repo.FullNode)
+	if err != nil {
+		return xerrors.Errorf("error locking repo: %w", err)
+	}
+	// Ensure that lockedRepo is closed when this function exits
+	defer lockedRepo.Close()
+
+	cfg, err := lockedRepo.Config()
+	if err != nil {
+		return xerrors.Errorf("error getting config: %w", err)
+	}
+
+	fullNodeConfig, ok := cfg.(*config.FullNode)
+	if !ok {
+		return xerrors.Errorf("wrong config type: %T", cfg)
+	}
+
+	if fullNodeConfig.Chainstore.EnableSplitstore {
+		log.Info("removing splitstore directory...")
+		err = deleteSplitstoreDir(lockedRepo)
+		if err != nil {
+			return xerrors.Errorf("error removing splitstore directory: %w", err)
+		}
+	}
+
+	// Get the base repo path
+	repoPath := lockedRepo.Path()
+
+	// Construct the path to the chain directory
+	chainPath := filepath.Join(repoPath, "datastore", "chain")
+
+	log.Info("removing chain directory:", chainPath)
+
+	err = os.RemoveAll(chainPath)
+	if err != nil {
+		return xerrors.Errorf("error removing chain directory: %w", err)
+	}
+
+	log.Info("chain and splitstore data have been removed")
+	return nil
 }
 
 func deleteSplitstoreDir(lr repo.LockedRepo) error {

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -65,6 +65,7 @@ OPTIONS:
    --bootstrap               (default: true)
    --import-chain value      on first run, load chain from given file or url and validate
    --import-snapshot value   import chain state from a given chain export file or url
+   --remove-existing-chain   remove existing chain and splitstore data on a snapshot-import (default: false)
    --halt-after-import       halt the process after importing chain from file (default: false)
    --lite                    start lotus in lite mode (default: false)
    --pprof value             specify name of file for writing cpu profile to


### PR DESCRIPTION
## Related Issues
Closes: https://github.com/filecoin-project/lotus/issues/10958

## Proposed Changes
Add a flag (`remove-existing-chain`) to remove the existing chain data on import of a snapshot, reducing manual operation needed when node operators want to prune their current chain.

## Additional Info
**Some open questions:**
- Do we only want the removal of the chain data to be possible when importing a snapshot?
   - Do we want it to default to true when importing a snapshot?
- Do we want to clear the chain data dirs, or delete it?
   - Are there any edge-cases where deleting the chain data dir is bad before importing a snapshot? 

**Testing:**
- [x] Tested on a node without SplitStore
- [x] Tested on a node with SplitStore

**Docs (todo):**
- [ ] Update this section: https://lotus.filecoin.io/lotus/manage/chain-management/#compacting-the-chain-data

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
