### PR TITLE
fix: sync: do not include incoming in return of syncFork

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -896,7 +896,7 @@ func (syncer *Syncer) syncFork(ctx context.Context, incoming *types.TipSet, know
 
 	if commonParent {
 		// known contains at least one of incoming's Parents => the common ancestor is known's Parents (incoming's Grandparents)
-		// in this case, we need to return {incoming, incoming.Parents()}
+		// in this case, we need to return {incoming.Parents()}
 		incomingParents, err := syncer.store.LoadTipSet(ctx, incomingParentsTsk)
 		if err != nil {
 			// fallback onto the network
@@ -912,7 +912,7 @@ func (syncer *Syncer) syncFork(ctx context.Context, incoming *types.TipSet, know
 			incomingParents = tips[0]
 		}
 
-		return []*types.TipSet{incoming, incomingParents}, nil
+		return []*types.TipSet{incomingParents}, nil
 	}
 
 	// TODO: Does this mean we always ask for ForkLengthThreshold blocks from the network, even if we just need, like, 2? Yes.


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Both @TippyFlitsUK and I ran into failures on [this line](https://github.com/filecoin-project/lotus/blob/7f684ec84008c6996bb2c6f39ce444ca4623c278/chain/exchange/client.go#L278) when running latest master. This is due to a bug in #11533, which causes us to return one EXTRA tipset in the return. This return then gets folded into the `blockSet`, which includes the `incoming` tipset already, leading to us having a non-continuous "chain".

## Proposed Changes
<!-- A clear list of the changes being made -->

Only return `incomingParents` in this case.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Please don't merge until I've done some additional testing.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
