### PR TITLE
fix: build: an epoch is near an upgrade iff the upgrade is enabled

### DIFF
--- a/build/isnearupgrade.go
+++ b/build/isnearupgrade.go
@@ -5,5 +5,5 @@ import (
 )
 
 func IsNearUpgrade(epoch, upgradeEpoch abi.ChainEpoch) bool {
-	return epoch > upgradeEpoch-Finality && epoch < upgradeEpoch+Finality
+	return upgradeEpoch >= 0 && epoch > upgradeEpoch-Finality && epoch < upgradeEpoch+Finality
 }

--- a/build/isnearupgrade.go
+++ b/build/isnearupgrade.go
@@ -5,5 +5,8 @@ import (
 )
 
 func IsNearUpgrade(epoch, upgradeEpoch abi.ChainEpoch) bool {
-	return upgradeEpoch >= 0 && epoch > upgradeEpoch-Finality && epoch < upgradeEpoch+Finality
+	if upgradeEpoch < 0 {
+		return false
+	}
+	return epoch > upgradeEpoch-Finality && epoch < upgradeEpoch+Finality
 }


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Only consider an epoch near an upgrade if the upgrade is enabled (the upgrade epoch is >= 0). This isn't a huge deal, but we'd otherwise consider the first finality epochs (or so) to be "near" any disabled upgrade.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] CI is green