### PR TITLE
fix: local storage reservations fixes

### DIFF
--- a/curiosrc/ffi/sdr_funcs.go
+++ b/curiosrc/ffi/sdr_funcs.go
@@ -148,6 +148,14 @@ func (sb *SealCalls) GenerateSDR(ctx context.Context, taskID harmonytask.TaskID,
 		return xerrors.Errorf("computing replica id: %w", err)
 	}
 
+	// make sure the cache dir is empty
+	if err := os.RemoveAll(paths.Cache); err != nil {
+		return xerrors.Errorf("removing cache dir: %w", err)
+	}
+	if err := os.MkdirAll(paths.Cache, 0755); err != nil {
+		return xerrors.Errorf("mkdir cache dir: %w", err)
+	}
+
 	// generate new sector key
 	err = ffi.GenerateSDR(
 		sector.ProofType,

--- a/curiosrc/ffi/task_storage.go
+++ b/curiosrc/ffi/task_storage.go
@@ -2,6 +2,7 @@ package ffi
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -170,9 +171,14 @@ func (t *TaskStorage) Claim(taskID int) error {
 		return err
 	}
 
+	var releaseOnce sync.Once
+	releaseFunc := func() {
+		releaseOnce.Do(release)
+	}
+
 	sres := &StorageReservation{
 		SectorRef: sectorRef,
-		Release:   release,
+		Release:   releaseFunc,
 		Paths:     pathsFs,
 		PathIDs:   pathIDs,
 

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -507,7 +507,7 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 
 		resID := sectorFile{sid.ID, fileType}
 
-		log.Debugw("reserve add", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead)
+		log.Debugw("reserve add", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead, "reserved-before", p.reserved, "reserved-after", p.reserved+overhead)
 
 		p.reserved += overhead
 		p.reservations[resID] = overhead
@@ -519,7 +519,7 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 			st.localLk.Lock()
 			defer st.localLk.Unlock()
 
-			log.Debugw("reserve done", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead)
+			log.Debugw("reserve done", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead, "reserved-before", p.reserved, "reserved-after", p.reserved-overhead)
 
 			p.reserved -= overhead
 			delete(p.reservations, resID)

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -118,7 +118,7 @@ func (p *path) stat(ls LocalStorage, newReserve ...statExistingSectorForReservat
 	}
 	for _, reservation := range newReserve {
 		for _, fileType := range reservation.ft.AllSet() {
-			log.Debugw("accounting existing files for new reservation", "id", reservation.id, "fileType", fileType, "overhead", reservation.overhead, "accounted", p.reservations[sectorFile{reservation.id, fileType}])
+			log.Debugw("accounting existing files for new reservation", "id", reservation.id, "fileType", fileType, "overhead", reservation.overhead)
 
 			resID := sectorFile{reservation.id, fileType}
 
@@ -507,6 +507,8 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 
 		resID := sectorFile{sid.ID, fileType}
 
+		log.Debugw("reserve add", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead)
+
 		p.reserved += overhead
 		p.reservations[resID] = overhead
 
@@ -516,6 +518,8 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 
 			st.localLk.Lock()
 			defer st.localLk.Unlock()
+
+			log.Debugw("reserve done", "id", id, "sector", sid, "fileType", fileType, "overhead", overhead)
 
 			p.reserved -= overhead
 			delete(p.reservations, resID)


### PR DESCRIPTION
## Related Issues


## Proposed Changes
More debugging of accounting issues in the storage reservation mechanism in Curio.

* This PR adds a lot more debug logging to storage reservation code
* Fixes a bug in curio task storage where in some cases we'd release storage multiple times
  * Fixed with sync.once as other ways of fixing it would be either very complicated or would trade robustness in favour of sometimes maybe not releasing storage
* Also a small drive-by fix which drops existing SDR layers on sdr restart - seems like this was one of the causes of corrupted sectors

Currently testing on my mainnet setup, seems to work very well so far

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
