### PR TITLE
chore: revert "Update SupportedProofTypes (#11988)"

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -88,10 +88,8 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg2KiBV1_1,
-	abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg8MiBV1_1,
-	abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg2KiBV1,
+	abi.RegisteredSealProof_StackedDrg8MiBV1,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2048)
 var MinVerifiedDealSize = abi.NewStoragePower(256)

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -71,12 +71,9 @@ const UpgradeWatermelonFix2Height = -101
 const UpgradeCalibrationDragonFixHeight = -102
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg512MiBV1_1,
-	abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg512MiBV1,
+	abi.RegisteredSealProof_StackedDrg32GiBV1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2 << 30)
 var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -102,10 +102,8 @@ const UpgradeCalibrationDragonFixHeight = 1493854
 const UpgradeAussieHeight = 999999999999999
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg32GiBV1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(32 << 30)
 var MinVerifiedDealSize = abi.NewStoragePower(1 << 20)

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -75,12 +75,9 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg2KiBV1_1,
-	abi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg8MiBV1_1,
-	abi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg512MiBV1_1,
-	abi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg2KiBV1,
+	abi.RegisteredSealProof_StackedDrg8MiBV1,
+	abi.RegisteredSealProof_StackedDrg512MiBV1,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(2048)
 var MinVerifiedDealSize = abi.NewStoragePower(256)

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -119,10 +119,8 @@ const UpgradeWatermelonFix2Height = -2
 const UpgradeCalibrationDragonFixHeight = -3
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1,
-	abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+	abi.RegisteredSealProof_StackedDrg32GiBV1,
+	abi.RegisteredSealProof_StackedDrg64GiBV1,
 }
 var ConsensusMinerMinPower = abi.NewStoragePower(10 << 40)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -35,10 +35,8 @@ var (
 	PropagationDelaySecs  = uint64(6)
 	EquivocationDelaySecs = uint64(2)
 	SupportedProofTypes   = []abi.RegisteredSealProof{
-		abi.RegisteredSealProof_StackedDrg32GiBV1_1,
-		abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
-		abi.RegisteredSealProof_StackedDrg64GiBV1_1,
-		abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep,
+		abi.RegisteredSealProof_StackedDrg32GiBV1,
+		abi.RegisteredSealProof_StackedDrg64GiBV1,
 	}
 	ConsensusMinerMinPower  = abi.NewStoragePower(10 << 40)
 	PreCommitChallengeDelay = abi.ChainEpoch(150)


### PR DESCRIPTION
#11988 was introduces earlier today, to update `SupportedProofTypes` in `Filecoin.StateGetNetworkParams` to return the correct ProofsTypes.

But this [change caused panics in tooling](https://filecoinproject.slack.com/archives/CP50PPW2X/p1715622977236679) used for spinning up devnets, and its not clear to me how to fix those, and if there are other connections in the above changes to the Lotus-Miner. For now it seems best to revert this PR, until we have a clearer view of how these pieces are connected.

## Proposed Changes
Revert #11988. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
