### PR TITLE
fix: actor events: read entries from event index in order of their insertion

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -733,21 +733,20 @@ func (ei *EventIndex) prefillFilter(ctx context.Context, f *eventFilter, exclude
 		ces = append(ces, ce)
 	}
 
-	// collected event list is in inverted order since we selected only the most recent events
-	// sort it into height order
-	sort.Slice(ces, func(i, j int) bool { return ces[i].height < ces[j].height })
-
-	// sort the entries in the collected event by ordering
-	for _, ce := range ces {
-		sort.Slice(ce.entries, func(i, j int) bool { return ce.entries[i].ordering < ce.entries[j].ordering })
-	}
-
 	if len(ces) == 0 {
 		return nil
 	}
 
+	// collected event list is in inverted order since we selected only the most recent events
+	// sort it into height order
+	sort.Slice(ces, func(i, j int) bool { return ces[i].height < ces[j].height })
+
 	var collectedEvents []*CollectedEvent
+	// sort the entries in the collected event by ordering
 	for _, ce := range ces {
+		ce := ce
+		sort.Slice(ce.entries, func(i, j int) bool { return ce.entries[i].ordering < ce.entries[j].ordering })
+
 		evt := &CollectedEvent{
 			EmitterAddr: ce.emitterAddr,
 			Height:      ce.height,


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/11823

## Proposed Changes
Event entries should be read from the event index in the order of their insertion


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
