### PR TITLE
opt: use method to obtain miner sector expiration

### DIFF
--- a/storage/pipeline/precommit_policy.go
+++ b/storage/pipeline/precommit_policy.go
@@ -127,7 +127,7 @@ func (p *BasicPreCommitPolicy) getCCSectorLifetime(nv network.Version) (abi.Chai
 		ccLifetimeEpochs = maxCommitment
 	}
 
-	if minExpiration := abi.ChainEpoch(policy.GetMinSectorExpiration()); ccLifetimeEpochs < minExpiration {
+	if minExpiration := policy.GetMinSectorExpiration(); ccLifetimeEpochs < minExpiration {
 		log.Warnf("value for CommittedCapacitySectorLiftime is too short, using default minimum (%d epochs)", minExpiration)
 		return minExpiration, nil
 	}

--- a/storage/pipeline/precommit_policy.go
+++ b/storage/pipeline/precommit_policy.go
@@ -127,7 +127,7 @@ func (p *BasicPreCommitPolicy) getCCSectorLifetime(nv network.Version) (abi.Chai
 		ccLifetimeEpochs = maxCommitment
 	}
 
-	if minExpiration := abi.ChainEpoch(miner.MinSectorExpiration); ccLifetimeEpochs < minExpiration {
+	if minExpiration := abi.ChainEpoch(policy.GetMinSectorExpiration()); ccLifetimeEpochs < minExpiration {
 		log.Warnf("value for CommittedCapacitySectorLiftime is too short, using default minimum (%d epochs)", minExpiration)
 		return minExpiration, nil
 	}

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -395,7 +395,7 @@ func (m *Sealing) preCommitInfo(ctx statemachine.Context, sector SectorInfo) (*m
 		return nil, big.Zero(), types.EmptyTSK, ctx.Send(SectorSealPreCommit1Failed{xerrors.Errorf("failed to get max prove commit duration: %w", err)})
 	}
 
-	if minExpiration := sector.TicketEpoch + policy.MaxPreCommitRandomnessLookback + msd + miner.MinSectorExpiration; expiration < minExpiration {
+	if minExpiration := sector.TicketEpoch + policy.MaxPreCommitRandomnessLookback + msd + policy.GetMinSectorExpiration(); expiration < minExpiration {
 		expiration = minExpiration
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

use method `GetMinSectorExpiration ` to obtain miner sector expiration

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
