### PR TITLE
fix: Add time slicing to splitstore purging to reduce lock congestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## New features
 - feat: Added new tracing API (**HIGHLY EXPERIMENTAL**) supporting two RPC methods: `trace_block` and `trace_replayBlockTransactions` ([filecoin-project/lotus#11100](https://github.com/filecoin-project/lotus/pull/11100))
 
+## Improvements
+- fix: Add time slicing to splitstore purging step during compaction to reduce lock congestion [filecoin-project/lotus#11269](https://github.com/filecoin-project/lotus/pull/11269)
+
 # v1.23.3 / 2023-08-01
 
 This feature release of Lotus includes numerous improvements and enhancements for node operators, ETH RPC-providers and storage providers.

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -1377,7 +1377,7 @@ func (s *SplitStore) purge(coldr *ColdSetReader, checkpoint *Checkpoint, markSet
 	err := coldr.ForEach(func(c cid.Cid) error {
 		batch = append(batch, c)
 		if len(batch) == batchSize {
-			// add some throttling to the purge as this a very disk I/O heavy operation that
+			// add some time slicing to the purge as this a very disk I/O heavy operation that
 			// requires write access to txnLk that may starve other operations that require
 			// access to the blockstore.
 			if time.Since(now) > time.Second {

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -66,8 +66,9 @@ var (
 )
 
 const (
-	batchSize  = 16384
-	cidKeySize = 128
+	batchSize              = 16384
+	cidKeySize             = 128
+	purgeWorkSliceDuration = time.Second
 )
 
 func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
@@ -1381,8 +1382,8 @@ func (s *SplitStore) purge(coldr *ColdSetReader, checkpoint *Checkpoint, markSet
 			// requires write access to txnLk that may starve other operations that require
 			// access to the blockstore.
 			elapsed := time.Since(now)
-			if elapsed > time.Second {
-				// work 1 second, sleep 4, or 20% utilization
+			if elapsed > purgeWorkSliceDuration {
+				// work 1 slice, sleep 4 slices, or 20% utilization
 				time.Sleep(4 * elapsed)
 				now = time.Now()
 			}

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -1380,8 +1380,10 @@ func (s *SplitStore) purge(coldr *ColdSetReader, checkpoint *Checkpoint, markSet
 			// add some time slicing to the purge as this a very disk I/O heavy operation that
 			// requires write access to txnLk that may starve other operations that require
 			// access to the blockstore.
-			if time.Since(now) > time.Second {
-				time.Sleep(time.Second)
+			elapsed := time.Since(now)
+			if elapsed > time.Second {
+				// work 1 second, sleep 4, or 20% utilization
+				time.Sleep(4 * elapsed)
 				now = time.Now()
 			}
 


### PR DESCRIPTION
## Related Issues
See https://github.com/filecoin-project/lotus/issues/11251

## Context
When splitstore is enabled we perform compaction every 7h30m. During this compaction (which takes several minutes on my fast SSD) there is  relatively small purging step which takes approx 15sec. The purging step chunks the cids which should be purged and operates on them in blocks. In each block it acquires an exclusive lock which it shares with other I/O operation (for example FVM when applying messages). 

So when purging happens, other operations like MpoolSelect block for the whole 15sec duration when it needs to compute tipset state (TipSetState).

## Proposed Changes
I added a simple time slicing to the purging step which only tries to purge for 1 sec, while pausing for 1 sec until it is done. This effectively makes the purge 2x slower, but I don't think we care so much as it only happens every 7h30m and purging is already relatively fast compare the the whole splitstore compaction.

## Test plan
Using the same testing method as described in this [comment](https://github.com/filecoin-project/lotus/issues/11251#issuecomment-1717753704) I observed with this fix that during splitstore compaction the whole TipSetState went down from 15sec to ~2sec.

## Additional Info
See https://github.com/filecoin-project/lotus/issues/11251#issuecomment-1717753704

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
