### PR TITLE
fix: worker: Connect when --listen is not set

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -627,7 +627,7 @@ var runCmd = &cli.Command{
 			Storage:    lr,
 		}
 
-		log.Info("Setting up control endpoint at " + address)
+		log.Info("Setting up control endpoint at " + newAddress)
 
 		timeout, err := time.ParseDuration(cctx.String("http-server-timeout"))
 		if err != nil {
@@ -652,13 +652,13 @@ var runCmd = &cli.Command{
 			log.Warn("Graceful shutdown successful")
 		}()
 
-		nl, err := net.Listen("tcp", address)
+		nl, err := net.Listen("tcp", newAddress)
 		if err != nil {
 			return err
 		}
 
 		{
-			a, err := net.ResolveTCPAddr("tcp", address)
+			a, err := net.ResolveTCPAddr("tcp", newAddress)
 			if err != nil {
 				return xerrors.Errorf("parsing address: %w", err)
 			}
@@ -739,7 +739,7 @@ var runCmd = &cli.Command{
 
 					select {
 					case <-readyCh:
-						if err := nodeApi.WorkerConnect(ctx, "http://"+address+"/rpc/v0"); err != nil {
+						if err := nodeApi.WorkerConnect(ctx, "http://"+newAddress+"/rpc/v0"); err != nil {
 							log.Errorf("Registering worker failed: %+v", err)
 							cancel()
 							return
@@ -801,6 +801,9 @@ func extractRoutableIP(timeout time.Duration) (string, error) {
 	}
 
 	minerIP, _ := maddr.ValueForProtocol(multiaddr.P_IP6)
+	if minerIP == "" {
+		minerIP, _ = maddr.ValueForProtocol(multiaddr.P_IP4)
+	}
 	minerPort, _ := maddr.ValueForProtocol(multiaddr.P_TCP)
 
 	// Check if the IP is IPv6 and format the address appropriately

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -806,13 +806,8 @@ func extractRoutableIP(timeout time.Duration) (string, error) {
 	}
 	minerPort, _ := maddr.ValueForProtocol(multiaddr.P_TCP)
 
-	// Check if the IP is IPv6 and format the address appropriately
-	var addressToDial string
-	if ip := net.ParseIP(minerIP); ip.To4() == nil && ip.To16() != nil {
-		addressToDial = "[" + minerIP + "]:" + minerPort
-	} else {
-		addressToDial = minerIP + ":" + minerPort
-	}
+	// Format the address appropriately
+	addressToDial := net.JoinHostPort(minerIP, minerPort)
 
 	conn, err := net.DialTimeout("tcp", addressToDial, timeout)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
Fix regression introduces in https://github.com/filecoin-project/lotus/pull/11141, where a remote lotus-worker was unable to connect, unless the --listen flag was specified.

Should be backported to the `release/v1.23.4` branch.

## Proposed Changes
Starting the lotus-worker on a remote server w/different IP-address, failed unless the `--listen` was set after adding https://github.com/filecoin-project/lotus/pull/11141.

Testing cases:

- [x] Running a remote lotus-worker connecting to a lotus-miner with an IPv4 MINER_AP_INFO, and without --listen flag:
```
./lotus-worker run --no-default=true --unseal=true
2023-09-23T07:41:22.600Z        INFO    main    lotus-worker/main.go:298        Starting lotus worker
2023-09-23T07:41:22.604Z        INFO    main    lotus-worker/main.go:384        Remote version 1.23.4-rc1+mainnet+git.c7b3d84cc.dirty+api1.5.0
----
2023-09-23T07:41:22.627Z        INFO    main    lotus-worker/main.go:725        Making sure no local tasks are running
2023-09-23T07:41:23.441Z        INFO    main    lotus-worker/main.go:748        Worker registered successfully, waiting for tasks
```

- [x] Running a remote lotus-worker with IPv6, and without --listen flag:
```
./lotus-worker run --no-default=true --unseal=true
-----
2023-09-25T13:26:51.408+0200    INFO    main    lotus-worker/main.go:556        Opening local storage; connecting to master
2023-09-25T13:26:51.417+0200    INFO    main    lotus-worker/main.go:630        Setting up control endpoint at [::1]:3456
2023-09-25T13:26:51.419+0200    INFO    main    lotus-worker/main.go:725        Making sure no local tasks are running
2023-09-25T13:26:51.472+0200    INFO    main    lotus-worker/main.go:748        Worker registered successfully, waiting for tasks
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
