### PR TITLE
sealing pipeline: Output DDO pieces in SectorStatus

### DIFF
--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -952,20 +952,30 @@ func (m *Sealing) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showO
 		return api.SectorInfo{}, err
 	}
 
+	nv, err := m.Api.StateNetworkVersion(ctx, types.EmptyTSK)
+	if err != nil {
+		return api.SectorInfo{}, xerrors.Errorf("getting network version: %w", err)
+	}
+
 	deals := make([]abi.DealID, len(info.Pieces))
 	pieces := make([]api.SectorPiece, len(info.Pieces))
 	for i, piece := range info.Pieces {
-		// todo make this work with DDO deals in some reasonable way
-
 		pieces[i].Piece = piece.Piece()
-		if !piece.HasDealInfo() || piece.Impl().PublishCid == nil {
+
+		if !piece.HasDealInfo() {
 			continue
 		}
 
-		pdi := piece.DealInfo().Impl() // copy
+		pdi := piece.Impl()
+		if pdi.Valid(nv) != nil {
+			continue
+		}
+
 		pieces[i].DealInfo = &pdi
 
-		deals[i] = piece.DealInfo().Impl().DealID
+		if pdi.PublishCid != nil {
+			deals[i] = pdi.DealID
+		}
 	}
 
 	log := make([]api.SectorLog, len(info.Log))


### PR DESCRIPTION
## Related Issues
@LexLuthr reported on slack that lotus-miner doesn't return PieceInfos for DDO deals - https://filecoinproject.slack.com/archives/C06GD1SS56Y/p1710190186610709

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
