### PR TITLE
harmony: Fix task reclaim on restart

### DIFF
--- a/lib/harmony/harmonytask/harmonytask.go
+++ b/lib/harmony/harmonytask/harmonytask.go
@@ -176,7 +176,7 @@ func New(
 					continue // not really fatal, but not great
 				}
 			}
-			if !h.considerWork("recovered", []TaskID{TaskID(w.ID)}) {
+			if !h.considerWork(workSourceRecover, []TaskID{TaskID(w.ID)}) {
 				log.Error("Strange: Unable to accept previously owned task: ", w.ID, w.Name)
 			}
 		}
@@ -285,7 +285,7 @@ func (e *TaskEngine) pollerTryAllWork() {
 			continue
 		}
 		if len(unownedTasks) > 0 {
-			accepted := v.considerWork("poller", unownedTasks)
+			accepted := v.considerWork(workSourcePoller, unownedTasks)
 			if accepted {
 				return // accept new work slowly and in priority order
 			}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
On restart harmony would fail to reclaim tasks claimed because the owner_id was already non-null. With this change we just take ownership of all tasks which are recovered

```
2023-12-07T11:26:05.521+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "\n\t\t\tWITH upsert AS (\n\t\t\t\tUPDATE harmony_machines\n\t\t\t\tSET cpu = $2, ram = $3, gpu = $4, last_contact = CURRENT_TIMESTAMP\n\t\t\t\tWHERE host_and_port = $1\n\t\t\t\tRETURNING id\n\t\t\t),\n\t\t\tinserted AS (\n\t\t\t\tINSERT INTO harmony_machines (host_and_port, cpu, ram, gpu, last_contact)\n\t\t\t\tSELECT $1, $2, $3, $4, CURRENT_TIMESTAMP\n\t\t\t\tWHERE NOT EXISTS (SELECT id FROM upsert)\n\t\t\t\tRETURNING id\n\t\t\t)\n\t\t\tSELECT id FROM upsert\n\t\t\tUNION ALL\n\t\t\tSELECT id FROM inserted;\n\t\t", "err": null, "rowCt": 1, "milliseconds": 51}
2023-12-07T11:26:05.532+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "DELETE FROM harmony_machines WHERE last_contact < CURRENT_TIMESTAMP - INTERVAL '1 MILLISECOND' * $1 ", "err": null, "rowCt": 0, "milliseconds": 11}
2023-12-07T11:26:05.532+0100	INFO	harmonytask	resources/resources.go:77	Cleaned up machines	{"count": 0}
2023-12-07T11:26:05.544+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "SELECT id, name from harmony_task WHERE owner_id=$1", "err": null, "rowCt": 8, "milliseconds": 11}
2023-12-07T11:26:05.545+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "UPDATE harmony_task SET owner_id=$1 WHERE id=$2 AND owner_id IS NULL", "err": null, "rowCt": 0, "milliseconds": 1}
2023-12-07T11:26:05.545+0100	INFO	harmonytask	harmonytask/task_type_handler.go:97	did not accept task	{"task_id": "20241", "reason": "already Taken", "name": "WdPostRecover"}
2023-12-07T11:26:05.557+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "SELECT epoch FROM mining_tasks WHERE task_id = $1", "err": null, "rowCt": 1, "milliseconds": 11}
2023-12-07T11:26:05.558+0100	DEBUG	harmonydb	harmonydb/harmonydb.go:133	SQL run	{"query": "UPDATE harmony_task SET owner_id=$1 WHERE id=$2 AND owner_id IS NULL", "err": null, "rowCt": 0, "milliseconds": 0}
2023-12-07T11:26:05.558+0100	INFO	harmonytask	harmonytask/task_type_handler.go:97	did not accept task	{"task_id": "24308", "reason": "already Taken", "name": "WinPost"}

```

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
