### PR TITLE
fix: send errs then retries despite being sent

### DIFF
--- a/provider/lpwindow/recover_task.go
+++ b/provider/lpwindow/recover_task.go
@@ -191,7 +191,7 @@ func (w *WdPostRecoverDeclareTask) Do(taskID harmonytask.TaskID, stillOwned func
 		return false, xerrors.Errorf("sending declare recoveries message: %w", err)
 	}
 
-	mc, err := w.sender.Send(ctx, msg, mss, "declare-recoveries")
+	mc, err := w.sender.Send(ctx, msg, mss, "declare-recoveries", taskID)
 	if err != nil {
 		return false, xerrors.Errorf("sending declare recoveries message: %w", err)
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
1. Fix a SQL query bug that was erroring out Send() after sending, causing weird retry. 
2. Added a backstop to stop retrying a send when the error is that it's already sent. 

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
