### PR TITLE
ci: remove apple intel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1035,7 +1035,6 @@ workflows:
       - release:
           name: "Release"
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:
@@ -1049,7 +1048,6 @@ workflows:
           name: "Release (dry-run)"
           dry-run: true
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,34 +269,11 @@ jobs:
           paths:
             - linux_amd64_v1
 
-  build-darwin-amd64:
-    description: build darwin lotus binary
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
-    macos:
-      xcode: "13.4.1"
-    steps:
-      - build-platform-specific:
-          linux: false
-          darwin: true
-          darwin-architecture: amd64
-      - run: make lotus lotus-miner lotus-worker
-      - run: otool -hv lotus
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - run: |
-          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
-          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - darwin_amd64_v1
-
   build-darwin-arm64:
     description: self-hosted m1 runner
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     machine: true
-    resource_class: filecoin-project/self-hosted-m1
+    resource_class: macos.x86.medium.gen2
     steps:
       - run: echo 'export PATH=/opt/homebrew/bin:"$PATH"' >> "$BASH_ENV"
       - build-platform-specific:
@@ -1037,16 +1014,6 @@ workflows:
     jobs:
       - build-linux-amd64:
           name: "Build ( linux / amd64 )"
-          filters:
-            branches:
-              only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-                - /^ci\/.*$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-darwin-amd64:
-          name: "Build ( darwin / amd64 )"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
     description: self-hosted m1 runner
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     machine: true
-    resource_class: macos.x86.medium.gen2
+    resource_class: filecoin-project/self-hosted-m1
     steps:
       - run: echo 'export PATH=/opt/homebrew/bin:"$PATH"' >> "$BASH_ENV"
       - build-platform-specific:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -269,29 +269,6 @@ jobs:
           paths:
             - linux_amd64_v1
 
-  build-darwin-amd64:
-    description: build darwin lotus binary
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
-    macos:
-      xcode: "13.4.1"
-    steps:
-      - build-platform-specific:
-          linux: false
-          darwin: true
-          darwin-architecture: amd64
-      - run: make lotus lotus-miner lotus-worker
-      - run: otool -hv lotus
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - run: |
-          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
-          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - darwin_amd64_v1
-
   build-darwin-arm64:
     description: self-hosted m1 runner
     working_directory: ~/go/src/github.com/filecoin-project/lotus
@@ -586,16 +563,6 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-darwin-amd64:
-          name: "Build ( darwin / amd64 )"
-          filters:
-            branches:
-              only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-                - /^ci\/.*$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-darwin-arm64:
           name: "Build ( darwin / arm64 )"
           filters:
@@ -609,7 +576,6 @@ workflows:
       - release:
           name: "Release"
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:
@@ -623,7 +589,6 @@ workflows:
           name: "Release (dry-run)"
           dry-run: true
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR removes CircleCI jobs that were using Apple Intel executors.

## Proposed Changes
<!-- A clear list of the changes being made -->
To remove CircleCI jobs that are using Apple Intel executors.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
https://discuss.circleci.com/t/macos-resource-deprecation-update/46891

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
