### PR TITLE
ci: ci: create gh workflow that runs go tests

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -1,0 +1,16 @@
+name: Install Go
+description: Install Go for Filecoin Lotus
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+        cache: false
+    - id: go-mod
+      uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@main
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ fromJSON(steps.go-mod.outputs.json).Go }}.x
+        cache: false

--- a/.github/actions/install-ubuntu-deps/action.yml
+++ b/.github/actions/install-ubuntu-deps/action.yml
@@ -1,0 +1,10 @@
+name: Install Ubuntu Dependencies
+description: Install Ubuntu dependencies for Filecoin Lotus
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        sudo apt-get update -y
+        sudo apt-get install -y ocl-icd-opencl-dev libhwloc-dev pkg-config
+      shell: bash

--- a/.github/actions/start-yugabytedb/action.yml
+++ b/.github/actions/start-yugabytedb/action.yml
@@ -1,0 +1,16 @@
+name: Start YugabyteDB
+description: Install Yugabyte Database for Filecoin Lotus
+
+runs:
+  using: composite
+  steps:
+    - run: docker run --rm --name yugabyte -d -p 5433:5433 yugabytedb/yugabyte:2.18.0.0-b65 bin/yugabyted start --daemon=false
+      shell: bash
+    - run: |
+        while true; do
+          status=$(docker exec yugabyte bin/yugabyted status);
+          echo $status;
+          echo $status | grep Running && break;
+          sleep 1;
+        done
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - release/*
+      - ipdx-gha-test
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,68 +51,84 @@ jobs:
               }
             ]
           # Mapping from test group names to custom runner labels
-          # NOTE:
-          # - It is OK if the mapping contains non-existent test groups;
-          #   The tests default to running on the default runners.
-          # - We use large, and xlarge self-hosted runners as inexpensive replacement for the default runners;
-          #   This is to free up the default runners for other workflows;
-          #   On a current plan, we can use up to 60 concurrent hosted runners.
-          # - We use 2xlarge, and 4xlarge self-hosted runners for resource-intensive tests;
-          #   This reduces the overall execution time of the workflow.
+          # The jobs default to running on the default hosted runners (4 CPU, 16 RAM).
+          # We use self-hosted xlarge (4 CPU, 8 RAM; and large - 2 CPU, 4 RAM) runners
+          #   to extend the available runner capacity (60 default hosted runners).
+          # We use self-hosted 4xlarge (16 CPU, 32 RAM; and 2xlarge - 8 CPU, 16 RAM) self-hosted
+          #   to support resource intensive jobs.
+          # In CircleCI, the jobs defaulted to running on medium+ runners (3 CPU, 6 RAM).
+          # The following jobs were scheduled to run on 2xlarge runners (16 CPU, 32 RAM):
+          # - itest-deals_concurrent (✅)
+          # - itest-sector_pledge (✅)
+          # - itest-wdpost_worker_config (❌)
+          # - itest-worker (✅)
+          # - unit-cli (❌)
+          # - unit-rest (❌)
           runners: |
             {
-              "itest-batch_deal": ["self-hosted", "linux", "x64", "large"],
-              "itest-deadlines": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-deals_anycid": ["self-hosted", "linux", "x64", "large"],
-              "itest-deals_concurrent": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "large"],
-              "itest-deals_max_staging_deals": ["self-hosted", "linux", "x64", "large"],
-              "itest-deals_publish": ["self-hosted", "linux", "x64", "large"],
-              "itest-deals_remote_retrieval": ["self-hosted", "linux", "x64", "large"],
-              "itest-deals": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-decode_params": ["self-hosted", "linux", "x64", "large"],
-              "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_balance": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_bytecode": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_config": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_conformance": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_deploy": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_fee_history": ["self-hosted", "linux", "x64", "large"],
-              "itest-eth_transactions": ["self-hosted", "linux", "x64", "large"],
-              "itest-fevm_events": ["self-hosted", "linux", "x64", "large"],
-              "itest-gas_estimation": ["self-hosted", "linux", "x64", "large"],
-              "itest-gateway": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "large"],
-              "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "large"],
-              "itest-mempool": ["self-hosted", "linux", "x64", "large"],
-              "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "large"],
-              "itest-msgindex": ["self-hosted", "linux", "x64", "large"],
-              "itest-multisig": ["self-hosted", "linux", "x64", "large"],
-              "itest-nonce": ["self-hosted", "linux", "x64", "large"],
-              "itest-pending_deal_allocation": ["self-hosted", "linux", "x64", "large"],
-              "itest-remove_verifreg_datacap": ["self-hosted", "linux", "x64", "large"],
-              "itest-sector_import_full": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_import_simple": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_miner_collateral": ["self-hosted", "linux", "x64", "large"],
-              "itest-sector_numassign": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals_concurrent": ["self-hosted", "linux", "x64", "4xlarge"],
               "itest-sector_pledge": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-self_sent_txn": ["self-hosted", "linux", "x64", "large"],
-              "itest-splitstore": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-verifreg": ["self-hosted", "linux", "x64", "large"],
-              "itest-wdpost_config": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-wdpost_no_miner_storage": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-wdpost": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-worker": ["self-hosted", "linux", "x64", "2xlarge"],
-              "multicore-sdr": ["self-hosted", "linux", "x64", "large"],
-              "unit-cli": ["self-hosted", "linux", "x64", "xlarge"],
-              "unit-node": ["self-hosted", "linux", "x64", "xlarge"],
-              "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"]
+              "itest-worker": ["self-hosted", "linux", "x64", "4xlarge"],
+
+              "itest-gateway": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-sector_import_full": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-sector_import_simple": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-wdpost": ["self-hosted", "linux", "x64", "2xlarge"],
+              "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"],
+
+              "itest-batch_deal": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-cli": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_512mb": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_anycid": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_max_staging_deals": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_partial_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_publish": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-deals_remote_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-decode_params": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_api": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_balance": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_bytecode": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_config": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_conformance": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_deploy": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_fee_history": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-eth_transactions": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-fevm_address": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-fevm_events": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-gas_estimation": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-lite_migration": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-mempool": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-mpool_msg_uuid": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-msgindex": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-multisig": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-net": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-nonce": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-path_detach_redeclare": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-pending_deal_allocation": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-remove_verifreg_datacap": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-sector_miner_collateral": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-sector_numassign": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-self_sent_txn": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-verifreg": ["self-hosted", "linux", "x64", "xlarge"],
+              "multicore-sdr": ["self-hosted", "linux", "x64", "xlarge"],
+              "unit-node": ["self-hosted", "linux", "x64", "xlarge"]
             }
           # A list of test groups that require YugabyteDB to be running
+          # In CircleCI, all jobs had yugabytedb running as a sidecar.
           yugabytedb: |
             ["itest-harmonydb", "itest-harmonytask"]
           # A list of test groups that require Proof Parameters to be fetched
+          # In CircleCI, only the following jobs had get-params set:
+          # - unit-cli (✅)
+          # - unit-storage (✅)
+          # - itest-sector_pledge (✅)
+          # - itest-wdpost (✅)
           parameters: |
             [
               "conformance",
@@ -135,6 +151,7 @@ jobs:
               "itest-sector_unseal",
               "itest-wdpost_no_miner_storage",
               "itest-wdpost_worker_config",
+              "itest-wdpost",
               "itest-worker_upgrade",
               "itest-worker",
               "multicore-sdr",
@@ -225,7 +242,9 @@ jobs:
       - uses: ./.github/actions/install-ubuntu-deps
       - uses: ./.github/actions/install-go
       - run: go install gotest.tools/gotestsum@latest
-      - run: make deps
+      - env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: make deps
       - if: ${{ matrix.needs_parameters }}
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,266 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - release/*
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    name: Discover Test Groups
+    runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.test.outputs.groups }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - id: test
+        env:
+          # Unit test groups other than unit-rest
+          utests: |
+            [
+              {"name": "unit-cli", "packages": ["./cli/...", "./cmd/...", "./api/..."]},
+              {"name": "unit-storage", "packages": ["./storage/...", "./extern/..."]},
+              {"name": "unit-node", "packages": ["./node/..."]}
+            ]
+          # Other tests that require special configuration
+          otests: |
+            [
+              {
+                "name": "multicore-sdr",
+                "packages": ["./storage/sealer/ffiwrapper"],
+                "go_test_flags": "-run=TestMulticoreSDR",
+                "test_rustproofs_logs": "1"
+              }, {
+                "name": "conformance",
+                "packages": ["./conformance"],
+                "go_test_flags": "-run=TestConformance",
+                "skip_conformance": "0"
+              }
+            ]
+          # Mapping from test group names to custom runner labels
+          # NOTE:
+          # - It is OK if the mapping contains non-existent test groups;
+          #   The tests default to running on the default runners.
+          # - We use large, and xlarge self-hosted runners as inexpensive replacement for the default runners;
+          #   This is to free up the default runners for other workflows;
+          #   On a current plan, we can use up to 60 concurrent hosted runners.
+          # - We use 2xlarge, and 4xlarge self-hosted runners for resource-intensive tests;
+          #   This reduces the overall execution time of the workflow.
+          runners: |
+            {
+              "itest-batch_deal": ["self-hosted", "linux", "x64", "large"],
+              "itest-deadlines": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-deals_anycid": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals_concurrent": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals_max_staging_deals": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals_publish": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals_remote_retrieval": ["self-hosted", "linux", "x64", "large"],
+              "itest-deals": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-decode_params": ["self-hosted", "linux", "x64", "large"],
+              "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_balance": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_bytecode": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_config": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_conformance": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_deploy": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_fee_history": ["self-hosted", "linux", "x64", "large"],
+              "itest-eth_transactions": ["self-hosted", "linux", "x64", "large"],
+              "itest-fevm_events": ["self-hosted", "linux", "x64", "large"],
+              "itest-gas_estimation": ["self-hosted", "linux", "x64", "large"],
+              "itest-gateway": ["self-hosted", "linux", "x64", "large"],
+              "itest-gateway": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "large"],
+              "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "large"],
+              "itest-mempool": ["self-hosted", "linux", "x64", "large"],
+              "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "large"],
+              "itest-msgindex": ["self-hosted", "linux", "x64", "large"],
+              "itest-multisig": ["self-hosted", "linux", "x64", "large"],
+              "itest-nonce": ["self-hosted", "linux", "x64", "large"],
+              "itest-pending_deal_allocation": ["self-hosted", "linux", "x64", "large"],
+              "itest-remove_verifreg_datacap": ["self-hosted", "linux", "x64", "large"],
+              "itest-sector_import_full": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-sector_import_simple": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-sector_miner_collateral": ["self-hosted", "linux", "x64", "large"],
+              "itest-sector_numassign": ["self-hosted", "linux", "x64", "large"],
+              "itest-sector_pledge": ["self-hosted", "linux", "x64", "4xlarge"],
+              "itest-self_sent_txn": ["self-hosted", "linux", "x64", "large"],
+              "itest-splitstore": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-verifreg": ["self-hosted", "linux", "x64", "large"],
+              "itest-wdpost_config": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-wdpost_no_miner_storage": ["self-hosted", "linux", "x64", "2xlarge"],
+              "itest-wdpost": ["self-hosted", "linux", "x64", "4xlarge"],
+              "itest-worker": ["self-hosted", "linux", "x64", "2xlarge"],
+              "multicore-sdr": ["self-hosted", "linux", "x64", "large"],
+              "unit-cli": ["self-hosted", "linux", "x64", "xlarge"],
+              "unit-node": ["self-hosted", "linux", "x64", "xlarge"],
+              "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"]
+            }
+          # A list of test groups that require YugabyteDB to be running
+          yugabytedb: |
+            ["itest-harmonydb", "itest-harmonytask"]
+          # A list of test groups that require Proof Parameters to be fetched
+          parameters: |
+            [
+              "conformance",
+              "itest-api",
+              "itest-deals_offline",
+              "itest-deals_padding",
+              "itest-deals_partial_retrieval_dm-level",
+              "itest-deals_pricing",
+              "itest-deals",
+              "itest-direct_data_onboard_verified",
+              "itest-direct_data_onboard",
+              "itest-net",
+              "itest-path_detach_redeclare",
+              "itest-path_type_filters",
+              "itest-sealing_resources",
+              "itest-sector_finalize_early",
+              "itest-sector_import_full",
+              "itest-sector_import_simple",
+              "itest-sector_pledge",
+              "itest-sector_unseal",
+              "itest-wdpost_no_miner_storage",
+              "itest-wdpost_worker_config",
+              "itest-worker_upgrade",
+              "itest-worker",
+              "multicore-sdr",
+              "unit-cli",
+              "unit-storage"
+            ]
+        run: |
+          # Create a list of integration test groups
+          itests="$(
+            find ./itests -name "*_test.go" | \
+              jq -R '{
+                "name": "itest-\(. | split("/") | .[2] | sub("_test.go$";""))",
+                "packages": [.]
+              }' | jq -s
+            )"
+
+          # Create a list of packages that are covered by the integration and unit tests
+          packages="$(jq -n --argjson utests "$utests" '$utests | map(.packages) | flatten | . + ["./itests/..."]')"
+
+          # Create a new group for the unit tests that are not yet covered
+          rest="$(
+            find . -name "*_test.go" | cut -d/ -f2 | sort | uniq | \
+              jq -R '"./\(.)/..."' | \
+              jq -s --argjson p "$packages" '{"name": "unit-rest", "packages": (. - $p)}'
+          )"
+
+          # Combine the groups for integration tests, unit tests, the new unit-rest group, and the other tests
+          groups="$(jq -n --argjson i "$itests" --argjson u "$utests" --argjson r "$rest" --argjson o "$otests" '$i + $u + [$r] + $o')"
+
+          # Apply custom runner labels to the groups
+          groups="$(jq -n --argjson g "$groups" --argjson r "$runners" '$g | map(. + {"runner": (.name as $n | $r | .[$n]) })')"
+
+          # Apply the needs_yugabytedb flag to the groups
+          groups="$(jq -n --argjson g "$groups" --argjson y "$yugabytedb" '$g | map(. + {"needs_yugabytedb": ([.name] | inside($y)) })')"
+
+          # Apply the needs_parameters flag to the groups
+          groups="$(jq -n --argjson g "$groups" --argjson p "$parameters" '$g | map(. + {"needs_parameters": ([.name] | inside($p)) })')"
+
+          # Output the groups
+          echo "groups=$groups"
+          echo "groups=$(jq -nc --argjson g "$groups" '$g')" >> $GITHUB_OUTPUT
+  fetch:
+    name: Fetch Proof Parameters
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{ steps.cache.outputs.key }}
+      path: ${{ steps.cache.outputs.path }}
+    steps:
+      - id: cache
+        run: |
+          echo "key=v26-2k-lotus-params" | tee -a $GITHUB_OUTPUT
+          echo "path=/var/tmp/filecoin-proof-parameters/" | tee -a $GITHUB_OUTPUT
+      - id: params
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.cache.outputs.key }}
+          path: ${{ steps.cache.outputs.path }}
+          lookup-only: true
+      - if: steps.params.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - if: steps.params.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-ubuntu-deps
+      - if: steps.params.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-go
+      - if: steps.params.outputs.cache-hit != 'true'
+        run: make lotus
+      - if: steps.params.outputs.cache-hit != 'true'
+        run: ./lotus fetch-params 2048
+      - if: steps.params.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.cache.outputs.key }}
+          path: ${{ steps.cache.outputs.path }}
+  test:
+    needs: [discover, fetch]
+    name: Test (${{ matrix.name }})
+    runs-on: ${{ github.repository == 'filecoin-project/lotus' && matrix.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.groups) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: ./.github/actions/install-ubuntu-deps
+      - uses: ./.github/actions/install-go
+      - run: go install gotest.tools/gotestsum@latest
+      - run: make deps
+      - if: ${{ matrix.needs_parameters }}
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.fetch.outputs.key }}
+          path: ${{ needs.fetch.outputs.path }}
+          fail-on-cache-miss: true
+      - if: ${{ matrix.needs_yugabytedb }}
+        uses: ./.github/actions/start-yugabytedb
+        timeout-minutes: 3
+      # TODO: Install statediff (used to be used for conformance)
+      - id: reports
+        run: mktemp -d | xargs -0 -I{} echo "path={}" | tee -a $GITHUB_OUTPUT
+      # TODO: Track coverage (used to be tracked for conformance)
+      - env:
+          NAME: ${{ matrix.name }}
+          LOTUS_SRC_DIR: ${{ github.workspace }}
+          LOTUS_HARMONYDB_HOSTS: 127.0.0.1
+          REPORTS_PATH: ${{ steps.reports.outputs.path }}
+          SKIP_CONFORMANCE: ${{ matrix.skip_conformance || '1' }}
+          TEST_RUSTPROOFS_LOGS: ${{ matrix.test_rustproofs_logs || '0' }}
+          FORMAT: ${{ matrix.format || 'standard-verbose' }}
+          PACKAGES: ${{ join(matrix.packages, ' ') }}
+        run: |
+          gotestsum \
+            --format "$FORMAT" \
+            --junitfile "$REPORTS_PATH/$NAME.xml" \
+            --jsonfile "$REPORTS_PATH/$NAME.json" \
+            --packages="$PACKAGES" \
+            -- ${{ matrix.go_test_flags || '' }}
+      - if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: |
+            ${{ steps.reports.outputs.path }}/${{ matrix.name }}.xml
+            ${{ steps.reports.outputs.path }}/${{ matrix.name }}.json
+        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   discover:
     name: Discover Test Groups

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,39 +194,69 @@ jobs:
           echo "groups=$groups"
           echo "groups=$(jq -nc --argjson g "$groups" '$g')" >> $GITHUB_OUTPUT
   fetch:
-    name: Fetch Proof Parameters
+    name: Fetch Dependencies
     runs-on: ubuntu-latest
     outputs:
-      key: ${{ steps.cache.outputs.key }}
-      path: ${{ steps.cache.outputs.path }}
+      parameters_key: ${{ steps.parameters.outputs.key }}
+      parameters_path: ${{ steps.parameters.outputs.path }}
+      filcrypto_key: ${{ steps.filcrypto.outputs.key }}
+      filcrypto_path: ${{ steps.filcrypto.outputs.path }}
     steps:
-      - id: cache
-        run: |
-          echo "key=v26-2k-lotus-params" | tee -a $GITHUB_OUTPUT
-          echo "path=/var/tmp/filecoin-proof-parameters/" | tee -a $GITHUB_OUTPUT
-      - id: params
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.cache.outputs.key }}
-          path: ${{ steps.cache.outputs.path }}
-          lookup-only: true
-      - if: steps.params.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - if: steps.params.outputs.cache-hit != 'true'
+      - id: parameters
+        env:
+          CACHE_KEY: filecoin-proof-parameters-${{ hashFiles('./extern/filecoin-ffi/parameters.json') }}
+          CACHE_PATH: |
+            /var/tmp/filecoin-proof-parameters/
+        run: |
+          echo -e "key=$CACHE_KEY" | tee -a $GITHUB_OUTPUT
+          echo -e "path<<EOF\n$CACHE_PATH\nEOF" | tee -a $GITHUB_OUTPUT
+      - id: filcrypto
+        env:
+          CACHE_KEY: ${{ runner.os }}-${{ runner.arch }}-filcrypto-${{ hashFiles('./extern/filecoin-ffi/install-filcrypto') }}-${{ hashFiles('./extern/filecoin-ffi/rust/rustc-target-features-optimized.json') }}
+          CACHE_PATH: |
+            ./extern/filecoin-ffi/filcrypto.h
+            ./extern/filecoin-ffi/libfilcrypto.a
+            ./extern/filecoin-ffi/filcrypto.pc
+        run: |
+          echo -e "key=$CACHE_KEY" | tee -a $GITHUB_OUTPUT
+          echo -e "path<<EOF\n$CACHE_PATH\nEOF" | tee -a $GITHUB_OUTPUT
+      - id: restore_parameters
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.parameters.outputs.key }}
+          path: ${{ steps.parameters.outputs.path }}
+          lookup-only: true
+      - id: restore_filcrypto
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.filcrypto.outputs.key }}
+          path: ${{ steps.filcrypto.outputs.path }}
+          lookup-only: true
+      - if: steps.restore_parameters.outputs.cache-hit != 'true'
         uses: ./.github/actions/install-ubuntu-deps
-      - if: steps.params.outputs.cache-hit != 'true'
+      - if: steps.restore_parameters.outputs.cache-hit != 'true'
         uses: ./.github/actions/install-go
-      - if: steps.params.outputs.cache-hit != 'true'
+      - if: steps.restore_parameters.outputs.cache-hit != 'true' || steps.restore_filcrypto.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: make deps
+      - if: steps.restore_parameters.outputs.cache-hit != 'true'
         run: make lotus
-      - if: steps.params.outputs.cache-hit != 'true'
+      - if: steps.restore_parameters.outputs.cache-hit != 'true'
         run: ./lotus fetch-params 2048
-      - if: steps.params.outputs.cache-hit != 'true'
+      - if: steps.restore_parameters.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.cache.outputs.key }}
-          path: ${{ steps.cache.outputs.path }}
+          key: ${{ steps.parameters.outputs.key }}
+          path: ${{ steps.parameters.outputs.path }}
+      - if: steps.restore_filcrypto.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.filcrypto.outputs.key }}
+          path: ${{ steps.filcrypto.outputs.path }}
   test:
     needs: [discover, fetch]
     name: Test (${{ matrix.name }})
@@ -242,14 +272,18 @@ jobs:
       - uses: ./.github/actions/install-ubuntu-deps
       - uses: ./.github/actions/install-go
       - run: go install gotest.tools/gotestsum@latest
-      - env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: make deps
-      - if: ${{ matrix.needs_parameters }}
+      - name: Install filcrypto
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.fetch.outputs.key }}
-          path: ${{ needs.fetch.outputs.path }}
+          key: ${{ needs.fetch.outputs.filcrypto_key }}
+          path: ${{ needs.fetch.outputs.filcrypto_path }}
+          fail-on-cache-miss: true
+      - if: ${{ matrix.needs_parameters }}
+        name: Fetch Proof Parameters
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.fetch.outputs.parameters_key }}
+          path: ${{ needs.fetch.outputs.parameters_path }}
           fail-on-cache-miss: true
       - if: ${{ matrix.needs_yugabytedb }}
         uses: ./.github/actions/start-yugabytedb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,6 @@ jobs:
               "itest-eth_transactions": ["self-hosted", "linux", "x64", "large"],
               "itest-fevm_events": ["self-hosted", "linux", "x64", "large"],
               "itest-gas_estimation": ["self-hosted", "linux", "x64", "large"],
-              "itest-gateway": ["self-hosted", "linux", "x64", "large"],
               "itest-gateway": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "large"],
               "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "large"],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,29 +193,29 @@ jobs:
           # Output the groups
           echo "groups=$groups"
           echo "groups=$(jq -nc --argjson g "$groups" '$g')" >> $GITHUB_OUTPUT
-  fetch:
-    name: Fetch Dependencies
+  cache:
+    name: Cache Dependencies
     runs-on: ubuntu-latest
     outputs:
-      parameters_key: ${{ steps.parameters.outputs.key }}
-      parameters_path: ${{ steps.parameters.outputs.path }}
-      filcrypto_key: ${{ steps.filcrypto.outputs.key }}
-      filcrypto_path: ${{ steps.filcrypto.outputs.path }}
+      fetch_params_key: ${{ steps.fetch_params.outputs.key }}
+      fetch_params_path: ${{ steps.fetch_params.outputs.path }}
+      make_deps_key: ${{ steps.make_deps.outputs.key }}
+      make_deps_path: ${{ steps.make_deps.outputs.path }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - id: parameters
+      - id: fetch_params
         env:
-          CACHE_KEY: filecoin-proof-parameters-${{ hashFiles('./extern/filecoin-ffi/parameters.json') }}
+          CACHE_KEY: fetch-params-${{ hashFiles('./extern/filecoin-ffi/parameters.json') }}
           CACHE_PATH: |
             /var/tmp/filecoin-proof-parameters/
         run: |
           echo -e "key=$CACHE_KEY" | tee -a $GITHUB_OUTPUT
           echo -e "path<<EOF\n$CACHE_PATH\nEOF" | tee -a $GITHUB_OUTPUT
-      - id: filcrypto
+      - id: make_deps
         env:
-          CACHE_KEY: ${{ runner.os }}-${{ runner.arch }}-filcrypto-${{ hashFiles('./extern/filecoin-ffi/install-filcrypto') }}-${{ hashFiles('./extern/filecoin-ffi/rust/rustc-target-features-optimized.json') }}
+          CACHE_KEY: ${{ runner.os }}-${{ runner.arch }}-make-deps-${{ hashFiles('./extern/filecoin-ffi/install-filcrypto') }}-${{ hashFiles('./extern/filecoin-ffi/rust/rustc-target-features-optimized.json') }}
           CACHE_PATH: |
             ./extern/filecoin-ffi/filcrypto.h
             ./extern/filecoin-ffi/libfilcrypto.a
@@ -223,42 +223,42 @@ jobs:
         run: |
           echo -e "key=$CACHE_KEY" | tee -a $GITHUB_OUTPUT
           echo -e "path<<EOF\n$CACHE_PATH\nEOF" | tee -a $GITHUB_OUTPUT
-      - id: restore_parameters
+      - id: restore_fetch_params
         uses: actions/cache/restore@v4
         with:
-          key: ${{ steps.parameters.outputs.key }}
-          path: ${{ steps.parameters.outputs.path }}
+          key: ${{ steps.fetch_params.outputs.key }}
+          path: ${{ steps.fetch_params.outputs.path }}
           lookup-only: true
-      - id: restore_filcrypto
+      - id: restore_make_deps
         uses: actions/cache/restore@v4
         with:
-          key: ${{ steps.filcrypto.outputs.key }}
-          path: ${{ steps.filcrypto.outputs.path }}
+          key: ${{ steps.make_deps.outputs.key }}
+          path: ${{ steps.make_deps.outputs.path }}
           lookup-only: true
-      - if: steps.restore_parameters.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true'
         uses: ./.github/actions/install-ubuntu-deps
-      - if: steps.restore_parameters.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true'
         uses: ./.github/actions/install-go
-      - if: steps.restore_parameters.outputs.cache-hit != 'true' || steps.restore_filcrypto.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true' || steps.restore_make_deps.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: make deps
-      - if: steps.restore_parameters.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true'
         run: make lotus
-      - if: steps.restore_parameters.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true'
         run: ./lotus fetch-params 2048
-      - if: steps.restore_parameters.outputs.cache-hit != 'true'
+      - if: steps.restore_fetch_params.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.parameters.outputs.key }}
-          path: ${{ steps.parameters.outputs.path }}
-      - if: steps.restore_filcrypto.outputs.cache-hit != 'true'
+          key: ${{ steps.fetch_params.outputs.key }}
+          path: ${{ steps.fetch_params.outputs.path }}
+      - if: steps.restore_make_deps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.filcrypto.outputs.key }}
-          path: ${{ steps.filcrypto.outputs.path }}
+          key: ${{ steps.make_deps.outputs.key }}
+          path: ${{ steps.make_deps.outputs.path }}
   test:
-    needs: [discover, fetch]
+    needs: [discover, cache]
     name: Test (${{ matrix.name }})
     runs-on: ${{ github.repository == 'filecoin-project/lotus' && matrix.runner || 'ubuntu-latest' }}
     strategy:
@@ -272,18 +272,18 @@ jobs:
       - uses: ./.github/actions/install-ubuntu-deps
       - uses: ./.github/actions/install-go
       - run: go install gotest.tools/gotestsum@latest
-      - name: Install filcrypto
+      - name: Restore cached make deps outputs
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.fetch.outputs.filcrypto_key }}
-          path: ${{ needs.fetch.outputs.filcrypto_path }}
+          key: ${{ needs.cache.outputs.make_deps_key }}
+          path: ${{ needs.cache.outputs.make_deps_path }}
           fail-on-cache-miss: true
       - if: ${{ matrix.needs_parameters }}
-        name: Fetch Proof Parameters
+        name: Restore cached fetch params outputs
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.fetch.outputs.parameters_key }}
-          path: ${{ needs.fetch.outputs.parameters_path }}
+          key: ${{ needs.cache.outputs.fetch_params_key }}
+          path: ${{ needs.cache.outputs.fetch_params_path }}
           fail-on-cache-miss: true
       - if: ${{ matrix.needs_yugabytedb }}
         uses: ./.github/actions/start-yugabytedb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - release/*
-      - ipdx-gha-test
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/11734

## Proposed Changes
<!-- A clear list of the changes being made -->
This PR creates a new GitHub Actions workflow (`check.yml`) that performs the following jobs previously handled exclusively by CircleCI:
- test
- test-conformance
- test-itest-*
- test-unit-*

## Additional Info
<!-- Callouts, links to documentation, and etc -->
You can find an example run of the workflow at: https://github.com/filecoin-project/lotus/actions/runs/8376141826?pr=11762

Unlike the CircleCI test jobs, the ones from the newly added workflow do not have to wait for the build (`make lotus deps`) to finish. Instead, the test jobs call `make deps` as needed (we didn't find an instance where `make lotus` was needed). This results in some work duplication but reduces the overall workflow runtime by ~3 minutes.

We did use a configuration matrix in the newly added workflow because the number of jobs executed by the workflow is huge. We were able to use a single job "template" since all the test jobs are executed in almost exactly the same manner. In particular, we didn't split out test-conformance definition like it was done in CircleCI.

The newly added workflow makes use of 3 helper actions:
- install-ubuntu-deps: which installs `ocl-icd-opencl-dev libhwloc-dev pkg-config` on the runner
- install-go: which installs `go` on the runner (it uses the version it finds in the go.mod file)
- start-yugabytedb: which starts `yugabytedb` docker container and waits for the DB to start running

The workflow's jobs run on a combination of self-hosted and hosted runners. We use self-hosted runners for two reasons: for resource-intensive jobs (`2xlarge` and `4xlarge`) and to increase runner availability (`large` and `xlarge`). We can only use a limited number of hosted runners concurrently (60).

How did we decide what jobs to run on which runners? We used the largest runners - 4xlarge (16 CPU, 32 RAM) - only for some of the jobs that used to run on 2xlarge (16 CPU, 32 RAM) in CircleCI; namely - itest-deals_concurrent, itest-sector_pledge, and itest-worker. We used 2xlarge (8 CPU, 16 RAM) for jobs that, for whatever reason, we saw failing on hosted runners. These include itest-gateway, itest-sector_import_full, itest-sector_import_simple, itest-wdpost, unit-storage. Our assumption here is that more resources could help reduce the flakiness but it is to be verified in practice. Finally, we used xlarge (4 CPU, 8 RAM) for 42 jobs (half of overall 84) that were the quickest in one of the test runs where we run almost everything on xlarge runners. In other words, those jobs scheduled to run on xlarge now should be fine running on hosted runners too (or large (2 CPU, 4 RAM) to reduce the cost; we're sticking with xlarge not to accidentally introduce more flakiness during the evaluation period). Everything else runs on the default GitHub hosted runners (4 CPU, 16 RAM). This entire assignment is a subject to change but we do have to start somewhere and it seems to us like a sensible spot.

We decided to cache Proof Parameters because trying to download them from many jobs at the same time resulted in a number of connection closed errors. The job that ensures the proof parameters are cached properly adds only seconds of overhead to the workflow.

We decided to generate the test job matrix on the fly (instead of pre-generating it like it was for CircleCI). The job matrix generation is executed on every workflow run. It uses bash tools to combine JSON inputs into a final matrix. We evaluated keeping matrix generation as a Go script, but, in our opinion, it made it harder to reason about what the generation does and how the final matrix is configured. It also added a little bit of extra overhead required for Go setup (~40s vs ~10s).

The newly added workflow is intended to run alongside its' CircleCI counterpart for at least 1-2 weeks. After that period, we want to evaluate its success rate and execution time. Based on this information, we'll either remove the applicable CircleCI jobs or apply necessary fixes to the new workflow and repeat the evaluation.

During testing, we have seen one instance of self-hosted runners failing to be scheduled (https://github.com/filecoin-project/lotus/actions/runs/8362652752/attempts/2). This was caused by the self-hosted runners' setup being rate-limited by the AWS Parameter Store. We'll apply for a higher quota (https://aws.amazon.com/about-aws/whats-new/2023/07/aws-systems-manager-parameter-store-api-limit/) and evaluate whether a patch that introduces retries for that error is in order.

We have also noticed one instance where `make deps` failed due to rate limiting applied by GitHub. Since then we provisioned the step with a proper GitHub Token which should make it less prone to failure, but we'll also watch if this issue reappears during normal usage. If so, we'd propose restoring caching for the `make dep` result. This would add only <30 seconds of overhead to the workflow.

We have seen some test flakiness around tests like itest-sector_import_simple, itest-deals_concurrent, itest-sector_import_full, itest-gateway, itest-deals_anycid. The flakiness happened at different stages of the workflow development, and it might or might not have been related to the new setup. At this stage, we think it would be the most beneficial to start running the CircleCI and GitHub Actions workflows alongside each other as this will provide better data on which tests and how often flake and whether it's platform-specific or not. 

We did not install statediff because we couldn't install it successfully. It used to be used only in the conformance test job, which was the only one that gathered coverage data, but it seemed to be unused.

## Questions
1. Is statediff still needed for conformance?
2. Is coverage still needed for conformance?

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
