### PR TITLE
Avoid duplicate messages when looking for receipts

### DIFF
--- a/itests/direct_data_onboard_test.go
+++ b/itests/direct_data_onboard_test.go
@@ -498,10 +498,15 @@ func buildActorEventsFromMessages(ctx context.Context, t *testing.T, node v1api.
 
 	head, err := node.ChainHead(ctx)
 	require.NoError(t, err)
+	var lastts types.TipSetKey
 	for height := 0; height < int(head.Height()); height++ {
 		// for each tipset
 		ts, err := node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height), types.EmptyTSK)
 		require.NoError(t, err)
+		if ts.Key() == lastts {
+			continue
+		}
+		lastts = ts.Key()
 		messages, err := node.ChainGetMessagesInTipset(ctx, ts.Key())
 		require.NoError(t, err)
 		if len(messages) == 0 {


### PR DESCRIPTION
From CI failure in https://github.com/filecoin-project/lotus/pull/11626

I think it's possible to get the same tipset for a height, somehow; or maybe it's too early to be getting the final tipset for the head's height? I'd like an explanation for this if someone has it.