### PR TITLE
fix: DecodeRLP can panic

### DIFF
--- a/chain/types/ethtypes/rlp.go
+++ b/chain/types/ethtypes/rlp.go
@@ -157,6 +157,9 @@ func decodeLength(data []byte, lenInBytes int) (length int, err error) {
 	if err := binary.Read(r, binary.BigEndian, &decodedLength); err != nil {
 		return 0, xerrors.Errorf("invalid rlp data: cannot parse string length: %w", err)
 	}
+	if decodedLength < 0 {
+		return 0, xerrors.Errorf("invalid rlp data: negative string length")
+	}
 	if lenInBytes+int(decodedLength) > len(data) {
 		return 0, xerrors.Errorf("invalid rlp data: out of bound while parsing list")
 	}

--- a/chain/types/ethtypes/rlp_test.go
+++ b/chain/types/ethtypes/rlp_test.go
@@ -143,6 +143,19 @@ func TestDecodeList(t *testing.T) {
 	}
 }
 
+func TestDecodeNegativeLength(t *testing.T) {
+	testcases := [][]byte{
+		mustDecodeHex("0xbfffffffffffffff0041424344"),
+		mustDecodeHex("0xc1bFFF1111111111111111"),
+		mustDecodeHex("0xbFFF11111111111111"),
+	}
+
+	for _, tc := range testcases {
+		_, err := DecodeRLP(tc)
+		require.Error(t, err, "invalid rlp data: negative string length")
+	}
+}
+
 func TestDecodeEncodeTx(t *testing.T) {
 	testcases := [][]byte{
 		mustDecodeHex("0xdc82013a0185012a05f2008504a817c8008080872386f26fc1000000c0"),


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/filecoin-project/lotus/issues/11053

## Proposed Changes
It was possible to pass to `DecodeRLP` a certain byte slices that resulted in a panic caused by unchecked decode length. This PR adds a check for this condition and adds a test case to make sure this check is triggered. 

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
