### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Global owners
 # Ensure maintainers team is a requested reviewer for non-draft PRs
-*                       @filecoin-project/lotus-maintainers
+*                       @jennijuju @Stebalien @snadrus @aarshkshah1992 @magik6k @zengroud0 @arajasek @rjan90 @masih @rvagg


### PR DESCRIPTION
These are the folks who are actively contributing to lotus maintenance, issue triaging, PR reviews and development. 

Made this change to decouple lotus ownership with other filecoin core repo's ownership and maintainership that comes with lotus-maintainer perm