### PR TITLE
chore: build: Sanity-check calibraiton patch on butterfly

### DIFF
--- a/build/builtin_actors.go
+++ b/build/builtin_actors.go
@@ -46,7 +46,7 @@ func init() {
 	// The following code cid existed temporarily on the calibnet testnet, as a "buggy" storage miner actor implementation.
 	// We include it in our builtin bundle, but intentionally omit from metadata.
 	if NetworkBundle == "butterflynet" {
-		actors.AddActorMeta("storageminer", cid.MustParse("bafy2bzaceb7s3k6zyuubqil7s2rwdcdyslqqx2fn2cj536yh3hexlyi4syyk6"), actorstypes.Version12)
+		actors.AddActorMeta("storageminer", cid.MustParse("bafk2bzaceaaztuglvw6pw5xohwfekbw47iyugbyftxrp6hwygsaiu6rebtcty"), actorstypes.Version12)
 	}
 }
 

--- a/build/builtin_actors.go
+++ b/build/builtin_actors.go
@@ -45,8 +45,8 @@ func init() {
 
 	// The following code cid existed temporarily on the calibnet testnet, as a "buggy" storage miner actor implementation.
 	// We include it in our builtin bundle, but intentionally omit from metadata.
-	if NetworkBundle == "calibrationnet" {
-		actors.AddActorMeta("storageminer", cid.MustParse("bafk2bzacecnh2ouohmonvebq7uughh4h3ppmg4cjsk74dzxlbbtlcij4xbzxq"), actorstypes.Version12)
+	if NetworkBundle == "butterflynet" {
+		actors.AddActorMeta("storageminer", cid.MustParse("bafy2bzaceb7s3k6zyuubqil7s2rwdcdyslqqx2fn2cj536yh3hexlyi4syyk6"), actorstypes.Version12)
 	}
 }
 

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -57,8 +57,8 @@ const UpgradeThunderHeight = -23
 
 const UpgradeWatermelonHeight = 400
 
-// This fix upgrade only ran on calibrationnet
-const UpgradeWatermelonFixHeight = -100
+// Sanity-check on Butterflynet
+const UpgradeWatermelonFixHeight = 17311
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg512MiBV1,

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -1922,20 +1922,20 @@ func upgradeActorsV12Common(
 	}
 
 	var manifestCid cid.Cid
-	if initState.NetworkName == "calibrationnet" {
-		embedded, ok := build.GetEmbeddedBuiltinActorsBundle(actorstypes.Version12, "calibrationnet-buggy")
+	if initState.NetworkName == "butterflynet" {
+		embedded, ok := build.GetEmbeddedBuiltinActorsBundle(actorstypes.Version12, "butterflynet-buggy")
 		if !ok {
-			return cid.Undef, xerrors.Errorf("didn't find buggy calibrationnet bundle")
+			return cid.Undef, xerrors.Errorf("didn't find buggy butterflynet bundle")
 		}
 
 		var err error
 		manifestCid, err = bundle.LoadBundle(ctx, writeStore, bytes.NewReader(embedded))
 		if err != nil {
-			return cid.Undef, xerrors.Errorf("failed to load buggy calibnet bundle: %w", err)
+			return cid.Undef, xerrors.Errorf("failed to load buggy butterflynet bundle: %w", err)
 		}
 
 		if manifestCid != calibnetv12BuggyBundle {
-			return cid.Undef, xerrors.Errorf("didn't find expected buggy calibnet bundle manifest: %s != %s", manifestCid, calibnetv12BuggyBundle)
+			return cid.Undef, xerrors.Errorf("didn't find expected buggy butterfly bundle manifest: %s != %s", manifestCid, calibnetv12BuggyBundle)
 		}
 	} else {
 		ok := false
@@ -1976,7 +1976,7 @@ func upgradeActorsV12Common(
 
 //////////////////////
 
-var calibnetv12BuggyMinerCID = cid.MustParse("bafk2bzacecnh2ouohmonvebq7uughh4h3ppmg4cjsk74dzxlbbtlcij4xbzxq")
+var Butterflyv12BuggyMinerCID = cid.MustParse("bafk2bzaceaaztuglvw6pw5xohwfekbw47iyugbyftxrp6hwygsaiu6rebtcty")
 
 func upgradeActorsV12Fix(ctx context.Context, sm *stmgr.StateManager, cache stmgr.MigrationCache, cb stmgr.ExecMonitor,
 	root cid.Cid, epoch abi.ChainEpoch, ts *types.TipSet) (cid.Cid, error) {
@@ -2086,7 +2086,7 @@ func upgradeActorsV12Fix(ctx context.Context, sm *stmgr.StateManager, cache stmg
 		}
 
 		// This is the hard-coded "buggy" miner actor Code ID
-		if inActor.Code != calibnetv12BuggyMinerCID && inActor.Code != outActor.Code {
+		if inActor.Code != Butterflyv12BuggyMinerCID && inActor.Code != outActor.Code {
 			return xerrors.Errorf("unexpected change in code for actor %s", a)
 		}
 


### PR DESCRIPTION
**Do not merge!**

## Proposed Changes
Sanity-check the Code-CID migration path on Butterfly-network. The Butterfly-network was reset last week, to be in the same state as Calibration-network (rotten Watermelon), this PR aims to sanity check that the Code CID-migration works.

Current bundle on Butterfly:

```
lotus state actor-cids
Network Version: 21
Actor Version: 12
Manifest CID: bafy2bzaceb7s3k6zyuubqil7s2rwdcdyslqqx2fn2cj536yh3hexlyi4syyk6

Actor             CID  
storagemarket     bafk2bzaceb2tdeqtt2eqpzeb3gezuchb7g7uzbd52bgvcdt6bg3ckq7oisb74
storageminer      bafk2bzaceaaztuglvw6pw5xohwfekbw47iyugbyftxrp6hwygsaiu6rebtcty
system            bafk2bzacec3vwj2chzaram3iqupkbfiein5h2l5qiltlrngbju2vg5umelclm
verifiedregistry  bafk2bzacedv2irkql7nil3w5v3ohqq3e54w62pxeoppjmaktzokolaaoh5ksu
eam               bafk2bzacebzwt4v4hqoltiblhliwrnttxpr2dggbu3wsrvq4pwzisp7idu5w4
init              bafk2bzaceagyf3pwsthod7klfi25ow2zf2i5isfrrgr5ua3lvkgfojalrdbhw
multisig          bafk2bzacedgfo5mw2zqjwi37lah27sfxj4cw2abylgtxf3ucep4dyhgnppmqe
reward            bafk2bzacedebvitdsztwebi44t5es4ls3p3hor252igzawr3s6uznmbvzh2ou
evm               bafk2bzacebygt6zh6p52rkg2ugehm4k5yuu6f56i2pu6ywrmjez4n4zsje4p4
placeholder       bafk2bzacedfvut2myeleyq67fljcrw4kkmn5pb5dpyozovj7jpoez5irnc3ro
cron              bafk2bzacecu2y3awtemmglpkroiglulc2fj3gpdn6eazdqr6avcautiaighrg
datacap           bafk2bzacebbh5aynu3v3fluqqrcdsphleodoig42xkid2ccwdnff3avhbdop4
ethaccount        bafk2bzaceb5f6vgjkl7ic6ry5sjspqm2iij6qlcdovwi3haodb7wn37pgebii
account           bafk2bzacebp7anjdtg2sohyt6lromx4xs7nujtwdfcsffnptphaayabx7ysxs
paymentchannel    bafk2bzacebm37tgu52cgzmiln6iip6etfmq73fd3qqz2j5gxlhtvachs7kw4c
storagepower      bafk2bzacedxvlj5xmhytdjrjqyonz37duvxb2ioyzk75c27yypkqalxuh3xh6
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
