### PR TITLE
fix: api: Length check the array sent to RPC.

### DIFF
--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -692,7 +692,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
 		if len(*params.RewardPercentiles) > maxEthFeeHistoryRewardPercentiles {
-			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length of the reward percentile array cannot be greater than 100")
+			return ethtypes.EthFeeHistory{}, errors.New("length of the reward percentile array cannot be greater than 100")
 		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)
 	}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -687,6 +687,9 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	if params.BlkCount > 1024 {
 		return ethtypes.EthFeeHistory{}, fmt.Errorf("block count should be smaller than 1024")
 	}
+	if len(*params.RewardPercentiles) >= 100 {
+		return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
+	}
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -40,6 +40,7 @@ import (
 )
 
 var ErrUnsupported = errors.New("unsupported method")
+
 const maxEthFeeHistoryRewardPercentiles = 100
 
 type EthModuleAPI interface {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -40,7 +40,7 @@ import (
 )
 
 var ErrUnsupported = errors.New("unsupported method")
-var RewardPercentileArrayLimit = 100
+var RewardPercentileArrayLimit int = 100
 
 type EthModuleAPI interface {
 	EthBlockNumber(ctx context.Context) (ethtypes.EthUint64, error)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -40,6 +40,7 @@ import (
 )
 
 var ErrUnsupported = errors.New("unsupported method")
+var RewardPercentileArrayLimit = 100
 
 type EthModuleAPI interface {
 	EthBlockNumber(ctx context.Context) (ethtypes.EthUint64, error)
@@ -689,7 +690,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	}
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
-		if len(*params.RewardPercentiles) > 100 {
+		if len(*params.RewardPercentiles) > RewardPercentileArrayLimit {
 			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
 		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -687,11 +687,11 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	if params.BlkCount > 1024 {
 		return ethtypes.EthFeeHistory{}, fmt.Errorf("block count should be smaller than 1024")
 	}
-	if len(*params.RewardPercentiles) >= 100 {
-		return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
-	}
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
+		if len(*params.RewardPercentiles) >= 100 {
+			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
+		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)
 	}
 	for i, rp := range rewardPercentiles {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -692,7 +692,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
 		if len(*params.RewardPercentiles) > maxEthFeeHistoryRewardPercentiles {
-			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length of the precentile array cannot be greater than 100")
+			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length of the reward percentile array cannot be greater than 100")
 		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)
 	}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -40,7 +40,7 @@ import (
 )
 
 var ErrUnsupported = errors.New("unsupported method")
-var RewardPercentileArrayLimit int = 100
+const maxEthFeeHistoryRewardPercentiles = 100
 
 type EthModuleAPI interface {
 	EthBlockNumber(ctx context.Context) (ethtypes.EthUint64, error)
@@ -690,8 +690,8 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	}
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
-		if len(*params.RewardPercentiles) > RewardPercentileArrayLimit {
-			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
+		if len(*params.RewardPercentiles) > maxEthFeeHistoryRewardPercentiles {
+			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length of the precentile array cannot be greater than 100")
 		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)
 	}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -689,7 +689,7 @@ func (a *EthModule) EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (eth
 	}
 	rewardPercentiles := make([]float64, 0)
 	if params.RewardPercentiles != nil {
-		if len(*params.RewardPercentiles) >= 100 {
+		if len(*params.RewardPercentiles) > 100 {
 			return ethtypes.EthFeeHistory{}, fmt.Errorf("Length cannot be greater than 100")
 		}
 		rewardPercentiles = append(rewardPercentiles, *params.RewardPercentiles...)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
When calling **eth_feeHistory**, it takes input a rewardPercentile array. Currently, there isn't any restriction on the length of the array, can result in high computation and potentially leading to OOM issues in RPC nodes. The fix is to set a hard limit of the array to 100. 
## Proposed Changes
<!-- A clear list of the changes being made -->
Changing the length of RewardPercentiles Array to upto 100.
## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
