### PR TITLE
test: eth: deflake EthBlockHashesCorrect_MultiBlockTipset

### DIFF
--- a/itests/eth_block_hash_test.go
+++ b/itests/eth_block_hash_test.go
@@ -26,30 +26,36 @@ import (
 func TestEthBlockHashesCorrect_MultiBlockTipset(t *testing.T) {
 	// miner is connected to the first node, and we want to observe the chain
 	// from the second node.
-	blocktime := 250 * time.Millisecond
+	blocktime := 100 * time.Millisecond
 	n1, m1, m2, ens := kit.EnsembleOneTwo(t,
 		kit.MockProofs(),
 		kit.ThroughRPC(),
 	)
 	ens.InterconnectAll().BeginMining(blocktime)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	n1.WaitTillChain(ctx, kit.HeightAtLeast(abi.ChainEpoch(5)))
-	defer cancel()
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		n1.WaitTillChain(ctx, kit.HeightAtLeast(abi.ChainEpoch(5)))
+		cancel()
+	}
 
 	var n2 kit.TestFullNode
 	ens.FullNode(&n2, kit.ThroughRPC()).Start().Connect(n2, n1)
 
-	// find the first tipset where all miners mined a block.
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
-	n2.WaitTillChain(ctx, kit.BlocksMinedByAll(m1.ActorAddr, m2.ActorAddr))
-	defer cancel()
+	{
+		// find the first tipset where all miners mined a block.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		n2.WaitTillChain(ctx, kit.BlocksMinedByAll(m1.ActorAddr, m2.ActorAddr))
+		cancel()
+	}
 
 	head, err := n2.ChainHead(context.Background())
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// let the chain run a little bit longer to minimise the chance of reorgs
-	n2.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+50))
+	n2.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+10))
 
 	tsk := head.Key()
 	for i := 1; i <= int(head.Height()); i++ {

--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -256,8 +256,6 @@ func (bm *BlockMiner) MineBlocksMustPost(ctx context.Context, blocktime time.Dur
 }
 
 func (bm *BlockMiner) MineBlocks(ctx context.Context, blocktime time.Duration) {
-	time.Sleep(time.Second)
-
 	// wrap context in a cancellable context.
 	ctx, bm.cancel = context.WithCancel(ctx)
 
@@ -278,8 +276,11 @@ func (bm *BlockMiner) MineBlocks(ctx context.Context, blocktime time.Duration) {
 			default:
 			}
 
+			now := time.Duration(time.Now().UnixNano())
+			delay := blocktime - (now % blocktime)
+
 			select {
-			case <-time.After(blocktime):
+			case <-time.After(delay):
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
Increase the chances of having multiple blocks at the same height by aligning block times across test miners. Also, make the block hash test faster.