### PR TITLE
feat: curio: storage index gc task

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -3,7 +3,7 @@ package tasks
 
 import (
 	"context"
-	"github.com/filecoin-project/lotus/curiosrc/gc"
+
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
@@ -14,6 +14,7 @@ import (
 	curio "github.com/filecoin-project/lotus/curiosrc"
 	"github.com/filecoin-project/lotus/curiosrc/chainsched"
 	"github.com/filecoin-project/lotus/curiosrc/ffi"
+	"github.com/filecoin-project/lotus/curiosrc/gc"
 	"github.com/filecoin-project/lotus/curiosrc/message"
 	"github.com/filecoin-project/lotus/curiosrc/piece"
 	"github.com/filecoin-project/lotus/curiosrc/seal"

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -3,7 +3,7 @@ package tasks
 
 import (
 	"context"
-
+	"github.com/filecoin-project/lotus/curiosrc/gc"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
@@ -129,6 +129,12 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 			commitTask := seal.NewSubmitCommitTask(sp, db, full, sender, as, cfg.Fees.MaxCommitGasFee)
 			activeTasks = append(activeTasks, commitTask)
 		}
+	}
+
+	if hasAnySealingTask {
+		// Sealing nodes maintain storage index when bored
+		storageEndpointGcTask := gc.NewStorageEndpointGC(si, stor, db)
+		activeTasks = append(activeTasks, storageEndpointGcTask)
 	}
 
 	if needProofParams {

--- a/curiosrc/gc/storage_endpoint_gc.go
+++ b/curiosrc/gc/storage_endpoint_gc.go
@@ -20,7 +20,7 @@ import (
 
 var log = logging.Logger("curiogc")
 
-const StorageEndpointGCInterval = 2 * time.Minute
+const StorageEndpointGCInterval = 2 * time.Minute // todo bump post testing
 const StorageEndpointDeadTime = 15 * time.Minute
 const MaxParallelEndpointChecks = 32
 
@@ -28,6 +28,14 @@ type StorageEndpointGC struct {
 	si     *paths.DBIndex
 	remote *paths.Remote
 	db     *harmonydb.DB
+}
+
+func NewStorageEndpointGC(si *paths.DBIndex, remote *paths.Remote, db *harmonydb.DB) *StorageEndpointGC {
+	return &StorageEndpointGC{
+		si:     si,
+		remote: remote,
+		db:     db,
+	}
 }
 
 func (s *StorageEndpointGC) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {

--- a/curiosrc/gc/storage_endpoint_gc.go
+++ b/curiosrc/gc/storage_endpoint_gc.go
@@ -2,6 +2,15 @@ package gc
 
 import (
 	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/samber/lo"
+	"golang.org/x/xerrors"
+
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/lib/harmony/harmonytask"
 	"github.com/filecoin-project/lotus/lib/harmony/resources"
@@ -9,13 +18,6 @@ import (
 	"github.com/filecoin-project/lotus/storage/paths"
 	"github.com/filecoin-project/lotus/storage/sealer/fsutil"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
-	logging "github.com/ipfs/go-log/v2"
-	"github.com/samber/lo"
-	"golang.org/x/xerrors"
-	"os"
-	"strings"
-	"sync"
-	"time"
 )
 
 var log = logging.Logger("curiogc")

--- a/curiosrc/gc/storage_endpoint_gc.go
+++ b/curiosrc/gc/storage_endpoint_gc.go
@@ -1,0 +1,34 @@
+package gc
+
+import (
+	"github.com/filecoin-project/lotus/lib/harmony/harmonytask"
+	"github.com/filecoin-project/lotus/lib/harmony/resources"
+)
+
+type StorageEndpointGC struct {
+}
+
+func (s *StorageEndpointGC) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *StorageEndpointGC) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *StorageEndpointGC) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Max:  1,
+		Name: "",
+		Cost: resources.Resources{},
+	}
+}
+
+func (s *StorageEndpointGC) Adder(taskFunc harmonytask.AddTaskFunc) {
+	//TODO implement me
+	panic("implement me")
+}
+
+var _ harmonytask.TaskInterface = &StorageEndpointGC{}

--- a/lib/harmony/harmonydb/sql/20240416-harmony_singleton_task.sql
+++ b/lib/harmony/harmonydb/sql/20240416-harmony_singleton_task.sql
@@ -1,0 +1,8 @@
+create table harmony_task_singletons (
+    task_name varchar(255) not null,
+    task_id bigint,
+    last_run_time timestamp,
+
+    primary key (task_name),
+    foreign key (task_id) references harmony_task (id) on delete set null
+);

--- a/lib/harmony/harmonydb/sql/20240416-sector_index_gc.sql
+++ b/lib/harmony/harmonydb/sql/20240416-sector_index_gc.sql
@@ -1,0 +1,13 @@
+create table sector_path_url_liveness (
+    storage_id text,
+    url text,
+
+    last_checked timestamp not null,
+    last_live timestamp,
+    last_dead timestamp,
+    last_dead_reason text,
+
+    primary key (storage_id, url),
+
+    foreign key (storage_id) references storage_path (storage_id)
+)

--- a/lib/harmony/harmonydb/sql/20240417-sector_index_gc.sql
+++ b/lib/harmony/harmonydb/sql/20240417-sector_index_gc.sql
@@ -9,5 +9,5 @@ create table sector_path_url_liveness (
 
     primary key (storage_id, url),
 
-    foreign key (storage_id) references storage_path (storage_id)
+    foreign key (storage_id) references storage_path (storage_id) on delete cascade
 )

--- a/lib/harmony/harmonydb/userfuncs.go
+++ b/lib/harmony/harmonydb/userfuncs.go
@@ -236,6 +236,10 @@ func (t *Tx) Select(sliceOfStructPtr any, sql rawStringOnly, arguments ...any) e
 	return pgxscan.Select(t.ctx, t.Tx, sliceOfStructPtr, string(sql), arguments...)
 }
 
