### PR TITLE
feat: curio: Storage reservations when fetching

### DIFF
--- a/curiosrc/ffi/task_storage.go
+++ b/curiosrc/ffi/task_storage.go
@@ -158,7 +158,7 @@ func (t *TaskStorage) Claim(taskID int) error {
 	// be fetched, so we will need to create reservations for that too.
 	// NOTE localStore.AcquireSector does not open or create any files, nor does it reserve space. It only proposes
 	// paths to be used.
-	pathsFs, pathIDs, err := t.sc.sectors.localStore.AcquireSector(ctx, sectorRef.Ref(), storiface.FTNone, requestedTypes, storiface.PathSealing, storiface.AcquireMove)
+	pathsFs, pathIDs, err := t.sc.sectors.localStore.AcquireSector(ctx, sectorRef.Ref(), storiface.FTNone, requestedTypes, t.pathType, storiface.AcquireMove)
 	if err != nil {
 		return err
 	}

--- a/curiosrc/ffi/task_storage.go
+++ b/curiosrc/ffi/task_storage.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/filecoin-project/lotus/lib/harmony/harmonytask"
 	"github.com/filecoin-project/lotus/lib/harmony/resources"
-	"github.com/filecoin-project/lotus/lib/must"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
 )
 
@@ -111,6 +110,11 @@ func (t *TaskStorage) HasCapacity() bool {
 }
 
 func (t *TaskStorage) Claim(taskID int) error {
+	// TaskStorage Claim Attempts to reserve storage for the task
+	// A: Create a reservation for files to be allocated
+	// B: Create a reservation for existing files to be fetched into local storage
+	// C: Create a reservation for existing files in local storage which may be extended (e.g. sector cache when computing Trees)
+
 	ctx := context.Background()
 
 	sectorRef, err := t.taskToSectorRef(harmonytask.TaskID(taskID))
@@ -121,7 +125,7 @@ func (t *TaskStorage) Claim(taskID int) error {
 	// storage writelock sector
 	lkctx, cancel := context.WithCancel(ctx)
 
-	allocate := storiface.FTCache
+	requestedTypes := t.alloc | t.existing
 
 	lockAcquireTimuout := time.Second * 10
 	lockAcquireTimer := time.NewTimer(lockAcquireTimuout)
@@ -135,7 +139,7 @@ func (t *TaskStorage) Claim(taskID int) error {
 		}
 	}()
 
-	if err := t.sc.sectors.sindex.StorageLock(lkctx, sectorRef.ID(), storiface.FTNone, allocate); err != nil {
+	if err := t.sc.sectors.sindex.StorageLock(lkctx, sectorRef.ID(), storiface.FTNone, requestedTypes); err != nil {
 		// timer will expire
 		return xerrors.Errorf("claim StorageLock: %w", err)
 	}
@@ -149,39 +153,18 @@ func (t *TaskStorage) Claim(taskID int) error {
 		lockAcquireTimer.Reset(0)
 	}()
 
-	// find anywhere
-	//  if found return nil, for now
-	s, err := t.sc.sectors.sindex.StorageFindSector(ctx, sectorRef.ID(), allocate, must.One(sectorRef.RegSealProof.SectorSize()), false)
-	if err != nil {
-		return xerrors.Errorf("claim StorageFindSector: %w", err)
-	}
-
-	lp, err := t.sc.sectors.localStore.Local(ctx)
-	if err != nil {
-		return err
-	}
-
-	// see if there are any non-local sector files in storage
-	for _, info := range s {
-		for _, l := range lp {
-			if l.ID == info.ID {
-				continue
-			}
-
-			// TODO: Create reservation for fetching; This will require quite a bit more refactoring, but for now we'll
-			//  only care about new allocations
-			return nil
-		}
-	}
-
-	// acquire a path to make a reservation in
-	pathsFs, pathIDs, err := t.sc.sectors.localStore.AcquireSector(ctx, sectorRef.Ref(), storiface.FTNone, allocate, storiface.PathSealing, storiface.AcquireMove)
+	// First see what we have locally. We are putting allocate and existing together because local acquire will look
+	// for existing files for allocate requests, separately existing files which aren't found locally will be need to
+	// be fetched, so we will need to create reservations for that too.
+	// NOTE localStore.AcquireSector does not open or create any files, nor does it reserve space. It only proposes
+	// paths to be used.
+	pathsFs, pathIDs, err := t.sc.sectors.localStore.AcquireSector(ctx, sectorRef.Ref(), storiface.FTNone, requestedTypes, storiface.PathSealing, storiface.AcquireMove)
 	if err != nil {
 		return err
 	}
 
 	// reserve the space
-	release, err := t.sc.sectors.localStore.Reserve(ctx, sectorRef.Ref(), allocate, pathIDs, storiface.FSOverheadSeal)
+	release, err := t.sc.sectors.localStore.Reserve(ctx, sectorRef.Ref(), requestedTypes, pathIDs, storiface.FSOverheadSeal)
 	if err != nil {
 		return err
 	}

--- a/itests/path_type_filters_test.go
+++ b/itests/path_type_filters_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestPathTypeFilters(t *testing.T) {
+	kit.QuietMiningLogs()
 
 	runTest := func(t *testing.T, name string, asserts func(t *testing.T, ctx context.Context, miner *kit.TestMiner, run func())) {
 		t.Run(name, func(t *testing.T) {

--- a/storage/paths/interface.go
+++ b/storage/paths/interface.go
@@ -35,7 +35,7 @@ type PartialFileHandler interface {
 //go:generate go run github.com/golang/mock/mockgen -destination=mocks/store.go -package=mocks . Store
 
 type Store interface {
-	AcquireSector(ctx context.Context, s storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, sealing storiface.PathType, op storiface.AcquireMode) (paths storiface.SectorPaths, stores storiface.SectorPaths, err error)
+	AcquireSector(ctx context.Context, s storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, sealing storiface.PathType, op storiface.AcquireMode, opts ...storiface.AcquireOption) (paths storiface.SectorPaths, stores storiface.SectorPaths, err error)
 	Remove(ctx context.Context, s abi.SectorID, types storiface.SectorFileType, force bool, keepIn []storiface.ID) error
 
 	// like remove, but doesn't remove the primary sector copy, nor the last

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -460,7 +460,7 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 	return done, nil
 }
 
-func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, pathType storiface.PathType, op storiface.AcquireMode) (storiface.SectorPaths, storiface.SectorPaths, error) {
+func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, pathType storiface.PathType, op storiface.AcquireMode, opts ...storiface.AcquireOption) (storiface.SectorPaths, storiface.SectorPaths, error) {
 	if existing|allocate != existing^allocate {
 		return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.New("can't both find and allocate a sector")
 	}

--- a/storage/paths/mocks/store.go
+++ b/storage/paths/mocks/store.go
@@ -41,9 +41,13 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // AcquireSector mocks base method.
-func (m *MockStore) AcquireSector(arg0 context.Context, arg1 storiface.SectorRef, arg2, arg3 storiface.SectorFileType, arg4 storiface.PathType, arg5 storiface.AcquireMode) (storiface.SectorPaths, storiface.SectorPaths, error) {
+func (m *MockStore) AcquireSector(arg0 context.Context, arg1 storiface.SectorRef, arg2, arg3 storiface.SectorFileType, arg4 storiface.PathType, arg5 storiface.AcquireMode, arg6 ...storiface.AcquireOption) (storiface.SectorPaths, storiface.SectorPaths, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AcquireSector", arg0, arg1, arg2, arg3, arg4, arg5)
+	varargs := []interface{}{arg0, arg1, arg2, arg3, arg4, arg5}
+	for _, a := range arg6 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AcquireSector", varargs...)
 	ret0, _ := ret[0].(storiface.SectorPaths)
 	ret1, _ := ret[1].(storiface.SectorPaths)
 	ret2, _ := ret[2].(error)
@@ -51,9 +55,10 @@ func (m *MockStore) AcquireSector(arg0 context.Context, arg1 storiface.SectorRef
 }
 
 // AcquireSector indicates an expected call of AcquireSector.
-func (mr *MockStoreMockRecorder) AcquireSector(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) AcquireSector(arg0, arg1, arg2, arg3, arg4, arg5 interface{}, arg6 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireSector", reflect.TypeOf((*MockStore)(nil).AcquireSector), arg0, arg1, arg2, arg3, arg4, arg5)
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3, arg4, arg5}, arg6...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireSector", reflect.TypeOf((*MockStore)(nil).AcquireSector), varargs...)
 }
 
 // FsStat mocks base method.

--- a/storage/paths/remote.go
+++ b/storage/paths/remote.go
@@ -167,6 +167,8 @@ func (r *Remote) AcquireSector(ctx context.Context, s storiface.SectorRef, exist
 			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("allocate local sector for fetching: %w", err)
 		}
 
+		log.Debugw("Fetching sector data without existing reservation", "sector", s, "toFetch", toFetch, "fetchPaths", fetchPaths, "fetchIDs", fetchIDs)
+
 		overheadTable := storiface.FSOverheadSeal
 		if pathType == storiface.PathStorage {
 			overheadTable = storiface.FsOverheadFinalized
@@ -183,6 +185,8 @@ func (r *Remote) AcquireSector(ctx context.Context, s storiface.SectorRef, exist
 	} else {
 		fetchPaths = settings.Into.Paths
 		fetchIDs = settings.Into.IDs
+
+		log.Debugw("Fetching sector data with existing reservation", "sector", s, "toFetch", toFetch, "fetchPaths", fetchPaths, "fetchIDs", fetchIDs)
 	}
 
 	for _, fileType := range toFetch.AllSet() {

--- a/storage/paths/remote.go
+++ b/storage/paths/remote.go
@@ -93,9 +93,26 @@ func NewRemote(local Store, index SectorIndex, auth http.Header, fetchLimit int,
 	}
 }
 
-func (r *Remote) AcquireSector(ctx context.Context, s storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, pathType storiface.PathType, op storiface.AcquireMode) (storiface.SectorPaths, storiface.SectorPaths, error) {
+func (r *Remote) AcquireSector(ctx context.Context, s storiface.SectorRef, existing storiface.SectorFileType, allocate storiface.SectorFileType, pathType storiface.PathType, op storiface.AcquireMode, opts ...storiface.AcquireOption) (storiface.SectorPaths, storiface.SectorPaths, error) {
 	if existing|allocate != existing^allocate {
 		return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.New("can't both find and allocate a sector")
+	}
+
+	settings := storiface.AcquireSettings{
+		// Into will tell us which paths things should be fetched into or allocated in.
+		Into: nil,
+	}
+	for _, o := range opts {
+		o(&settings)
+	}
+
+	if settings.Into != nil {
+		if !allocate.IsNone() {
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.New("cannot specify Into with allocate")
+		}
+		if !settings.Into.HasAllSet(existing) {
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.New("Into has to have all existing paths")
+		}
 	}
 
 	// First make sure that no other goroutines are trying to fetch this sector;
@@ -134,47 +151,43 @@ func (r *Remote) AcquireSector(ctx context.Context, s storiface.SectorRef, exist
 	}
 
 	var toFetch storiface.SectorFileType
-	for _, fileType := range storiface.PathTypes {
-		if fileType&existing == 0 {
-			continue
-		}
-
+	for _, fileType := range existing.AllSet() {
 		if storiface.PathByType(paths, fileType) == "" {
 			toFetch |= fileType
 		}
 	}
 
 	// get a list of paths to fetch data into. Note: file type filters will apply inside this call.
-	fetchPaths, ids, err := r.local.AcquireSector(ctx, s, storiface.FTNone, toFetch, pathType, op)
-	if err != nil {
-		return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("allocate local sector for fetching: %w", err)
-	}
+	var fetchPaths, fetchIDs storiface.SectorPaths
 
-	overheadTable := storiface.FSOverheadSeal
-	if pathType == storiface.PathStorage {
-		overheadTable = storiface.FsOverheadFinalized
-	}
-
-	// If any path types weren't found in local storage, try fetching them
-
-	// First reserve storage
-	releaseStorage, err := r.local.Reserve(ctx, s, toFetch, ids, overheadTable)
-	if err != nil {
-		return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("reserving storage space: %w", err)
-	}
-	defer releaseStorage()
-
-	for _, fileType := range storiface.PathTypes {
-		if fileType&existing == 0 {
-			continue
+	if settings.Into == nil {
+		// fetching without existing reservation, so allocate paths and create a reservation
+		fetchPaths, fetchIDs, err = r.local.AcquireSector(ctx, s, storiface.FTNone, toFetch, pathType, op)
+		if err != nil {
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("allocate local sector for fetching: %w", err)
 		}
 
-		if storiface.PathByType(paths, fileType) != "" {
-			continue
+		overheadTable := storiface.FSOverheadSeal
+		if pathType == storiface.PathStorage {
+			overheadTable = storiface.FsOverheadFinalized
 		}
 
+		// If any path types weren't found in local storage, try fetching them
+
+		// First reserve storage
+		releaseStorage, err := r.local.Reserve(ctx, s, toFetch, fetchIDs, overheadTable)
+		if err != nil {
+			return storiface.SectorPaths{}, storiface.SectorPaths{}, xerrors.Errorf("reserving storage space: %w", err)
+		}
+		defer releaseStorage()
+	} else {
+		fetchPaths = settings.Into.Paths
+		fetchIDs = settings.Into.IDs
+	}
+
+	for _, fileType := range toFetch.AllSet() {
 		dest := storiface.PathByType(fetchPaths, fileType)
-		storageID := storiface.PathByType(ids, fileType)
+		storageID := storiface.PathByType(fetchIDs, fileType)
 
 		url, err := r.acquireFromRemote(ctx, s.ID, fileType, dest)
 		if err != nil {

--- a/storage/sealer/storiface/filetype.go
+++ b/storage/sealer/storiface/filetype.go
@@ -214,6 +214,10 @@ func (t SectorFileType) All() [FileTypes]bool {
 	return out
 }
 
+func (t SectorFileType) IsNone() bool {
+	return t == 0
+}
+
 type SectorPaths struct {
 	ID abi.SectorID
 
@@ -223,6 +227,28 @@ type SectorPaths struct {
 	Update      string
 	UpdateCache string
 	Piece       string
+}
+
+func (sp SectorPaths) HasAllSet(ft SectorFileType) bool {
+	for _, fileType := range ft.AllSet() {
+		if PathByType(sp, fileType) == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (sp SectorPaths) Subset(filter SectorFileType) SectorPaths {
+	var out SectorPaths
+
+	for _, fileType := range filter.AllSet() {
+		SetPathByType(&out, fileType, PathByType(sp, fileType))
+	}
+
+	out.ID = sp.ID
+
+	return out
 }
 
 func ParseSectorID(baseName string) (abi.SectorID, error) {
@@ -281,4 +307,13 @@ func SetPathByType(sps *SectorPaths, fileType SectorFileType, p string) {
 	case FTPiece:
 		sps.Piece = p
 	}
+}
+
+type PathsWithIDs struct {
+	Paths SectorPaths
+	IDs   SectorPaths
+}
+
+func (p PathsWithIDs) HasAllSet(ft SectorFileType) bool {
+	return p.Paths.HasAllSet(ft) && p.IDs.HasAllSet(ft)
 }

--- a/storage/sealer/storiface/paths.go
+++ b/storage/sealer/storiface/paths.go
@@ -25,3 +25,15 @@ type SectorLock struct {
 type SectorLocks struct {
 	Locks []SectorLock
 }
+
+type AcquireSettings struct {
+	Into *PathsWithIDs
+}
+
+type AcquireOption func(*AcquireSettings)
+
+func AcquireInto(pathIDs PathsWithIDs) AcquireOption {
+	return func(settings *AcquireSettings) {
+		settings.Into = &pathIDs
+	}
+}


### PR DESCRIPTION
## Related Issues
On top of https://github.com/filecoin-project/lotus/pull/11730 because that PR has related fixes needed for this PR to work.

This PR fixes failing test-itest-path_type_filters on master

## Proposed Changes
* [x] Make it possible to tell the sector starage system which paths sector data should be fetched to if fetching is needed
* [x] Make reservations not double-count storage when requested with existing data
* [x] Propagate Curio reservations to sector storage
* [x] Enable storage reservations on SDRTrees
* [ ] <s>Enable storage reservations on MoveStorage</s> Touches more code, can be a separate PR.

## Additional Info
TODO:
- [x] Complete changes
- [x] Test on mainnet

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
