### PR TITLE
feat: daemon: import: only setup stmgr if validating chain

### DIFF
--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -571,17 +571,17 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 		return err
 	}
 
-	shd, err := drand.BeaconScheduleFromDrandSchedule(build.DrandConfigSchedule(), gb.MinTimestamp(), nil)
-	if err != nil {
-		return xerrors.Errorf("failed to construct beacon schedule: %w", err)
-	}
-
-	stm, err := stmgr.NewStateManager(cst, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), shd, mds, index.DummyMsgIndex)
-	if err != nil {
-		return err
-	}
-
 	if !snapshot {
+		shd, err := drand.BeaconScheduleFromDrandSchedule(build.DrandConfigSchedule(), gb.MinTimestamp(), nil)
+		if err != nil {
+			return xerrors.Errorf("failed to construct beacon schedule: %w", err)
+		}
+
+		stm, err := stmgr.NewStateManager(cst, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), shd, mds, index.DummyMsgIndex)
+		if err != nil {
+			return err
+		}
+
 		log.Infof("validating imported chain...")
 		if err := stm.ValidateChain(ctx, ts); err != nil {
 			return xerrors.Errorf("chain validation failed: %w", err)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@snissn reported that when running `lotus daemon --halt-after-import --import-snapshot  /mnt/latest.zst`, he was getting the following error:

```
2023-07-17T20:27:58.025Z        INFO    drand   drand/drand.go:114      drand beacon without pubsub
2023-07-17T20:27:58.025Z        WARN    chainstore      store/store.go:634      reorgWorker quit
2023-07-17T20:27:58.356Z        INFO    badgerbs        v2@v2.2007.4/db.go:1027 Storing value log head: {Fid:98 Len:33 Offset:255692644}

2023-07-17T20:27:58.649Z        INFO    badgerbs        v2@v2.2007.4/levels.go:1000     [Compactor: 173] Running compaction: {level:0 score:1.73 dropPrefixes:[]} for level: 0

2023-07-17T20:28:00.533Z        INFO    badgerbs        v2@v2.2007.4/levels.go:962      LOG Compact 0->1, del 8 tables, add 6 tables, took 1.883811354s

2023-07-17T20:28:00.533Z        INFO    badgerbs        v2@v2.2007.4/levels.go:1010     [Compactor: 173] Compaction for level: 0 DONE
2023-07-17T20:28:00.533Z        INFO    badgerbs        v2@v2.2007.4/db.go:550  Force compaction on level 0 done
ERROR: failed to construct beacon schedule: creating drand beacon: creating drand client: no points of contact specified
```

The immediate cause is that #11080 caused us to start using the "real" drand config when importing chains. While correct, this is exposing a longer-running issue related to trying to create drand clients without any specified servers. We [walked up to this issue before, but hacked around it ](https://github.com/filecoin-project/lotus/pull/9654/files/62fedfbce3feb078cff785b8550d97c3bcb7eafe#r1025800178)without actual understanding. 

## Proposed Changes
<!-- A clear list of the changes being made -->

We need an _actual_ fix to this issue, for which I'll open a separate PR and issue. For now, we can make a quick improvement that also unblocks @snissn, which is to only bother creating the stmgr (and so setting up the beacon schedule) if we're actually validating the imported chain. We don't need to be doing this if we're just importing a snapshot and trusting it.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
