### PR TITLE
fix: cli: Datacap should only be checked if user agrees to spend it

### DIFF
--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -1311,21 +1311,6 @@ func CreateExtendClaimMsg(ctx context.Context, api api.FullNode, pcm map[verifre
 	}
 
 	if len(newClaims) > 0 {
-		// Get datacap balance
-		aDataCap, err := api.StateVerifiedClientStatus(ctx, wallet, types.EmptyTSK)
-		if err != nil {
-			return nil, err
-		}
-
-		if aDataCap == nil {
-			return nil, xerrors.Errorf("wallet %s does not have any datacap", wallet)
-		}
-
-		// Check that we have enough data cap to make the allocation
-		if rDataCap.GreaterThan(big.NewInt(aDataCap.Int64())) {
-			return nil, xerrors.Errorf("requested datacap %s is greater then the available datacap %s", rDataCap, aDataCap)
-		}
-
 		if !assumeYes {
 			out := fmt.Sprintf("Some of the specified allocation have a different client address and will require %d Datacap to extend. Proceed? Yes [Y/y] / No [N/n], Ctrl+C (^C) to exit", rDataCap.Int)
 			validate := func(input string) error {
@@ -1359,6 +1344,21 @@ func CreateExtendClaimMsg(ctx context.Context, api api.FullNode, pcm map[verifre
 				fmt.Println("Dropping the extension for claims that require Datacap")
 				return msgs, nil
 			}
+		}
+
+		// Get datacap balance
+		aDataCap, err := api.StateVerifiedClientStatus(ctx, wallet, types.EmptyTSK)
+		if err != nil {
+			return nil, err
+		}
+
+		if aDataCap == nil {
+			return nil, xerrors.Errorf("wallet %s does not have any datacap", wallet)
+		}
+
+		// Check that we have enough data cap to make the allocation
+		if rDataCap.GreaterThan(big.NewInt(aDataCap.Int64())) {
+			return nil, xerrors.Errorf("requested datacap %s is greater then the available datacap %s", rDataCap, aDataCap)
 		}
 
 		// Create a map of just keys, so we can easily batch based on the numeric keys


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/11810
## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
