### PR TITLE
feat!: build: separate miner and node version strings

### DIFF
--- a/api/docgen-openrpc/openrpc.go
+++ b/api/docgen-openrpc/openrpc.go
@@ -106,7 +106,7 @@ func NewLotusOpenRPCDocument(Comments, GroupDocs map[string]string) *go_openrpc_
 			title := "Lotus RPC API"
 			info.Title = (*meta_schema.InfoObjectProperties)(&title)
 
-			version := build.BuildVersion
+			version := build.NodeBuildVersion
 			info.Version = (*meta_schema.InfoObjectVersion)(&version)
 			return info
 		},

--- a/build/version.go
+++ b/build/version.go
@@ -2,6 +2,8 @@ package build
 
 import "os"
 
+type BuildVersion string
+
 var CurrentCommit string
 var BuildType int
 
@@ -36,13 +38,24 @@ func BuildTypeString() string {
 	}
 }
 
-// BuildVersion is the local build version
-const BuildVersion = "1.27.1-dev"
+// NodeBuildVersion is the local build version of the Lotus daemon
+const NodeBuildVersion string = "1.27.1-dev"
 
-func UserVersion() string {
+func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
-		return BuildVersion
+		return BuildVersion(NodeBuildVersion)
 	}
 
-	return BuildVersion + BuildTypeString() + CurrentCommit
+	return BuildVersion(NodeBuildVersion + BuildTypeString() + CurrentCommit)
+}
+
+// MinerBuildVersion is the local build version of the Lotus miner
+const MinerBuildVersion = "1.27.1-dev"
+
+func MinerUserVersion() BuildVersion {
+	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
+		return BuildVersion(MinerBuildVersion)
+	}
+
+	return BuildVersion(MinerBuildVersion + BuildTypeString() + CurrentCommit)
 }

