### PR TITLE
feat: ETH compatibility in Filecoin : Support EIP-155 Ethereum transactions in Filecoin

### DIFF
--- a/chain/types/ethtypes/eth_1559_transactions.go
+++ b/chain/types/ethtypes/eth_1559_transactions.go
@@ -64,7 +64,7 @@ func (tx *Eth1559TxArgs) ToRlpUnsignedMsg() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append([]byte{Eip1559TxType}, encoded...), nil
+	return append([]byte{EIP1559TxType}, encoded...), nil
 }
 
 func (tx *Eth1559TxArgs) TxHash() (EthHash, error) {
@@ -166,7 +166,7 @@ func (tx *Eth1559TxArgs) ToEthTx(smsg *types.SignedMessage) (EthTx, error) {
 
 	ethTx := EthTx{
 		ChainID:              EthUint64(build.Eip155ChainId),
-		Type:                 Eip1559TxType,
+		Type:                 EIP1559TxType,
 		Nonce:                EthUint64(tx.Nonce),
 		Hash:                 hash,
 		To:                   tx.To,
@@ -261,8 +261,8 @@ func (tx *Eth1559TxArgs) packTxFields() ([]interface{}, error) {
 }
 
 func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
-	if data[0] != Eip1559TxType {
-		return nil, xerrors.Errorf(fmt.Sprintf("not an EIP-1559 transaction: first byte is not %d", Eip1559TxType))
+	if data[0] != EIP1559TxType {
+		return nil, xerrors.Errorf("not an EIP-1559 transaction: first byte is not %d", EIP1559TxType)
 	}
 
 	d, err := DecodeRLP(data[1:])

--- a/chain/types/ethtypes/eth_legacy_155_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions.go
@@ -15,6 +15,10 @@ var _ EthTransaction = (*EthLegacy155TxArgs)(nil)
 
 // EthLegacy155TxArgs is a legacy Ethereum transaction that uses the EIP-155 chain replay protection mechanism
 // by incorporating the chainId in the signature.
+// See how the `V` value in the signature is derived from the chainId at
+// https://github.com/ethereum/go-ethereum/blob/86a1f0c39494c8f5caddf6bd9fbddd4bdfa944fd/core/types/transaction_signing.go#L424
+// For EthLegacy155TxArgs, the digest that is used to create a signed transaction includes the `ChainID` but the serialised RLP transaction
+// does not include the `ChainID` as an explicit field. Instead, the `ChainID` is included in the V value of the signature as mentioned above.
 type EthLegacy155TxArgs struct {
 	LegacyTx *EthLegacyHomesteadTxArgs
 }
@@ -141,6 +145,7 @@ func (tx *EthLegacy155TxArgs) ToVerifiableSignature(sig []byte) ([]byte, error) 
 	// Extract the 'v' value from the signature
 	vValue := big.NewFromGo(big.NewInt(0).SetBytes(sig[64:]))
 
+	// See https://github.com/ethereum/go-ethereum/blob/86a1f0c39494c8f5caddf6bd9fbddd4bdfa944fd/core/types/transaction_signing.go#L424
 	chainIdMul := big.Mul(big.NewIntUnsigned(build.Eip155ChainId), big.NewInt(2))
 	vValue = big.Sub(vValue, chainIdMul)
 	vValue = big.Sub(vValue, big8)

--- a/chain/types/ethtypes/eth_legacy_155_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions.go
@@ -229,7 +229,7 @@ func (tx *EthLegacy155TxArgs) packTxFields() ([]interface{}, error) {
 		return nil, err
 	}
 
-	chainIdBigInt := deriveEIP155ChainId(tx.LegacyTx.V)
+	chainIdBigInt := big.NewIntUnsigned(build.Eip155ChainId)
 	chainId, err := formatBigInt(chainIdBigInt)
 	if err != nil {
 		return nil, err

--- a/chain/types/ethtypes/eth_legacy_155_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions.go
@@ -145,6 +145,10 @@ func (tx *EthLegacy155TxArgs) ToVerifiableSignature(sig []byte) ([]byte, error) 
 	// Extract the 'v' value from the signature
 	vValue := big.NewFromGo(big.NewInt(0).SetBytes(sig[64:]))
 
+	if err := validateEIP155ChainId(vValue); err != nil {
+		return nil, fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+
 	// See https://github.com/ethereum/go-ethereum/blob/86a1f0c39494c8f5caddf6bd9fbddd4bdfa944fd/core/types/transaction_signing.go#L424
 	chainIdMul := big.Mul(big.NewIntUnsigned(build.Eip155ChainId), big.NewInt(2))
 	vValue = big.Sub(vValue, chainIdMul)

--- a/chain/types/ethtypes/eth_legacy_155_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions.go
@@ -1,0 +1,190 @@
+package ethtypes
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/big"
+	typescrypto "github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var _ EthTransaction = (*EthLegacy155TxArgs)(nil)
+
+type EthLegacy155TxArgs struct {
+	legacyTx *EthLegacyHomesteadTxArgs
+}
+
+// implement all interface methods
+func (tx *EthLegacy155TxArgs) ToEthTx(smsg *types.SignedMessage) (EthTx, error) {
+	ethTx, err := tx.legacyTx.ToEthTx(smsg)
+	if err != nil {
+		return EthTx{}, fmt.Errorf("failed to convert legacy tx to eth tx: %w", err)
+	}
+	if err := validateEIP155ChainId(tx.legacyTx.V); err != nil {
+		return EthTx{}, fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+
+	ethTx.ChainID = build.Eip155ChainId
+	return ethTx, nil
+}
+
+func (tx *EthLegacy155TxArgs) ToUnsignedFilecoinMessage(from address.Address) (*types.Message, error) {
+	if err := validateEIP155ChainId(tx.legacyTx.V); err != nil {
+		return nil, fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+	return tx.legacyTx.ToUnsignedFilecoinMessage(from)
+}
+
+func (tx *EthLegacy155TxArgs) ToRlpUnsignedMsg() ([]byte, error) {
+	return tx.legacyTx.ToRlpUnsignedMsg()
+}
+
+func (tx *EthLegacy155TxArgs) TxHash() (EthHash, error) {
+	return tx.legacyTx.TxHash()
+}
+
+func (tx *EthLegacy155TxArgs) ToRlpSignedMsg() ([]byte, error) {
+	return tx.legacyTx.ToRlpSignedMsg()
+}
+
+func (tx *EthLegacy155TxArgs) Signature() (*typescrypto.Signature, error) {
+	if err := validateEIP155ChainId(tx.legacyTx.V); err != nil {
+		return nil, fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+	r := tx.legacyTx.R.Int.Bytes()
+	s := tx.legacyTx.S.Int.Bytes()
+	v := tx.legacyTx.V.Int.Bytes()
+
+	sig := append([]byte{}, padLeadingZeros(r, 32)...)
+	sig = append(sig, padLeadingZeros(s, 32)...)
+	sig = append(sig, v...)
+
+	// pre-pend a one byte marker so nodes know that this is a legacy transaction
+	sig = append([]byte{EthLegacy155TxSignaturePrefix}, sig...)
+
+	if len(sig) != EthLegacy155TxSignatureLen {
+		return nil, fmt.Errorf("signature is not %d bytes; it is %d bytes", EthLegacy155TxSignatureLen, len(sig))
+	}
+
+	return &typescrypto.Signature{
+		Type: typescrypto.SigTypeDelegated, Data: sig,
+	}, nil
+}
+
+func (tx *EthLegacy155TxArgs) Sender() (address.Address, error) {
+	if err := validateEIP155ChainId(tx.legacyTx.V); err != nil {
+		return address.Address{}, fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+	return tx.legacyTx.Sender()
+}
+
+var big8 = big.NewInt(8)
+
+func (tx *EthLegacy155TxArgs) ToVerifiableSignature(sig []byte) ([]byte, error) {
+	if len(sig) != EthLegacy155TxSignatureLen {
+		return nil, fmt.Errorf("signature should be %d bytes long (1 byte metadata, %d bytes sig data), but got %d bytes",
+			EthLegacy155TxSignatureLen, EthLegacy155TxSignatureLen-1, len(sig))
+	}
+	if sig[0] != EthLegacy155TxSignaturePrefix {
+		return nil, fmt.Errorf("expected signature prefix 0x%x, but got 0x%x", EthLegacy155TxSignaturePrefix, sig[0])
+	}
+
+	// Remove the prefix byte as it's only used for legacy transaction identification
+	sig = sig[1:]
+
+	// Extract the 'v' value from the signature, which is the last byte in Ethereum signatures
+	vValue := big.NewFromGo(big.NewInt(0).SetBytes(sig[64:]))
+
+	chainIdMul := big.Mul(big.NewIntUnsigned(build.Eip155ChainId), big.NewInt(2))
+	vValue = big.Sub(vValue, chainIdMul)
+	vValue = big.Sub(vValue, big8)
+
+	// Adjust 'v' value for compatibility with new transactions: 27 -> 0, 28 -> 1
+	if vValue.Equals(big.NewInt(27)) {
+		sig[64] = 0
+	} else if vValue.Equals(big.NewInt(28)) {
+		sig[64] = 1
+	} else {
+		return nil, fmt.Errorf("invalid 'v' value: expected 27 or 28, got %d", vValue.Int64())
+	}
+
+	return sig, nil
+
+}
+
+func (tx *EthLegacy155TxArgs) InitialiseSignature(sig typescrypto.Signature) error {
+	if sig.Type != typescrypto.SigTypeDelegated {
+		return fmt.Errorf("RecoverSignature only supports Delegated signature")
+	}
+
+	if len(sig.Data) != EthLegacy155TxSignatureLen {
+		return fmt.Errorf("signature should be %d bytes long, but got %d bytes", EthLegacy155TxSignatureLen, len(sig.Data))
+	}
+
+	if sig.Data[0] != EthLegacy155TxSignaturePrefix {
+		return fmt.Errorf("expected signature prefix 0x01, but got 0x%x", sig.Data[0])
+	}
+
+	// ignore the first byte of the tx as it's only used for legacy transaction identification
+	r_, err := parseBigInt(sig.Data[1:33])
+	if err != nil {
+		return fmt.Errorf("cannot parse r into EthBigInt: %w", err)
+	}
+
+	s_, err := parseBigInt(sig.Data[33:65])
+	if err != nil {
+		return fmt.Errorf("cannot parse s into EthBigInt: %w", err)
+	}
+
+	v_, err := parseBigInt(sig.Data[65:])
+	if err != nil {
+		return fmt.Errorf("cannot parse v into EthBigInt: %w", err)
+	}
+
+	if err := validateEIP155ChainId(v_); err != nil {
+		return fmt.Errorf("failed to validate EIP155 chain id: %w", err)
+	}
+
+	tx.legacyTx.R = r_
+	tx.legacyTx.S = s_
+	tx.legacyTx.V = v_
+	return nil
+}
+
+func (tx *EthLegacy155TxArgs) packTxFields() ([]interface{}, error) {
+	return tx.legacyTx.packTxFields()
+}
+
+func validateEIP155ChainId(v big.Int) error {
+	chainId := deriveEIP155ChainId(v)
+	if !chainId.Equals(big.NewIntUnsigned(build.Eip155ChainId)) {
+		return fmt.Errorf("invalid chain id, expected %d, got %s", build.Eip155ChainId, chainId.String())
+	}
+	return nil
+}
+
+// deriveEIP155ChainId derives the chain id from the given v parameter
+func deriveEIP155ChainId(v big.Int) big.Int {
+	if big.BitLen(v) <= 64 {
+		vUint64 := v.Uint64()
+		if vUint64 == 27 || vUint64 == 28 {
+			return big.NewInt(0)
+		}
+		return big.NewIntUnsigned((vUint64 - 35) / 2)
+	}
+
+	v = big.Sub(v, big.NewInt(35))
+	return big.Div(v, big.NewInt(2))
+}
+
+func calcEIP155TxSignatureLen(chain uint64) int {
+	chainId := big.NewIntUnsigned(chain)
+	vVal := big.Add(big.Mul(chainId, big.NewInt(2)), big.NewInt(36))
+	vLen := len(vVal.Int.Bytes())
+
+	// EthLegacyHomesteadTxSignatureLen includes the 1 byte legacy tx marker prefix and also 1 byte for the V value.
+	// So we subtract 1 to not double count the length of the v value
+	return EthLegacyHomesteadTxSignatureLen + vLen - 1
+}

--- a/chain/types/ethtypes/eth_legacy_155_transactions_test.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions_test.go
@@ -179,7 +179,7 @@ func TestCalcEIP155TxSignatureLen(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calcEIP155TxSignatureLen(tt.chainID)
+			result := calcEIP155TxSignatureLen(tt.chainID, 1)
 			if result != tt.expected {
 				t.Errorf("calcEIP155TxSignatureLen(%d) = %d, want %d", tt.chainID, result, tt.expected)
 			}

--- a/chain/types/ethtypes/eth_legacy_155_transactions_test.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions_test.go
@@ -1,0 +1,167 @@
+package ethtypes
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/lotus/lib/sigs"
+)
+
+func TestEthLegacy155TxArgs(t *testing.T) {
+	testcases := []struct {
+		RawTx            string
+		ExpectedNonce    uint64
+		ExpectedTo       string
+		ExpectedInput    string
+		ExpectedGasPrice big.Int
+		ExpectedGasLimit int
+
+		ExpectErr bool
+	}{
+		{
+			"0xf8708310aa048504a817c80083015f9094f8c911c68f6a6b912fe735bbd953c3379336cbf3880e19fb7ff12c8c308025a09abb6d2bb66c9520f76391169e1155e8426e41ce9888e16d93512083038de023a020bbd446f8dcbdd996a5e1d0663ec8e28c33d5cb254e323855331be71bc8b0fb",
+			0x0,
+			"0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+			"0xdeadbeef0000000101010010101010101010101010101aaabbbbbbcccccccddddddddd",
+			big.NewInt(1),
+			0x5408,
+			false,
+		},
+		/*{
+			"0xf85f030182520794b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ba098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa07778cde41a8a37f6a087622b38bc201bd3e7df06dce067569d4def1b53dba98c",
+			0x3,
+			"0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+			"0x",
+			big.NewInt(1),
+			0x5207,
+			false,
+		},
+		*/
+	}
+
+	for i, tc := range testcases {
+		// parse txargs
+		tx, err := parseLegacyTx(mustDecodeHex(tc.RawTx))
+		require.NoError(t, err)
+
+		msgRecovered, err := tx.ToRlpUnsignedMsg()
+		require.NoError(t, err)
+
+		// verify signatures
+		from, err := tx.Sender()
+		require.NoError(t, err)
+
+		smsg, err := ToSignedFilecoinMessage(tx)
+		require.NoError(t, err)
+
+		sig := smsg.Signature.Data[:]
+		sig = sig[1:]
+		vValue := big.NewInt(0).SetBytes(sig[64:])
+		vValue_ := big.Sub(big.NewFromGo(vValue), big.NewInt(27))
+		sig[64] = byte(vValue_.Uint64())
+		smsg.Signature.Data = sig
+
+		err = sigs.Verify(&smsg.Signature, from, msgRecovered)
+		require.NoError(t, err)
+
+		txArgs := tx.(*EthLegacyHomesteadTxArgs)
+		// verify data
+		require.EqualValues(t, tc.ExpectedNonce, txArgs.Nonce, i)
+
+		expectedTo, err := ParseEthAddress(tc.ExpectedTo)
+		require.NoError(t, err)
+		require.EqualValues(t, expectedTo, *txArgs.To, i)
+		require.EqualValues(t, tc.ExpectedInput, "0x"+hex.EncodeToString(txArgs.Input))
+		require.EqualValues(t, tc.ExpectedGasPrice, txArgs.GasPrice)
+		require.EqualValues(t, tc.ExpectedGasLimit, txArgs.GasLimit)
+	}
+}
+
+func TestDeriveEIP155ChainId(t *testing.T) {
+	tests := []struct {
+		name            string
+		v               big.Int
+		expectedChainId big.Int
+	}{
+		{
+			name:            "V equals 27",
+			v:               big.NewInt(27),
+			expectedChainId: big.NewInt(0),
+		},
+		{
+			name:            "V equals 28",
+			v:               big.NewInt(28),
+			expectedChainId: big.NewInt(0),
+		},
+		{
+			name:            "V small chain ID",
+			v:               big.NewInt(37), // (37 - 35) / 2 = 1
+			expectedChainId: big.NewInt(1),
+		},
+		{
+			name:            "V large chain ID",
+			v:               big.NewInt(1001), // (1001 - 35) / 2 = 483
+			expectedChainId: big.NewInt(483),
+		},
+		{
+			name:            "V very large chain ID",
+			v:               big.NewInt(1 << 20), // (1048576 - 35) / 2 = 524770
+			expectedChainId: big.NewInt(524270),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deriveEIP155ChainId(tt.v)
+			assert.True(t, result.Equals(tt.expectedChainId), "Expected %s, got %s for V=%s", tt.expectedChainId.String(), result.String(), tt.v.String())
+		})
+	}
+}
+
+func TestCalcEIP155TxSignatureLen(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainID  uint64
+		expected int
+	}{
+		{
+			name:     "ChainID that fits in 1 byte",
+			chainID:  0x01,
+			expected: EthLegacyHomesteadTxSignatureLen + 1 - 1,
+		},
+		{
+			name:     "ChainID that fits in 2 bytes",
+			chainID:  0x0100,
+			expected: EthLegacyHomesteadTxSignatureLen + 2 - 1,
+		},
+		{
+			name:     "ChainID that fits in 3 bytes",
+			chainID:  0x010000,
+			expected: EthLegacyHomesteadTxSignatureLen + 3 - 1,
+		},
+		{
+			name:     "ChainID that fits in 4 bytes",
+			chainID:  0x01000000,
+			expected: EthLegacyHomesteadTxSignatureLen + 4 - 1,
+		},
+		{
+			name:     "ChainID that fits in 6 bytes",
+			chainID:  0x010000000000,
+			expected: EthLegacyHomesteadTxSignatureLen + 6 - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calcEIP155TxSignatureLen(tt.chainID)
+			if result != tt.expected {
+				t.Errorf("calcEIP155TxSignatureLen(%d) = %d, want %d", tt.chainID, result, tt.expected)
+			}
+		})
+	}
+}

--- a/chain/types/ethtypes/eth_legacy_homestead_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_homestead_transactions.go
@@ -164,7 +164,7 @@ func (tx *EthLegacyHomesteadTxArgs) InitialiseSignature(sig typescrypto.Signatur
 		return fmt.Errorf("expected signature prefix 0x01, but got 0x%x", sig.Data[0])
 	}
 
-	// ignore the first byte of the tx as it's only used for legacy transaction identification
+	// ignore the first byte of the signature as it's only used for legacy transaction identification
 	r_, err := parseBigInt(sig.Data[1:33])
 	if err != nil {
 		return fmt.Errorf("cannot parse r into EthBigInt: %w", err)

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -35,11 +35,13 @@ const (
 )
 
 var (
-	EthLegacy155TxSignatureLen int
+	EthLegacy155TxSignatureLen0 int
+	EthLegacy155TxSignatureLen1 int
 )
 
 func init() {
-	EthLegacy155TxSignatureLen = calcEIP155TxSignatureLen(build.Eip155ChainId)
+	EthLegacy155TxSignatureLen0 = calcEIP155TxSignatureLen(build.Eip155ChainId, 35)
+	EthLegacy155TxSignatureLen1 = calcEIP155TxSignatureLen(build.Eip155ChainId, 36)
 }
 
 // EthTransaction defines the interface for Ethereum-like transactions.
@@ -155,7 +157,7 @@ func EthTransactionFromSignedFilecoinMessage(smsg *types.SignedMessage) (EthTran
 		}
 		return &tx, nil
 
-	case EthLegacyHomesteadTxSignatureLen, EthLegacy155TxSignatureLen:
+	case EthLegacyHomesteadTxSignatureLen, EthLegacy155TxSignatureLen0, EthLegacy155TxSignatureLen1:
 		legacyTx := &EthLegacyHomesteadTxArgs{
 			Nonce:    int(smsg.Message.Nonce),
 			To:       to,

--- a/itests/eth_legacy_transactions_test.go
+++ b/itests/eth_legacy_transactions_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/big"
 
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/itests/kit"
@@ -55,7 +56,7 @@ func TestLegacyValueTransferValidSignature(t *testing.T) {
 		S:        big.Zero(),
 	}
 
-	client.EVM().SignLegacyTransaction(&tx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(&tx, key.PrivateKey)
 	// Mangle signature
 	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
 
@@ -66,7 +67,7 @@ func TestLegacyValueTransferValidSignature(t *testing.T) {
 	require.Error(t, err)
 
 	// Submit transaction with valid signature
-	client.EVM().SignLegacyTransaction(&tx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(&tx, key.PrivateKey)
 
 	hash := client.EVM().SubmitTransaction(ctx, &tx)
 
@@ -101,10 +102,7 @@ func TestLegacyValueTransferValidSignature(t *testing.T) {
 	require.EqualValues(t, tx.V, ethTx.V)
 }
 
-func TestEIP155Tx(t *testing.T) {
-	rlpHex := "f86d8083030e1b83291e739490322092a524e0e43a2ec80ec6f35100d24799f28898a7d9b8314c000080820298a0dc782de2fec8cd45e699075beb756ad731943d19a33332fa36e72fd94802ed10a056b3e1e36f2851402661daf0b3284bc8d15db005d1fade908c1117c6ae37429d"
-	rlpBytes, err := hex.DecodeString(rlpHex)
-	require.NoError(t, err)
+func TestLegacyEIP155ValueTransferValidSignature(t *testing.T) {
 	blockTime := 100 * time.Millisecond
 	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
 
@@ -113,25 +111,84 @@ func TestEIP155Tx(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	from := "0xf0a3b487d026406F5ca18891dB6896a3dA900F29"
-	ea, err := ethtypes.ParseEthAddress(from)
-	require.NoError(t, err)
-	fa, err := ea.ToFilecoinAddress()
-	require.NoError(t, err)
-	fmt.Println("fil addr is", fa.String())
-	kit.SendFunds(ctx, t, client, fa, types.FromFil(20000))
+	// create a new Ethereum account
+	key, ethAddr, deployer := client.EVM().NewAccount()
+	_, ethAddr2, _ := client.EVM().NewAccount()
 
-	hash, err := client.EthSendRawTransaction(ctx, rlpBytes)
+	kit.SendFunds(ctx, t, client, deployer, types.FromFil(1000))
+
+	gasParams, err := json.Marshal(ethtypes.EthEstimateGasParams{Tx: ethtypes.EthCall{
+		From:  &ethAddr,
+		To:    &ethAddr2,
+		Value: ethtypes.EthBigInt(big.NewInt(100)),
+	}})
+	require.NoError(t, err)
+
+	gaslimit, err := client.EthEstimateGas(ctx, gasParams)
+	require.NoError(t, err)
+
+	legacyTx := &ethtypes.EthLegacyHomesteadTxArgs{
+		Value:    big.NewInt(100),
+		Nonce:    0,
+		To:       &ethAddr2,
+		GasPrice: types.NanoFil,
+		GasLimit: int(gaslimit),
+		V:        big.Zero(),
+		R:        big.Zero(),
+		S:        big.Zero(),
+	}
+	tx := &ethtypes.EthLegacy155TxArgs{
+		LegacyTx: legacyTx,
+	}
+
+	client.EVM().SignLegacyEIP155Transaction(tx, key.PrivateKey, big.NewInt(build.Eip155ChainId))
+	// Mangle signature
+	tx.LegacyTx.V.Int.Xor(tx.LegacyTx.V.Int, big.NewInt(1).Int)
+
+	signed, err := tx.ToRawTxBytesSigned()
+	require.NoError(t, err)
+	// Submit transaction with bad signature
+	_, err = client.EVM().EthSendRawTransaction(ctx, signed)
+	require.Error(t, err)
+
+	// Submit transaction with valid signature but incorrect chain ID
+	client.EVM().SignLegacyEIP155Transaction(tx, key.PrivateKey, big.NewInt(build.Eip155ChainId))
+
+	signed, err = tx.ToRawTxBytesSigned()
+	require.NoError(t, err)
+
+	hash, err := client.EVM().EthSendRawTransaction(ctx, signed)
 	require.NoError(t, err)
 
 	receipt, err := client.EVM().WaitTransaction(ctx, hash)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
+	require.EqualValues(t, ethAddr, receipt.From)
+	require.EqualValues(t, ethAddr2, *receipt.To)
 	require.EqualValues(t, hash, receipt.TransactionHash)
 
 	// Success.
 	require.EqualValues(t, ethtypes.EthUint64(0x1), receipt.Status)
 
+	// Validate that we sent the expected transaction.
+	ethTx, err := client.EthGetTransactionByHash(ctx, &hash)
+	require.NoError(t, err)
+	require.Nil(t, ethTx.MaxPriorityFeePerGas)
+	require.Nil(t, ethTx.MaxFeePerGas)
+
+	require.EqualValues(t, ethAddr, ethTx.From)
+	require.EqualValues(t, ethAddr2, *ethTx.To)
+	require.EqualValues(t, tx.LegacyTx.Nonce, ethTx.Nonce)
+	require.EqualValues(t, hash, ethTx.Hash)
+	require.EqualValues(t, tx.LegacyTx.Value, ethTx.Value)
+	require.EqualValues(t, 0, ethTx.Type)
+	require.EqualValues(t, build.Eip155ChainId, ethTx.ChainID)
+	require.EqualValues(t, ethtypes.EthBytes{}, ethTx.Input)
+	require.EqualValues(t, tx.LegacyTx.GasLimit, ethTx.Gas)
+	require.EqualValues(t, tx.LegacyTx.GasPrice, *ethTx.GasPrice)
+	require.EqualValues(t, tx.LegacyTx.R, ethTx.R)
+	require.EqualValues(t, tx.LegacyTx.S, ethTx.S)
+	require.EqualValues(t, tx.LegacyTx.V, ethTx.V)
 }
 
 func TestLegacyContractInvocation(t *testing.T) {
@@ -152,7 +209,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 	tx, err := deployLegacyContractTx(t, ctx, client, ethAddr)
 	require.NoError(t, err)
 
-	client.EVM().SignLegacyTransaction(tx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(tx, key.PrivateKey)
 	// Mangle signature
 	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
 
@@ -163,7 +220,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 	require.Error(t, err)
 
 	// Submit transaction with valid signature
-	client.EVM().SignLegacyTransaction(tx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(tx, key.PrivateKey)
 
 	hash := client.EVM().SubmitTransaction(ctx, tx)
 
@@ -208,7 +265,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 		S:        big.Zero(),
 	}
 
-	client.EVM().SignLegacyTransaction(&invokeTx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(&invokeTx, key.PrivateKey)
 	// Mangle signature
 	invokeTx.V.Int.Xor(invokeTx.V.Int, big.NewInt(1).Int)
 
@@ -219,7 +276,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 	require.Error(t, err)
 
 	// Submit transaction with valid signature
-	client.EVM().SignLegacyTransaction(&invokeTx, key.PrivateKey)
+	client.EVM().SignLegacyHomesteadTransaction(&invokeTx, key.PrivateKey)
 	hash = client.EVM().SubmitTransaction(ctx, &invokeTx)
 
 	receipt, err = client.EVM().WaitTransaction(ctx, hash)

--- a/itests/kit/evm.go
+++ b/itests/kit/evm.go
@@ -53,7 +53,7 @@ func (e *EVM) SignLegacyTransaction(tx *ethtypes.EthLegacyHomesteadTxArgs, privK
 	signature, err := sigs.Sign(crypto.SigTypeDelegated, privKey, preimage)
 	require.NoError(e.t, err)
 
-	signature.Data = append([]byte{ethtypes.LegacyHomesteadEthTxSignaturePrefix}, signature.Data...)
+	signature.Data = append([]byte{ethtypes.EthLegacyHomesteadTxSignaturePrefix}, signature.Data...)
 	signature.Data[len(signature.Data)-1] += 27
 
 	err = tx.InitialiseSignature(*signature)

--- a/itests/kit/evm.go
+++ b/itests/kit/evm.go
@@ -55,8 +55,6 @@ func (e *EVM) SignLegacyEIP155Transaction(tx *ethtypes.EthLegacy155TxArgs, privK
 
 	signature.Data = append([]byte{ethtypes.EthLegacy155TxSignaturePrefix}, signature.Data...)
 
-	fmt.Println(build.Eip155ChainId)
-
 	chainIdMul := big.Mul(chainID, big.NewInt(2))
 	vVal := big.Add(chainIdMul, big.NewIntUnsigned(35))
 

--- a/itests/kit/evm.go
+++ b/itests/kit/evm.go
@@ -44,8 +44,37 @@ func (f *TestFullNode) EVM() *EVM {
 	return &EVM{f}
 }
 
-// SignLegacyTransaction signs a legacy Homstead Ethereum transaction in place with the supplied private key.
-func (e *EVM) SignLegacyTransaction(tx *ethtypes.EthLegacyHomesteadTxArgs, privKey []byte) {
+// SignLegacyHomesteadTransaction signs a legacy Homstead Ethereum transaction in place with the supplied private key.
+func (e *EVM) SignLegacyEIP155Transaction(tx *ethtypes.EthLegacy155TxArgs, privKey []byte, chainID big.Int) {
+	preimage, err := tx.ToRlpUnsignedMsg()
+	require.NoError(e.t, err)
+
+	// sign the RLP payload
+	signature, err := sigs.Sign(crypto.SigTypeDelegated, privKey, preimage)
+	require.NoError(e.t, err)
+
+	signature.Data = append([]byte{ethtypes.EthLegacy155TxSignaturePrefix}, signature.Data...)
+
+	fmt.Println(build.Eip155ChainId)
+
+	chainIdMul := big.Mul(chainID, big.NewInt(2))
+	vVal := big.Add(chainIdMul, big.NewIntUnsigned(35))
+
+	switch signature.Data[len(signature.Data)-1] {
+	case 0:
+		vVal = big.Add(vVal, big.NewInt(0))
+	case 1:
+		vVal = big.Add(vVal, big.NewInt(1))
+	}
+
+	signature.Data = append(signature.Data[:65], vVal.Int.Bytes()...)
+
+	err = tx.InitialiseSignature(*signature)
+	require.NoError(e.t, err)
+}
+
+// SignLegacyHomesteadTransaction signs a legacy Homstead Ethereum transaction in place with the supplied private key.
+func (e *EVM) SignLegacyHomesteadTransaction(tx *ethtypes.EthLegacyHomesteadTxArgs, privKey []byte) {
 	preimage, err := tx.ToRlpUnsignedMsg()
 	require.NoError(e.t, err)
 

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -3,6 +3,7 @@ package full
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -819,6 +820,8 @@ func (a *EthModule) EthGasPrice(ctx context.Context) (ethtypes.EthBigInt, error)
 }
 
 func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx ethtypes.EthBytes) (ethtypes.EthHash, error) {
+	log.Warn("rawTx", "rawTx", hex.EncodeToString(rawTx))
+
 	txArgs, err := ethtypes.ParseEthTransaction(rawTx)
 	if err != nil {
 		return ethtypes.EmptyEthHash, err

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -3,7 +3,6 @@ package full
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -820,7 +819,7 @@ func (a *EthModule) EthGasPrice(ctx context.Context) (ethtypes.EthBigInt, error)
 }
 
 func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx ethtypes.EthBytes) (ethtypes.EthHash, error) {
-	log.Warn("rawTx", "rawTx", hex.EncodeToString(rawTx))
+	log.Warnw("raw tx", "raw", rawTx)
 
 	txArgs, err := ethtypes.ParseEthTransaction(rawTx)
 	if err != nil {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -3,6 +3,7 @@ package full
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -819,7 +820,7 @@ func (a *EthModule) EthGasPrice(ctx context.Context) (ethtypes.EthBigInt, error)
 }
 
 func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx ethtypes.EthBytes) (ethtypes.EthHash, error) {
-	log.Warnw("raw tx", "raw", rawTx)
+	fmt.Println("raw tx", hex.EncodeToString(rawTx))
 
 	txArgs, err := ethtypes.ParseEthTransaction(rawTx)
 	if err != nil {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -3,7 +3,6 @@ package full
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -820,8 +819,6 @@ func (a *EthModule) EthGasPrice(ctx context.Context) (ethtypes.EthBigInt, error)
 }
 
 func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx ethtypes.EthBytes) (ethtypes.EthHash, error) {
-	fmt.Println("raw tx", hex.EncodeToString(rawTx))
-
 	txArgs, err := ethtypes.ParseEthTransaction(rawTx)
 	if err != nil {
 		return ethtypes.EmptyEthHash, err

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -543,7 +543,7 @@ func ethTxFromNativeMessage(msg *types.Message, st *state.StateTree) (ethtypes.E
 		Nonce:                ethtypes.EthUint64(msg.Nonce),
 		ChainID:              ethtypes.EthUint64(build.Eip155ChainId),
 		Value:                ethtypes.EthBigInt(msg.Value),
-		Type:                 ethtypes.Eip1559TxType,
+		Type:                 ethtypes.EIP1559TxType,
 		Gas:                  ethtypes.EthUint64(msg.GasLimit),
 		MaxFeePerGas:         &maxFeePerGas,
 		MaxPriorityFeePerGas: &maxPriorityFeePerGas,


### PR DESCRIPTION
## Related Issues
For https://github.com/filecoin-project/lotus/issues/11859 (for the EIP-155 transactions support)
FIP at https://github.com/filecoin-project/FIPs/pull/995

## Proposed Changes
This PR enables support for EIP-155 transactions with chain replay protection in Filecoin.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
