### PR TITLE
chore: lint: update linter settings, fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,12 @@ linters:
     - govet
     - goimports
     - misspell
-    - goconst
-    - golint
+    - revive
     - errcheck
     - gosec
     - unconvert
     - staticcheck
-    - varcheck
-    - deadcode
-    - scopelint
+    - exportloopref
     - unused
 
 # We don't want to skip builtin/
@@ -25,36 +22,35 @@ skip-dirs:
 
 issues:
   exclude:
-    - "by other packages, and that stutters; consider calling this"
-    - "Potential file inclusion via variable"
-    - "should have( a package)? comment"
-    - "Error return value of `logging.SetLogLevel` is not checked"
-    - "comment on exported"
-    - "(func|method) \\w+ should be \\w+"
-    - "(type|var|struct field|(method|func) parameter) `\\w+` should be `\\w+`"
-    - "(G306|G301|G307|G108|G302|G204|G104)"
-    - "don't use ALL_CAPS in Go names"
-    - "string .* has .* occurrences, make it a constant"
-    - "a blank import should be only in a main or test package, or have a comment justifying it"
-    - "package comment should be of the form"
-    - "Potential hardcoded credentials"
-    - "Use of weak random number generator"
-    - "xerrors.* is deprecated"
+    # gosec
+    - "^G101: Potential hardcoded credentials"
+    - "^G108: Profiling endpoint is automatically exposed on /debug/pprof"
+    - "^G204: Subprocess launched with (variable|a potential tainted input or cmd arguments)"
+    - "^G301: Expect directory permissions to be 0750 or less"
+    - "^G302: Expect file permissions to be 0600 or less"
+    - "^G304: Potential file inclusion via variable"
+    - "^G306: Expect WriteFile permissions to be 0600 or less"
+    - "^G404: Use of weak random number generator"
+    # staticcheck
+    - "^SA1019: xerrors.* is deprecated: As of Go 1.13, use errors"
+    # revive
+    - "^blank-imports: a blank import should be only in a main or test package, or have a comment justifying it"
+    - "^dot-imports: should not use dot imports"
+    - "^exported: (func|type) name will be used as [^\\s]+ by other packages, and that stutters; consider calling this \\w+"
+    - "^exported: comment on exported (const|function|method|type|var) [^\\s]+ should be of the form \"\\w+ ...\""
+    - "^exported: exported (const|function|method|type|var) [^\\s]+ should have comment (\\(or a comment on this block\\) )?or be unexported"
+    - "^indent-error-flow: if block ends with a return statement, so drop this else and outdent its block \\(move short variable declaration to its own line if necessary\\)"
+    - "^package-comments: package comment should be of the form \"Package \\w+ ...\""
+    - "^package-comments: should have a package comment"
+    - "^unexported-return: exported func \\w+ returns unexported type [^\\s]+, which can be annoying to use"
+    - "^unused-parameter: parameter '\\w+' seems to be unused, consider removing or renaming it as _"
+    - "^var-naming: (const|func|type|var|struct field|(method|func|interface method) parameter) [A-Z]\\w+ should be"
+    - "^var-naming: (method|range var) \\w*(Api|Http|Id|Rpc|Url)[^\\s]* should be \\w*(API|HTTP|ID|RPC|URL)"
+    - "^var-naming: don't use underscores in Go names"
+    - "^var-naming: don't use ALL_CAPS in Go names; use CamelCase"
 
   exclude-use-default: false
   exclude-rules:
-
-    - path: node/modules/lp2p
-      linters:
-        - golint
-
-    - path: build/params_.*\.go
-      linters:
-        - golint
-
-    - path: api/apistruct/struct.go
-      linters:
-        - golint
 
     - path: .*_test.go
       linters:
@@ -67,12 +63,3 @@ issues:
     - path: cmd/lotus-bench/.*
       linters:
         - gosec
-
-    - path: api/test/.*
-      text: "context.Context should be the first parameter"
-      linters:
-        - golint
-
-linters-settings:
-  goconst:
-    min-occurrences: 6

