### PR TITLE
ci: configure itests in build constraints, detect in Actions script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
                 "skip_conformance": "0"
               }
             ]
+        run: |
           # Mapping from test group names to custom runner labels
           # The jobs default to running on the default hosted runners (4 CPU, 16 RAM).
           # We use self-hosted xlarge (4 CPU, 8 RAM; and large - 2 CPU, 4 RAM) runners
@@ -67,101 +68,54 @@ jobs:
           # - itest-worker (✅)
           # - unit-cli (❌)
           # - unit-rest (❌)
-          runners: |
-            {
-              "itest-deals_concurrent": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-sector_pledge": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-worker": ["self-hosted", "linux", "x64", "4xlarge"],
+          runners='{
+            "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"],
+            "multicore-sdr": ["self-hosted", "linux", "x64", "xlarge"],
+            "unit-node": ["self-hosted", "linux", "x64", "xlarge"],
+          '
+          # Detect integration test groups that require non-default runners
+          for file in $(find ./itests -name '*_test.go'); do
+              if grep -q '//go:build integration .*xlarge' $file; then
+                  base_name=$(basename -- "$file")
+                  test_name="${base_name%_test.go}"
+                  runner_size=$(grep -o '.*xlarge' $file | awk '{print $NF}')
+                  runners+=$'\n'"\"itest-$test_name\": [\"self-hosted\", \"linux\", \"x64\", \"$runner_size\"],"
+              fi
+          done
+          runners=${runners%?}
+          runners+=$'\n'"}"
 
-              "itest-gateway": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-sector_import_full": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-sector_import_simple": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-wdpost": ["self-hosted", "linux", "x64", "2xlarge"],
-              "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"],
+          # A list of test groups that require YugabyteDB to be started
+          yugabytedb=""
+          for file in $(find ./itests -name '*_test.go'); do
+              if grep -q '//go:build integration .* db' $file; then
+                  base_name=$(basename -- "$file")
+                  test_name="${base_name%_test.go}"
+                  yugabytedb+=$'\n'"\"itest-$test_name\","
+              fi
+          done
+          yugabytedb="[${yugabytedb%?}]"
 
-              "itest-batch_deal": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-cli": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_512mb": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_anycid": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_max_staging_deals": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_partial_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_publish": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_remote_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-decode_params": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_api": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_balance": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_bytecode": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_config": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_conformance": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_deploy": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_fee_history": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_transactions": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-fevm_address": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-fevm_events": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-gas_estimation": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-lite_migration": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mempool": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mpool_msg_uuid": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-msgindex": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-multisig": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-net": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-nonce": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-path_detach_redeclare": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-pending_deal_allocation": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-remove_verifreg_datacap": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_miner_collateral": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_numassign": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-self_sent_txn": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-verifreg": ["self-hosted", "linux", "x64", "xlarge"],
-              "multicore-sdr": ["self-hosted", "linux", "x64", "xlarge"],
-              "unit-node": ["self-hosted", "linux", "x64", "xlarge"]
-            }
-          # A list of test groups that require YugabyteDB to be running
-          # In CircleCI, all jobs had yugabytedb running as a sidecar.
-          yugabytedb: |
-            ["itest-harmonydb", "itest-harmonytask"]
           # A list of test groups that require Proof Parameters to be fetched
           # In CircleCI, only the following jobs had get-params set:
           # - unit-cli (✅)
           # - unit-storage (✅)
           # - itest-sector_pledge (✅)
           # - itest-wdpost (✅)
