### PR TITLE
fix: curio: base config by default

### DIFF
--- a/cmd/lotus-provider/config.go
+++ b/cmd/lotus-provider/config.go
@@ -22,7 +22,7 @@ import (
 
 var configCmd = &cli.Command{
 	Name:  "config",
-	Usage: "Manage node config by layers. The layer 'base' will always be applied. ",
+	Usage: "Manage node config by layers. The layer 'base' will always be applied to a new Curio instance. ",
 	Subcommands: []*cli.Command{
 		configDefaultCmd,
 		configSetCmd,
@@ -168,7 +168,7 @@ func getConfig(db *harmonydb.DB, layer string) (string, error) {
 var configListCmd = &cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
-	Usage:   "List config layers you can get.",
+	Usage:   "List config layers present in the DB.",
 	Flags:   []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
 		db, err := deps.MakeDB(cctx)
@@ -221,8 +221,7 @@ var configViewCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:     "layers",
-			Usage:    "comma or space separated list of layers to be interpreted",
-			Value:    cli.NewStringSlice("base"),
+			Usage:    "comma or space separated list of layers to be interpreted (base is always applied)",
 			Required: true,
 		},
 	},
@@ -261,7 +260,7 @@ var configEditCmd = &cli.Command{
 			DefaultText: "<edited layer>",
 		},
 		&cli.BoolFlag{
-			Name:  "allow-owerwrite",
+			Name:  "allow-overwrite",
 			Usage: "allow overwrite of existing layer if source is a different layer",
 		},
 		&cli.BoolFlag{

--- a/cmd/lotus-provider/deps/deps.go
+++ b/cmd/lotus-provider/deps/deps.go
@@ -273,7 +273,7 @@ func LoadConfigWithUpgrades(text string, lp *config.LotusProviderConfig) (toml.M
 func GetConfig(cctx *cli.Context, db *harmonydb.DB) (*config.LotusProviderConfig, error) {
 	lp := config.DefaultLotusProvider()
 	have := []string{}
-	layers := cctx.StringSlice("layers")
+	layers := append([]string{"base"}, cctx.StringSlice("layers")...) // Always stack on top of "base" layer
 	for _, layer := range layers {
 		text := ""
 		err := db.QueryRow(cctx.Context, `SELECT config FROM harmony_config WHERE title=$1`, layer).Scan(&text)

--- a/cmd/lotus-provider/main.go
+++ b/cmd/lotus-provider/main.go
@@ -126,9 +126,8 @@ func main() {
 			},
 			&cli.StringSliceFlag{
 				Name:    "layers",
-				EnvVars: []string{"CURIO_LAYERS"},
+				EnvVars: []string{"CURIO_CONFIG_LAYERS"},
 				Usage:   "list of layers to be interpreted (atop defaults). Default: base",
-				Value:   cli.NewStringSlice("base"),
 			},
 			&cli.StringFlag{
 				Name:    deps.FlagRepoPath,

--- a/cmd/lotus-provider/proving.go
+++ b/cmd/lotus-provider/proving.go
@@ -54,6 +54,10 @@ var wdPostTaskCmd = &cli.Command{
 			Usage: "deadline to compute WindowPoSt for ",
 			Value: 0,
 		},
+		&cli.StringSliceFlag{
+			Name:  "layers",
+			Usage: "list of layers to be interpreted (atop defaults). Default: base",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := context.Background()
@@ -140,7 +144,6 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 		&cli.StringSliceFlag{
 			Name:  "layers",
 			Usage: "list of layers to be interpreted (atop defaults). Default: base",
-			Value: cli.NewStringSlice("base"),
 		},
 		&cli.StringFlag{
 			Name:  "storage-json",

--- a/documentation/en/cli-lotus-provider.md
+++ b/documentation/en/cli-lotus-provider.md
@@ -13,7 +13,7 @@ COMMANDS:
    cli      Execute cli commands
    run      Start a lotus provider process
    stop     Stop a running lotus provider
-   config   Manage node config by layers. The layer 'base' will always be applied. 
+   config   Manage node config by layers. The layer 'base' will always be applied to a new Curio instance. 
    test     Utility functions for testing
    web      Start lotus provider web interface
    seal     Manage the sealing pipeline
@@ -31,7 +31,7 @@ GLOBAL OPTIONS:
    --db-name value                    (default: "yugabyte") [$LOTUS_DB_NAME, $LOTUS_HARMONYDB_HOSTS]
    --db-user value                    (default: "yugabyte") [$LOTUS_DB_USER, $LOTUS_HARMONYDB_USERNAME]
    --db-password value                (default: "yugabyte") [$LOTUS_DB_PASSWORD, $LOTUS_HARMONYDB_PASSWORD]
-   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base (default: "base") [$CURIO_LAYERS]
+   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base [$CURIO_CONFIG_LAYERS]
    --repo-path value                  (default: "~/.lotusprovider") [$LOTUS_REPO_PATH]
    --vv                               enables very verbose mode, useful for debugging the CLI (default: false)
    --help, -h                         show help
@@ -91,7 +91,7 @@ OPTIONS:
 ## lotus-provider config
 ```
 NAME:
-   lotus-provider config - Manage node config by layers. The layer 'base' will always be applied. 
+   lotus-provider config - Manage node config by layers. The layer 'base' will always be applied to a new Curio instance. 
 
 USAGE:
    lotus-provider config command [command options] [arguments...]
@@ -100,7 +100,7 @@ COMMANDS:
    default, defaults                Print default node config
    set, add, update, create         Set a config layer or the base by providing a filename or stdin.
    get, cat, show                   Get a config layer by name. You may want to pipe the output to a file, or use 'less'
-   list, ls                         List config layers you can get.
+   list, ls                         List config layers present in the DB.
    interpret, view, stacked, stack  Interpret stacked config layers by this version of lotus-provider, with system-generated comments.
    remove, rm, del, delete          Remove a named config layer.
    edit                             edit a config layer
@@ -153,7 +153,7 @@ OPTIONS:
 ### lotus-provider config list
 ```
 NAME:
-   lotus-provider config list - List config layers you can get.
+   lotus-provider config list - List config layers present in the DB.
 
 USAGE:
    lotus-provider config list [command options] [arguments...]
@@ -171,7 +171,7 @@ USAGE:
    lotus-provider config interpret [command options] a list of layers to be interpreted as the final config
 
 OPTIONS:
-   --layers value [ --layers value ]  comma or space separated list of layers to be interpreted (default: "base")
+   --layers value [ --layers value ]  comma or space separated list of layers to be interpreted (base is always applied)
    --help, -h                         show help
 ```
 
@@ -198,7 +198,7 @@ USAGE:
 OPTIONS:
    --editor value         editor to use (default: "vim") [$EDITOR]
    --source value         source config layer (default: <edited layer>)
-   --allow-owerwrite      allow overwrite of existing layer if source is a different layer (default: false)
+   --allow-overwrite      allow overwrite of existing layer if source is a different layer (default: false)
    --no-source-diff       save the whole config into the layer, not just the diff (default: false)
    --no-interpret-source  do not interpret source layer (default: true if --source is set)
    --help, -h             show help
@@ -281,7 +281,7 @@ DESCRIPTION:
 
 OPTIONS:
    --deadline value                   deadline to compute WindowPoSt for  (default: 0)
-   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base (default: "base")
+   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
    --storage-json value               path to json file containing storage config (default: "~/.lotus-provider/storage.json")
    --partition value                  partition to compute WindowPoSt for (default: 0)
    --help, -h                         show help
@@ -296,8 +296,9 @@ USAGE:
    lotus-provider test window-post task [command options] [arguments...]
 
 OPTIONS:
-   --deadline value  deadline to compute WindowPoSt for  (default: 0)
-   --help, -h        show help
+   --deadline value                   deadline to compute WindowPoSt for  (default: 0)
+   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
+   --help, -h                         show help
 ```
 
 ## lotus-provider web


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
The base layer will now be applied by default for all Curio instances.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
