### PR TITLE
feat: sealing: load SectorsSummary from sealing SectorStats instead of calling API each time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 - chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
 - feat: metric: export Mpool message count ([filecoin-project/lotus#11361](https://github.com/filecoin-project/lotus/pull/11361))
+- feat: sealing: load SectorsSummary from sealing SectorStats instead of calling API each time ([filecoin-project/lotus#11353](https://github.com/filecoin-project/lotus/pull/11353))
 
 ## New features
 - feat: Added new tracing API (**HIGHLY EXPERIMENTAL**) supporting two RPC methods: `trace_block` and `trace_replayBlockTransactions` ([filecoin-project/lotus#11100](https://github.com/filecoin-project/lotus/pull/11100))

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -338,15 +338,7 @@ func (sm *StorageMinerAPI) SectorsListInStates(ctx context.Context, states []api
 
 // Use SectorsSummary from stats (prometheus) for faster result
 func (sm *StorageMinerAPI) SectorsSummary(ctx context.Context) (map[api.SectorState]int, error) {
-	sectorStats := sm.Miner.SectorsSummary(ctx)
-	out := make(map[api.SectorState]int)
-
-	for st, count := range sectorStats {
-		state := api.SectorState(st)
-		out[state] = int(count)
-	}
-
-	return out, nil
+	return sm.Miner.SectorsSummary(ctx), nil
 }
 
 func (sm *StorageMinerAPI) StorageLocal(ctx context.Context) (map[storiface.ID]string, error) {

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -336,16 +336,14 @@ func (sm *StorageMinerAPI) SectorsListInStates(ctx context.Context, states []api
 	return sns, nil
 }
 
+// Use SectorsSummary from stats (prometheus) for faster result
 func (sm *StorageMinerAPI) SectorsSummary(ctx context.Context) (map[api.SectorState]int, error) {
-	sectors, err := sm.Miner.ListSectors()
-	if err != nil {
-		return nil, err
-	}
-
+	sectorStats := sm.Miner.SectorsSummary(ctx)
 	out := make(map[api.SectorState]int)
-	for i := range sectors {
-		state := api.SectorState(sectors[i].State)
-		out[state]++
+
+	for st, count := range sectorStats {
+		state := api.SectorState(st)
+		out[state] = int(count)
 	}
 
 	return out, nil

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -304,6 +304,10 @@ func (m *Sealing) TerminateSector(ctx context.Context, sid abi.SectorNumber) err
 	return m.sectors.Send(uint64(sid), SectorTerminate{})
 }
 
+func (m *Sealing) SectorsSummary(ctx context.Context) map[SectorState]int64 {
+	return m.stats.byState
+}
+
 func (m *Sealing) TerminateFlush(ctx context.Context) (*cid.Cid, error) {
 	return m.terminator.Flush(ctx)
 }

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -304,8 +304,18 @@ func (m *Sealing) TerminateSector(ctx context.Context, sid abi.SectorNumber) err
 	return m.sectors.Send(uint64(sid), SectorTerminate{})
 }
 
-func (m *Sealing) SectorsSummary(ctx context.Context) map[SectorState]int64 {
-	return m.stats.byState
+func (m *Sealing) SectorsSummary(ctx context.Context) map[api.SectorState]int {
+	m.stats.lk.Lock()
+	defer m.stats.lk.Unlock()
+
+	out := make(map[api.SectorState]int)
+
+	for st, count := range m.stats.byState {
+		state := api.SectorState(st)
+		out[state] = int(count)
+	}
+
+	return out
 }
 
 func (m *Sealing) TerminateFlush(ctx context.Context) (*cid.Cid, error) {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/boost/issues/1733
https://github.com/filecoin-project/boost/issues/1747
(**summary of these issues is available in `Additional Info` below**)

## Proposed Changes
Based on the discussions in the two issues mentioned above, and initial issue by @ze42 and @cryptowhizzard, I propose to retrieve the information from the stats (prometheus) rather than from the API. 

This PR was quickly discussed by @s0nik42 with @magik6k, and here is a list of changes mades:

- Create a method in `Sealing` called `SectorsSummary` in order to return the stats by states available in `SectorStats`
- Update the SectorsSummary method in StorageMinerAPI, to use the previous method. This allows to return the result more quickly (already updated with each state modification), and to avoid recalculating it from the list of sectors each time.

## Additional Info
This is a quick summary to explain the why and why of this change

1. I provide this change, because @cryptowhizzard report a boost issue when receiving 200+ online deals.
2. After some investigations, the problem is caused by the deal filter, that need to compute a lot of info = massive delays.
3. Going deeper into the deal filter code, the call that causes this delay is `SectorsSummary`, that will fill the proposal `SealingPipelineState.SectorStates`, because it iterates over all sectors to compute the states
4. This call can be very slow, espececially on 30 PB+ like @cryptowhizzard 
5. But the sector states are already available in Prometheus, each time a sector is updated
6. This change proposes to get them directly from Prometheus, in order to drastically reduce the delays

Once this is done, our wish with CIDgravity is to add information in the proposal, information available on boost directly (checkpoints, [see issue #1747 here](https://github.com/filecoin-project/boost/issues/1747))

## Checklist
Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
