### PR TITLE
sector import: fix evaluating randomness when importing a sector

### DIFF
--- a/storage/pipeline/receive.go
+++ b/storage/pipeline/receive.go
@@ -123,7 +123,7 @@ func (m *Sealing) checkSectorMeta(ctx context.Context, meta api.RemoteSectorMeta
 		if err := m.maddr.MarshalCBOR(maddrBuf); err != nil {
 			return SectorInfo{}, xerrors.Errorf("marshal miner address for seed check: %w", err)
 		}
-		rand, err := m.Api.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, meta.SeedEpoch, maddrBuf.Bytes(), ts.Key())
+		rand, err := m.Api.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, meta.SeedEpoch, maddrBuf.Bytes(), ts.Key())
 		if err != nil {
 			return SectorInfo{}, xerrors.Errorf("generating check seed: %w", err)
 		}


### PR DESCRIPTION


## Related Issues
Fixes #11122 

## Proposed Changes
`SectorReceive` API mistakenly expects RandomnessFromTicket as a result of WaitSeed. However, we should be using RandomnessFromBeacon instead.  Hence, I have changed a call of `StateGetRandomnessFromTickets` with `StateGetRandomnessFromBeacon`. 

## Additional Info
Info about this issue discussed on [Filecoin slack, #fil-lotus-dev, ID p1690821347448089](https://filecoinproject.slack.com/archives/CP50PPW2X/p1690821347448089)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
