### PR TITLE
[WIP] feat: curio c1go: Pure Go vanilla challenge generation

### DIFF
--- a/curiosrc/proof/porep_vproof.go
+++ b/curiosrc/proof/porep_vproof.go
@@ -1,0 +1,134 @@
+package proof
+
+// This file contains some type definitions from
+// - https://github.com/filecoin-project/rust-fil-proofs/tree/master/storage-proofs-core/src/merkle
+// - https://github.com/filecoin-project/rust-fil-proofs/tree/master/storage-proofs-porep/src/stacked/vanilla
+// - https://github.com/filecoin-project/rust-filecoin-proofs-api/tree/master/src
+
+// core
+
+type Commitment [32]byte
+type Ticket [32]byte
+
+type StringRegisteredProofType string // e.g. "StackedDrg2KiBV1"
+
+type HasherDomain = any
+
+type Sha256Domain [32]byte
+
+type PoseidonDomain [32]byte // Fr
+
+type MerkleProof[H HasherDomain] struct {
+	Data ProofData[H] `json:"data"`
+}
+
+type ProofData[H HasherDomain] struct {
+	Single *SingleProof[H] `json:"Single,omitempty"`
+	Sub    *SubProof[H]    `json:"Sub,omitempty"`
+	Top    *TopProof[H]    `json:"Top,omitempty"`
+}
+
+type SingleProof[H HasherDomain] struct {
+	Root H                `json:"root"`
+	Leaf H                `json:"leaf"`
+	Path InclusionPath[H] `json:"path"`
+}
+
+type SubProof[H HasherDomain] struct {
+	BaseProof InclusionPath[H] `json:"base_proof"`
+	SubProof  InclusionPath[H] `json:"sub_proof"`
+	Root      H                `json:"root"`
+	Leaf      H                `json:"leaf"`
+}
+
+type TopProof[H HasherDomain] struct {
+	BaseProof InclusionPath[H] `json:"base_proof"`
+	SubProof  InclusionPath[H] `json:"sub_proof"`
+	TopProof  InclusionPath[H] `json:"top_proof"`
+
+	Root H `json:"root"`
+	Leaf H `json:"leaf"`
+}
+
+type InclusionPath[H HasherDomain] struct {
+	Path []PathElement[H] `json:"path"`
+}
+
+type PathElement[H HasherDomain] struct {
+	Hashes []H    `json:"hashes"`
+	Index  uint64 `json:"index"`
+}
+
+// porep
+
+type Label struct {
+	ID            string `json:"id"`
+	Path          string `json:"path"`
+	RowsToDiscard int    `json:"rows_to_discard"`
+	Size          int    `json:"size"`
+}
+
+type Labels struct {
+	H      any     `json:"_h"` // todo ?
+	Labels []Label `json:"labels"`
+}
+
+type PreCommit1OutRaw struct {
+	LotusSealRand []byte `json:"_lotus_SealRandomness"`
+
+	CommD           Commitment                           `json:"comm_d"`
+	Config          Label                                `json:"config"`
+	Labels          map[StringRegisteredProofType]Labels `json:"labels"`
+	RegisteredProof StringRegisteredProofType            `json:"registered_proof"`
+}
+
+type Commit1OutRaw struct {
+	CommD           Commitment                `json:"comm_d"`
+	CommR           Commitment                `json:"comm_r"`
+	RegisteredProof StringRegisteredProofType `json:"registered_proof"`
+	ReplicaID       Commitment                `json:"replica_id"`
+	Seed            Ticket                    `json:"seed"`
+	Ticket          Ticket                    `json:"ticket"`
+
+	VanillaProofs map[StringRegisteredProofType][][]VanillaStackedProof `json:"vanilla_proofs"`
+}
+
+type VanillaStackedProof struct {
+	CommDProofs    MerkleProof[Sha256Domain]   `json:"comm_d_proofs"`
+	CommRLastProof MerkleProof[PoseidonDomain] `json:"comm_r_last_proof"`
+
+	ReplicaColumnProofs ReplicaColumnProof[PoseidonDomain] `json:"replica_column_proofs"`
+	LabelingProofs      []LabelingProof[PoseidonDomain]    `json:"labeling_proofs"`
+	EncodingProof       EncodingProof[PoseidonDomain]      `json:"encoding_proof"`
+}
+
+type ReplicaColumnProof[H HasherDomain] struct {
+	C_X        ColumnProof[H]   `json:"c_x"`
+	DrgParents []ColumnProof[H] `json:"drg_parents"`
+	ExpParents []ColumnProof[H] `json:"exp_parents"`
+}
+
+type ColumnProof[H HasherDomain] struct {
+	Column         Column[H]      `json:"column"`
+	InclusionProof MerkleProof[H] `json:"inclusion_proof"`
+}
+
+type Column[H HasherDomain] struct {
+	Index uint32 `json:"index"`
+	Rows  []H    `json:"rows"`
+	H     any    `json:"_h"`
+}
+
+type LabelingProof[H HasherDomain] struct {
+	Parents    []H    `json:"parents"`
+	LayerIndex uint32 `json:"layer_index"`
+	Node       uint64 `json:"node"`
+	//H          any    `json:"_h"`
+}
+
+type EncodingProof[H HasherDomain] struct {
+	Parents    []H    `json:"parents"`
+	LayerIndex uint32 `json:"layer_index"`
+	Node       uint64 `json:"node"`
+	//H          any    `json:"_h"`
+}

