### PR TITLE
CI trigger for current releases branch HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 # v1.26.2 / 2024-04-08
 
+bork
+
 **This is a mandatory patch release for the Filecoin network version 22 mainnet upgrade, for all node operators.**
 
 There is an update in the upgrade epoch for nv22, you can read the [full discussion in Slack here.](https://filecoinproject.slack.com/archives/C05P37R9KQD/p1712548103521969)


### PR DESCRIPTION
DO NOT MERGE

I'm just doing a trivial commit on top of the current `releases` branch. I merged on CLI rather than through a PR so I didn't get the full CI treatment for the current HEAD of that branch (see notes in https://github.com/filecoin-project/lotus/issues/11853). Doing it in here as proxy.