### PR TITLE
fix: piece: Don't return StartEport in PieceDealInfo.EndEpoch

### DIFF
--- a/storage/pipeline/piece/piece_info.go
+++ b/storage/pipeline/piece/piece_info.go
@@ -147,7 +147,7 @@ func (ds *PieceDealInfo) EndEpoch() (abi.ChainEpoch, error) {
 	default:
 		// note - when implementing make sure to cache any dynamically computed values
 		// todo do we want a smarter mechanism here
-		return ds.DealSchedule.StartEpoch, nil
+		return ds.DealSchedule.EndEpoch, nil
 	}
 }
 


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/11821

Slack discussion: https://filecoinproject.slack.com/archives/CPFTWMY7N/p1711693422625719

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
