### PR TITLE
feat: miner: defensive check for equivocation

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -594,7 +594,7 @@ func (m *Miner) mineOne(ctx context.Context, base *MiningBase) (minedBlock *type
 			}
 		}
 
-		if len(refreshedBaseBlocks) != len(base.TipSet.Blocks()) {
+		if len(refreshedBaseBlocks) != 0 && len(refreshedBaseBlocks) != len(base.TipSet.Blocks()) {
 			refreshedBase, err := types.NewTipSet(refreshedBaseBlocks)
 			if err != nil {
 				err = xerrors.Errorf("failed to create new tipset when refreshing: %w", err)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@Stebalien was concerned that this could cause miners to fail to produce blocks when if they see a reorg of height > 1 partway through the mining loop. The issue is that if the tipset at the height of the base's parent changes, the intersection between old and new base MUST be null, and the miner will fail.

## Proposed Changes
<!-- A clear list of the changes being made -->

Weaken the check against equivocation a little -- if the intersection is null, just use the old base (even though it risks "allowing" some equivocation.).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
