### PR TITLE
ci: ci: fix when sorted pr checks workflow is executed

### DIFF
--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -20,12 +20,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number || 'unknown' }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 jobs:
   comment:
-    if: github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0]
+    if: github.event.inputs.pull_number || github.event.workflow_run.event == 'pull_request'
     uses: ipdxco/sorted-pr-checks/.github/workflows/comment.yml@v1
     with:
       pull_number: ${{ github.event.inputs.pull_number || github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/pull/323#issuecomment-2068979790

## Proposed Changes
<!-- A clear list of the changes being made -->
Do not comment when the workflow_run that triggered the sorted PR checks workflow was itself triggered by events other than the pull request event.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
The check for `github.event.workflow_run.pull_requests[0]` is not sufficient because there are PRs with lotus:master as head (e.g. https://github.com/DIGIIX-Ltd/lotus/pull/323).

I disabled the workflow until this is merged.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
