### PR TITLE
chore: release: Set calibration upgrade height

### DIFF
--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -79,8 +79,8 @@ const UpgradeLightningHeight = 489094
 // 2023-04-21T16:00:00Z
 const UpgradeThunderHeight = UpgradeLightningHeight + 3120
 
-// ??????????
-const UpgradeWatermelonHeight = 999999999999999
+// 2023-10-19T13:00:00Z
+const UpgradeWatermelonHeight = 1013200
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -80,7 +80,7 @@ const UpgradeLightningHeight = 489094
 const UpgradeThunderHeight = UpgradeLightningHeight + 3120
 
 // 2023-10-19T13:00:00Z
-const UpgradeWatermelonHeight = 1013200
+const UpgradeWatermelonHeight = 1013134
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,


### PR DESCRIPTION
## Proposed Changes
Set the calibration upgrade height to `epoch 1013200`. Which should be equal to:
- 13:00 UTC on October 19th, 2023
   - 6:00 AM in Los Angeles - 2:00 PM in London - 9:00 PM in Beijing

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
