### PR TITLE
fix: eth: decode as actor creation iff "to" is the EAM

### DIFF
--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -548,7 +548,9 @@ func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) (ethtypes.E
 		AccessList:           []ethtypes.EthHash{},
 	}
 
-	// Then we try to see if it's "special".
+	// Then we try to see if it's "special". If we fail, we ignore the error and keep treating
+	// it as a native message. Unfortunately, the user is free to send garbage that may not
+	// properly decode.
 	if msg.Method == builtintypes.MethodsEVM.InvokeContract {
 		// try to decode it as a contract invocation first.
 		if inp, err := decodePayload(msg.Params, codec); err == nil {

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -524,9 +525,6 @@ func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) (ethtypes.E
 		}
 		to = revertedEthAddress
 	}
-	toPtr := &to
-
-	// Finally, convert the input parameters to "solidity ABI".
 
 	// For empty, we use "0" as the codec. Otherwise, we use CBOR for message
 	// parameters.
@@ -535,31 +533,11 @@ func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) (ethtypes.E
 		codec = uint64(multicodec.Cbor)
 	}
 
-	// We try to decode the input as an EVM method invocation and/or a contract creation. If
-	// that fails, we encode the "native" parameters as Solidity ABI.
-	var input []byte
-	switch msg.Method {
-	case builtintypes.MethodsEVM.InvokeContract, builtintypes.MethodsEAM.CreateExternal:
-		inp, err := decodePayload(msg.Params, codec)
-		if err == nil {
-			// If this is a valid "create external", unset the "to" address.
-			if msg.Method == builtintypes.MethodsEAM.CreateExternal {
-				toPtr = nil
-			}
-			input = []byte(inp)
-			break
-		}
-		// Yeah, we're going to ignore errors here because the user can send whatever they
-		// want and may send garbage.
-		fallthrough
-	default:
-		input = encodeFilecoinParamsAsABI(msg.Method, codec, msg.Params)
-	}
-
-	return ethtypes.EthTx{
-		To:                   toPtr,
+	// We decode as a native call first.
+	ethTx := ethtypes.EthTx{
+		To:                   &to,
 		From:                 from,
-		Input:                input,
+		Input:                encodeFilecoinParamsAsABI(msg.Method, codec, msg.Params),
 		Nonce:                ethtypes.EthUint64(msg.Nonce),
 		ChainID:              ethtypes.EthUint64(build.Eip155ChainId),
 		Value:                ethtypes.EthBigInt(msg.Value),
@@ -568,7 +546,23 @@ func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) (ethtypes.E
 		MaxFeePerGas:         ethtypes.EthBigInt(msg.GasFeeCap),
 		MaxPriorityFeePerGas: ethtypes.EthBigInt(msg.GasPremium),
 		AccessList:           []ethtypes.EthHash{},
-	}, nil
+	}
+
+	// Then we try to see if it's "special".
+	if msg.Method == builtintypes.MethodsEVM.InvokeContract {
+		// try to decode it as a contract invocation first.
+		if inp, err := decodePayload(msg.Params, codec); err == nil {
+			ethTx.Input = []byte(inp)
+		}
+	} else if msg.To == builtin.EthereumAddressManagerActorAddr && msg.Method == builtintypes.MethodsEAM.CreateExternal {
+		// Then, try to decode it as a contract deployment from an EOA.
+		if inp, err := decodePayload(msg.Params, codec); err == nil {
+			ethTx.Input = []byte(inp)
+			ethTx.To = nil
+		}
+	}
+
+	return ethTx, nil
 }
 
 func getSignedMessage(ctx context.Context, cs *store.ChainStore, msgCid cid.Cid) (*types.SignedMessage, error) {


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Decode messages as contract deployments if and only if the "to" address is the EAM.

Previously, we weren't checking the "to" address. I've also re-ordered the operations in this function to make it easier to reason about them. It'll have a slight runtime cost (we _always_ ABI-encode the parameters, then throw away the result if it turns out we're actually dealing with an Ethereum transaction), but it's _much_ simpler.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green