### PR TITLE
fix: curio: gui listen conflict

### DIFF
--- a/cmd/curio/deps/deps.go
+++ b/cmd/curio/deps/deps.go
@@ -223,6 +223,9 @@ func (deps *Deps) PopulateRemainingDeps(ctx context.Context, cctx *cli.Context, 
 		if err != nil {
 			return xerrors.Errorf("populate config: %w", err)
 		}
+		if cctx.IsSet("gui-listen") {
+			deps.Cfg.Subsystems.GuiAddress = cctx.String("gui-listen")
+		}
 	}
 
 	log.Debugw("config", "config", deps.Cfg)

--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -37,6 +37,12 @@ var runCmd = &cli.Command{
 			Value:   "0.0.0.0:12300",
 			EnvVars: []string{"LOTUS_WORKER_LISTEN"},
 		},
+		&cli.StringFlag{
+			Name:   "gui-listen",
+			Usage:  "host address and port the gui will listen on",
+			Value:  "127.0.0.1:4701",
+			Hidden: true,
+		},
 		&cli.BoolFlag{
 			Name:  "nosync",
 			Usage: "don't check full-node sync status",
@@ -156,7 +162,7 @@ var webCmd = &cli.Command{
 	This creates the 'web' layer if it does not exist, then calls run with that layer.`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "listen",
+			Name:  "gui-listen",
 			Usage: "Address to listen on",
 			Value: "127.0.0.1:4701",
 		},

--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -40,7 +40,6 @@ var runCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:   "gui-listen",
 			Usage:  "host address and port the gui will listen on",
-			Value:  "127.0.0.1:4701",
 			Hidden: true,
 		},
 		&cli.BoolFlag{

--- a/documentation/en/cli-curio.md
+++ b/documentation/en/cli-curio.md
@@ -469,7 +469,7 @@ DESCRIPTION:
      This creates the 'web' layer if it does not exist, then calls run with that layer.
 
 OPTIONS:
-   --listen value                     Address to listen on (default: "127.0.0.1:4701")
+   --gui-listen value                 Address to listen on (default: "127.0.0.1:4701")
    --nosync                           don't check full-node sync status (default: false)
    --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
    --help, -h                         show help

--- a/documentation/en/default-curio-config.toml
+++ b/documentation/en/default-curio-config.toml
@@ -169,7 +169,7 @@
   # The address that should listen for Web GUI requests.
   #
   # type: string
-  #GuiAddress = ":4701"
+  #GuiAddress = "127.0.0.1:4701"
 
 
 [Fees]

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -331,7 +331,7 @@ const (
 func DefaultCurioConfig() *CurioConfig {
 	return &CurioConfig{
 		Subsystems: CurioSubsystemsConfig{
-			GuiAddress:    ":4701",
+			GuiAddress:    "127.0.0.1:4701",
 			BoostAdapters: []string{},
 		},
 		Fees: CurioFees{


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/11941
Previous PR： https://github.com/filecoin-project/lotus/pull/11944
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Change the default value of `Subsystems.GuiAddress` from `:4701` to `127.0.0.1:4701`.
2. Rename the `--listen` parameter of `curio web` to `--gui-listen`, making it common and clear in both `curio web` and `curio run`.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
