### PR TITLE
feat: curio: Cleanup files after failed TreeDRC

### DIFF
--- a/curiosrc/proof/treed_build.go
+++ b/curiosrc/proof/treed_build.go
@@ -58,6 +58,15 @@ func BuildTreeD(data io.Reader, unpaddedData bool, outPath string, size abi.Padd
 	}
 	defer func() {
 		cerr := out.Close()
+
+		if err != nil {
+			// remove the file, it's probably bad
+			rerr := os.Remove(outPath)
+			if rerr != nil {
+				err = multierror.Append(err, rerr)
+			}
+		}
+
 		if cerr != nil {
 			err = multierror.Append(err, cerr)
 		}

--- a/storage/sealer/proofpaths/cachefiles.go
+++ b/storage/sealer/proofpaths/cachefiles.go
@@ -2,12 +2,36 @@ package proofpaths
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
 const dataFilePrefix = "sc-02-data-"
 const TreeDName = dataFilePrefix + "tree-d.dat"
+
+const TreeRLastPrefix = dataFilePrefix + "tree-r-last-"
+const TreeCPrefix = dataFilePrefix + "tree-c-"
+
+func IsFileTreeD(baseName string) bool {
+	return baseName == TreeDName
+}
+
+func IsFileTreeRLast(baseName string) bool {
+	// TreeRLastPrefix<int>.dat
+	reg := fmt.Sprintf(`^%s\d+\.dat$`, TreeRLastPrefix)
+	return regexp.MustCompile(reg).MatchString(baseName)
+}
+
+func IsFileTreeC(baseName string) bool {
+	// TreeCPrefix<int>.dat
+	reg := fmt.Sprintf(`^%s\d+\.dat$`, TreeCPrefix)
+	return regexp.MustCompile(reg).MatchString(baseName)
+}
+
+func IsTreeFile(baseName string) bool {
+	return IsFileTreeD(baseName) || IsFileTreeRLast(baseName) || IsFileTreeC(baseName)
+}
 
 func LayerFileName(layer int) string {
 	return fmt.Sprintf("%slayer-%d.dat", dataFilePrefix, layer)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
The tree tasks should cleanup after failed execution. This is especially useful when the error was caused by running out of disk space for whatever reason (which shouldn't ever happen, at least if the storage reservation mechanism wasn't buggy (fixed in another PR))

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
