### PR TITLE
fix: sealing: Fix RetryCommitWait loop when sector cron activation fails

### DIFF
--- a/itests/kit/deals.go
+++ b/itests/kit/deals.go
@@ -87,6 +87,17 @@ func NewDealHarness(t *testing.T, client *TestFullNode, main *TestMiner, market 
 //
 // TODO: convert input parameters to struct, and add size as an input param.
 func (dh *DealHarness) MakeOnlineDeal(ctx context.Context, params MakeFullDealParams) (deal *cid.Cid, res *api.ImportRes, path string) {
+	deal, res, path = dh.StartRandomDeal(ctx, params)
+
+	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
+	time.Sleep(time.Second)
+	fmt.Printf("WAIT DEAL SEALEDS START\n")
+	dh.WaitDealSealed(ctx, deal, false, false, nil)
+	fmt.Printf("WAIT DEAL SEALEDS END\n")
+	return deal, res, path
+}
+
+func (dh *DealHarness) StartRandomDeal(ctx context.Context, params MakeFullDealParams) (deal *cid.Cid, res *api.ImportRes, path string) {
 	if params.UseCARFileForStorageDeal {
 		res, _, path = dh.client.ClientImportCARFile(ctx, params.Rseed, 200)
 	} else {
@@ -107,11 +118,6 @@ func (dh *DealHarness) MakeOnlineDeal(ctx context.Context, params MakeFullDealPa
 	dp.FastRetrieval = params.FastRet
 	deal = dh.StartDeal(ctx, dp)
 
-	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
-	time.Sleep(time.Second)
-	fmt.Printf("WAIT DEAL SEALEDS START\n")
-	dh.WaitDealSealed(ctx, deal, false, false, nil)
-	fmt.Printf("WAIT DEAL SEALEDS END\n")
 	return deal, res, path
 }
 

--- a/itests/kit/deals.go
+++ b/itests/kit/deals.go
@@ -89,8 +89,6 @@ func NewDealHarness(t *testing.T, client *TestFullNode, main *TestMiner, market 
 func (dh *DealHarness) MakeOnlineDeal(ctx context.Context, params MakeFullDealParams) (deal *cid.Cid, res *api.ImportRes, path string) {
 	deal, res, path = dh.StartRandomDeal(ctx, params)
 
-	// TODO: this sleep is only necessary because deals don't immediately get logged in the dealstore, we should fix this
-	time.Sleep(time.Second)
 	fmt.Printf("WAIT DEAL SEALEDS START\n")
 	dh.WaitDealSealed(ctx, deal, false, false, nil)
 	fmt.Printf("WAIT DEAL SEALEDS END\n")

--- a/itests/kit/log.go
+++ b/itests/kit/log.go
@@ -21,6 +21,7 @@ func QuietMiningLogs() {
 	_ = logging.SetLogLevel("pubsub", "ERROR")
 	_ = logging.SetLogLevel("gen", "ERROR")
 	_ = logging.SetLogLevel("rpc", "ERROR")
+	_ = logging.SetLogLevel("consensus-common", "ERROR")
 	_ = logging.SetLogLevel("dht/RtRefreshManager", "ERROR")
 }
 

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -197,7 +197,7 @@ func OwnerAddr(wk *key.Key) NodeOpt {
 // the node.
 func ConstructorOpts(extra ...node.Option) NodeOpt {
 	return func(opts *nodeOpts) error {
-		opts.extraNodeOpts = extra
+		opts.extraNodeOpts = append(opts.extraNodeOpts, extra...)
 		return nil
 	}
 }
@@ -286,6 +286,13 @@ func SplitstoreMessges() NodeOpt {
 		cfg.Chainstore.EnableSplitstore = true
 		cfg.Chainstore.Splitstore.HotStoreFullGCFrequency = 0 // turn off full gc
 		cfg.Chainstore.Splitstore.ColdStoreType = "messages"  // universal bs is coldstore, and it accepts messages
+		return nil
+	})
+}
+
+func SplitstoreDisable() NodeOpt {
+	return WithCfgOpt(func(cfg *config.FullNode) error {
+		cfg.Chainstore.EnableSplitstore = false
 		return nil
 	})
 }

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -730,3 +730,83 @@ waitForProof:
 	require.NoError(t, params.UnmarshalCBOR(bytes.NewBuffer(slmsg.Params)))
 	require.Equal(t, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1, params.Proofs[0].PoStProof)
 }
+
+func TestWorkerPledgeExpireCommit(t *testing.T) {
+	kit.QuietMiningLogs()
+	_ = logging.SetLogLevel("sectors", "debug")
+
+	var tasksNoC2 = kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTAddPiece, sealtasks.TTDataCid, sealtasks.TTPreCommit1, sealtasks.TTPreCommit2, sealtasks.TTCommit2,
+		sealtasks.TTUnseal, sealtasks.TTFetch, sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTFinalizeUnsealed})
+
+	fc := config.DefaultStorageMiner().Fees
+	fc.MaxCommitGasFee = types.FIL(abi.NewTokenAmount(10000)) // 10000 attofil, way too low for anything to land
+
+	ctx := context.Background()
+	client, miner, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+		kit.MutateSealingConfig(func(sc *config.SealingConfig) {
+			sc.BatchPreCommits = false
+			sc.AggregateCommits = true
+		}),
+		kit.ConstructorOpts(
+			node.Override(new(*sealing.Sealing), modules.SealingPipeline(fc)),
+		),
+		kit.SplitstoreDisable(), // enable splitstore because messages which take a long time may get dropped
+		tasksNoC2)               // no mock proofs
+
+	ens.InterconnectAll().BeginMiningMustPost(2 * time.Millisecond)
+
+	e, err := worker.Enabled(ctx)
+	require.NoError(t, err)
+	require.True(t, e)
+
+	dh := kit.NewDealHarness(t, client, miner, miner)
+
+	startEpoch := abi.ChainEpoch(4 << 10)
+
+	dh.StartRandomDeal(ctx, kit.MakeFullDealParams{
+		Rseed:      7,
+		StartEpoch: startEpoch,
+	})
+
+	var sn abi.SectorNumber
+
+	require.Eventually(t, func() bool {
+		s, err := miner.SectorsListNonGenesis(ctx)
+		require.NoError(t, err)
+		if len(s) == 0 {
+			return false
+		}
+		if len(s) > 1 {
+			t.Fatalf("expected 1 sector, got %d", len(s))
+		}
+		sn = s[0]
+		return true
+	}, 30*time.Second, 1*time.Second)
+
+	t.Log("sector", sn)
+
+	t.Log("sector committing")
+
+	// wait until after startEpoch
+	client.WaitTillChain(ctx, kit.HeightAtLeast(startEpoch+20))
+
+	t.Log("after start")
+
+	sstate, err := miner.SectorsStatus(ctx, sn, false)
+	require.NoError(t, err)
+	require.Equal(t, api.SectorState(sealing.SubmitCommitAggregate), sstate.State)
+
+	_, err = miner.SectorCommitFlush(ctx)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		sstate, err := miner.SectorsStatus(ctx, sn, false)
+		require.NoError(t, err)
+
+		t.Logf("sector state: %s", sstate.State)
+
+		return sstate.State == api.SectorState(sealing.Removed)
+	}, 30*time.Second, 1*time.Second)
+
+	t.Log("sector removed")
+}

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -750,7 +750,7 @@ func TestWorkerPledgeExpireCommit(t *testing.T) {
 		kit.ConstructorOpts(
 			node.Override(new(*sealing.Sealing), modules.SealingPipeline(fc)),
 		),
-		kit.SplitstoreDisable(), // enable splitstore because messages which take a long time may get dropped
+		kit.SplitstoreDisable(), // disable splitstore because messages which take a long time may get dropped
 		tasksNoC2)               // no mock proofs
 
 	ens.InterconnectAll().BeginMiningMustPost(2 * time.Millisecond)


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/9841

## Proposed Changes
In the CommitFailed state handler, if we see a successful commit message still check if the sector is visible on chain. If it's not run full checks, which will catch things like expired deals, and most likely will remove the sector.

Testing:
- [x] ITest
- [x] Real setup: check that a sector which is stuck in CommitWait (e.g. due to low feecap) beyond its start epoch is correctly removed, and doesn't spin through CommitWaitFailed

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
