### PR TITLE
fix: chainstore: do not get stuck in unhappy equivocation cases

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -446,13 +446,15 @@ func (cs *ChainStore) RefreshHeaviestTipSet(ctx context.Context, newTsHeight abi
 			}
 		}
 
-		if newHeaviest == nil {
-			return xerrors.Errorf("failed to refresh to a new valid tipset")
-		}
-
-		errTake := cs.takeHeaviestTipSet(ctx, newHeaviest)
-		if errTake != nil {
-			return xerrors.Errorf("failed to take newHeaviest tipset as head: %w", err)
+		// if we've found something, we know it's the heaviest equivocation-free head, take it IMMEDIATELY
+		if newHeaviest != nil {
+			errTake := cs.takeHeaviestTipSet(ctx, newHeaviest)
+			if errTake != nil {
+				return xerrors.Errorf("failed to take newHeaviest tipset as head: %w", err)
+			}
+		} else {
+			// if we haven't found something, just stay with our equivocation-y head
+			newHeaviest = cs.heaviest
 		}
 	}
 

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -396,8 +396,9 @@ func TestEquivocations(t *testing.T) {
 	require.Nil(t, tryTs2)
 	require.True(t, tryTsWeight2.IsZero())
 
-	// now we "notify" at this height -- it should fail, because we cannot refresh our head due to equivocation and nulls
-	require.ErrorContains(t, cg.ChainStore().RefreshHeaviestTipSet(ctx, blkAfterNulls.Height), "failed to refresh to a new valid tipset")
+	// now we "notify" at this height -- it should lead to no head change because there's no formable head in near epochs
+	require.NoError(t, cg.ChainStore().RefreshHeaviestTipSet(ctx, blkAfterNulls.Height))
+	require.True(t, headAfterNulls.TipSet.TipSet().Equals(cg.ChainStore().GetHeaviestTipSet()))
 }
 
 func addBlockToTracker(t *testing.T, cs *store.ChainStore, blk *types.BlockHeader) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

I was doing some manual testing / code inspection of #11104, and realized there's an unfortunate case here where we can get stuck, especially immediately after startup when the `tipsets` cache isn't populated

## Proposed Changes
<!-- A clear list of the changes being made -->

When refreshing our current head, try to find something within 5 epochs. If we find NOTHING (due to equivocation, or due to the `tipsets` cache being unpopulated), just stick with your equivocated head.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
