### PR TITLE
fix: eth rpc: ETH Subscription RPC API should return blocks that are one epoch behind the current epoch

### DIFF
--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -137,6 +137,40 @@ func TestEthNewPendingTransactionFilter(t *testing.T) {
 	}
 }
 
+func TestEthNewHeadsSub(t *testing.T) {
+	require := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	kit.QuietAllLogsExcept("events", "messagepool")
+
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.WithEthRPC())
+	ens.InterconnectAll().BeginMining(10 * time.Millisecond)
+
+	// install filter
+	subId, err := client.EthSubscribe(ctx, res.Wrap[jsonrpc.RawParams](json.Marshal(ethtypes.EthSubscribeParams{EventType: "newHeads"})).Assert(require.NoError))
+	require.NoError(err)
+
+	err = client.EthSubRouter.AddSub(ctx, subId, func(ctx context.Context, resp *ethtypes.EthSubscriptionResponse) error {
+		rs := *resp
+		block, ok := rs.Result.(map[string]interface{})
+		require.True(ok)
+		blockNumber, ok := block["number"].(string)
+		require.True(ok)
+
+		blk, err := client.EthGetBlockByNumber(ctx, blockNumber, false)
+		require.NoError(err)
+		require.NotNil(blk)
+		// block hashes should match
+		require.Equal(block["hash"], blk.Hash.String())
+
+		return nil
+	})
+	require.NoError(err)
+	time.Sleep(2 * time.Second)
+}
+
 func TestEthNewPendingTransactionSub(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Related Issues
Closes #11807 

## Proposed Changes
ETH Subscription RPC API should return blocks that are one epoch behind the current epoch to match the contract of the `eth_getBlockByNumber` API

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
