### PR TITLE
fix: lpwinning: Fix MiningBase.afterPropDelay

### DIFF
--- a/provider/lpwinning/winning_task.go
+++ b/provider/lpwinning/winning_task.go
@@ -178,7 +178,7 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	})
 
 	// MAKE A MINING ATTEMPT!!
-	log.Debugw("attempting to mine a block", "tipset", types.LogCids(base.TipSet.Cids()))
+	log.Debugw("attempting to mine a block", "tipset", types.LogCids(base.TipSet.Cids()), "null-rounds", base.AddRounds)
 
 	mbi, err := t.api.MinerGetBaseInfo(ctx, maddr, round, base.TipSet.Key())
 	if err != nil {
@@ -225,6 +225,8 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 			return persistNoWin()
 		}
 	}
+
+	log.Infow("WinPostTask won election", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "eproof", eproof)
 
 	// winning PoSt
 	var wpostProof []prooftypes.PoStProof
@@ -277,6 +279,8 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		}
 	}
 
+	log.Infow("WinPostTask winning PoSt computed", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "proofs", wpostProof)
+
 	ticket, err := t.computeTicket(ctx, maddr, &rbase, round, base.TipSet.MinTicket(), mbi)
 	if err != nil {
 		return false, xerrors.Errorf("scratching ticket failed: %w", err)
@@ -287,6 +291,8 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	if err != nil {
 		return false, xerrors.Errorf("failed to select messages for block: %w", err)
 	}
+
+	log.Infow("WinPostTask selected messages", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "messages", len(msgs))
 
 	// equivocation handling
 	{
@@ -358,6 +364,8 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		}
 	}
 
+	log.Infow("WinPostTask base ready", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "ticket", ticket)
+
 	// block construction
 	var blockMsg *types.BlockMsg
 	{
@@ -379,6 +387,8 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		}
 	}
 
+	log.Infow("WinPostTask block ready", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "block", blockMsg.Header.Cid(), "timestamp", blockMsg.Header.Timestamp)
+
 	// persist in db
 	{
 		bhjson, err := json.Marshal(blockMsg.Header)
@@ -396,11 +406,13 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 
 	// wait until block timestamp
 	{
+		log.Infow("WinPostTask waiting for block timestamp", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "block", blockMsg.Header.Cid(), "until", time.Unix(int64(blockMsg.Header.Timestamp), 0))
 		time.Sleep(time.Until(time.Unix(int64(blockMsg.Header.Timestamp), 0)))
 	}
 
 	// submit block!!
 	{
+		log.Infow("WinPostTask submitting block", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "block", blockMsg.Header.Cid())
 		if err := t.api.SyncSubmitBlock(ctx, blockMsg); err != nil {
 			return false, xerrors.Errorf("failed to submit block: %w", err)
 		}
@@ -489,7 +501,7 @@ func (mb MiningBase) baseTime() time.Time {
 }
 
 func (mb MiningBase) afterPropDelay() time.Time {
-	return mb.baseTime().Add(randTimeOffset(time.Second))
+	return mb.baseTime().Add(time.Duration(build.PropagationDelaySecs) * time.Second).Add(randTimeOffset(time.Second))
 }
 
 func (t *WinPostTask) mineBasic(ctx context.Context) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
When calculating the time after propagation delay for a given epoch we weren't adding the propagation delay. Now we are.

## Additional Info
(this does not affect lotus-miner in any way, separate code)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
