### PR TITLE
fix: curio: Update pgx imports, fix db_storage alloc

### DIFF
--- a/curiosrc/market/lmrpc/lmrpc.go
+++ b/curiosrc/market/lmrpc/lmrpc.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/google/uuid"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/jackc/pgx/v5"
 	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"

--- a/lib/harmony/harmonytask/singleton_task.go
+++ b/lib/harmony/harmonytask/singleton_task.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/jackc/pgx/v5"
+	"github.com/yugabyte/pgx/v5"
 
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/lib/passcall"

--- a/storage/paths/db_index.go
+++ b/storage/paths/db_index.go
@@ -723,7 +723,7 @@ func (dbi *DBIndex) StorageBestAlloc(ctx context.Context, allocate storiface.Sec
 						 FROM storage_path 
 						 WHERE available >= $1
 						 and NOW()-($2 * INTERVAL '1 second') < last_heartbeat
-						 and heartbeat_err = ''
+						 and heartbeat_err IS NULL
 						 and (($3 and can_seal = TRUE) or ($4 and can_store = TRUE))
 						order by (available::numeric * weight) desc`,
 		spaceReq,


### PR DESCRIPTION
## Related Issues
* Undo the change from https://github.com/filecoin-project/lotus/pull/11881
  * `heartbeat_err` is a nullable varchar, and afaict it's completely ignored in the db_index (it's not ever set anywhere); The string based check was definitely broken for me
* Also update pgx imports to the yugabyte one so that ErrNoRows checks work correctly

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
