### PR TITLE
Add lotus-provider to build to match install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ lotus-gateway: $(BUILD_DEPS)
 .PHONY: lotus-gateway
 BINS+=lotus-gateway
 
-build: lotus lotus-miner lotus-worker 
+build: lotus lotus-miner lotus-worker lotus-provider
 	@[[ $$(type -P "lotus") ]] && echo "Caution: you have \
 an existing lotus binary in your PATH. This may cause problems if you don't run 'sudo make install'" || true
 


### PR DESCRIPTION
There's currently a mismatch between `build` and `install` in that `install` always tries to install `lotus-provider` and will error if it's not built, but `build` doesn't build it for you; so a `make clean && make build && sudo make install` will always fail.

This adds `lotus-provider` to `build`, but the alternative is to remove `lotus-provider` from `install`. That option may be more appropriate since it's still under development?