### PR TITLE
Feat: Lotus cli: actor: Support move partition command to move partitions' deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Lotus changelog
 
 # UNRELEASED
+- feat: Add move-partition command ([filecoin-project/lotus#11290](https://github.com/filecoin-project/lotus/pull/11290))
 - chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
 
 ## New features

--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
+	minerV12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/network"
 
@@ -49,6 +50,7 @@ var actorCmd = &cli.Command{
 		actorProposeChangeWorker,
 		actorConfirmChangeWorker,
 		actorCompactAllocatedCmd,
+		actorMovePartitionsCmd,
 		actorProposeChangeBeneficiary,
 		actorConfirmChangeBeneficiary,
 	},
@@ -1286,13 +1288,134 @@ var actorConfirmChangeBeneficiary = &cli.Command{
 	},
 }
 
+var actorMovePartitionsCmd = &cli.Command{
+	Name:  "move-partitions",
+	Usage: "move deadline of specified partitions from one to another",
+	Flags: []cli.Flag{
+		&cli.Int64SliceFlag{
+			Name:  "partition-indices",
+			Usage: "Indices of partitions to update, separated by comma",
+		},
+		&cli.Uint64Flag{
+			Name:  "orig-deadline",
+			Usage: "Deadline to move partition from",
+		},
+		&cli.Uint64Flag{
+			Name:  "dest-deadline",
+			Usage: "Deadline to move partition to",
+		},
+		&cli.BoolFlag{
+			Name:  "really-do-it",
+			Usage: "Actually send transaction performing the action",
+			Value: false,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Present() {
+			fmt.Println("Please use flags to provide arguments. See --help")
+		}
+
+		ctx := lcli.ReqContext(cctx)
+
+		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		maddr, err := minerApi.ActorAddress(ctx)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Miner: %s\n", color.BlueString("%s", maddr))
+
+		fullNodeApi, acloser, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer acloser()
+
+		minfo, err := fullNodeApi.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Worker: %s\n", color.BlueString("%s", minfo.Worker))
+
+		origDeadline := cctx.Uint64("orig-deadline")
+		if origDeadline > miner.WPoStPeriodDeadlines {
+			return fmt.Errorf("orig-deadline %d out of range", origDeadline)
+		}
+		destDeadline := cctx.Uint64("dest-deadline")
+		if origDeadline > miner.WPoStPeriodDeadlines {
+			return fmt.Errorf("dest-deadline %d out of range", destDeadline)
+		}
+		if origDeadline == destDeadline {
+			return fmt.Errorf("dest-desdline cannot be the same as orig-deadline")
+		}
+
+		partitions := cctx.Int64Slice("partition-indices")
+		if len(partitions) == 0 {
+			return fmt.Errorf("must include at least one partition to move")
+		}
+
+		fmt.Printf("Moving %d paritions\n", len(partitions))
+
+		partitionsBf := bitfield.New()
+		for _, partition := range partitions {
+			partitionsBf.Set(uint64(partition))
+		}
+
+		params := minerV12.MovePartitionsParams{
+			OrigDeadline: origDeadline,
+			DestDeadline: destDeadline,
+			Partitions:   partitionsBf,
+		}
+
+		serializedParams, aerr := actors.SerializeParams(&params)
+		if aerr != nil {
+			return xerrors.Errorf("serializing params: %w", err)
+		}
+
+		smsg, err := fullNodeApi.MpoolPushMessage(ctx, &types.Message{
+			From:   minfo.Worker,
+			To:     maddr,
+			Method: builtin.MethodsMiner.MovePartitions,
+			Value:  big.Zero(),
+			Params: serializedParams,
+		}, nil)
+		if err != nil {
+			return xerrors.Errorf("mpool push: %w", err)
+		}
+
+		fmt.Println("MovePartitions Message CID:", smsg.Cid())
+
+		// wait for it to get mined into a block
+		wait, err := fullNodeApi.StateWaitMsg(ctx, smsg.Cid(), build.MessageConfidence)
+		if err != nil {
+			return err
+		}
+
+		// check it executed successfully
+		if wait.Receipt.ExitCode.IsError() {
+			// TODO(jie): Fix error message
+			fmt.Println("Propose owner change failed!")
+			return err
+		}
+
+		fmt.Print("DoneDone")
+
+		return nil
+	},
+}
+
 var actorCompactAllocatedCmd = &cli.Command{
 	Name:  "compact-allocated",
 	Usage: "compact allocated sectors bitfield",
 	Flags: []cli.Flag{
 		&cli.Uint64Flag{
 			Name:  "mask-last-offset",
-			Usage: "Mask sector IDs from 0 to 'higest_allocated - offset'",
+			Usage: "Mask sector IDs from 0 to 'highest_allocated - offset'",
 		},
 		&cli.Uint64Flag{
 			Name:  "mask-upto-n",


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/11272

## Proposed Changes
Add `move-partition` subcommand to `lotus-miner actor` command.

## Additional Info
Still waiting for corresponding actor changes to merge https://github.com/filecoin-project/builtin-actors/pull/1326/files

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green

# Example usage
Before
```
$ ./lotus-miner proving deadlines
Miner: t01000
deadline  partitions  sectors (faults)  proven partitions
0         0           0 (0)             0
1         0           0 (0)             0
2         0           0 (0)             0
3         0           0 (0)             0
4         0           0 (0)             0
5         0           0 (0)             0
6         0           0 (0)             0
7         0           0 (0)             0
8         0           0 (0)             0
9         0           0 (0)             0
10        0           0 (0)             0
11        0           0 (0)             0
12        0           0 (0)             0
13        0           0 (0)             0
14        0           0 (0)             0  (current)
15        0           0 (0)             0
16        0           0 (0)             0
17        0           0 (0)             0
18        0           0 (0)             0
19        0           0 (0)             0
20        1           2 (0)             0
21        0           0 (0)             0
22        0           0 (0)             0
23        0           0 (0)             0
24        0           0 (0)             0
25        0           0 (0)             0
26        0           0 (0)             0
27        0           0 (0)             0
28        0           0 (0)             0
29        0           0 (0)             0
30        0           0 (0)             0
31        0           0 (0)             0
32        0           0 (0)             0
33        0           0 (0)             0
34        0           0 (0)             0
35        0           0 (0)             0
36        0           0 (0)             0
37        0           0 (0)             0
38        0           0 (0)             0
39        0           0 (0)             0
40        0           0 (0)             0
41        0           0 (0)             0
42        0           0 (0)             0
43        0           0 (0)             0
44        0           0 (0)             0
45        0           0 (0)             0
46        0           0 (0)             0
47        0           0 (0)             0
```

Then use
```
$ ./lotus-miner actor move-partitions --partition-indices 0 --orig-deadline 20 --dest-deadline 17
Miner: t01000
Moving 1 paritions
MovePartitions Message CID: bafy2bzaceaxz7ujzanqq5k5yhvszzgqyydxhylhfy7vrcywv4rbi76j2zicfk
Waiting for block confirmation...
Move partition confirmed
```

Check deadline has been moved

```
$ ./lotus-miner proving deadlines                                                                
Miner: t01000
deadline  partitions  sectors (faults)  proven partitions
0         0           0 (0)             0
1         0           0 (0)             0
2         0           0 (0)             0
3         0           0 (0)             0
4         0           0 (0)             0
5         0           0 (0)             0
6         0           0 (0)             0
7         0           0 (0)             0
8         0           0 (0)             0
9         0           0 (0)             0
10        0           0 (0)             0
11        0           0 (0)             0
12        0           0 (0)             0
13        0           0 (0)             0
14        0           0 (0)             0
15        0           0 (0)             0  (current)
16        0           0 (0)             0
17        1           2 (0)             0
18        0           0 (0)             0
19        0           0 (0)             0
20        0           0 (0)             0
21        0           0 (0)             0
22        0           0 (0)             0
23        0           0 (0)             0
24        0           0 (0)             0
25        0           0 (0)             0
26        0           0 (0)             0
27        0           0 (0)             0
28        0           0 (0)             0
29        0           0 (0)             0
30        0           0 (0)             0
31        0           0 (0)             0
32        0           0 (0)             0
33        0           0 (0)             0
34        0           0 (0)             0
35        0           0 (0)             0
36        0           0 (0)             0
37        0           0 (0)             0
38        0           0 (0)             0
39        0           0 (0)             0
40        0           0 (0)             0
41        0           0 (0)             0
42        0           0 (0)             0
43        0           0 (0)             0
44        0           0 (0)             0
45        0           0 (0)             0
46        0           0 (0)             0
47        0           0 (0)             0
```