### PR TITLE
feat: exchange: change GetBlocks to always fetch the requested number of tipsets

### DIFF
--- a/chain/exchange/client.go
+++ b/chain/exchange/client.go
@@ -284,16 +284,18 @@ func (c *client) validateCompressedIndices(chain []*BSTipSet) error {
 				len(msgs.SecpkIncludes), blocksNum)
 		}
 
+		blsLen := uint64(len(msgs.Bls))
+		secpLen := uint64(len(msgs.Secpk))
 		for blockIdx := 0; blockIdx < blocksNum; blockIdx++ {
 			for _, mi := range msgs.BlsIncludes[blockIdx] {
-				if int(mi) >= len(msgs.Bls) {
+				if mi >= blsLen {
 					return xerrors.Errorf("index in BlsIncludes (%d) exceeds number of messages (%d)",
 						mi, len(msgs.Bls))
 				}
 			}
 
 			for _, mi := range msgs.SecpkIncludes[blockIdx] {
-				if int(mi) >= len(msgs.Secpk) {
+				if mi >= secpLen {
 					return xerrors.Errorf("index in SecpkIncludes (%d) exceeds number of messages (%d)",
 						mi, len(msgs.Secpk))
 				}
@@ -315,18 +317,36 @@ func (c *client) GetBlocks(ctx context.Context, tsk types.TipSetKey, count int) 
 		)
 	}
 
-	req := &Request{
-		Head:    tsk.Cids(),
-		Length:  uint64(count),
-		Options: Headers,
+	var ret []*types.TipSet
+	start := tsk.Cids()
+	for len(ret) < count {
+		req := &Request{
+			Head:    start,
+			Length:  uint64(count - len(ret)),
+			Options: Headers,
+		}
+
+		validRes, err := c.doRequest(ctx, req, nil, nil)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to doRequest: %w", err)
+		}
+
+		if len(validRes.tipsets) == 0 {
+			return nil, xerrors.Errorf("doRequest fetched zero tipsets: %w", err)
+		}
+
+		ret = append(ret, validRes.tipsets...)
+
+		last := validRes.tipsets[len(validRes.tipsets)-1]
+		if last.Height() <= 1 {
+			// we've walked all the way up to genesis, return
+			break
+		}
+
+		start = last.Parents().Cids()
 	}
 
-	validRes, err := c.doRequest(ctx, req, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return validRes.tipsets, nil
+	return ret, nil
 }
 
 // GetFullTipSet implements Client.GetFullTipSet(). Refer to the godocs there.
@@ -341,12 +361,16 @@ func (c *client) GetFullTipSet(ctx context.Context, peer peer.ID, tsk types.TipS
 
 	validRes, err := c.doRequest(ctx, req, &peer, nil)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to doRequest: %w", err)
 	}
 
-	return validRes.toFullTipSets()[0], nil
-	// If `doRequest` didn't fail we are guaranteed to have at least
-	//  *one* tipset here, so it's safe to index directly.
+	fullTipsets := validRes.toFullTipSets()
+
+	if len(fullTipsets) == 0 {
+		return nil, xerrors.New("unexpectedly got no tipsets in exchange")
+	}
+
+	return fullTipsets[0], nil
 }
 
 // GetChainMessages implements Client.GetChainMessages(). Refer to the godocs there.

--- a/chain/exchange/interfaces.go
+++ b/chain/exchange/interfaces.go
@@ -28,8 +28,8 @@ type Server interface {
 // used by the Syncer.
 type Client interface {
 	// GetBlocks fetches block headers from the network, from the provided
-	// tipset *backwards*, returning as many tipsets as the count parameter,
-	// or less.
+	// tipset *backwards*, returning as many tipsets as the count parameter.
+	// The ONLY case in which we return fewer than `count` tipsets is if we hit genesis.
 	GetBlocks(ctx context.Context, tsk types.TipSetKey, count int) ([]*types.TipSet, error)
 
 	// GetChainMessages fetches messages from the network, starting from the first provided tipset


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Fixes #11529 

## Proposed Changes
<!-- A clear list of the changes being made -->

Change `GetBlocks` to always return `count` tipsets, unless we hit genesis. Partial responses are treated as correct, but the exchanger will still request more tipsets (instead of returning fewer than requested tipsets to the caller).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
