### PR TITLE
fix: worker: Convert `DC_[SectorSize]_[ResourceRestriction]` if set

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -322,7 +322,7 @@ var runCmd = &cli.Command{
 			}
 		}
 
-		// Check DC-enviroment variable
+		// Check DC-environment variable
 		sectorSizes := []string{"2KiB", "8MiB", "512MiB", "32GiB", "64GiB"}
 		resourcesType := reflect.TypeOf(storiface.Resources{})
 

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -318,6 +319,29 @@ var runCmd = &cli.Command{
 		default:
 			if limit < build.MinerFDLimit {
 				return xerrors.Errorf("soft file descriptor limit (ulimit -n) too low, want %d, current %d", build.MinerFDLimit, limit)
+			}
+		}
+
+		// Check DC-enviroment variable
+		sectorSizes := []string{"2KiB", "8MiB", "512MiB", "32GiB", "64GiB"}
+		resourcesType := reflect.TypeOf(storiface.Resources{})
+
+		for _, sectorSize := range sectorSizes {
+			for i := 0; i < resourcesType.NumField(); i++ {
+				field := resourcesType.Field(i)
+				envName := field.Tag.Get("envname")
+				if envName != "" {
+					// Check if DC_[SectorSize]_[ResourceRestriction] is set
+					envVar, ok := os.LookupEnv("DC_" + sectorSize + "_" + envName)
+					if ok {
+						// If it is set, convert it to DC_[ResourceRestriction]
+						err := os.Setenv("DC_"+envName, envVar)
+						if err != nil {
+							log.Fatalf("Error setting environment variable: %v", err)
+						}
+						log.Warnf("Converted DC_%s_%s to DC_%s, because DC is a sector-size independent job", sectorSize, envName, envName)
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## Related Issues
Closes #11223 

## Proposed Changes
Check if `DC_[SectorSize]_[ResourceRestriction]` enviroment variable is set and convert it to `DC_[ResourceRestriction]` to make sure its enforced as DC is a sector-size independent job.

## Testing

- export `DC_512MiB_MAX_CONCURRENT=1`
- export `DC_512MiB_MAX_PARALLELISM=1`

On startup of the worker, check that the env-variables are being converted:
```
lotus-worker run --data-cid=true --addpiece=false --precommit1=false --unseal=false --precommit2=false --commit=false --replica-update=false --prove-replica-update2=false --regen-sector-key=false --sector-download=false 
2023-08-30T05:18:50.118-0400    INFO    main    lotus-worker/main.go:297        Starting lotus worker
2023-08-30T05:18:50.118-0400    WARN    main    lotus-worker/main.go:343        Converted DC_512MiB_MAX_PARALLELISM to DC_MAX_PARALLELISM, because DC is a sector-size independent job
2023-08-30T05:18:50.118-0400    WARN    main    lotus-worker/main.go:343        Converted DC_512MiB_MAX_CONCURRENT to DC_MAX_CONCURRENT, because DC is a sector-size independent job
2023-08-30T05:18:50.121-0400    INFO    main    lotus-worker/main.go:385        Remote version 1.23.3-rc2+butterflynet+git.1eec81622.dirty+api1.5.0
```

Scheduled a couple of DC-tasks with `lotus-miner sealing data-cid 10gb-filecoin-payload.bin` and checked that DC-limit is being enforced:
```
lotus-miner sealing workers
Worker 5d9c766a-abf0-4815-a4f4-c42cc3d38896, host Ubuntu-2004-focal-amd64-base
        TASK: UNK(1) DC(1/1) 
        CPU:  [|||||                                                           ] 1/12 core(s) in use
        RAM:  [|||||                                                           ] 8% 9.09 GiB/62.78 GiB
        VMEM: [|||||                                                           ] 8% 5.09 GiB/62.78 GiB
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
