### PR TITLE
fix: lotus-provider: show addresses in log

### DIFF
--- a/cmd/lotus-provider/run.go
+++ b/cmd/lotus-provider/run.go
@@ -176,7 +176,7 @@ var runCmd = &cli.Command{
 			}
 		}
 		log.Infow("This lotus_provider instance handles",
-			"miner_addresses", maddrs,
+			"miner_addresses", minerAddressesToStrings(maddrs),
 			"tasks", lo.Map(activeTasks, func(t harmonytask.TaskInterface, _ int) string { return t.TypeDetails().Name }))
 
 		taskEngine, err := harmonytask.New(db, activeTasks, deps.listenAddr)
@@ -456,4 +456,12 @@ func (p *ProviderAPI) Version(context.Context) (api.Version, error) {
 func (p *ProviderAPI) Shutdown(context.Context) error {
 	close(p.ShutdownChan)
 	return nil
+}
+
+func minerAddressesToStrings(maddrs []dtypes.MinerAddress) []string {
+	strs := make([]string, len(maddrs))
+	for i, addr := range maddrs {
+		strs[i] = address.Address(addr).String()
+	}
+	return strs
 }


### PR DESCRIPTION
## Proposed Changes
Display the addresses in lotus-providers `This lotus_provider instance handles` log.

## Additional Info
**Before:**
` This lotus_provider instance handles {"miner_addresses": ["{}"], "tasks": ["SendMessage", "WdPost", "WdPostSubmit", "WdPostRecoverDeclare"]}`

**After:**
` This lotus_provider instance handles {"miner_addresses": ["t01000"], "tasks": ["SendMessage", "WdPost", "WdPostSubmit", "WdPostRecoverDeclare"]}`

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
