### PR TITLE
fix(events): properly disable actor events API via cfg

### DIFF
--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -164,9 +164,13 @@ func EventFilterManager(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.L
 
 func ActorEventHandler(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *filter.EventFilterManager, *store.ChainStore, *stmgr.StateManager, EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI) (*full.ActorEventHandler, error) {
 	return func(mctx helpers.MetricsCtx, r repo.LockedRepo, lc fx.Lifecycle, fm *filter.EventFilterManager, cs *store.ChainStore, sm *stmgr.StateManager, evapi EventHelperAPI, mp *messagepool.MessagePool, stateapi full.StateAPI, chainapi full.ChainAPI) (*full.ActorEventHandler, error) {
-
 		if !cfg.EnableActorEventsAPI || cfg.DisableRealTimeFilterAPI {
-			fm = nil
+			return full.NewActorEventHandler(
+				cs,
+				nil, // no EventFilterManager disables API calls
+				time.Duration(build.BlockDelaySecs)*time.Second,
+				abi.ChainEpoch(cfg.MaxFilterHeightRange),
+			), nil
 		}
 
 		return full.NewActorEventHandler(


### PR DESCRIPTION
Picked up an RPC panic in testing. Now that `EventFilterManager` is received as an interface, setting it to `nil` isn't enough for the `== nil` checks inside `ActorEventHandler`.