### PR TITLE
fix(events): properly decorate events db errors

### DIFF
--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.uber.org/fx"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -105,7 +106,7 @@ func EventFilterManager(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.L
 			if cfg.DatabasePath == "" {
 				sqlitePath, err := r.SqlitePath()
 				if err != nil {
-					return nil, err
+					return nil, xerrors.Errorf("failed to resolve event index database path: %w", err)
 				}
 				dbPath = filepath.Join(sqlitePath, "events.db")
 			} else {
@@ -115,7 +116,7 @@ func EventFilterManager(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.L
 			var err error
 			eventIndex, err = filter.NewEventIndex(ctx, dbPath, chainapi.Chain)
 			if err != nil {
-				return nil, err
+				return nil, xerrors.Errorf("failed to initialize event index database: %w", err)
 			}
 
 			lc.Append(fx.Hook{


### PR DESCRIPTION
From @TippyFlitsUK, likely a result of running something off `master` and then "upgrading" to 1.26.2 which doesn't have version 3. We'll just make this more informative.

```
024-04-09T00:20:38.736Z	INFO	messagepool	messagepool/messagepool.go:446	mpool ready
ERROR: initializing node: starting node: could not build arguments for function "reflect".makeFuncStub (/usr/local/go/src/reflect/asm_amd64.s:28): failed to build full.EthEventAPI: could not build arguments for function "reflect".makeFuncStub (/usr/local/go/src/reflect/asm_amd64.s:28): failed to build *filter.EventFilterManager: received non-nil error from function "reflect".makeFuncStub (/usr/local/go/src/reflect/asm_amd64.s:28): invalid database version: got 3, expected 2
```