### PR TITLE
fix: curio: halt looping sectors/pieces

### DIFF
--- a/curiosrc/piece/task_cleanup_piece.go
+++ b/curiosrc/piece/task_cleanup_piece.go
@@ -40,7 +40,7 @@ func (c *CleanupPieceTask) pollCleanupTasks(ctx context.Context) {
 			ID storiface.PieceNumber `db:"id"`
 		}
 
-		err := c.db.Select(ctx, &pieceIDs, `SELECT id FROM parked_pieces WHERE cleanup_task_id IS NULL AND (SELECT count(*) FROM parked_piece_refs WHERE piece_id = parked_pieces.id) = 0`)
+		err := c.db.Select(ctx, &pieceIDs, `SELECT id FROM parked_pieces WHERE sched_cleanup_count < $1 AND cleanup_task_id IS NULL AND (SELECT count(*) FROM parked_piece_refs WHERE piece_id = parked_pieces.id) = 0`, MaxParkTries)
 		if err != nil {
 			log.Errorf("failed to get parked pieces: %s", err)
 			time.Sleep(PieceParkPollInterval)
@@ -58,7 +58,7 @@ func (c *CleanupPieceTask) pollCleanupTasks(ctx context.Context) {
 			// create a task for each piece
 			c.TF.Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, err error) {
 				// update
-				n, err := tx.Exec(`UPDATE parked_pieces SET cleanup_task_id = $1 WHERE id = $2 AND (SELECT count(*) FROM parked_piece_refs WHERE piece_id = parked_pieces.id) = 0`, id, pieceID.ID)
+				n, err := tx.Exec(`UPDATE parked_pieces SET cleanup_task_id = $1, sched_cleanup_count = sched_cleanup_count + 1 WHERE id = $2 AND (SELECT count(*) FROM parked_piece_refs WHERE piece_id = parked_pieces.id) = 0`, id, pieceID.ID)
 				if err != nil {
 					return false, xerrors.Errorf("updating parked piece: %w", err)
 				}

--- a/curiosrc/seal/poller.go
+++ b/curiosrc/seal/poller.go
@@ -158,9 +158,9 @@ func (s *SealPoller) poll(ctx context.Context) error {
 		}
 		if task.SchedCount > MaxSchedCountBeforeFail {
 			log.Errorw("sector scheduled too many times, giving up", "spid", task.SpID, "sector", task.SectorNumber, "reason", "too many scheduling attempts")
-			_, err := s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline SET sched_count = 0, failed = true, failed_reason = $1 WHERE sp_id = $2 AND sector_number = $3`, "too many scheduling attempts", task.SpID, task.SectorNumber)
+			_, err := s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline SET sched_count = 0, failed = true, failed_reason = $1 WHERE sp_id = $2 AND sector_number = $3`, "retry-limit", task.SpID, task.SectorNumber)
 			if err != nil {
-				return xerrors.Errorf("marking sector as failed: %w", err)
+				log.Errorw("failed to update sector", "spid", task.SpID, "sector", task.SectorNumber, "error", err)
 			}
 			continue
 		}

--- a/curiosrc/seal/poller_commit_msg.go
+++ b/curiosrc/seal/poller_commit_msg.go
@@ -17,7 +17,7 @@ import (
 func (s *SealPoller) pollStartCommitMsg(ctx context.Context, task pollTask) {
 	if task.afterPoRep() && len(task.PoRepProof) > 0 && task.TaskCommitMsg == nil && !task.AfterCommitMsg && s.pollers[pollerCommitMsg].IsSet() {
 		s.pollers[pollerCommitMsg].Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-			n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_commit_msg = $1 WHERE sp_id = $2 AND sector_number = $3 AND task_id_commit_msg IS NULL`, id, task.SpID, task.SectorNumber)
+			n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_commit_msg = $1, sched_count = sched_count + 1 WHERE sp_id = $2 AND sector_number = $3 AND task_id_commit_msg IS NULL`, id, task.SpID, task.SectorNumber)
 			if err != nil {
 				return false, xerrors.Errorf("update sectors_sdr_pipeline: %w", err)
 			}

--- a/curiosrc/seal/poller_precommit_msg.go
+++ b/curiosrc/seal/poller_precommit_msg.go
@@ -18,7 +18,7 @@ import (
 func (s *SealPoller) pollStartPrecommitMsg(ctx context.Context, task pollTask) {
 	if task.TaskPrecommitMsg == nil && !task.AfterPrecommitMsg && task.afterTreeRC() && s.pollers[pollerPrecommitMsg].IsSet() {
 		s.pollers[pollerPrecommitMsg].Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-			n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_precommit_msg = $1 WHERE sp_id = $2 AND sector_number = $3 AND task_id_precommit_msg IS NULL AND after_tree_r = TRUE AND after_tree_d = TRUE`, id, task.SpID, task.SectorNumber)
+			n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_precommit_msg = $1, sched_count = sched_count + 1 WHERE sp_id = $2 AND sector_number = $3 AND task_id_precommit_msg IS NULL AND after_tree_r = TRUE AND after_tree_d = TRUE`, id, task.SpID, task.SectorNumber)
 			if err != nil {
 				return false, xerrors.Errorf("update sectors_sdr_pipeline: %w", err)
 			}

--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -122,7 +122,7 @@ create table sectors_sdr_initial_pieces (
     -- direct_piece_activation_manifest jsonb,
 
     -- sched counters
-    -- added in 20240502-sdr-pipeline-sched-count.sql
+    -- added in 20240502-sched-counters.sql
     -- sched_count bigint,
 
     -- foreign key

--- a/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/lib/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -121,6 +121,10 @@ create table sectors_sdr_initial_pieces (
     -- direct_end_epoch bigint,
     -- direct_piece_activation_manifest jsonb,
 
+    -- sched counters
+    -- added in 20240502-sdr-pipeline-sched-count.sql
+    -- sched_count bigint,
+
     -- foreign key
     foreign key (sp_id, sector_number) references sectors_sdr_pipeline (sp_id, sector_number) on delete cascade,
 

--- a/lib/harmony/harmonydb/sql/20240228-piece-park.sql
+++ b/lib/harmony/harmonydb/sql/20240228-piece-park.sql
@@ -11,6 +11,10 @@ create table parked_pieces (
 
     cleanup_task_id bigint default null,
 
+    -- added in 20240502-sched-counters
+    -- sched_count biging not null default 0,
+    -- sched_cleanup_count bigint not null default 0,
+
     foreign key (task_id) references harmony_task (id) on delete set null,
     foreign key (cleanup_task_id) references harmony_task (id) on delete set null,
     unique (piece_cid)

--- a/lib/harmony/harmonydb/sql/20240502-sched-counters.sql
+++ b/lib/harmony/harmonydb/sql/20240502-sched-counters.sql
@@ -1,0 +1,8 @@
+ALTER TABLE sectors_sdr_pipeline
+    ADD COLUMN sched_count BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE parked_pieces
+    ADD COLUMN sched_count BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE parked_pieces
+    ADD COLUMN sched_cleanup_count BIGINT NOT NULL DEFAULT 0;
+

--- a/lib/harmony/harmonydb/sql/20240502-sdr-pipeline-sched-count.sql
+++ b/lib/harmony/harmonydb/sql/20240502-sdr-pipeline-sched-count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sectors_sdr_pipeline
+    ADD COLUMN sched_count BIGINT NOT NULL DEFAULT 0;

--- a/lib/harmony/harmonydb/sql/20240502-sdr-pipeline-sched-count.sql
+++ b/lib/harmony/harmonydb/sql/20240502-sdr-pipeline-sched-count.sql
@@ -1,2 +1,0 @@
-ALTER TABLE sectors_sdr_pipeline
-    ADD COLUMN sched_count BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR adds some basic guard logic preventing the poller code from banging it's head against the wall for multiple hours/days in cases where it can't come up with a working repair/retry strategy; Now it will mark the sector as failed after a few minutes of retries.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
