### PR TITLE
Feat: Lotus Daemon CLI: Auto remove existing chain if importing chain file or snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This feature release requires a **minimum Go version of v1.19.12 or higher to su
   - feat: Lotus Gateway: add MpoolPending, ChainGetBlock and MinerGetBaseInfo ([filecoin-project/lotus#10929](https://github.com/filecoin-project/lotus/pull/10929))
 
 ## Improvements
+  - chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
   - chore: update ffi & fvm ([filecoin-project/lotus#11040](https://github.com/filecoin-project/lotus/pull/11040))
   - feat: Make sure we don't store duplidate actor events caused to reorgs in events.db ([filecoin-project/lotus#11015](https://github.com/filecoin-project/lotus/pull/11015))
   - sealing: Use only non-assigned deals when selecting snap sectors ([filecoin-project/lotus#11002](https://github.com/filecoin-project/lotus/pull/11002))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Lotus changelog
 
 # UNRELEASED
+- chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
 
 ## New features
 - feat: Added new tracing API (**HIGHLY EXPERIMENTAL**) supporting two RPC methods: `trace_block` and `trace_replayBlockTransactions` ([filecoin-project/lotus#11100](https://github.com/filecoin-project/lotus/pull/11100))
@@ -34,7 +35,6 @@ This feature release requires a **minimum Go version of v1.19.12 or higher to su
   - feat: Lotus Gateway: add MpoolPending, ChainGetBlock and MinerGetBaseInfo ([filecoin-project/lotus#10929](https://github.com/filecoin-project/lotus/pull/10929))
 
 ## Improvements
-  - chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
   - chore: update ffi & fvm ([filecoin-project/lotus#11040](https://github.com/filecoin-project/lotus/pull/11040))
   - feat: Make sure we don't store duplidate actor events caused to reorgs in events.db ([filecoin-project/lotus#11015](https://github.com/filecoin-project/lotus/pull/11015))
   - sealing: Use only non-assigned deals when selecting snap sectors ([filecoin-project/lotus#11002](https://github.com/filecoin-project/lotus/pull/11002))

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -269,7 +269,17 @@ var DaemonCmd = &cli.Command{
 			}
 		}
 
-		if cctx.Bool("remove-existing-chain") {
+		chainfile := cctx.String("import-chain")
+		snapshot := cctx.String("import-snapshot")
+		willImportChain := false
+		if chainfile != "" || snapshot != "" {
+			if chainfile != "" && snapshot != "" {
+				return fmt.Errorf("cannot specify both 'import-snapshot' and 'import-chain'")
+			}
+			willImportChain = true
+		}
+
+		if cctx.Bool("remove-existing-chain") || willImportChain {
 			lr, err := repo.NewFS(cctx.String("repo"))
 			if err != nil {
 				return xerrors.Errorf("error opening fs repo: %w", err)
@@ -289,12 +299,7 @@ var DaemonCmd = &cli.Command{
 			}
 		}
 
-		chainfile := cctx.String("import-chain")
-		snapshot := cctx.String("import-snapshot")
-		if chainfile != "" || snapshot != "" {
-			if chainfile != "" && snapshot != "" {
-				return fmt.Errorf("cannot specify both 'import-snapshot' and 'import-chain'")
-			}
+		if willImportChain {
 			var issnapshot bool
 			if chainfile == "" {
 				chainfile = snapshot

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -295,7 +295,7 @@ var DaemonCmd = &cli.Command{
 			} else if userInput == "no" {
 				willRemoveChain = false
 			} else {
-				return fmt.Errorf("Invalid input. Please answer with 'yes' or 'no'.")
+				return fmt.Errorf("invalid input. please answer with 'yes' or 'no'")
 			}
 		}
 


### PR DESCRIPTION
## Related Issues
Based on the discussion https://filecoinproject.slack.com/archives/CP50PPW2X/p1695108301930859

## Proposed Changes
When user wants to import chain file or snapshot, we will by default remove the local chain data, unless the user says otherwise.

## Additional Info
None.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
