### PR TITLE
fix: alert: Check UDPbuffer-size

### DIFF
--- a/node/builder.go
+++ b/node/builder.go
@@ -90,6 +90,7 @@ const (
 	// health checks
 	CheckFDLimit
 	CheckFvmConcurrency
+	CheckUDPBufferSize
 	LegacyMarketsEOL
 
 	// libp2p
@@ -169,6 +170,7 @@ func defaults() []Option {
 
 		Override(CheckFDLimit, modules.CheckFdLimit(build.DefaultFDLimit)),
 		Override(CheckFvmConcurrency, modules.CheckFvmConcurrency()),
+		Override(CheckUDPBufferSize, modules.CheckUDPBufferSize(2048*1024)),
 
 		Override(new(system.MemoryConstraints), modules.MemoryConstraints),
 		Override(InitMemoryWatchdog, modules.MemoryWatchdog),

--- a/node/modules/alerts.go
+++ b/node/modules/alerts.go
@@ -1,8 +1,10 @@
 package modules
 
 import (
+	"net"
 	"os"
 	"strconv"
+	"syscall"
 
 	"github.com/filecoin-project/lotus/journal/alerting"
 	"github.com/filecoin-project/lotus/lib/ulimit"
@@ -30,6 +32,61 @@ func CheckFdLimit(min uint64) func(al *alerting.Alerting) {
 				"message":         "soft FD limit is low",
 				"soft_limit":      soft,
 				"recommended_min": min,
+			})
+		}
+	}
+}
+
+func CheckUDPBufferSize(wanted int) func(al *alerting.Alerting) {
+	return func(al *alerting.Alerting) {
+		conn, err := net.Dial("udp", "localhost:0")
+		if err != nil {
+			alert := al.AddAlertType("process", "udp-buffer-size")
+			al.Raise(alert, map[string]string{
+				"message": "Failed to create UDP connection",
+				"error":   err.Error(),
+			})
+			return
+		}
+		defer conn.Close()
+
+		udpConn, ok := conn.(*net.UDPConn)
+		if !ok {
+			alert := al.AddAlertType("process", "udp-buffer-size")
+			al.Raise(alert, map[string]string{
+				"message": "Failed to cast connection to UDPConn",
+			})
+			return
+		}
+
+		file, err := udpConn.File()
+		if err != nil {
+			alert := al.AddAlertType("process", "udp-buffer-size")
+			al.Raise(alert, map[string]string{
+				"message": "Failed to get file descriptor from UDPConn",
+				"error":   err.Error(),
+			})
+			return
+		}
+		defer file.Close()
+
+		size, err := syscall.GetsockoptInt(int(file.Fd()), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		if err != nil {
+			alert := al.AddAlertType("process", "udp-buffer-size")
+			al.Raise(alert, map[string]string{
+				"message": "Failed to get UDP buffer size",
+				"error":   err.Error(),
+			})
+			return
+		}
+
+		if size < wanted {
+			alert := al.AddAlertType("process", "udp-buffer-size")
+			al.Raise(alert, map[string]interface{}{
+				"message":      "UDP buffer size is low",
+				"current_size": size,
+				"wanted_size":  wanted,
+				"help":         "See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.",
 			})
 		}
 	}


### PR DESCRIPTION
## Related Issues
Closes #11289 

## Proposed Changes
In Lotus today, you will encounter this error on startup if the UDP Buffer size is lower than 2048 KiB.
```
2023/10/28 11:53:26 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
```

This PR adds it as an alert in the `lotus info` system:

```
lotus log alerts
active   process:udp-buffer-size
         last raised at 2023-10-30 05:46:32.415 -0400 EDT; reason: {"current_size":212992,"help":"See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.","message":"UDP buffer size is low","wanted_size":2097152}
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
