### PR TITLE
ci: remove darwin amd64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ jobs:
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
     steps:
       - build-platform-specific:
           linux: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,30 +269,6 @@ jobs:
           paths:
             - linux_amd64_v1
 
-  build-darwin-amd64:
-    description: build darwin lotus binary
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
-    macos:
-      xcode: "13.4.1"
-    resource_class: macos.x86.medium.gen2
-    steps:
-      - build-platform-specific:
-          linux: false
-          darwin: true
-          darwin-architecture: amd64
-      - run: make lotus lotus-miner lotus-worker
-      - run: otool -hv lotus
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - run: |
-          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
-          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - darwin_amd64_v1
-
   build-darwin-arm64:
     description: self-hosted m1 runner
     working_directory: ~/go/src/github.com/filecoin-project/lotus
@@ -1046,16 +1022,6 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-darwin-amd64:
-          name: "Build ( darwin / amd64 )"
-          filters:
-            branches:
-              only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-                - /^ci\/.*$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-darwin-arm64:
           name: "Build ( darwin / arm64 )"
           filters:
@@ -1069,7 +1035,6 @@ workflows:
       - release:
           name: "Release"
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:
@@ -1083,7 +1048,6 @@ workflows:
           name: "Release (dry-run)"
           dry-run: true
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -269,30 +269,6 @@ jobs:
           paths:
             - linux_amd64_v1
 
-  build-darwin-amd64:
-    description: build darwin lotus binary
-    working_directory: ~/go/src/github.com/filecoin-project/lotus
-    macos:
-      xcode: "13.4.1"
-    resource_class: macos.x86.medium.gen2
-    steps:
-      - build-platform-specific:
-          linux: false
-          darwin: true
-          darwin-architecture: amd64
-      - run: make lotus lotus-miner lotus-worker
-      - run: otool -hv lotus
-      - run:
-          name: check tag and version output match
-          command: ./scripts/version-check.sh ./lotus
-      - run: |
-          mkdir -p /tmp/workspace/darwin_amd64_v1 && \
-          mv lotus lotus-miner lotus-worker /tmp/workspace/darwin_amd64_v1/
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - darwin_amd64_v1
-
   build-darwin-arm64:
     description: self-hosted m1 runner
     working_directory: ~/go/src/github.com/filecoin-project/lotus
@@ -587,16 +563,6 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+(-rc\d+)?$/
-      - build-darwin-amd64:
-          name: "Build ( darwin / amd64 )"
-          filters:
-            branches:
-              only:
-                - /^release\/v\d+\.\d+\.\d+(-rc\d+)?$/
-                - /^ci\/.*$/
-            tags:
-              only:
-                - /^v\d+\.\d+\.\d+(-rc\d+)?$/
       - build-darwin-arm64:
           name: "Build ( darwin / arm64 )"
           filters:
@@ -610,7 +576,6 @@ workflows:
       - release:
           name: "Release"
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:
@@ -624,7 +589,6 @@ workflows:
           name: "Release (dry-run)"
           dry-run: true
           requires:
-            - "Build ( darwin / amd64 )"
             - "Build ( linux / amd64 )"
             - "Build ( darwin / arm64 )"
           filters:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -274,6 +274,7 @@ jobs:
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
     steps:
       - build-platform-specific:
           linux: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,8 @@ builds:
     ignore:
       - goos: linux
         goarch: arm64
+      - goos: darwin
+        goarch: amd64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus
   - id: lotus-miner
@@ -42,6 +44,8 @@ builds:
     ignore:
       - goos: linux
         goarch: arm64
+      - goos: darwin
+        goarch: amd64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-miner
   - id: lotus-worker
@@ -58,6 +62,8 @@ builds:
     ignore:
       - goos: linux
         goarch: arm64
+      - goos: darwin
+        goarch: amd64
     prebuilt:
       path: /tmp/workspace/{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/lotus-worker
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
This PR removes builds on Apple Intel executors in preparation for their January 2024 deprecation. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718. 

Alternatively, self-hosted Apple Intel runners would have to be set up.

## Proposed Changes
<!-- A clear list of the changes being made -->
This PR removes darwin amd64 builds altogether .

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
