### PR TITLE
fix: daemon: set real beacon schedule when importing chain

### DIFF
--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -235,3 +235,16 @@ func (db *DrandBeacon) maxBeaconRoundV2(latestTs uint64) uint64 {
 }
 
 var _ beacon.RandomBeacon = (*DrandBeacon)(nil)
+
+func BeaconScheduleFromDrandSchedule(dcs dtypes.DrandSchedule, genesisTime uint64, ps *pubsub.PubSub) (beacon.Schedule, error) {
+	shd := beacon.Schedule{}
+	for _, dc := range dcs {
+		bc, err := NewDrandBeacon(genesisTime, build.BlockDelaySecs, ps, dc.Config)
+		if err != nil {
+			return nil, xerrors.Errorf("creating drand beacon: %w", err)
+		}
+		shd = append(shd, beacon.BeaconPoint{Start: dc.Start, Beacon: bc})
+	}
+
+	return shd, nil
+}

--- a/cmd/lotus-shed/gas-estimation.go
+++ b/cmd/lotus-shed/gas-estimation.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/beacon/drand"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
@@ -100,15 +99,11 @@ var gasTraceCmd = &cli.Command{
 			return err
 		}
 
-		dcs := build.DrandConfigSchedule()
-		shd := beacon.Schedule{}
-		for _, dc := range dcs {
-			bc, err := drand.NewDrandBeacon(MAINNET_GENESIS_TIME, build.BlockDelaySecs, nil, dc.Config)
-			if err != nil {
-				return xerrors.Errorf("creating drand beacon: %w", err)
-			}
-			shd = append(shd, beacon.BeaconPoint{Start: dc.Start, Beacon: bc})
+		shd, err := drand.BeaconScheduleFromDrandSchedule(build.DrandConfigSchedule(), MAINNET_GENESIS_TIME, nil)
+		if err != nil {
+			return err
 		}
+
 		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
 		defer cs.Close() //nolint:errcheck
 
@@ -200,14 +195,9 @@ var replayOfflineCmd = &cli.Command{
 			return err
 		}
 
-		dcs := build.DrandConfigSchedule()
-		shd := beacon.Schedule{}
-		for _, dc := range dcs {
-			bc, err := drand.NewDrandBeacon(MAINNET_GENESIS_TIME, build.BlockDelaySecs, nil, dc.Config)
-			if err != nil {
-				return xerrors.Errorf("creating drand beacon: %w", err)
-			}
-			shd = append(shd, beacon.BeaconPoint{Start: dc.Start, Beacon: bc})
+		shd, err := drand.BeaconScheduleFromDrandSchedule(build.DrandConfigSchedule(), MAINNET_GENESIS_TIME, nil)
+		if err != nil {
+			return err
 		}
 
 		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -40,6 +40,7 @@ import (
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/beacon/drand"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
@@ -570,8 +571,12 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 		return err
 	}
 
-	// TODO: We need to supply the actual beacon after v14
-	stm, err := stmgr.NewStateManager(cst, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil, mds, index.DummyMsgIndex)
+	shd, err := drand.BeaconScheduleFromDrandSchedule(build.DrandConfigSchedule(), gb.MinTimestamp(), nil)
+	if err != nil {
+		return xerrors.Errorf("failed to construct beacon schedule: %w", err)
+	}
+
+	stm, err := stmgr.NewStateManager(cst, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), shd, mds, index.DummyMsgIndex)
 	if err != nil {
 		return err
 	}

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -265,13 +265,9 @@ func RandomSchedule(lc fx.Lifecycle, mctx helpers.MetricsCtx, p RandomBeaconPara
 		return nil, err
 	}
 
-	shd := beacon.Schedule{}
-	for _, dc := range p.DrandConfig {
-		bc, err := drand.NewDrandBeacon(gen.Timestamp, build.BlockDelaySecs, p.PubSub, dc.Config)
-		if err != nil {
-			return nil, xerrors.Errorf("creating drand beacon: %w", err)
-		}
-		shd = append(shd, beacon.BeaconPoint{Start: dc.Start, Beacon: bc})
+	shd, err := drand.BeaconScheduleFromDrandSchedule(p.DrandConfig, gen.Timestamp, p.PubSub)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create beacon schedule: %w", err)
 	}
 
 	return shd, nil


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#11041 

## Proposed Changes
<!-- A clear list of the changes being made -->

- Unify the code that creates beacon schedules from drand config
- Actually set the beacon schedule when running import-chain

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Syncs mainnet :heavy_check_mark: 
Repro in #11041 no longer panics :heavy_check_mark: 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
