### PR TITLE
Add new lotus-shed command for backfillling actor events

### DIFF
--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path"
@@ -8,12 +9,17 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/multiformats/go-varint"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	lcli "github.com/filecoin-project/lotus/cli"
 )
@@ -31,6 +37,283 @@ var indexesCmd = &cli.Command{
 		withCategory("msgindex", backfillMsgIndexCmd),
 		withCategory("msgindex", pruneMsgIndexCmd),
 		withCategory("txhash", backfillTxHashCmd),
+		withCategory("events", backfillEventsCmd),
+	},
+}
+
+var backfillEventsCmd = &cli.Command{
+	Name:  "backfill-events",
+	Usage: "Backfill the events.db for a number of epochs starting from a specified height",
+	Flags: []cli.Flag{
+		&cli.UintFlag{
+			Name:  "from",
+			Value: 0,
+			Usage: "the tipset height to start backfilling from (0 is head of chain)",
+		},
+		&cli.IntFlag{
+			Name:  "epochs",
+			Value: 2000,
+			Usage: "the number of epochs to backfill",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		srv, err := lcli.GetFullNodeServices(cctx)
+		if err != nil {
+			return err
+		}
+		defer srv.Close() //nolint:errcheck
+
+		api := srv.FullNodeAPI()
+		ctx := lcli.ReqContext(cctx)
+
+		// currTs will be the tipset where we start backfilling from
+		currTs, err := api.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+		if cctx.IsSet("from") {
+			// we need to fetch the tipset after the epoch being specified since we will need to advance currTs
+			currTs, err = api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(cctx.Int("from")+1), currTs.Key())
+			if err != nil {
+				return err
+			}
+		}
+
+		// advance currTs by one epoch and maintain prevTs as the previous tipset (this allows us to easily use the ChainGetParentMessages/Receipt API)
+		prevTs := currTs
+		currTs, err = api.ChainGetTipSet(ctx, currTs.Parents())
+		if err != nil {
+			return fmt.Errorf("failed to load tipset %s: %w", prevTs.Parents(), err)
+		}
+
+		epochs := cctx.Int("epochs")
+
+		basePath, err := homedir.Expand(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		dbPath := path.Join(basePath, "sqlite", "events.db")
+		db, err := sql.Open("sqlite3", dbPath)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			err := db.Close()
+			if err != nil {
+				fmt.Printf("ERROR: closing db: %s", err)
+			}
+		}()
+
+		stmtSelectEvent, err := db.Prepare("SELECT MAX(id) from event WHERE height=? AND tipset_key=? and tipset_key_cid=? and emitter_addr=? and event_index=? and message_cid=? and message_index=? and reverted=false")
+		if err != nil {
+			return err
+		}
+		stmtSelectEntry, err := db.Prepare("SELECT EXISTS(SELECT 1 from event_entry WHERE event_id=? and indexed=? and flags=? and key=? and codec=? and value=?)")
+		if err != nil {
+			return err
+		}
+		stmtEvent, err := db.Prepare("INSERT INTO event (height, tipset_key, tipset_key_cid, emitter_addr, event_index, message_cid, message_index, reverted) VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
+		if err != nil {
+			return err
+		}
+		stmtEntry, err := db.Prepare("INSERT INTO event_entry(event_id, indexed, flags, key, codec, value) VALUES(?, ?, ?, ?, ?, ?)")
+		if err != nil {
+			return err
+		}
+
+		addressLookups := make(map[abi.ActorID]address.Address)
+
+		resolveFn := func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool) {
+			// we only want to match using f4 addresses
+			idAddr, err := address.NewIDAddress(uint64(emitter))
+			if err != nil {
+				return address.Undef, false
+			}
+
+			actor, err := api.StateGetActor(ctx, idAddr, ts.Key())
+			if err != nil || actor.Address == nil {
+				return address.Undef, false
+			}
+
+			// if robust address is not f4 then we won't match against it so bail early
+			if actor.Address.Protocol() != address.Delegated {
+				return address.Undef, false
+			}
+
+			// we have an f4 address, make sure it's assigned by the EAM
+			if namespace, _, err := varint.FromUvarint(actor.Address.Payload()); err != nil || namespace != builtintypes.EthereumAddressManagerActorID {
+				return address.Undef, false
+			}
+			return *actor.Address, true
+		}
+
+		isIndexedValue := func(b uint8) bool {
+			// currently we mark the full entry as indexed if either the key
+			// or the value are indexed; in the future we will need finer-grained
+			// management of indices
+			return b&(types.EventFlagIndexedKey|types.EventFlagIndexedValue) > 0
+		}
+
+		var eventsAffected int64
+		var entriesAffected int64
+		for i := 0; i < epochs; i++ {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+
+			log.Infof("[%d] backfilling actor events epoch:%d, eventsAffected:%d, entriesAffected:%d", i, currTs.Height(), eventsAffected, entriesAffected)
+
+			blockCid := prevTs.Blocks()[0].Cid()
+
+			// get messages for the parent of the previous tipset (which will be currTs)
+			msgs, err := api.ChainGetParentMessages(ctx, blockCid)
+			if err != nil {
+				return fmt.Errorf("failed to get parent messages for block %s: %w", blockCid, err)
+			}
+
+			// get receipts for the parent of the previous tipset (which will be currTs)
+			receipts, err := api.ChainGetParentReceipts(ctx, blockCid)
+			if err != nil {
+				return fmt.Errorf("failed to get parent receipts for block %s: %w", blockCid, err)
+			}
+
+			if len(msgs) != len(receipts) {
+				return fmt.Errorf("mismatched in message and receipt count: %d != %d", len(msgs), len(receipts))
+			}
+
+			// loop over each message receipt and backfill the events
+			for idx, receipt := range receipts {
+				msg := msgs[idx]
+
+				if receipt.ExitCode != exitcode.Ok {
+					continue
+				}
+
+				if receipt.EventsRoot == nil {
+					continue
+				}
+
+				events, err := api.ChainGetEvents(ctx, *receipt.EventsRoot)
+				if err != nil {
+					return fmt.Errorf("failed to load events for tipset %s: %w", currTs, err)
+				}
+
+				for eventIdx, event := range events {
+					addr, found := addressLookups[event.Emitter]
+					if !found {
+						var ok bool
+						addr, ok = resolveFn(ctx, event.Emitter, currTs)
+						if !ok {
+							// not an address we will be able to match against
+							continue
+						}
+						addressLookups[event.Emitter] = addr
+					}
+
+					tsKeyCid, err := currTs.Key().Cid()
+					if err != nil {
+						return fmt.Errorf("failed to get tipset key cid: %w", err)
+					}
+
+					// select the highest event id that exists in database, or null if none exists
+					var entryID sql.NullInt64
+					err = stmtSelectEvent.QueryRow(
+						currTs.Height(),
+						currTs.Key().Bytes(),
+						tsKeyCid.Bytes(),
+						addr.Bytes(),
+						eventIdx,
+						msg.Cid.Bytes(),
+						idx,
+					).Scan(&entryID)
+					if err != nil {
+						return fmt.Errorf("error checking if event exists: %w", err)
+					}
+
+					if !entryID.Valid {
+						// event does not exist, lets backfill it
+						res, err := stmtEvent.Exec(
+							currTs.Height(),      // height
+							currTs.Key().Bytes(), // tipset_key
+							tsKeyCid.Bytes(),     // tipset_key_cid
+							addr.Bytes(),         // emitter_addr
+							eventIdx,             // event_index
+							msg.Cid.Bytes(),      // message_cid
+							idx,                  // message_index
+							false,                // reverted
+						)
+
+						if err != nil {
+							return fmt.Errorf("error inserting event: %w", err)
+						}
+
+						entryID.Int64, err = res.LastInsertId()
+						if err != nil {
+							return fmt.Errorf("could not get last insert id: %w", err)
+						}
+
+						rowsAffected, err := res.RowsAffected()
+						if err != nil {
+							return fmt.Errorf("error getting rows affected: %s", err)
+						}
+
+						eventsAffected += rowsAffected
+					}
+
+					for _, entry := range event.Entries {
+						// check if entry exists
+						var exists bool
+						err = stmtSelectEntry.QueryRow(
+							entryID.Int64,
+							isIndexedValue(entry.Flags),
+							[]byte{entry.Flags},
+							entry.Key,
+							entry.Codec,
+							entry.Value,
+						).Scan(&exists)
+						if err != nil {
+							return fmt.Errorf("error checking if entry exists: %w", err)
+						}
+
+						if !exists {
+							// entry does not exist, lets backfill it
+							res, err := stmtEntry.Exec(
+								entryID.Int64,               // event_id
+								isIndexedValue(entry.Flags), // indexed
+								[]byte{entry.Flags},         // flags
+								entry.Key,                   // key
+								entry.Codec,                 // codec
+								entry.Value,                 // value
+							)
+							if err != nil {
+								return fmt.Errorf("error inserting entry: %w", err)
+							}
+
+							rowsAffected, err := res.RowsAffected()
+							if err != nil {
+								return fmt.Errorf("error getting rows affected: %s", err)
+							}
+							entriesAffected += rowsAffected
+						}
+					}
+				}
+			}
+
+			// advance prevTs and currTs up the chain
+			prevTs = currTs
+			currTs, err = api.ChainGetTipSet(ctx, currTs.Parents())
+			if err != nil {
+				return fmt.Errorf("failed to load tipset %s: %w", currTs, err)
+			}
+		}
+
+		log.Infof("backfilling events complete, eventsAffected:%d, entriesAffected:%d", eventsAffected, entriesAffected)
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
Related issue: https://github.com/filecoin-project/lotus/issues/10807
Replaces previous PR: https://github.com/filecoin-project/lotus/pull/10939

## Context
When lotus is configured to enable indexing of actor events (when `EnableEthRPC=true` and `DisableHistoricFilterAPI=false`) then Lotus will observe for new tipset and store all the actor events in a sqlite table stored at `sqlite/events.db`. 

We however, don't have any way to backfill these actor events. This PR therefore implements this backfilling using a new lotus-shed` command.

Note that this implementation does not compute state (it only looks up the receipts so they need to exist on chain).

## Test plan

**Backfill active node that is already storing events**

As expected, backfilling should not have any side effects on a node that is already saving actor events.

```
lotus-shed indexes backfill-events --epochs=1000
2023-07-20T10:45:13.018Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [0] backfilling actor events epoch:3051449, eventsAffected:0, entriesAffected:0
2023-07-20T10:45:13.029Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [1] backfilling actor events epoch:3051448, eventsAffected:0, entriesAffected:0
2023-07-20T10:45:13.045Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [2] backfilling actor events epoch:3051447, eventsAffected:0, entriesAffected:0
...
2023-07-20T10:46:14.769Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [996] backfilling actor events epoch:3050448, eventsAffected:0, entriesAffected:0
2023-07-20T10:46:14.782Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [997] backfilling actor events epoch:3050447, eventsAffected:0, entriesAffected:0
2023-07-20T10:46:14.814Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [998] backfilling actor events epoch:3050446, eventsAffected:0, entriesAffected:0
2023-07-20T10:46:14.825Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [999] backfilling actor events epoch:3050445, eventsAffected:0, entriesAffected:0
2023-07-20T10:46:14.843Z        INFO    lotus-shed      lotus-shed/indexes.go:318       backfilling events complete, eventsAffected:0, entriesAffected:0
```
**Backfill a node that had never stored any events**

```
lotus-shed indexes backfill-events  --epochs=100000
2023-07-20T10:29:37.535Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [0] backfilling actor events epoch:3051307, eventsAffected:0, entriesAffected:0
2023-07-20T10:29:37.548Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [1] backfilling actor events epoch:3051306, eventsAffected:7, entriesAffected:25
2023-07-20T10:29:37.559Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [2] backfilling actor events epoch:3051305, eventsAffected:11, entriesAffected:39
2023-07-20T10:29:37.565Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [3] backfilling actor events epoch:3051304, eventsAffected:11, entriesAffected:39
...
2023-07-20T10:32:31.736Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7068] backfilling actor events epoch:3044289, eventsAffected:15491, entriesAffected:55988
2023-07-20T10:32:31.744Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7069] backfilling actor events epoch:3044288, eventsAffected:15491, entriesAffected:55988
2023-07-20T10:32:31.777Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7070] backfilling actor events epoch:3044287, eventsAffected:15491, entriesAffected:55988
2023-07-20T10:32:31.800Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7071] backfilling actor events epoch:3044286, eventsAffected:15491, entriesAffected:55988
2023-07-20T10:32:31.832Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7072] backfilling actor events epoch:3044285, eventsAffected:15491, entriesAffected:55988
2023-07-20T10:32:31.857Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7073] backfilling actor events epoch:3044284, eventsAffected:15492, entriesAffected:55992
2023-07-20T10:32:31.884Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7074] backfilling actor events epoch:3044283, eventsAffected:15492, entriesAffected:55992
2023-07-20T10:32:31.924Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7075] backfilling actor events epoch:3044282, eventsAffected:15494, entriesAffected:56000
2023-07-20T10:32:31.966Z        INFO    lotus-shed      lotus-shed/indexes.go:168       [7076] backfilling actor events epoch:3044281, eventsAffected:15496, entriesAffected:56008
```

**Verify backfill results**

I compared the `events.db` that was generated from scratch via backfill to another `events.db` which was generated from by an active lotus node. I attached the second database as `events2` and used the following sql to verify there are no missing events:

```sql
SELECT * FROM (
  SELECT e.height, e.tipset_key, e.emitter_addr, e.event_index,  e.message_index, e.reverted, ee.indexed, ee.flags, ee.key, ee.codec, ee.value 
  FROM event e, event_entry ee
  WHERE ee.event_id = e.id AND e.height > 3044282 AND e.height < 3050445
  EXCEPT
  SELECT e.height, e.tipset_key, e.emitter_addr, e.event_index,  e.message_index, e.reverted, ee.indexed, ee.flags, ee.key, ee.codec, ee.value 
  FROM events2.event e, events2.event_entry ee
  WHERE ee.event_id = e.id AND e.height > 3044282 AND e.height < 3050445
) WHERE reverted = 0

Result: 0 rows returned in 259ms
```
