### PR TITLE
fix: networking: avoid dialing when trying to handshake peers

### DIFF
--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -11,6 +12,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
@@ -66,32 +68,27 @@ func RunHello(mctx helpers.MetricsCtx, lc fx.Lifecycle, h host.Host, svc *hello.
 	ctx := helpers.LifecycleCtx(mctx, lc)
 
 	go func() {
+		// We want to get information on connected peers, we don't want to trigger new connections.
+		ctx := network.WithNoDial(ctx, "filecoin hello")
 		for evt := range sub.Out() {
 			pic := evt.(event.EvtPeerIdentificationCompleted)
+			// We just finished identifying the peer, that means we should know what
+			// protocols it speaks. Check if it speeks the Filecoin hello protocol
+			// before continuing.
+			if p, _ := h.Peerstore().FirstSupportedProtocol(pic.Peer, hello.ProtocolID); p != hello.ProtocolID {
+				continue
+			}
+
 			go func() {
 				if err := svc.SayHello(ctx, pic.Peer); err != nil {
 					protos, _ := h.Peerstore().GetProtocols(pic.Peer)
 					agent, _ := h.Peerstore().Get(pic.Peer, "AgentVersion")
-					if protosContains(protos, hello.ProtocolID) {
-						log.Warnw("failed to say hello", "error", err, "peer", pic.Peer, "supported", protos, "agent", agent)
-					} else {
-						log.Debugw("failed to say hello", "error", err, "peer", pic.Peer, "supported", protos, "agent", agent)
-					}
-					return
+					log.Warnw("failed to say hello", "error", err, "peer", pic.Peer, "supported", protos, "agent", agent)
 				}
 			}()
 		}
 	}()
 	return nil
-}
-
-func protosContains(protos []protocol.ID, search protocol.ID) bool {
-	for _, p := range protos {
-		if p == search {
-			return true
-		}
-	}
-	return false
 }
 
 func RunPeerMgr(mctx helpers.MetricsCtx, lc fx.Lifecycle, pmgr *peermgr.PeerMgr) {

--- a/node/modules/services.go
+++ b/node/modules/services.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Avoid dialing when trying to handshake peers. We're trying to handshake with _connected_ peers, but that doesn't mean we want to re-connect if the connection was transient. Also, avoid handshaking with peers that don't support the handshake protocol.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Reported in slack https://filecoinproject.slack.com/archives/C03K82MU486/p1694181455279969

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green