### PR TITLE
Add `unittests` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,10 @@ install-completions:
 	install -C ./scripts/bash-completion/lotus /usr/share/bash-completion/completions/lotus
 	install -C ./scripts/zsh-completion/lotus /usr/local/share/zsh/site-functions/_lotus
 
+unittests:
+	@$(GOCC) test $(shell go list ./... | grep -v /lotus/itests)
+.PHONY: unittests
+
 clean:
 	rm -rf $(CLEAN) $(BINS)
 	-$(MAKE) -C $(FFI_PATH) clean


### PR DESCRIPTION
Is there a better way of doing this currently that I'm not seeing? I can see in the CircleCI config that we're explicitly listing packages and grouping them to be run on different machines.