### PR TITLE
opt(cli): ouput deadline open time

### DIFF
--- a/cmd/lotus-miner/proving.go
+++ b/cmd/lotus-miner/proving.go
@@ -307,15 +307,13 @@ var provingDeadlinesCmd = &cli.Command{
 }
 
 func deadlineOpenTime(ts *types.TipSet, dlIdx uint64, di *dline.Info) string {
-	// 30 minutes a deadline
-	thirtyMinutes := uint64(30 * 60)
 	gapIdx := dlIdx - di.Index
-	gapHeight := thirtyMinutes / build.BlockDelaySecs * gapIdx
+	gapHeight := uint64(di.WPoStProvingPeriod) / di.WPoStPeriodDeadlines * gapIdx
 
 	openHeight := di.Open + abi.ChainEpoch(gapHeight)
-	genesisBlockTimestamp := ts.Blocks()[0].Timestamp - uint64(ts.Height())*build.BlockDelaySecs
+	genesisBlockTimestamp := ts.MinTimestamp() - uint64(ts.Height())*build.BlockDelaySecs
 
-	return time.Unix(int64(genesisBlockTimestamp+build.BlockDelaySecs*uint64(openHeight)), 0).Format("15:04:05")
+	return time.Unix(int64(genesisBlockTimestamp+build.BlockDelaySecs*uint64(openHeight)), 0).Format(time.TimeOnly)
 }
 
 var provingDeadlineInfoCmd = &cli.Command{


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

Print the open time of the deadline.

The adjusted results are printed as follows.

```
./lotus-miner proving  deadlines 
Miner: t01000
deadline  open      partitions  sectors (faults)  proven partitions
0         17:00:22  1           2 (0)             0
1         17:30:22  0           0 (0)             0
2         18:00:22  0           0 (0)             0
3         18:30:22  0           0 (0)             0
4         19:00:22  0           0 (0)             0
5         19:30:22  0           0 (0)             0
6         20:00:22  0           0 (0)             0
7         20:30:22  0           0 (0)             0
8         21:00:22  0           0 (0)             0
9         21:30:22  0           0 (0)             0
10        22:00:22  0           0 (0)             0
11        22:30:22  0           0 (0)             0
12        23:00:22  0           0 (0)             0
13        23:30:22  0           0 (0)             0
14        00:00:22  0           0 (0)             0
15        00:30:22  0           0 (0)             0
16        01:00:22  0           0 (0)             0
17        01:30:22  0           0 (0)             0
18        02:00:22  0           0 (0)             0
19        02:30:22  0           0 (0)             0
20        03:00:22  0           0 (0)             0
21        03:30:22  0           0 (0)             0
22        04:00:22  0           0 (0)             0
23        04:30:22  0           0 (0)             0
24        05:00:22  0           0 (0)             0
25        05:30:22  0           0 (0)             0
26        06:00:22  0           0 (0)             0
27        06:30:22  0           0 (0)             0
28        07:00:22  0           0 (0)             0
29        07:30:22  0           0 (0)             0
30        08:00:22  0           0 (0)             0
31        08:30:22  0           0 (0)             0
32        09:00:22  0           0 (0)             0
33        09:30:22  0           0 (0)             0
34        10:00:22  0           0 (0)             0
35        10:30:22  0           0 (0)             0
36        11:00:22  0           0 (0)             0
37        11:30:22  0           0 (0)             0  (current)
38        12:00:22  0           0 (0)             0
39        12:30:22  0           0 (0)             0
40        13:00:22  0           0 (0)             0
41        13:30:22  0           0 (0)             0
42        14:00:22  0           0 (0)             0
43        14:30:22  0           0 (0)             0
44        15:00:22  0           0 (0)             0
45        15:30:22  0           0 (0)             0
46        16:00:22  0           0 (0)             0
47        16:30:22  0           0 (0)             0
```

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
