### PR TITLE
feat: miner: implement FRC-0051

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -132,6 +132,8 @@ const BlockDelaySecs = uint64(4)
 
 const PropagationDelaySecs = uint64(1)
 
+var EquivocationDelaySecs = uint64(0)
+
 // SlashablePowerDelay is the number of epochs after ElectionPeriodStart, after
 // which the miner is slashed
 //

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -86,6 +86,8 @@ const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)
 
 const PropagationDelaySecs = uint64(6)
 
+var EquivocationDelaySecs = uint64(2)
+
 // BootstrapPeerThreshold is the minimum number peers we need to track for a sync worker to start
 const BootstrapPeerThreshold = 2
 

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -123,6 +123,8 @@ const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)
 
 var PropagationDelaySecs = uint64(10)
 
+var EquivocationDelaySecs = uint64(2)
+
 // BootstrapPeerThreshold is the minimum number peers we need to track for a sync worker to start
 const BootstrapPeerThreshold = 4
 

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -121,6 +121,8 @@ const BlockDelaySecs = uint64(builtin2.EpochDurationSeconds)
 
 const PropagationDelaySecs = uint64(6)
 
+var EquivocationDelaySecs = uint64(2)
+
 // BootstrapPeerThreshold is the minimum number peers we need to track for a sync worker to start
 const BootstrapPeerThreshold = 2
 

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -105,6 +105,7 @@ var SupportedProofTypes = []abi.RegisteredSealProof{
 var ConsensusMinerMinPower = abi.NewStoragePower(10 << 40)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)
 var PropagationDelaySecs = uint64(10)
+
 var EquivocationDelaySecs = uint64(2)
 
 func init() {

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -105,6 +105,7 @@ var SupportedProofTypes = []abi.RegisteredSealProof{
 var ConsensusMinerMinPower = abi.NewStoragePower(10 << 40)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)
 var PropagationDelaySecs = uint64(10)
+var EquivocationDelaySecs = uint64(2)
 
 func init() {
 	if os.Getenv("LOTUS_USE_TEST_ADDRESSES") != "1" {

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -9,7 +9,6 @@ package build
 
 import (
 	"math/big"
-	"time"
 
 	"github.com/ipfs/go-cid"
 
@@ -34,6 +33,7 @@ var (
 	MinimumBaseFee        = int64(100)
 	BlockDelaySecs        = uint64(builtin2.EpochDurationSeconds)
 	PropagationDelaySecs  = uint64(6)
+	EquivocationDelaySecs = uint64(2)
 	SupportedProofTypes   = []abi.RegisteredSealProof{
 		abi.RegisteredSealProof_StackedDrg32GiBV1,
 		abi.RegisteredSealProof_StackedDrg64GiBV1,
@@ -139,7 +139,3 @@ const BootstrapPeerThreshold = 1
 // ChainId defines the chain ID used in the Ethereum JSON-RPC endpoint.
 // As per https://github.com/ethereum-lists/chains
 const Eip155ChainId = 31415926
-
-// Reducing the delivery delay for equivocation of
-// consistent broadcast to just half a second.
-var CBDeliveryDelay = 500 * time.Millisecond

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -169,6 +169,8 @@ func NewEnsemble(t *testing.T, opts ...EnsembleOpt) *Ensemble {
 		require.NoError(t, build.UseNetworkBundle("testing"))
 	}
 
+	build.EquivocationDelaySecs = 0
+
 	return n
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/golang-lru/arc/v2"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"go.opencensus.io/trace"
@@ -577,7 +578,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (minedBlock *type
 
 	// If the base has changed, we take the _intersection_ of our old base and new base,
 	// thus ejecting blocks from any equivocating miners, without taking any new blocks.
-	if !newBase.TipSet.Equals(base.TipSet) {
+	if newBase.TipSet.Height() == base.TipSet.Height() && !newBase.TipSet.Equals(base.TipSet) {
 		newBaseMap := map[cid.Cid]struct{}{}
 		for _, newBaseBlk := range newBase.TipSet.Cids() {
 			newBaseMap[newBaseBlk] = struct{}{}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#11104 

## Proposed Changes
<!-- A clear list of the changes being made -->

- Add a (currently unconfigurable) EquivocationDelaySecs build parameter set to 2 seconds for all networks besides devnets
- In the `mineOne` process, at the _very end_, refresh the base we're mining on
- If the base has changed, we "refresh" our base to be the _intersection_ of the old base and new base. The only effect this should have is to _remove_ any blocks from miners that have equivocated.
  - If we do this, we need to re-select messages (since some might no longer be valid), and re-compute ticket if the MinTicket has changed
- If the base hasn't changed, proceed as always

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
