### PR TITLE
feat: cli,events: speed up backfill with temporary index

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -32,6 +32,8 @@ var pragmas = []string{
 	"PRAGMA read_uncommitted = ON",
 }
 
+// Any changes to this schema should be matched for the `lotus-shed indexes backfill-events` command
+
 var ddls = []string{
 	`CREATE TABLE IF NOT EXISTS event (
 		id INTEGER PRIMARY KEY,


### PR DESCRIPTION
From experience running this:

1. Add a warning about running this against a node that's actively collecting events, you'll have trouble
2. Use `IMMEDIATE` transactions so we know as soon as we start a transaction whether we can get an exclusive lock for a write or not so we can error more easily.
3. Add an optional temporary index for our query which significantly speeds up this process (a _lot_).
4. Run an optional vacuum after we're done.