### PR TITLE
fix: eth: re-execute tipsets on missing events

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -422,15 +422,7 @@ func (a *EthModule) EthGetTransactionReceiptLimited(ctx context.Context, txHash 
 		return nil, xerrors.Errorf("failed to convert %s into an Eth Txn: %w", txHash, err)
 	}
 
-	var events []types.Event
-	if rct := msgLookup.Receipt; rct.EventsRoot != nil {
-		events, err = a.ChainAPI.ChainGetEvents(ctx, *rct.EventsRoot)
-		if err != nil {
-			return nil, xerrors.Errorf("failed get events for %s", txHash)
-		}
-	}
-
-	receipt, err := newEthTxReceipt(ctx, tx, msgLookup, events, a.Chain, a.StateAPI)
+	receipt, err := newEthTxReceipt(ctx, tx, msgLookup, a.ChainAPI, a.StateAPI)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to convert %s into an Eth Receipt: %w", txHash, err)
 	}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes #11335

## Proposed Changes
<!-- A clear list of the changes being made -->

This will re-execute tipsets to forcibly re-compute and store events when they're missing. This is effectively lazy backfilling of events.

NOTE: This _won't_ backfill the index itself, it'll just give us the events.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green