+func (t *Tx) Get(s any, sql rawStringOnly, arguments ...any) error {
+	return pgxscan.Get(t.ctx, t.Tx, s, string(sql), arguments...)
+}
+
 func IsErrUniqueContraint(err error) bool {
 	var e2 *pgconn.PgError
 	return errors.As(err, &e2) && e2.Code == pgerrcode.UniqueViolation

--- a/lib/harmony/harmonytask/singleton_task.go
+++ b/lib/harmony/harmonytask/singleton_task.go
@@ -2,10 +2,12 @@ package harmonytask
 
 import (
 	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/lib/passcall"
-	"github.com/jackc/pgx/v5"
-	"time"
 )
 
 func SingletonTaskAdder(minInterval time.Duration, task TaskInterface) func(AddTaskFunc) error {

--- a/lib/harmony/harmonytask/singleton_task.go
+++ b/lib/harmony/harmonytask/singleton_task.go
@@ -1,0 +1,50 @@
+package harmonytask
+
+import (
+	"errors"
+	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
+	"github.com/filecoin-project/lotus/lib/passcall"
+	"github.com/jackc/pgx/v5"
+	"time"
+)
+
+func SingletonTaskAdder(minInterval time.Duration, task TaskInterface) func(AddTaskFunc) error {
+	return passcall.Every(minInterval, func(add AddTaskFunc) error {
+		taskName := task.TypeDetails().Name
+
+		add(func(taskID TaskID, tx *harmonydb.Tx) (shouldCommit bool, err error) {
+			var existingTaskID *int64
+			var lastRunTime time.Time
+
+			// Query to check the existing task entry
+			err = tx.QueryRow(`SELECT task_id, last_run_time FROM harmony_task_singletons WHERE task_name = $1`, taskName).Scan(&existingTaskID, &lastRunTime)
+			if err != nil {
+				if !errors.Is(err, pgx.ErrNoRows) {
+					return false, err // return error if query failed and it's not because of missing row
+				}
+			}
+
+			now := time.Now()
+			// Determine if the task should run based on the absence of a record or outdated last_run_time
+			shouldRun := err == pgx.ErrNoRows || (existingTaskID == nil && lastRunTime.Add(minInterval).Before(now))
+			if !shouldRun {
+				return false, nil
+			}
+
+			// Conditionally insert or update the task entry
+			n, err := tx.Exec(`
+                INSERT INTO harmony_task_singletons (task_name, task_id, last_run_time)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (task_name) DO UPDATE
+                SET task_id = COALESCE(harmony_task_singletons.task_id, $2),
+                    last_run_time = $3
+                WHERE harmony_task_singletons.task_id IS NULL
+            `, taskName, taskID, now)
+			if err != nil {
+				return false, err
+			}
+			return n > 0, nil
+		})
+		return nil
+	})
+}

--- a/lib/passcall/every.go
+++ b/lib/passcall/every.go
@@ -1,0 +1,28 @@
+package passcall
+
+import (
+	"sync"
+	"time"
+)
+
+// Every is a helper function that will call the provided callback
+// function at most once every `passEvery` duration. If the function is called
+// more frequently than that, it will return nil and not call the callback.
+func Every[P, R any](passInterval time.Duration, cb func(P) R) func(P) R {
+	var lastCall time.Time
+	var lk sync.Mutex
+
+	return func(param P) R {
+		lk.Lock()
+		defer lk.Unlock()
+
+		if time.Since(lastCall) < passInterval {
+			return *new(R)
+		}
+
+		defer func() {
+			lastCall = time.Now()
+		}()
+		return cb(param)
+	}
+}

--- a/storage/paths/remote.go
+++ b/storage/paths/remote.go
@@ -416,47 +416,53 @@ func (r *Remote) FsStat(ctx context.Context, id storiface.ID) (fsutil.FsStat, er
 	}
 
 	for _, urlStr := range si.URLs {
-		rl, err := url.Parse(urlStr)
+		out, err := r.StatUrl(ctx, urlStr, id)
 		if err != nil {
-			log.Warnw("failed to parse URL", "url", urlStr, "error", err)
-			continue // Try the next URL
+			log.Warnw("stat url failed", "url", urlStr, "error", err)
+			continue
 		}
 
-		rl.Path = gopath.Join(rl.Path, "stat", string(id))
-
-		req, err := http.NewRequest("GET", rl.String(), nil)
-		if err != nil {
-			log.Warnw("creating request failed", "url", rl.String(), "error", err)
-			continue // Try the next URL
-		}
-		req.Header = r.auth
-		req = req.WithContext(ctx)
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			log.Warnw("request failed", "url", rl.String(), "error", err)
-			continue // Try the next URL
-		}
-
-		if resp.StatusCode == 200 {
-			var out fsutil.FsStat
-			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-				_ = resp.Body.Close()
-				log.Warnw("decoding response failed", "url", rl.String(), "error", err)
-				continue // Try the next URL
-			}
-			_ = resp.Body.Close()
-			return out, nil // Successfully decoded, return the result
-		}
-
-		// non-200 status code
-		b, _ := io.ReadAll(resp.Body) // Best-effort read the body for logging
-		log.Warnw("request to endpoint failed", "url", rl.String(), "statusCode", resp.StatusCode, "response", string(b))
-		_ = resp.Body.Close()
-		// Continue to try the next URL, don't return here as we want to try all URLs
+		return out, nil
 	}
 
 	return fsutil.FsStat{}, xerrors.Errorf("all endpoints failed for remote storage %s", id)
