### PR TITLE
fix: worker: Support IPv6 formatted API-keys

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -779,7 +779,15 @@ func extractRoutableIP(timeout time.Duration) (string, error) {
 	minerIP, _ := maddr.ValueForProtocol(multiaddr.P_IP6)
 	minerPort, _ := maddr.ValueForProtocol(multiaddr.P_TCP)
 
-	conn, err := net.DialTimeout("tcp", minerIP+":"+minerPort, timeout)
+	// Check if the IP is IPv6 and format the address appropriately
+	var addressToDial string
+	if ip := net.ParseIP(minerIP); ip.To4() == nil && ip.To16() != nil {
+		addressToDial = "[" + minerIP + "]:" + minerPort
+	} else {
+		addressToDial = minerIP + ":" + minerPort
+	}
+
+	conn, err := net.DialTimeout("tcp", addressToDial, timeout)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -779,11 +779,16 @@ func extractRoutableIP(timeout time.Duration) (string, error) {
 	minerIP, _ := maddr.ValueForProtocol(multiaddr.P_IP6)
 	minerPort, _ := maddr.ValueForProtocol(multiaddr.P_TCP)
 
-	conn, err := net.DialTimeout("tcp", "["+minerIP+"]:"+minerPort, timeout) // Enclose IPv6 address in brackets
+	conn, err := net.DialTimeout("tcp", minerIP+":"+minerPort, timeout)
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
+
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Errorf("Error closing connection: %v", cerr)
+		}
+	}()
 
 	localAddr := conn.LocalAddr().(*net.TCPAddr)
 	return localAddr.IP.String(), nil


### PR DESCRIPTION
## Related Issues
Closes: #11138

## Proposed Changes
Add support for IPv6 formatted API keys in the lotus-worker.


## Additional Info
Testing plan:

- [x] Check that IPv6 formatted MINER_API_INFO works with the lotus-worker: https://github.com/filecoin-project/lotus/pull/11141#issuecomment-1669578727
- [x] Check that IPv4 formatted MINER_API_INFO works with the lotus-worker https://github.com/filecoin-project/lotus/pull/11141#issuecomment-1669374477

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
