### PR TITLE
chore: make: set required env vars for mac users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ ifeq ($(shell uname -s), Darwin)
 export CGO_ENABLED=1
     ifeq ($(shell uname -m), arm64)
 export GOARCH=arm64
-export LIBRARY_PATH="$(brew --prefix)/lib"
+export LIBRARY_PATH=$(shell brew --prefix)/lib
 export FFI_BUILD_FROM_SOURCE=1
-export PATH:="$(brew --prefix coreutils)/libexec/gnubin:/usr/local/bin:$(PATH)"
+export PATH:=$(shell brew --prefix coreutils)/libexec/gnubin:/usr/local/bin:$(PATH)
     endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ FFI_DEPS:=$(addprefix $(FFI_PATH),$(FFI_DEPS))
 
 $(FFI_DEPS): build/.filecoin-install ;
 
+ifeq ($(shell uname -s), Darwin)
+export CGO_ENABLED=1
+    ifeq ($(shell uname -m), arm64)
+export GOARCH=arm64
+export LIBRARY_PATH="$(brew --prefix)/lib"
+export FFI_BUILD_FROM_SOURCE=1
+    endif
+endif
+
 build/.filecoin-install: $(FFI_PATH)
 	$(MAKE) -C $(FFI_PATH) $(FFI_DEPS:$(FFI_PATH)%=%)
 	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ export CGO_ENABLED=1
 export GOARCH=arm64
 export LIBRARY_PATH="$(brew --prefix)/lib"
 export FFI_BUILD_FROM_SOURCE=1
+export PATH:="$(brew --prefix coreutils)/libexec/gnubin:/usr/local/bin:$(PATH)"
     endif
 endif
 


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/discussions/5557
This makes it easier for Mac (& Mac M1 users) to run `make` commands as it sets the required env variables.

## Proposed Changes
In the Makefile, set the following env variables if the user is running macOS:

```
export CGO_ENABLED=1
export GOARCH=arm64
export LIBRARY_PATH="$(brew --prefix)/lib"
export FFI_BUILD_FROM_SOURCE=1
```

## Additional Info
- https://lotus.filecoin.io/lotus/install/macos/

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io) ([related PR for lotus-docs](https://github.com/filecoin-project/lotus-docs/pull/631))
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
