### PR TITLE
fix: gateway: return an error when an Eth filter is not found

### DIFF
--- a/gateway/proxy_eth.go
+++ b/gateway/proxy_eth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/events/filter"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
@@ -427,7 +428,7 @@ func (gw *Node) EthGetFilterChanges(ctx context.Context, id ethtypes.EthFilterID
 	ft.lk.Unlock()
 
 	if !ok {
-		return nil, nil
+		return nil, filter.ErrFilterNotFound
 	}
 
 	return gw.target.EthGetFilterChanges(ctx, id)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Reported on slack.

## Proposed Changes
<!-- A clear list of the changes being made -->

In the gateway, return an error when an Eth filter is not found instead of returning "nil".

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green