### PR TITLE
fix(events,gateway): check that filter.FromHeight isn't too far back for gateway calls

### DIFF
--- a/gateway/proxy_fil.go
+++ b/gateway/proxy_fil.go
@@ -441,12 +441,22 @@ func (gw *Node) GetActorEvents(ctx context.Context, filter *types.ActorEventFilt
 	if err := gw.limit(ctx, stateRateLimitTokens); err != nil {
 		return nil, err
 	}
+	if filter != nil && filter.FromHeight != nil {
+		if err := gw.checkTipSetHeight(ctx, *filter.FromHeight, types.EmptyTSK); err != nil {
+			return nil, err
+		}
+	}
 	return gw.target.GetActorEvents(ctx, filter)
 }
 
 func (gw *Node) SubscribeActorEvents(ctx context.Context, filter *types.ActorEventFilter) (<-chan *types.ActorEvent, error) {
 	if err := gw.limit(ctx, stateRateLimitTokens); err != nil {
 		return nil, err
+	}
+	if filter != nil && filter.FromHeight != nil {
+		if err := gw.checkTipSetHeight(ctx, *filter.FromHeight, types.EmptyTSK); err != nil {
+			return nil, err
+		}
 	}
 	return gw.target.SubscribeActorEvents(ctx, filter)
 }


### PR DESCRIPTION
TIL about this limiting (from #11700), this seems appropriate to do for the new events calls.