### PR TITLE
Add missing fields for v12 miner

### DIFF
--- a/chain/actors/builtin/miner/v12.go
+++ b/chain/actors/builtin/miner/v12.go
@@ -543,6 +543,8 @@ func fromV12SectorOnChainInfo(v12 miner12.SectorOnChainInfo) SectorOnChainInfo {
 		InitialPledge:         v12.InitialPledge,
 		ExpectedDayReward:     v12.ExpectedDayReward,
 		ExpectedStoragePledge: v12.ExpectedStoragePledge,
+		PowerBaseEpoch:        v12.PowerBaseEpoch,
+		ReplacedDayReward:     v12.ReplacedDayReward,
 
 		SectorKeyCID: v12.SectorKeyCID,
 	}


### PR DESCRIPTION
## Related Issues

https://github.com/filecoin-project/lotus/pull/11566


## Proposed Changes

Add data for `PowerBaseEpoch` and `ReplacedDayReward` fields so they appear in the JSON-RPC API.
