### PR TITLE
curio web: Task summaries in Cluster machines category

### DIFF
--- a/curiosrc/web/hapi/simpleinfo.go
+++ b/curiosrc/web/hapi/simpleinfo.go
@@ -35,6 +35,8 @@ type actorInfo struct {
 
 	ActorBalance, ActorAvailable, WorkerBalance string
 
+	Win1, Win7, Win30 int64
+
 	Deadlines []actorDeadline
 }
 

--- a/curiosrc/web/hapi/simpleinfo.go
+++ b/curiosrc/web/hapi/simpleinfo.go
@@ -33,6 +33,8 @@ type actorInfo struct {
 	QualityAdjustedPower string
 	RawBytePower         string
 
+	ActorBalance, ActorAvailable, WorkerBalance string
+
 	Deadlines []actorDeadline
 }
 

--- a/curiosrc/web/hapi/web/actor_summary.gohtml
+++ b/curiosrc/web/hapi/web/actor_summary.gohtml
@@ -15,6 +15,9 @@
             {{end}}
         </div>
     </td>
+    <td>{{.ActorBalance}}</td>
+    <td>{{.ActorAvailable}}</td>
+    <td>{{.WorkerBalance}}</td>
 </tr>
 {{end}}
 {{end}}

--- a/curiosrc/web/hapi/web/actor_summary.gohtml
+++ b/curiosrc/web/hapi/web/actor_summary.gohtml
@@ -18,6 +18,13 @@
     <td>{{.ActorBalance}}</td>
     <td>{{.ActorAvailable}}</td>
     <td>{{.WorkerBalance}}</td>
+    <td>
+        <table>
+            <tr><td>1day:&nbsp; {{.Win1}}</td></tr>
+            <tr><td>7day:&nbsp; {{.Win7}}</td></tr>
+            <tr><td>30day: {{.Win30}}</td></tr>
+        </table>
+    </td>
 </tr>
 {{end}}
 {{end}}

--- a/curiosrc/web/hapi/web/cluster_machines.gohtml
+++ b/curiosrc/web/hapi/web/cluster_machines.gohtml
@@ -3,8 +3,10 @@
     <tr>
         <td>{{.Address}}</td>
         <td>{{.ID}}</td>
-        <td>todo</td>
         <td>{{.SinceContact}}</td>
+        {{range .RecentTasks}}
+            <td>{{.TaskName}}:{{.Success}}{{if ne 0 .Fail}}(<i class="{{if eq 0 .Success}}error{{else}}warning{{end}}">{{.Fail}}</i>){{end}}</td>
+        {{end}}
     </tr>
 {{end}}
 {{end}}

--- a/curiosrc/web/static/index.html
+++ b/curiosrc/web/static/index.html
@@ -60,6 +60,7 @@
                 <th>Host</th>
                 <th>ID</th>
                 <th>Last Contact</th>
+                <th>Tasks (24h)</th>
             </tr>
             </thead>
             <tbody hx-get="/hapi/simpleinfo/machines" hx-trigger="load,every 5s">
@@ -100,6 +101,7 @@
                 <th>Balance</th>
                 <th>Available</th>
                 <th>Worker</th>
+                <th>Wins</th>
             </tr>
             </thead>
             <tbody hx-get="/hapi/simpleinfo/actorsummary" hx-trigger="load,every 5s">

--- a/curiosrc/web/static/index.html
+++ b/curiosrc/web/static/index.html
@@ -97,6 +97,9 @@
                 <th>Config Layers</th>
                 <th>QaP</th>
                 <th>Deadlines</th>
+                <th>Balance</th>
+                <th>Available</th>
+                <th>Worker</th>
             </tr>
             </thead>
             <tbody hx-get="/hapi/simpleinfo/actorsummary" hx-trigger="load,every 5s">

--- a/curiosrc/web/static/index.html
+++ b/curiosrc/web/static/index.html
@@ -59,7 +59,6 @@
             <tr>
                 <th>Host</th>
                 <th>ID</th>
-                <th>Config Layers</th>
                 <th>Last Contact</th>
             </tr>
             </thead>

--- a/lib/harmony/harmonydb/sql/20240317-tasksummary-index.sql
+++ b/lib/harmony/harmonydb/sql/20240317-tasksummary-index.sql
@@ -1,0 +1,3 @@
+/* Used for webui clusterMachineSummary */
+CREATE INDEX harmony_task_history_work_index
+	ON harmony_task_history (completed_by_host_and_port ASC, name ASC, result ASC, work_end DESC);

--- a/lib/harmony/harmonydb/sql/20240317-web-summary-index.sql
+++ b/lib/harmony/harmonydb/sql/20240317-web-summary-index.sql
@@ -1,3 +1,7 @@
 /* Used for webui clusterMachineSummary */
 CREATE INDEX harmony_task_history_work_index
 	ON harmony_task_history (completed_by_host_and_port ASC, name ASC, result ASC, work_end DESC);
+
+/* Used for webui actorSummary sp wins */
+create index mining_tasks_won_sp_id_base_compute_time_index
+    on mining_tasks (won asc, sp_id asc, base_compute_time desc);

--- a/lib/harmony/harmonydb/sql/20240317-web-summary-index.sql
+++ b/lib/harmony/harmonydb/sql/20240317-web-summary-index.sql
@@ -3,5 +3,5 @@ CREATE INDEX harmony_task_history_work_index
 	ON harmony_task_history (completed_by_host_and_port ASC, name ASC, result ASC, work_end DESC);
 
 /* Used for webui actorSummary sp wins */
-create index mining_tasks_won_sp_id_base_compute_time_index
-    on mining_tasks (won asc, sp_id asc, base_compute_time desc);
+CREATE INDEX mining_tasks_won_sp_id_base_compute_time_index
+    ON mining_tasks (won ASC, sp_id ASC, base_compute_time DESC);


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
3 incremental improvements to Curio webui, implemented because I had a hard time seeing the high-level state of my setup

* Add a task summary of tasks executed in past 24h to machine summary
  * Really useful to see how machines are performing, gives a nice view of anomalies
* Add really basic wallet infos to actor info
* Add recent win stats to actor info

## Additional Info
![2024-03-17-231222_1331x695_scrot](https://github.com/filecoin-project/lotus/assets/3867941/a2a6faaa-4f24-4705-8dd2-8502d50af06a)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
