### PR TITLE
fix: harmonydb: Use timestampz instead of timestamp across the schema

### DIFF
--- a/.github/actions/start-yugabytedb/action.yml
+++ b/.github/actions/start-yugabytedb/action.yml
@@ -4,7 +4,7 @@ description: Install Yugabyte Database for Filecoin Lotus
 runs:
   using: composite
   steps:
-    - run: docker run --rm --name yugabyte -d -p 5433:5433 yugabytedb/yugabyte:2.18.0.0-b65 bin/yugabyted start --daemon=false
+    - run: docker run --rm --name yugabyte -d -p 5433:5433 yugabytedb/yugabyte:2.21.0.1-b1 bin/yugabyted start --daemon=false
       shell: bash
     - run: |
         while true; do

--- a/lib/harmony/harmonydb/sql/20240522-ts-to-timestampz.sql
+++ b/lib/harmony/harmonydb/sql/20240522-ts-to-timestampz.sql
@@ -6,24 +6,32 @@ ALTER COLUMN last_contact TYPE TIMESTAMPTZ
 -- Convert timestamps in harmony_task table
 ALTER TABLE harmony_task
 ALTER COLUMN update_time TYPE TIMESTAMPTZ
-    USING update_time AT TIME ZONE 'UTC',
-    ALTER COLUMN posted_time TYPE TIMESTAMPTZ
+    USING update_time AT TIME ZONE 'UTC';
+
+ALTER TABLE harmony_task
+ALTER COLUMN posted_time TYPE TIMESTAMPTZ
     USING posted_time AT TIME ZONE 'UTC';
 
 -- Convert timestamps in harmony_task_history table
 ALTER TABLE harmony_task_history
 ALTER COLUMN posted TYPE TIMESTAMPTZ
-    USING posted AT TIME ZONE 'UTC',
-    ALTER COLUMN work_start TYPE TIMESTAMPTZ
-    USING work_start AT TIME ZONE 'UTC',
-    ALTER COLUMN work_end TYPE TIMESTAMPTZ
+    USING posted AT TIME ZONE 'UTC';
+
+ALTER TABLE harmony_task_history
+ALTER COLUMN work_start TYPE TIMESTAMPTZ
+    USING work_start AT TIME ZONE 'UTC';
+
+ALTER TABLE harmony_task_history
+ALTER COLUMN work_end TYPE TIMESTAMPTZ
     USING work_end AT TIME ZONE 'UTC';
 
 -- Convert timestamps in sector_location table
 ALTER TABLE sector_location
 ALTER COLUMN read_ts TYPE TIMESTAMPTZ
-    USING read_ts AT TIME ZONE 'UTC',
-    ALTER COLUMN write_ts TYPE TIMESTAMPTZ
+    USING read_ts AT TIME ZONE 'UTC';
+
+ALTER TABLE sector_location
+ALTER COLUMN write_ts TYPE TIMESTAMPTZ
     USING write_ts AT TIME ZONE 'UTC';
 
 -- Convert timestamps in storage_path table
@@ -34,10 +42,14 @@ ALTER COLUMN last_heartbeat TYPE TIMESTAMPTZ
 -- Convert timestamps in mining_tasks table
 ALTER TABLE mining_tasks
 ALTER COLUMN base_compute_time TYPE TIMESTAMPTZ
-    USING base_compute_time AT TIME ZONE 'UTC',
-    ALTER COLUMN mined_at TYPE TIMESTAMPTZ
-    USING mined_at AT TIME ZONE 'UTC',
-    ALTER COLUMN submitted_at TYPE TIMESTAMPTZ
+    USING base_compute_time AT TIME ZONE 'UTC';
+
+ALTER TABLE mining_tasks
+ALTER COLUMN mined_at TYPE TIMESTAMPTZ
+    USING mined_at AT TIME ZONE 'UTC';
+
+ALTER TABLE mining_tasks
+ALTER COLUMN submitted_at TYPE TIMESTAMPTZ
     USING submitted_at AT TIME ZONE 'UTC';
 
 -- Convert timestamps in itest_scratch table
@@ -63,10 +75,14 @@ ALTER COLUMN last_run_time TYPE TIMESTAMPTZ
 -- Convert timestamps in sector_path_url_liveness table
 ALTER TABLE sector_path_url_liveness
 ALTER COLUMN last_checked TYPE TIMESTAMPTZ
-    USING last_checked AT TIME ZONE 'UTC',
-    ALTER COLUMN last_live TYPE TIMESTAMPTZ
-    USING last_live AT TIME ZONE 'UTC',
-    ALTER COLUMN last_dead TYPE TIMESTAMPTZ
+    USING last_checked AT TIME ZONE 'UTC';
+
+ALTER TABLE sector_path_url_liveness
+ALTER COLUMN last_live TYPE TIMESTAMPTZ
+    USING last_live AT TIME ZONE 'UTC';
+
+ALTER TABLE sector_path_url_liveness
+ALTER COLUMN last_dead TYPE TIMESTAMPTZ
     USING last_dead AT TIME ZONE 'UTC';
 
 -- Convert timestamps in harmony_machine_details table
@@ -87,8 +103,10 @@ ALTER COLUMN created_at TYPE TIMESTAMPTZ
 -- Convert timestamps in sectors_sdr_pipeline table
 ALTER TABLE sectors_sdr_pipeline
 ALTER COLUMN create_time TYPE TIMESTAMPTZ
-    USING create_time AT TIME ZONE 'UTC',
-    ALTER COLUMN failed_at TYPE TIMESTAMPTZ
+    USING create_time AT TIME ZONE 'UTC';
+
+ALTER TABLE sectors_sdr_pipeline
+ALTER COLUMN failed_at TYPE TIMESTAMPTZ
     USING failed_at AT TIME ZONE 'UTC';
 
 -- Convert timestamps in sectors_sdr_initial_pieces table

