### PR TITLE
feat:state:Ignore market balance after nv23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,6 +967,12 @@ workflows:
           suite: itest-splitstore
           target: "./itests/splitstore_test.go"
       - test:
+          name: test-itest-supply
+          requires:
+            - build
+          suite: itest-supply
+          target: "./itests/supply_test.go"
+      - test:
           name: test-itest-verifreg
           requires:
             - build

--- a/chain/stmgr/supply.go
+++ b/chain/stmgr/supply.go
@@ -303,11 +303,14 @@ func getFilPowerLocked(ctx context.Context, st *state.StateTree) (abi.TokenAmoun
 	return pst.TotalLocked()
 }
 
-func GetFilLocked(ctx context.Context, st *state.StateTree) (abi.TokenAmount, error) {
-
-	filMarketLocked, err := getFilMarketLocked(ctx, st)
-	if err != nil {
-		return big.Zero(), xerrors.Errorf("failed to get filMarketLocked: %w", err)
+func GetFilLocked(ctx context.Context, st *state.StateTree, height abi.ChainEpoch) (abi.TokenAmount, error) {
+	filMarketLocked := big.Zero()
+	if height <= build.UpgradeAussieHeight {
+		var err error
+		filMarketLocked, err = getFilMarketLocked(ctx, st)
+		if err != nil {
+			return big.Zero(), xerrors.Errorf("failed to get filMarketLocked: %w", err)
+		}
 	}
 
 	filPowerLocked, err := getFilPowerLocked(ctx, st)
@@ -360,7 +363,7 @@ func (sm *StateManager) GetVMCirculatingSupplyDetailed(ctx context.Context, heig
 		return api.CirculatingSupply{}, xerrors.Errorf("failed to calculate filBurnt: %w", err)
 	}
 
-	filLocked, err := GetFilLocked(ctx, st)
+	filLocked, err := GetFilLocked(ctx, st, height)
 	if err != nil {
 		return api.CirculatingSupply{}, xerrors.Errorf("failed to calculate filLocked: %w", err)
 	}

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -142,7 +142,7 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 	require.NoError(t, err, "Failed to fetch nv23 circulating supply")
 
 	// Unfortunately there's still some non-determinism in supply dynamics so check for equality within a tolerance
-	tolerance := big.Mul(abi.NewTokenAmount(200), abi.NewTokenAmount(1e18))
+	tolerance := big.Mul(abi.NewTokenAmount(1000), abi.NewTokenAmount(1e18))
 	totalLocked := big.Sum(lockedClientBalance, lockedProviderBalance)
 	diff := big.Sub(
 		big.Sum(totalLocked, nv23Supply.FilLocked),
@@ -182,7 +182,7 @@ func makePSDMessage(
 		StoragePricePerEpoch: ppe,
 	}
 	buf := bytes.NewBuffer(nil)
-	proposal.MarshalCBOR(buf)
+	require.NoError(t, proposal.MarshalCBOR(buf))
 	sig, err := signFunc(ctx, client, buf.Bytes())
 	require.NoError(t, err)
 	// Publish storage deal

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -154,8 +154,9 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 }
 
 // Message will be valid and lock funds but the data is fake so the deal will never be activated
-func makePSDMessage(t *testing.T,
+func makePSDMessage(
 	ctx context.Context,
+	t *testing.T,
 	provider,
 	worker,
 	client address.Address,

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -56,8 +56,8 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 
 		psd0, err := fullNode0.MpoolPushMessage(ctx,
 			makePSDMessage(
-				t,
 				ctx,
+				t,
 				blockMiner0.ActorAddr,
 				worker0,
 				wallet0,
@@ -95,8 +95,8 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 
 		psd1, err := fullNode1.MpoolPushMessage(ctx,
 			makePSDMessage(
-				t,
 				ctx,
+				t,
 				blockMiner1.ActorAddr,
 				worker1,
 				wallet1,

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -1,0 +1,218 @@
+package itests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/builtin/v9/market"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCirciulationSupplyUpgrade(t *testing.T) {
+	kit.QuietMiningLogs()
+	ctx := context.Background()
+
+	// Choosing something divisible by epochs per day to remove error with simple deal duration
+	lockedClientBalance := big.Mul(abi.NewTokenAmount(11_520_000), abi.NewTokenAmount(1e18))
+	lockedProviderBalance := big.Mul(abi.NewTokenAmount(1_000_000), abi.NewTokenAmount(1e18))
+	var height0 abi.ChainEpoch
+	var height1 abi.ChainEpoch
+	// Lock collateral in market on nv22 network
+	fullNode0, blockMiner0, ens0 := kit.EnsembleMinimal(t,
+		kit.GenesisNetworkVersion(network.Version22),
+		kit.MockProofs(),
+	)
+	{
+
+		worker0 := blockMiner0.OwnerKey.Address
+		ens0.InterconnectAll().BeginMining(50 * time.Millisecond)
+
+		// Lock collateral in market actor
+		wallet0, err := fullNode0.WalletDefaultAddress(ctx)
+		require.NoError(t, err)
+
+		// Add 1 FIL to cover provider collateral
+		c00, err := fullNode0.MarketAddBalance(ctx, wallet0, wallet0, lockedClientBalance)
+		require.NoError(t, err)
+		fullNode0.WaitMsg(ctx, c00)
+		c01, err := blockMiner0.FullNode.MarketAddBalance(ctx, worker0, blockMiner0.ActorAddr, lockedProviderBalance)
+		require.NoError(t, err)
+		fullNode0.WaitMsg(ctx, c01)
+
+		prePSDSupply, err := fullNode0.StateCirculatingSupply(ctx, types.EmptyTSK)
+		require.NoError(t, err, "Failed to fetch pre-upgrade circulating supply")
+		fmt.Printf("\n\n\n\n------prePSDSupply: %v\n\n\n\n", prePSDSupply)
+
+		psd0, err := fullNode0.MpoolPushMessage(ctx,
+			makePSDMessage(
+				t,
+				ctx,
+				blockMiner0.ActorAddr,
+				worker0,
+				wallet0,
+				lockedProviderBalance,
+				lockedClientBalance,
+				fullNode0.WalletSign,
+			),
+			nil,
+		)
+		require.NoError(t, err)
+		fullNode0.WaitMsg(ctx, psd0.Cid())
+		head, err := fullNode0.ChainHead(ctx)
+		require.NoError(t, err)
+		height0 = head.Height()
+	}
+	fmt.Printf("height0: %v\n", height0)
+
+	// Lock collateral in market on nv23 network
+	fullNode1, blockMiner1, ens1 := kit.EnsembleMinimal(t,
+		kit.GenesisNetworkVersion(network.Version23),
+		kit.MockProofs(),
+	)
+	{
+		worker1 := blockMiner1.OwnerKey.Address
+		ens1.InterconnectAll().BeginMining(50 * time.Millisecond)
+
+		// Lock collateral in market actor
+		wallet1, err := fullNode1.WalletDefaultAddress(ctx)
+		require.NoError(t, err)
+		c10, err := fullNode1.MarketAddBalance(ctx, wallet1, wallet1, lockedClientBalance)
+		require.NoError(t, err)
+		fullNode1.WaitMsg(ctx, c10)
+		c11, err := blockMiner1.FullNode.MarketAddBalance(ctx, worker1, blockMiner1.ActorAddr, lockedProviderBalance)
+		require.NoError(t, err)
+		fullNode1.WaitMsg(ctx, c11)
+
+		prePSDSupply, err := fullNode1.StateCirculatingSupply(ctx, types.EmptyTSK)
+		require.NoError(t, err, "Failed to fetch pre-upgrade circulating supply")
+		fmt.Printf("\n\n\n\n------prePSDSupply: %v\n\n\n\n", prePSDSupply)
+
+		psd1, err := fullNode1.MpoolPushMessage(ctx,
+			makePSDMessage(
+				t,
+				ctx,
+				blockMiner1.ActorAddr,
+				worker1,
+				wallet1,
+				lockedProviderBalance,
+				lockedClientBalance,
+				fullNode1.WalletSign,
+			),
+			nil,
+		)
+		require.NoError(t, err)
+		fullNode1.WaitMsg(ctx, psd1.Cid())
+		head, err := fullNode1.ChainHead(ctx)
+		require.NoError(t, err)
+		height1 = head.Height()
+	}
+	fmt.Printf("height1: %v\n", height1)
+
+	// Measure each circulating supply at the latest height where market balance was locked
+	// This allows us to normalize against fluctuations in circulating supply based on the underlying
+	// dynamics irrelevant to this change
+
+	max := height0
+	if height0 < height1 {
+		max = height1
+	}
+	max = max + 1 // Measure supply at height after the deal locking funds was published
+
+	// Let both chains catch up
+	fullNode0.WaitTillChain(ctx, func(ts *types.TipSet) bool {
+		return ts.Height() >= max
+	})
+	fullNode1.WaitTillChain(ctx, func(ts *types.TipSet) bool {
+		return ts.Height() >= max
+	})
+
+	ts0, err := fullNode0.ChainGetTipSetByHeight(ctx, max, types.EmptyTSK)
+	require.NoError(t, err)
+	ts1, err := fullNode1.ChainGetTipSetByHeight(ctx, max, types.EmptyTSK)
+	require.NoError(t, err)
+
+	nv22Supply, err := fullNode0.StateCirculatingSupply(ctx, ts0.Key())
+	require.NoError(t, err, "Failed to fetch nv22 circulating supply")
+	nv23Supply, err := fullNode1.StateCirculatingSupply(ctx, ts1.Key())
+	require.NoError(t, err, "Failed to fetch nv23 circulating supply")
+
+	fmt.Printf("\n\n\n\n\n\n------------------before %v, after %v, diff: %v----------------\n\n\n\n\n", nv22Supply, nv23Supply, big.Sub(nv23Supply, nv22Supply))
+	nv22, err := fullNode0.StateNetworkVersion(ctx, ts0.Key())
+	require.NoError(t, err)
+	nv23, err := fullNode1.StateNetworkVersion(ctx, ts1.Key())
+	require.NoError(t, err)
+	fmt.Printf("\n\n\n\n\n\n------------------nv22: %v, nv23: %v----------------\n\n\n\n\n", nv22, nv23)
+
+	// Unfortunately there's still some non-determinism in supply dynamics so check for equality within a tolerance
+	tolerance := big.Mul(abi.NewTokenAmount(100), abi.NewTokenAmount(1e18))
+	totalLocked := big.Sum(lockedClientBalance, lockedProviderBalance)
+	require.Equal(t, -1, big.Cmp(
+		big.Sub(
+			big.Sum(totalLocked, nv23Supply),
+			nv22Supply,
+		),
+		tolerance), "Supply difference exceeds tolerance")
+}
+
+// Message will be valid and lock funds but the data is fake so the deal will never be activated
+func makePSDMessage(t *testing.T,
+	ctx context.Context,
+	provider,
+	worker,
+	client address.Address,
+	providerLocked,
+	clientLocked abi.TokenAmount,
+	signFunc func(context.Context, address.Address, []byte) (*crypto.Signature, error)) *types.Message {
+
+	dummyCid, err := cid.Parse("baga6ea4seaqflae5c3k2odz4sqfufmrmoegplhk5jbq3co4fgmmy56yc2qfh4aq")
+	require.NoError(t, err)
+
+	duration := 2880 * 200 // 200 days
+	ppe := big.Div(clientLocked, big.NewInt(2880*200))
+	proposal := market.DealProposal{
+		PieceCID:             dummyCid,
+		PieceSize:            abi.PaddedPieceSize(128),
+		VerifiedDeal:         false,
+		Client:               client,
+		Provider:             provider,
+		ClientCollateral:     big.Zero(),
+		ProviderCollateral:   providerLocked,
+		StartEpoch:           10000,
+		EndEpoch:             10000 + abi.ChainEpoch(duration),
+		StoragePricePerEpoch: ppe,
+	}
+	buf := bytes.NewBuffer(nil)
+	proposal.MarshalCBOR(buf)
+	sig, err := signFunc(ctx, client, buf.Bytes())
+	require.NoError(t, err)
+	// Publish storage deal
+	params, err := actors.SerializeParams(&market.PublishStorageDealsParams{
+		Deals: []market.ClientDealProposal{
+			{
+				Proposal:        proposal,
+				ClientSignature: *sig,
+			},
+		},
+	})
+	require.NoError(t, err)
+	return &types.Message{
+		To:     builtin.StorageMarketActorAddr,
+		From:   worker,
+		Value:  types.NewInt(0),
+		Method: builtin.MethodsMarket.PublishStorageDeals,
+		Params: params,
+	}
+}

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -142,15 +142,15 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 	require.NoError(t, err, "Failed to fetch nv23 circulating supply")
 
 	// Unfortunately there's still some non-determinism in supply dynamics so check for equality within a tolerance
-	tolerance := big.Mul(abi.NewTokenAmount(100), abi.NewTokenAmount(1e18))
+	tolerance := big.Mul(abi.NewTokenAmount(200), abi.NewTokenAmount(1e18))
 	totalLocked := big.Sum(lockedClientBalance, lockedProviderBalance)
 	diff := big.Sub(
-		big.Sum(totalLocked, nv22Supply.FilCirculating),
-		nv23Supply.FilCirculating,
+		big.Sum(totalLocked, nv23Supply.FilLocked),
+		nv22Supply.FilLocked,
 	)
 	assert.Equal(t, -1, big.Cmp(
 		diff.Abs(),
-		tolerance), "Supply difference exceeds tolerance")
+		tolerance), "Difference from expected locked supply between versions exceeds tolerance")
 }
 
 // Message will be valid and lock funds but the data is fake so the deal will never be activated


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Closes #11921 
## Proposed Changes
<!-- A clear list of the changes being made -->
Drop builtin market calculation from locked balance calculation after nv23

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
