### PR TITLE
refactor: cli: Avoid disputing WindowedPoSt messages when the target miner has no balance to pay rewards

### DIFF
--- a/cli/disputer.go
+++ b/cli/disputer.go
@@ -251,9 +251,6 @@ var disputerStartCmd = &cli.Command{
 				proofsChecked += disputableProofs
 
 				ms, err := makeDisputeWindowedPosts(ctx, api, dl, disputableProofs, fromAddr)
-				if ms == nil {
-					continue
-				}
 				if err != nil {
 					return xerrors.Errorf("failed to check for disputes: %w", err)
 				}
@@ -369,7 +366,7 @@ func makeDisputeWindowedPosts(ctx context.Context, api v0api.FullNode, dl minerD
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get wallet balance while checking to send dispute messages to miner %w: %w", dl.miner, err)
 	}
-	if walletBalance.Equals(big.Zero()) {
+	if walletBalance.IsZero() {
 		disputeLog.Warnw("wallet balance is zero, skipping dispute message", "wallet", dl.miner)
 		return nil, nil
 	}

--- a/cli/disputer.go
+++ b/cli/disputer.go
@@ -255,7 +255,9 @@ var disputerStartCmd = &cli.Command{
 					return xerrors.Errorf("failed to check for disputes: %w", err)
 				}
 
-				dpmsgs = append(dpmsgs, ms...)
+				if ms != nil {
+					dpmsgs = append(dpmsgs, ms...)
+				}
 
 				dClose, dl, err := makeMinerDeadline(ctx, api, dl.miner)
 				if err != nil {

--- a/cli/disputer.go
+++ b/cli/disputer.go
@@ -238,6 +238,15 @@ var disputerStartCmd = &cli.Command{
 
 			// TODO: Parallelizeable
 			for _, dl := range dls {
+				// CHECK: if miner waller balance is zero then skip sending dispute message
+				walletBalance, err := api.WalletBalance(ctx, dl.miner)
+				if err != nil {
+					return xerrors.Errorf("failed to get wallet balance while checking to send dispute messages to miner %w: %w", dl.miner, err)
+				}
+				if walletBalance.Equals(big.Zero()) {
+					disputeLog.Warnw("wallet balance is zero, skipping dispute message", "wallet", dl.miner)
+					return nil
+				}
 				fullDeadlines, err := api.StateMinerDeadlines(ctx, dl.miner, tsk)
 				if err != nil {
 					return xerrors.Errorf("failed to load deadlines: %w", err)

--- a/cli/disputer.go
+++ b/cli/disputer.go
@@ -255,9 +255,7 @@ var disputerStartCmd = &cli.Command{
 					return xerrors.Errorf("failed to check for disputes: %w", err)
 				}
 
-				if ms != nil {
-					dpmsgs = append(dpmsgs, ms...)
-				}
+				dpmsgs = append(dpmsgs, ms...)
 
 				dClose, dl, err := makeMinerDeadline(ctx, api, dl.miner)
 				if err != nil {


### PR DESCRIPTION
Avoid disputing WindowedPoSt messages when the target Miner has no balance to pay rewards

## Related Issues
fixes #11715

## Proposed Changes
In https://github.com/filecoin-project/lotus/issues/11703, a user came across an edge case where an SP:

1. Submitted a bad PoSt.
2. Terminated their sectors.
3. Withdrew all funds (after paying all fees).

This left the SP's miner actor with a bad proof but without any funds to pay for disputes. On the other hand, given that the sectors have been terminated and termination fees were already paid we don't really care about fining the SP for the bad proofs anyways.

But... we still don't want to submit dispute messages in this case because doing so isn't free and doesn't really serve a purpose.

So add a check to fetch miner wallet balance and only send disputing messages if balance is non zero.

## Additional Info
look at disputer.go line no 241 onwards

