### PR TITLE
fix(events): don't log.Warn for EVM events with non-Raw codec

### DIFF
--- a/node/impl/full/eth_events.go
+++ b/node/impl/full/eth_events.go
@@ -39,9 +39,9 @@ func ethLogFromEvent(entries []types.EventEntry) (data []byte, topics []ethtypes
 	// Topics must be non-nil, even if empty. So we might as well pre-allocate for 4 (the max).
 	topics = make([]ethtypes.EthHash, 0, 4)
 	for _, entry := range entries {
-		// Drop events with non-raw topics to avoid mistakes.
+		// Drop events with non-raw topics. Built-in actors emit CBOR, and anything else would be
+		// invalid anyway.
 		if entry.Codec != cid.Raw {
-			log.Warnw("did not expect an event entry with a non-raw codec", "codec", entry.Codec, "key", entry.Key)
 			return nil, nil, false
 		}
 		// Check if the key is t1..t4


### PR DESCRIPTION
Codec != Raw likely means built-in actor events, which we can safely skip, so avoid filling up logs with warnings for every built-in actor event that comes past this point.

## Related Issues

Fixes: https://github.com/filecoin-project/lotus/issues/11718

## Proposed Changes

Don't log anything at all. I originally proposed downgrading to a debug bit I don't think there's much point once we're here because it'll be so common and not unexpected.
