### PR TITLE
fix:sealing:ReplicaUpdate:invalid replica proof

### DIFF
--- a/storage/pipeline/fsm.go
+++ b/storage/pipeline/fsm.go
@@ -192,6 +192,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 	FinalizeReplicaUpdate: planOne(
 		on(SectorFinalized{}, SubmitReplicaUpdate),
 		on(SectorFinalizeFailed{}, FinalizeReplicaUpdateFailed),
+		on(SectorRetryReplicaUpdate{}, UpdateReplica),
 	),
 	SubmitReplicaUpdate: planOne(
 		on(SectorReplicaUpdateSubmitted{}, ReplicaUpdateWait),

--- a/storage/pipeline/states_failed.go
+++ b/storage/pipeline/states_failed.go
@@ -235,7 +235,7 @@ func (m *Sealing) handleSubmitReplicaUpdateFailed(ctx statemachine.Context, sect
 		return nil
 	}
 
-	if err := checkReplicaUpdate(ctx.Context(), m.maddr, sector, ts.Key(), m.Api); err != nil {
+	if err := checkReplicaUpdate(ctx.Context(), m.maddr, sector, ts.Key(), m.Api, m.verif); err != nil {
 		switch err.(type) {
 		case *ErrApi:
 			log.Errorf("handleSubmitReplicaUpdateFailed: api error, not proceeding: %+v", err)


### PR DESCRIPTION
## Proposed Changes
1.Add replica proof check in `checkReplicaUpdate`

2.Optimize the check process of replica proof.
   -    When the replica proof check fails, it may be a problem with ProveReplicaUpdate2 (the calculation of the graphics card is wrong), or the sector file is damaged during the transmission of the ReplicaUpdate process? Therefore, after the proof check fails, jump directly to redo ReplicaUpdate.
   -  Put checkReplicaUpdate inside FinalizeReplicaUpdate to reduce wrong sector transfers to storage

## Additional Info

When updating CC sectors with new data, an invalid replica proof was found.
```
2023-09-06T22:46:49.034+0800 ERROR sectors pipeline/states_replica_update.go:229 handleSubmitReplicaUpdate: error sending message: GasEstimateMessageGas error: message execution failed: exit 16, reason: message failed with backtrace:
00: f0xxxxxx (method 27) -- failed to verify replica proof for sector 1521: invalid replica (16)
 (RetCode=16)
2023-09-06T22:46:49.037+0800 INFO sectors pipeline/states_failed.go:39 ReplicaUpdateFailed(1521), waiting 59.962918001s before retrying
```
When this problem occurs, the status of the sector will continue to flow between `SectorSubmitReplicaUpdateFailed` and `SectorRetrySubmitReplicaUpdate`. (Will keep trying again until the deals expires)
```
21.	2023-09-06 21:45:43 +0800 CST:	[event;sealing.SectorFinalized]	{"User":{}}
22.	2023-09-06 21:45:44 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
23.	2023-09-06 21:46:44 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
24.	2023-09-06 21:46:45 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
25.	2023-09-06 21:47:45 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
26.	2023-09-06 21:47:46 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
27.	2023-09-06 21:48:46 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
28.	2023-09-06 21:48:47 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
29.	2023-09-06 21:49:47 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
30.	2023-09-06 21:49:48 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
31.	2023-09-06 21:50:48 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
32.	2023-09-06 21:50:49 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
33.	2023-09-06 21:51:49 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
34.	2023-09-06 21:51:49 +0800 CST:	[event;sealing.SectorSubmitReplicaUpdateFailed]	{"User":{}}
35.	2023-09-06 21:52:49 +0800 CST:	[event;sealing.SectorRetrySubmitReplicaUpdate]	{"User":{}}
```


