### PR TITLE
fix: cli: json flag

### DIFF
--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -394,6 +394,11 @@ var filplusListClaimsCmd = &cli.Command{
 			Name:  "expired",
 			Usage: "list only expired claims",
 		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "output results in json format",
+			Value: false,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() > 1 {

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1297,6 +1297,7 @@ USAGE:
 
 OPTIONS:
    --expired   list only expired claims (default: false)
+   --json      output results in json format (default: false)
    --help, -h  show help
 ```
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

`lotus list-claims` can output in json format, however the `--json` flag is missing.

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
