### PR TITLE
fix: curio seal: Fix partial Finalize retry

### DIFF
--- a/itests/sector_import_simple_test.go
+++ b/itests/sector_import_simple_test.go
@@ -42,7 +42,7 @@ func TestSectorImportAfterPC2(t *testing.T) {
 	// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
 	client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC())
 
-	ens.InterconnectAll().BeginMining(blockTime)
+	ens.InterconnectAll().BeginMiningMustPost(blockTime)
 
 	ctx := context.Background()
 

--- a/itests/sector_import_simple_test.go
+++ b/itests/sector_import_simple_test.go
@@ -42,7 +42,7 @@ func TestSectorImportAfterPC2(t *testing.T) {
 	// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
 	client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC())
 
-	ens.InterconnectAll().BeginMiningMustPost(blockTime)
+	ens.InterconnectAll().BeginMining(blockTime)
 
 	ctx := context.Background()
 

--- a/storage/sealer/storiface/filetype.go
+++ b/storage/sealer/storiface/filetype.go
@@ -174,6 +174,10 @@ func (t SectorFileType) SubAllowed(allowTypes []string, denyTypes []string) Sect
 	return t & denyMask
 }
 
+func (t SectorFileType) Unset(toUnset SectorFileType) SectorFileType {
+	return t &^ toUnset
+}
+
 func (t SectorFileType) AnyAllowed(allowTypes []string, denyTypes []string) bool {
 	return t.SubAllowed(allowTypes, denyTypes) != t
 }


### PR DESCRIPTION
## Related Issues
For now on top of https://github.com/filecoin-project/lotus/pull/11664, will rebase to master once that has landed.

## Proposed Changes
This PR fixes an edge-case in Curio finalize where somehow first try may not fully execute all steps, and on retry we'd already see some data moved. Observed on my SP setup, also confirmed the fix works.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
