### PR TITLE
experiment:splitstore:No redundant delete on moving GC

### DIFF
--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -1426,11 +1426,10 @@ func (s *SplitStore) purgeBatch(batch, deadCids []cid.Cid, checkpoint *Checkpoin
 	case hot:
 		// Short circuit deleting in the case we are just going to throw this away
 		fullGCPending := s.cfg.HotStoreFullGCFrequency > 0 && s.compactionIndex%int64(s.cfg.HotStoreFullGCFrequency) == 0
-		if fullGCPending {
-			return len(deadCids), liveCnt, nil
-		}
-		if err := s.hot.DeleteMany(s.ctx, deadCids); err != nil {
-			return 0, liveCnt, xerrors.Errorf("error purging cold objects: %w", err)
+		if !fullGCPending {
+			if err := s.hot.DeleteMany(s.ctx, deadCids); err != nil {
+				return 0, liveCnt, xerrors.Errorf("error purging cold objects: %w", err)
+			}
 		}
 	case cold:
 		if err := s.cold.DeleteMany(s.ctx, deadCids); err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

#11778 

## Proposed Changes
<!-- A clear list of the changes being made -->

@ribasushi points out that we do a full cold deletion purge in the event we are going to throw out the entire coldstore entirely anyway.  This is particularly wasteful when moving GC frequency is 1.  

I don't want to skip the purging process entirely because missing the criticial section opens up serious safety problems.  That's the "right" way to do this.  But let's see if this simple and trivially safe change can get us 80% of the way there.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
