### PR TITLE
Enable event storage config for Actor events as well

### DIFF
--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -223,7 +223,7 @@ func ConfigFullNode(c interface{}) Option {
 		// If the Eth JSON-RPC is enabled, enable storing events at the ChainStore.
 		// This is the case even if real-time and historic filtering are disabled,
 		// as it enables us to serve logs in eth_getTransactionReceipt.
-		If(cfg.Fevm.EnableEthRPC, Override(StoreEventsKey, modules.EnableStoringEvents)),
+		If(cfg.Fevm.EnableEthRPC || cfg.Events.EnableActorEventsAPI, Override(StoreEventsKey, modules.EnableStoringEvents)),
 
 		Override(new(dtypes.ClientImportMgr), modules.ClientImportMgr),
 


### PR DESCRIPTION
We should enable the storage of Actor events even if 'EnableETHRPC' is set to false. Just tested this on a calibnet node and things look good now.