### PR TITLE
fix(events): check for sync-in-progress

### DIFF
--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -375,12 +375,12 @@ func (m *EventFilterManager) Revert(ctx context.Context, from, to *types.TipSet)
 func (m *EventFilterManager) Install(ctx context.Context, minHeight, maxHeight abi.ChainEpoch, tipsetCid cid.Cid, addresses []address.Address,
 	keysWithCodec map[string][]types.ActorEventBlock, excludeReverted bool) (EventFilter, error) {
 	m.mu.Lock()
+	if m.currentHeight == 0 {
+		// sync in progress, we haven't had an Apply
+		m.currentHeight = m.ChainStore.GetHeaviestTipSet().Height()
+	}
 	currentHeight := m.currentHeight
 	m.mu.Unlock()
-
-	if currentHeight == 0 {
-		return nil, xerrors.Errorf("sync in progress, cannot install event filter")
-	}
 
 	if m.EventIndex == nil && minHeight != -1 && minHeight < currentHeight {
 		return nil, xerrors.Errorf("historic event index disabled")

--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -378,6 +378,10 @@ func (m *EventFilterManager) Install(ctx context.Context, minHeight, maxHeight a
 	currentHeight := m.currentHeight
 	m.mu.Unlock()
 
+	if currentHeight == 0 {
+		return nil, xerrors.Errorf("sync in progress, cannot install event filter")
+	}
+
 	if m.EventIndex == nil && minHeight != -1 && minHeight < currentHeight {
 		return nil, xerrors.Errorf("historic event index disabled")
 	}


### PR DESCRIPTION
We use `currentHeight` to figure out where we are to know whether we need to backfill a filter or not. Unfortunately, we collect this from `Apply()` so if you install a filter _prior_ to processing a message, we can't know where we are and what we should do about it.

The current behaviour is that it will fail the `minHeight < currentHeight` test further down in this file, not perform a pre-fill, and we end up with an empty filter (initially). So any calls to `GetActorEventsRaw` or `SubscribeActorEventsRaw` wanting backfill will not get any of it and will return a `null` to the user. But, this behaviour is the same as "there are no events in this range", so the user has no way of differentiating between "node is starting" and "no events".

This new behaviour will send an error in response to a `GetActorEventsRaw` or `SubscribeActorEventsRaw` or even `eth_getLogs` if the node is still starting and we haven't seen our first `Apply`.

An alternative to this behaviour is to go ask the chain what the current head is, but I don't think we currently have the means to do this in `EventFilterManager`, we only have a `ChainStore` to work with.