### PR TITLE
feat: types: apply a max length when decoding events

### DIFF
--- a/chain/types/event.go
+++ b/chain/types/event.go
@@ -1,11 +1,6 @@
 package types
 
 import (
-	"bytes"
-	"fmt"
-
-	cbg "github.com/whyrusleeping/cbor-gen"
-
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
@@ -38,24 +33,3 @@ type EventEntry struct {
 }
 
 type FilterID [32]byte // compatible with EthHash
-
-// DecodeEvents decodes a CBOR list of CBOR-encoded events.
-func DecodeEvents(input []byte) ([]Event, error) {
-	r := bytes.NewReader(input)
-	typ, len, err := cbg.NewCborReader(r).ReadHeader()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read events: %w", err)
-	}
-	if typ != cbg.MajArray {
-		return nil, fmt.Errorf("expected a CBOR list, was major type %d", typ)
-	}
-	events := make([]Event, 0, len)
-	for i := 0; i < int(len); i++ {
-		var evt Event
-		if err := evt.UnmarshalCBOR(r); err != nil {
-			return nil, fmt.Errorf("failed to parse event: %w", err)
-		}
-		events = append(events, evt)
-	}
-	return events, nil
-}

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -458,7 +458,7 @@ func (vm *FVM) ApplyMessage(ctx context.Context, cmsg types.ChainMsg) (*ApplyRet
 	}
 
 	if vm.returnEvents && len(ret.EventsBytes) > 0 {
-		applyRet.Events, err = types.DecodeEvents(ret.EventsBytes)
+		applyRet.Events, err = decodeEvents(ret.EventsBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode events returned by the FVM: %w", err)
 		}
@@ -514,7 +514,7 @@ func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*
 	}
 
 	if vm.returnEvents && len(ret.EventsBytes) > 0 {
-		applyRet.Events, err = types.DecodeEvents(ret.EventsBytes)
+		applyRet.Events, err = decodeEvents(ret.EventsBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode events returned by the FVM: %w", err)
 		}

--- a/chain/vm/fvm_util.go
+++ b/chain/vm/fvm_util.go
@@ -1,0 +1,39 @@
+package vm
+
+import (
+	"bytes"
+	"fmt"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+const MaxEventSliceLength = 6_000_000
+
+// DecodeEvents decodes a CBOR list of CBOR-encoded events.
+func decodeEvents(input []byte) ([]types.Event, error) {
+	r := bytes.NewReader(input)
+	typ, length, err := cbg.NewCborReader(r).ReadHeader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read events: %w", err)
+	}
+
+	if length > MaxEventSliceLength {
+		log.Errorf("extremely long event slice (len %d) returned, not decoding", length)
+		return nil, nil
+	}
+
+	if typ != cbg.MajArray {
+		return nil, fmt.Errorf("expected a CBOR list, was major type %d", typ)
+	}
+	events := make([]types.Event, 0, length)
+	for i := 0; i < int(length); i++ {
+		var evt types.Event
+		if err := evt.UnmarshalCBOR(r); err != nil {
+			return nil, fmt.Errorf("failed to parse event: %w", err)
+		}
+		events = append(events, evt)
+	}
+	return events, nil
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

A security report pointed out the unbounded allocation here, which could be problematic. In practice, this is not a problem, since we can trust the FVM not too return dangerously large data, which can in turn trust gas costs to not allow several GiBs of events.

## Proposed Changes
<!-- A clear list of the changes being made -->

Despite that, we might as well apply some limit here. I settled on 6 million, since it seems like a good theoretical limit, given that a single message can't use more than 10 Billion gas (block gas limit), and a single event must cost at least 1750 gas, leading to a theoretical max of 5.7 Million entries.

I'm happy to use something bigger or smaller, this number is only consensus critical for folks actually decoding events, which Lotus doesn't do by default.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
