### PR TITLE
fix: wallet: Make import handle SIGINT/SIGTERM

### DIFF
--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -338,15 +338,12 @@ var walletImport = &cli.Command{
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Print("Enter private key(not display in the terminal): ")
 
-				// Create a channel to receive OS signals
 				sigCh := make(chan os.Signal, 1)
 				// Notify the channel when SIGINT is received
-				signal.Notify(sigCh, syscall.SIGINT)
+				signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 				go func() {
-					// Wait for SIGINT signal
 					<-sigCh
-					// Perform cleanup or other actions as needed
 					fmt.Println("\nInterrupt signal received. Exiting...")
 					os.Exit(1)
 				}()

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/term"
@@ -335,6 +337,20 @@ var walletImport = &cli.Command{
 		if !cctx.Args().Present() || cctx.Args().First() == "-" {
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Print("Enter private key(not display in the terminal): ")
+
+				// Create a channel to receive OS signals
+				sigCh := make(chan os.Signal, 1)
+				// Notify the channel when SIGINT is received
+				signal.Notify(sigCh, syscall.SIGINT)
+
+				go func() {
+					// Wait for SIGINT signal
+					<-sigCh
+					// Perform cleanup or other actions as needed
+					fmt.Println("\nInterrupt signal received. Exiting...")
+					os.Exit(1)
+				}()
+
 				inpdata, err = term.ReadPassword(int(os.Stdin.Fd()))
 				if err != nil {
 					return err


### PR DESCRIPTION
## Related Issues
Closes #4866

## Proposed Changes
Make `lotus wallet import handle SIGINT. When Ctrl+C when "Enter private key:" prompt is active, it now exits with:

```
lotus wallet import
Enter private key(not display in the terminal): 
Interrupt signal received. Exiting...
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
