### PR TITLE
feat: build: Add SupraSeal-PC2 binary script

### DIFF
--- a/scripts/supraseal-pc2.sh
+++ b/scripts/supraseal-pc2.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+#set -o xtrace
+
+# By default compile for 512MiB and 32GiB sectors only, use `-r` to compile for
+# other sector test sector sizes as well.
+SECTOR_SIZE=""
+while getopts r flag
+do
+    case "${flag}" in
+        r) SECTOR_SIZE="-DRUNTIME_SECTOR_SIZE";;
+        *) ;;
+    esac
+done
+
+if [ ! -d "supra_seal" ]; then
+    git clone https://github.com/supranational/supra_seal.git
+fi
+
+cd supra_seal
+
+rm -fr obj
+mkdir -p obj
+
+rm -fr bin
+mkdir -p bin
+
+mkdir -p deps
+if [ ! -d "deps/sppark" ]; then
+    git clone https://github.com/supranational/sppark.git deps/sppark
+fi
+if [ ! -d "deps/blst" ]; then
+    git clone https://github.com/supranational/blst.git deps/blst
+    (cd deps/blst
+     ./build.sh -march=native)
+fi
+
+# Generate .h files for the Poseidon constants
+xxd -i poseidon/constants/constants_2  > obj/constants_2.h
+xxd -i poseidon/constants/constants_4  > obj/constants_4.h
+xxd -i poseidon/constants/constants_8  > obj/constants_8.h
+xxd -i poseidon/constants/constants_11 > obj/constants_11.h
+xxd -i poseidon/constants/constants_16 > obj/constants_16.h
+xxd -i poseidon/constants/constants_24 > obj/constants_24.h
+xxd -i poseidon/constants/constants_36 > obj/constants_36.h
+
+nvcc ${SECTOR_SIZE} -DNO_SPDK -DSTREAMING_NODE_READER_FILES \
+     -arch=sm_80 -gencode arch=compute_70,code=sm_70 -t0 \
+     -std=c++17 -g -O3 -Xcompiler -march=native \
+     -Xcompiler -Wall,-Wextra,-Werror \
+     -Xcompiler -Wno-subobject-linkage,-Wno-unused-parameter \
+     -x cu tools/pc2.cu -o bin/pc2 \
+     -Iposeidon -Ideps/sppark -Ideps/sppark/util -Ideps/blst/src -L deps/blst -lblst -lconfig++


### PR DESCRIPTION
## Proposed Changes
Add the SupraSeal-PC2 script made by @vmx 🙏 to the `/scripts` folder in Lotus, to make building the SupraSeal-PC2 binary easier and without needing SPDK checkout.

## Testing
Running the script on a machine with the proper pre-requisites (which will be in the Lotus documentation)

```
cd scripts/
./supraseal-pc2.sh
Cloning into 'supra_seal'...
remote: Enumerating objects: 772, done.
remote: Counting objects: 100% (299/299), done.
remote: Compressing objects: 100% (139/139), done.
----
+ cc -O2 -fno-builtin -fPIC -Wall -Wextra -Werror -march=native -D__ADX__ -mno-avx -c ./src/server.c
+ cc -O2 -fno-builtin -fPIC -Wall -Wextra -Werror -march=native -D__ADX__ -mno-avx -c ./build/assembly.S
+ ar rc libblst.a assembly.o server.o
```

Which will give you the supra_seal folder with the pc2-binary ready for 32GiB and 512MiB-sectors

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
