### PR TITLE
feat: bench: flag to output GenerateWinningPoStWithVanilla params

### DIFF
--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -659,7 +659,7 @@ var simpleWinningPost = &cli.Command{
 			Value: "t01000",
 		},
 		&cli.BoolFlag{
-			Name:  "output-inputs",
+			Name:  "show-inputs",
 			Usage: "output inputs for winning post generation",
 		},
 	},
@@ -733,7 +733,7 @@ var simpleWinningPost = &cli.Command{
 		fmt.Printf("Proof %s (%s)\n", end.Sub(challenge), bps(sectorSize, 1, end.Sub(challenge)))
 		fmt.Println(base64.StdEncoding.EncodeToString(proof[0].ProofBytes))
 
-		if cctx.Bool("output-inputs") {
+		if cctx.Bool("show-inputs") {
 			fmt.Println("GenerateWinningPoStWithVanilla info:")
 
 			fmt.Printf(" wpt: %d\n", wpt)

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -658,6 +658,10 @@ var simpleWinningPost = &cli.Command{
 			Usage: "pass miner address (only necessary if using existing sectorbuilder)",
 			Value: "t01000",
 		},
+		&cli.BoolFlag{
+			Name:  "output-inputs",
+			Usage: "output inputs for winning post generation",
+		},
 	},
 	ArgsUsage: "[sealed] [cache] [comm R] [sector num]",
 	Action: func(cctx *cli.Context) error {
@@ -728,6 +732,17 @@ var simpleWinningPost = &cli.Command{
 		fmt.Printf("Vanilla %s (%s)\n", challenge.Sub(start), bps(sectorSize, 1, challenge.Sub(start)))
 		fmt.Printf("Proof %s (%s)\n", end.Sub(challenge), bps(sectorSize, 1, end.Sub(challenge)))
 		fmt.Println(base64.StdEncoding.EncodeToString(proof[0].ProofBytes))
+
+		if cctx.Bool("output-inputs") {
+			fmt.Println("GenerateWinningPoStWithVanilla info:")
+
+			fmt.Printf(" wpt: %d\n", wpt)
+			fmt.Printf(" mid: %d\n", mid)
+			fmt.Printf(" rand: %x\n", rand)
+			fmt.Printf(" vp: %x\n", vp)
+			fmt.Printf(" proof: %x\n", proof)
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
Need this to generate static info for winningPoSt warmup in lotus-provider

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
