### PR TITLE
fix: sealing pipeline: Fix PC1 retry loop

### DIFF
--- a/storage/pipeline/cbor_gen.go
+++ b/storage/pipeline/cbor_gen.go
@@ -31,7 +31,7 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write([]byte{184, 38}); err != nil {
+	if _, err := cw.Write([]byte{184, 39}); err != nil {
 		return err
 	}
 
@@ -563,6 +563,22 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		if err := cbg.WriteCid(cw, *t.UpdateUnsealed); err != nil {
 			return xerrors.Errorf("failed to write cid field t.UpdateUnsealed: %w", err)
 		}
+	}
+
+	// t.PreCommit1Fails (uint64) (uint64)
+	if len("PreCommit1Fails") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PreCommit1Fails\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("PreCommit1Fails"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PreCommit1Fails")); err != nil {
+		return err
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.PreCommit1Fails)); err != nil {
+		return err
 	}
 
 	// t.PreCommit2Fails (uint64) (uint64)
@@ -1401,6 +1417,21 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) (err error) {
 
 					t.UpdateUnsealed = &c
 				}
+
+			}
+			// t.PreCommit1Fails (uint64) (uint64)
+		case "PreCommit1Fails":
+
+			{
+
+				maj, extra, err = cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PreCommit1Fails = uint64(extra)
 
 			}
 			// t.PreCommit2Fails (uint64) (uint64)

--- a/storage/pipeline/fsm_events.go
+++ b/storage/pipeline/fsm_events.go
@@ -182,6 +182,8 @@ func (evt SectorSealPreCommit1Failed) FormatError(xerrors.Printer) (next error) 
 func (evt SectorSealPreCommit1Failed) apply(si *SectorInfo) {
 	si.InvalidProofs = 0 // reset counter
 	si.PreCommit2Fails = 0
+
+	si.PreCommit1Fails++
 }
 
 type SectorSealPreCommit2Failed struct{ error }

--- a/storage/pipeline/states_failed.go
+++ b/storage/pipeline/states_failed.go
@@ -54,7 +54,13 @@ func (m *Sealing) checkPreCommitted(ctx statemachine.Context, sector SectorInfo)
 	return info, true
 }
 
+var MaxPreCommit1Retries = uint64(3)
+
 func (m *Sealing) handleSealPrecommit1Failed(ctx statemachine.Context, sector SectorInfo) error {
+	if sector.PreCommit1Fails > MaxPreCommit1Retries {
+		return ctx.Send(SectorRemove{})
+	}
+
 	if err := failedCooldown(ctx, sector); err != nil {
 		return err
 	}

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
@@ -213,6 +215,40 @@ func (m *Sealing) handleGetTicket(ctx statemachine.Context, sector SectorInfo) e
 	})
 }
 
+var SoftErrRetryWait = 5 * time.Second
+
+func retrySoftErr(ctx context.Context, cb func() error) error {
+	for {
+		err := cb()
+		if err == nil {
+			return nil
+		}
+
+		var cerr storiface.WorkError
+
+		if errors.As(err, &cerr) {
+			switch cerr.ErrCode() {
+			case storiface.ErrTempWorkerRestart:
+				fallthrough
+			case storiface.ErrTempAllocateSpace:
+				// retry
+			default:
+				// non-temp error
+				return err
+			}
+
+			// retry
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			time.Sleep(SoftErrRetryWait)
+		} else {
+			return err
+		}
+	}
+}
+
 func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) error {
 	if err := checkPieces(ctx.Context(), m.maddr, sector.SectorNumber, sector.Pieces, m.Api, false); err != nil { // Sanity check state
 		switch err.(type) {
@@ -269,7 +305,11 @@ func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) 
 		}
 	}
 
-	pc1o, err := m.sealer.SealPreCommit1(sector.sealingCtx(ctx.Context()), m.minerSector(sector.SectorType, sector.SectorNumber), sector.TicketValue, sector.pieceInfos())
+	var pc1o storiface.PreCommit1Out
+	err = retrySoftErr(ctx.Context(), func() (err error) {
+		pc1o, err = m.sealer.SealPreCommit1(sector.sealingCtx(ctx.Context()), m.minerSector(sector.SectorType, sector.SectorNumber), sector.TicketValue, sector.pieceInfos())
+		return err
+	})
 	if err != nil {
 		return ctx.Send(SectorSealPreCommit1Failed{xerrors.Errorf("seal pre commit(1) failed: %w", err)})
 	}
@@ -280,7 +320,12 @@ func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) 
 }
 
 func (m *Sealing) handlePreCommit2(ctx statemachine.Context, sector SectorInfo) error {
-	cids, err := m.sealer.SealPreCommit2(sector.sealingCtx(ctx.Context()), m.minerSector(sector.SectorType, sector.SectorNumber), sector.PreCommit1Out)
+	var cids storiface.SectorCids
+
+	err := retrySoftErr(ctx.Context(), func() (err error) {
+		cids, err = m.sealer.SealPreCommit2(sector.sealingCtx(ctx.Context()), m.minerSector(sector.SectorType, sector.SectorNumber), sector.PreCommit1Out)
+		return err
+	})
 	if err != nil {
 		return ctx.Send(SectorSealPreCommit2Failed{xerrors.Errorf("seal pre commit(2) failed: %w", err)})
 	}

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -237,11 +237,12 @@ func retrySoftErr(ctx context.Context, cb func() error) error {
 				return err
 			}
 
-			// retry
+			// check if the context got cancelled early
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 
+			// retry
 			time.Sleep(SoftErrRetryWait)
 		} else {
 			return err

--- a/storage/pipeline/types.go
+++ b/storage/pipeline/types.go
@@ -56,6 +56,8 @@ type SectorInfo struct {
 	TicketEpoch   abi.ChainEpoch
 	PreCommit1Out storiface.PreCommit1Out
 
+	PreCommit1Fails uint64
+
 	// PreCommit2
 	CommD *cid.Cid
 	CommR *cid.Cid // SectorKey

--- a/storage/sealer/storiface/worker.go
+++ b/storage/sealer/storiface/worker.go
@@ -186,10 +186,18 @@ const (
 	ErrTempAllocateSpace
 )
 
+type WorkError interface {
+	ErrCode() ErrorCode
+}
+
 type CallError struct {
 	Code    ErrorCode
 	Message string
 	sub     error
+}
+
+func (c *CallError) ErrCode() ErrorCode {
+	return c.Code
 }
 
 func (c *CallError) Error() string {
@@ -203,6 +211,8 @@ func (c *CallError) Unwrap() error {
 
 	return errors.New(c.Message)
 }
+
+var _ WorkError = &CallError{}
 
 func Err(code ErrorCode, sub error) *CallError {
 	return &CallError{


### PR DESCRIPTION
## Related Issues
* Any issue which refers PC1 loops

## Proposed Changes
Instead of retrying PC1 forever, only retry PC1 up to 3 times

## Additional Info
This fixes the issue where PC1 will be retried e.g. in cases where for whatever reason unsealed data doesn't match what should have come from deals:

```
	seal pre commit(1) failed: storage call error 0: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match [name: okonomiyaki]: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match
7928.	2023-07-18 21:52:31 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
7929.	2023-07-18 21:54:09 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match [name: okonomiyaki]: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match
7930.	2023-07-18 21:55:09 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
7931.	2023-07-18 21:56:45 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match [name: okonomiyaki]: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match
7932.	2023-07-18 21:57:45 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
7933.	2023-07-18 21:59:24 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match [name: okonomiyaki]: presealing sector 6705 (/data/4/store/unsealed/s-t02620-6705): pieces and comm_d do not match
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