--- a/curiosrc/proof/porep_vproof_challenges.go
+++ b/curiosrc/proof/porep_vproof_challenges.go
@@ -1,0 +1,65 @@
+package proof
+
+import (
+	"encoding/binary"
+	"github.com/minio/sha256-simd"
+	"math/big"
+)
+
+// https://github.com/filecoin-project/rust-fil-proofs/blob/8f5bd86be36a55e33b9b293ba22ea13ca1f28163/storage-proofs-porep/src/stacked/vanilla/challenges.rs#L21
+
+func DeriveInteractiveChallenges(
+	challengesPerPartition uint64,
+	sectorNnodes SectorNodes,
+	ReplicaID Commitment,
+	Seed Ticket,
+	k uint8,
+) []uint64 {
+	var jbuf [4]byte
+
+	out := make([]uint64, challengesPerPartition)
+
+	for i := uint64(0); i < challengesPerPartition; i++ {
+		// let j: u32 = ((self.challenges_per_partition * k as usize) + i) as u32;
+		j := uint32((challengesPerPartition * uint64(k)) + i)
+
+		/*
+			let hash = Sha256::new()
+				.chain_update(replica_id.into_bytes())
+				.chain_update(seed)
+				.chain_update(j.to_le_bytes())
+				.finalize();
+
+			let bigint = BigUint::from_bytes_le(hash.as_ref());
+			bigint_to_challenge(bigint, sector_nodes)
+		*/
+		hasher := sha256.New()
+		hasher.Write(ReplicaID[:])
+		hasher.Write(Seed[:])
+
+		binary.LittleEndian.PutUint32(jbuf[:], j)
+		hasher.Write(jbuf[:])
+
+		hash := hasher.Sum(nil)
+		bigint := new(big.Int).SetBytes(hash) // SetBytes is big-endian
+
+		out[i] = bigintToChallenge(bigint, sectorNnodes)
+	}
+
+	return out
+}
+
+/*
+	fn bigint_to_challenge(bigint: BigUint, sector_nodes: usize) -> usize {
+	    debug_assert!(sector_nodes < 1 << 32);
+	    // Ensure that we don't challenge the first node.
+	    let non_zero_node = (bigint % (sector_nodes - 1)) + 1usize;
+	    non_zero_node.to_u32_digits()[0] as usize
+	}
+*/
+func bigintToChallenge(bigint *big.Int, sectorNodes SectorNodes) uint64 {
+	// Ensure that we don't challenge the first node.
+	nonZeroNode := new(big.Int).Mod(bigint, big.NewInt(int64(sectorNodes-1)))
+	nonZeroNode.Add(nonZeroNode, big.NewInt(1))
+	return nonZeroNode.Uint64()
+}

