### PR TITLE
fix: cli: Replace tablewriter.NewLineCol with tablewriter.Col in ListAllocations and ListClaimsCmd

### DIFF
--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -330,7 +330,7 @@ var filplusListAllocationsCmd = &cli.Command{
 				tablewriter.Col(pieceSize),
 				tablewriter.Col(tMin),
 				tablewriter.Col(tMax),
-				tablewriter.NewLineCol(expr))
+				tablewriter.Col(expr))
 			// populate it with content
 			for _, alloc := range allocs {
 				tw.Write(alloc)
@@ -479,7 +479,7 @@ var filplusListClaimsCmd = &cli.Command{
 				tablewriter.Col(tMin),
 				tablewriter.Col(tMax),
 				tablewriter.Col(tStart),
-				tablewriter.NewLineCol(sector))
+				tablewriter.Col(sector))
 			// populate it with content
 			for _, alloc := range claimList {
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
I have no idea why this change happened, but from a user usage perspective it must have been wrong, so I changed it back to the way it was.
`tablewriter.Col` -> `tablewriter.NewLineCol` ❌

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
