### PR TITLE
fix: stores: Tune down StorageDeclareSector` log-lvl

### DIFF
--- a/storage/paths/index.go
+++ b/storage/paths/index.go
@@ -366,7 +366,7 @@ loop:
 				if !sid.primary && primary {
 					sid.primary = true
 				} else {
-					log.Warnf("sector %v redeclared in %s", s, storageID)
+					log.Debugf("sector %v redeclared in %s", s, storageID)
 				}
 				continue loop
 			}


### PR DESCRIPTION
## Related Issues
Closes: #10901

## Proposed Changes
Tune down the log-level on `StorageDeclareSector` to debug. 

## Additional Info
Boost added an index integrity check in [Boost 1.7.0](https://github.com/filecoin-project/boost/releases/tag/v1.7.0) which causes users to see logs like these more often:

```
2023-05-22T13:51:13.217Z	WARN	stores	paths/index.go:369	sector {1278 997} redeclared in d8cfac01-4999-45d5-8231-8aa9423224e2
```

The WARN level here seems wrong as these are expected, and the interval of how often this gets called can be tuned in the configs on Boost.

I have added a KB-article explaining why users might see these logs as well here: https://lotus.filecoin.io/kb/redeclared-sector-log/

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
