### PR TITLE
Remove singapore drand testnet host from config

### DIFF
--- a/build/drand.go
+++ b/build/drand.go
@@ -48,12 +48,10 @@ var DrandConfigs = map[DrandEnum]dtypes.DrandConfig{
 		Servers: []string{
 			"https://pl-eu.testnet.drand.sh",
 			"https://pl-us.testnet.drand.sh",
-			"https://pl-sin.testnet.drand.sh",
 		},
 		Relays: []string{
 			"/dnsaddr/pl-eu.testnet.drand.sh/",
 			"/dnsaddr/pl-us.testnet.drand.sh/",
-			"/dnsaddr/pl-sin.testnet.drand.sh/",
 		},
 		ChainInfoJSON: `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"84b2234fb34e835dccd048255d7ad3194b81af7d978c3bf157e3469592ae4e02","groupHash":"4dd408e5fdff9323c76a9b6f087ba8fdc5a6da907bd9217d9d10f2287d081957"}`,
 	},


### PR DESCRIPTION
Not sure what the history is but this host isn't resolvable.

Found this confirmation that it doesn't exist anymore: https://github.com/filecoin-project/lotus/issues/3256#issuecomment-678817335