### PR TITLE
feat: Add ETA to lotus sync wait

### DIFF
--- a/cli/sync.go
+++ b/cli/sync.go
@@ -263,8 +263,8 @@ func SyncWait(ctx context.Context, napi v0api.FullNode, watch bool) error {
 	}
 	firstApp = state.VMApplied
 
-	// eta computes the ETA for the sync to complete (with a lookback of 30 processed items)
-	eta := cliutil.NewETA(30)
+	// eta computes the ETA for the sync to complete (with a lookback of 10 processed items)
+	eta := cliutil.NewETA(10)
 
 	for {
 		state, err := napi.SyncState(ctx)

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 )
 
 var SyncCmd = &cli.Command{
@@ -262,6 +263,9 @@ func SyncWait(ctx context.Context, napi v0api.FullNode, watch bool) error {
 	}
 	firstApp = state.VMApplied
 
+	// eta computes the ETA for the sync to complete (with a lookback of 30 processed items)
+	eta := cliutil.NewETA(30)
+
 	for {
 		state, err := napi.SyncState(ctx)
 		if err != nil {
@@ -312,8 +316,10 @@ func SyncWait(ctx context.Context, napi v0api.FullNode, watch bool) error {
 			fmt.Print("\r\x1b[2K\x1b[A")
 		}
 
+		todo := theight - ss.Height
+
 		fmt.Printf("Worker: %d; Base: %d; Target: %d (diff: %d)\n", workerID, baseHeight, theight, heightDiff)
-		fmt.Printf("State: %s; Current Epoch: %d; Todo: %d\n", ss.Stage, ss.Height, theight-ss.Height)
+		fmt.Printf("State: %s; Current Epoch: %d; Todo: %d, ETA: %s\n", ss.Stage, ss.Height, todo, eta.Update(int64(todo)))
 		lastLines = 2
 
 		if i%samples == 0 {

--- a/cli/util/eta.go
+++ b/cli/util/eta.go
@@ -1,6 +1,9 @@
 package cliutil
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // ETA is a very simple ETA calculator
 type ETA struct {
@@ -54,12 +57,18 @@ func (e *ETA) Update(remaining int64) string {
 	avg := diffMs / int64(len(e.buff))
 
 	// use that average processing time to estimate how long the remaining items will take
-	var t time.Time
-	t = t.Add(time.Duration(avg*remaining) * time.Millisecond)
-
-	// cache the ETA so we don't have to recalculate it on every update unless the remaining
-	// value changes
-	e.cachedETA = t.Format("12h:34m:56s")
+	// and cache that ETA so we don't have to recalculate it on every update unless the
+	// remaining value changes
+	e.cachedETA = msToETA(avg * remaining)
 
 	return e.cachedETA
+}
+
+func msToETA(ms int64) string {
+	seconds := ms / 1000
+	sec := seconds % 60
+	minutes := seconds / 60
+	min := minutes % 60
+	hour := minutes / 60
+	return fmt.Sprintf("%02dh:%02dm:%02ds", hour, min, sec)
 }

--- a/cli/util/eta.go
+++ b/cli/util/eta.go
@@ -1,0 +1,65 @@
+package cliutil
+
+import "time"
+
+// ETA is a very simple ETA calculator
+type ETA struct {
+	// how many items in buff we use for calculating ETA
+	size int
+	// buffer of processing time of past size updates
+	buff []item
+	// we store the last calculated ETA which we reuse if there was not change in remaining items
+	cachedETA string
+}
+
+type item struct {
+	timestamp time.Time
+	remaining int64
+}
+
+// NewETA creates a new ETA calculator with the given buffer size
+func NewETA(size int) *ETA {
+	return &ETA{
+		size: size,
+		buff: make([]item, 0),
+	}
+}
+
+// Update updates the ETA calculator with the remaining number of items and returns the ETA
+func (e *ETA) Update(remaining int64) string {
+	item := item{
+		timestamp: time.Now(),
+		remaining: remaining,
+	}
+
+	if len(e.buff) == 0 {
+		e.buff = append(e.buff, item)
+		return ""
+	}
+
+	// we ignore updates with the same remaining value and just return the previous ETA
+	if e.buff[len(e.buff)-1].remaining == remaining {
+		return e.cachedETA
+	}
+
+	// remove oldest item from buffer if its full
+	if len(e.buff) >= e.size {
+		e.buff = e.buff[1:]
+	}
+
+	e.buff = append(e.buff, item)
+
+	// calculate the average processing time per item in the buffer
+	diffMs := e.buff[len(e.buff)-1].timestamp.Sub(e.buff[0].timestamp).Milliseconds()
+	avg := diffMs / int64(len(e.buff))
+
+	// use that average processing time to estimate how long the remaining items will take
+	var t time.Time
+	t = t.Add(time.Duration(avg*remaining) * time.Millisecond)
+
+	// cache the ETA so we don't have to recalculate it on every update unless the remaining
+	// value changes
+	e.cachedETA = t.Format("12h:34m:56s")
+
+	return e.cachedETA
+}


### PR DESCRIPTION
## Related Issues
none

## Proposed Changes
This PR adds a ETA indicator to `lotus sync wait` command which I felt was missing when waiting for my node to finish syncing

## Additional Info
![image](https://github.com/filecoin-project/lotus/assets/124135/d227f871-10d6-49f5-83d3-4b4eccf181ac)


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
