### PR TITLE
fix: deps: stop using go-libp2p deprecated peer.ID.Pretty

### DIFF
--- a/chain/exchange/client.go
+++ b/chain/exchange/client.go
@@ -381,7 +381,7 @@ func (c *client) sendRequestToPeer(ctx context.Context, peer peer.ID, req *Reque
 	defer span.End()
 	if span.IsRecordingEvents() {
 		span.AddAttributes(
-			trace.StringAttribute("peer", peer.Pretty()),
+			trace.StringAttribute("peer", peer.String()),
 		)
 	}
 	defer func() {

--- a/cli/net.go
+++ b/cli/net.go
@@ -282,7 +282,7 @@ var NetDisconnect = &cli.Command{
 				fmt.Println("failure")
 				return err
 			}
-			fmt.Printf("disconnect %s: ", pid.Pretty())
+			fmt.Printf("disconnect %s: ", pid)
 			err = api.NetDisconnect(ctx, pid)
 			if err != nil {
 				fmt.Println("failure")
@@ -312,7 +312,7 @@ var NetConnect = &cli.Command{
 		}
 
 		for _, pi := range pis {
-			fmt.Printf("connect %s: ", pi.ID.Pretty())
+			fmt.Printf("connect %s: ", pi.ID)
 			err := api.NetConnect(ctx, pi)
 			if err != nil {
 				fmt.Println("failure")

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -86,7 +86,7 @@ func (ts *apiSuite) testID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	require.Regexp(t, "^12", id.Pretty())
+	require.Regexp(t, "^12", id.String())
 }
 
 func (ts *apiSuite) testConnectTwo(t *testing.T) {

--- a/lib/consensus/raft/consensus.go
+++ b/lib/consensus/raft/consensus.go
@@ -342,7 +342,7 @@ func (cc *Consensus) RedirectToLeader(method string, arg interface{}, ret interf
 			return false, nil
 		}
 
-		logger.Debugf("redirecting %s to leader: %s", method, leader.Pretty())
+		logger.Debugf("redirecting %s to leader: %s", method, leader)
 		finalErr = cc.RpcClient.CallContext(
 			ctx,
 			leader,
@@ -394,7 +394,7 @@ func (cc *Consensus) Commit(ctx context.Context, op *ConsensusOp) error {
 func (cc *Consensus) AddPeer(ctx context.Context, pid peer.ID) error {
 	var finalErr error
 	for i := 0; i <= cc.config.CommitRetries; i++ {
-		logger.Debugf("attempt #%d: AddPeer %s", i, pid.Pretty())
+		logger.Debugf("attempt #%d: AddPeer %s", i, pid)
 		if finalErr != nil {
 			logger.Errorf("retrying to add peer. Attempt #%d failed: %s", i, finalErr)
 		}
@@ -408,7 +408,7 @@ func (cc *Consensus) AddPeer(ctx context.Context, pid peer.ID) error {
 			time.Sleep(cc.config.CommitRetryDelay)
 			continue
 		}
-		logger.Infof("peer added to Raft: %s", pid.Pretty())
+		logger.Infof("peer added to Raft: %s", pid)
 		break
 	}
 	return finalErr
@@ -419,7 +419,7 @@ func (cc *Consensus) AddPeer(ctx context.Context, pid peer.ID) error {
 func (cc *Consensus) RmPeer(ctx context.Context, pid peer.ID) error {
 	var finalErr error
 	for i := 0; i <= cc.config.CommitRetries; i++ {
-		logger.Debugf("attempt #%d: RmPeer %s", i, pid.Pretty())
+		logger.Debugf("attempt #%d: RmPeer %s", i, pid)
 		if finalErr != nil {
 			logger.Errorf("retrying to remove peer. Attempt #%d failed: %s", i, finalErr)
 		}
@@ -433,7 +433,7 @@ func (cc *Consensus) RmPeer(ctx context.Context, pid peer.ID) error {
 			time.Sleep(cc.config.CommitRetryDelay)
 			continue
 		}
-		logger.Infof("peer removed from Raft: %s", pid.Pretty())
+		logger.Infof("peer removed from Raft: %s", pid)
 		break
 	}
 	return finalErr

--- a/node/impl/net/rcmgr.go
+++ b/node/impl/net/rcmgr.go
@@ -36,7 +36,7 @@ func (a *NetAPI) NetStat(ctx context.Context, scope string) (result api.NetStat,
 		if len(stat.Peers) > 0 {
 			result.Peers = make(map[string]network.ScopeStat, len(stat.Peers))
 			for p, stat := range stat.Peers {
-				result.Peers[p.Pretty()] = stat
+				result.Peers[p.String()] = stat
 			}
 		}
 

--- a/node/modules/lp2p/host.go
+++ b/node/modules/lp2p/host.go
@@ -41,7 +41,7 @@ func Peerstore() (peerstore.Peerstore, error) {
 func Host(mctx helpers.MetricsCtx, lc fx.Lifecycle, params P2PHostIn) (RawHost, error) {
 	pkey := params.Peerstore.PrivKey(params.ID)
 	if pkey == nil {
-		return nil, fmt.Errorf("missing private key for node ID: %s", params.ID.Pretty())
+		return nil, fmt.Errorf("missing private key for node ID: %s", params.ID)
 	}
 
 	opts := []libp2p.Option{


### PR DESCRIPTION
The `go-libp2p` peerID Pretty method is already deprecated, switch it to call String method.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
