### PR TITLE
storage: Return soft err when sector alloc fails in acquire

### DIFF
--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -548,7 +548,7 @@ func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, exi
 		}
 
 		if best == "" {
-			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("couldn't find a suitable path for a sector")
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, storiface.Err(storiface.ErrTempAllocateSpace, xerrors.Errorf("couldn't find a suitable path for a sector"))
 		}
 
 		storiface.SetPathByType(&out, fileType, best)

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -232,6 +232,7 @@ func retrySoftErr(ctx context.Context, cb func() error) error {
 				fallthrough
 			case storiface.ErrTempAllocateSpace:
 				// retry
+				log.Errorw("retrying soft error", "err", err, "code", cerr.ErrCode())
 			default:
 				// non-temp error
 				return err


### PR DESCRIPTION
## Related Issues
#11087 is missing one case making it possible that some sectors will get removed when SP pipelines are under heavy load

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
Example logs before
```
3.	2023-10-17 03:04:43 +0200 CEST:	[event;sealing.SectorStartPacking]	{"User":{}}
4.	2023-10-17 03:04:43 +0200 CEST:	[event;sealing.SectorPacked]	{"User":{"FillerPieces":null}}
5.	2023-10-17 03:04:43 +0200 CEST:	[event;sealing.SectorTicket]	{"User":{"TicketValue":"ai7dVU55W2rBSUfblw+o8f81YfGyIWKjQu8eSV1KibA=","TicketEpoch":3305709}}
6.	2023-10-17 03:16:38 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector [name: okonomiyaki]: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector
7.	2023-10-17 03:17:38 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
8.	2023-10-17 04:30:32 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector [name: okonomiyaki]: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector
9.	2023-10-17 04:31:32 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
10.	2023-10-17 04:44:06 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector [name: okonomiyaki]: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector
11.	2023-10-17 04:45:06 +0200 CEST:	[event;sealing.SectorRetrySealPreCommit1]	{"User":{}}
12.	2023-10-17 05:05:54 +0200 CEST:	[event;sealing.SectorSealPreCommit1Failed]	{"User":{}}
	seal pre commit(1) failed: storage call error 0: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector [name: okonomiyaki]: acquiring sector paths: local acquire error: couldn't find a suitable path for a sector
13.	2023-10-17 05:05:54 +0200 CEST:	[event;sealing.SectorRemove]	{"User":{}}
14.	2023-10-17 05:05:55 +0200 CEST:	[event;sealing.SectorRemoved]	{"User":{}}
```

TODO:
- [ ] Try to repro on a real setup, look for the new `retrying soft error`

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
