### PR TITLE
fix: cli: Only display `warning` if behind sync

### DIFF
--- a/cli/wallet_test.go
+++ b/cli/wallet_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	apitypes "github.com/filecoin-project/lotus/api/types"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/mock"
 )
 
 func TestWalletNew(t *testing.T) {
@@ -133,6 +134,11 @@ func TestWalletBalance(t *testing.T) {
 
 	balance := big.NewInt(1234)
 
+	// add blocks to the chain
+	first := mock.TipSet(mock.MkBlock(nil, 5, 4))
+	head := mock.TipSet(mock.MkBlock(first, 15, 7))
+
+	mockApi.EXPECT().ChainHead(ctx).Return(head, nil)
 	mockApi.EXPECT().WalletBalance(ctx, addr).Return(balance, nil)
 
 	//stm: @CLI_WALLET_BALANCE_001


### PR DESCRIPTION
## Related Issues
Closes #11134

## Proposed Changes
Only display the `warning: may display 0 if chain sync in progress` if behind sync and balance is 0 in the `lotus wallet balance <f....>`

## Additional Info
Tested on the butterfly-network. Address with a balance of 1000 FIL at a later epoch, deleted the chain data, and synced from scratch:

When sync in progress:
```
lotus sync wait
Worker: 0; Base: 0; Target: 2104 (diff: 2104)
State: message sync; Current Epoch: 1983; Todo: 121
Validated 648 messages (115 per second)
```

Wallet balance displays the error:
```
lotus wallet balance t1yhrjgfj6lknqbdbe2px2vgljltgxbwyt6em3r6q
0 FIL (warning: may display 0 if chain sync in progress)
```

After syncing past the epoch where it got funds, not displaying the warning:
```
lotus wallet balance t1yhrjgfj6lknqbdbe2px2vgljltgxbwyt6em3r6q
1000 FIL
```

On a new wallet with a 0 balance and you are in sync, it does not display the warning:
```
 lotus wallet new
t1ntydo3kn3umlmghkknoijtrzx4jxidzjzk5nwbi
-----
lotus wallet balance t1ntydo3kn3umlmghkknoijtrzx4jxidzjzk5nwbi
0 FIL
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
