### PR TITLE
fix: state: remove watermelon migration hack

### DIFF
--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -178,18 +178,16 @@ func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, heig
 	retCid := root
 	u := sm.stateMigrations[height]
 	if u != nil && u.upgrade != nil {
-		if height != build.UpgradeWatermelonFixHeight {
-			migCid, ok, err := u.migrationResultCache.Get(ctx, root)
-			if err == nil {
-				if ok {
-					log.Infow("CACHED migration", "height", height, "from", root, "to", migCid)
-					return migCid, nil
-				}
-			} else if !errors.Is(err, datastore.ErrNotFound) {
-				log.Errorw("failed to lookup previous migration result", "err", err)
-			} else {
-				log.Debug("no cached migration found, migrating from scratch")
+		migCid, ok, err := u.migrationResultCache.Get(ctx, root)
+		if err == nil {
+			if ok {
+				log.Infow("CACHED migration", "height", height, "from", root, "to", migCid)
+				return migCid, nil
 			}
+		} else if !errors.Is(err, datastore.ErrNotFound) {
+			log.Errorw("failed to lookup previous migration result", "err", err)
+		} else {
+			log.Debug("no cached migration found, migrating from scratch")
 		}
 
 		startTime := time.Now()
@@ -197,7 +195,6 @@ func (sm *StateManager) HandleStateForks(ctx context.Context, root cid.Cid, heig
 		// Yes, we clone the cache, even for the final upgrade epoch. Why? Reverts. We may
 		// have to migrate multiple times.
 		tmpCache := u.cache.Clone()
-		var err error
 		retCid, err = u.upgrade(ctx, sm, tmpCache, cb, root, height, ts)
 		if err != nil {
 			log.Errorw("FAILED migration", "height", height, "from", root, "error", err)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

Remove migration cache skip hack from the StateManager.

We did this to avoid using cached migrations in the borked watermelon upgrade on calibrationnet, but we don't need to keep this in the code (even for users syncing from scratch).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green