### PR TITLE
perf: api: add indexes to event topics and emitter addr

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -46,6 +46,7 @@ var ddls = []string{
 	)`,
 
 	`CREATE INDEX IF NOT EXISTS height_tipset_key ON event (height,tipset_key)`,
+	`CREATE INDEX IF NOT EXISTS event_emitter_addr ON event (emitter_addr)`,
 
 	`CREATE TABLE IF NOT EXISTS event_entry (
 		event_id INTEGER,
@@ -325,9 +326,10 @@ func NewEventIndex(ctx context.Context, path string, chainStore *store.ChainStor
 		}
 
 		if version == 2 {
-			log.Infof("upgrading event index from version 1 to version 2")
+			log.Infof("upgrading event index from version 2 to version 3")
 
-			// to upgrade to version 3 we only need to create an index on the event entries table (key) column
+			// to upgrade to version 3 we only need to create an index on the event_entry.key column
+			// and on the event.emitter_addr column
 			// which means we can just reapply the schema (it will not have any effect on existing data)
 			for _, ddl := range ddls {
 				if _, err := db.Exec(ddl); err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
Add indexes to the events.db `event_entry.key` column and `event.emitter_addr` column.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
These indexes improve the performance for `eth_getLog` queries with filters that contain multiple contract addresses or topics to search against. In our tests a query filter with 10 topics saw a >100x improvement in response time (from ~45s to ~0.4s). Applying these indexes increased the size of our archive node events.db from 383 MB to 428 MB. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in (N/A)
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior (N/A)
- [ ] CI is green