--- a/curiosrc/proof/porep_vproof_test.go
+++ b/curiosrc/proof/porep_vproof_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	ffi "github.com/filecoin-project/filecoin-ffi"
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -77,14 +78,14 @@ func TestRoundtripPorepVproof(t *testing.T) {
 	c1out, err := ffi.SealCommitPhase1(spt, sealed, unsealed, cacheFile, sealedFile, num, miner, ticket[:], seed[:], pieces)
 	require.NoError(t, err)
 
-	t.Run("json-type-check", func(t *testing.T) {
-		// deserialize the proof with Go types
-		var proof1 Commit1OutRaw
-		err = json.Unmarshal(c1out, &proof1)
-		require.NoError(t, err)
+	// deserialize the proof with Go types
+	var realVProof Commit1OutRaw
+	err = json.Unmarshal(c1out, &realVProof)
+	require.NoError(t, err)
 
+	t.Run("json-roundtrip-check", func(t *testing.T) {
 		// serialize the proof to JSON
-		proof1out, err := json.Marshal(proof1)
+		proof1out, err := json.Marshal(realVProof)
 		require.NoError(t, err)
 
 		// check that the JSON is as expected
@@ -101,4 +102,68 @@ func TestRoundtripPorepVproof(t *testing.T) {
 
 		require.True(t, cmp.Equal(rustObj, goObj))
 	})
+
+	t.Run("check-toplevel", func(t *testing.T) {
+		/*
+			type Commit1OutRaw struct {
+				CommD           Commitment                `json:"comm_d"` // CHECK
+				CommR           Commitment                `json:"comm_r"` // CHECK
+				RegisteredProof StringRegisteredProofType `json:"registered_proof"` // CHECK
+				ReplicaID       Commitment                `json:"replica_id"` // CHECK
+				Seed            Ticket                    `json:"seed"` // CHECK
+				Ticket          Ticket                    `json:"ticket"` // CHECK
+
+				VanillaProofs map[StringRegisteredProofType][][]VanillaStackedProof `json:"vanilla_proofs"`
+			}
+		*/
+
+		rawCommD, err := commcid.CIDToDataCommitmentV1(unsealed)
+		require.NoError(t, err)
+		rawCommR, err := commcid.CIDToReplicaCommitmentV1(sealed)
+		require.NoError(t, err)
+
+		require.Equal(t, realVProof.CommD, Commitment(rawCommD))
+		require.Equal(t, realVProof.CommR, Commitment(rawCommR))
+
+		require.Equal(t, realVProof.RegisteredProof, StringRegisteredProofType("StackedDrg2KiBV1_1"))
+
+		replicaID, err := spt.ReplicaId(miner, num, ticket[:], realVProof.CommD[:])
+		require.NoError(t, err)
+		require.Equal(t, realVProof.ReplicaID, Commitment(replicaID))
+
+		require.Equal(t, realVProof.Seed, Ticket(seed))
+		require.Equal(t, realVProof.Ticket, Ticket(ticket))
+	})
+
+	t.Run("check-d-proofs", func(t *testing.T) {
+		require.Len(t, realVProof.VanillaProofs, 1)
+
+		expected := extractDProofs(realVProof.VanillaProofs["StackedDrg2KiBV1"]) // fun fact: this doesn't have _1 in the name...
+
+		// todo compute + extract
+		var actual [][]MerkleProof[Sha256Domain]
+
+		requireNoDiff(t, expected, actual)
+	})
+}
+
+func extractDProofs(vp [][]VanillaStackedProof) [][]MerkleProof[Sha256Domain] {
+	var out [][]MerkleProof[Sha256Domain]
+	for _, v := range vp {
+		var proofs []MerkleProof[Sha256Domain]
+		for _, p := range v {
+			proofs = append(proofs, p.CommDProofs)
+		}
+		out = append(out, proofs)
+	}
+	return out
+}
+
+func requireNoDiff(t *testing.T, rustObj, goObj interface{}) {
+	diff := cmp.Diff(rustObj, goObj)
+	if !cmp.Equal(rustObj, goObj) {
+		t.Errorf("proof mismatch: %s", diff)
+	}
+
+	require.True(t, cmp.Equal(rustObj, goObj))
 }

--- a/curiosrc/proof/porep_vproof_test.go
+++ b/curiosrc/proof/porep_vproof_test.go
@@ -1,0 +1,104 @@
+package proof
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRoundtripPorepVproof(t *testing.T) {
+	// seal a sector (random data)
+	testDir := t.TempDir()
+
+	paddedSize := abi.PaddedPieceSize(2048)
+	unpaddedSize := paddedSize.Unpadded()
+
+	// generate a random sector
+	sectorData := make([]byte, unpaddedSize)
+	_, err := rand.Read(sectorData)
+	require.NoError(t, err)
+
+	unsFile := filepath.Join(testDir, "unsealed")
+	cacheFile := filepath.Join(testDir, "cache")
+	sealedFile := filepath.Join(testDir, "sealed")
+
+	{
+		err = os.MkdirAll(cacheFile, 0755)
+		require.NoError(t, err)
+		f, err := os.Create(sealedFile)
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+	}
+
+	commd, err := BuildTreeD(bytes.NewReader(sectorData), true, unsFile, 2048)
+	require.NoError(t, err)
+	fmt.Println("D:", commd)
+
+	err = os.Truncate(unsFile, int64(paddedSize)) // prefix contains exactly unsealed data
+	require.NoError(t, err)
+
+	spt := abi.RegisteredSealProof_StackedDrg2KiBV1_1
+	num := abi.SectorNumber(234)
+	miner := abi.ActorID(123)
+
+	var ticket [32]byte
+	_, err = rand.Read(ticket[:])
+	require.NoError(t, err)
+	ticket[31] &= 0x3f // fr32
+
+	pieces := []abi.PieceInfo{{
+		Size:     paddedSize,
+		PieceCID: commd,
+	}}
+
+	p1o, err := ffi.SealPreCommitPhase1(spt, cacheFile, unsFile, sealedFile, num, miner, ticket[:], pieces)
+	require.NoError(t, err)
+
+	sealed, unsealed, err := ffi.SealPreCommitPhase2(p1o, cacheFile, sealedFile)
+	require.NoError(t, err)
+	_ = sealed
+	_ = unsealed
+
+	// generate a proof
+	var seed [32]byte
+	_, err = rand.Read(seed[:])
+	require.NoError(t, err)
+	seed[31] &= 0x3f // fr32
+
+	c1out, err := ffi.SealCommitPhase1(spt, sealed, unsealed, cacheFile, sealedFile, num, miner, ticket[:], seed[:], pieces)
+	require.NoError(t, err)
+
+	t.Run("json-type-check", func(t *testing.T) {
+		// deserialize the proof with Go types
+		var proof1 Commit1OutRaw
+		err = json.Unmarshal(c1out, &proof1)
+		require.NoError(t, err)
+
+		// serialize the proof to JSON
+		proof1out, err := json.Marshal(proof1)
+		require.NoError(t, err)
+
+		// check that the JSON is as expected
+		var rustObj, goObj map[string]interface{}
+		err = json.Unmarshal(c1out, &rustObj)
+		require.NoError(t, err)
+		err = json.Unmarshal(proof1out, &goObj)
+		require.NoError(t, err)
+
+		diff := cmp.Diff(rustObj, goObj)
+		if !cmp.Equal(rustObj, goObj) {
+			t.Errorf("proof mismatch: %s", diff)
+		}
+
+		require.True(t, cmp.Equal(rustObj, goObj))
+	})
+}

--- a/curiosrc/proof/porep_vproof_types.go
+++ b/curiosrc/proof/porep_vproof_types.go
@@ -90,6 +90,7 @@ type Commit1OutRaw struct {
 	Seed            Ticket                    `json:"seed"`
 	Ticket          Ticket                    `json:"ticket"`
 
+	// ProofType -> [partitions] -> [challenge_index?] -> Proof
 	VanillaProofs map[StringRegisteredProofType][][]VanillaStackedProof `json:"vanilla_proofs"`
 }
 
@@ -132,3 +133,8 @@ type EncodingProof[H HasherDomain] struct {
 	Node       uint64 `json:"node"`
 	//H          any    `json:"_h"`
 }
+
+const NODE_SIZE = 32
+
+// SectorNodes is sector size as node count
+type SectorNodes uint64

--- a/curiosrc/proof/porep_vproof_vanilla.go
+++ b/curiosrc/proof/porep_vproof_vanilla.go
@@ -1,0 +1,11 @@
+package proof
+
+// https://github.com/filecoin-project/rust-fil-proofs/blob/8f5bd86be36a55e33b9b293ba22ea13ca1f28163/storage-proofs-porep/src/stacked/vanilla/proof_scheme.rs#L60
+func ProveAllPartitions() {
+
+}
+
+// https://github.com/filecoin-project/rust-fil-proofs/blob/8f5bd86be36a55e33b9b293ba22ea13ca1f28163/storage-proofs-porep/src/stacked/vanilla/proof.rs#L96
+func ProveLayers() {
+
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Implement a pure-Go version of Commit1, for now just supporting basic interactive PoRep.

The main goal is to get much better feedback from the code when things break so that Curio knows which parts of data appear to be corrupted.

Also makes debugging issues with sealing much, much easier.

## Additional Info
Extremely WIP, 80% of the code is not here yet. Shouldn't be hard to implement, but it's also not a big priority, so it's probably only going to move forward when I get really annoyed at the rust impl.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
