### PR TITLE
fix: curio: fix incorrect null check for varchar column

### DIFF
--- a/lib/harmony/harmonytask/harmonytask.go
+++ b/lib/harmony/harmonytask/harmonytask.go
@@ -313,7 +313,8 @@ func (e *TaskEngine) pollerTryAllWork() bool {
 		resources.CleanupMachines(e.ctx, e.db)
 	}
 	for _, v := range e.handlers {
-		if v.AssertMachineHasCapacity() != nil {
+		if err := v.AssertMachineHasCapacity(); err != nil {
+			log.Debugf("skipped scheduling %s type tasks on due to %s", v.Name, err.Error())
 			continue
 		}
 		var unownedTasks []TaskID

--- a/storage/paths/db_index.go
+++ b/storage/paths/db_index.go
@@ -723,7 +723,7 @@ func (dbi *DBIndex) StorageBestAlloc(ctx context.Context, allocate storiface.Sec
 						 FROM storage_path 
 						 WHERE available >= $1
 						 and NOW()-($2 * INTERVAL '1 second') < last_heartbeat
-						 and heartbeat_err is null
+						 and heartbeat_err = ''
 						 and (($3 and can_seal = TRUE) or ($4 and can_store = TRUE))
 						order by (available::numeric * weight) desc`,
 		spaceReq,


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
`null` check against a varchar column can result in false negatives. 

```
yugabyte=# SELECT * FROM curio.storage_path WHERE available >= 118279372 and NOW()-(50000000000 * INTERVAL '1 second') < last_heartbeat and heartbeat_err is null and ((true and can_seal = TRUE) or (false and can_store = TRUE)) order by (available::numeric * weight) desc;
 storage_id | urls | weight | max_storage | can_seal | can_store | groups | allow_to | allow_types | deny_types | capacity | available | fs_available | reserved | used | last_heartbeat | heartbeat_err | allow_miners | deny_miners 
------------+------+--------+-------------+----------+-----------+--------+----------+-------------+------------+----------+-----------+--------------+----------+------+----------------+---------------+--------------+-------------
(0 rows)

yugabyte=# SELECT * FROM curio.storage_path;
              storage_id              |             urls              | weight | max_storage | can_seal | can_store | groups | allow_to | allow_types | deny_types |   capacity   |  available   | fs_available | reserved | used |       last_heartbeat       | heartbeat_err | allow_miners | deny_miners 
--------------------------------------+-------------------------------+--------+-------------+----------+-----------+--------+----------+-------------+------------+--------------+--------------+--------------+----------+------+----------------------------+---------------+--------------+-------------
 01756dc0-3889-42a8-9b27-c831e9f413f7 | http://127.0.0.1:12300/remote |     10 |           0 | t        | t         |        |          |             |            | 994662584320 | 449571401728 | 449571401728 |        0 |    0 | 2024-04-16 00:17:30.920622 |               |              | 
(1 row)

yugabyte=# SELECT * FROM curio.storage_path WHERE available >= 118279372 and NOW()-(50000000000 * INTERVAL '1 second') < last_heartbeat and heartbeat_err = '' and ((true and can_seal = TRUE) or (false and can_store = TRUE)) order by (available::numeric * weight) desc;
              storage_id              |             urls              | weight | max_storage | can_seal | can_store | groups | allow_to | allow_types | deny_types |   capacity   |  available   | fs_available | reserved | used |       last_heartbeat       | heartbeat_err | allow_miners | deny_miners 
--------------------------------------+-------------------------------+--------+-------------+----------+-----------+--------+----------+-------------+------------+--------------+--------------+--------------+----------+------+----------------------------+---------------+--------------+-------------
 01756dc0-3889-42a8-9b27-c831e9f413f7 | http://127.0.0.1:12300/remote |     10 |           0 | t        | t         |        |          |             |            | 994662584320 | 449591689216 | 449591689216 |        0 |    0 | 2024-04-16 00:20:30.984384 |               |              | 
(1 row)
```

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
