### PR TITLE
chore: backport 11338 onto release/v1.25.0

### DIFF
--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -548,7 +548,7 @@ func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, exi
 		}
 
 		if best == "" {
-			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("couldn't find a suitable path for a sector")
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, storiface.Err(storiface.ErrTempAllocateSpace, xerrors.Errorf("couldn't find a suitable path for a sector"))
 		}
 
 		storiface.SetPathByType(&out, fileType, best)

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -232,6 +232,7 @@ func retrySoftErr(ctx context.Context, cb func() error) error {
 				fallthrough
 			case storiface.ErrTempAllocateSpace:
 				// retry
+				log.Errorw("retrying soft error", "err", err, "code", cerr.ErrCode())
 			default:
 				// non-temp error
 				return err


### PR DESCRIPTION
## Related Issues
#11338 

## Proposed Changes
https://github.com/filecoin-project/lotus/pull/11087 (currently in release/v1.25.0) was missing one error-case, making it possible that some sectors will get removed when SP pipelines are under heavy load. This backport ensures that a soft err  is returned when sector alloc fails in acquire.

## Additional Info
Testing: https://github.com/filecoin-project/lotus/pull/11338#issuecomment-1768583993

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
