### PR TITLE
feat: shed: Add exec traces to `lotus-shed msg`

### DIFF
--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -64,7 +64,11 @@ var msgCmd = &cli.Command{
 
 		// Print the execution trace and receipt
 		color.Green("Execution trace:")
-		fmt.Println(res.ExecutionTrace)
+		trace, err := json.MarshalIndent(res.ExecutionTrace, "", "  ")
+		if err != nil {
+			return xerrors.Errorf("marshaling execution trace: %w", err)
+		}
+		fmt.Println(string(trace))
 		fmt.Println()
 		color.Green("Receipt:")
 		fmt.Printf("Exit code: %d\n", res.MsgRct.ExitCode)

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -26,6 +26,12 @@ var msgCmd = &cli.Command{
 	Aliases:   []string{"msg"},
 	Usage:     "Translate message between various formats",
 	ArgsUsage: "Message in any form",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "exec-trace",
+			Usage: "Print the execution trace",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
 			return lcli.IncorrectNumArgs(cctx)
@@ -62,14 +68,16 @@ var msgCmd = &cli.Command{
 			return xerrors.Errorf("replay call failed: %w", err)
 		}
 
-		// Print the execution trace and receipt
-		color.Green("Execution trace:")
-		trace, err := json.MarshalIndent(res.ExecutionTrace, "", "  ")
-		if err != nil {
-			return xerrors.Errorf("marshaling execution trace: %w", err)
+		if cctx.Bool("exec-trace") {
+			// Print the execution trace
+			color.Green("Execution trace:")
+			trace, err := json.MarshalIndent(res.ExecutionTrace, "", "  ")
+			if err != nil {
+				return xerrors.Errorf("marshaling execution trace: %w", err)
+			}
+			fmt.Println(string(trace))
+			fmt.Println()
 		}
-		fmt.Println(string(trace))
-		fmt.Println()
 		color.Green("Receipt:")
 		fmt.Printf("Exit code: %d\n", res.MsgRct.ExitCode)
 		fmt.Printf("Return: %x\n", res.MsgRct.Return)

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -63,10 +63,13 @@ var msgCmd = &cli.Command{
 		}
 
 		// Print the execution trace and receipt
-		fmt.Println("Execution trace:")
+		color.Green("Execution trace:")
 		fmt.Println(res.ExecutionTrace)
-		fmt.Println("Receipt:")
-		fmt.Println(res.MsgRct)
+		fmt.Println()
+		color.Green("Receipt:")
+		fmt.Printf("Exit code: %d\n", res.MsgRct.ExitCode)
+		fmt.Printf("Return: %x\n", res.MsgRct.Return)
+		fmt.Printf("Gas Used: %d\n", res.MsgRct.GasUsed)
 
 		switch msg := msg.(type) {
 		case *types.SignedMessage:


### PR DESCRIPTION
## Related Issues
#10254

## Proposed Changes
Adds receipts and exec-traces to the `lotus-shed msg` cmd

## Additional Info
Tested in a local-devnet, the `./lotus-shed msg baf...x5u` now prints:

```
/lotus-shed msg bafy2bzaceaa7xynhzusr2erwhfx6y27eael77i2rfvplwsucj3jkn5cakgx5u       
Execution trace:
{
  "Msg": {
    "From": "f0100",
    "To": "f01000",
    "Value": "0",
    "Method": 16,
    "Params": "gUoABWvHXi1jEAAA",
    "ParamsCodec": 81
  },
  "MsgRct": {
    "ExitCode": 0,
    "Return": "SgAFa8deLWMQAAA=",
    "ReturnCodec": 81
  },
  "GasCharges": [
    {
      "Name": "OnChainMessage",
      "tg": 675063,
      "cg": 38863,
      "sg": 636200,
      "tt": 0
    },
    {
 .....
 ......
 ........
  "Subcalls": [
    {
      "Msg": {
        "From": "f01000",
        "To": "f0100",
        "Value": "100000000000000000000",
        "Method": 0,
        "Params": null,
        "ParamsCodec": 0
      },
      "MsgRct": {
        "ExitCode": 0,
        "Return": null,
        "ReturnCodec": 0
      },
      "GasCharges": [
        {
          "Name": "OnValueTransfer",
          "tg": 6000,
          "cg": 6000,
          "sg": 0,
          "tt": 0
        }
      ],
      "Subcalls": null
    }
  ]
}

Receipt:
Exit code: 0
Return: 4a00056bc75e2d63100000
Gas Used: 18705701

Unsigned:
CID: bafy2bzaceaa7xynhzusr2erwhfx6y27eael77i2rfvplwsucj3jkn5cakgx5u
HEX: 8a004300e80758310384383195e34cf78d01dc374fed72d19064ef6d9d2b6fd1cbaea24f3a6050062be4efdf4a80775dd36f317f8e60d783c701401a01637e5a440001a1894400018549104c814a00056bc75e2d63100000
B64: igBDAOgHWDEDhDgxleNM940B3DdP7XLRkGTvbZ0rb9HLrqJPOmBQBivk799KgHdd028xf45g14PHAUAaAWN+WkQAAaGJRAABhUkQTIFKAAVrx14tYxAAAA==
JSON: {
  "Version": 0,
  "To": "f01000",
  "From": "f3qq4ddfpdjt3y2ao4g5h624wrsbso63m5fnx5ds5oujhtuycqayv6j367jkahoxotn4yx7dta26b4o5ylx2jq",
  "Nonce": 1,
  "Value": "0",
  "GasLimit": 23297626,
  "GasFeeCap": "106889",
  "GasPremium": "99657",
  "Method": 16,
  "Params": "gUoABWvHXi1jEAAA",
  "CID": {
    "/": "bafy2bzaceaa7xynhzusr2erwhfx6y27eael77i2rfvplwsucj3jkn5cakgx5u"
  }
}

---
Message Details:
Value: 0 FIL
Max Fees: 0.000002490259945514 FIL
Max Total Cost: 0.000002490259945514 FIL
Method: 
Params: raw:814a00056bc75e2d63100000 
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