+}
+
+func (r *Remote) StatUrl(ctx context.Context, urlStr string, id storiface.ID) (fsutil.FsStat, error) {
+	rl, err := url.Parse(urlStr)
+	if err != nil {
+		return fsutil.FsStat{}, xerrors.Errorf("parsing URL: %w", err)
+	}
+
+	rl.Path = gopath.Join(rl.Path, "stat", string(id))
+
+	req, err := http.NewRequest("GET", rl.String(), nil)
+	if err != nil {
+		return fsutil.FsStat{}, xerrors.Errorf("creating request failed: %w", err)
+	}
+	req.Header = r.auth
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fsutil.FsStat{}, xerrors.Errorf("do request: %w", err)
+	}
+
+	if resp.StatusCode == 200 {
+		var out fsutil.FsStat
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			_ = resp.Body.Close()
+			return fsutil.FsStat{}, xerrors.Errorf("decoding response failed: %w", err)
+		}
+		_ = resp.Body.Close()
+		return out, nil // Successfully decoded, return the result
+	}
+
+	// non-200 status code
+	b, _ := io.ReadAll(resp.Body) // Best-effort read the body for logging
+	_ = resp.Body.Close()
+
+	return fsutil.FsStat{}, xerrors.Errorf("endpoint failed %s: %d %s", rl.String(), resp.StatusCode, string(b))
 }
 
 func (r *Remote) readRemote(ctx context.Context, url string, offset, size abi.PaddedPieceSize) (io.ReadCloser, error) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
* Add a harmonytask helper for defining "singleton" tasks - tasks which run as at most one instance across the whole cluster
  * This construction also helps with scheduled tasks which only run every so often without requiring a separate table for each task - which will be handy for other periodic cleanup tasks.
* Implement a storage path endpoint cleanup task
  * This task scans the sector index pinging all endpoints, and removes the ones which appear to be dead for a long time
    * (lotus-miner never had that, but because the index there was in-memory, cleanup was done by restarting the process..)
  * Curio needs this because the index is now in the database, and after migrating from lotus-miner there are guaranteed to be stale endpoints in the sector DBIndex. The remote storage code can cope with those, but it's not great to keep dead references in the index.

## Additional Info
TODO:
* [ ] Do a dry run on a setup with stale references
* [ ] Do a real run
* [ ] Increase intervals, drop the dryrun guard

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
