### PR TITLE
fix: cli: Wrap error in wallet sign

### DIFF
--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -463,7 +463,7 @@ var walletSign = &cli.Command{
 			// Check if the address is a multisig address
 			act, actErr := api.StateGetActor(ctx, addr, types.EmptyTSK)
 			if actErr == nil && builtin.IsMultisigActor(act.Code) {
-				return xerrors.Errorf("multisig is an actor account that doesn’t have keys to sign transactions. To send a message with a multisig, signers of the multisig need to propose and approve transactions.")
+				return xerrors.Errorf("specified signer address is a multisig actor, it doesn’t have keys to sign transactions. To send a message with a multisig, signers of the multisig need to propose and approve transactions.")
 			}
 			return xerrors.Errorf("failed to sign message: %w", err)
 		}

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 )
@@ -459,7 +460,12 @@ var walletSign = &cli.Command{
 		sig, err := api.WalletSign(ctx, addr, msg)
 
 		if err != nil {
-			return err
+			// Check if the address is a multisig address
+			act, actErr := api.StateGetActor(ctx, addr, types.EmptyTSK)
+			if actErr == nil && builtin.IsMultisigActor(act.Code) {
+				return xerrors.Errorf("multisig is an actor account that doesn’t have keys to sign transactions. To send a message with a multisig, signers of the multisig need to propose and approve transactions.")
+			}
+			return xerrors.Errorf("failed to sign message: %w", err)
 		}
 
 		sigBytes := append([]byte{byte(sig.Type)}, sig.Data...)


### PR DESCRIPTION
## Related Issues
Closes: #7919

## Proposed Changes
Wrap error when a msig is trying to sign a msg, explaining that msig messages needs to propose & approve.

## Additional Info
When trying to sign with a msig, error is now wrapped as:
```
lotus wallet sign t2pgqal7cetyqb6thbkb6s4nlbx3to5mm4azc43si 3fa85f6457174562b3fc2c963f66afa6
ERROR: multisig is an actor account that doesn’t have keys to sign transactions. To send a message with a multisig, signers of the multisig need to propose and approve transactions.
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
