### PR TITLE
feat: vm: allow raw "cbor" in state and use the new go-multicodec

### DIFF
--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
-	mh "github.com/multiformats/go-multihash"
+	"github.com/multiformats/go-multicodec"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
@@ -38,7 +38,6 @@ import (
 )
 
 const MaxCallDepth = 4096
-const CborCodec = 0x51
 
 var (
 	log            = logging.Logger("vm")
@@ -128,7 +127,7 @@ func (bs *gasChargingBlocks) Put(ctx context.Context, blk block.Block) error {
 func (vm *LegacyVM) makeRuntime(ctx context.Context, msg *types.Message, parent *Runtime) *Runtime {
 	paramsCodec := uint64(0)
 	if len(msg.Params) > 0 {
-		paramsCodec = CborCodec
+		paramsCodec = uint64(multicodec.Cbor)
 	}
 	rt := &Runtime{
 		ctx:         ctx,
@@ -385,7 +384,7 @@ func (vm *LegacyVM) send(ctx context.Context, msg *types.Message, parent *Runtim
 
 	retCodec := uint64(0)
 	if len(ret) > 0 {
-		retCodec = CborCodec
+		retCodec = uint64(multicodec.Cbor)
 	}
 	rt.executionTrace.MsgRct = types.ReturnTrace{
 		ExitCode:    aerrors.RetCode(err),
@@ -700,15 +699,15 @@ func (vm *LegacyVM) ActorStore(ctx context.Context) adt.Store {
 }
 
 func linksForObj(blk block.Block, cb func(cid.Cid)) error {
-	switch blk.Cid().Prefix().Codec {
-	case cid.DagCBOR:
+	switch multicodec.Code(blk.Cid().Prefix().Codec) {
+	case multicodec.DagCbor:
 		err := cbg.ScanForLinks(bytes.NewReader(blk.RawData()), cb)
 		if err != nil {
 			return xerrors.Errorf("cbg.ScanForLinks: %w", err)
 		}
 		return nil
-	case cid.Raw:
-		// We implicitly have all children of raw blocks.
+	case multicodec.Raw, multicodec.Cbor:
+		// We implicitly have all children of raw/cbor blocks.
 		return nil
 	default:
 		return xerrors.Errorf("vm flush copy method only supports dag cbor")
@@ -808,14 +807,17 @@ func copyRec(ctx context.Context, from, to blockstore.Blockstore, root cid.Cid, 
 		}
 
 		prefix := link.Prefix()
-		if prefix.Codec == cid.FilCommitmentSealed || prefix.Codec == cid.FilCommitmentUnsealed {
+		codec := multicodec.Code(prefix.Codec)
+		switch codec {
+		case multicodec.FilCommitmentSealed, cid.FilCommitmentUnsealed:
 			return
 		}
 
 		// We always have blocks inlined into CIDs, but we may not have their children.
-		if prefix.MhType == mh.IDENTITY {
+		if multicodec.Code(prefix.MhType) == multicodec.Identity {
 			// Unless the inlined block has no children.
-			if prefix.Codec == cid.Raw {
+			switch codec {
+			case multicodec.Raw, multicodec.Cbor:
 				return
 			}
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.9.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multibase v0.2.0
+	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
@@ -278,7 +279,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
-	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/nikkolasg/hexjson v0.1.0 // indirect
 	github.com/nkovacs/streamquote v1.0.0 // indirect


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Switch to go-multicodec as the source of multicodec code information. This gives us a central, generated source of multicodec codes.
2. Use this library inside the VM and shapshot logic to consistently allow CBOR, in addition to DagCBOR.
3. Remove the hard-coded CBOR constant.

This doesn't add any functionality in practice, it's just a post FEVM cleanup.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green