### PR TITLE
feat: Add a metric to display pruning of the node's peer

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -116,6 +116,7 @@ var (
 	PubsubDeliverMessage                = stats.Int64("pubsub/delivered", "Counter for total delivered messages", stats.UnitDimensionless)
 	PubsubRejectMessage                 = stats.Int64("pubsub/rejected", "Counter for total rejected messages", stats.UnitDimensionless)
 	PubsubDuplicateMessage              = stats.Int64("pubsub/duplicate", "Counter for total duplicate messages", stats.UnitDimensionless)
+	PubsubPruneMessage                  = stats.Int64("pubsub/prune", "Counter for total prune messages", stats.UnitDimensionless)
 	PubsubRecvRPC                       = stats.Int64("pubsub/recv_rpc", "Counter for total received RPCs", stats.UnitDimensionless)
 	PubsubSendRPC                       = stats.Int64("pubsub/send_rpc", "Counter for total sent RPCs", stats.UnitDimensionless)
 	PubsubDropRPC                       = stats.Int64("pubsub/drop_rpc", "Counter for total dropped RPCs", stats.UnitDimensionless)
@@ -324,6 +325,10 @@ var (
 	}
 	PubsubDuplicateMessageView = &view.View{
 		Measure:     PubsubDuplicateMessage,
+		Aggregation: view.Count(),
+	}
+	PubsubPruneMessageView = &view.View{
+		Measure:     PubsubPruneMessage,
 		Aggregation: view.Count(),
 	}
 	PubsubRecvRPCView = &view.View{

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -765,6 +765,7 @@ var ChainNodeViews = append([]*view.View{
 	PubsubDeliverMessageView,
 	PubsubRejectMessageView,
 	PubsubDuplicateMessageView,
+	PubsubPruneMessageView,
 	PubsubRecvRPCView,
 	PubsubSendRPCView,
 	PubsubDropRPCView,

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -559,6 +559,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 		}
 
 	case pubsub_pb.TraceEvent_PRUNE:
+		stats.Record(context.TODO(), metrics.PubsubPruneMessage.M(1))
 		if trw.traceMessage(evt.GetPrune().GetTopic()) {
 			if trw.lp2pTracer != nil {
 				trw.lp2pTracer.Trace(evt)

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -560,7 +560,6 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 
 	case pubsub_pb.TraceEvent_PRUNE:
 		stats.Record(context.TODO(), metrics.PubsubPruneMessage.M(1))
-		log.Errorf("********************TRACE EVENT PRUNE****************************")
 		if trw.traceMessage(evt.GetPrune().GetTopic()) {
 			if trw.lp2pTracer != nil {
 				trw.lp2pTracer.Trace(evt)

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -560,6 +560,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 
 	case pubsub_pb.TraceEvent_PRUNE:
 		stats.Record(context.TODO(), metrics.PubsubPruneMessage.M(1))
+		log.Errorf("********************TRACE EVENT PRUNE****************************")
 		if trw.traceMessage(evt.GetPrune().GetTopic()) {
 			if trw.lp2pTracer != nil {
 				trw.lp2pTracer.Trace(evt)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
#11044 

## Proposed Changes
<!-- A clear list of the changes being made -->
Add a metric to display when external peers are pruning your libp2p peer

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
