### PR TITLE
feat: curio: Cleanup data copies after seal ops

### DIFF
--- a/curiosrc/ffi/piece_funcs.go
+++ b/curiosrc/ffi/piece_funcs.go
@@ -15,7 +15,7 @@ import (
 func (sb *SealCalls) WritePiece(ctx context.Context, taskID *harmonytask.TaskID, pieceID storiface.PieceNumber, size int64, data io.Reader) error {
 	// todo: config(?): allow setting PathStorage for this
 	// todo storage reservations
-	paths, done, err := sb.sectors.AcquireSector(ctx, taskID, pieceID.Ref(), storiface.FTNone, storiface.FTPiece, storiface.PathSealing)
+	paths, _, done, err := sb.sectors.AcquireSector(ctx, taskID, pieceID.Ref(), storiface.FTNone, storiface.FTPiece, storiface.PathSealing)
 	if err != nil {
 		return err
 	}

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -178,7 +178,7 @@ func (sb *SealCalls) ensureOneCopy(ctx context.Context, sid abi.SectorID, pathID
 
 		log.Debugw("ensureOneCopy", "sector", sid, "type", fileType, "keep", keepIn)
 
-		if err := sb.sectors.storage.Remove(ctx, sid, storiface.FTCache, true, keepIn); err != nil {
+		if err := sb.sectors.storage.Remove(ctx, sid, fileType, true, keepIn); err != nil {
 			return err
 		}
 	}

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -60,7 +60,7 @@ type storageProvider struct {
 	storageReservations *xsync.MapOf[harmonytask.TaskID, *StorageReservation]
 }
 
-func (l *storageProvider) AcquireSector(ctx context.Context, taskID *harmonytask.TaskID, sector storiface.SectorRef, existing, allocate storiface.SectorFileType, sealing storiface.PathType) (storiface.SectorPaths, storiface.SectorPaths, func(), error) {
+func (l *storageProvider) AcquireSector(ctx context.Context, taskID *harmonytask.TaskID, sector storiface.SectorRef, existing, allocate storiface.SectorFileType, sealing storiface.PathType) (fspaths, ids storiface.SectorPaths, release func(), err error) {
 	var paths, storageIDs storiface.SectorPaths
 	var releaseStorage func()
 

--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -168,10 +168,16 @@ func (sb *SealCalls) GenerateSDR(ctx context.Context, taskID harmonytask.TaskID,
 // ensureOneCopy makes sure that there is only one version of sector data.
 // Usually called after a successful operation was done successfully on sector data.
 func (sb *SealCalls) ensureOneCopy(ctx context.Context, sid abi.SectorID, pathIDs storiface.SectorPaths, fts storiface.SectorFileType) error {
+	if !pathIDs.HasAllSet(fts) {
+		return xerrors.Errorf("ensure one copy: not all paths are set")
+	}
+
 	for _, fileType := range fts.AllSet() {
 		pid := storiface.PathByType(pathIDs, fileType)
-
 		keepIn := []storiface.ID{storiface.ID(pid)}
+
+		log.Debugw("ensureOneCopy", "sector", sid, "type", fileType, "keep", keepIn)
+
 		if err := sb.sectors.storage.Remove(ctx, sid, storiface.FTCache, true, keepIn); err != nil {
 			return err
 		}

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -663,6 +663,8 @@ func (st *Local) Remove(ctx context.Context, sid abi.SectorID, typ storiface.Sec
 		return xerrors.New("delete expects one file type")
 	}
 
+	log.Debugw("Remove called", "sid", sid, "type", typ, "force", force, "keepIn", keepIn)
+
 	si, err := st.index.StorageFindSector(ctx, sid, typ, 0, false)
 	if err != nil {
 		return xerrors.Errorf("finding existing sector %d(t:%d) failed: %w", sid, typ, err)
@@ -739,7 +741,7 @@ func (st *Local) removeSector(ctx context.Context, sid abi.SectorID, typ storifa
 	}
 
 	spath := p.sectorPath(sid, typ)
-	log.Infof("remove %s", spath)
+	log.Infow("remove", "path", spath, "id", sid, "type", typ, "storage", storage)
 
 	if err := os.RemoveAll(spath); err != nil {
 		log.Errorf("removing sector (%v) from %s: %+v", sid, spath, err)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR makes it so that after each porep pipeline step tasks will ensure that only the latest version of sector files remain in storage. This should make future retry logic much easier to implement - e.g. retrying SDR will now just be setting after_sdr/after_tree.. fields for a given sector to false.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
