### PR TITLE
fix: test: temporarily exempt SynthPorep constants from test

### DIFF
--- a/storage/sealer/proofpaths/cachefiles_test.go
+++ b/storage/sealer/proofpaths/cachefiles_test.go
@@ -10,6 +10,10 @@ import (
 
 func TestSDRLayersDefined(t *testing.T) {
 	for proof := range abi.SealProofInfos {
+		// TODO: Drop after feat/nv21 is merged in (that is, when SynthPoRep changes land)
+		if proof >= abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep && proof <= abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep {
+			continue
+		}
 		_, err := SDRLayers(proof)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

TestSDRLayersDefined has been failing on master, it's new in #11011. This is because it tests over all SealProofInfos as defined in go-state-types, which includes synth porep stuff. 

## Proposed Changes
<!-- A clear list of the changes being made -->

- Explicitly skip this check for the synth porep range for now
- We should remove this when `feat/nv21` is merged into master (will open issue for it)
- The real solution is that we're gonna need to start having integration branches in go-state-types for stuff like this

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
