### PR TITLE
fix: chain: cancel long operations upon ctx cancelation

### DIFF
--- a/chain/stmgr/supply.go
+++ b/chain/stmgr/supply.go
@@ -388,6 +388,14 @@ func (sm *StateManager) GetCirculatingSupply(ctx context.Context, height abi.Cha
 	circ := big.Zero()
 	unCirc := big.Zero()
 	err := st.ForEach(func(a address.Address, actor *types.Actor) error {
+		// this can be a lengthy operation, we need to cancel early when
+		// the context is cancelled to avoid resource exhaustion
+		select {
+		case <-ctx.Done():
+			// this will cause ForEach to return
+			return ctx.Err()
+		default:
+		}
 		switch {
 		case actor.Balance.IsZero():
 			// Do nothing for zero-balance actors


### PR DESCRIPTION
## Related Issues
Currently there are some operations that are relatively long winded and can be triggered through a remote RPC call and that will carry out even in case of a context cancellation.

Sadly, the ratelimiting done in `proxy_fil.go` is not enough since it doesn't take into account the fact that some operations can take many minutes to finish.

## Proposed Changes
Given how Context are passed to all operations, a RPC call that is being cancelled by the client will cause a Context cancellation that trickles down to the lengthy operations, therefore checking for such context cancellation in the lengthy operations allows us to cancel early when we can. 

## Additional Info
Sadly it seems this area of the code is heavily untested and I could not make a test for it. I have however tested it locally as well as on a mainnet node running 1.23.3 and confirmed it did now cancel the operations upon cancelling the RPC calls.

Should we do the same for more operations? I noticed these two that are fairly expensive, but there might be other I did not spot?

A better fix might be to have a limit on the max amount of concurrent expensive operations we agree to do, instead of just ratelimiting the incoming requests, but this would require significant changes.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
