### PR TITLE
fix: shed: additional metrics in `mpool miner-select-messages`

### DIFF
--- a/cmd/lotus-shed/mpool.go
+++ b/cmd/lotus-shed/mpool.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -43,10 +44,20 @@ var minerSelectMsgsCmd = &cli.Command{
 			return err
 		}
 
+		// Get the size of the mempool
+		pendingMsgs, err := api.MpoolPending(ctx, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+		mpoolSize := len(pendingMsgs)
+
+		// Measure the time taken by MpoolSelect
+		startTime := time.Now()
 		msgs, err := api.MpoolSelect(ctx, head.Key(), cctx.Float64("ticket-quality"))
 		if err != nil {
 			return err
 		}
+		duration := time.Since(startTime)
 
 		var totalGas int64
 		for i, f := range msgs {
@@ -64,6 +75,9 @@ var minerSelectMsgsCmd = &cli.Command{
 			totalGas += f.Message.GasLimit
 		}
 
+		// Log the duration, size of the mempool, and number of selected messages
+		fmt.Printf("Message selection took %s\n", duration)
+		fmt.Printf("Size of the mempool: %d\n", mpoolSize)
 		fmt.Println("selected messages: ", len(msgs))
 		fmt.Printf("total gas limit of selected messages: %d / %d (%0.2f%%)\n", totalGas, build.BlockGasLimit, 100*float64(totalGas)/float64(build.BlockGasLimit))
 		return nil

--- a/cmd/lotus-shed/mpool.go
+++ b/cmd/lotus-shed/mpool.go
@@ -75,7 +75,7 @@ var minerSelectMsgsCmd = &cli.Command{
 			totalGas += f.Message.GasLimit
 		}
 
-		// Log the duration, size of the mempool, and number of selected messages
+		// Log the duration, size of the mempool, selected messages and total gas limit of selected messages
 		fmt.Printf("Message selection took %s\n", duration)
 		fmt.Printf("Size of the mempool: %d\n", mpoolSize)
 		fmt.Println("selected messages: ", len(msgs))


### PR DESCRIPTION
## Related Issues
Used when investigating #11233

## Proposed Changes
- Add timing to the MpoolSelect function in `lotus-shed mpool miner-select-messages` cmd.
- Print amount of message in the mpool at the time of selection

## Additional Info

`./lotus-shed mpool miner-select-messages` now outputs:
```
0: ...7pujnqji -> ...vmfvetfq, method 3844450837, gasFeecap 46289400, gasPremium 40492000, gasLimit 10000000, val 8.27 FIL
1: ...kg3xciiq -> ...s2ocur4i, method 0, gasFeecap 182943, gasPremium 182943, gasLimit 6045518, val 2.480098894014800526 FIL
2: ...r7bysmqa -> ...02246008, method 7, gasFeecap 398186, gasPremium 125034, gasLimit 84979263, val 4.072569871868727119 FIL
3: ...zzdz67wq -> f062937, method 5, gasFeecap 10000000000, gasPremium 120603, gasLimit 41479801, val 0 FIL
4: ...zzdz67wq -> f062937, method 5, gasFeecap 10000000000, gasPremium 120154, gasLimit 43024377, val 0 FIL
5: ...6au6kffq -> ...02226869, method 6, gasFeecap 100028285, gasPremium 109853, gasLimit 62008600, val 0.095865452766559008 FIL
6: ...va26xira -> ...yjut75ga, method 3844450837, gasFeecap 230534, gasPremium 109578, gasLimit 6155817, val 0.8552 FIL
7: ...o4wef4wa -> f020522, method 27, gasFeecap 5000000000, gasPremium 101298, gasLimit 399501441, val 1.769356502851573108 FIL
8: ...245rlcja -> ...01936176, method 7, gasFeecap 399291, gasPremium 101084, gasLimit 75320501, val 0.167405394238476086 FIL
9: ...qbpwkpza -> f0730670, method 5, gasFeecap 399225, gasPremium 101018, gasLimit 29653671, val 0 FIL
10: ...j4m5khoa -> ...02315355, method 6, gasFeecap 406561, gasPremium 100952, gasLimit 69357660, val 0.047932726383279503 FIL
11: ...xa4heiwq -> f0103704, method 5, gasFeecap 399002, gasPremium 100795, gasLimit 25511465, val 0 FIL
12: ...yttwgdcq -> ...02221113, method 6, gasFeecap 406341, gasPremium 100732, gasLimit 69145536, val 0 FIL
13: ...4ewcwh5a -> ...02368751, method 7, gasFeecap 406307, gasPremium 100698, gasLimit 121970488, val 0 FIL
14: ...ilfmg4mq -> ...02041085, method 7, gasFeecap 406163, gasPremium 100554, gasLimit 79292858, val 0 FIL
15: ...ilfmg4mq -> ...02041085, method 7, gasFeecap 406192, gasPremium 100583, gasLimit 89020038, val 0 FIL
16: ...xwywzqia -> ...01166098, method 5, gasFeecap 398769, gasPremium 100562, gasLimit 28761666, val 0 FIL
17: ...z2horhaa -> ...01394448, method 5, gasFeecap 398753, gasPremium 100546, gasLimit 29407978, val 0 FIL
18: ...gi6qg6za -> f0442370, method 5, gasFeecap 398713, gasPremium 100506, gasLimit 1491593082, val 0 FIL
19: ...6au6kffq -> ...02226869, method 6, gasFeecap 398653, gasPremium 100446, gasLimit 64460358, val 0.095865407110443715 FIL
20: ...aryby2da -> ...01782079, method 5, gasFeecap 398631, gasPremium 100424, gasLimit 40597098, val 0 FIL
21: ...jtaihfha -> ...02252111, method 7, gasFeecap 5000000000, gasPremium 100417, gasLimit 96066336, val 4.030143206844937364 FIL
22: ...gqqavdla -> ...01422327, method 7, gasFeecap 5000000000, gasPremium 100412, gasLimit 77547977, val 4.030035268751105123 FIL
23: ...qhztbpeq -> ...02221112, method 7, gasFeecap 406014, gasPremium 100405, gasLimit 79547273, val 0 FIL
24: ...obgonltq -> f05, method 4, gasFeecap 405815, gasPremium 100206, gasLimit 2360865476, val 0 FIL
25: ...obgonltq -> f05, method 4, gasFeecap 398782, gasPremium 100575, gasLimit 2308073315, val 0 FIL
26: ...yihz6g3q -> ...02238701, method 7, gasFeecap 398582, gasPremium 100375, gasLimit 78979406, val 0 FIL
27: ...6nlgz2sq -> ...02368314, method 6, gasFeecap 398237, gasPremium 100030, gasLimit 53401782, val 0 FIL
28: ...6nlgz2sq -> ...02368314, method 6, gasFeecap 398904, gasPremium 100697, gasLimit 55735610, val 0 FIL
29: ...qhztbpeq -> ...02221112, method 6, gasFeecap 405971, gasPremium 100362, gasLimit 73741478, val 0 FIL
30: ...vtiuzs2q -> ...01090983, method 5, gasFeecap 398556, gasPremium 100349, gasLimit 52283812, val 0 FIL
31: ...dksoqmta -> ...01372912, method 5, gasFeecap 405934, gasPremium 100325, gasLimit 198148780, val 0 FIL
32: ...wqkzsrnq -> ...02368321, method 7, gasFeecap 398525, gasPremium 100318, gasLimit 88188810, val 0 FIL
33: ...n3xcmx6q -> ...01660008, method 5, gasFeecap 398514, gasPremium 100307, gasLimit 30200985, val 0 FIL
34: ...hh3horja -> f05, method 4, gasFeecap 398503, gasPremium 100296, gasLimit 1340931455, val 0 FIL
35: ...y2xkzc2q -> ...02085743, method 5, gasFeecap 405895, gasPremium 100286, gasLimit 26239946, val 0 FIL
36: ...jjsgtgga -> ...01521877, method 5, gasFeecap 398451, gasPremium 100244, gasLimit 27589896, val 0 FIL
37: ...cwt2yd6a -> ...01084913, method 6, gasFeecap 398445, gasPremium 100238, gasLimit 176616456, val 0 FIL
Message selection took 65.060285ms
Size of the mempool: 190
selected messages:  38
total gas limit of selected messages: 9991446009 / 10000000000 (99.91%)
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
