### PR TITLE
fix: curio: Start BoostAdapters before blocking rpc serve

### DIFF
--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -131,13 +131,13 @@ var runCmd = &cli.Command{
 		}
 		defer taskEngine.GracefullyTerminate()
 
+		if err := lmrpc.ServeCurioMarketRPCFromConfig(dependencies.DB, dependencies.Full, dependencies.Cfg); err != nil {
+			return xerrors.Errorf("starting market RPCs: %w", err)
+		}
+
 		err = rpc.ListenAndServe(ctx, dependencies, shutdownChan) // Monitor for shutdown.
 		if err != nil {
 			return err
-		}
-
-		if err := lmrpc.ServeCurioMarketRPCFromConfig(dependencies.DB, dependencies.Full, dependencies.Cfg); err != nil {
-			return xerrors.Errorf("starting market RPCs: %w", err)
 		}
 
 		finishCh := node.MonitorShutdown(shutdownChan) //node.ShutdownHandler{Component: "rpc server", StopFunc: rpcStopper},

--- a/curiosrc/market/lmrpc/lmrpc.go
+++ b/curiosrc/market/lmrpc/lmrpc.go
@@ -68,9 +68,8 @@ func MakeTokens(cfg *config.CurioConfig) (map[address.Address]string, error) {
 			return xerrors.Errorf("net resolve: %w", err)
 		}
 
-		if len(laddr.IP) == 0 {
-			// set localhost
-			laddr.IP = net.IPv4(127, 0, 0, 1)
+		if len(laddr.IP) == 0 || laddr.IP.IsUnspecified() {
+			return xerrors.Errorf("market rpc server listen address must be a specific address, not %s (probably missing bind IP)", listen)
 		}
 
 		// need minimal provider with just the config
@@ -171,9 +170,8 @@ func ServeCurioMarketRPC(db *harmonydb.DB, full api.FullNode, maddr address.Addr
 		return xerrors.Errorf("net resolve: %w", err)
 	}
 
-	if len(laddr.IP) == 0 {
-		// set localhost
-		laddr.IP = net.IPv4(127, 0, 0, 1)
+	if len(laddr.IP) == 0 || laddr.IP.IsUnspecified() {
+		return xerrors.Errorf("market rpc server listen address must be a specific address, not %s (probably missing bind IP)", listen)
 	}
 	rootUrl := url.URL{
 		Scheme: "http",


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR makes the boost adapters start correctly.

`rpc.ListenAndServe` is blocking and make the boost adapter code unreachable.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
