### PR TITLE
feat:market:add lotus filplus cli for extend claims terms

### DIFF
--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1192,6 +1192,7 @@ COMMANDS:
    list-claims                    List claims made by provider
    remove-expired-allocations     remove expired allocations (if no allocations are specified all eligible allocations are removed)
    remove-expired-claims          remove expired claims (if no claims are specified all eligible claims are removed)
+   extend-claims-terms            extend claims terms
    help, h                        Shows a list of commands or help for one command
 
 OPTIONS:
@@ -1322,6 +1323,22 @@ USAGE:
 OPTIONS:
    --from value  optionally specify the account to send the message from
    --help, -h    show help
+```
+
+### lotus filplus extend-claims-terms
+```
+NAME:
+   lotus filplus extend-claims-terms - extend claims terms
+
+USAGE:
+   lotus filplus extend-claims-terms [command options] providerAddress Optional[...claimId]
+
+OPTIONS:
+   --from value            specify the account to send the message from, it's client address
+   --extension value       try to extend selected sectors by this number of epochs, defaults to 180 days (default: 518400)
+   --new-expiration value  try to extend selected sectors to this epoch, ignoring extension (default: 0)
+   --really-do-it          pass this flag to really extend sectors, otherwise will only print out json representation of parameters (default: false)
+   --help, -h              show help
 ```
 
 ## lotus paych


### PR DESCRIPTION
## Related Issues
resolve #10908

## Proposed Changes
Add the CLI command for deal renewal

## Additional Info
Name:      "extend-claims-terms",
	Usage:     "extend claims terms",
	ArgsUsage: "providerAddress Optional[...claimId]",
	Flags: []cli.Flag{
		&cli.StringFlag{
			Name:     "from",
			Usage:    "specify the account to send the message from, it's client address",
			Required: true,
		},
		&cli.Int64Flag{
			Name:  "extension",
			Usage: "try to extend selected sectors by this number of epochs, defaults to 180 days",
			Value: 518400,
		},
		&cli.Int64Flag{
			Name:  "new-expiration",
			Usage: "try to extend selected sectors to this epoch, ignoring extension",
		},
		&cli.BoolFlag{
			Name:  "really-do-it",
			Usage: "pass this flag to really extend sectors, otherwise will only print out json representation of parameters",
		},
	},

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
