### PR TITLE
fix: params: Update SupportedProofTypes to the correct ones

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -88,8 +88,10 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg2KiBV1,
-	abi.RegisteredSealProof_StackedDrg8MiBV1,
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1,
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2048)
 var MinVerifiedDealSize = abi.NewStoragePower(256)

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -71,9 +71,12 @@ const UpgradeWatermelonFix2Height = -101
 const UpgradeCalibrationDragonFixHeight = -102
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg512MiBV1,
-	abi.RegisteredSealProof_StackedDrg32GiBV1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2 << 30)
 var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -102,8 +102,10 @@ const UpgradeCalibrationDragonFixHeight = 1493854
 const UpgradeAussieHeight = 999999999999999
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg32GiBV1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(32 << 30)
 var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -75,9 +75,12 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg2KiBV1,
-	abi.RegisteredSealProof_StackedDrg8MiBV1,
-	abi.RegisteredSealProof_StackedDrg512MiBV1,
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1,
+	abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1,
+	abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1,
+	abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2048)
 var MinVerifiedDealSize = abi.NewStoragePower(256)

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -119,8 +119,10 @@ const UpgradeWatermelonFix2Height = -2
 const UpgradeCalibrationDragonFixHeight = -3
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg32GiBV1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(10 << 40)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -35,8 +35,10 @@ var (
 	PropagationDelaySecs  = uint64(6)
 	EquivocationDelaySecs = uint64(2)
 	SupportedProofTypes   = []abi.RegisteredSealProof{
-		abi.RegisteredSealProof_StackedDrg32GiBV1,
-		abi.RegisteredSealProof_StackedDrg64GiBV1,
+		abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+		abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+		abi.RegisteredSealProof_StackedDrg64GiBV1_1,
+		abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
 	}
 	ConsensusMinerMinPower  = abi.NewStoragePower(10 << 40)
 	PreCommitChallengeDelay = abi.ChainEpoch(150)


### PR DESCRIPTION
It was noted by [Hubert](https://filecoinproject.slack.com/archives/CP50PPW2X/p1715340266433729) that `Filecoin.StateGetNetworkParams` returns the wrong `SupportedProofTypes`:

Example:
```
curl -X POST 'http://127.0.0.1:1234/rpc/v0' \
>     -H 'Content-Type: application/json' \
>     --data '{"jsonrpc":"2.0","id":1,"method":"Filecoin.StateGetNetworkParams","params":[]}'
{"jsonrpc":"2.0","result":{"NetworkName":"mainnet","BlockDelaySecs":30,"ConsensusMinerMinPower":"10995116277760","SupportedProofTypes":[3,4],"PreCommitChallengeDelay":150,"
------
UpgradeWatermelonHeight":3469380,"UpgradeDragonHeight":3855360,"UpgradePhoenixHeight":3855480},"Eip155ChainID":314},"id":1}
```

## Proposed Changes
Update the `SupportedProofsTypes` in `build/params_*` to the correct set of ProofTypes supported in the different networks.

## Additional Info
Given that nobody has not complained about this earlier, it brings the question if this field is worth keeping? 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
