### PR TITLE
fix: worker: listen for interrupt signals in GetStorageMinerAPI loop

### DIFF
--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -379,7 +379,6 @@ var runCmd = &cli.Command{
 			}
 		}
 		defer closer()
-		ctx, cancel = context.WithCancel(ctx)
 		defer cancel()
 		// Register all metric views
 		if err := view.Register(

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -348,6 +349,18 @@ var runCmd = &cli.Command{
 		// Connect to storage-miner
 		ctx := lcli.ReqContext(cctx)
 
+		// Create a new context with cancel function
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Listen for interrupt signals
+		go func() {
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt)
+			<-c
+			cancel()
+		}()
+
 		var nodeApi api.StorageMiner
 		var closer func()
 		for {
@@ -359,14 +372,15 @@ var runCmd = &cli.Command{
 				}
 			}
 			fmt.Printf("\r\x1b[0KConnecting to miner API... (%s)", err)
-			time.Sleep(time.Second)
-			continue
+			select {
+			case <-ctx.Done():
+				return xerrors.New("Interrupted by user")
+			case <-time.After(time.Second):
+			}
 		}
-
 		defer closer()
-		ctx, cancel := context.WithCancel(ctx)
+		ctx, cancel = context.WithCancel(ctx)
 		defer cancel()
-
 		// Register all metric views
 		if err := view.Register(
 			metrics.DefaultViews...,

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -379,7 +379,6 @@ var runCmd = &cli.Command{
 			}
 		}
 		defer closer()
-		defer cancel()
 		// Register all metric views
 		if err := view.Register(
 			metrics.DefaultViews...,


### PR DESCRIPTION
## Proposed Changes
Listen for interrupt signals in GetStorageMinerAPI loop, allowing for graceful shutdown in case the worker is brought up before the lotus-miner process is running.

## Additional Info
**Before:**
```
lotus-worker run
2023-10-03T04:19:52.209-0400    INFO    main    lotus-worker/main.go:296        Starting lotus worker
Connecting to miner API... (RPC client error: sendRequest failed: Post "http://10.2.2.22:2345/rpc/v0": context canceled)
Connecting to miner API... (RPC client error: sendRequest failed: Post "http://10.2.2.22:2345/rpc/v0": context canceled)
Connecting to miner API... (RPC client error: sendRequest failed: Post "http://10.2.2.22:2345/rpc/v0": context canceled)^C^C^C
Connecting to miner API... (RPC client error: sendRequest failed: Post "http://10.2.2.22:2345/rpc/v0": context canceled)^C
```

**After:**
```
lotus-worker run
2023-10-03T05:51:09.475-0400    INFO    main    lotus-worker/main.go:297        Starting lotus worker
Connecting to miner API... (RPC client error: sendRequest failed: Post "http://127.0.0.1:2345/rpc/v0": dial tcp 127.0.0.1:2345: connect: connection refused)^C2023-10-03T05:51:10.343-0400       WARN    main    lotus-worker/main.go:115 Interrupted by user:
    main.glob..func6
        /root/lotus/cmd/lotus-worker/main.go:352
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
