### PR TITLE
feat: lotus-provider: Storage reservations in SDR

### DIFF
--- a/itests/harmonytask_test.go
+++ b/itests/harmonytask_test.go
@@ -46,8 +46,8 @@ func (t *task1) Do(tID harmonytask.TaskID, stillOwned func() bool) (done bool, e
 	t.WorkCompleted = append(t.WorkCompleted, fmt.Sprintf("taskResult%d", t.myPersonalTable[tID]))
 	return true, nil
 }
-func (t *task1) CanAccept(list []harmonytask.TaskID, e *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
-	return &list[0], nil
+func (t *task1) CanAccept(list []harmonytask.TaskID, e *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
+	return &list[0], nil, nil
 }
 func (t *task1) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
@@ -107,7 +107,7 @@ type passthru struct {
 func (t *passthru) Do(tID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	return t.do(tID, stillOwned)
 }
-func (t *passthru) CanAccept(list []harmonytask.TaskID, e *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (t *passthru) CanAccept(list []harmonytask.TaskID, e *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	return t.canAccept(list, e)
 }
 func (t *passthru) TypeDetails() harmonytask.TaskTypeDetails {

--- a/lib/harmony/harmonytask/harmonytask.go
+++ b/lib/harmony/harmonytask/harmonytask.go
@@ -41,6 +41,11 @@ type TaskTypeDetails struct {
 	Follows map[string]func(TaskID, AddTaskFunc) (bool, error)
 }
 
+type AcceptData interface {
+	// NotClaimed is called by harmonytask when the task is not claimed by this node
+	NotClaimed() error
+}
+
 // TaskInterface must be implemented in order to have a task used by harmonytask.
 type TaskInterface interface {
 	// Do the task assigned. Call stillOwned before making single-writer-only

--- a/lib/harmony/harmonytask/harmonytask.go
+++ b/lib/harmony/harmonytask/harmonytask.go
@@ -54,13 +54,15 @@ type TaskInterface interface {
 	// ONLY be called by harmonytask.
 	// Indicate if the task no-longer needs scheduling with done=true including
 	// cases where it's past the deadline.
-	Do(taskID TaskID, stillOwned func() bool) (done bool, err error)
+	Do(taskID TaskID, acceptData AcceptData, stillOwned func() bool) (done bool, err error)
 
 	// CanAccept should return if the task can run on this machine. It should
 	// return null if the task type is not allowed on this machine.
 	// It should select the task it most wants to accomplish.
 	// It is also responsible for determining & reserving disk space (including scratch).
-	CanAccept([]TaskID, *TaskEngine) (*TaskID, error)
+	// AcceptData is an optional parameter which can be used to pass data to the Do function.
+	// If the task is not claimed on this node, harmonytask will call NotClaimed on the AcceptData.
+	CanAccept([]TaskID, *TaskEngine) (*TaskID, AcceptData, error)
 
 	// TypeDetails() returns static details about how this task behaves and
 	// how this machine will run it. Read once at the beginning.

--- a/provider/lpmessage/sender.go
+++ b/provider/lpmessage/sender.go
@@ -59,7 +59,7 @@ type SendTask struct {
 	db *harmonydb.DB
 }
 
-func (s *SendTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (s *SendTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.TODO()
 
 	// get message from db
@@ -219,18 +219,18 @@ func (s *SendTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done b
 	return true, nil
 }
 
-func (s *SendTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (s *SendTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	if len(ids) == 0 {
 		// probably can't happen, but panicking is bad
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if s.signer == nil {
 		// can't sign messages here
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	return &ids[0], nil
+	return &ids[0], nil, nil
 }
 
 func (s *SendTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_movestorage.go
+++ b/provider/lpseal/task_movestorage.go
@@ -31,7 +31,7 @@ func NewMoveStorageTask(sp *SealPoller, sc *lpffi.SealCalls, db *harmonydb.DB, m
 	}
 }
 
-func (m *MoveStorageTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (m *MoveStorageTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	var tasks []struct {
 		SpID         int64 `db:"sp_id"`
 		SectorNumber int64 `db:"sector_number"`
@@ -71,7 +71,7 @@ func (m *MoveStorageTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) 
 	return true, nil
 }
 
-func (m *MoveStorageTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (m *MoveStorageTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 
 	ctx := context.Background()
 	/*
@@ -117,7 +117,7 @@ func (m *MoveStorageTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytas
 	////
 	ls, err := m.sc.LocalStorage(ctx)
 	if err != nil {
-		return nil, xerrors.Errorf("getting local storage: %w", err)
+		return nil, nil, xerrors.Errorf("getting local storage: %w", err)
 	}
 	var haveStorage bool
 	for _, l := range ls {
@@ -128,11 +128,11 @@ func (m *MoveStorageTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytas
 	}
 
 	if !haveStorage {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (m *MoveStorageTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_porep.go
+++ b/provider/lpseal/task_porep.go
@@ -43,7 +43,7 @@ func NewPoRepTask(db *harmonydb.DB, api PoRepAPI, sp *SealPoller, sc *lpffi.Seal
 	}
 }
 
-func (p *PoRepTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (p *PoRepTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
 	var sectorParamsArr []struct {
@@ -129,11 +129,11 @@ func (p *PoRepTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 	return true, nil
 }
 
-func (p *PoRepTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (p *PoRepTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	// todo sort by priority
 
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (p *PoRepTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_sdr.go
+++ b/provider/lpseal/task_sdr.go
@@ -188,6 +188,7 @@ func (s *SDRTask) getTicket(ctx context.Context, maddr address.Address) (abi.Sea
 
 func (s *SDRTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
 	// todo check storage (reserve too?)
+	//_ =s.sc.ReserveSDRStorage()
 
 	id := ids[0]
 	return &id, nil

--- a/provider/lpseal/task_sdr.go
+++ b/provider/lpseal/task_sdr.go
@@ -50,7 +50,7 @@ func NewSDRTask(api SDRAPI, db *harmonydb.DB, sp *SealPoller, sc *lpffi.SealCall
 	}
 }
 
-func (s *SDRTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (s *SDRTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
 	var sectorParamsArr []struct {
@@ -186,12 +186,12 @@ func (s *SDRTask) getTicket(ctx context.Context, maddr address.Address) (abi.Sea
 	return abi.SealRandomness(rand), ticketEpoch, nil
 }
 
-func (s *SDRTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (s *SDRTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	// todo check storage (reserve too?)
 	//_ =s.sc.ReserveSDRStorage()
 
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (s *SDRTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_submit_commit.go
+++ b/provider/lpseal/task_submit_commit.go
@@ -53,7 +53,7 @@ func NewSubmitCommitTask(sp *SealPoller, db *harmonydb.DB, api SubmitCommitAPI, 
 	}
 }
 
-func (s *SubmitCommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (s *SubmitCommitTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
 	var sectorParamsArr []struct {
@@ -153,9 +153,9 @@ func (s *SubmitCommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	return true, nil
 }
 
-func (s *SubmitCommitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (s *SubmitCommitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (s *SubmitCommitTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_submit_precommit.go
+++ b/provider/lpseal/task_submit_precommit.go
@@ -52,7 +52,7 @@ func NewSubmitPrecommitTask(sp *SealPoller, db *harmonydb.DB, api SubmitPrecommi
 	}
 }
 
-func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
 	var sectorParamsArr []struct {
@@ -189,9 +189,9 @@ func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 	return true, nil
 }
 
-func (s *SubmitPrecommitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (s *SubmitPrecommitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (s *SubmitPrecommitTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpseal/task_trees.go
+++ b/provider/lpseal/task_trees.go
@@ -39,7 +39,7 @@ func NewTreesTask(sp *SealPoller, db *harmonydb.DB, sc *lpffi.SealCalls, maxTree
 	}
 }
 
-func (t *TreesTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (t *TreesTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
 	var sectorParamsArr []struct {
@@ -170,11 +170,11 @@ func (t *TreesTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 	return true, nil
 }
 
-func (t *TreesTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (t *TreesTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	// todo reserve storage
 
 	id := ids[0]
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (t *TreesTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpwindow/recover_task.go
+++ b/provider/lpwindow/recover_task.go
@@ -86,7 +86,7 @@ func NewWdPostRecoverDeclareTask(sender *lpmessage.Sender,
 	return t, nil
 }
 
-func (w *WdPostRecoverDeclareTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (w *WdPostRecoverDeclareTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	log.Debugw("WdPostRecoverDeclareTask.Do()", "taskID", taskID)
 	ctx := context.Background()
 
@@ -202,18 +202,18 @@ func (w *WdPostRecoverDeclareTask) Do(taskID harmonytask.TaskID, stillOwned func
 	return true, nil
 }
 
-func (w *WdPostRecoverDeclareTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (w *WdPostRecoverDeclareTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	if len(ids) == 0 {
 		// probably can't happen, but panicking is bad
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if w.sender == nil {
 		// we can't send messages
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	return &ids[0], nil
+	return &ids[0], nil, nil
 }
 
 func (w *WdPostRecoverDeclareTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpwindow/submit_task.go
+++ b/provider/lpwindow/submit_task.go
@@ -71,7 +71,7 @@ func NewWdPostSubmitTask(pcs *chainsched.ProviderChainSched, send *lpmessage.Sen
 	return res, nil
 }
 
-func (w *WdPostSubmitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (w *WdPostSubmitTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	log.Debugw("WdPostSubmitTask.Do", "taskID", taskID)
 
 	var spID uint64
@@ -167,18 +167,18 @@ func (w *WdPostSubmitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	return true, nil
 }
 
-func (w *WdPostSubmitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (w *WdPostSubmitTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	if len(ids) == 0 {
 		// probably can't happen, but panicking is bad
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if w.sender == nil {
 		// we can't send messages
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	return &ids[0], nil
+	return &ids[0], nil, nil
 }
 
 func (w *WdPostSubmitTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/provider/lpwinning/winning_task.go
+++ b/provider/lpwinning/winning_task.go
@@ -86,7 +86,7 @@ func NewWinPostTask(max int, db *harmonydb.DB, prover ProverWinningPoSt, verifie
 	return t
 }
 
-func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+func (t *WinPostTask) Do(taskID harmonytask.TaskID, data harmonytask.AcceptData, stillOwned func() bool) (done bool, err error) {
 	log.Debugw("WinPostTask.Do()", "taskID", taskID)
 
 	ctx := context.TODO()
@@ -421,10 +421,10 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	return true, nil
 }
 
-func (t *WinPostTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+func (t *WinPostTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, harmonytask.AcceptData, error) {
 	if len(ids) == 0 {
 		// probably can't happen, but panicking is bad
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// select lowest epoch
@@ -434,7 +434,7 @@ func (t *WinPostTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.Ta
 		var epoch uint64
 		err := t.db.QueryRow(context.Background(), `SELECT epoch FROM mining_tasks WHERE task_id = $1`, id).Scan(&epoch)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if lowestEpoch == 0 || abi.ChainEpoch(epoch) < lowestEpoch {
@@ -443,7 +443,7 @@ func (t *WinPostTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.Ta
 		}
 	}
 
-	return &lowestEpochID, nil
+	return &lowestEpochID, nil, nil
 }
 
 func (t *WinPostTask) TypeDetails() harmonytask.TaskTypeDetails {

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -437,6 +437,10 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 			return nil, storiface.Err(storiface.ErrTempAllocateSpace, xerrors.Errorf("can't reserve %d bytes in '%s' (id:%s), only %d available", overhead, p.local, id, stat.Available))
 		}
 
+		if _, ok := p.reservations[sid.ID]; ok {
+			return nil, xerrors.Errorf("sector %v already reserved on %s", sid, id)
+		}
+
 		p.reserved += overhead
 		p.reservations[sid.ID] |= fileType
 


### PR DESCRIPTION
## Related Issues
This PR addresses one of the remaining items from https://github.com/filecoin-project/lotus/pull/11534

## Proposed Changes
* Add a mechanism to `CanAccept` which makes it possible to reserve a resource which will be freed if task isn't taken, or will get passed to `Do` if it is.
* Use this mechanism to implement early storage reservation in the SDR task

## Additional Info
I did some manual testing on mainnet, and it seems to work flawlessly.
* Started a batch of 12 sectors with one SDR node which is only able to take 8
* Because the machine has multiple drives the initial batch didn't get space all at once
* Second run of CanAccept succeed for more sectors on the other drive
* Now it's just calmly waiting for more storage to become available
* At no point has the task registered an error, because it never errored!

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
