### PR TITLE
feat: drand: refactor round verification

### DIFF
--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -170,10 +170,6 @@ func (db *DrandBeacon) VerifyEntry(curr types.BeaconEntry, prev types.BeaconEntr
 		return nil
 	}
 
-	if curr.Round != prev.Round+1 {
-		return xerrors.Errorf("invalid beacon entry: cur (%d) != prev (%d) + 1", curr.Round, prev.Round)
-	}
-
 	if be := db.getCachedValue(curr.Round); be != nil {
 		if !bytes.Equal(curr.Data, be.Data) {
 			return xerrors.New("invalid beacon value, does not match cached good value")
@@ -190,7 +186,8 @@ func (db *DrandBeacon) VerifyEntry(curr types.BeaconEntry, prev types.BeaconEntr
 	if err == nil {
 		db.cacheValue(curr)
 	}
-	return err
+
+	return nil
 }
 
 func (db *DrandBeacon) MaxBeaconRoundForEpoch(nv network.Version, filEpoch abi.ChainEpoch) uint64 {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -704,25 +704,25 @@ func (syncer *Syncer) collectHeaders(ctx context.Context, incoming *types.TipSet
 	}
 
 	{
-		// ensure consistency of beacon entires
+		// ensure consistency of beacon entries
 		targetBE := incoming.Blocks()[0].BeaconEntries
 		sorted := sort.SliceIsSorted(targetBE, func(i, j int) bool {
 			return targetBE[i].Round < targetBE[j].Round
 		})
 		if !sorted {
-			syncer.bad.Add(incoming.Cids()[0], NewBadBlockReason(incoming.Cids(), "wrong order of beacon entires"))
-			return nil, xerrors.Errorf("wrong order of beacon entires")
+			syncer.bad.Add(incoming.Cids()[0], NewBadBlockReason(incoming.Cids(), "wrong order of beacon entries"))
+			return nil, xerrors.Errorf("wrong order of beacon entries")
 		}
 
 		for _, bh := range incoming.Blocks()[1:] {
 			if len(targetBE) != len(bh.BeaconEntries) {
 				// cannot mark bad, I think @Kubuxu
-				return nil, xerrors.Errorf("tipset contained different number for beacon entires")
+				return nil, xerrors.Errorf("tipset contained different number for beacon entries")
 			}
 			for i, be := range bh.BeaconEntries {
 				if targetBE[i].Round != be.Round || !bytes.Equal(targetBE[i].Data, be.Data) {
 					// cannot mark bad, I think @Kubuxu
-					return nil, xerrors.Errorf("tipset contained different beacon entires")
+					return nil, xerrors.Errorf("tipset contained different beacon entries")
 				}
 			}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

This is a refactor of some of the beacon logic in preparation of FIP-0063, although this doesn't actually implement any logic towards that. 

We currently assume that the beacon entries included in blocks must make a contiguous chain (no skipped rounds). This is currently needed, because we're using chained randomness.

## Proposed Changes
<!-- A clear list of the changes being made -->

This PR doesn't lead to any change in behaviour, but changes the logic to instead rely on expected _rounds_. We expect a certain _round_ for every epoch, and include the beacon entry corresponding to that round in our blocks.

This makes the logic easier to extend when we switch to unchained randomness with a different period than Filecoin.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
