### PR TITLE
fix: spcli: add reference to the terminate command

### DIFF
--- a/cmd/sptool/sector.go
+++ b/cmd/sptool/sector.go
@@ -36,7 +36,7 @@ var sectorsCmd = &cli.Command{
 		spcli.SectorsCheckExpireCmd(SPTActorGetter),
 		sectorsExpiredCmd, // in-house b/c chain-only is so different
 		spcli.SectorsExtendCmd(SPTActorGetter),
-		//spcli.SectorsTerminateCmd(SPTActorGetter), // Could not trace through the state-machine
+		spcli.TerminateSectorCmd(SPTActorGetter),
 		spcli.SectorsCompactPartitionsCmd(SPTActorGetter),
 	}}
 

--- a/documentation/en/cli-sptool.md
+++ b/documentation/en/cli-sptool.md
@@ -275,6 +275,7 @@ COMMANDS:
    check-expire        Inspect expiring sectors
    expired             Get or cleanup expired sectors
    extend              Extend expiring sectors while not exceeding each sector's max life
+   terminate           Forcefully terminate a sector (WARNING: This means losing power and pay a one-time termination penalty(including collateral) for the terminated sector)
    compact-partitions  removes dead sectors from partitions and reduces the number of partitions used if possible
    help, h             Shows a list of commands or help for one command
 
@@ -370,6 +371,21 @@ OPTIONS:
    --max-sectors value     the maximum number of sectors contained in each message (default: 0)
    --really-do-it          pass this flag to really extend sectors, otherwise will only print out json representation of parameters (default: false)
    --help, -h              show help
+```
+
+### sptool sectors terminate
+```
+NAME:
+   sptool sectors terminate - Forcefully terminate a sector (WARNING: This means losing power and pay a one-time termination penalty(including collateral) for the terminated sector)
+
+USAGE:
+   sptool sectors terminate [command options] [sectorNum1 sectorNum2 ...]
+
+OPTIONS:
+   --actor value   specify the address of miner actor
+   --really-do-it  pass this flag if you know what you are doing (default: false)
+   --from value    specify the address to send the terminate message from
+   --help, -h      show help
 ```
 
 ### sptool sectors compact-partitions


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/pull/11788/commits/280c9ac75ef09a978e7cde0b02e5fce1411de914 moved terminate from lotus-shed to the spcli package, but didn't add it to sptool

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
