### PR TITLE
feat: FVM: do not error on unsuccessful implicit messages

### DIFF
--- a/chain/consensus/compute_state.go
+++ b/chain/consensus/compute_state.go
@@ -135,6 +135,10 @@ func (t *TipSetExecutor) ApplyBlocks(ctx context.Context,
 			return xerrors.Errorf("running cron: %w", err)
 		}
 
+		if !ret.ExitCode.IsSuccess() {
+			return xerrors.Errorf("cron failed with exit code %d: %w", ret.ExitCode, ret.ActorErr)
+		}
+
 		cronGas += ret.GasUsed
 
 		if em != nil {

--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -80,6 +80,11 @@ var RewardFunc = func(ctx context.Context, vmi vm.Interface, em stmgr.ExecMonito
 	if actErr != nil {
 		return xerrors.Errorf("failed to apply reward message: %w", actErr)
 	}
+
+	if !ret.ExitCode.IsSuccess() {
+		return xerrors.Errorf("reward actor failed with exit code %d: %w", ret.ExitCode, ret.ActorErr)
+	}
+
 	if em != nil {
 		if err := em.MessageApplied(ctx, ts, rwMsg.Cid(), rwMsg, ret, true); err != nil {
 			return xerrors.Errorf("callback failed on reward message: %w", err)

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -520,10 +520,6 @@ func (vm *FVM) ApplyImplicitMessage(ctx context.Context, cmsg *types.Message) (*
 		}
 	}
 
-	if ret.ExitCode != 0 {
-		return applyRet, fmt.Errorf("implicit message failed with exit code: %d and error: %w", ret.ExitCode, applyRet.ActorErr)
-	}
-
 	return applyRet, nil
 }
 

--- a/itests/remove_verifreg_datacap_test.go
+++ b/itests/remove_verifreg_datacap_test.go
@@ -275,7 +275,7 @@ func TestNoRemoveDatacapFromVerifreg(t *testing.T) {
 		Params: params,
 		Value:  big.Zero(),
 	}, types.EmptyTSK)
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.False(t, callResult.MsgRct.ExitCode.IsSuccess())
 
 	verifregDatacapAfter, err := clientApi.StateVerifiedClientStatus(ctx, builtin.VerifiedRegistryActorAddr, types.EmptyTSK)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#11061

The FVM currently errors on unsuccessful `Implicit` messages -- that is, a failure exit code is treated as an error. This essentially assumes that all callers of `ApplyImplicitMessage` wants to treat a non-zero code as an error. While this is generally true, some callers (eg. when simulating messages) might not want to handle non-zero exit codes as errors.

## Proposed Changes
<!-- A clear list of the changes being made -->

- Change the FVM to NOT treat non-zero exit codes as errors
- Change the core state computation pipeline to explicitly check exit codes for Cron and Reward actors, and fail if unsuccessful

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
