### PR TITLE
feat: curio: Add schemas for DDO deal support

### DIFF
--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -115,6 +115,12 @@ create table sectors_sdr_initial_pieces (
     f05_deal_start_epoch bigint,
     f05_deal_end_epoch bigint,
 
+    -- ddo deal info
+    -- added in 20240402-sdr-pipeline-ddo-deal-info.sql
+    -- direct_start_epoch bigint,
+    -- direct_end_epoch bigint,
+    -- direct_piece_activation_manifest jsonb,
+
     -- foreign key
     foreign key (sp_id, sector_number) references sectors_sdr_pipeline (sp_id, sector_number) on delete cascade,
 

--- a/lib/harmony/harmonydb/sql/20240402-sdr-pipeline-ddo-deal-info.sql
+++ b/lib/harmony/harmonydb/sql/20240402-sdr-pipeline-ddo-deal-info.sql
@@ -1,0 +1,8 @@
+ALTER TABLE sectors_sdr_initial_pieces
+    ADD COLUMN direct_start_epoch BIGINT;
+
+ALTER TABLE sectors_sdr_initial_pieces
+    ADD COLUMN direct_end_epoch BIGINT;
+
+ALTER TABLE sectors_sdr_initial_pieces
+    ADD COLUMN direct_piece_activation_manifest JSONB;


### PR DESCRIPTION
## Related Issues
Initial part of ddo support needed for https://github.com/filecoin-project/lotus/issues/11754

## Proposed Changes
This just modifies the sealing pipeline sql schema so that a future migration won't be needed when full DDO support is added.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
