### PR TITLE
ci: ci: create gh workflow that updates sorted pr checks

### DIFF
--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -29,3 +29,4 @@ jobs:
     uses: ipdxco/sorted-pr-checks/.github/workflows/comment.yml@v1
     with:
       pull_number: ${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number }}
+      template: grouped_by_result

--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -1,0 +1,31 @@
+name: Comment with sorted PR checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: 'Pull request number'
+        required: true
+  workflow_run:
+    workflows:
+      - Build
+      - Check
+      - CodeQL
+      - Test
+    types:
+      - requested
+      - completed
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number || 'unknown' }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0]
+    uses: ipdxco/sorted-pr-checks/.github/workflows/comment.yml@v1
+    with:
+      pull_number: ${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -29,4 +29,4 @@ jobs:
     uses: ipdxco/sorted-pr-checks/.github/workflows/comment.yml@v1
     with:
       pull_number: ${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number }}
-      template: grouped_by_result
+      template: unsuccessful_only


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/11734

## Proposed Changes
<!-- A clear list of the changes being made -->
I propose to introduce a workflow that is going to post a nicely formatted list of completed checks on a PR once all the GitHub Actions workflow runs finish for the PR in question. 

## Additional Info
<!-- Callouts, links to documentation, and etc -->
The issue with GitHub PR Checks was originally reported here - https://filecoinproject.slack.com/archives/CP50PPW2X/p1711707107172389

Unfortunately, it is unlikely to be resolved by GitHub any time soon - https://github.com/orgs/community/discussions/7885

We developed an alternative solution to the problem that relies on posting a sticky comment to a PR which a sorted/grouped list of checks after all the GitHub Actions workflows are finished - https://github.com/ipdxco/sorted-pr-checks

Please note that the comment only includes information about GitHub Actions workflows, it does NOT include CircleCI checks.

We can choose between two(three) flavours of the comment:
A. Sorted by result and then alphabetically - https://github.com/filecoin-project/lotus/pull/11861#issuecomment-2044753484
B. Grouped by result and then sorted alphabetically within the group - https://github.com/filecoin-project/lotus/pull/11861#issuecomment-2044919152
C. Create a new comment template

Given the number of checks that we have here, I'd suggest the grouped comment.

There is one more alternative solution to the problem. The Refined GitHub extension - https://github.com/refined-github/refined-github - implements GitHub status checks sorting. While the extension is really useful and makes using GitHub nicer, I don't think we can rely on it and expect all contributors to install it. That's why I'd suggest proceeding with the introduction of this workflow nonetheless.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
