### PR TITLE
chore: sync: cleanup sync serve and reduce log noise

### DIFF
--- a/chain/exchange/server.go
+++ b/chain/exchange/server.go
@@ -137,7 +137,7 @@ func (s *server) serviceRequest(ctx context.Context, req *validatedRequest) (*Re
 
 	chain, err := collectChainSegment(ctx, s.cs, req)
 	if err != nil {
-		log.Warn("block sync request: collectChainSegment failed: ", err)
+		log.Debug("block sync request: collectChainSegment failed: ", err)
 		return &Response{
 			Status:       InternalError,
 			ErrorMessage: err.Error(),
@@ -171,17 +171,12 @@ func collectChainSegment(ctx context.Context, cs *store.ChainStore, req *validat
 		}
 
 		if req.options.IncludeMessages {
-			bmsgs, bmincl, smsgs, smincl, err := gatherMessages(ctx, cs, ts)
+			bst.Messages, err = gatherMessages(ctx, cs, ts)
 			if err != nil {
+				log.Warn("collectChainSegment failed: ", err)
 				return nil, xerrors.Errorf("gather messages failed: %w", err)
 			}
 
-			// FIXME: Pass the response to `gatherMessages()` and set all this there.
-			bst.Messages = &CompactedMessages{}
-			bst.Messages.Bls = bmsgs
-			bst.Messages.BlsIncludes = bmincl
-			bst.Messages.Secpk = smsgs
-			bst.Messages.SecpkIncludes = smincl
 		}
 
 		bstips = append(bstips, &bst)
@@ -196,16 +191,16 @@ func collectChainSegment(ctx context.Context, cs *store.ChainStore, req *validat
 	}
 }
 
-func gatherMessages(ctx context.Context, cs *store.ChainStore, ts *types.TipSet) ([]*types.Message, [][]uint64, []*types.SignedMessage, [][]uint64, error) {
+func gatherMessages(ctx context.Context, cs *store.ChainStore, ts *types.TipSet) (*CompactedMessages, error) {
+	msgs := new(CompactedMessages)
 	blsmsgmap := make(map[cid.Cid]uint64)
 	secpkmsgmap := make(map[cid.Cid]uint64)
-	var secpkincl, blsincl [][]uint64
 
 	var blscids, secpkcids []cid.Cid
 	for _, block := range ts.Blocks() {
 		bc, sc, err := cs.ReadMsgMetaCids(ctx, block.Messages)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, err
 		}
 
 		// FIXME: DRY. Use `chain.Message` interface.
@@ -220,7 +215,7 @@ func gatherMessages(ctx context.Context, cs *store.ChainStore, ts *types.TipSet)
 
 			bmi = append(bmi, i)
 		}
-		blsincl = append(blsincl, bmi)
+		msgs.BlsIncludes = append(msgs.BlsIncludes, bmi)
 
 		smi := make([]uint64, 0, len(sc))
 		for _, m := range sc {
@@ -233,18 +228,19 @@ func gatherMessages(ctx context.Context, cs *store.ChainStore, ts *types.TipSet)
 
 			smi = append(smi, i)
 		}
-		secpkincl = append(secpkincl, smi)
+		msgs.SecpkIncludes = append(msgs.SecpkIncludes, smi)
 	}
 
-	blsmsgs, err := cs.LoadMessagesFromCids(ctx, blscids)
+	var err error
+	msgs.Bls, err = cs.LoadMessagesFromCids(ctx, blscids)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 
-	secpkmsgs, err := cs.LoadSignedMessagesFromCids(ctx, secpkcids)
+	msgs.Secpk, err = cs.LoadSignedMessagesFromCids(ctx, secpkcids)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 
-	return blsmsgs, blsincl, secpkmsgs, secpkincl, nil
+	return msgs, nil
 }


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Demote a noisy blocksync request error to debug. All this warning means is that someone is requesting a tipset we don't have.
2. Add a separate warning if we fail to collect a chain. If we have the tipsets but fail to collect the chain, something is actually wrong.
3. Fix a TODO and return a single CompactedMessages rather than 4 separate values.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green