### PR TITLE
fix(events): register events index db migration v4

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -356,6 +356,10 @@ func (ei *EventIndex) migrateToVersion4(ctx context.Context) error {
 		}
 	}
 
+	if _, err = tx.Exec("INSERT OR IGNORE INTO _meta (version) VALUES (4)"); err != nil {
+		return xerrors.Errorf("increment _meta version: %w", err)
+	}
+
 	err = tx.Commit()
 	if err != nil {
 		return xerrors.Errorf("commit transaction: %w", err)


### PR DESCRIPTION
Very embarrassing, second fix to my original v4 PR.

Found while debugging https://github.com/filecoin-project/lotus/pull/11723. `master` should work fine but it'll repeat the v4 migration on startup which will be a noop, so shouldn't be fatal. But When https://github.com/filecoin-project/lotus/pull/11723 is applied, it always tries to do v4 and then v5, and v5 isn't a noop when run again, so it fails.