### PR TITLE
fix: test: TestForkPreMigration hanging when env-var is set

### DIFF
--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -375,6 +375,14 @@ func testForkRefuseCall(t *testing.T, nullsBefore, nullsAfter int) {
 }
 
 func TestForkPreMigration(t *testing.T) {
+	// Backup the original value of the DISABLE_PRE_MIGRATIONS environment variable
+	originalValue, _ := os.LookupEnv("LOTUS_DISABLE_PRE_MIGRATIONS")
+
+	// Unset the DISABLE_PRE_MIGRATIONS environment variable for the test
+	os.Unsetenv("LOTUS_DISABLE_PRE_MIGRATIONS")
+
+	// Restore the original DISABLE_PRE_MIGRATIONS environment variable at the end of the test
+	defer os.Setenv("LOTUS_DISABLE_PRE_MIGRATIONS", originalValue)
 	//stm: @CHAIN_GEN_NEXT_TIPSET_001,
 	//stm: @CHAIN_STATE_RESOLVE_TO_KEY_ADDR_001, @CHAIN_STATE_SET_VM_CONSTRUCTOR_001
 	logging.SetAllLoggers(logging.LevelInfo)

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -379,10 +379,16 @@ func TestForkPreMigration(t *testing.T) {
 	originalValue, _ := os.LookupEnv("LOTUS_DISABLE_PRE_MIGRATIONS")
 
 	// Unset the DISABLE_PRE_MIGRATIONS environment variable for the test
-	os.Unsetenv("LOTUS_DISABLE_PRE_MIGRATIONS")
+	if err := os.Unsetenv("LOTUS_DISABLE_PRE_MIGRATIONS"); err != nil {
+		t.Fatalf("failed to unset LOTUS_DISABLE_PRE_MIGRATIONS: %v", err)
+	}
 
 	// Restore the original DISABLE_PRE_MIGRATIONS environment variable at the end of the test
-	defer os.Setenv("LOTUS_DISABLE_PRE_MIGRATIONS", originalValue)
+	defer func() {
+		if err := os.Setenv("LOTUS_DISABLE_PRE_MIGRATIONS", originalValue); err != nil {
+			t.Fatalf("failed to restore LOTUS_DISABLE_PRE_MIGRATIONS: %v", err)
+		}
+	}()
 	//stm: @CHAIN_GEN_NEXT_TIPSET_001,
 	//stm: @CHAIN_STATE_RESOLVE_TO_KEY_ADDR_001, @CHAIN_STATE_SET_VM_CONSTRUCTOR_001
 	logging.SetAllLoggers(logging.LevelInfo)


### PR DESCRIPTION
## Related Issues
Fixes #11824 

The `TestForkPreMigration`-test would hang indefinitely if the LOTUS_DISABLE_PRE_MIGRATIONS=1 environment variable was set. 

## Proposed Changes
Temporarily unsets the LOTUS_DISABLE_PRE_MIGRATIONS environment variable before running the test, and restore it afterward.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
