### PR TITLE
fix: stmgr: do not use cached migration results if absent from the blockstore

### DIFF
--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -113,6 +113,10 @@ func (m *migrationResultCache) Store(ctx context.Context, root cid.Cid, resultCi
 	return nil
 }
 
+func (m *migrationResultCache) Delete(ctx context.Context, root cid.Cid) {
+	_ = m.ds.Delete(ctx, m.keyForMigration(root))
+}
+
 type Executor interface {
 	NewActorRegistry() *vm.ActorRegistry
 	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor, vmTracing bool) (stateroot cid.Cid, rectsroot cid.Cid, err error)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@rjan90 reported that a node he was running on butterflynet failed the migration after reimporting from a snapshot taken before the migration.

This is because his node had _cached_ the result of the migration, but didn't check whether it actually had the migrated result in its blockstore, and so hit not found errors.

## Proposed Changes
<!-- A clear list of the changes being made -->

Check whether we actually have the cached result before relying on it to short-circuit the migration. If we don't, delete the cached result and run the migration as normal.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
