### PR TITLE
fix: eth: correctly encode and simplify native input/output encoding

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -948,10 +948,7 @@ func (a *EthModule) EthTraceReplayBlockTransactions(ctx context.Context, blkNum 
 				return nil, xerrors.Errorf("failed to decode payload: %w", err)
 			}
 		} else {
-			output, err = encodeFilecoinReturnAsABI(ir.ExecutionTrace.MsgRct.ExitCode, ir.ExecutionTrace.MsgRct.ReturnCodec, ir.ExecutionTrace.MsgRct.Return)
-			if err != nil {
-				return nil, xerrors.Errorf("could not convert output: %w", err)
-			}
+			output = encodeFilecoinReturnAsABI(ir.ExecutionTrace.MsgRct.ExitCode, ir.ExecutionTrace.MsgRct.ReturnCodec, ir.ExecutionTrace.MsgRct.Return)
 		}
 
 		t := ethtypes.EthTraceReplayBlockTransaction{

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -948,7 +948,7 @@ func (a *EthModule) EthTraceReplayBlockTransactions(ctx context.Context, blkNum 
 				return nil, xerrors.Errorf("failed to decode payload: %w", err)
 			}
 		} else {
-			output, err = handleFilecoinMethodOutput(ir.ExecutionTrace.MsgRct.ExitCode, ir.ExecutionTrace.MsgRct.ReturnCodec, ir.ExecutionTrace.MsgRct.Return)
+			output, err = encodeFilecoinReturnAsABI(ir.ExecutionTrace.MsgRct.ExitCode, ir.ExecutionTrace.MsgRct.ReturnCodec, ir.ExecutionTrace.MsgRct.Return)
 			if err != nil {
 				return nil, xerrors.Errorf("could not convert output: %w", err)
 			}

--- a/node/impl/full/eth_test.go
+++ b/node/impl/full/eth_test.go
@@ -1,6 +1,7 @@
 package full
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -161,4 +162,18 @@ func TestRewardPercentiles(t *testing.T) {
 		require.Equal(t, len(ans), len(tc.percentiles))
 		require.Equal(t, ans, rewards)
 	}
+}
+
+func TestABIEncoding(t *testing.T) {
+	// Generated from https://abi.hashex.org/
+	const expected = "000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000510000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001b1111111111111111111020200301000000044444444444444444010000000000"
+	const data = "111111111111111111102020030100000004444444444444444401"
+
+	expectedBytes, err := hex.DecodeString(expected)
+	require.NoError(t, err)
+
+	dataBytes, err := hex.DecodeString(data)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedBytes, encodeAsABIHelper(22, 81, dataBytes))
 }

--- a/node/impl/full/eth_trace.go
+++ b/node/impl/full/eth_trace.go
@@ -124,11 +124,11 @@ func buildTraces(ctx context.Context, traces *[]*ethtypes.EthTrace, parent *etht
 	} else {
 		// we are going to assume a native method, but we may change it in one of the edge cases below
 		// TODO: only do this if we know it's a native method (optimization)
-		trace.Action.Input, err = handleFilecoinMethodInput(et.Msg.Method, et.Msg.ParamsCodec, et.Msg.Params)
+		trace.Action.Input, err = encodeFilecoinParamsAsABI(et.Msg.Method, et.Msg.ParamsCodec, et.Msg.Params)
 		if err != nil {
 			return xerrors.Errorf("buildTraces: %w", err)
 		}
-		trace.Result.Output, err = handleFilecoinMethodOutput(et.MsgRct.ExitCode, et.MsgRct.ReturnCodec, et.MsgRct.Return)
+		trace.Result.Output, err = encodeFilecoinReturnAsABI(et.MsgRct.ExitCode, et.MsgRct.ReturnCodec, et.MsgRct.Return)
 		if err != nil {
 			return xerrors.Errorf("buildTraces: %w", err)
 		}
@@ -288,66 +288,4 @@ func writePadded(w io.Writer, data any, size int) error {
 	}
 
 	return nil
-}
-
-func handleFilecoinMethodInput(method abi.MethodNum, codec uint64, params []byte) ([]byte, error) {
-	NATIVE_METHOD_SELECTOR := []byte{0x86, 0x8e, 0x10, 0xc4}
-	EVM_WORD_SIZE := 32
-
-	staticArgs := []uint64{
-		uint64(method),
-		codec,
-		uint64(EVM_WORD_SIZE) * 3,
-		uint64(len(params)),
-	}
-	totalWords := len(staticArgs) + (len(params) / EVM_WORD_SIZE)
-	if len(params)%EVM_WORD_SIZE != 0 {
-		totalWords++
-	}
-	len := 4 + totalWords*EVM_WORD_SIZE
-
-	w := &bytes.Buffer{}
-	err := binary.Write(w, binary.BigEndian, NATIVE_METHOD_SELECTOR)
-	if err != nil {
-		return nil, fmt.Errorf("handleFilecoinMethodInput: failed writing method selector: %w", err)
-	}
-
-	for _, arg := range staticArgs {
-		err := writePadded(w, arg, 32)
-		if err != nil {
-			return nil, fmt.Errorf("handleFilecoinMethodInput: %w", err)
-		}
-	}
-	err = binary.Write(w, binary.BigEndian, params)
-	if err != nil {
-		return nil, fmt.Errorf("handleFilecoinMethodInput: failed writing params: %w", err)
-	}
-	remain := len - w.Len()
-	for i := 0; i < remain; i++ {
-		err = binary.Write(w, binary.BigEndian, uint8(0))
-		if err != nil {
-			return nil, fmt.Errorf("handleFilecoinMethodInput: failed writing tailing zeros: %w", err)
-		}
-	}
-
-	return w.Bytes(), nil
-}
-
-func handleFilecoinMethodOutput(exitCode exitcode.ExitCode, codec uint64, data []byte) ([]byte, error) {
-	w := &bytes.Buffer{}
-
-	values := []interface{}{uint32(exitCode), codec, uint32(w.Len()), uint32(len(data))}
-	for _, v := range values {
-		err := writePadded(w, v, 32)
-		if err != nil {
-			return nil, fmt.Errorf("handleFilecoinMethodOutput: %w", err)
-		}
-	}
-
-	err := binary.Write(w, binary.BigEndian, data)
-	if err != nil {
-		return nil, fmt.Errorf("handleFilecoinMethodOutput: failed writing data: %w", err)
-	}
-
-	return w.Bytes(), nil
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

When generating eth traces, we encode "native" message inputs/outputs to "solidity ABI" by formatting the inputs/outputs the same way we do in FEVM's "handle_native_method". However, we had quite a few bugs with the implementation:

1. We were right-aligning 64bit values in 256bit words, instead of left-aligning (as we should given that these values are big-endian).
2. The return-value encoding wasn't correctly handling lengths.

This patch:

1. Fixes those bugs.
2. Deduplicates the logic (we're doing _basically_ the same thing in both cases).
3. Removes all error paths (these functions can't fail).

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - bug in unreleased (I think) code
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green