### PR TITLE
ci: ci: list processes before calling apt-get to enable debugging

### DIFF
--- a/.github/actions/install-system-dependencies/action.yml
+++ b/.github/actions/install-system-dependencies/action.yml
@@ -6,6 +6,8 @@ runs:
   steps:
     - if: runner.os == 'Linux'
       run: |
+        # List processes to enable debugging in case /var/lib/apt/lists/ is locked 
+        ps aux
         sudo apt-get update -y
         sudo apt-get install -y ocl-icd-opencl-dev libhwloc-dev pkg-config
       shell: bash


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/11734#issuecomment-2033165180

## Proposed Changes
<!-- A clear list of the changes being made -->
I propose to list processes before calling apt-get to enable debugging the issue raised in https://github.com/filecoin-project/lotus/issues/11734#issuecomment-2033165180.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
