### PR TITLE
fix: harmony: Try other tasks when storage claim fails

### DIFF
--- a/lib/harmony/harmonytask/task_type_handler.go
+++ b/lib/harmony/harmonytask/task_type_handler.go
@@ -85,6 +85,7 @@ top:
 	}
 
 	// 3. What does the impl say?
+canAcceptAgain:
 	tID, err := h.CanAccept(ids, h.TaskEngine)
 	if err != nil {
 		log.Error(err)
@@ -100,6 +101,18 @@ top:
 	if h.TaskTypeDetails.Cost.Storage != nil {
 		if err = h.TaskTypeDetails.Cost.Storage.Claim(int(*tID)); err != nil {
 			log.Infow("did not accept task", "task_id", strconv.Itoa(int(*tID)), "reason", "storage claim failed", "name", h.Name, "error", err)
+
+			if len(ids) > 1 {
+				var tryAgain = make([]TaskID, 0, len(ids)-1)
+				for _, id := range ids {
+					if id != *tID {
+						tryAgain = append(tryAgain, id)
+					}
+				}
+				ids = tryAgain
+				goto canAcceptAgain
+			}
+
 			return false
 		}
 		releaseStorage = func() {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Before this fix if considerWork was called with a bunch of tasks, and the one selected first by CanAccept was consistently failing to claim storage, we'd get stuck never trying to claim other tasks. Combined with the bug in storage reservations (https://github.com/filecoin-project/lotus/pull/11825) this could lead to pile-ups which would make everything clog up, and no tasks would get executed.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
