### PR TITLE
ci: use gen2 macos executors explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ jobs:
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
     steps:
       - build-platform-specific:
           linux: false

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -274,6 +274,7 @@ jobs:
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
     steps:
       - build-platform-specific:
           linux: false


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
This PR ensures builds on Apple Intel executors continue to work beyond October 2. Gen 1 Apple Intel executors are getting deprecated then - https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718. By the end of January 2024, we'll have to:
- either deprecate Apple Intel builds (https://github.com/filecoin-project/lotus/pull/11307)
- or set up self-hosted Apple Intel runners.

## Proposed Changes
<!-- A clear list of the changes being made -->
This PR makes the choice of executor type for Apple Intel builds explicit.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
