### PR TITLE
feat: deflake: TestGetBlockByNumber

### DIFF
--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -310,13 +310,23 @@ func TestGetBlockByNumber(t *testing.T) {
 
 	afterNullHeight := hc[0].Val.Height()
 
+	nullHeight := afterNullHeight - 1
+	for nullHeight > 0 {
+		ts, err := client.ChainGetTipSetByHeight(ctx, nullHeight, types.EmptyTSK)
+		require.NoError(t, err)
+		if ts.Height() == nullHeight {
+			nullHeight--
+		} else {
+			break
+		}
+	}
+
 	// Fail when trying to fetch a null round.
-	_, err = client.EthGetBlockByNumber(ctx, (ethtypes.EthUint64(afterNullHeight - 1)).Hex(), true)
+	_, err = client.EthGetBlockByNumber(ctx, (ethtypes.EthUint64(nullHeight)).Hex(), true)
 	require.Error(t, err)
 
 	// Fetch balance on a null round; should not fail and should return previous balance.
-	// Should be lower than original balance.
-	bal, err := client.EthGetBalance(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromNumber(ethtypes.EthUint64(afterNullHeight-1)))
+	bal, err := client.EthGetBalance(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromNumber(ethtypes.EthUint64(nullHeight)))
 	require.NoError(t, err)
 	require.NotEqual(t, big.Zero(), bal)
 	require.Equal(t, types.FromFil(10).Int, bal.Int)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This test has been observed to flake, eg. https://app.circleci.com/pipelines/github/filecoin-project/lotus/29804/workflows/e8335521-f9ab-49c3-adea-5c2252ceb830/jobs/1024823. The source of the flake is that `afterNullHeight - 1` may not necessarily be a null round.

I'm a little surprised this is flaky, but it's easy enough to just check and be confident we've hit a null round.

## Proposed Changes
<!-- A clear list of the changes being made -->

Walk up until we are confident we've identified a null round, use that for the test's assertions.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
