### PR TITLE
fix: ethtypes: handle length overflow case

### DIFF
--- a/chain/types/ethtypes/rlp.go
+++ b/chain/types/ethtypes/rlp.go
@@ -134,7 +134,7 @@ func decodeRLP(data []byte) (res interface{}, consumed int, err error) {
 			return nil, 0, err
 		}
 		totalLen := 1 + strLenInBytes + strLen
-		if totalLen > len(data) {
+		if totalLen > len(data) || totalLen < 0 {
 			return nil, 0, xerrors.Errorf("invalid rlp data: out of bound while parsing string")
 		}
 		return data[1+strLenInBytes : totalLen], totalLen, nil
@@ -160,7 +160,9 @@ func decodeLength(data []byte, lenInBytes int) (length int, err error) {
 	if decodedLength < 0 {
 		return 0, xerrors.Errorf("invalid rlp data: negative string length")
 	}
-	if lenInBytes+int(decodedLength) > len(data) {
+
+	totalLength := lenInBytes + int(decodedLength)
+	if totalLength < 0 || totalLength > len(data) {
 		return 0, xerrors.Errorf("invalid rlp data: out of bound while parsing list")
 	}
 	return int(decodedLength), nil

--- a/chain/types/ethtypes/rlp_test.go
+++ b/chain/types/ethtypes/rlp_test.go
@@ -148,11 +148,12 @@ func TestDecodeNegativeLength(t *testing.T) {
 		mustDecodeHex("0xbfffffffffffffff0041424344"),
 		mustDecodeHex("0xc1bFFF1111111111111111"),
 		mustDecodeHex("0xbFFF11111111111111"),
+		mustDecodeHex("0xbf7fffffffffffffff41424344"),
 	}
 
 	for _, tc := range testcases {
 		_, err := DecodeRLP(tc)
-		require.Error(t, err, "invalid rlp data: negative string length")
+		require.ErrorContains(t, err, "invalid rlp data")
 	}
 }
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Similar to #11053 

## Proposed Changes
<!-- A clear list of the changes being made -->

The string length field can overflow and turn negative here, leading to a panic

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
