### PR TITLE
feat: curio: Keep more sector metadata in the DB long-term

### DIFF
--- a/cmd/curio/guidedsetup/guidedsetup.go
+++ b/cmd/curio/guidedsetup/guidedsetup.go
@@ -279,7 +279,7 @@ func configToDB(d *MigrationData) {
 
 	chainApiInfo := fmt.Sprintf("%s:%s", string(token), ainfo.Addr)
 
-	d.MinerID, err = SaveConfigToLayer(d.MinerConfigPath, chainApiInfo)
+	d.MinerID, err = SaveConfigToLayerMigrateSectors(d.MinerConfigPath, chainApiInfo)
 	if err != nil {
 		d.say(notice, "Error saving config to layer: %s. Aborting Migration", err.Error())
 		os.Exit(1)

--- a/cmd/curio/guidedsetup/guidedsetup.go
+++ b/cmd/curio/guidedsetup/guidedsetup.go
@@ -279,7 +279,22 @@ func configToDB(d *MigrationData) {
 
 	chainApiInfo := fmt.Sprintf("%s:%s", string(token), ainfo.Addr)
 
-	d.MinerID, err = SaveConfigToLayerMigrateSectors(d.MinerConfigPath, chainApiInfo)
+	shouldErrPrompt := func() bool {
+		i, _, err := (&promptui.Select{
+			Label: d.T("Unmigratable sectors found. Do you want to continue?"),
+			Items: []string{
+				d.T("Yes, continue"),
+				d.T("No, abort")},
+			Templates: d.selectTemplates,
+		}).Run()
+		if err != nil {
+			d.say(notice, "Aborting migration.", err.Error())
+			os.Exit(1)
+		}
+		return i == 1
+	}
+
+	d.MinerID, err = SaveConfigToLayerMigrateSectors(d.MinerConfigPath, chainApiInfo, shouldErrPrompt)
 	if err != nil {
 		d.say(notice, "Error saving config to layer: %s. Aborting Migration", err.Error())
 		os.Exit(1)

--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -326,7 +326,7 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 	}
 
 	for _, sector := range sectors {
-		if !migratableState(sector.State) {
+		if !migratableState(sector.State) || sector.State == sealing.Removed {
 			continue
 		}
 
@@ -357,6 +357,9 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 			sector.SeedValue,
 		)
 		if err != nil {
+			b, _ := json.MarshalIndent(sector, "", "  ")
+			fmt.Println(string(b))
+
 			return xerrors.Errorf("inserting/updating sectors_meta for sector %d: %w", sector.SectorNumber, err)
 		}
 
@@ -415,6 +418,9 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 				pamJSON,
 			)
 			if err != nil {
+				b, _ := json.MarshalIndent(sector, "", "  ")
+				fmt.Println(string(b))
+
 				return xerrors.Errorf("inserting/updating sector_meta_pieces for sector %d, piece %d: %w", sector.SectorNumber, j, err)
 			}
 		}

--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -4,23 +4,29 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-statestore"
 
 	"github.com/filecoin-project/lotus/cmd/curio/deps"
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
+	"github.com/filecoin-project/lotus/lib/must"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/repo"
+	sealing "github.com/filecoin-project/lotus/storage/pipeline"
 )
 
 const (
@@ -29,7 +35,7 @@ const (
 
 const FlagMinerRepoDeprecation = "storagerepo"
 
-func SaveConfigToLayer(minerRepoPath, chainApiInfo string) (minerAddress address.Address, err error) {
+func SaveConfigToLayerMigrateSectors(minerRepoPath, chainApiInfo string) (minerAddress address.Address, err error) {
 	_, say := SetupLanguage()
 	ctx := context.Background()
 
@@ -97,9 +103,6 @@ func SaveConfigToLayer(minerRepoPath, chainApiInfo string) (minerAddress address
 	if err != nil {
 		return minerAddress, xerrors.Errorf("opening miner metadata datastore: %w", err)
 	}
-	defer func() {
-		// _ = mmeta.Close()
-	}()
 
 	maddrBytes, err := mmeta.Get(ctx, datastore.NewKey("miner-address"))
 	if err != nil {
@@ -109,6 +112,12 @@ func SaveConfigToLayer(minerRepoPath, chainApiInfo string) (minerAddress address
 	addr, err := address.NewFromBytes(maddrBytes)
 	if err != nil {
 		return minerAddress, xerrors.Errorf("parsing miner actor address: %w", err)
+	}
+
+	if err := MigrateSectors(ctx, addr, mmeta, db, func(nSectors int) {
+		say(plain, "Migrating metadata for %d sectors. ", nSectors)
+	}); err != nil {
+		return address.Address{}, xerrors.Errorf("migrating sectors: %w", err)
 	}
 
 	minerAddress = addr
@@ -255,4 +264,155 @@ func ensureEmptyArrays(cfg *config.CurioConfig) {
 	if cfg.Apis.ChainApiInfo == nil {
 		cfg.Apis.ChainApiInfo = []string{}
 	}
+}
+
+func cidPtrToStrptr(c *cid.Cid) *string {
+	if c == nil {
+		return nil
+	}
+	s := c.String()
+	return &s
+}
+
+func coalescePtrs[A any](a, b *A) *A {
+	if a != nil {
+		return a
+	}
+	return b
+}
+
+func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.Batching, db *harmonydb.DB, logMig func(int)) error {
+	mid, err := address.IDFromAddress(maddr)
+	if err != nil {
+		return xerrors.Errorf("getting miner ID: %w", err)
+	}
+
+	sts := statestore.New(namespace.Wrap(mmeta, datastore.NewKey(sealing.SectorStorePrefix)))
+
+	var sectors []sealing.SectorInfo
+	if err := sts.List(&sectors); err != nil {
+		return xerrors.Errorf("getting sector list: %w", err)
+	}
+
+	logMig(len(sectors))
+
+	migratableState := func(state sealing.SectorState) bool {
+		switch state {
+		case sealing.Proving, sealing.Available, sealing.Removed:
+			return true
+		default:
+			return false
+		}
+	}
+
+	unmigratable := map[sealing.SectorState]int{}
+
+	for _, sector := range sectors {
+		if !migratableState(sector.State) {
+			unmigratable[sector.State]++
+			continue
+		}
+	}
+
+	if len(unmigratable) > 0 {
+		fmt.Println("The following sector states are not migratable:")
+		for state, count := range unmigratable {
+			fmt.Printf("  %s: %d\n", state, count)
+		}
+
+		return xerrors.Errorf("cannot migrate sectors with these states")
+	}
+
+	for _, sector := range sectors {
+		// Insert sector metadata
+		_, err := db.Exec(ctx, `
+        INSERT INTO sectors_meta (sp_id, sector_num, reg_seal_proof, ticket_epoch, ticket_value,
+                                  orig_sealed_cid, orig_unsealed_cid, cur_sealed_cid, cur_unsealed_cid,
+                                  msg_cid_precommit, msg_cid_commit, msg_cid_update, seed_epoch, seed_value)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        ON CONFLICT (sp_id, sector_num) DO UPDATE
+        SET reg_seal_proof = excluded.reg_seal_proof, ticket_epoch = excluded.ticket_epoch, ticket_value = excluded.ticket_value,
+            orig_sealed_cid = excluded.orig_sealed_cid, orig_unsealed_cid = excluded.orig_unsealed_cid, cur_sealed_cid = excluded.cur_sealed_cid,
+            cur_unsealed_cid = excluded.cur_unsealed_cid, msg_cid_precommit = excluded.msg_cid_precommit, msg_cid_commit = excluded.msg_cid_commit,
+            msg_cid_update = excluded.msg_cid_update, seed_epoch = excluded.seed_epoch, seed_value = excluded.seed_value`,
+			mid,
+			sector.SectorNumber,
+			sector.SectorType,
+			sector.TicketEpoch,
+			sector.TicketValue,
+			cidPtrToStrptr(sector.CommR),
+			cidPtrToStrptr(sector.CommD),
+			cidPtrToStrptr(coalescePtrs(sector.UpdateSealed, sector.CommR)),
+			cidPtrToStrptr(coalescePtrs(sector.UpdateUnsealed, sector.CommD)),
+			cidPtrToStrptr(sector.PreCommitMessage),
+			cidPtrToStrptr(sector.CommitMessage),
+			cidPtrToStrptr(sector.ReplicaUpdateMessage),
+			sector.SeedEpoch,
+			sector.SeedValue,
+		)
+		if err != nil {
+			return xerrors.Errorf("inserting/updating sectors_meta for sector %d: %w", sector.SectorNumber, err)
+		}
+
+		// Process each piece within the sector
+		for j, piece := range sector.Pieces {
+			dealID := int64(0)
+			startEpoch := int64(0)
+			endEpoch := int64(0)
+			var pamJSON *string
+
+			if piece.HasDealInfo() {
+				dealInfo := piece.DealInfo()
+				if dealInfo.Impl().DealProposal != nil {
+					dealID = int64(dealInfo.Impl().DealID)
+				}
+
+				startEpoch = int64(must.One(dealInfo.StartEpoch()))
+				endEpoch = int64(must.One(dealInfo.EndEpoch()))
+				if piece.Impl().PieceActivationManifest != nil {
+					pam, err := json.Marshal(piece.Impl().PieceActivationManifest)
+					if err != nil {
+						return xerrors.Errorf("error marshalling JSON for piece %d in sector %d: %w", j, sector.SectorNumber, err)
+					}
+					ps := string(pam)
+					pamJSON = &ps
+				}
+			}
+
+			// Splitting the SQL statement for readability and adding new fields
+			_, err = db.Exec(ctx, `
+					INSERT INTO sector_meta_pieces (
+						sp_id, sector_num, piece_num, piece_cid, piece_size, 
+						requested_keep_data, raw_data_size, start_epoch, orig_end_epoch,
+						f05_deal_id, ddo_pam
+					) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+					ON CONFLICT (sp_id, sector_num, piece_num) DO UPDATE
+					SET 
+						piece_cid = excluded.piece_cid, 
+						piece_size = excluded.piece_size, 
+						requested_keep_data = excluded.requested_keep_data, 
+						raw_data_size = excluded.raw_data_size,
+						start_epoch = excluded.start_epoch, 
+						orig_end_epoch = excluded.orig_end_epoch,
+						f05_deal_id = excluded.f05_deal_id, 
+						ddo_pam = excluded.ddo_pam`,
+				mid,
+				sector.SectorNumber,
+				j,
+				piece.PieceCID(),
+				piece.Piece().Size,
+				piece.HasDealInfo(),
+				nil, // raw_data_size might be calculated based on the piece size, or retrieved if available
+				startEpoch,
+				endEpoch,
+				dealID,
+				pamJSON,
+			)
+			if err != nil {
+				return xerrors.Errorf("inserting/updating sector_meta_pieces for sector %d, piece %d: %w", sector.SectorNumber, j, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -390,7 +390,7 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 
 			// Splitting the SQL statement for readability and adding new fields
 			_, err = db.Exec(ctx, `
-					INSERT INTO sector_meta_pieces (
+					INSERT INTO sectors_meta_pieces (
 						sp_id, sector_num, piece_num, piece_cid, piece_size, 
 						requested_keep_data, raw_data_size, start_epoch, orig_end_epoch,
 						f05_deal_id, ddo_pam

--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -115,7 +115,7 @@ func SaveConfigToLayerMigrateSectors(minerRepoPath, chainApiInfo string) (minerA
 	}
 
 	if err := MigrateSectors(ctx, addr, mmeta, db, func(nSectors int) {
-		say(plain, "Migrating metadata for %d sectors. ", nSectors)
+		say(plain, "Migrating metadata for %d sectors.", nSectors)
 	}); err != nil {
 		return address.Address{}, xerrors.Errorf("migrating sectors: %w", err)
 	}

--- a/cmd/curio/migrate.go
+++ b/cmd/curio/migrate.go
@@ -1,1 +1,0 @@
-package main

--- a/cmd/curio/pipeline.go
+++ b/cmd/curio/pipeline.go
@@ -151,7 +151,7 @@ var sealMigrateLMSectorsCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
-		dep, err := deps.GetDepsCLI(ctx, cctx)
+		db, err := deps.MakeDB(cctx)
 		if err != nil {
 			return err
 		}
@@ -196,7 +196,7 @@ var sealMigrateLMSectorsCmd = &cli.Command{
 			return xerrors.Errorf("parsing miner actor address: %w", err)
 		}
 
-		err = guidedsetup.MigrateSectors(ctx, addr, mmeta, dep.DB, func(n int) {
+		err = guidedsetup.MigrateSectors(ctx, addr, mmeta, db, func(n int) {
 			fmt.Printf("Migrating %d sectors\n", n)
 		})
 		if err != nil {

--- a/cmd/curio/pipeline.go
+++ b/cmd/curio/pipeline.go
@@ -148,6 +148,12 @@ var sealMigrateLMSectorsCmd = &cli.Command{
 			Usage: "Path to miner repo",
 			Value: "~/.lotusminer",
 		},
+		&cli.BoolFlag{
+			Name:    "seal-ignore",
+			Usage:   "Ignore sectors that cannot be migrated",
+			Value:   false,
+			EnvVars: []string{"CURUO_MIGRATE_SEAL_IGNORE"},
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lcli.ReqContext(cctx)
@@ -196,9 +202,11 @@ var sealMigrateLMSectorsCmd = &cli.Command{
 			return xerrors.Errorf("parsing miner actor address: %w", err)
 		}
 
+		unmigSectorShouldFail := func() bool { return !cctx.Bool("seal-ignore") }
+
 		err = guidedsetup.MigrateSectors(ctx, addr, mmeta, db, func(n int) {
 			fmt.Printf("Migrating %d sectors\n", n)
-		})
+		}, unmigSectorShouldFail)
 		if err != nil {
 			return xerrors.Errorf("migrating sectors: %w", err)
 		}

--- a/curiosrc/market/deal_ingest.go
+++ b/curiosrc/market/deal_ingest.go
@@ -109,11 +109,14 @@ func (p *PieceIngester) AllocatePieceToSector(ctx context.Context, maddr address
                                         f05_deal_id,
                                         f05_deal_proposal,
                                         f05_deal_start_epoch,
-                                        f05_deal_end_epoch) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+                                        f05_deal_end_epoch,
+                                        
+                                        requested_keep_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
 			mid, n, 0,
 			piece.DealProposal.PieceCID, piece.DealProposal.PieceSize,
 			source.String(), dataHdrJson, rawSize, !piece.KeepUnsealed,
-			piece.PublishCid, piece.DealID, dealProposalJson, piece.DealSchedule.StartEpoch, piece.DealSchedule.EndEpoch)
+			piece.PublishCid, piece.DealID, dealProposalJson,
+			piece.DealSchedule.StartEpoch, piece.DealSchedule.EndEpoch, piece.KeepUnsealed)
 		if err != nil {
 			return false, xerrors.Errorf("inserting into sectors_sdr_initial_pieces: %w", err)
 		}

--- a/curiosrc/market/deal_ingest.go
+++ b/curiosrc/market/deal_ingest.go
@@ -109,14 +109,12 @@ func (p *PieceIngester) AllocatePieceToSector(ctx context.Context, maddr address
                                         f05_deal_id,
                                         f05_deal_proposal,
                                         f05_deal_start_epoch,
-                                        f05_deal_end_epoch,
-                                        
-                                        requested_keep_data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+                                        f05_deal_end_epoch) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 			mid, n, 0,
 			piece.DealProposal.PieceCID, piece.DealProposal.PieceSize,
 			source.String(), dataHdrJson, rawSize, !piece.KeepUnsealed,
 			piece.PublishCid, piece.DealID, dealProposalJson,
-			piece.DealSchedule.StartEpoch, piece.DealSchedule.EndEpoch, piece.KeepUnsealed)
+			piece.DealSchedule.StartEpoch, piece.DealSchedule.EndEpoch)
 		if err != nil {
 			return false, xerrors.Errorf("inserting into sectors_sdr_initial_pieces: %w", err)
 		}

--- a/curiosrc/seal/task_submit_commit.go
+++ b/curiosrc/seal/task_submit_commit.go
@@ -211,7 +211,7 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
 
 	// Execute the query for piece metadata
 	if _, err := s.db.Exec(ctx, `
-        INSERT INTO sector_meta_pieces (
+        INSERT INTO sectors_meta_pieces (
             sp_id,
             sector_num,
             piece_num,

--- a/curiosrc/seal/task_submit_commit.go
+++ b/curiosrc/seal/task_submit_commit.go
@@ -152,7 +152,7 @@ func (s *SubmitCommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	}
 
 	if err := s.transferFinalizedSectorData(ctx, sectorParams.SpID, sectorParams.SectorNumber); err != nil {
-		return false, xerrors.Errorf("transfering finalized sector data: %w", err)
+		return false, xerrors.Errorf("transferring finalized sector data: %w", err)
 	}
 
 	return true, nil
@@ -230,7 +230,7 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             piece_index AS piece_num,
             piece_cid,
             piece_size,
-            TRUE AS requested_keep_data,
+            requested_keep_data,
             data_raw_size,
             COALESCE(f05_deal_start_epoch, direct_start_epoch) as start_epoch,
             COALESCE(f05_deal_end_epoch, direct_end_epoch) as orig_end_epoch,

--- a/curiosrc/seal/task_submit_commit.go
+++ b/curiosrc/seal/task_submit_commit.go
@@ -230,7 +230,7 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             piece_index AS piece_num,
             piece_cid,
             piece_size,
-            requested_keep_data,
+            not data_delete_on_finalize as requested_keep_data,
             data_raw_size,
             COALESCE(f05_deal_start_epoch, direct_start_epoch) as start_epoch,
             COALESCE(f05_deal_end_epoch, direct_end_epoch) as orig_end_epoch,

--- a/curiosrc/seal/task_submit_commit.go
+++ b/curiosrc/seal/task_submit_commit.go
@@ -193,8 +193,7 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             sectors_sdr_pipeline
         WHERE
             sp_id = $1 AND
-            sector_number = $2 AND
-            after_finalize = true
+            sector_number = $2
         ON CONFLICT (sp_id, sector_num) DO UPDATE SET
             reg_seal_proof = excluded.reg_seal_proof,
             ticket_epoch = excluded.ticket_epoch,

--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -121,7 +121,8 @@ create table sectors_sdr_initial_pieces (
     -- direct_end_epoch bigint,
     -- direct_piece_activation_manifest jsonb,
 
-    -- TODO keep_unsealed
+    -- added in 20240425-sector_metadata.sql
+    -- requested_keep_data bool
 
     -- foreign key
     foreign key (sp_id, sector_number) references sectors_sdr_pipeline (sp_id, sector_number) on delete cascade,

--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -121,6 +121,8 @@ create table sectors_sdr_initial_pieces (
     -- direct_end_epoch bigint,
     -- direct_piece_activation_manifest jsonb,
 
+    -- TODO keep_unsealed
+
     -- foreign key
     foreign key (sp_id, sector_number) references sectors_sdr_pipeline (sp_id, sector_number) on delete cascade,
 

--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -121,9 +121,6 @@ create table sectors_sdr_initial_pieces (
     -- direct_end_epoch bigint,
     -- direct_piece_activation_manifest jsonb,
 
-    -- added in 20240425-sector_metadata.sql
-    -- requested_keep_data bool
-
     -- foreign key
     foreign key (sp_id, sector_number) references sectors_sdr_pipeline (sp_id, sector_number) on delete cascade,
 

--- a/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
+++ b/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
@@ -1,0 +1,44 @@
+CREATE TABLE sectors_meta (
+    sp_id BIGINT NOT NULL,
+    sector_num BIGINT NOT NULL,
+
+    reg_seal_proof INT NOT NULL,
+    ticket_epoch BIGINT NOT NULL,
+    ticket_value BYTEA NOT NULL,
+
+    orig_sealed_cid TEXT NOT NULL,
+    orig_unsealed_cid TEXT NOT NULL,
+
+    cur_sealed_cid TEXT NOT NULL,
+    cur_unsealed_cid TEXT NOT NULL,
+
+    msg_cid_precommit TEXT,
+    msg_cid_commit TEXT,
+    msg_cid_update TEXT, -- snapdeal update
+
+    seed_epoch BIGINT NOT NULL,
+    seed_value BYTEA NOT NULL,
+
+    PRIMARY KEY (sp_id, sector_num)
+);
+
+CREATE TABLE sector_meta_pieces (
+    sp_id BIGINT NOT NULL,
+    sector_num BIGINT NOT NULL,
+    piece_num BIGINT NOT NULL,
+
+    piece_cid TEXT NOT NULL,
+    piece_size BIGINT NOT NULL, -- padded size
+
+    requested_keep_data BOOLEAN NOT NULL,
+    raw_data_size BIGINT, -- null = piece_size.unpadded()
+
+    start_epoch BIGINT,
+    orig_end_epoch BIGINT,
+
+    f05_deal_id BIGINT,
+    ddo_pam jsonb,
+
+    PRIMARY KEY (sp_id, sector_num, piece_num),
+    FOREIGN KEY (sp_id, sector_num) REFERENCES sectors_meta(sp_id, sector_num) ON DELETE CASCADE
+);

--- a/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
+++ b/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
@@ -22,7 +22,7 @@ CREATE TABLE sectors_meta (
     PRIMARY KEY (sp_id, sector_num)
 );
 
-CREATE TABLE sector_meta_pieces (
+CREATE TABLE sectors_meta_pieces (
     sp_id BIGINT NOT NULL,
     sector_num BIGINT NOT NULL,
     piece_num BIGINT NOT NULL,

--- a/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
+++ b/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
@@ -42,3 +42,5 @@ CREATE TABLE sectors_meta_pieces (
     PRIMARY KEY (sp_id, sector_num, piece_num),
     FOREIGN KEY (sp_id, sector_num) REFERENCES sectors_meta(sp_id, sector_num) ON DELETE CASCADE
 );
+
+ALTER TABLE sectors_sdr_initial_pieces ADD COLUMN requested_keep_data BOOL NOT NULL DEFAULT FALSE;

--- a/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
+++ b/lib/harmony/harmonydb/sql/20240425-sector_meta.sql
@@ -42,5 +42,3 @@ CREATE TABLE sectors_meta_pieces (
     PRIMARY KEY (sp_id, sector_num, piece_num),
     FOREIGN KEY (sp_id, sector_num) REFERENCES sectors_meta(sp_id, sector_num) ON DELETE CASCADE
 );
-
-ALTER TABLE sectors_sdr_initial_pieces ADD COLUMN requested_keep_data BOOL NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
* Add 2 new tables for sector metadata to the DB
* Add migration logic for those invoked in guided-setup and optionally as a curio cli command
* Add logic which populates the table from seal pipeline at the end of the commit-msg task.

## Additional Info
TODO: 
- [x] Test migration on a real setup
- [x] Check that sectors sealed with curio will get added to the long-term metadata table
- [x] Add the missing "keep unsealed" bool to curio seal pipeline

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
