### PR TITLE
feat: curio: Storage reservations in MoveStorage

### DIFF
--- a/cmd/curio/storage.go
+++ b/cmd/curio/storage.go
@@ -207,8 +207,14 @@ var storageDetachCmd = &cli.Command{
 }
 
 var storageListCmd = &cli.Command{
-	Name:        "list",
-	Usage:       "list local storage paths",
+	Name:  "list",
+	Usage: "list local storage paths",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "local",
+			Usage: "only list local storage paths",
+		},
+	},
 	Subcommands: []*cli.Command{
 		//storageListSectorsCmd,
 	},
@@ -238,6 +244,12 @@ var storageListCmd = &cli.Command{
 
 		sorted := make([]fsInfo, 0, len(st))
 		for id, decls := range st {
+			if cctx.Bool("local") {
+				if _, ok := local[id]; !ok {
+					continue
+				}
+			}
+
 			st, err := minerApi.StorageStat(ctx, id)
 			if err != nil {
 				sorted = append(sorted, fsInfo{ID: id, sectors: decls})

--- a/curiosrc/ffi/piece_funcs.go
+++ b/curiosrc/ffi/piece_funcs.go
@@ -8,13 +8,14 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lotus/lib/harmony/harmonytask"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
 )
 
-func (sb *SealCalls) WritePiece(ctx context.Context, pieceID storiface.PieceNumber, size int64, data io.Reader) error {
+func (sb *SealCalls) WritePiece(ctx context.Context, taskID *harmonytask.TaskID, pieceID storiface.PieceNumber, size int64, data io.Reader) error {
 	// todo: config(?): allow setting PathStorage for this
 	// todo storage reservations
-	paths, done, err := sb.sectors.AcquireSector(ctx, nil, pieceID.Ref(), storiface.FTNone, storiface.FTPiece, storiface.PathSealing)
+	paths, done, err := sb.sectors.AcquireSector(ctx, taskID, pieceID.Ref(), storiface.FTNone, storiface.FTPiece, storiface.PathSealing)
 	if err != nil {
 		return err
 	}

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -492,6 +492,9 @@ func (sb *SealCalls) MoveStorage(ctx context.Context, sector storiface.SectorRef
 	var opts []storiface.AcquireOption
 	if taskID != nil {
 		resv, ok := sb.sectors.storageReservations.Load(*taskID)
+		// if the reservation is missing MoveStorage will simply create one internally. This is fine as the reservation
+		// will only be missing when the node is restarting, which means that the missing reservations will get recreated
+		// anyways, and before we start claiming other tasks.
 		if ok {
 			defer resv.Release()
 

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -473,7 +473,7 @@ afterUnsealedMove:
 	return nil
 }
 
-func (sb *SealCalls) MoveStorage(ctx context.Context, sector storiface.SectorRef) error {
+func (sb *SealCalls) MoveStorage(ctx context.Context, sector storiface.SectorRef, taskID *harmonytask.TaskID) error {
 	// only move the unsealed file if it still exists and needs moving
 	moveUnsealed := storiface.FTUnsealed
 	{
@@ -489,7 +489,24 @@ func (sb *SealCalls) MoveStorage(ctx context.Context, sector storiface.SectorRef
 
 	toMove := storiface.FTCache | storiface.FTSealed | moveUnsealed
 
-	err := sb.sectors.storage.MoveStorage(ctx, sector, toMove)
+	var opts []storiface.AcquireOption
+	if taskID != nil {
+		resv, ok := sb.sectors.storageReservations.Load(*taskID)
+		if ok {
+			defer resv.Release()
+
+			if resv.Alloc != storiface.FTNone {
+				return xerrors.Errorf("task %d has storage reservation with alloc", taskID)
+			}
+			if resv.Existing != toMove|storiface.FTUnsealed {
+				return xerrors.Errorf("task %d has storage reservation with different existing", taskID)
+			}
+
+			opts = append(opts, storiface.AcquireInto(storiface.PathsWithIDs{Paths: resv.Paths, IDs: resv.PathIDs}))
+		}
+	}
+
+	err := sb.sectors.storage.MoveStorage(ctx, sector, toMove, opts...)
 	if err != nil {
 		return xerrors.Errorf("moving storage: %w", err)
 	}

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -161,13 +161,13 @@ func (sb *SealCalls) GenerateSDR(ctx context.Context, taskID harmonytask.TaskID,
 	return nil
 }
 
-func (sb *SealCalls) TreeDRC(ctx context.Context, sector storiface.SectorRef, unsealed cid.Cid, size abi.PaddedPieceSize, data io.Reader, unpaddedData bool) (cid.Cid, cid.Cid, error) {
+func (sb *SealCalls) TreeDRC(ctx context.Context, task *harmonytask.TaskID, sector storiface.SectorRef, unsealed cid.Cid, size abi.PaddedPieceSize, data io.Reader, unpaddedData bool) (cid.Cid, cid.Cid, error) {
 	p1o, err := sb.makePhase1Out(unsealed, sector.ProofType)
 	if err != nil {
 		return cid.Undef, cid.Undef, xerrors.Errorf("make phase1 output: %w", err)
 	}
 
-	paths, releaseSector, err := sb.sectors.AcquireSector(ctx, nil, sector, storiface.FTCache, storiface.FTSealed, storiface.PathSealing)
+	paths, releaseSector, err := sb.sectors.AcquireSector(ctx, task, sector, storiface.FTCache, storiface.FTSealed, storiface.PathSealing)
 	if err != nil {
 		return cid.Undef, cid.Undef, xerrors.Errorf("acquiring sector paths: %w", err)
 	}

--- a/curiosrc/piece/task_park_piece.go
+++ b/curiosrc/piece/task_park_piece.go
@@ -152,7 +152,7 @@ func (p *ParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 
 		pnum := storiface.PieceNumber(pieceData.PieceID)
 
-		if err := p.sc.WritePiece(ctx, pnum, pieceRawSize, upr); err != nil {
+		if err := p.sc.WritePiece(ctx, &taskID, pnum, pieceRawSize, upr); err != nil {
 			return false, xerrors.Errorf("write piece: %w", err)
 		}
 

--- a/curiosrc/seal/task_trees.go
+++ b/curiosrc/seal/task_trees.go
@@ -187,9 +187,9 @@ func (t *TreesTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 	}
 
 	// D / R / C
-	sealed, unsealed, err := t.sc.TreeDRC(ctx, sref, commd, abi.PaddedPieceSize(ssize), dataReader, unpaddedData)
+	sealed, unsealed, err := t.sc.TreeDRC(ctx, &taskID, sref, commd, abi.PaddedPieceSize(ssize), dataReader, unpaddedData)
 	if err != nil {
-		return false, xerrors.Errorf("computing tree r and c: %w", err)
+		return false, xerrors.Errorf("computing tree d, r and c: %w", err)
 	}
 
 	// todo synth porep

--- a/storage/paths/interface.go
+++ b/storage/paths/interface.go
@@ -43,7 +43,7 @@ type Store interface {
 	RemoveCopies(ctx context.Context, s abi.SectorID, types storiface.SectorFileType) error
 
 	// move sectors into storage
-	MoveStorage(ctx context.Context, s storiface.SectorRef, types storiface.SectorFileType) error
+	MoveStorage(ctx context.Context, s storiface.SectorRef, types storiface.SectorFileType, opts ...storiface.AcquireOption) error
 
 	FsStat(ctx context.Context, id storiface.ID) (fsutil.FsStat, error)
 

--- a/storage/paths/mocks/store.go
+++ b/storage/paths/mocks/store.go
@@ -107,17 +107,22 @@ func (mr *MockStoreMockRecorder) GenerateSingleVanillaProof(arg0, arg1, arg2, ar
 }
 
 // MoveStorage mocks base method.
-func (m *MockStore) MoveStorage(arg0 context.Context, arg1 storiface.SectorRef, arg2 storiface.SectorFileType) error {
+func (m *MockStore) MoveStorage(arg0 context.Context, arg1 storiface.SectorRef, arg2 storiface.SectorFileType, arg3 ...storiface.AcquireOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MoveStorage", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MoveStorage", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MoveStorage indicates an expected call of MoveStorage.
-func (mr *MockStoreMockRecorder) MoveStorage(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) MoveStorage(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveStorage", reflect.TypeOf((*MockStore)(nil).MoveStorage), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveStorage", reflect.TypeOf((*MockStore)(nil).MoveStorage), varargs...)
 }
 
 // Remove mocks base method.

--- a/storage/paths/remote.go
+++ b/storage/paths/remote.go
@@ -325,14 +325,14 @@ func (r *Remote) checkAllocated(ctx context.Context, url string, spt abi.Registe
 	}
 }
 
-func (r *Remote) MoveStorage(ctx context.Context, s storiface.SectorRef, types storiface.SectorFileType) error {
+func (r *Remote) MoveStorage(ctx context.Context, s storiface.SectorRef, types storiface.SectorFileType, opts ...storiface.AcquireOption) error {
 	// Make sure we have the data local
-	_, _, err := r.AcquireSector(ctx, s, types, storiface.FTNone, storiface.PathStorage, storiface.AcquireMove)
+	_, _, err := r.AcquireSector(ctx, s, types, storiface.FTNone, storiface.PathStorage, storiface.AcquireMove, opts...)
 	if err != nil {
 		return xerrors.Errorf("acquire src storage (remote): %w", err)
 	}
 
-	return r.local.MoveStorage(ctx, s, types)
+	return r.local.MoveStorage(ctx, s, types, opts...)
 }
 
 func (r *Remote) Remove(ctx context.Context, sid abi.SectorID, typ storiface.SectorFileType, force bool, keepIn []storiface.ID) error {


### PR DESCRIPTION
## Related Issues


## Proposed Changes
* Plumb storage reservation logic into MoveStorage
* Add Storage to the MoveStorage task

## Additional Info
Todo:
* [x] Fisish impl
* [x] Test on mainnet

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
