### PR TITLE
fix: docker: Dockerfile import snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY --from=lotus-builder /opt/filecoin/lotus /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-shed /usr/local/bin/
 COPY scripts/docker-lotus-entrypoint.sh /
 
-ARG DOCKER_LOTUS_IMPORT_SNAPSHOT https://snapshots.mainnet.filops.net/minimal/latest
+ARG DOCKER_LOTUS_IMPORT_SNAPSHOT=https://forest-archive.chainsafe.dev/latest/mainnet/
 ENV DOCKER_LOTUS_IMPORT_SNAPSHOT ${DOCKER_LOTUS_IMPORT_SNAPSHOT}
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV LOTUS_PATH /var/lib/lotus

--- a/scripts/docker-lotus-entrypoint.sh
+++ b/scripts/docker-lotus-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 
-if [ ! -z $DOCKER_LOTUS_IMPORT_SNAPSHOT ]; then
+if [ ! -z "$DOCKER_LOTUS_IMPORT_SNAPSHOT" ]; then
 	GATE="$LOTUS_PATH"/date_initialized
 	# Don't init if already initialized.
 	if [ ! -f "$GATE" ]; then
 		echo importing minimal snapshot
-		/usr/local/bin/lotus daemon --import-snapshot "$DOCKER_LOTUS_IMPORT_SNAPSHOT" --halt-after-import
+		/usr/local/bin/lotus daemon \
+			--import-snapshot "$DOCKER_LOTUS_IMPORT_SNAPSHOT" \
+			--remove-existing-chain=false \
+			--halt-after-import
 		# Block future inits
 		date > "$GATE"
 	fi
 fi
 
 # import wallet, if provided
-if [ ! -z $DOCKER_LOTUS_IMPORT_WALLET ]; then
+if [ ! -z "$DOCKER_LOTUS_IMPORT_WALLET" ]; then
 	/usr/local/bin/lotus-shed keyinfo import "$DOCKER_LOTUS_IMPORT_WALLET"
 fi
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
- Updates Dockerfile to default to a working snapshot endpoint
  ```bash
  curl -I https://snapshots.mainnet.filops.net/minimal/latest
  HTTP/1.1 503 Service Unavailable: Back-end server is at capacity
  Connection: keep-alive
  ```
  ```bash
    curl -I https://forest-archive.chainsafe.dev/latest/mainnet/
    HTTP/2 302
    ...
  ```
- Since 1.25.2, entrypoint script requires `yes` to import the snapshot

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
