### PR TITLE
Use existing trusted info for drand client test

### DIFF
--- a/chain/beacon/drand/drand_test.go
+++ b/chain/beacon/drand/drand_test.go
@@ -3,6 +3,7 @@
 package drand
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"testing"
@@ -18,7 +19,12 @@ import (
 
 func TestPrintGroupInfo(t *testing.T) {
 	server := build.DrandConfigs[build.DrandTestnet].Servers[0]
-	c, err := hclient.New(server, nil, nil)
+	chainInfo := build.DrandConfigs[build.DrandTestnet].ChainInfoJSON
+
+	drandChain, err := dchain.InfoFromJSON(bytes.NewReader([]byte(chainInfo)))
+	assert.NoError(t, err)
+	c, err := hclient.NewWithInfo(server, drandChain, nil)
+
 	assert.NoError(t, err)
 	cg := c.(interface {
 		FetchChainInfo(ctx context.Context, groupHash []byte) (*dchain.Info, error)


### PR DESCRIPTION
Ref: https://github.com/drand/drand/pull/1317

(test always times out for me on the underside of the world, see above thread for details)