### PR TITLE
fix: beacon: validate drand change at nv16 correctly

### DIFF
--- a/chain/beacon/beacon.go
+++ b/chain/beacon/beacon.go
@@ -89,11 +89,15 @@ func ValidateBlockValues(bSchedule Schedule, nv network.Version, h *types.BlockH
 		return xerrors.Errorf("expected final beacon entry in block to be at round %d, got %d", maxRound, last.Round)
 	}
 
-	// Verify that all other entries' rounds are as expected for the epochs in between parentEpoch and h.Height
-	for i, e := range h.BeaconEntries {
-		correctRound := currBeacon.MaxBeaconRoundForEpoch(nv, parentEpoch+abi.ChainEpoch(i)+1)
-		if e.Round != correctRound {
-			return xerrors.Errorf("unexpected beacon round %d, expected %d for epoch %d", e.Round, correctRound, parentEpoch+abi.ChainEpoch(i))
+	// If the beacon is UNchained, verify that the block only includes the rounds we want for the epochs in between parentEpoch and h.Height
+	// For chained beacons, you must have all the rounds forming a valid chain with prevEntry, so we can skip this step
+	if !currBeacon.IsChained() {
+		// Verify that all other entries' rounds are as expected for the epochs in between parentEpoch and h.Height
+		for i, e := range h.BeaconEntries {
+			correctRound := currBeacon.MaxBeaconRoundForEpoch(nv, parentEpoch+abi.ChainEpoch(i)+1)
+			if e.Round != correctRound {
+				return xerrors.Errorf("unexpected beacon round %d, expected %d for epoch %d", e.Round, correctRound, parentEpoch+abi.ChainEpoch(i))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

@rvagg reported an inability to sync epoch 510 on calibnet, the UpgradeSkyrHeight (nv16). This is because that upgrade included a "bump" in drand, that required 2 rounds to be included at that epoch. For more see #2170 and #8606.

The implementation of FIP-0073 introduced a new check that block headers only include precisely those rounds as matching the block epochs. This check works correctly for all epochs EXCEPT the UpgradeSkyrHeight, but is only _needed_ for nv22 and after when we have unchained randomness.

## Proposed Changes
<!-- A clear list of the changes being made -->

Apply the new check only if the source of randomness is unchained (effectively saying nv22 and after only).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
