### PR TITLE
lpwinning: Don't say a task is done when persistNoWin fails

### DIFF
--- a/lib/harmony/harmonytask/task_type_handler.go
+++ b/lib/harmony/harmonytask/task_type_handler.go
@@ -184,6 +184,9 @@ retryRecordCompletion:
 				return false, fmt.Errorf("could not log completion: %w", err)
 			}
 			result = ""
+			if doErr != nil {
+				result = "non-failing error: " + doErr.Error()
+			}
 		} else {
 			if doErr != nil {
 				result = "error: " + doErr.Error()

--- a/provider/lpwinning/winning_task.go
+++ b/provider/lpwinning/winning_task.go
@@ -167,7 +167,7 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 			return false, xerrors.Errorf("persist no win: no rows updated")
 		}
 
-		return false, nil
+		return true, nil
 	}
 
 	// ensure we have a beacon entry for the epoch we're mining on

--- a/provider/lpwinning/winning_task.go
+++ b/provider/lpwinning/winning_task.go
@@ -156,13 +156,18 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		ComputeTime: details.CompTime,
 	}
 
-	persistNoWin := func() error {
-		_, err := t.db.Exec(ctx, `UPDATE mining_base_block SET no_win = true WHERE task_id = $1`, taskID)
+	persistNoWin := func() (bool, error) {
+		n, err := t.db.Exec(ctx, `UPDATE mining_base_block SET no_win = true WHERE task_id = $1`, taskID)
 		if err != nil {
-			return xerrors.Errorf("marking base as not-won: %w", err)
+			return false, xerrors.Errorf("marking base as not-won: %w", err)
+		}
+		log.Debugw("persisted no-win", "rows", n)
+
+		if n == 0 {
+			return false, xerrors.Errorf("persist no win: no rows updated")
 		}
 
-		return nil
+		return false, nil
 	}
 
 	// ensure we have a beacon entry for the epoch we're mining on
@@ -182,13 +187,13 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	if mbi == nil {
 		// not eligible to mine on this base, we're done here
 		log.Debugw("WinPoSt not eligible to mine on this base", "tipset", types.LogCids(base.TipSet.Cids()))
-		return true, persistNoWin()
+		return persistNoWin()
 	}
 
 	if !mbi.EligibleForMining {
 		// slashed or just have no power yet, we're done here
 		log.Debugw("WinPoSt not eligible for mining", "tipset", types.LogCids(base.TipSet.Cids()))
-		return true, persistNoWin()
+		return persistNoWin()
 	}
 
 	if len(mbi.Sectors) == 0 {
@@ -217,7 +222,7 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		if eproof == nil {
 			// not a winner, we're done here
 			log.Debugw("WinPoSt not a winner", "tipset", types.LogCids(base.TipSet.Cids()))
-			return true, persistNoWin()
+			return persistNoWin()
 		}
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR fixes a small bug where occasionally in epochs where we didn't win a block we would, for whatever reason, fail to persist that we didn't won on a given mining base, but still would mark the task as successfully executed.

This could lead to an edge-case where if we could win in the next epoch mining on the same base, we wouldn't try, because that could trigger a slashing condition

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
