### PR TITLE
fix: hello: avoid dialing when fetching hello tipset

### DIFF
--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	inet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -121,7 +122,10 @@ func (hs *Service) HandleStream(s inet.Stream) {
 		hs.pmgr.AddFilecoinPeer(s.Conn().RemotePeer())
 	}
 
-	ts, err := hs.syncer.FetchTipSet(context.Background(), s.Conn().RemotePeer(), types.NewTipSetKey(hmsg.HeaviestTipSet...))
+	// We're trying to fetch the tipset from the peer that just said hello to us. No point in
+	// triggering any dials.
+	ctx := network.WithNoDial(context.Background(), "fetching filecoin hello tipset")
+	ts, err := hs.syncer.FetchTipSet(ctx, s.Conn().RemotePeer(), types.NewTipSetKey(hmsg.HeaviestTipSet...))
 	if err != nil {
 		log.Errorf("failed to fetch tipset from peer during hello: %+v", err)
 		return


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

We should already be connected to this peer and we're only fetching this tipset opportunistically. If we've already disconnected from them, move on.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green