### PR TITLE
fix: exchange: explicitly cast the block message limit const

### DIFF
--- a/chain/exchange/protocol_encoding.go
+++ b/chain/exchange/protocol_encoding.go
@@ -79,7 +79,7 @@ func (t *messageIndices) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra > build.BlockMessageLimit {
+	if extra > uint64(build.BlockMessageLimit) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 


### PR DESCRIPTION
It's not a const for the testground build, and needs to be an int 99% of the time. So we might as well just cast here.