### PR TITLE
Clean up warning message

### DIFF
--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -149,7 +149,7 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return xerrors.Errorf("block was from the future (now=%d, blk=%d): %w", now, h.Timestamp, consensus.ErrTemporal)
 	}
 	if h.Timestamp > now {
-		log.Warn("Got block from the future, but within threshold", h.Timestamp, build.Clock.Now().Unix())
+		log.Warnf("Got block from the future, but within threshold (%d > %d)", h.Timestamp, now)
 	}
 
 	minerCheck := async.Err(func() error {


### PR DESCRIPTION
Minor annoyance, there's no space after the text and the timestamp, also it should use `now` rather than recalc current unixtime.