--- a/blockstore/buffered.go
+++ b/blockstore/buffered.go
@@ -109,11 +109,9 @@ func (bs *BufferedBlockstore) DeleteMany(ctx context.Context, cids []cid.Cid) er
 
 func (bs *BufferedBlockstore) View(ctx context.Context, c cid.Cid, callback func([]byte) error) error {
 	// both stores are viewable.
-	if err := bs.write.View(ctx, c, callback); ipld.IsNotFound(err) {
-		// not found in write blockstore; fall through.
-	} else {
+	if err := bs.write.View(ctx, c, callback); !ipld.IsNotFound(err) {
 		return err // propagate errors, or nil, i.e. found.
-	}
+	} // else not found in write blockstore; fall through.
 	return bs.read.View(ctx, c, callback)
 }
 

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -282,14 +282,14 @@ func Open(path string, ds dstore.Datastore, hot, cold bstore.Blockstore, cfg *Co
 	if ss.checkpointExists() {
 		log.Info("found compaction checkpoint; resuming compaction")
 		if err := ss.completeCompaction(); err != nil {
-			markSetEnv.Close() //nolint:errcheck
+			_ = markSetEnv.Close()
 			return nil, xerrors.Errorf("error resuming compaction: %w", err)
 		}
 	}
 	if ss.pruneCheckpointExists() {
 		log.Info("found prune checkpoint; resuming prune")
 		if err := ss.completePrune(); err != nil {
-			markSetEnv.Close() //nolint:errcheck
+			_ = markSetEnv.Close()
 			return nil, xerrors.Errorf("error resuming prune: %w", err)
 		}
 	}

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -109,16 +109,13 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 		// TODO: ok to use hysteresis with no transitions between 30s and 1m?
 		if time.Since(timestamp) < SyncWaitTime {
 			/* Chain in sync */
-			if atomic.CompareAndSwapInt32(&s.outOfSync, 0, 0) {
-				// already in sync, no signaling necessary
-			} else {
+			if !atomic.CompareAndSwapInt32(&s.outOfSync, 0, 0) {
 				// transition from out of sync to in sync
 				s.chainSyncMx.Lock()
 				s.chainSyncFinished = true
 				s.chainSyncCond.Broadcast()
 				s.chainSyncMx.Unlock()
-			}
-
+			} // else already in sync, no signaling necessary
 		}
 		// 2. protect the new tipset(s)
 		s.protectTipSets(apply)

--- a/blockstore/splitstore/splitstore_test.go
+++ b/blockstore/splitstore/splitstore_test.go
@@ -32,7 +32,7 @@ func init() {
 	CompactionBoundary = 2
 	WarmupBoundary = 0
 	SyncWaitTime = time.Millisecond
-	logging.SetLogLevel("splitstore", "DEBUG")
+	_ = logging.SetLogLevel("splitstore", "DEBUG")
 }
 
 func testSplitStore(t *testing.T, cfg *Config) {

--- a/build/builtin_actors_gen.go
+++ b/build/builtin_actors_gen.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-var EmbeddedBuiltinActorsMetadata []*BuiltinActorsMetadata = []*BuiltinActorsMetadata{{
+var EmbeddedBuiltinActorsMetadata = []*BuiltinActorsMetadata{{
 	Network: "butterflynet",
 	Version: 8,
 

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -166,5 +166,5 @@ const BootstrapPeerThreshold = 4
 // As per https://github.com/ethereum-lists/chains
 const Eip155ChainId = 314
 
-// we skip checks on message validity in this block to sidestep the zero-bls signature
+// WhitelistedBlock skips checks on message validity in this block to sidestep the zero-bls signature
 var WhitelistedBlock = MustParseCid("bafy2bzaceapyg2uyzk7vueh3xccxkuwbz3nxewjyguoxvhx77malc2lzn2ybi")

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -124,6 +124,7 @@ const MinimumBaseFee = 100
 const PackingEfficiencyNum = 4
 const PackingEfficiencyDenom = 5
 
+// revive:disable-next-line:exported
 // Actor consts
 // TODO: pieceSize unused from actors
 var MinDealDuration, MaxDealDuration = policy.DealDurationBounds(0)

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -778,9 +778,7 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 	_, _ = mp.getStateNonce(ctx, m.Message.From, tmpCurTs)
 
 	mp.curTsLk.Lock()
-	if tmpCurTs == mp.curTs {
-		//with the lock enabled, mp.curTs is the same Ts as we just had, so we know that our computations are cached
-	} else {
+	if tmpCurTs != mp.curTs {
 		//curTs has been updated so we want to cache the new one:
 		tmpCurTs = mp.curTs
 		//we want to release the lock, cache the computations then grab it again
@@ -789,7 +787,7 @@ func (mp *MessagePool) Add(ctx context.Context, m *types.SignedMessage) error {
 		_, _ = mp.getStateNonce(ctx, m.Message.From, tmpCurTs)
 		mp.curTsLk.Lock()
 		//now that we have the lock, we continue, we could do this as a loop forever, but that's bad to loop forever, and this was added as an optimization and it seems once is enough because the computation < block time
-	}
+	} // else with the lock enabled, mp.curTs is the same Ts as we just had, so we know that our computations are cached
 
 	defer mp.curTsLk.Unlock()
 

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -1321,7 +1321,7 @@ func testCompetitiveMessageSelection(t *testing.T, rng *rand.Rand, getPremium fu
 		mustAdd(t, mp, m)
 	}
 
-	logging.SetLogLevel("messagepool", "error")
+	_ = logging.SetLogLevel("messagepool", "error")
 
 	// 1. greedy selection
 	gm, err := mp.selectMessagesGreedy(context.Background(), ts, ts)
@@ -1414,7 +1414,7 @@ func testCompetitiveMessageSelection(t *testing.T, rng *rand.Rand, getPremium fu
 	t.Logf("Average reward boost: %f", rewardBoost)
 	t.Logf("Average best tq reward: %f", totalBestTQReward/runs/1e12)
 
-	logging.SetLogLevel("messagepool", "info")
+	_ = logging.SetLogLevel("messagepool", "info")
 
 	return capacityBoost, rewardBoost, totalBestTQReward / runs / 1e12
 }

--- a/chain/rand/rand.go
+++ b/chain/rand/rand.go
@@ -184,9 +184,8 @@ func (sr *stateRand) GetBeaconRandomness(ctx context.Context, filecoinEpoch abi.
 		return sr.getBeaconRandomnessV3(ctx, filecoinEpoch)
 	} else if nv == network.Version13 {
 		return sr.getBeaconRandomnessV2(ctx, filecoinEpoch)
-	} else {
-		return sr.getBeaconRandomnessV1(ctx, filecoinEpoch)
 	}
+	return sr.getBeaconRandomnessV1(ctx, filecoinEpoch)
 }
 
 func (sr *stateRand) DrawChainRandomness(ctx context.Context, pers crypto.DomainSeparationTag, filecoinEpoch abi.ChainEpoch, entropy []byte) ([]byte, error) {

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -392,7 +392,7 @@ func (s *walkScheduler) Wait() error {
 		log.Errorw("error writing to CAR file", "error", err)
 		return errWrite
 	}
-	s.workerTasks.Close() //nolint:errcheck
+	_ = s.workerTasks.Close()
 	return err
 }
 

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -305,6 +305,7 @@ func (cs *ChainStore) SubHeadChanges(ctx context.Context) chan []*api.HeadChange
 			// Unsubscribe.
 			cs.bestTips.Unsub(subch)
 
+			// revive:disable-next-line:empty-block
 			// Drain the channel.
 			for range subch {
 			}
@@ -752,7 +753,7 @@ func FlushValidationCache(ctx context.Context, ds dstore.Batching) error {
 	for _, k := range allKeys {
 		if strings.HasPrefix(k.Key, blockValidationCacheKeyPrefix.String()) {
 			delCnt++
-			batch.Delete(ctx, dstore.RawKey(k.Key)) // nolint:errcheck
+			_ = batch.Delete(ctx, dstore.RawKey(k.Key))
 		}
 	}
 

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -85,7 +85,7 @@ type syncTestUtil struct {
 }
 
 func prepSyncTest(t testing.TB, h int) *syncTestUtil {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	g, err := gen.NewGenerator()
 	if err != nil {
@@ -115,7 +115,7 @@ func prepSyncTest(t testing.TB, h int) *syncTestUtil {
 }
 
 func prepSyncTestWithV5Height(t testing.TB, h int, v5height abi.ChainEpoch) *syncTestUtil {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	sched := stmgr.UpgradeSchedule{{
 		// prepare for upgrade.

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -927,7 +927,7 @@ func NewEthBlockNumberOrHashFromNumber(number EthUint64) EthBlockNumberOrHash {
 
 func NewEthBlockNumberOrHashFromHexString(str string) (EthBlockNumberOrHash, error) {
 	// check if block param is a number (decimal or hex)
-	var num EthUint64 = 0
+	var num EthUint64
 	err := num.UnmarshalJSON([]byte(str))
 	if err != nil {
 		return NewEthBlockNumberOrHashFromNumber(0), err

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -336,9 +336,7 @@ func (vm *LegacyVM) send(ctx context.Context, msg *types.Message, parent *Runtim
 					return nil, aerrors.Wrapf(err, "could not create account")
 				}
 				toActor = a
-				if vm.networkVersion <= network.Version3 {
-					// Leave the rt.Message as is
-				} else {
+				if vm.networkVersion > network.Version3 {
 					nmsg := Message{
 						msg: types.Message{
 							To:    aid,
@@ -346,9 +344,8 @@ func (vm *LegacyVM) send(ctx context.Context, msg *types.Message, parent *Runtim
 							Value: rt.Message.ValueReceived(),
 						},
 					}
-
 					rt.Message = &nmsg
-				}
+				} // else leave the rt.Message as is
 			} else {
 				return nil, aerrors.Escalate(err, "getting actor")
 			}

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -24,7 +24,7 @@ type BackupApiFn func(ctx *cli.Context) (BackupAPI, jsonrpc.ClientCloser, error)
 
 func BackupCmd(repoFlag string, rt repo.RepoType, getApi BackupApiFn) *cli.Command {
 	var offlineBackup = func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		repoPath := cctx.String(repoFlag)
 		r, err := repo.NewFS(repoPath)

--- a/cli/client.go
+++ b/cli/client.go
@@ -574,7 +574,7 @@ func interactiveDeal(cctx *cli.Context) error {
 	cs := readline.NewCancelableStdin(afmt.Stdin)
 	go func() {
 		<-ctx.Done()
-		cs.Close() // nolint:errcheck
+		_ = cs.Close()
 	}()
 
 	rl := bufio.NewReader(cs)
@@ -2327,7 +2327,7 @@ func OutputDataTransferChannels(out io.Writer, channels []lapi.DataTransferChann
 	for _, channel := range sendingChannels {
 		w.Write(toChannelOutput("Sending To", channel, verbose))
 	}
-	w.Flush(out) //nolint:errcheck
+	_ = w.Flush(out)
 
 	fmt.Fprintf(out, "\nReceiving Channels\n\n")
 	w = tablewriter.New(tablewriter.Col("ID"),
@@ -2341,7 +2341,7 @@ func OutputDataTransferChannels(out io.Writer, channels []lapi.DataTransferChann
 	for _, channel := range receivingChannels {
 		w.Write(toChannelOutput("Receiving From", channel, verbose))
 	}
-	w.Flush(out) //nolint:errcheck
+	_ = w.Flush(out)
 }
 
 func channelStatusString(status datatransfer.Status) string {

--- a/cli/info.go
+++ b/cli/info.go
@@ -131,9 +131,8 @@ func infoCmdAct(cctx *cli.Context) error {
 		if err != nil {
 			if strings.Contains(err.Error(), "actor not found") {
 				continue
-			} else {
-				return err
 			}
+			return err
 		}
 		mbLockedSum = big.Add(mbLockedSum, mbal.Locked)
 		mbAvailableSum = big.Add(mbAvailableSum, mbal.Escrow)

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	logging.SetLogLevel("watchdog", "ERROR")
+	_ = logging.SetLogLevel("watchdog", "ERROR")
 }

--- a/cli/sending_ui.go
+++ b/cli/sending_ui.go
@@ -122,7 +122,7 @@ func printChecks(printer io.Writer, checkGroups [][]api.MessageCheckStatus, prot
 func askUser(printer io.Writer, q string, def bool) bool {
 	var resp string
 	fmt.Fprint(printer, q)
-	fmt.Scanln(&resp)
+	_, _ = fmt.Scanln(&resp)
 	resp = strings.ToLower(resp)
 	if len(resp) == 0 {
 		return def

--- a/cmd/curio/config_test.go
+++ b/cmd/curio/config_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/lotus/node/config"
 )
 
-var baseText string = `
+var baseText = `
 [Subsystems]
   # EnableWindowPost enables window post to be executed on this curio instance. Each machine in the cluster
   # with WindowPoSt enabled will also participate in the window post scheduler. It is possible to have multiple

--- a/cmd/lotus-bench/cli.go
+++ b/cmd/lotus-bench/cli.go
@@ -270,7 +270,7 @@ func (c *CMD) startWorker(qpsTicker *time.Ticker) {
 
 		start := time.Now()
 
-		var statusCode int = 0
+		var statusCode int
 
 		arr := strings.Fields(c.cmd)
 

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -93,7 +93,7 @@ type Commit2In struct {
 }
 
 func main() {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	log.Info("Starting lotus-bench")
 

--- a/cmd/lotus-bench/reporter.go
+++ b/cmd/lotus-bench/reporter.go
@@ -88,7 +88,7 @@ func (r *Reporter) Print(elapsed time.Duration, w io.Writer) {
 		return r.latencies[i] < r.latencies[j]
 	})
 
-	var totalLatency int64 = 0
+	var totalLatency int64
 	for _, latency := range r.latencies {
 		totalLatency += latency
 	}

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -30,7 +30,7 @@ import (
 var log = logging.Logger("main")
 
 func main() {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	log.Info("Starting fountain")
 

--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -25,7 +25,7 @@ type CidWindow [][]cid.Cid
 var log = logging.Logger("lotus-health")
 
 func main() {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	log.Info("Starting health agent")
 

--- a/cmd/lotus-miner/sealing.go
+++ b/cmd/lotus-miner/sealing.go
@@ -151,7 +151,7 @@ func workersCmd(sealing bool) *cli.Command {
 				ramTotal := stat.Info.Resources.MemPhysical
 				ramTasks := stat.MemUsedMin
 				ramUsed := stat.Info.Resources.MemUsed
-				var ramReserved uint64 = 0
+				var ramReserved uint64
 				if ramUsed > ramTasks {
 					ramReserved = ramUsed - ramTasks
 				}
@@ -167,7 +167,7 @@ func workersCmd(sealing bool) *cli.Command {
 				vmemTotal := stat.Info.Resources.MemPhysical + stat.Info.Resources.MemSwap
 				vmemTasks := stat.MemUsedMax
 				vmemUsed := stat.Info.Resources.MemUsed + stat.Info.Resources.MemSwapUsed
-				var vmemReserved uint64 = 0
+				var vmemReserved uint64
 				if vmemUsed > vmemTasks {
 					vmemReserved = vmemUsed - vmemTasks
 				}

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -1305,14 +1305,11 @@ var sectorsBatchingPendingCommit = &cli.Command{
 				return cctx.Command.Action(cctx)
 			} else if userInput == "no" {
 				return nil
-			} else {
-				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
-				return nil
 			}
-
-		} else {
-			fmt.Println("No sectors queued to be committed")
+			fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
+			return nil
 		}
+		fmt.Println("No sectors queued to be committed")
 		return nil
 	},
 }
@@ -1384,14 +1381,11 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 				return cctx.Command.Action(cctx)
 			} else if userInput == "no" {
 				return nil
-			} else {
-				fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
-				return nil
 			}
-
-		} else {
-			fmt.Println("No sectors queued to be committed")
+			fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
+			return nil
 		}
+		fmt.Println("No sectors queued to be committed")
 		return nil
 	},
 }

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -26,7 +26,7 @@ import (
 var log = logging.Logger("lotus-seed")
 
 func main() {
-	logging.SetLogLevel("*", "INFO")
+	_ = logging.SetLogLevel("*", "INFO")
 
 	local := []*cli.Command{
 		genesisCmd,

--- a/cmd/lotus-shed/balances.go
+++ b/cmd/lotus-shed/balances.go
@@ -685,7 +685,7 @@ var chainPledgeCmd = &cli.Command{
 	},
 	ArgsUsage: "[stateroot epoch]",
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR")
+		_ = logging.SetLogLevel("badger", "ERROR")
 		ctx := context.TODO()
 
 		if !cctx.Args().Present() {
@@ -916,13 +916,13 @@ var fillBalancesCmd = &cli.Command{
 		}
 
 		w := csv.NewWriter(os.Stdout)
-		w.Write(append([]string{"Wallet Address"}, datestrs...)) // nolint:errcheck
+		_ = w.Write(append([]string{"Wallet Address"}, datestrs...))
 		for i := 0; i < len(addrs); i++ {
 			row := []string{addrs[i].String()}
 			for _, b := range balances[i] {
 				row = append(row, types.FIL(b).String())
 			}
-			w.Write(row) // nolint:errcheck
+			_ = w.Write(row)
 		}
 		w.Flush()
 		return nil

--- a/cmd/lotus-shed/datastore.go
+++ b/cmd/lotus-shed/datastore.go
@@ -57,7 +57,7 @@ var datastoreListCmd = &cli.Command{
 	},
 	ArgsUsage: "[namespace prefix]",
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		r, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {
@@ -123,7 +123,7 @@ var datastoreGetCmd = &cli.Command{
 	},
 	ArgsUsage: "[namespace key]",
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		r, err := repo.NewFS(cctx.String("repo"))
 		if err != nil {

--- a/cmd/lotus-shed/diff.go
+++ b/cmd/lotus-shed/diff.go
@@ -253,9 +253,8 @@ var diffStateTrees = &cli.Command{
 			if ok {
 				diff(stateA, stateB)
 				continue
-			} else {
-				fmt.Printf("  actor does not exist in second state-tree (%s)\n", rootB)
 			}
+			fmt.Printf("  actor does not exist in second state-tree (%s)\n", rootB)
 			fmt.Println()
 			delete(changedB, addr)
 		}
@@ -265,9 +264,8 @@ var diffStateTrees = &cli.Command{
 			if ok {
 				diff(stateA, stateB)
 				continue
-			} else {
-				fmt.Printf("  actor does not exist in first state-tree (%s)\n", rootA)
 			}
+			fmt.Printf("  actor does not exist in first state-tree (%s)\n", rootA)
 			fmt.Println()
 		}
 		return nil

--- a/cmd/lotus-shed/itestd.go
+++ b/cmd/lotus-shed/itestd.go
@@ -64,7 +64,7 @@ var itestdCmd = &cli.Command{
 		cs := readline.NewCancelableStdin(os.Stdin)
 		go func() {
 			<-cctx.Done()
-			cs.Close() // nolint:errcheck
+			_ = cs.Close()
 		}()
 
 		rl := bufio.NewReader(cs)

--- a/cmd/lotus-shed/market.go
+++ b/cmd/lotus-shed/market.go
@@ -214,7 +214,7 @@ var marketExportDatastoreCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		// If the backup dir is not specified, just use the OS temp dir
 		backupDir := cctx.String("backup-dir")
@@ -332,7 +332,7 @@ var marketImportDatastoreCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		logging.SetLogLevel("badger", "ERROR") // nolint:errcheck
+		_ = logging.SetLogLevel("badger", "ERROR")
 
 		backupPath := cctx.String("backup-path")
 

--- a/cmd/lotus-shed/rpc.go
+++ b/cmd/lotus-shed/rpc.go
@@ -67,7 +67,7 @@ var rpcCmd = &cli.Command{
 		cs := readline.NewCancelableStdin(afmt.Stdin)
 		go func() {
 			<-ctx.Done()
-			cs.Close() // nolint:errcheck
+			_ = cs.Close()
 		}()
 
 		send := func(method, params string) error {
@@ -148,9 +148,8 @@ var rpcCmd = &cli.Command{
 			if err == readline.ErrInterrupt {
 				if len(line) == 0 {
 					break
-				} else {
-					continue
 				}
+				continue
 			} else if err == io.EOF {
 				break
 			}

--- a/cmd/lotus-shed/state-stats.go
+++ b/cmd/lotus-shed/state-stats.go
@@ -723,7 +723,7 @@ to reduce the number of decode operations performed by caching the decoded objec
 
 		go func() {
 			// error is check later
-			eg.Wait() //nolint:errcheck
+			_ = eg.Wait()
 			close(results)
 		}()
 

--- a/conformance/chaos/actor.go
+++ b/conformance/chaos/actor.go
@@ -274,9 +274,8 @@ type AbortWithArgs struct {
 func (a Actor) AbortWith(rt runtime2.Runtime, args *AbortWithArgs) *abi.EmptyValue {
 	if args.Uncontrolled { // uncontrolled abort: directly panic
 		panic(args.Message)
-	} else {
-		rt.Abortf(args.Code, args.Message)
 	}
+	rt.Abortf(args.Code, args.Message)
 	return nil
 }
 

--- a/curiosrc/market/lmrpc/lmrpc.go
+++ b/curiosrc/market/lmrpc/lmrpc.go
@@ -390,9 +390,8 @@ func ServeCurioMarketRPC(db *harmonydb.DB, full api.FullNode, maddr address.Addr
 				}
 				if !taskResult {
 					return api.SectorOffset{}, xerrors.Errorf("park-piece task failed: %s", taskError)
-				} else {
-					return api.SectorOffset{}, xerrors.Errorf("park task succeeded but piece is not marked as complete")
 				}
+				return api.SectorOffset{}, xerrors.Errorf("park task succeeded but piece is not marked as complete")
 			}
 		}
 

--- a/curiosrc/window/compute_do.go
+++ b/curiosrc/window/compute_do.go
@@ -202,7 +202,7 @@ func (t *WdPostTask) DoPartition(ctx context.Context, ts *types.TipSet, maddr ad
 				Proofs:            postOut,
 				ChallengedSectors: sinfos,
 				Prover:            abi.ActorID(mid),
-			}); err != nil {
+			}); err != nil { // revive:disable-line:empty-block
 				/*log.Errorw("window post verification failed", "post", postOut, "error", err)
 				time.Sleep(5 * time.Second)
 				continue todo retry loop */
@@ -337,7 +337,7 @@ func (t *WdPostTask) sectorsForProof(ctx context.Context, maddr address.Address,
 }
 
 func (t *WdPostTask) generateWindowPoSt(ctx context.Context, ppt abi.RegisteredPoStProof, minerID abi.ActorID, sectorInfo []proof.ExtendedSectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, []abi.SectorID, error) {
-	var retErr error = nil
+	var retErr error
 	randomness[31] &= 0x3f
 
 	out := make([]proof.PoStProof, 0)

--- a/curiosrc/winning/winning_task.go
+++ b/curiosrc/winning/winning_task.go
@@ -667,7 +667,7 @@ func (t *WinPostTask) computeTicket(ctx context.Context, maddr address.Address, 
 
 func randTimeOffset(width time.Duration) time.Duration {
 	buf := make([]byte, 8)
-	rand.Reader.Read(buf) //nolint:errcheck
+	_, _ = rand.Reader.Read(buf)
 	val := time.Duration(binary.BigEndian.Uint64(buf) % uint64(width))
 
 	return val - (width / 2)

--- a/gateway/proxy_eth.go
+++ b/gateway/proxy_eth.go
@@ -90,7 +90,7 @@ func (gw *Node) checkEthBlockParam(ctx context.Context, blkParam ethtypes.EthBlo
 			return err
 		}
 
-		var num ethtypes.EthUint64 = 0
+		var num ethtypes.EthUint64
 		if blkParam.PredefinedBlock != nil {
 			if *blkParam.PredefinedBlock == "earliest" {
 				return fmt.Errorf("block param \"earliest\" is not supported")

--- a/gen/bundle/bundle.go
+++ b/gen/bundle/bundle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 )
 
-var tmpl *template.Template = template.Must(template.New("actor-metadata").Parse(`
+var tmpl = template.Must(template.New("actor-metadata").Parse(`
 // WARNING: This file has automatically been generated
 
 package build

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -579,7 +579,7 @@ func TestTxReceiptBloom(t *testing.T) {
 		kit.MockProofs(),
 		kit.ThroughRPC())
 	ens.InterconnectAll().BeginMining(blockTime)
-	logging.SetLogLevel("fullnode", "DEBUG")
+	_ = logging.SetLogLevel("fullnode", "DEBUG")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/itests/gas_estimation_test.go
+++ b/itests/gas_estimation_test.go
@@ -125,7 +125,7 @@ func TestEstimateInclusion(t *testing.T) {
 
 	// Mutate the last byte to get a new address of the same length.
 	toBytes := msg.To.Bytes()
-	toBytes[len(toBytes)-1] += 1 //nolint:golint
+	toBytes[len(toBytes)-1] += 1 // revive:disable-line:increment-decrement
 	newAddr, err := address.NewFromBytes(toBytes)
 	require.NoError(t, err)
 
@@ -158,7 +158,7 @@ func TestEstimateInclusion(t *testing.T) {
 
 	msg.Nonce = 2
 	msg.To = msg.From
-	msg.GasLimit -= 1 //nolint:golint
+	msg.GasLimit -= 1 // revive:disable-line:increment-decrement
 
 	smsg, err = client.WalletSignMessage(ctx, client.DefaultKey.Address, msg)
 	require.NoError(t, err)

--- a/itests/harmonytask_test.go
+++ b/itests/harmonytask_test.go
@@ -32,7 +32,7 @@ func withDbSetup(t *testing.T, f func(*kit.TestMiner)) {
 		kit.MockProofs(),
 		kit.WithSectorIndexDB(),
 	)
-	logging.SetLogLevel("harmonytask", "debug")
+	_ = logging.SetLogLevel("harmonytask", "debug")
 
 	f(miner)
 }

--- a/itests/kit/client.go
+++ b/itests/kit/client.go
@@ -141,7 +141,10 @@ func createRandomFile(rseed, size int) ([]byte, string, error) {
 		size = 1600
 	}
 	data := make([]byte, size)
-	_, _ = rand.New(rand.NewSource(int64(rseed))).Read(data)
+	_, err := rand.New(rand.NewSource(int64(rseed))).Read(data)
+	if err != nil {
+		return nil, "", err
+	}
 
 	dir, err := os.MkdirTemp(os.TempDir(), "test-make-deal-")
 	if err != nil {

--- a/itests/kit/client.go
+++ b/itests/kit/client.go
@@ -141,7 +141,7 @@ func createRandomFile(rseed, size int) ([]byte, string, error) {
 		size = 1600
 	}
 	data := make([]byte, size)
-	rand.New(rand.NewSource(int64(rseed))).Read(data)
+	_, _ = rand.New(rand.NewSource(int64(rseed))).Read(data)
 
 	dir, err := os.MkdirTemp(os.TempDir(), "test-make-deal-")
 	if err != nil {

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -709,9 +709,9 @@ func (n *Ensemble) Start() *Ensemble {
 
 		var mineBlock = make(chan lotusminer.MineReq)
 
-		copy := *m.FullNode
-		copy.FullNode = modules.MakeUuidWrapper(copy.FullNode)
-		m.FullNode = &copy
+		minerCopy := *m.FullNode
+		minerCopy.FullNode = modules.MakeUuidWrapper(minerCopy.FullNode)
+		m.FullNode = &minerCopy
 
 		opts := []node.Option{
 			node.StorageMiner(&m.StorageMiner, cfg.Subsystems),

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -413,9 +413,8 @@ func (g *Garbager) Exists(ctx context.Context, c cid.Cid) bool {
 	} else if err != nil {
 		g.t.Fatalf("ChainReadObj failure on existence check: %s", err)
 		return false // unreachable
-	} else {
-		return true
 	}
+	return true
 }
 
 func (g *Garbager) newPeerID(ctx context.Context) abi.ChainEpoch {

--- a/lib/ulimit/ulimit_test.go
+++ b/lib/ulimit/ulimit_test.go
@@ -46,8 +46,8 @@ func TestManageInvalidNFds(t *testing.T) {
 
 	t.Logf("setting ulimit to %d, max %d, cur %d", value, rlimit.Max, rlimit.Cur)
 
-	if changed, new, err := ManageFdLimit(); err == nil {
-		t.Errorf("ManageFdLimit should return an error: changed %t, new: %d", changed, new)
+	if changed, isNew, err := ManageFdLimit(); err == nil {
+		t.Errorf("ManageFdLimit should return an error: changed %t, new: %d", changed, isNew)
 	} else if err != nil {
 		flag := strings.Contains(err.Error(),
 			"failed to raise ulimit to LOTUS_FD_MAX")

--- a/markets/dagstore/miner_api.go
+++ b/markets/dagstore/miner_api.go
@@ -201,7 +201,5 @@ func (m *minerAPI) GetUnpaddedCARSize(ctx context.Context, pieceCid cid.Cid) (ui
 		return 0, xerrors.Errorf("no storage deals found for piece %s", pieceCid)
 	}
 
-	l := pieceInfo.Deals[0].Length
-
-	return uint64(l), nil
+	return uint64(pieceInfo.Deals[0].Length), nil
 }

--- a/markets/dagstore/miner_api.go
+++ b/markets/dagstore/miner_api.go
@@ -201,7 +201,7 @@ func (m *minerAPI) GetUnpaddedCARSize(ctx context.Context, pieceCid cid.Cid) (ui
 		return 0, xerrors.Errorf("no storage deals found for piece %s", pieceCid)
 	}
 
-	len := pieceInfo.Deals[0].Length
+	l := pieceInfo.Deals[0].Length
 
-	return uint64(len), nil
+	return uint64(l), nil
 }

--- a/markets/dagstore/miner_api_test.go
+++ b/markets/dagstore/miner_api_test.go
@@ -129,9 +129,9 @@ func TestLotusAccessorGetUnpaddedCARSize(t *testing.T) {
 
 	// Check that the data length is correct
 	//stm: @MARKET_DAGSTORE_GET_UNPADDED_CAR_SIZE_001
-	len, err := api.GetUnpaddedCARSize(ctx, cid1)
+	l, err := api.GetUnpaddedCARSize(ctx, cid1)
 	require.NoError(t, err)
-	require.EqualValues(t, 10, len)
+	require.EqualValues(t, 10, l)
 }
 
 func TestThrottle(t *testing.T) {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -53,7 +53,7 @@ type waitFunc func(ctx context.Context, baseTime uint64) (func(bool, abi.ChainEp
 
 func randTimeOffset(width time.Duration) time.Duration {
 	buf := make([]byte, 8)
-	rand.Reader.Read(buf) //nolint:errcheck
+	_, _ = rand.Reader.Read(buf)
 	val := time.Duration(binary.BigEndian.Uint64(buf) % uint64(width))
 
 	return val - (width / 2)

--- a/node/health.go
+++ b/node/health.go
@@ -48,7 +48,7 @@ func NewLiveHandler(api lapi.FullNode) *HealthHandler {
 		var (
 			countdown int32
 			headCh    <-chan []*lapi.HeadChange
-			backoff   time.Duration = minbackoff
+			backoff   = minbackoff
 			err       error
 		)
 		minutely := time.NewTicker(time.Minute)
@@ -66,10 +66,9 @@ func NewLiveHandler(api lapi.FullNode) *HealthHandler {
 					}
 					backoff = nextbackoff
 					continue
-				} else {
-					healthlog.Infof("started ChainNotify channel")
-					backoff = minbackoff
 				}
+				healthlog.Infof("started ChainNotify channel")
+				backoff = minbackoff
 			}
 			select {
 			case <-minutely.C:

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -644,8 +644,8 @@ func (a *ChainAPI) ChainExport(ctx context.Context, nroots abi.ChainEpoch, skipo
 		bw := bufio.NewWriterSize(w, 1<<20)
 
 		err := a.Chain.Export(ctx, ts, nroots, skipoldmsgs, bw)
-		bw.Flush()            //nolint:errcheck // it is a write to a pipe
-		w.CloseWithError(err) //nolint:errcheck // it is a pipe
+		_ = bw.Flush()            // it is a write to a pipe
+		_ = w.CloseWithError(err) // it is a pipe
 	}()
 
 	go func() {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -965,9 +965,8 @@ func (a *StateAPI) StateComputeDataCID(ctx context.Context, maddr address.Addres
 		return a.stateComputeDataCIDv1(ctx, maddr, sectorType, deals, tsk)
 	} else if nv < network.Version21 {
 		return a.stateComputeDataCIDv2(ctx, maddr, sectorType, deals, tsk)
-	} else {
-		return a.stateComputeDataCIDv3(ctx, maddr, sectorType, deals, tsk)
 	}
+	return a.stateComputeDataCIDv3(ctx, maddr, sectorType, deals, tsk)
 }
 
 func (a *StateAPI) stateComputeDataCIDv1(ctx context.Context, maddr address.Address, sectorType abi.RegisteredSealProof, deals []abi.DealID, tsk types.TipSetKey) (cid.Cid, error) {

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -594,7 +594,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 		msgsRPC := evt.GetRecvRPC().GetMeta().GetMessages()
 
 		// check if any of the messages we are sending belong to a trackable topic
-		var validTopic bool = false
+		var validTopic = false
 		for _, topic := range msgsRPC {
 			if trw.traceMessage(topic.GetTopic()) {
 				validTopic = true
@@ -602,7 +602,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 			}
 		}
 		// track if the Iwant / Ihave messages are from a valid Topic
-		var validIhave bool = false
+		var validIhave = false
 		for _, msgs := range ihave {
 			if trw.traceMessage(msgs.GetTopic()) {
 				validIhave = true
@@ -630,7 +630,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 		msgsRPC := evt.GetSendRPC().GetMeta().GetMessages()
 
 		// check if any of the messages we are sending belong to a trackable topic
-		var validTopic bool = false
+		var validTopic = false
 		for _, topic := range msgsRPC {
 			if trw.traceMessage(topic.GetTopic()) {
 				validTopic = true
@@ -638,7 +638,7 @@ func (trw *tracerWrapper) Trace(evt *pubsub_pb.TraceEvent) {
 			}
 		}
 		// track if the Iwant / Ihave messages are from a valid Topic
-		var validIhave bool = false
+		var validIhave = false
 		for _, msgs := range ihave {
 			if trw.traceMessage(msgs.GetTopic()) {
 				validIhave = true

--- a/node/modules/lp2p/rcmgr.go
+++ b/node/modules/lp2p/rcmgr.go
@@ -38,7 +38,7 @@ func ResourceManager(connMgrHi uint) func(lc fx.Lifecycle, repo repo.LockedRepo)
 
 		log.Info("libp2p resource manager is enabled")
 		// enable debug logs for rcmgr
-		logging.SetLogLevel("rcmgr", "debug")
+		_ = logging.SetLogLevel("rcmgr", "debug")
 
 		// Adjust default defaultLimits
 		// - give it more memory, up to 4G, min of 1G

--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -288,7 +288,7 @@ func (fsr *FsRepo) Init(t RepoType) error {
 	}
 
 	log.Infof("Initializing repo at '%s'", fsr.path)
-	err = os.MkdirAll(fsr.path, 0755) //nolint: gosec
+	err = os.MkdirAll(fsr.path, 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}

--- a/storage/paths/index_test.go
+++ b/storage/paths/index_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	logging.SetLogLevel("stores", "DEBUG")
+	_ = logging.SetLogLevel("stores", "DEBUG")
 }
 
 func newTestStorage() storiface.StorageInfo {

--- a/storage/sealer/ffiwrapper/sealer_test.go
+++ b/storage/sealer/ffiwrapper/sealer_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func init() {
-	logging.SetLogLevel("*", "DEBUG") //nolint: errcheck
+	_ = logging.SetLogLevel("*", "DEBUG")
 }
 
 var sealProofType = abi.RegisteredSealProof_StackedDrg2KiBV1

--- a/storage/sealer/manager_post.go
+++ b/storage/sealer/manager_post.go
@@ -108,7 +108,7 @@ func dedupeSectorInfo(sectorInfo []proof.ExtendedSectorInfo) []proof.ExtendedSec
 }
 
 func (m *Manager) generateWindowPoSt(ctx context.Context, minerID abi.ActorID, ppt abi.RegisteredPoStProof, sectorInfo []proof.ExtendedSectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, []abi.SectorID, error) {
-	var retErr error = nil
+	var retErr error
 	randomness[31] &= 0x3f
 
 	out := make([]proof.PoStProof, 0)

--- a/storage/sealer/sched_post.go
+++ b/storage/sealer/sched_post.go
@@ -56,7 +56,7 @@ func (ps *poStScheduler) MaybeAddWorker(wid storiface.WorkerID, tasks map[sealta
 func (ps *poStScheduler) delWorker(wid storiface.WorkerID) *WorkerHandle {
 	ps.lk.Lock()
 	defer ps.lk.Unlock()
-	var w *WorkerHandle = nil
+	var w *WorkerHandle
 	if wh, ok := ps.workers[wid]; ok {
 		w = wh
 		delete(ps.workers, wid)

--- a/storage/wdpost/wdpost_changehandler_test.go
+++ b/storage/wdpost/wdpost_changehandler_test.go
@@ -84,10 +84,10 @@ func (m *mockAPI) setDeadline(di *dline.Info) {
 }
 
 func (m *mockAPI) getDeadline(currentEpoch abi.ChainEpoch) *dline.Info {
-	close := minertypes.WPoStChallengeWindow - 1
+	closeEpoch := minertypes.WPoStChallengeWindow - 1
 	dlIdx := uint64(0)
-	for close < currentEpoch {
-		close += minertypes.WPoStChallengeWindow
+	for closeEpoch < currentEpoch {
+		closeEpoch += minertypes.WPoStChallengeWindow
 		dlIdx++
 	}
 	return NewDeadlineInfo(0, dlIdx, currentEpoch)

--- a/storage/wdpost/wdpost_run_faults.go
+++ b/storage/wdpost/wdpost_run_faults.go
@@ -23,7 +23,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-var RecoveringSectorLimit uint64 = 0
+var RecoveringSectorLimit uint64
 
 func init() {
 	if rcl := os.Getenv("LOTUS_RECOVERING_SECTOR_LIMIT"); rcl != "" {


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lotus/issues/11967

This isn't complete, I just banged through a few iterations of it to see the kinds of changes we're being asked to make. I think a better approach here is to add some exclusion error regexes. Most of the issues fall into two categories:

1. Named but unused parameters
2. Acronym capitalisation - Api -> API, Http -> HTTP, Url -> URL, Id -> ID

The latter suck in particular because a lot of them are on API methods. I've started adding explicit exclusions for those in here, but we could opt for a global exclusion (minimal might be something like `var-naming: var [A-Z].+ should be ` to capture public variables).

Or we could just hammer it with exclusions to minimise the diff in this PR in particular, even turn off `var-naming` entirely.