### PR TITLE
fix: paths/local: Fix on-disk storage accounting in new reservations

### DIFF
--- a/curiosrc/seal/task_trees.go
+++ b/curiosrc/seal/task_trees.go
@@ -211,8 +211,6 @@ func (t *TreesTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 }
 
 func (t *TreesTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
-	// todo reserve storage
-
 	id := ids[0]
 	return &id, nil
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Previously `Reserve` would instruct `stat` to include any sector files already on disk to lower what it consider as reserved, which in turn would lower Available storage less - The issue is that the new reservation isn't reflected in p.reserved at the time when stat is called, which means that usually we'd hit the `if stat.Reserved < 0 {.. stat.Reserved = 0` condition, making the accounting inaccurate.

This PR makes stat just return how much data is on-disk for the new reservation, and shifts the accounting to the Reserve function.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
