### PR TITLE
eth_filter flake debug

### DIFF
--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
@@ -543,6 +544,7 @@ func TestTxReceiptBloom(t *testing.T) {
 		kit.MockProofs(),
 		kit.ThroughRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
+	logging.SetLogLevel("fullnode", "DEBUG")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -577,6 +579,10 @@ func TestTxReceiptBloom(t *testing.T) {
 		}
 	}
 
+	// Deflake plan: (Flake: 5 bits instead of 6)
+	//   Debug + search logs for "LogsBloom"
+	//   compare to passing case.
+	//
 	// 3 bits from the topic, 3 bits from the address
 	require.Equal(t, 6, bitsSet)
 }

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -665,6 +665,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 				continue
 			}
 			for _, topic := range topics {
+				log.Debug("LogsBloom set for ", topic)
 				ethtypes.EthBloomSet(receipt.LogsBloom, topic[:])
 			}
 			l.Data = data


### PR DESCRIPTION
Attempting to debug the rare flake of eth_filter_test.go's TestTxReceiptBloom 5 instead of 6

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
