### PR TITLE
fix(build): disable phoenix drand upgrade if LOTUS_DISABLE_DRAGON

### DIFF
--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -132,6 +132,7 @@ func init() {
 
 	if os.Getenv("LOTUS_DISABLE_DRAGON") == "1" {
 		UpgradeDragonHeight = math.MaxInt64 - 1
+		delete(DrandSchedule, UpgradePhoenixHeight)
 		UpgradePhoenixHeight = math.MaxInt64
 	}
 


### PR DESCRIPTION
This is a bit too late for 1.26.0 and 1.26.1 but it at least gives mitigation if there was some reason to use this env var to disable proper nv22 upgrade.