### PR TITLE
ci: fix: keep lotus checkout clean in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+          path: lotus
       - uses: actions/download-artifact@v4
         with:
           name: lotus-Linux-X64
@@ -95,11 +96,14 @@ jobs:
           distribution: goreleaser-pro
           version: latest
           args: release --clean --debug ${{ env.PUBLISH == 'false' && '--snapshot' || '' }}
+          workdir: lotus
         env:
           GITHUB_TOKEN: ${{ env.PUBLISH == 'true' && github.token || '' }}
           GORELEASER_KEY: ${{ env.PUBLISH == 'true' && secrets.GORELEASER_KEY || '' }}
       - run: ./scripts/generate-checksums.sh
+        working-directory: lotus
       - if: env.PUBLISH == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./scripts/publish-checksums.sh
+        working-directory: lotus


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/actions/runs/9124502463/job/25262400685#step:8:71

## Proposed Changes
<!-- A clear list of the changes being made -->
Check out lotus under `lotus` directory.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
By checking out `lotus` under a separate directory, we ensure that the checkout remains clean after we download prebuilt lotus binaries under other directories in the GitHub workspace directory. 

This should fix the issue we encountered with goreleaser complaining about the dirty state of the lotus checkout.

Here's a dry run ensuring that the new setup still works - https://github.com/filecoin-project/lotus/actions/runs/9186795575. 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