--- a/chain/beacon/drand/drand.go
+++ b/chain/beacon/drand/drand.go
@@ -97,7 +97,7 @@ func NewDrandBeacon(genesisTs, interval uint64, ps *pubsub.PubSub, config dtypes
 		if err != nil {
 			return nil, xerrors.Errorf("could not create http drand client: %w", err)
 		}
-		hc.(DrandHTTPClient).SetUserAgent("drand-client-lotus/" + build.BuildVersion)
+		hc.(DrandHTTPClient).SetUserAgent("drand-client-lotus/" + build.NodeBuildVersion)
 		clients = append(clients, hc)
 
 	}

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -100,7 +100,7 @@ func main() {
 	app := &cli.App{
 		Name:                      "lotus-bench",
 		Usage:                     "Benchmark performance of lotus on your hardware",
-		Version:                   build.UserVersion(),
+		Version:                   string(build.NodeUserVersion()),
 		DisableSliceFlagSeparator: true,
 		Commands: []*cli.Command{
 			proveCmd,

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -41,7 +41,7 @@ func main() {
 	app := &cli.App{
 		Name:    "lotus-fountain",
 		Usage:   "Devnet token distribution utility",
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "repo",

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -40,7 +40,7 @@ func main() {
 	app := &cli.App{
 		Name:    "lotus-gateway",
 		Usage:   "Public API server for lotus",
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "repo",

--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -36,7 +36,7 @@ func main() {
 	app := &cli.App{
 		Name:     "lotus-health",
 		Usage:    "Tools for monitoring lotus daemon health",
-		Version:  build.UserVersion(),
+		Version:  string(build.NodeUserVersion()),
 		Commands: local,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/lotus-miner/main.go
+++ b/cmd/lotus-miner/main.go
@@ -101,7 +101,7 @@ func main() {
 	app := &cli.App{
 		Name:                 "lotus-miner",
 		Usage:                "Filecoin decentralized storage network miner",
-		Version:              build.UserVersion(),
+		Version:              string(build.MinerUserVersion()),
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -159,7 +159,7 @@ func main() {
 		After: func(c *cli.Context) error {
 			if r := recover(); r != nil {
 				// Generate report in LOTUS_PATH and re-raise panic
-				build.GeneratePanicReport(c.String("panic-reports"), c.String(FlagMinerRepo), c.App.Name)
+				build.GenerateMinerPanicReport(c.String("panic-reports"), c.String(FlagMinerRepo), c.App.Name)
 				panic(r)
 			}
 			return nil

--- a/cmd/lotus-miner/run.go
+++ b/cmd/lotus-miner/run.go
@@ -57,7 +57,7 @@ var runCmd = &cli.Command{
 		}
 
 		ctx, _ := tag.New(lcli.DaemonContext(cctx),
-			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Version, build.MinerBuildVersion),
 			tag.Insert(metrics.Commit, build.CurrentCommit),
 			tag.Insert(metrics.NodeType, "miner"),
 		)

--- a/cmd/lotus-pcr/main.go
+++ b/cmd/lotus-pcr/main.go
@@ -70,7 +70,7 @@ func main() {
    A single message will be produced per miner totaling their refund for all PreCommitSector messages
    in a tipset.
 `,
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "lotus-path",

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -38,7 +38,7 @@ func main() {
 	app := &cli.App{
 		Name:    "lotus-seed",
 		Usage:   "Seal sectors for genesis miner",
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "sector-dir",

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -97,7 +97,7 @@ func main() {
 	app := &cli.App{
 		Name:     "lotus-shed",
 		Usage:    "A place for all the lotus tools",
-		Version:  build.UserVersion(),
+		Version:  string(build.NodeUserVersion()),
 		Commands: local,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/lotus-stats/main.go
+++ b/cmd/lotus-stats/main.go
@@ -42,7 +42,7 @@ func main() {
 	app := &cli.App{
 		Name:    "lotus-stats",
 		Usage:   "Collect basic information about a filecoin network using lotus",
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "lotus-path",

--- a/cmd/lotus-wallet/main.go
+++ b/cmd/lotus-wallet/main.go
@@ -52,7 +52,7 @@ func main() {
 	app := &cli.App{
 		Name:    "lotus-wallet",
 		Usage:   "Basic external wallet",
-		Version: build.UserVersion(),
+		Version: string(build.NodeUserVersion()),
 		Description: `
 lotus-wallet provides a remote wallet service for lotus.
 

--- a/cmd/lotus-worker/main.go
+++ b/cmd/lotus-worker/main.go
@@ -70,7 +70,7 @@ func main() {
 	app := &cli.App{
 		Name:                 "lotus-worker",
 		Usage:                "Remote miner worker",
-		Version:              build.UserVersion(),
+		Version:              string(build.MinerUserVersion()),
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -104,7 +104,7 @@ func main() {
 		After: func(c *cli.Context) error {
 			if r := recover(); r != nil {
 				// Generate report in LOTUS_PANIC_REPORT_PATH and re-raise panic
-				build.GeneratePanicReport(c.String("panic-reports"), c.String(FlagWorkerRepo), c.App.Name)
+				build.GenerateMinerPanicReport(c.String("panic-reports"), c.String(FlagWorkerRepo), c.App.Name)
 				panic(r)
 			}
 			return nil

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -209,7 +209,7 @@ var DaemonCmd = &cli.Command{
 		}
 
 		ctx, _ := tag.New(context.Background(),
-			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Version, build.NodeBuildVersion),
 			tag.Insert(metrics.Commit, build.CurrentCommit),
 			tag.Insert(metrics.NodeType, "chain"),
 		)

--- a/cmd/lotus/main.go
+++ b/cmd/lotus/main.go
@@ -72,7 +72,7 @@ func main() {
 	app := &cli.App{
 		Name:                 "lotus",
 		Usage:                "Filecoin decentralized storage network client",
-		Version:              build.UserVersion(),
+		Version:              string(build.NodeUserVersion()),
 		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -107,7 +107,7 @@ func main() {
 		After: func(c *cli.Context) error {
 			if r := recover(); r != nil {
 				// Generate report in LOTUS_PATH and re-raise panic
-				build.GeneratePanicReport(c.String("panic-reports"), c.String("repo"), c.App.Name)
+				build.GenerateNodePanicReport(c.String("panic-reports"), c.String("repo"), c.App.Name)
 				panic(r)
 			}
 			return nil

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -74,7 +74,7 @@ func (ts *apiSuite) testVersion(t *testing.T) {
 
 	versions := strings.Split(v.Version, "+")
 	require.NotZero(t, len(versions), "empty version")
-	require.Equal(t, versions[0], build.BuildVersion)
+	require.Equal(t, versions[0], build.NodeBuildVersion)
 }
 
 func (ts *apiSuite) testID(t *testing.T) {

--- a/node/builder.go
+++ b/node/builder.go
@@ -266,12 +266,13 @@ func Base() Option {
 }
 
 // Config sets up constructors based on the provided Config
-func ConfigCommon(cfg *config.Common, enableLibp2pNode bool) Option {
+func ConfigCommon(cfg *config.Common, buildVersion build.BuildVersion, enableLibp2pNode bool) Option {
 	// setup logging early
 	lotuslog.SetLevelsFromConfig(cfg.Logging.SubsystemLevels)
 
 	return Options(
 		func(s *Settings) error { s.Config = true; return nil },
+		Override(new(build.BuildVersion), buildVersion),
 		Override(new(dtypes.APIEndpoint), func() (dtypes.APIEndpoint, error) {
 			return multiaddr.NewMultiaddr(cfg.API.ListenAddress)
 		}),

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/consensus"
@@ -184,7 +185,7 @@ func ConfigFullNode(c interface{}) Option {
 	enableLibp2pNode := true // always enable libp2p for full nodes
 
 	return Options(
-		ConfigCommon(&cfg.Common, enableLibp2pNode),
+		ConfigCommon(&cfg.Common, build.NodeUserVersion(), enableLibp2pNode),
 
 		Override(new(dtypes.UniversalBlockstore), modules.UniversalBlockstore),
 

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -84,7 +84,7 @@ func ConfigStorageMiner(c interface{}) Option {
 		Override(new(dtypes.DrandSchedule), modules.BuiltinDrandConfig),
 		Override(new(dtypes.BootstrapPeers), modules.BuiltinBootstrap),
 		Override(new(dtypes.DrandBootstrap), modules.DrandBootstrap),
-		ConfigCommon(&cfg.Common, enableLibp2pNode),
+		ConfigCommon(&cfg.Common, build.NodeUserVersion(), enableLibp2pNode),
 
 		Override(CheckFDLimit, modules.CheckFdLimit(build.MinerFDLimit)), // recommend at least 100k FD limit to miners
 

--- a/node/impl/common/common.go
+++ b/node/impl/common/common.go
@@ -24,6 +24,8 @@ var session = uuid.New()
 type CommonAPI struct {
 	fx.In
 
+	BuildVersion build.BuildVersion
+
 	Alerting     *alerting.Alerting
 	APISecret    *dtypes.APIAlg
 	ShutdownChan dtypes.ShutdownChan
@@ -63,7 +65,7 @@ func (a *CommonAPI) Version(context.Context) (api.APIVersion, error) {
 	}
 
 	return api.APIVersion{
-		Version:    build.UserVersion(),
+		Version:    string(a.BuildVersion),
 		APIVersion: v,
 
 		BlockDelay: build.BlockDelaySecs,

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -836,7 +836,7 @@ func (a *EthModule) EthSendRawTransaction(ctx context.Context, rawTx ethtypes.Et
 }
 
 func (a *EthModule) Web3ClientVersion(ctx context.Context) (string, error) {
-	return build.UserVersion(), nil
+	return string(build.NodeUserVersion()), nil
 }
 
 func (a *EthModule) EthTraceBlock(ctx context.Context, blkNum string) ([]*ethtypes.EthTraceBlock, error) {

--- a/node/modules/lp2p/host.go
+++ b/node/modules/lp2p/host.go
@@ -38,7 +38,7 @@ func Peerstore() (peerstore.Peerstore, error) {
 	return pstoremem.NewPeerstore()
 }
 
-func Host(mctx helpers.MetricsCtx, lc fx.Lifecycle, params P2PHostIn) (RawHost, error) {
+func Host(mctx helpers.MetricsCtx, buildVersion build.BuildVersion, lc fx.Lifecycle, params P2PHostIn) (RawHost, error) {
 	pkey := params.Peerstore.PrivKey(params.ID)
 	if pkey == nil {
 		return nil, fmt.Errorf("missing private key for node ID: %s", params.ID)
@@ -49,7 +49,7 @@ func Host(mctx helpers.MetricsCtx, lc fx.Lifecycle, params P2PHostIn) (RawHost, 
 		libp2p.Peerstore(params.Peerstore),
 		libp2p.NoListenAddrs,
 		libp2p.Ping(true),
-		libp2p.UserAgent("lotus-" + build.UserVersion()),
+		libp2p.UserAgent("lotus-" + string(buildVersion)),
 	}
 	for _, o := range params.Opts {
 		opts = append(opts, o...)


### PR DESCRIPTION
_Proposal asking for feedback._

This removes `build.BuildVersion` and `build.UserVersion()` and replaces them with `build.NodeBuildVersion`, `build.MinerBuildVersion` and `build.NodeUserVersion()`, `build.MinerUserVersion()` so they can be incremented separately.

Why? Because as per https://github.com/filecoin-project/lotus/issues/12010 we would like to be able to release them separately. This has two problems:

1. Once we fix the version number in here without a `-dev` and tag it, you can build both miner and node with that version string and it looks official. But, we may be prepared to release one and not the other (node vs miner) and may consider one of them not release-ready so not deserving of an official release.
2. We would like to automate the build and release process such that it only produces the binaries we want, either node or miner, not both, so we can release them separately and clearly signal such.

I'm thinking that we could copy the ipdx `version.json` pattern implemented by https://github.com/ipdxco/unified-github-workflows/blob/main/.github/workflows/release-check.yml but with some minor tweaks.

Instead of doing the version.json check:

```sh
version="$(gh api -X GET "repos/$HEAD_FULL_NAME/contents/version.json" -f ref="$HEAD_SHA" --jq '.content' | base64 -d | jq -r '.version')"
```

We could run two checks on PRs (probably just on the `releases` branch?):

```sh
node_version="$(gh api -X GET "repos/$HEAD_FULL_NAME/contents/build/version.go" -f ref="$HEAD_SHA" --jq '.content' | base64 -d | grep '^const NodeBuildVersion = ' | cut -d\" -f2)"
miner_version="$(gh api -X GET "repos/$HEAD_FULL_NAME/contents/build/version.go" -f ref="$HEAD_SHA" --jq '.content' | base64 -d | grep '^const MinerBuildVersion = ' | cut -d\" -f2)"
```

Then, for both:

1. If it ends in `-dev`, no more need for further checks.
2. If there isn't a tag for that version and proceed with roughly the same things it does now, including making a draft release that can be further edited (could even build in some smarts to copypasta the versioned section of the changelog, but that'd be a stretch-goal).
3. It needs to remember whether it's `Node` or `Miner` and then either run `make deps lotus` or `make deps lotus-miner lotus-worker` and also probably do something different on the release draft.

I'm not sure yet what it should do if they both pass that, probably that just shouldn't be allowed and it has an error condition with a "nope" comment in the PR.