### PR TITLE
fix: api: compute gasUsedRatio based on max gas in the tipset

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -733,10 +733,11 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 		}
 
 		rewards, totalGasUsed := calculateRewardsAndGasUsed(rewardPercentiles, txGasRewards)
+		maxGas := build.BlockGasLimit * int64(len(ts.Blocks()))
 
 		// arrays should be reversed at the end
 		baseFeeArray = append(baseFeeArray, ethtypes.EthBigInt(basefee))
-		gasUsedRatioArray = append(gasUsedRatioArray, float64(totalGasUsed)/float64(build.BlockGasLimit))
+		gasUsedRatioArray = append(gasUsedRatioArray, float64(totalGasUsed)/float64(maxGas))
 		rewardsArray = append(rewardsArray, rewards)
 		oldestBlkHeight = uint64(ts.Height())
 		blocksIncluded++


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes #10515

## Proposed Changes
<!-- A clear list of the changes being made -->

When computing the `gasUsedRatio` in the Ethereum JSON-RPC APIs use `MaxBlockGas * len(TipSet)`, instead of the max block gas. Otherwise, we get ratios over 1.

The new value isn't entirely correct either (we should probably compute an average of the gas used in each block in the tipset?), but it's good enough.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green