-          parameters: |
-            [
-              "conformance",
-              "itest-api",
-              "itest-deals_offline",
-              "itest-deals_padding",
-              "itest-deals_partial_retrieval_dm-level",
-              "itest-deals_pricing",
-              "itest-deals",
-              "itest-direct_data_onboard_verified",
-              "itest-direct_data_onboard",
-              "itest-net",
-              "itest-path_detach_redeclare",
-              "itest-path_type_filters",
-              "itest-sealing_resources",
-              "itest-sector_finalize_early",
-              "itest-sector_import_full",
-              "itest-sector_import_simple",
-              "itest-sector_pledge",
-              "itest-sector_unseal",
-              "itest-wdpost_no_miner_storage",
-              "itest-wdpost_worker_config",
-              "itest-wdpost",
-              "itest-worker_upgrade",
-              "itest-worker",
-              "multicore-sdr",
-              "unit-cli",
-              "unit-storage"
-            ]
-        run: |
+          parameters='
+            "conformance",
+            "multicore-sdr",
+            "unit-cli",
+            "unit-storage",'
+          for file in $(find ./itests -name '*_test.go'); do
+              if grep -q '//go:build integration .* parameters' $file; then
+                  base_name=$(basename -- "$file")
+                  test_name="${base_name%_test.go}"
+                  parameters+=$'\n'"\"itest-$test_name\","
+              fi
+          done
+          parameters="[${parameters%?}]"
+
           # Create a list of integration test groups
           itests="$(
             find ./itests -name "*_test.go" | \

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/batch_deal_test.go
+++ b/itests/batch_deal_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/cli_test.go
+++ b/itests/cli_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/deadlines_test.go
+++ b/itests/deadlines_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/deals_512mb_test.go
+++ b/itests/deals_512mb_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/deals_anycid_test.go
+++ b/itests/deals_anycid_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/deals_concurrent_test.go
+++ b/itests/deals_concurrent_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 4xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/deals_invalid_utf8_label_test.go
+++ b/itests/deals_invalid_utf8_label_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/deals_max_staging_deals_test.go
+++ b/itests/deals_max_staging_deals_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/deals_offline_test.go
+++ b/itests/deals_offline_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/deals_padding_test.go
+++ b/itests/deals_padding_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/deals_partial_retrieval_dm-level_test.go
+++ b/itests/deals_partial_retrieval_dm-level_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/deals_partial_retrieval_test.go
+++ b/itests/deals_partial_retrieval_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/deals_power_test.go
+++ b/itests/deals_power_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/deals_pricing_test.go
+++ b/itests/deals_pricing_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/deals_publish_test.go
+++ b/itests/deals_publish_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/deals_remote_retrieval_test.go
+++ b/itests/deals_remote_retrieval_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/deals_retry_deal_no_funds_test.go
+++ b/itests/deals_retry_deal_no_funds_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/deals_test.go
+++ b/itests/deals_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/decode_params_test.go
+++ b/itests/decode_params_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/direct_data_onboard_test.go
+++ b/itests/direct_data_onboard_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/direct_data_onboard_verified_test.go
+++ b/itests/direct_data_onboard_verified_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/dup_mpool_messages_test.go
+++ b/itests/dup_mpool_messages_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_account_abstraction_test.go
+++ b/itests/eth_account_abstraction_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_balance_test.go
+++ b/itests/eth_balance_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_block_hash_test.go
+++ b/itests/eth_block_hash_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/eth_bytecode_test.go
+++ b/itests/eth_bytecode_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_config_test.go
+++ b/itests/eth_config_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/eth_conformance_test.go
+++ b/itests/eth_conformance_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_deploy_test.go
+++ b/itests/eth_deploy_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_fee_history_test.go
+++ b/itests/eth_fee_history_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/eth_hash_lookup_test.go
+++ b/itests/eth_hash_lookup_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/fevm_address_test.go
+++ b/itests/fevm_address_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/fevm_events_test.go
+++ b/itests/fevm_events_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/gas_estimation_test.go
+++ b/itests/gas_estimation_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/gateway_test.go
+++ b/itests/gateway_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 2xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/get_messages_in_ts_test.go
+++ b/itests/get_messages_in_ts_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/harmonydb_test.go
+++ b/itests/harmonydb_test.go
@@ -1,3 +1,5 @@
+//go:build integration && db
+
 package itests
 
 import (

--- a/itests/harmonytask_test.go
+++ b/itests/harmonytask_test.go
@@ -1,3 +1,5 @@
+//go:build integration && db
+
 package itests
 
 import (

--- a/itests/lite_migration_test.go
+++ b/itests/lite_migration_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/lookup_robust_address_test.go
+++ b/itests/lookup_robust_address_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/mempool_test.go
+++ b/itests/mempool_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/mpool_msg_uuid_test.go
+++ b/itests/mpool_msg_uuid_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/mpool_push_with_uuid_test.go
+++ b/itests/mpool_push_with_uuid_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/msgindex_test.go
+++ b/itests/msgindex_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/multisig_test.go
+++ b/itests/multisig_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/net_test.go
+++ b/itests/net_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/nonce_test.go
+++ b/itests/nonce_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/path_detach_redeclare_test.go
+++ b/itests/path_detach_redeclare_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge && parameters
+
 package itests
 
 import (

--- a/itests/path_type_filters_test.go
+++ b/itests/path_type_filters_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/paych_api_test.go
+++ b/itests/paych_api_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/paych_cli_test.go
+++ b/itests/paych_cli_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/pending_deal_allocation_test.go
+++ b/itests/pending_deal_allocation_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/remove_verifreg_datacap_test.go
+++ b/itests/remove_verifreg_datacap_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/sealing_resources_test.go
+++ b/itests/sealing_resources_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/sector_finalize_early_test.go
+++ b/itests/sector_finalize_early_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/sector_import_full_test.go
+++ b/itests/sector_import_full_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 2xlarge && parameters
+
 package itests
 
 import (

--- a/itests/sector_import_simple_test.go
+++ b/itests/sector_import_simple_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 2xlarge && parameters
+
 package itests
 
 import (

--- a/itests/sector_miner_collateral_test.go
+++ b/itests/sector_miner_collateral_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/sector_numassign_test.go
+++ b/itests/sector_numassign_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 package itests
 
 import (

--- a/itests/sector_pledge_test.go
+++ b/itests/sector_pledge_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 4xlarge && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/sector_terminate_test.go
+++ b/itests/sector_terminate_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/self_sent_txn_test.go
+++ b/itests/self_sent_txn_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/verifreg_test.go
+++ b/itests/verifreg_test.go
@@ -1,3 +1,5 @@
+//go:build integration && xlarge
+
 // stm: #integration
 package itests
 

--- a/itests/wdpost_config_test.go
+++ b/itests/wdpost_config_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package itests
 
 import (

--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // stm: #integration
 package itests
 

--- a/itests/wdpost_no_miner_storage_test.go
+++ b/itests/wdpost_no_miner_storage_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 2xlarge && parameters
+
 // stm: #integration
 package itests
 

--- a/itests/wdpost_worker_config_test.go
+++ b/itests/wdpost_worker_config_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -1,3 +1,5 @@
+//go:build integration && 4xlarge && parameters
+
 package itests
 
 import (

--- a/itests/worker_upgrade_test.go
+++ b/itests/worker_upgrade_test.go
@@ -1,3 +1,5 @@
+//go:build integration && parameters
+
 package itests
 
 import (


### PR DESCRIPTION
This is a stacked PR against #11762 and I'm exploring ways to configure itests inline, mainly because I'd like to not restrict this to the CI config, but also make it available in other ways, such as in the `Makefile`, as discussed in #11780. I can also imagine this being used to build some kind of fancy Docker or k8s config to do something similar, particularly as we get YugabyteDB involved.

A `make itests` would ideally not copy config that exists in the Actions config already (adding a new itest shouldn't involve wiring it up in multiple places—ideally no places but the itest itself!). It's also not really practical to be parsing yaml from `make`. So my thought here is to just use Go build constraints since they are an existing annotation pattern already. You could even use them to run them as a group with `go test`.