### PR TITLE
fix: lmcli: make 'sectors list' DDO-aware

### DIFF
--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -310,6 +310,13 @@ var sectorsListCmd = &cli.Command{
 				}
 			}
 
+			var pams int
+			for _, p := range st.Pieces {
+				if p.DealInfo != nil && p.DealInfo.PieceActivationManifest != nil {
+					pams++
+				}
+			}
+
 			exp := st.Expiration
 			if st.OnTime > 0 && st.OnTime < exp {
 				exp = st.OnTime // Can be different when the sector was CC upgraded
@@ -324,6 +331,8 @@ var sectorsListCmd = &cli.Command{
 
 			if deals > 0 {
 				m["Deals"] = color.GreenString("%d", deals)
+			} else if pams > 0 {
+				m["Deals"] = color.MagentaString("DDO:%d", pams)
 			} else {
 				m["Deals"] = color.BlueString("CC")
 				if st.ToUpgrade {


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/filecoin-project/lotus/issues/11833

## Proposed Changes
* Be DDO-aware in `lotus-miner sectors list`
* Also add DDO-related output to `lotus-miner sectors status`

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
