### PR TITLE
test: eth: wait longer for chain to settle in block hash test

### DIFF
--- a/itests/eth_block_hash_test.go
+++ b/itests/eth_block_hash_test.go
@@ -55,7 +55,7 @@ func TestEthBlockHashesCorrect_MultiBlockTipset(t *testing.T) {
 	ctx := context.Background()
 
 	// let the chain run a little bit longer to minimise the chance of reorgs
-	n2.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+10))
+	n2.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+50))
 
 	tsk := head.Key()
 	for i := 1; i <= int(head.Height()); i++ {


### PR DESCRIPTION
I shrunk this down to 10 when I last deflaked this test, but I was too optimistic. I'm bringing this back up to 50.

See https://gist.github.com/Stebalien/701039637361b3b9cb328d7c2d61beda
Fixes failure found in https://github.com/filecoin-project/lotus/pull/11858