### PR TITLE
harmonytask feature: find clean-up work when underutilized. 

### DIFF
--- a/itests/harmonytask_test.go
+++ b/itests/harmonytask_test.go
@@ -298,6 +298,6 @@ func TestBoredom(t *testing.T) {
 		ht, err := harmonytask.New(cdb, []harmonytask.TaskInterface{boredParty}, "test:1")
 		require.NoError(t, err)
 		require.Eventually(t, func() bool { return ran }, time.Second, time.Millisecond*100)
-		ht.GracefullyTerminate(time.Hour)
+		ht.GracefullyTerminate()
 	})
 }

--- a/lib/harmony/harmonytask/harmonytask.go
+++ b/lib/harmony/harmonytask/harmonytask.go
@@ -345,6 +345,7 @@ func (e *TaskEngine) pollerTryAllWork() bool {
 	}
 	// if no work was accepted, are we bored? Then find work in priority order.
 	for _, v := range e.handlers {
+		v := v
 		if v.AssertMachineHasCapacity() != nil {
 			continue
 		}

--- a/lib/harmony/harmonytask/task_type_handler.go
+++ b/lib/harmony/harmonytask/task_type_handler.go
@@ -53,8 +53,9 @@ retryAddTask:
 }
 
 const (
-	workSourcePoller  = "poller"
-	workSourceRecover = "recovered"
+	WorkSourcePoller   = "poller"
+	WorkSourceRecover  = "recovered"
+	WorkSourceIAmBored = "bored"
 )
 
 // considerWork is called to attempt to start work on a task-id of this task type.
@@ -84,9 +85,14 @@ top:
 		return false
 	}
 
+	h.TaskEngine.WorkOrigin = from
+
 	// 3. What does the impl say?
 canAcceptAgain:
 	tID, err := h.CanAccept(ids, h.TaskEngine)
+
+	h.TaskEngine.WorkOrigin = ""
+
 	if err != nil {
 		log.Error(err)
 		return false
@@ -123,7 +129,7 @@ canAcceptAgain:
 	}
 
 	// if recovering we don't need to try to claim anything because those tasks are already claimed by us
-	if from != workSourceRecover {
+	if from != WorkSourceRecover {
 		// 4. Can we claim the work for our hostname?
 		ct, err := h.TaskEngine.db.Exec(h.TaskEngine.ctx, "UPDATE harmony_task SET owner_id=$1 WHERE id=$2 AND owner_id IS NULL", h.TaskEngine.ownerID, *tID)
 		if err != nil {


### PR DESCRIPTION
A helper for correct handling of different syncs for potential new harmony tasks. This will allow tasks to be created on demand of available resources so that both batching and non-batching processes can consume from the same inflow. 

## Proposed Changes
Pipelines' first steps can implement TaskDefinition.IAmBored to scrounge up more work when they have the capacity to work it. 
Mid-pipeline stages can look at later failed stages for advanced recovery.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
