### PR TITLE
fix: api: skip evm events where we no longer have the associated txn

### DIFF
--- a/node/impl/full/eth_events.go
+++ b/node/impl/full/eth_events.go
@@ -121,6 +121,10 @@ func ethFilterResultFromEvents(ctx context.Context, evs []*filter.CollectedEvent
 		if err != nil {
 			return nil, err
 		}
+		if log.TransactionHash == ethtypes.EmptyEthHash {
+			// We've garbage collected the message, ignore the events and continue.
+			continue
+		}
 		c, err := ev.TipSetKey.Cid()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

fixes #11117

## Proposed Changes
<!-- A clear list of the changes being made -->

In the Eth JSON-RPC API, skip events where we don't have the associated message. This can happen if, e.g., we run a splitstore garbage collection. We _could_ have tried to lookup the message in the message index (as suggested by the submitter), but I'm concerned we'll end up with inconsistent information in that case.

TL;DR: Avoid returning incorrect information.

The full fix is to prune the indices when pruning the splitstore: https://github.com/filecoin-project/lotus/issues/11681

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green