### PR TITLE
feat: worker: Graceful-shutdown of lotus-worker

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -122,7 +122,7 @@ var stopCmd = &cli.Command{
 	Usage: "Stop a running lotus worker",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
-			Name:  "forcefully",
+			Name:  "force",
 			Usage: "Forcefully stop the worker without waiting for tasks to finish",
 		},
 	},
@@ -136,7 +136,7 @@ var stopCmd = &cli.Command{
 		ctx := lcli.ReqContext(cctx)
 
 		// If forcefully flag is not set, perform a graceful shutdown
-		if !cctx.Bool("forcefully") {
+		if !cctx.Bool("force") {
 			// Step 1: Disable new tasks being scheduled
 			for taskType := range allowSetting {
 				if err := api.TaskDisable(ctx, taskType); err != nil {

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -147,8 +147,12 @@ var stopCmd = &cli.Command{
 			// Step 2: Wait for existing jobs to complete
 			// Repeat 30 times to ensure all tasks have finished
 			for i := 0; i < 30; i++ {
-				time.Sleep(time.Second) // wait for 1 second
-				api.WaitQuiet(ctx)      // wait for tasks to finish
+				time.Sleep(time.Second)   // wait for 1 second
+				err := api.WaitQuiet(ctx) // wait for tasks to finish
+				if err != nil {
+					log.Errorf("Error waiting for tasks to finish: %v", err)
+					return err
+				}
 			}
 		}
 

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -69,7 +69,8 @@ USAGE:
    lotus-worker stop [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help
+   --forcefully  Forcefully stop the worker without waiting for tasks to finish (default: false)
+   --help, -h    show help
 ```
 
 ## lotus-worker info

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -69,8 +69,8 @@ USAGE:
    lotus-worker stop [command options] [arguments...]
 
 OPTIONS:
-   --forcefully  Forcefully stop the worker without waiting for tasks to finish (default: false)
-   --help, -h    show help
+   --force     Forcefully stop the worker without waiting for tasks to finish (default: false)
+   --help, -h  show help
 ```
 
 ## lotus-worker info


### PR DESCRIPTION
## Related Issues
Closes #10942

As discussed in https://github.com/filecoin-project/lotus/pull/10944#issuecomment-1581006916, this makes the graceful shutdown the default.

## Proposed Changes
- Make `lotus-worker stop` be a graceful way to shutdown the worker (wait till the existing jobs has completed).
- Add a `forcefully` option, which keeps todays way of shutting down the worker. I.e without considering and waiting for running tasks to finish, proceeds directly to detach any storage associated with the worker and shut it down.

## Testing plan

- [ ] Check that `lotus-worker stop --force` forcefully stops the worker.
- [ ] Check that `lotus-worker stop` waits for tasks to finish, before detaching storage and shutting down the worker.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
