### PR TITLE
fix: miner info: Show correct sector state counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - chore: Auto remove local chain data when importing chain file or snapshot ([filecoin-project/lotus#11277](https://github.com/filecoin-project/lotus/pull/11277))
 - feat: metric: export Mpool message count ([filecoin-project/lotus#11361](https://github.com/filecoin-project/lotus/pull/11361))
 - feat: sealing: load SectorsSummary from sealing SectorStats instead of calling API each time ([filecoin-project/lotus#11353](https://github.com/filecoin-project/lotus/pull/11353))
+- fix: miner info: Show correct sector state counts ([filecoin-project/lotus#11456](https://github.com/filecoin-project/lotus/pull/11456))
 
 ## Improvements
 - fix: Add time slicing to splitstore purging step during compaction to reduce lock congestion [filecoin-project/lotus#11269](https://github.com/filecoin-project/lotus/pull/11269)

--- a/itests/sector_pledge_test.go
+++ b/itests/sector_pledge_test.go
@@ -223,3 +223,29 @@ func TestPledgeSynth(t *testing.T) {
 		runTest(t, 3)
 	})
 }
+
+func TestSectorsSummary(t *testing.T) {
+	kit.QuietMiningLogs()
+
+	blockTime := 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nPreseal := 2
+
+	_, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.PresealSectors(nPreseal))
+	ens.InterconnectAll().BeginMining(blockTime)
+
+	miner.PledgeSectors(ctx, 1, 0, nil)
+
+	ms, err := miner.SectorsSummary(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, ms, 1) // all proving
+
+	for st, n := range ms {
+		require.Equal(t, api.SectorState(sealing.Proving), st)
+		require.Equal(t, 1+nPreseal, n)
+	}
+}

--- a/storage/pipeline/stats.go
+++ b/storage/pipeline/stats.go
@@ -44,6 +44,10 @@ func (ss *SectorStats) updateSector(ctx context.Context, cfg sealiface.Config, i
 		ss.totals[toStatState(oldst, cfg.FinalizeEarly)]--
 		ss.byState[oldst]--
 
+		if ss.byState[oldst] <= 0 {
+			delete(ss.byState, oldst)
+		}
+
 		mctx, _ := tag.New(ctx, tag.Upsert(metrics.SectorState, string(oldst)))
 		stats.Record(mctx, metrics.SectorStates.M(ss.byState[oldst]))
 	}


### PR DESCRIPTION
## Related Issues
Fixes a small regression from https://github.com/filecoin-project/lotus/pull/11353

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
Before this fix `lotus-miner info` would show zero counts for states through which at least one sector has passed since starting the miner process:
```
Sectors:
	Total: 8268
	Proving: 3194
	Available: 165
	WaitDeals: 0
	AddPiece: 1
	: 0
	Packing: 0
	GetTicket: 0
	PreCommit1: 11
	Committing: 0
	CommitFinalize: 0
	SubmitCommit: 0
	CommitWait: 1
	FinalizeSector: 0
	Removed: 4896
```

After this PR:
```
Sectors:
	Total: 8269
	Proving: 3194
	Available: 165
	AddPiece: 1
	Packing: 1
	PreCommit1: 11
	CommitWait: 1
	Removed: 4896
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
