### PR TITLE
chore : CoreTypes : Remove stray C dependency

### DIFF
--- a/build/builtin_actors.go
+++ b/build/builtin_actors.go
@@ -12,10 +12,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/zstd"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/ipld/go-car"
+	"github.com/klauspost/compress/zstd"
 	"golang.org/x/xerrors"
 
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
@@ -160,7 +160,10 @@ func readEmbeddedBuiltinActorsMetadata(bundle string) ([]*BuiltinActorsMetadata,
 	}
 	defer fi.Close() //nolint
 
-	uncompressed := zstd.NewReader(fi)
+	uncompressed, err := zstd.NewReader(fi)
+	if err != nil {
+		return nil, err
+	}
 	defer uncompressed.Close() //nolint
 
 	var bundles []*BuiltinActorsMetadata
@@ -255,7 +258,10 @@ func GetEmbeddedBuiltinActorsBundle(version actorstypes.Version, networkBundleNa
 	}
 	defer fi.Close() //nolint
 
-	uncompressed := zstd.NewReader(fi)
+	uncompressed, err := zstd.NewReader(fi)
+	if err != nil {
+		return nil, false
+	}
 	defer uncompressed.Close() //nolint
 
 	tarReader := tar.NewReader(uncompressed)

--- a/build/builtin_actors_gen_test.go
+++ b/build/builtin_actors_gen_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/zstd"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car/v2"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
@@ -46,7 +46,9 @@ func TestEmbeddedBuiltinActorsMetadata(t *testing.T) {
 		cachedCar, err := os.Open(fmt.Sprintf("./actors/v%v.tar.zst", version))
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, cachedCar.Close()) })
-		tarReader := tar.NewReader(zstd.NewReader(cachedCar))
+		zstReader, err := zstd.NewReader(cachedCar)
+		require.NoError(t, err)
+		tarReader := tar.NewReader(zstReader)
 		for {
 			header, err := tarReader.Next()
 			if errors.Is(err, io.EOF) {

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/ipni/index-provider v0.12.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/klauspost/compress v1.17.8
 	github.com/koalacxr/quantile v0.0.1
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.33.2
@@ -263,7 +264,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
-	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -953,8 +953,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2eRGjI=
-github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
+github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
Without this change the following test fails:

`CGO_ENABLED=0 go test -count=1 ./chain/types_test.go`

Without this fix importing the chain types into a fully-static executable is not possible.

I am not adding a test, as that should be done within the CI harness somehow (there is no way to force-disable compile-time flags from a test itself). Someone more familiar with how tests are run on a macro-level (@rvagg ?) should add a one-liner somewhere so things do not regress in the future.