### PR TITLE
fix: eth: remove trace sanity check

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -842,16 +842,6 @@ func (a *EthModule) EthTraceBlock(ctx context.Context, blkNum string) ([]*ethtyp
 		return nil, xerrors.Errorf("failed when calling ExecutionTrace: %w", err)
 	}
 
-	tsParent, err := a.ChainAPI.ChainGetTipSetByHeight(ctx, ts.Height()+1, a.Chain.GetHeaviestTipSet().Key())
-	if err != nil {
-		return nil, xerrors.Errorf("cannot get tipset at height: %v", ts.Height()+1)
-	}
-
-	msgs, err := a.ChainGetParentMessages(ctx, tsParent.Blocks()[0].Cid())
-	if err != nil {
-		return nil, xerrors.Errorf("failed to get parent messages: %w", err)
-	}
-
 	cid, err := ts.Key().Cid()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get tipset key cid: %w", err)
@@ -870,11 +860,6 @@ func (a *EthModule) EthTraceBlock(ctx context.Context, blkNum string) ([]*ethtyp
 			continue
 		}
 
-		// as we include TransactionPosition in the results, lets do sanity checking that the
-		// traces are indeed in the message execution order
-		if ir.Msg.Cid() != msgs[msgIdx].Message.Cid() {
-			return nil, xerrors.Errorf("traces are not in message execution order")
-		}
 		msgIdx++
 
 		txHash, err := a.EthGetTransactionHashByCid(ctx, ir.MsgCid)


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

We added this check as a self-test to make sure that the message indices in our trace matched up with those in the block. Unfortunately, this only works for blocks on the main-chain, and breaks tracing of uncle blocks (and tracing of head).

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] CI is green