### PR TITLE
refactor:ffi: replace ClearLayerData with ClearCache

### DIFF
--- a/storage/sealer/ffiwrapper/sealer_cgo.go
+++ b/storage/sealer/ffiwrapper/sealer_cgo.go
@@ -928,7 +928,7 @@ func (sb *Sealer) SealPreCommit2(ctx context.Context, sector storiface.SectorRef
 				return storiface.SectorCids{}, xerrors.Errorf("generate synth proofs: %w", err)
 			}
 
-			if err = ffi.ClearCache(ssize, paths.Cache); err != nil {
+			if err = ffi.ClearCache(uint64(ssize), paths.Cache); err != nil {
 				log.Warn("failed to GenerateSynthProofs(): ", err)
 				log.Warnf("num:%d tkt:%v, sealedCID:%v, unsealedCID:%v", sector.ID.Number, ticket, sealedCID, unsealedCID)
 				return storiface.SectorCids{

--- a/storage/sealer/ffiwrapper/sealer_cgo.go
+++ b/storage/sealer/ffiwrapper/sealer_cgo.go
@@ -928,7 +928,7 @@ func (sb *Sealer) SealPreCommit2(ctx context.Context, sector storiface.SectorRef
 				return storiface.SectorCids{}, xerrors.Errorf("generate synth proofs: %w", err)
 			}
 
-			if err = ffi.ClearLayerData(ssize, paths.Cache); err != nil {
+			if err = ffi.ClearCache(ssize, paths.Cache); err != nil {
 				log.Warn("failed to GenerateSynthProofs(): ", err)
 				log.Warnf("num:%d tkt:%v, sealedCID:%v, unsealedCID:%v", sector.ID.Number, ticket, sealedCID, unsealedCID)
 				return storiface.SectorCids{


### PR DESCRIPTION

## Related Issues

API surface reduction.

## Proposed Changes

The `ClearLayerData` FFI call was accidentally introduced with the Synthetic PoRep. The call does under the hood exactly what `ClearCache` is doing. This is a first step to remove `ClearLayerData`t also from the FFI again, in order to reduce the API surface.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
