### PR TITLE
chore: forward-port calibnet hotfix to master

### DIFF
--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -2064,7 +2064,7 @@ func upgradeActorsV12Fix(ctx context.Context, sm *stmgr.StateManager, cache stmg
 	}
 
 	systemState.BuiltinActors = newManifest.Data
-	newSystemHead, err := adtStore.Put(ctx, systemState)
+	newSystemHead, err := adtStore.Put(ctx, &systemState)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to put new system state: %w", err)
 	}
@@ -2094,7 +2094,7 @@ func upgradeActorsV12Fix(ctx context.Context, sm *stmgr.StateManager, cache stmg
 			return xerrors.Errorf("mismatched address for actor %s: %s != %s", a, inActor.Address, outActor.Address)
 		}
 
-		if inActor.Head != outActor.Head {
+		if inActor.Head != outActor.Head && a != builtin.SystemActorAddr {
 			return xerrors.Errorf("mismatched head for actor %s", a)
 		}
 

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -2063,6 +2063,19 @@ func upgradeActorsV12Fix(ctx context.Context, sm *stmgr.StateManager, cache stmg
 		return cid.Undef, xerrors.Errorf("failed to perform migration: %w", err)
 	}
 
+	systemState.BuiltinActors = newManifest.Data
+	newSystemHead, err := adtStore.Put(ctx, systemState)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to put new system state: %w", err)
+	}
+
+	systemActor.Head = newSystemHead
+	if err = actorsOut.SetActor(builtin.SystemActorAddr, systemActor); err != nil {
+		return cid.Undef, xerrors.Errorf("failed to put new system actor: %w", err)
+	}
+
+	// Sanity checking
+
 	err = actorsIn.ForEach(func(a address.Address, inActor *types.Actor) error {
 		outActor, err := actorsOut.GetActor(a)
 		if err != nil {

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -177,7 +177,7 @@ func (us UpgradeSchedule) GetNtwkVersion(e abi.ChainEpoch) (network.Version, err
 func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, height abi.ChainEpoch, cb ExecMonitor, ts *types.TipSet) (cid.Cid, error) {
 	retCid := root
 	u := sm.stateMigrations[height]
-	if u != nil && u.upgrade != nil {
+	if u != nil && u.upgrade != nil && height != build.UpgradeWatermelonFixHeight {
 		migCid, ok, err := u.migrationResultCache.Get(ctx, root)
 		if err == nil {
 			if ok {

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -177,17 +177,19 @@ func (us UpgradeSchedule) GetNtwkVersion(e abi.ChainEpoch) (network.Version, err
 func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, height abi.ChainEpoch, cb ExecMonitor, ts *types.TipSet) (cid.Cid, error) {
 	retCid := root
 	u := sm.stateMigrations[height]
-	if u != nil && u.upgrade != nil && height != build.UpgradeWatermelonFixHeight {
-		migCid, ok, err := u.migrationResultCache.Get(ctx, root)
-		if err == nil {
-			if ok {
-				log.Infow("CACHED migration", "height", height, "from", root, "to", migCid)
-				return migCid, nil
+	if u != nil && u.upgrade != nil {
+		if height != build.UpgradeWatermelonFixHeight {
+			migCid, ok, err := u.migrationResultCache.Get(ctx, root)
+			if err == nil {
+				if ok {
+					log.Infow("CACHED migration", "height", height, "from", root, "to", migCid)
+					return migCid, nil
+				}
+			} else if !errors.Is(err, datastore.ErrNotFound) {
+				log.Errorw("failed to lookup previous migration result", "err", err)
+			} else {
+				log.Debug("no cached migration found, migrating from scratch")
 			}
-		} else if !errors.Is(err, datastore.ErrNotFound) {
-			log.Errorw("failed to lookup previous migration result", "err", err)
-		} else {
-			log.Debug("no cached migration found, migrating from scratch")
 		}
 
 		startTime := time.Now()
@@ -195,6 +197,7 @@ func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, heig
 		// Yes, we clone the cache, even for the final upgrade epoch. Why? Reverts. We may
 		// have to migrate multiple times.
 		tmpCache := u.cache.Clone()
+		var err error
 		retCid, err = u.upgrade(ctx, sm, tmpCache, cb, root, height, ts)
 		if err != nil {
 			log.Errorw("FAILED migration", "height", height, "from", root, "error", err)

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -92,6 +92,15 @@ func (x *FvmExtern) VerifyConsensusFault(ctx context.Context, a, b, extra []byte
 		log.Info("invalid consensus fault: submitted blocks are the same")
 		return ret, totalGas
 	}
+
+	// workaround chain halt
+	if build.IsNearUpgrade(blockA.Height, build.UpgradeWatermelonFixHeight) {
+		return ret, totalGas
+	}
+	if build.IsNearUpgrade(blockB.Height, build.UpgradeWatermelonFixHeight) {
+		return ret, totalGas
+	}
+
 	// (1) check conditions necessary to any consensus fault
 
 	// were blocks mined by same miner?

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -325,7 +325,7 @@ minerLoop:
 					"block-time", btime, "time", build.Clock.Now(), "difference", build.Clock.Since(btime))
 			}
 
-			if os.Getenv("LOTUS_MINER_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" {
+			if os.Getenv("LOTUS_MINER_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" && !build.IsNearUpgrade(base.TipSet.Height(), build.UpgradeWatermelonFixHeight) {
 				witness, fault, err := m.sf.MinedBlock(ctx, b.Header, base.TipSet.Height()+base.NullRounds)
 				if err != nil {
 					log.Errorf("<!!> SLASH FILTER ERRORED: %s", err)

--- a/node/impl/full/sync.go
+++ b/node/impl/full/sync.go
@@ -57,7 +57,7 @@ func (a *SyncAPI) SyncSubmitBlock(ctx context.Context, blk *types.BlockMsg) erro
 		return xerrors.Errorf("loading parent block: %w", err)
 	}
 
-	if a.SlashFilter != nil && os.Getenv("LOTUS_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" {
+	if a.SlashFilter != nil && os.Getenv("LOTUS_NO_SLASHFILTER") != "_yes_i_know_i_can_and_probably_will_lose_all_my_fil_and_power_" && !build.IsNearUpgrade(blk.Header.Height, build.UpgradeWatermelonFixHeight) {
 		witness, fault, err := a.SlashFilter.MinedBlock(ctx, blk.Header, parent.Height)
 		if err != nil {
 			log.Errorf("<!!> SLASH FILTER ERRORED: %s", err)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This hotfix has landed in the 1.24.0 and 1.25.0 branches, but is needed in master to sync calibnet. The plan was to just wait those release branches get merged to master, but given the uncertainty around nv21, let's forward-port this so we can sync calibnet on master again.

## Proposed Changes
<!-- A clear list of the changes being made -->

Forward-port calibnet hotfix patch.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
