### PR TITLE
chore: cli: Revert move-partitions cmd

### DIFF
--- a/cmd/lotus-miner/actor.go
+++ b/cmd/lotus-miner/actor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
-	minerV12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/network"
 
@@ -50,7 +49,6 @@ var actorCmd = &cli.Command{
 		actorProposeChangeWorker,
 		actorConfirmChangeWorker,
 		actorCompactAllocatedCmd,
-		actorMovePartitionsCmd,
 		actorProposeChangeBeneficiary,
 		actorConfirmChangeBeneficiary,
 	},
@@ -1283,142 +1281,6 @@ var actorConfirmChangeBeneficiary = &cli.Command{
 		} else {
 			fmt.Println("Beneficiary address change awaiting additional confirmations")
 		}
-
-		return nil
-	},
-}
-
-var actorMovePartitionsCmd = &cli.Command{
-	Name:  "move-partitions",
-	Usage: "move deadline of specified partitions from one to another",
-	Flags: []cli.Flag{
-		&cli.Int64SliceFlag{
-			Name:  "partition-indices",
-			Usage: "Indices of partitions to update, separated by comma",
-		},
-		&cli.Uint64Flag{
-			Name:  "orig-deadline",
-			Usage: "Deadline to move partition from",
-		},
-		&cli.Uint64Flag{
-			Name:  "dest-deadline",
-			Usage: "Deadline to move partition to",
-		},
-		&cli.BoolFlag{
-			Name:  "really-do-it",
-			Usage: "Actually send transaction performing the action",
-			Value: false,
-		},
-	},
-	Action: func(cctx *cli.Context) error {
-		if !cctx.Bool("really-do-it") {
-			fmt.Println("Pass --really-do-it to actually execute this action")
-			return nil
-		}
-
-		if cctx.Args().Present() {
-			return fmt.Errorf("please use flags to provide arguments")
-		}
-
-		ctx := lcli.ReqContext(cctx)
-
-		minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
-		maddr, err := minerApi.ActorAddress(ctx)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Miner: %s\n", color.BlueString("%s", maddr))
-
-		fullNodeApi, acloser, err := lcli.GetFullNodeAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer acloser()
-
-		minfo, err := fullNodeApi.StateMinerInfo(ctx, maddr, types.EmptyTSK)
-		if err != nil {
-			return err
-		}
-
-		origDeadline := cctx.Uint64("orig-deadline")
-		if origDeadline > miner.WPoStPeriodDeadlines {
-			return fmt.Errorf("orig-deadline %d out of range", origDeadline)
-		}
-		destDeadline := cctx.Uint64("dest-deadline")
-		if destDeadline > miner.WPoStPeriodDeadlines {
-			return fmt.Errorf("dest-deadline %d out of range", destDeadline)
-		}
-		if origDeadline == destDeadline {
-			return fmt.Errorf("dest-desdline cannot be the same as orig-deadline")
-		}
-
-		partitions := cctx.Int64Slice("partition-indices")
-		if len(partitions) == 0 {
-			return fmt.Errorf("must include at least one partition to move")
-		}
-
-		curPartitions, err := fullNodeApi.StateMinerPartitions(ctx, maddr, origDeadline, types.EmptyTSK)
-		if err != nil {
-			return fmt.Errorf("getting partitions for deadline %d: %w", origDeadline, err)
-		}
-		if len(partitions) > len(curPartitions) {
-			return fmt.Errorf("partition size(%d) cannot be bigger than current partition size(%d) for deadline %d", len(partitions), len(curPartitions), origDeadline)
-		}
-
-		fmt.Printf("Moving %d paritions\n", len(partitions))
-
-		partitionsBf := bitfield.New()
-		for _, partition := range partitions {
-			if partition >= int64(len(curPartitions)) {
-				return fmt.Errorf("partition index(%d) doesn't exist", partition)
-			}
-			partitionsBf.Set(uint64(partition))
-		}
-
-		params := minerV12.MovePartitionsParams{
-			OrigDeadline: origDeadline,
-			DestDeadline: destDeadline,
-			Partitions:   partitionsBf,
-		}
-
-		serializedParams, err := actors.SerializeParams(&params)
-		if err != nil {
-			return fmt.Errorf("serializing params: %w", err)
-		}
-
-		smsg, err := fullNodeApi.MpoolPushMessage(ctx, &types.Message{
-			From:   minfo.Worker,
-			To:     maddr,
-			Method: builtin.MethodsMiner.MovePartitions,
-			Value:  big.Zero(),
-			Params: serializedParams,
-		}, nil)
-		if err != nil {
-			return fmt.Errorf("mpool push: %w", err)
-		}
-
-		fmt.Println("MovePartitions Message CID:", smsg.Cid())
-
-		// wait for it to get mined into a block
-		fmt.Println("Waiting for block confirmation...")
-		wait, err := fullNodeApi.StateWaitMsg(ctx, smsg.Cid(), build.MessageConfidence)
-		if err != nil {
-			return err
-		}
-
-		// check it executed successfully
-		if wait.Receipt.ExitCode.IsError() {
-			fmt.Println("Moving partitions failed!")
-			return err
-		}
-
-		fmt.Println("Move partition confirmed")
 
 		return nil
 	},

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -223,7 +223,6 @@ COMMANDS:
    propose-change-worker       Propose a worker address change
    confirm-change-worker       Confirm a worker address change
    compact-allocated           compact allocated sectors bitfield
-   move-partitions             move deadline of specified partitions from one to another
    propose-change-beneficiary  Propose a beneficiary address change
    confirm-change-beneficiary  Confirm a beneficiary address change
    help, h                     Shows a list of commands or help for one command
@@ -371,22 +370,6 @@ OPTIONS:
    --mask-upto-n value       Mask sector IDs from 0 to 'n' (default: 0)
    --really-do-it            Actually send transaction performing the action (default: false)
    --help, -h                show help
-```
-
-### lotus-miner actor move-partitions
-```
-NAME:
-   lotus-miner actor move-partitions - move deadline of specified partitions from one to another
-
-USAGE:
-   lotus-miner actor move-partitions [command options] [arguments...]
-
-OPTIONS:
-   --partition-indices value [ --partition-indices value ]  Indices of partitions to update, separated by comma
-   --orig-deadline value                                    Deadline to move partition from (default: 0)
-   --dest-deadline value                                    Deadline to move partition to (default: 0)
-   --really-do-it                                           Actually send transaction performing the action (default: false)
-   --help, -h                                               show help
 ```
 
 ### lotus-miner actor propose-change-beneficiary


### PR DESCRIPTION
## Related Issues
This PRs mergeability depends on the resolution of the [nv21 decision matrix for the FIP0070 bug](https://filecoin.notion.site/nv21-decision-matrix-for-FIP0070-bug-a39174216ee1479eab9a55b2f23da520).

Specifically, it should only be merged if `Option 2: Descope FIP-0070 from nv21`  is chosen as the preferred course of action. If Option 2 is preferred, it should also be backported to the `release/v1.24.0` and `release/v1.25.0` branches.

## Proposed Changes
Remove the `lotus-miner actors move-partitions` command.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
