### PR TITLE
Take Download out of Sealer time

### DIFF
--- a/storage/sealer/ffiwrapper/sealer_test.go
+++ b/storage/sealer/ffiwrapper/sealer_test.go
@@ -412,6 +412,16 @@ func TestSealPoStNoCommit(t *testing.T) {
 	fmt.Printf("EPoSt: %s\n", epost.Sub(precommit).String())
 }
 
+func TestMain(m *testing.M) {
+	//setup()
+	// Here it no-longer is bound to 30s but has 1m30s for the whole suite.
+	getGrothParamFileAndVerifyingKeys(sectorSize)
+
+	code := m.Run()
+	//shutdown()
+	os.Exit(code)
+}
+
 func TestSealAndVerify3(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
@@ -423,8 +433,6 @@ func TestSealAndVerify3(t *testing.T) {
 		t.Skip("this is slow")
 	}
 	_ = os.Setenv("RUST_LOG", "trace")
-
-	getGrothParamFileAndVerifyingKeys(sectorSize)
 
 	dir, err := os.MkdirTemp("", "sbtest")
 	if err != nil {


### PR DESCRIPTION
Downloading a 1GB file during a unit test is bad enough, but doing it in serial with a 600mb file followed by a lot of work is too much. 

A patch sent to Orjan downloads those in parallel. 

This takes the download out of the 30s timer and into a 1m30m (all test targets) window.
This will buy more time for the test to complete no matter what the delay is (if the problem is a timeout).

IF this fixes CI, we should discuss why we are having repeated, enormous downloads from filecoin websites as part of unit testing.