### PR TITLE
feat: api: add an FEVM events threshold start epoch configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Improvements
 - fix: Add time slicing to splitstore purging step during compaction to reduce lock congestion [filecoin-project/lotus#11269](https://github.com/filecoin-project/lotus/pull/11269)
 - feat: Added instructions on how to setup Prometheus/Grafana for monitoring a local Lotus node [filecoin-project/lotus#11276](https://github.com/filecoin-project/lotus/pull/11276)
+- feat: Add a `FilterThresholdEpoch` configuration option [filecoin-project/lotus#11346](https://github.com/filecoin-project/lotus/pull/11346)
 
 ## New features
 - feat: Add move-partition command ([filecoin-project/lotus#11290](https://github.com/filecoin-project/lotus/pull/11290))

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -17,7 +17,7 @@
 [Backup]
   # When set to true disables metadata log (.lotus/kvlog). This can save disk
   # space by reducing metadata redundancy.
-  # 
+  #
   # Note that in case of metadata corruption it might be much harder to recover
   # your node if metadata log is disabled
   #
@@ -379,6 +379,21 @@
     # type: uint64
     # env var: LOTUS_FEVM_EVENTS_MAXFILTERHEIGHTRANGE
     #MaxFilterHeightRange = 2880
+
+    # FilterThresholdSet signals whether a FilterThresholdEpoch is set. If it is it will be used instead of
+    # MaxFilterHeightRange to define the supported range.
+    #
+    # type: bool
+    # env var: LOTUS_FEVM_EVENTS_FILTERTHRESHOLDSET
+    #FilterThresholdSet = false
+
+    # FilterThresholdEpoch specifies an epoch above which the node will support returning filtered logs.
+    # This is useful for setting a static start epoch for support, rather than a static window size with a start epoch
+    # that shifts as the chain progresses.
+    #
+    # type: uint64
+    # env var: LOTUS_FEVM_EVENTS_FILTERTHRESHOLDEPOCH
+    #FilterThresholdEpoch = 2683348
 
     # DatabasePath is the full path to a sqlite database that will be used to index actor events to
     # support the historic filter APIs. If the database does not exist it will be created. The directory containing

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -17,7 +17,7 @@
 [Backup]
   # When set to true disables metadata log (.lotus/kvlog). This can save disk
   # space by reducing metadata redundancy.
-  #
+  # 
   # Note that in case of metadata corruption it might be much harder to recover
   # your node if metadata log is disabled
   #

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -116,7 +116,9 @@ func DefaultFullNode() *FullNode {
 				FilterTTL:                Duration(time.Hour * 24),
 				MaxFilters:               100,
 				MaxFilterResults:         10000,
-				MaxFilterHeightRange:     2880, // conservative limit of one day
+				MaxFilterHeightRange:     2880,    // conservative limit of one day
+				FilterThresholdSet:       false,   // use MaxFilterHeightRange by default
+				FilterThresholdEpoch:     2683348, // FEVM start epoch
 			},
 		},
 	}

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -385,6 +385,21 @@ this time become eligible for automatic deletion.`,
 the entire chain)`,
 		},
 		{
+			Name: "FilterThresholdSet",
+			Type: "bool",
+
+			Comment: `FilterThresholdSet signals whether a FilterThresholdEpoch is set. If it is it will be used instead of
+MaxFilterHeightRange to define the supported range.`,
+		},
+		{
+			Name: "FilterThresholdEpoch",
+			Type: "uint64",
+
+			Comment: `FilterThresholdEpoch specifies an epoch above which the node will support returning filtered logs.
+This is useful for setting a static start epoch for support, rather than a static window size with a start epoch
+that shifts as the chain progresses.`,
+		},
+		{
 			Name: "DatabasePath",
 			Type: "string",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -717,6 +717,16 @@ type Events struct {
 	// the entire chain)
 	MaxFilterHeightRange uint64
 
+	// FilterThresholdSet signals whether a FilterThresholdEpoch is set. If it is it will be used instead of
+	// MaxFilterHeightRange to define the supported range.
+	FilterThresholdSet bool
+
+	// FilterThresholdEpoch specifies an epoch above which the node will support returning filtered logs.
+	// This is useful for setting a static start epoch for support, rather than a static window size with a start epoch
+	// that shifts as the chain progresses.
+	FilterThresholdEpoch uint64
+
+
 	// DatabasePath is the full path to a sqlite database that will be used to index actor events to
 	// support the historic filter APIs. If the database does not exist it will be created. The directory containing
 	// the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -726,7 +726,6 @@ type Events struct {
 	// that shifts as the chain progresses.
 	FilterThresholdEpoch uint64
 
-
 	// DatabasePath is the full path to a sqlite database that will be used to index actor events to
 	// support the historic filter APIs. If the database does not exist it will be created. The directory containing
 	// the database must already exist and be writeable. If a relative path is provided here, sqlite treats it as

--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -40,7 +40,7 @@ func EthEventAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo
 		ee := &full.EthEvent{
 			Chain:                cs,
 			MaxFilterHeightRange: abi.ChainEpoch(cfg.Events.MaxFilterHeightRange),
-			FilterThresholdSet:  cfg.Events.FilterThresholdSet,
+			FilterThresholdSet:   cfg.Events.FilterThresholdSet,
 			FilterThresholdEpoch: abi.ChainEpoch(cfg.Events.FilterThresholdEpoch),
 			SubscribtionCtx:      ctx,
 		}

--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -40,6 +40,8 @@ func EthEventAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo
 		ee := &full.EthEvent{
 			Chain:                cs,
 			MaxFilterHeightRange: abi.ChainEpoch(cfg.Events.MaxFilterHeightRange),
+			FilterThresholdSet:  cfg.Events.FilterThresholdSet,
+			FilterThresholdEpoch: abi.ChainEpoch(cfg.Events.FilterThresholdEpoch),
 			SubscribtionCtx:      ctx,
 		}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
This is a QoL addition for FEVM RPC providers. As a node operator serving FEVM data it is useful to be able to define a static starting epoch at which we begin supporting returning filtered log events, e.g. at the epoch where a specific contract was deployed. This is in contrast to the existing `MaxFilterHeightRange` configuration parameter which defines a static range size such that as the chain progresses the supported starting epoch of this window shifts forward.

## Proposed Changes
<!-- A clear list of the changes being made -->
Add and wire in two new configuration parameters:
1. `FilterThresholdEpoch` a uint64 which defines a specific epoch at and above which the node will support returning log events.
2. `FilterThresholdSet` a bool which specifies that the node should use `FilterThresholdEpoch` to define the supported log events range instead of using the moving window defined by `MaxFilterHeightRange`. 

`MaxFilterHeightRange` is left as the default configuration.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green (failing test appears to be some CI finickyness)
