### PR TITLE
feat: shed: fix blockstore prune

### DIFF
--- a/blockstore/idstore.go
+++ b/blockstore/idstore.go
@@ -183,3 +183,17 @@ func (b *idstore) Close() error {
 func (b *idstore) Flush(ctx context.Context) error {
 	return b.bs.Flush(ctx)
 }
+
+func (b *idstore) CollectGarbage(ctx context.Context, options ...BlockstoreGCOption) error {
+	if bs, ok := b.bs.(BlockstoreGC); ok {
+		return bs.CollectGarbage(ctx, options...)
+	}
+	return xerrors.Errorf("not supported")
+}
+
+func (b *idstore) GCOnce(ctx context.Context, options ...BlockstoreGCOption) error {
+	if bs, ok := b.bs.(BlockstoreGCOnce); ok {
+		return bs.GCOnce(ctx, options...)
+	}
+	return xerrors.Errorf("not supported")
+}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Implement a pass-through for garbage collection on the idstore.
2. Fix the `lotus-shed state-prune` command.

NOTE: the new performance of running a full prune will be significantly less as this version doesn't batch. However, it should now actually _work_ and most users will be using the splitstore anyways.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- x ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green