### PR TITLE
fix: build: Remove lotus-provider from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,6 @@ COPY --from=lotus-builder /opt/filecoin/lotus-wallet   /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-gateway  /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-miner    /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-worker   /usr/local/bin/
-COPY --from=lotus-builder /opt/filecoin/lotus-provider    /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-stats    /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-fountain /usr/local/bin/
 
@@ -118,13 +117,11 @@ RUN mkdir /var/lib/lotus
 RUN mkdir /var/lib/lotus-miner
 RUN mkdir /var/lib/lotus-worker
 RUN mkdir /var/lib/lotus-wallet
-RUN mkdir /var/lib/lotus-provider
 RUN chown fc: /var/tmp/filecoin-proof-parameters
 RUN chown fc: /var/lib/lotus
 RUN chown fc: /var/lib/lotus-miner
 RUN chown fc: /var/lib/lotus-worker
 RUN chown fc: /var/lib/lotus-wallet
-RUN chown fc: /var/lib/lotus-provider
 
 
 VOLUME /var/tmp/filecoin-proof-parameters
@@ -132,7 +129,6 @@ VOLUME /var/lib/lotus
 VOLUME /var/lib/lotus-miner
 VOLUME /var/lib/lotus-worker
 VOLUME /var/lib/lotus-wallet
-VOLUME /var/lib/lotus-provider
 
 EXPOSE 1234
 EXPOSE 2345


### PR DESCRIPTION
## Related Issues
In the last step before for cutting the v1.25.2 release, [merging `release/v1.25.2` to the `releases`](https://github.com/filecoin-project/lotus/pull/11553), the CI docker build [fails with](https://app.circleci.com/pipelines/github/filecoin-project/lotus/31802/workflows/0e96d132-07e7-47b3-b1e6-e90e590420c2/jobs/1114601): 

```
=> ERROR [lotus-all-in-one  8/22] COPY --from=lotus-builder /opt/filecoi  0.0s
------
 > [lotus-all-in-one  8/22] COPY --from=lotus-builder /opt/filecoin/lotus-provider    /usr/local/bin/:
------
failed to compute cache key: failed to calculate checksum of ref 4dddd76b-5b3a-43be-86d2-b72bdebbcc1a::qyvt7ranlgym2ld0zjo6g0a5i: "/opt/filecoin/lotus-provider": not found
Exited with code exit status 1
```

l could not find who owns/where one adds code to `lotus-all-in-one` docker for unblocking shipping lotus-provider with it. 

## Proposed Changes
I propose removing lotus-provider from the dockerfile for now, as its still in alpha-state, and should not block the release of v1.25.2.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
