### PR TITLE
chore: config: Update todo in UseSyntheticPoRep

### DIFF
--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -666,9 +666,9 @@
   # env var: LOTUS_SEALING_TERMINATEBATCHWAIT
   #TerminateBatchWait = "5m0s"
 
-  # UseSyntheticPoRep will reduce the amout of data held on disk in the WaitSeed phase to 32GiB
-  # at the cost of having to precompute the synthetic challenges.
-  # TODO: put estimated costs here
+  # UseSyntheticPoRep, when set to true, will reduce the amount of cache data held on disk after the completion of PreCommit 2 to 11GiB.
+  # This is achieved by precomputing "synthetic" challenges from CommR.
+  # Note that this comes at a cost of additional computation to generate these synthetic challenges.
   #
   # type: bool
   # env var: LOTUS_SEALING_USESYNTHETICPOREP

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1299,9 +1299,9 @@ Submitting a smaller number of prove commits per epoch would reduce the possibil
 			Name: "UseSyntheticPoRep",
 			Type: "bool",
 
-			Comment: `UseSyntheticPoRep will reduce the amout of data held on disk in the WaitSeed phase to 32GiB
-at the cost of having to precompute the synthetic challenges.
-TODO: put estimated costs here`,
+			Comment: `UseSyntheticPoRep, when set to true, will reduce the amount of cache data held on disk after the completion of PreCommit 2 to 11GiB.
+This is achieved by precomputing "synthetic" challenges from CommR.
+Note that this comes at a cost of additional computation to generate these synthetic challenges.`,
 		},
 	},
 	"Splitstore": []DocField{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -430,9 +430,9 @@ type SealingConfig struct {
 
 	// todo TargetSectors - stop auto-pleding new sectors after this many sectors are sealed, default CC upgrade for deals sectors if above
 
-	// UseSyntheticPoRep will reduce the amout of data held on disk in the WaitSeed phase to 32GiB
-	// at the cost of having to precompute the synthetic challenges.
-	// TODO: put estimated costs here
+	// UseSyntheticPoRep, when set to true, will reduce the amount of cache data held on disk after the completion of PreCommit 2 to 11GiB.
+	// This is achieved by precomputing "synthetic" challenges from CommR.
+	// Note that this comes at a cost of additional computation to generate these synthetic challenges.
 	UseSyntheticPoRep bool
 }
 


### PR DESCRIPTION
## Proposed Changes
Updates the UseSyntheticPoRep config with actual numbers of what the cache-size is (11GiB) after completing PreCommit 2.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