--- a/lib/harmony/harmonydb/sql/20240522-ts-to-timestampz.sql
+++ b/lib/harmony/harmonydb/sql/20240522-ts-to-timestampz.sql
@@ -1,0 +1,97 @@
+-- Convert timestamps in harmony_machines table
+ALTER TABLE harmony_machines
+ALTER COLUMN last_contact TYPE TIMESTAMPTZ
+    USING last_contact AT TIME ZONE 'UTC';
+
+-- Convert timestamps in harmony_task table
+ALTER TABLE harmony_task
+ALTER COLUMN update_time TYPE TIMESTAMPTZ
+    USING update_time AT TIME ZONE 'UTC',
+    ALTER COLUMN posted_time TYPE TIMESTAMPTZ
+    USING posted_time AT TIME ZONE 'UTC';
+
+-- Convert timestamps in harmony_task_history table
+ALTER TABLE harmony_task_history
+ALTER COLUMN posted TYPE TIMESTAMPTZ
+    USING posted AT TIME ZONE 'UTC',
+    ALTER COLUMN work_start TYPE TIMESTAMPTZ
+    USING work_start AT TIME ZONE 'UTC',
+    ALTER COLUMN work_end TYPE TIMESTAMPTZ
+    USING work_end AT TIME ZONE 'UTC';
+
+-- Convert timestamps in sector_location table
+ALTER TABLE sector_location
+ALTER COLUMN read_ts TYPE TIMESTAMPTZ
+    USING read_ts AT TIME ZONE 'UTC',
+    ALTER COLUMN write_ts TYPE TIMESTAMPTZ
+    USING write_ts AT TIME ZONE 'UTC';
+
+-- Convert timestamps in storage_path table
+ALTER TABLE storage_path
+ALTER COLUMN last_heartbeat TYPE TIMESTAMPTZ
+    USING last_heartbeat AT TIME ZONE 'UTC';
+
+-- Convert timestamps in mining_tasks table
+ALTER TABLE mining_tasks
+ALTER COLUMN base_compute_time TYPE TIMESTAMPTZ
+    USING base_compute_time AT TIME ZONE 'UTC',
+    ALTER COLUMN mined_at TYPE TIMESTAMPTZ
+    USING mined_at AT TIME ZONE 'UTC',
+    ALTER COLUMN submitted_at TYPE TIMESTAMPTZ
+    USING submitted_at AT TIME ZONE 'UTC';
+
+-- Convert timestamps in itest_scratch table
+ALTER TABLE itest_scratch
+ALTER COLUMN update_time TYPE TIMESTAMPTZ
+    USING update_time AT TIME ZONE 'UTC';
+
+-- Convert timestamps in message_sends table
+ALTER TABLE message_sends
+ALTER COLUMN send_time TYPE TIMESTAMPTZ
+    USING send_time AT TIME ZONE 'UTC';
+
+-- Convert timestamps in message_send_locks table
+ALTER TABLE message_send_locks
+ALTER COLUMN claimed_at TYPE TIMESTAMPTZ
+    USING claimed_at AT TIME ZONE 'UTC';
+
+-- Convert timestamps in harmony_task_singletons table
+ALTER TABLE harmony_task_singletons
+ALTER COLUMN last_run_time TYPE TIMESTAMPTZ
+    USING last_run_time AT TIME ZONE 'UTC';
+
+-- Convert timestamps in sector_path_url_liveness table
+ALTER TABLE sector_path_url_liveness
+ALTER COLUMN last_checked TYPE TIMESTAMPTZ
+    USING last_checked AT TIME ZONE 'UTC',
+    ALTER COLUMN last_live TYPE TIMESTAMPTZ
+    USING last_live AT TIME ZONE 'UTC',
+    ALTER COLUMN last_dead TYPE TIMESTAMPTZ
+    USING last_dead AT TIME ZONE 'UTC';
+
+-- Convert timestamps in harmony_machine_details table
+ALTER TABLE harmony_machine_details
+ALTER COLUMN startup_time TYPE TIMESTAMPTZ
+    USING startup_time AT TIME ZONE 'UTC';
+
+-- Convert timestamps in open_sector_pieces table
+ALTER TABLE open_sector_pieces
+ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at AT TIME ZONE 'UTC';
+
+-- Convert timestamps in parked_pieces table
+ALTER TABLE parked_pieces
+ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at AT TIME ZONE 'UTC';
+
+-- Convert timestamps in sectors_sdr_pipeline table
+ALTER TABLE sectors_sdr_pipeline
+ALTER COLUMN create_time TYPE TIMESTAMPTZ
+    USING create_time AT TIME ZONE 'UTC',
+    ALTER COLUMN failed_at TYPE TIMESTAMPTZ
+    USING failed_at AT TIME ZONE 'UTC';
+
+-- Convert timestamps in sectors_sdr_initial_pieces table
+ALTER TABLE sectors_sdr_initial_pieces
+ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at AT TIME ZONE 'UTC';


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
It appears that pgx doesn't pay attention to time.Time timezone field, and fails to convert the time value to whatever Timezone the backing postgres (yb) is configured to run; At the same time our schema uses the `timestamp [without time zone]` type all over the place, and that type accounts for time is units of seconds starting at postgres epoch as defined in the databases local timezone.

To make postgres store time in terms of seconds since postgres epoch in UTC we need to switch to `timestampz` (iiuc same type as `TIMESTAMP WITH TIME ZONE`), or alternatively do `SET TIME ZONE 'UTC'` on all connections - tho that option is much less robust imo (falls apart when external application connects to the database which will then think that it is in a different TZ).

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
