### PR TITLE
fix: eth: use the correct state-tree when resolving addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - fix: Add time slicing to splitstore purging step during compaction to reduce lock congestion [filecoin-project/lotus#11269](https://github.com/filecoin-project/lotus/pull/11269)
 - feat: Added instructions on how to setup Prometheus/Grafana for monitoring a local Lotus node [filecoin-project/lotus#11276](https://github.com/filecoin-project/lotus/pull/11276)
 - fix: Exclude reverted events in `eth_getLogs` results [filecoin-project/lotus#11318](https://github.com/filecoin-project/lotus/pull/11318)
+- fix: `eth_GetTransaction*` methods will now never leave the from/to addresses blank for native messages. Instead:
+    - Pending messages from native account types won't be visible in the Ethereum API. Pending Ethereum transactions and native messages that have landed on-chain will still be visible.
+    - When encoded as an Ethereum transaction, native messages with a "to" address that cannot be resolved to a 0x-style address will appear to have been sent to `0xff0000000000000000000000ffffffffffffffff`. This can only happen when the native transaction _reverted_ (failing to create an account at the specified "to" address).
 
 ## New features
 - feat: Add move-partition command ([filecoin-project/lotus#11290](https://github.com/filecoin-project/lotus/pull/11290))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@
 - fix: Add time slicing to splitstore purging step during compaction to reduce lock congestion [filecoin-project/lotus#11269](https://github.com/filecoin-project/lotus/pull/11269)
 - feat: Added instructions on how to setup Prometheus/Grafana for monitoring a local Lotus node [filecoin-project/lotus#11276](https://github.com/filecoin-project/lotus/pull/11276)
 - fix: Exclude reverted events in `eth_getLogs` results [filecoin-project/lotus#11318](https://github.com/filecoin-project/lotus/pull/11318)
-- fix: `eth_GetTransaction*` methods will now never leave the from/to addresses blank for native messages. Instead:
-    - Pending messages from native account types won't be visible in the Ethereum API. Pending Ethereum transactions and native messages that have landed on-chain will still be visible.
-    - When encoded as an Ethereum transaction, native messages with a "to" address that cannot be resolved to a 0x-style address will appear to have been sent to `0xff0000000000000000000000ffffffffffffffff`. This can only happen when the native transaction _reverted_ (failing to create an account at the specified "to" address).
+- fix: The Ethereum API will now use the correct state-tree when resolving "native" addresses into masked ID addresses. Additionally, pending messages from native account types won't be visible in the Ethereum API because there is no "correct" state-tree to pick in this case. However, pending _Ethereum_ transactions and native messages that have landed on-chain will still be visible through the Ethereum API.
 
 ## New features
 - feat: Add move-partition command ([filecoin-project/lotus#11290](https://github.com/filecoin-project/lotus/pull/11290))

--- a/itests/eth_hash_lookup_test.go
+++ b/itests/eth_hash_lookup_test.go
@@ -120,7 +120,6 @@ func TestTransactionHashLookupBlsFilecoinMessage(t *testing.T) {
 		kit.MockProofs(),
 		kit.ThroughRPC(),
 	)
-	ens.InterconnectAll().BeginMining(blocktime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -146,9 +145,13 @@ func TestTransactionHashLookupBlsFilecoinMessage(t *testing.T) {
 	hash, err := ethtypes.EthHashFromCid(sm.Message.Cid())
 	require.NoError(t, err)
 
-	mpoolTx, err := client.EthGetTransactionByHash(ctx, &hash)
-	require.NoError(t, err)
-	require.Equal(t, hash, mpoolTx.Hash)
+	// Assert that BLS messages cannot be retrieved from the message pool until it lands
+	// on-chain via the eth API.
+	_, err = client.EthGetTransactionByHash(ctx, &hash)
+	require.Error(t, err)
+
+	// Now start mining.
+	ens.InterconnectAll().BeginMining(blocktime)
 
 	// Wait for message to land on chain
 	var receipt *api.EthTxReceipt
@@ -177,6 +180,13 @@ func TestTransactionHashLookupBlsFilecoinMessage(t *testing.T) {
 	require.NotEmpty(t, *chainTx.BlockHash)
 	require.NotNil(t, chainTx.TransactionIndex)
 	require.Equal(t, uint64(*chainTx.TransactionIndex), uint64(0)) // only transaction
+
+	// verify that we correctly reported the to address.
+	toId, err := client.StateLookupID(ctx, addr, types.EmptyTSK)
+	require.NoError(t, err)
+	toEth, err := client.FilecoinAddressToEthAddress(ctx, toId)
+	require.NoError(t, err)
+	require.Equal(t, &toEth, chainTx.To)
 }
 
 // TestTransactionHashLookupSecpFilecoinMessage tests to see if lotus can find a Secp Filecoin Message using the transaction hash
@@ -228,10 +238,6 @@ func TestTransactionHashLookupSecpFilecoinMessage(t *testing.T) {
 	hash, err := ethtypes.EthHashFromCid(secpSmsg.Cid())
 	require.NoError(t, err)
 
-	mpoolTx, err := client.EthGetTransactionByHash(ctx, &hash)
-	require.NoError(t, err)
-	require.Equal(t, hash, mpoolTx.Hash)
-
 	_, err = client.StateWaitMsg(ctx, secpSmsg.Cid(), 3, api.LookbackNoLimit, true)
 	require.NoError(t, err)
 
@@ -253,6 +259,13 @@ func TestTransactionHashLookupSecpFilecoinMessage(t *testing.T) {
 	require.NotEmpty(t, *chainTx.BlockHash)
 	require.NotNil(t, chainTx.TransactionIndex)
 	require.Equal(t, uint64(*chainTx.TransactionIndex), uint64(0)) // only transaction
+
+	// verify that we correctly reported the to address.
+	toId, err := client.StateLookupID(ctx, client.DefaultKey.Address, types.EmptyTSK)
+	require.NoError(t, err)
+	toEth, err := client.FilecoinAddressToEthAddress(ctx, toId)
+	require.NoError(t, err)
+	require.Equal(t, &toEth, chainTx.To)
 }
 
 // TestTransactionHashLookupSecpFilecoinMessage tests to see if lotus can find a Secp Filecoin Message using the transaction hash

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
@@ -190,7 +191,8 @@ func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTx
 
 	bn := ethtypes.EthUint64(ts.Height())
 
-	blkCid, err := ts.Key().Cid()
+	tsk := ts.Key()
+	blkCid, err := tsk.Cid()
 	if err != nil {
 		return ethtypes.EthBlock{}, err
 	}
@@ -199,9 +201,14 @@ func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTx
 		return ethtypes.EthBlock{}, err
 	}
 
-	msgs, rcpts, err := messagesAndReceipts(ctx, ts, cs, sa)
+	stRoot, msgs, rcpts, err := executeTipset(ctx, ts, cs, sa)
 	if err != nil {
 		return ethtypes.EthBlock{}, xerrors.Errorf("failed to retrieve messages and receipts: %w", err)
+	}
+
+	st, err := sa.StateManager.StateTree(stRoot)
+	if err != nil {
+		return ethtypes.EthBlock{}, xerrors.Errorf("failed to load state-tree root %q: %w", stRoot, err)
 	}
 
 	block := ethtypes.NewEthBlock(len(msgs) > 0)
@@ -225,7 +232,7 @@ func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTx
 		default:
 			return ethtypes.EthBlock{}, xerrors.Errorf("failed to get signed msg %s: %w", msg.Cid(), err)
 		}
-		tx, err := newEthTxFromSignedMessage(ctx, smsg, sa)
+		tx, err := newEthTxFromSignedMessage(smsg, st)
 		if err != nil {
 			return ethtypes.EthBlock{}, xerrors.Errorf("failed to convert msg to ethTx: %w", err)
 		}
@@ -251,27 +258,27 @@ func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTx
 	return block, nil
 }
 
-func messagesAndReceipts(ctx context.Context, ts *types.TipSet, cs *store.ChainStore, sa StateAPI) ([]types.ChainMsg, []types.MessageReceipt, error) {
+func executeTipset(ctx context.Context, ts *types.TipSet, cs *store.ChainStore, sa StateAPI) (cid.Cid, []types.ChainMsg, []types.MessageReceipt, error) {
 	msgs, err := cs.MessagesForTipset(ctx, ts)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("error loading messages for tipset: %v: %w", ts, err)
+		return cid.Undef, nil, nil, xerrors.Errorf("error loading messages for tipset: %v: %w", ts, err)
 	}
 
-	_, rcptRoot, err := sa.StateManager.TipSetState(ctx, ts)
+	stRoot, rcptRoot, err := sa.StateManager.TipSetState(ctx, ts)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to compute state: %w", err)
+		return cid.Undef, nil, nil, xerrors.Errorf("failed to compute state: %w", err)
 	}
 
 	rcpts, err := cs.ReadReceipts(ctx, rcptRoot)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("error loading receipts for tipset: %v: %w", ts, err)
+		return cid.Undef, nil, nil, xerrors.Errorf("error loading receipts for tipset: %v: %w", ts, err)
 	}
 
 	if len(msgs) != len(rcpts) {
-		return nil, nil, xerrors.Errorf("receipts and message array lengths didn't match for tipset: %v: %w", ts, err)
+		return cid.Undef, nil, nil, xerrors.Errorf("receipts and message array lengths didn't match for tipset: %v: %w", ts, err)
 	}
 
-	return msgs, rcpts, nil
+	return stRoot, msgs, rcpts, nil
 }
 
 const errorFunctionSelector = "\x08\xc3\x79\xa0" // Error(string)
@@ -361,7 +368,7 @@ func parseEthRevert(ret []byte) string {
 //  3. Otherwise, we fall back to returning a masked ID Ethereum address. If the supplied address is an f0 address, we
 //     use that ID to form the masked ID address.
 //  4. Otherwise, we fetch the actor's ID from the state tree and form the masked ID with it.
-func lookupEthAddress(ctx context.Context, addr address.Address, sa StateAPI) (ethtypes.EthAddress, error) {
+func lookupEthAddress(addr address.Address, st *state.StateTree) (ethtypes.EthAddress, error) {
 	// BLOCK A: We are trying to get an actual Ethereum address from an f410 address.
 	// Attempt to convert directly, if it's an f4 address.
 	ethAddr, err := ethtypes.EthAddressFromFilecoinAddress(addr)
@@ -370,7 +377,7 @@ func lookupEthAddress(ctx context.Context, addr address.Address, sa StateAPI) (e
 	}
 
 	// Lookup on the target actor and try to get an f410 address.
-	if actor, err := sa.StateGetActor(ctx, addr, types.EmptyTSK); err != nil {
+	if actor, err := st.GetActor(addr); err != nil {
 		return ethtypes.EthAddress{}, err
 	} else if actor.Address != nil {
 		if ethAddr, err := ethtypes.EthAddressFromFilecoinAddress(*actor.Address); err == nil && !ethAddr.IsMaskedID() {
@@ -385,7 +392,7 @@ func lookupEthAddress(ctx context.Context, addr address.Address, sa StateAPI) (e
 	}
 
 	// Otherwise, resolve the ID addr.
-	idAddr, err := sa.StateLookupID(ctx, addr, types.EmptyTSK)
+	idAddr, err := st.LookupID(addr)
 	if err != nil {
 		return ethtypes.EthAddress{}, err
 	}
@@ -412,7 +419,7 @@ func ethTxHashFromMessageCid(ctx context.Context, c cid.Cid, sa StateAPI) (ethty
 	smsg, err := sa.Chain.GetSignedMessage(ctx, c)
 	if err == nil {
 		// This is an Eth Tx, Secp message, Or BLS message in the mpool
-		return ethTxHashFromSignedMessage(ctx, smsg, sa)
+		return ethTxHashFromSignedMessage(smsg)
 	}
 
 	_, err = sa.Chain.GetMessage(ctx, c)
@@ -424,13 +431,14 @@ func ethTxHashFromMessageCid(ctx context.Context, c cid.Cid, sa StateAPI) (ethty
 	return ethtypes.EmptyEthHash, nil
 }
 
-func ethTxHashFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, sa StateAPI) (ethtypes.EthHash, error) {
+func ethTxHashFromSignedMessage(smsg *types.SignedMessage) (ethtypes.EthHash, error) {
 	if smsg.Signature.Type == crypto.SigTypeDelegated {
-		ethTx, err := newEthTxFromSignedMessage(ctx, smsg, sa)
+		tx, err := ethtypes.EthTxFromSignedEthMessage(smsg)
 		if err != nil {
-			return ethtypes.EmptyEthHash, err
+			return ethtypes.EthHash{}, xerrors.Errorf("failed to convert from signed message: %w", err)
 		}
-		return ethTx.Hash, nil
+
+		return tx.TxHash()
 	} else if smsg.Signature.Type == crypto.SigTypeSecp256k1 {
 		return ethtypes.EthHashFromCid(smsg.Cid())
 	} else { // BLS message
@@ -438,7 +446,7 @@ func ethTxHashFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, 
 	}
 }
 
-func newEthTxFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, sa StateAPI) (ethtypes.EthTx, error) {
+func newEthTxFromSignedMessage(smsg *types.SignedMessage, st *state.StateTree) (ethtypes.EthTx, error) {
 	var tx ethtypes.EthTx
 	var err error
 
@@ -453,21 +461,14 @@ func newEthTxFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, s
 		if err != nil {
 			return ethtypes.EthTx{}, xerrors.Errorf("failed to calculate hash for ethTx: %w", err)
 		}
-
-		fromAddr, err := lookupEthAddress(ctx, smsg.Message.From, sa)
-		if err != nil {
-			return ethtypes.EthTx{}, xerrors.Errorf("failed to resolve Ethereum address: %w", err)
-		}
-
-		tx.From = fromAddr
 	} else if smsg.Signature.Type == crypto.SigTypeSecp256k1 { // Secp Filecoin Message
-		tx = ethTxFromNativeMessage(ctx, smsg.VMMessage(), sa)
+		tx = ethTxFromNativeMessage(smsg.VMMessage(), st)
 		tx.Hash, err = ethtypes.EthHashFromCid(smsg.Cid())
 		if err != nil {
 			return tx, err
 		}
 	} else { // BLS Filecoin message
-		tx = ethTxFromNativeMessage(ctx, smsg.VMMessage(), sa)
+		tx = ethTxFromNativeMessage(smsg.VMMessage(), st)
 		tx.Hash, err = ethtypes.EthHashFromCid(smsg.Message.Cid())
 		if err != nil {
 			return tx, err
@@ -482,10 +483,10 @@ func newEthTxFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, s
 // - BlockNumber
 // - TransactionIndex
 // - Hash
-func ethTxFromNativeMessage(ctx context.Context, msg *types.Message, sa StateAPI) ethtypes.EthTx {
+func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) ethtypes.EthTx {
 	// We don't care if we error here, conversion is best effort for non-eth transactions
-	from, _ := lookupEthAddress(ctx, msg.From, sa)
-	to, _ := lookupEthAddress(ctx, msg.To, sa)
+	from, _ := lookupEthAddress(msg.From, st)
+	to, _ := lookupEthAddress(msg.To, st)
 	return ethtypes.EthTx{
 		To:                   &to,
 		From:                 from,
@@ -566,7 +567,12 @@ func newEthTxFromMessageLookup(ctx context.Context, msgLookup *api.MsgLookup, tx
 		return ethtypes.EthTx{}, xerrors.Errorf("failed to get signed msg: %w", err)
 	}
 
-	tx, err := newEthTxFromSignedMessage(ctx, smsg, sa)
+	st, err := sa.StateManager.StateTree(ts.ParentState())
+	if err != nil {
+		return ethtypes.EthTx{}, xerrors.Errorf("failed to load message state tree: %w", err)
+	}
+
+	tx, err := newEthTxFromSignedMessage(smsg, st)
 	if err != nil {
 		return ethtypes.EthTx{}, err
 	}
@@ -576,7 +582,6 @@ func newEthTxFromMessageLookup(ctx context.Context, msgLookup *api.MsgLookup, tx
 		ti = ethtypes.EthUint64(txIdx)
 	)
 
-	tx.ChainID = ethtypes.EthUint64(build.Eip155ChainId)
 	tx.BlockHash = &blkHash
 	tx.BlockNumber = &bn
 	tx.TransactionIndex = &ti
@@ -627,6 +632,11 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 	ts, err := cs.GetTipSetFromKey(ctx, lookup.TipSet)
 	if err != nil {
 		return api.EthTxReceipt{}, xerrors.Errorf("failed to lookup tipset %s when constructing the eth txn receipt: %w", lookup.TipSet, err)
+	}
+
+	st, err := sa.StateManager.StateTree(ts.ParentState())
+	if err != nil {
+		return api.EthTxReceipt{}, xerrors.Errorf("failed to load the state %s when constructing the eth txn receipt: %w", ts.ParentState(), err)
 	}
 
 	// The tx is located in the parent tipset
@@ -684,7 +694,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 				return api.EthTxReceipt{}, xerrors.Errorf("failed to create ID address: %w", err)
 			}
 
-			l.Address, err = lookupEthAddress(ctx, addr, sa)
+			l.Address, err = lookupEthAddress(addr, st)
 			if err != nil {
 				return api.EthTxReceipt{}, xerrors.Errorf("failed to resolve Ethereum address: %w", err)
 			}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Part of #11355

## Proposed Changes
<!-- A clear list of the changes being made -->

We need to always use the state-tree from the tipset _after_ the message executed (i.e., the state-tree produced by executing the tipset). If we use any other state-tree, we might not find the address we're trying to resolve.

This change also has some implication for pending messages: there's no guarantee we'll be able to generate a 0x-style address for a pending native message. So, instead of trying, I've removed support for pending native messages from the Eth API. Messages from EthAccounts will still work, and native messages will still show up in blocks/traces, they just won't show up as "pending". Which should affect exactly nobody.

I'm also taking this opportunity to cleanup some edge-cases:

1. Pass contexts where appropriate.
2. Remove all state access from `ethTxHashFromSignedMessage`.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] CI is green