### PR TITLE
fix: curio: Check deal start epoch passed in PrecommitSubmit

### DIFF
--- a/curiosrc/seal/task_submit_precommit.go
+++ b/curiosrc/seal/task_submit_precommit.go
@@ -101,6 +101,11 @@ func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 
 	// 2. Prepare message params
 
+	head, err := s.api.ChainHead(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting chain head: %w", err)
+	}
+
 	params := miner.PreCommitSectorBatchParams2{}
 
 	expiration := sectorParams.TicketEpoch + miner12.MaxSectorExpirationExtension
@@ -119,12 +124,13 @@ func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 			PieceCID   string `db:"piece_cid"`
 			PieceSize  int64  `db:"piece_size"`
 
-			F05DealID       int64 `db:"f05_deal_id"`
-			F05DealEndEpoch int64 `db:"f05_deal_end_epoch"`
+			F05DealID         int64 `db:"f05_deal_id"`
+			F05DealEndEpoch   int64 `db:"f05_deal_end_epoch"`
+			F05DealStartEpoch int64 `db:"f05_deal_start_epoch"`
 		}
 
 		err = s.db.Select(ctx, &pieces, `
-		SELECT piece_index, piece_cid, piece_size, f05_deal_id, f05_deal_end_epoch
+		SELECT piece_index, piece_cid, piece_size, f05_deal_id, f05_deal_end_epoch, f05_deal_start_epoch
 		FROM sectors_sdr_initial_pieces
 		WHERE sp_id = $1 AND sector_number = $2 ORDER BY piece_index ASC`, sectorParams.SpID, sectorParams.SectorNumber)
 		if err != nil {
@@ -138,6 +144,17 @@ func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 		if len(pieces) > 0 {
 			params.Sectors[0].UnsealedCid = &unsealedCID
 			params.Sectors[0].Expiration = abi.ChainEpoch(pieces[0].F05DealEndEpoch)
+
+			if abi.ChainEpoch(pieces[0].F05DealStartEpoch) < head.Height() {
+				// deal start epoch is in the past, can't precommit this sector anymore
+				_, perr := s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline
+					SET failed = TRUE, failed_at = NOW(), failed_reason = 'past-start-epoch', failed_reason_msg = 'precommit: start epoch is in the past'
+					WHERE task_id_precommit_msg = $1`, taskID)
+				if perr != nil {
+					return false, xerrors.Errorf("persisting precommit start epoch expiry: %w", perr)
+				}
+				return true, xerrors.Errorf("deal start epoch is in the past")
+			}
 
 			for _, p := range pieces {
 				params.Sectors[0].DealIDs = append(params.Sectors[0].DealIDs, abi.DealID(p.F05DealID))


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Add a missing expired-deal-start-epoch check to the SubmitPrecommit task. Marks the sector as failed, which will later get it GCed from storage.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
