### PR TITLE
Manual CC & Snapdeals onboarding (No NI-Porep)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,7 @@ jobs:
               "itest-deals",
               "itest-direct_data_onboard_verified",
               "itest-direct_data_onboard",
+              "itest-manual_onboarding",
               "itest-net",
               "itest-path_detach_redeclare",
               "itest-path_type_filters",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
               "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-lite_migration": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "xlarge"],
+              "itest-manual_onboarding": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-mempool": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-mpool_msg_uuid": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "xlarge"],

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -329,39 +329,6 @@ func (n *Ensemble) MinerEnroll(minerNode *TestMiner, full *TestFullNode, opts ..
 	return n
 }
 
-func (n *Ensemble) UnmanagedMinerEnroll(minerNode *TestUnmanagedMiner, full *TestFullNode, opts ...NodeOpt) *Ensemble {
-	require.NotNil(n.t, full, "full node required when instantiating miner")
-
-	options := DefaultNodeOpts
-	for _, o := range opts {
-		err := o(&options)
-		require.NoError(n.t, err)
-	}
-
-	privkey, _, err := libp2pcrypto.GenerateEd25519Key(rand.Reader)
-	require.NoError(n.t, err)
-
-	peerId, err := peer.IDFromPrivateKey(privkey)
-	require.NoError(n.t, err)
-
-	actorAddr, err := address.NewIDAddress(genesis2.MinerStart + n.minerCount())
-	require.NoError(n.t, err)
-
-	require.NotNil(n.t, options.ownerKey, "manual miner key can't be null if initializing a miner after genesis")
-
-	*minerNode = TestUnmanagedMiner{
-		t:         n.t,
-		options:   options,
-		ActorAddr: actorAddr,
-		OwnerKey:  options.ownerKey,
-		FullNode:  full,
-	}
-	minerNode.Libp2p.PeerID = peerId
-	minerNode.Libp2p.PrivKey = privkey
-
-	return n
-}
-
 func (n *Ensemble) AddInactiveMiner(m *TestMiner) {
 	n.inactive.miners = append(n.inactive.miners, m)
 }
@@ -376,10 +343,13 @@ func (n *Ensemble) Miner(minerNode *TestMiner, full *TestFullNode, opts ...NodeO
 	return n
 }
 
-func (n *Ensemble) UnmanagedMiner(minerNode *TestUnmanagedMiner, full *TestFullNode, opts ...NodeOpt) *Ensemble {
-	n.UnmanagedMinerEnroll(minerNode, full, opts...)
+func (n *Ensemble) UnmanagedMiner(full *TestFullNode, opts ...NodeOpt) (*TestUnmanagedMiner, *Ensemble) {
+	actorAddr, err := address.NewIDAddress(genesis2.MinerStart + n.minerCount())
+	require.NoError(n.t, err)
+
+	minerNode := NewTestUnmanagedMiner(n.t, full, actorAddr, opts...)
 	n.AddInactiveUnmanagedMiner(minerNode)
-	return n
+	return minerNode, n
 }
 
 // Worker enrolls a new worker, using the provided full node for chain

--- a/itests/kit/node_full.go
+++ b/itests/kit/node_full.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"golang.org/x/xerrors"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -1,17 +1,26 @@
 package kit
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
 	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
 	cbg "github.com/whyrusleeping/cbor-gen"
-	"testing"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/wallet/key"
@@ -23,8 +32,19 @@ import (
 // infrastructure, all tasks must be manually executed, managed and scheduled by
 // the test or test kit.
 type TestUnmanagedMiner struct {
-	t       *testing.T
-	options nodeOpts
+	t                 *testing.T
+	options           nodeOpts
+	cacheDir          string
+	unsealedSectorDir string
+	sealedSectorDir   string
+	sectorSize        abi.SectorSize
+
+	CacheDirPaths       map[abi.SectorNumber]string
+	UnsealedSectorPaths map[abi.SectorNumber]string
+	SealedSectorPaths   map[abi.SectorNumber]string
+	SealedCids          map[abi.SectorNumber]cid.Cid
+	UnsealedCids        map[abi.SectorNumber]cid.Cid
+	SealTickets         map[abi.SectorNumber]abi.SealRandomness
 
 	ActorAddr address.Address
 	OwnerKey  *key.Key
@@ -33,179 +53,336 @@ type TestUnmanagedMiner struct {
 		PeerID  peer.ID
 		PrivKey libp2pcrypto.PrivKey
 	}
+
+	currentSectorNum abi.SectorNumber
 }
 
-func (tm *TestUnmanagedMiner) StartWindowedPostLoop(ctx context.Context, sectorNumber abi.SectorNumber, proofType abi.RegisteredSealProof) {
-	tm.t.Helper()
+func NewTestUnmanagedMiner(t *testing.T, full *TestFullNode, actorAddr address.Address, opts ...NodeOpt) *TestUnmanagedMiner {
+	require.NotNil(t, full, "full node required when instantiating miner")
 
-	go func() {
-		for ctx.Err() == nil {
-			currentEpoch, nextPost, err := tm.manualOnboardingCalculateNextPostEpoch(ctx, sectorNumber)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			nextPost += 5 // give a little buffer
-			fmt.Printf("WindowPoST(%d) Waiting %d until epoch %d to submit PoSt\n", sectorNumber, nextPost-currentEpoch, nextPost)
+	options := DefaultNodeOpts
+	for _, o := range opts {
+		err := o(&options)
+		require.NoError(t, err)
+	}
 
-			// Create channel to listen for chain head
-			heads, err := tm.FullNode.ChainNotify(ctx)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			// Wait for nextPost epoch
-			for chg := range heads {
-				var ts *types.TipSet
-				for _, c := range chg {
-					if c.Type != "apply" {
-						continue
-					}
-					ts = c.Val
-					if ts.Height() >= nextPost {
-						break
-					}
-				}
-				if ctx.Err() != nil {
-					return
-				}
-				if ts != nil && ts.Height() >= nextPost {
-					break
-				}
-			}
-			if ctx.Err() != nil {
-				return
-			}
+	privkey, _, err := libp2pcrypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
 
-			err = manualOnboardingSubmitWindowPost(ctx, withMockProofs, client, miner, sectorNumber, cacheDirPath, sealedSectorPath, sealedCid, proofType)
-			if err != nil {
-				errCh <- err
-				return
-			}
+	require.NotNil(t, options.ownerKey, "manual miner key can't be null if initializing a miner after genesis")
 
-			// signal first post is done
-			select {
-			case <-first:
-			default:
-				close(first)
-			}
-		}
-	}()
+	peerId, err := peer.IDFromPrivateKey(privkey)
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+
+	cacheDir := filepath.Join(tmpDir, fmt.Sprintf("cache-%s", actorAddr))
+	unsealedSectorDir := filepath.Join(tmpDir, fmt.Sprintf("unsealed-%s", actorAddr))
+	sealedSectorDir := filepath.Join(tmpDir, fmt.Sprintf("sealed-%s", actorAddr))
+
+	_ = os.Mkdir(cacheDir, 0755)
+	_ = os.Mkdir(unsealedSectorDir, 0755)
+	_ = os.Mkdir(sealedSectorDir, 0755)
+
+	tm := TestUnmanagedMiner{
+		t:                 t,
+		options:           options,
+		cacheDir:          cacheDir,
+		unsealedSectorDir: unsealedSectorDir,
+		sealedSectorDir:   sealedSectorDir,
+
+		CacheDirPaths:       make(map[abi.SectorNumber]string),
+		UnsealedSectorPaths: make(map[abi.SectorNumber]string),
+		SealedSectorPaths:   make(map[abi.SectorNumber]string),
+		SealedCids:          make(map[abi.SectorNumber]cid.Cid),
+		UnsealedCids:        make(map[abi.SectorNumber]cid.Cid),
+		SealTickets:         make(map[abi.SectorNumber]abi.SealRandomness),
+
+		ActorAddr:        actorAddr,
+		OwnerKey:         options.ownerKey,
+		FullNode:         full,
+		currentSectorNum: 101,
+	}
+	tm.Libp2p.PeerID = peerId
+	tm.Libp2p.PrivKey = privkey
+
+	return &tm
 }
 
-func (tm *TestUnmanagedMiner) manualOnboardingCalculateNextPostEpoch(
-	ctx context.Context,
-	sectorNumber abi.SectorNumber,
-) (abi.ChainEpoch, abi.ChainEpoch, error) {
+func (tm *TestUnmanagedMiner) CurrentPower(ctx context.Context) *api.MinerPower {
+	head, err := tm.FullNode.ChainHead(ctx)
+	require.NoError(tm.t, err)
+
+	p, err := tm.FullNode.StateMinerPower(ctx, tm.ActorAddr, head.Key())
+	require.NoError(tm.t, err)
+
+	return p
+}
+
+func (tm *TestUnmanagedMiner) AssertNoPower(ctx context.Context) {
+	p := tm.CurrentPower(ctx)
+	tm.t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	require.True(tm.t, p.MinerPower.RawBytePower.IsZero())
+}
+
+func (tm *TestUnmanagedMiner) AssertPower(ctx context.Context, raw uint64, qa uint64) {
+	req := require.New(tm.t)
+	p := tm.CurrentPower(ctx)
+	tm.t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	req.Equal(raw, p.MinerPower.RawBytePower.Uint64())
+	req.Equal(qa, p.MinerPower.QualityAdjPower.Uint64())
+
+}
+
+func (tm *TestUnmanagedMiner) OnboardCCSectorWithMockProofs(ctx context.Context, proofType abi.RegisteredSealProof) abi.SectorNumber {
+	req := require.New(tm.t)
+	sectorNumber := tm.currentSectorNum
+	tm.currentSectorNum++
+
+	tm.SealedCids[sectorNumber] = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
+
+	var sealRandEpoch abi.ChainEpoch
 
 	head, err := tm.FullNode.ChainHead(ctx)
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get chain head: %w", err)
-	}
+	require.NoError(tm.t, err)
 
-	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get sector partition: %w", err)
-	}
-
-	fmt.Printf("WindowPoST(%d): SectorPartition: %+v\n", sectorNumber, sp)
-
-	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-
-	fmt.Printf("WindowPoST(%d): ProvingDeadline: %+v\n", sectorNumber, di)
-
-	// periodStart tells us the first epoch of the current proving period (24h)
-	// although it may be in the future if we don't need to submit post in this period
-	periodStart := di.PeriodStart
-	if di.PeriodStart < di.CurrentEpoch && sp.Deadline <= di.Index {
-		// the deadline we want has past in this current proving period, so wait till the next one
-		periodStart += di.WPoStProvingPeriod
-	}
-	provingEpoch := periodStart + (di.WPoStProvingPeriod/abi.ChainEpoch(di.WPoStPeriodDeadlines))*abi.ChainEpoch(sp.Deadline)
-
-	return di.CurrentEpoch, provingEpoch, nil
-}
-
-func (tm *TestUnmanagedMiner) manualOnboardingSubmitWindowPost(
-	ctx context.Context,
-	withMockProofs bool,
-	sectorNumber abi.SectorNumber,
-	cacheDirPath, sealedSectorPath string,
-	sealedCid cid.Cid,
-	proofType abi.RegisteredSealProof,
-) error {
-	fmt.Printf("WindowPoST(%d): Running WindowPoSt ...\n", sectorNumber)
-
-	head, err := tm.FullNode.ChainHead(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get chain head: %w", err)
-	}
-
-	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get sector partition: %w", err)
-	}
-
-	// We should be up to the deadline we care about
-	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-	fmt.Printf("WindowPoST(%d): SectorPartition: %+v, ProvingDeadline: %+v\n", sectorNumber, sp, di)
-	if di.Index != sp.Deadline {
-		return fmt.Errorf("sector %d is not in the deadline %d, but %d", sectorNumber, sp.Deadline, di.Index)
-	}
-
-	var proofBytes []byte
-	if withMockProofs {
-		proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+	if head.Height() > policy.SealRandomnessLookback {
+		sealRandEpoch = head.Height() - policy.SealRandomnessLookback
 	} else {
-		proofBytes, err = manualOnboardingGenerateWindowPost(ctx, tm.FullNode, cacheDirPath, sealedSectorPath, tm.ActorAddr, sectorNumber, sealedCid, proofType)
-		if err != nil {
-			return fmt.Errorf("failed to generate window post: %w", err)
-		}
+		sealRandEpoch = policy.SealRandomnessLookback
+		tm.t.Logf("Waiting for at least epoch %d for seal randomness (current epoch %d) ...", sealRandEpoch+5, head.Height())
+		tm.FullNode.WaitTillChain(ctx, HeightAtLeast(sealRandEpoch+5))
 	}
 
-	fmt.Printf("WindowedPoSt(%d) Submitting ...\n", sectorNumber)
+	// Step 4 : Submit the Pre-Commit to the network
+	r := tm.manualOnboardingSubmitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
+		Sectors: []miner14.SectorPreCommitInfo{{
+			Expiration:    2880 * 300,
+			SectorNumber:  sectorNumber,
+			SealProof:     TestSpt,
+			SealedCID:     tm.SealedCids[sectorNumber],
+			SealRandEpoch: sealRandEpoch,
+		}},
+	}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
+	req.True(r.Receipt.ExitCode.IsSuccess())
 
-	chainRandomnessEpoch := di.Challenge
-	chainRandomness, err := tm.FullNode.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, chainRandomnessEpoch, nil, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get chain randomness: %w", err)
+	_, err = tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, r.TipSet)
+	req.NoError(err)
+
+	sectorProof := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	var seedRandomnessHeight abi.ChainEpoch
+
+	head, err = tm.FullNode.ChainHead(ctx)
+	require.NoError(tm.t, err)
+	preCommitInfo, err := tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	req.NoError(err)
+	seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+
+	tm.t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-head.Height(), seedRandomnessHeight, head.Height())
+	tm.FullNode.WaitTillChain(ctx, HeightAtLeast(seedRandomnessHeight+5))
+
+	r = tm.manualOnboardingSubmitMessage(ctx, &miner14.ProveCommitSectors3Params{
+		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: sectorNumber}},
+		SectorProofs:             [][]byte{sectorProof},
+		RequireActivationSuccess: true,
+	}, 0, builtin.MethodsMiner.ProveCommitSectors3)
+	req.NoError(err)
+	req.True(r.Receipt.ExitCode.IsSuccess())
+
+	return sectorNumber
+}
+
+func (tm *TestUnmanagedMiner) OnboardCCSectorWithRealProofs(ctx context.Context, proofType abi.RegisteredSealProof) abi.SectorNumber {
+	req := require.New(tm.t)
+	sectorNumber := tm.currentSectorNum
+	tm.currentSectorNum++
+
+	// --------------------Create pre-commit for the CC sector -> we'll just pre-commit `sector size` worth of 0s for this CC sector
+
+	// Step 1: Wait for the seal randomness to be available -> we want to draw seal randomess from a tipset that has achieved finality as PoReps are expensive to generate
+	// See if we already have such a epoch and wait if not
+	head, err := tm.FullNode.ChainHead(ctx)
+	require.NoError(tm.t, err)
+	var sealRandEpoch abi.ChainEpoch
+
+	if head.Height() > policy.SealRandomnessLookback {
+		sealRandEpoch = head.Height() - policy.SealRandomnessLookback
+	} else {
+		sealRandEpoch = policy.SealRandomnessLookback
+		tm.t.Logf("Waiting for at least epoch %d for seal randomness (current epoch %d) ...", sealRandEpoch+5, head.Height())
+		tm.FullNode.WaitTillChain(ctx, HeightAtLeast(sealRandEpoch+5))
 	}
 
-	minerInfo, err := tm.FullNode.StateMinerInfo(ctx, tm.ActorAddr, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get miner info: %w", err)
-	}
+	// Step 2: Write empty 32 bytes that we want to seal i.e. create our CC sector
+	unsealedSectorPath := filepath.Join(tm.unsealedSectorDir, fmt.Sprintf("%d", sectorNumber))
+	sealedSectorPath := filepath.Join(tm.sealedSectorDir, fmt.Sprintf("%d", sectorNumber))
 
-	r, err := manualOnboardingSubmitMessage(ctx, tm.FullNode, miner, &miner14.SubmitWindowedPoStParams{
-		ChainCommitEpoch: chainRandomnessEpoch,
-		ChainCommitRand:  chainRandomness,
-		Deadline:         sp.Deadline,
-		Partitions:       []miner14.PoStPartition{{Index: sp.Partition}},
-		Proofs:           []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
-	}, 0, builtin.MethodsMiner.SubmitWindowedPoSt)
-	if err != nil {
-		return fmt.Errorf("failed to submit PoSt: %w", err)
-	}
-	if !r.Receipt.ExitCode.IsSuccess() {
-		return fmt.Errorf("submitting PoSt failed: %s", r.Receipt.ExitCode)
-	}
+	unsealedSize := abi.PaddedPieceSize(tm.sectorSize).Unpadded()
+	req.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
+	req.NoError(os.WriteFile(sealedSectorPath, make([]byte, tm.sectorSize), 0644))
 
-	if !withMockProofs {
-		// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
-		if err := manualOnboardingDisputeWindowPost(ctx, client, miner, sectorNumber); err != nil {
-			return fmt.Errorf("failed to dispute PoSt: %w", err)
-		}
-	}
-	return nil
+	tm.t.Logf("Wrote unsealed sector to %s", unsealedSectorPath)
+	tm.t.Logf("Wrote sealed sector to %s", sealedSectorPath)
+
+	// Step 3: Generate a Pre-Commit for the CC sector -> this persists the proof on the Miner State
+	tm.manualOnboardingGeneratePreCommit(ctx, tm.cacheDir, unsealedSectorPath, sealedSectorPath, sectorNumber, sealRandEpoch, proofType)
+
+	// Step 4 : Submit the Pre-Commit to the network
+	r := tm.manualOnboardingSubmitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
+		Sectors: []miner14.SectorPreCommitInfo{{
+			Expiration:    2880 * 300,
+			SectorNumber:  sectorNumber,
+			SealProof:     TestSpt,
+			SealedCID:     tm.SealedCids[sectorNumber],
+			SealRandEpoch: sealRandEpoch,
+		}},
+	}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
+	req.True(r.Receipt.ExitCode.IsSuccess())
+
+	_, err = tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, r.TipSet)
+	req.NoError(err)
+
+	// Step 5: Generate a ProveCommit for the CC sector
+	proveCommit := tm.manualOnboardingGenerateProveCommit(ctx, sectorNumber, proofType)
+
+	// Step 6: Submit the ProveCommit to the network
+	tm.t.Log("Submitting MinerB ProveCommitSector ...")
+
+	r = tm.manualOnboardingSubmitMessage(ctx, &miner14.ProveCommitSectors3Params{
+		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: sectorNumber}},
+		SectorProofs:             [][]byte{proveCommit},
+		RequireActivationSuccess: true,
+	}, 0, builtin.MethodsMiner.ProveCommitSectors3)
+	req.NoError(err)
+	req.True(r.Receipt.ExitCode.IsSuccess())
+
+	return sectorNumber
+}
+
+func (tm *TestUnmanagedMiner) manualOnboardingGeneratePreCommit(
+	ctx context.Context,
+	cacheDirPath string,
+	unsealedSectorPath string,
+	sealedSectorPath string,
+	sectorNumber abi.SectorNumber,
+	sealRandEpoch abi.ChainEpoch,
+	proofType abi.RegisteredSealProof,
+) {
+
+	req := require.New(tm.t)
+	tm.t.Logf("Generating proof type %d PreCommit ...", proofType)
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	req.NoError(err)
+
+	minerAddrBytes := new(bytes.Buffer)
+	req.NoError(tm.ActorAddr.MarshalCBOR(minerAddrBytes))
+
+	rand, err := tm.FullNode.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_SealRandomness, sealRandEpoch, minerAddrBytes.Bytes(), head.Key())
+	req.NoError(err)
+	sealTickets := abi.SealRandomness(rand)
+
+	tm.t.Logf("Running proof type %d SealPreCommitPhase1 for sector %d...", proofType, sectorNumber)
+
+	actorIdNum, err := address.IDFromAddress(tm.ActorAddr)
+	req.NoError(err)
+	actorId := abi.ActorID(actorIdNum)
+
+	pc1, err := ffi.SealPreCommitPhase1(
+		proofType,
+		cacheDirPath,
+		unsealedSectorPath,
+		sealedSectorPath,
+		sectorNumber,
+		actorId,
+		sealTickets,
+		[]abi.PieceInfo{},
+	)
+	req.NoError(err)
+	req.NotNil(pc1)
+
+	tm.t.Logf("Running proof type %d SealPreCommitPhase2 for sector %d...", proofType, sectorNumber)
+
+	sealedCid, unsealedCid, err := ffi.SealPreCommitPhase2(
+		pc1,
+		cacheDirPath,
+		sealedSectorPath,
+	)
+	req.NoError(err)
+
+	tm.t.Logf("Unsealed CID: %s", unsealedCid)
+	tm.t.Logf("Sealed CID: %s", sealedCid)
+
+	tm.SealTickets[sectorNumber] = sealTickets
+	tm.SealedCids[sectorNumber] = sealedCid
+	tm.UnsealedCids[sectorNumber] = unsealedCid
+	tm.CacheDirPaths[sectorNumber] = cacheDirPath
+	tm.UnsealedSectorPaths[sectorNumber] = unsealedSectorPath
+	tm.SealedSectorPaths[sectorNumber] = sealedSectorPath
+}
+
+func (tm *TestUnmanagedMiner) manualOnboardingGenerateProveCommit(
+	ctx context.Context,
+	sectorNumber abi.SectorNumber,
+	proofType abi.RegisteredSealProof,
+) []byte {
+	req := require.New(tm.t)
+
+	tm.t.Logf("Generating proof type %d Sector Proof ...", proofType)
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	req.NoError(err)
+
+	var seedRandomnessHeight abi.ChainEpoch
+
+	preCommitInfo, err := tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	req.NoError(err)
+	seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+
+	tm.t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-head.Height(), seedRandomnessHeight, head.Height())
+	tm.FullNode.WaitTillChain(ctx, HeightAtLeast(seedRandomnessHeight+5))
+
+	head, err = tm.FullNode.ChainHead(ctx)
+	req.NoError(err)
+
+	minerAddrBytes := new(bytes.Buffer)
+	req.NoError(tm.ActorAddr.MarshalCBOR(minerAddrBytes))
+
+	tm.t.Logf("Getting seed randomness from beacon at epoch %d", seedRandomnessHeight)
+	tm.t.Logf("Getting seed randomness from tickets at epoch %d", head.Height())
+
+	rand, err := tm.FullNode.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, seedRandomnessHeight, minerAddrBytes.Bytes(), head.Key())
+	req.NoError(err)
+	seedRandomness := abi.InteractiveSealRandomness(rand)
+
+	actorIdNum, err := address.IDFromAddress(tm.ActorAddr)
+	req.NoError(err)
+	actorId := abi.ActorID(actorIdNum)
+
+	tm.t.Logf("Running proof type %d SealCommitPhase1 for sector %d...", proofType, sectorNumber)
+
+	scp1, err := ffi.SealCommitPhase1(
+		proofType,
+		tm.SealedCids[sectorNumber],
+		tm.UnsealedCids[sectorNumber],
+		tm.CacheDirPaths[sectorNumber],
+		tm.SealedSectorPaths[sectorNumber],
+		sectorNumber,
+		actorId,
+		tm.SealTickets[sectorNumber],
+		seedRandomness,
+		[]abi.PieceInfo{},
+	)
+	req.NoError(err)
+
+	tm.t.Logf("Running proof type %d SealCommitPhase2 for sector %d...", proofType, sectorNumber)
+
+	sectorProof, err := ffi.SealCommitPhase2(scp1, sectorNumber, actorId)
+	req.NoError(err)
+
+	tm.t.Logf("Got proof type %d sector proof of length %d", proofType, len(sectorProof))
+
+	return sectorProof
 }
 
 func (tm *TestUnmanagedMiner) manualOnboardingSubmitMessage(
@@ -213,11 +390,10 @@ func (tm *TestUnmanagedMiner) manualOnboardingSubmitMessage(
 	params cbg.CBORMarshaler,
 	value uint64,
 	method abi.MethodNum,
-) (*api.MsgLookup, error) {
+) *api.MsgLookup {
+
 	enc, aerr := actors.SerializeParams(params)
-	if aerr != nil {
-		return nil, fmt.Errorf("failed to serialize params: %w", aerr)
-	}
+	require.NoError(tm.t, aerr)
 
 	m, err := tm.FullNode.MpoolPushMessage(ctx, &types.Message{
 		To:     tm.ActorAddr,
@@ -226,9 +402,9 @@ func (tm *TestUnmanagedMiner) manualOnboardingSubmitMessage(
 		Method: method,
 		Params: enc,
 	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to push message: %w", err)
-	}
+	require.NoError(tm.t, err)
 
-	return tm.FullNode.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+	msg, err := tm.FullNode.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+	require.NoError(tm.t, err)
+	return msg
 }

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -30,6 +30,8 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet/key"
 )
 
+const sectorSize = abi.SectorSize(2 << 10) // 2KiB
+
 // TestUnmanagedMiner is a miner that's not managed by the storage/infrastructure, all tasks must be manually executed, managed and scheduled by the test or test kit.
 // Note: `TestUnmanagedMiner` is not thread safe and assumes linear access of it's methods
 type TestUnmanagedMiner struct {
@@ -39,7 +41,6 @@ type TestUnmanagedMiner struct {
 	cacheDir          string
 	unsealedSectorDir string
 	sealedSectorDir   string
-	sectorSize        abi.SectorSize
 	currentSectorNum  abi.SectorNumber
 
 	cacheDirPaths       map[abi.SectorNumber]string
@@ -151,13 +152,13 @@ func (tm *TestUnmanagedMiner) createCCSector(_ context.Context, sectorNumber abi
 
 	unsealedSectorPath := filepath.Join(tm.unsealedSectorDir, fmt.Sprintf("%d", sectorNumber))
 	sealedSectorPath := filepath.Join(tm.sealedSectorDir, fmt.Sprintf("%d", sectorNumber))
-	unsealedSize := abi.PaddedPieceSize(tm.sectorSize).Unpadded()
+	unsealedSize := abi.PaddedPieceSize(sectorSize).Unpadded()
 
 	err = os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644)
 	req.NoError(err)
 	tm.t.Logf("MinerB: Sector %d: wrote unsealed CC sector to %s", sectorNumber, unsealedSectorPath)
 
-	err = os.WriteFile(sealedSectorPath, make([]byte, tm.sectorSize), 0644)
+	err = os.WriteFile(sealedSectorPath, make([]byte, sectorSize), 0644)
 	req.NoError(err)
 	tm.t.Logf("MinerB: Sector %d: wrote sealed CC sector to %s", sectorNumber, sealedSectorPath)
 

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -23,8 +23,6 @@ import (
 	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/proof"
-	prooftypes "github.com/filecoin-project/go-state-types/proof"
-
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -259,26 +257,6 @@ func (tm *TestUnmanagedMiner) OnboardSectorWithPiecesAndRealProofs(ctx context.C
 	waitSeedRandomness := tm.proveCommitWaitSeed(ctx, sectorNumber)
 
 	proveCommit := tm.generateProveCommit(ctx, sectorNumber, proofType, waitSeedRandomness, pieces)
-
-	minerId, err := address.IDFromAddress(tm.ActorAddr)
-	require.NoError(tm.t, err)
-
-	// verify the 'ole proofy
-	isValid, err := ffi.VerifySeal(prooftypes.SealVerifyInfo{
-		SectorID: abi.SectorID{
-			Miner:  abi.ActorID(minerId),
-			Number: sectorNumber,
-		},
-		SealedCID:             tm.sealedCids[sectorNumber],
-		SealProof:             proofType,
-		Proof:                 proveCommit,
-		DealIDs:               []abi.DealID{},
-		Randomness:            tm.sealTickets[sectorNumber],
-		InteractiveRandomness: waitSeedRandomness,
-		UnsealedCID:           tm.unsealedCids[sectorNumber],
-	})
-	req.NoError(err)
-	req.True(isValid, "proof wasn't valid")
 
 	// Step 6: Submit the ProveCommit to the network
 	tm.t.Log("Submitting ProveCommitSector ...")

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/proof"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
@@ -28,18 +29,18 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// TestUnmanagedMiner is a miner that's not managed by the storage/
-// infrastructure, all tasks must be manually executed, managed and scheduled by
-// the test or test kit.
+// TestUnmanagedMiner is a miner that's not managed by the storage/infrastructure, all tasks must be manually executed, managed and scheduled by the test or test kit.
+// Note: `TestUnmanagedMiner` is not thread safe and assumes linear access of it's methods
 type TestUnmanagedMiner struct {
 	t                 *testing.T
 	options           nodeOpts
-	cacheDir          string
 	unsealedSectorDir string
 	sealedSectorDir   string
 	sectorSize        abi.SectorSize
+	currentSectorNum  abi.SectorNumber
 
-	CacheDirPaths       map[abi.SectorNumber]string
+	CacheDir string
+
 	UnsealedSectorPaths map[abi.SectorNumber]string
 	SealedSectorPaths   map[abi.SectorNumber]string
 	SealedCids          map[abi.SectorNumber]cid.Cid
@@ -54,7 +55,26 @@ type TestUnmanagedMiner struct {
 		PrivKey libp2pcrypto.PrivKey
 	}
 
-	currentSectorNum abi.SectorNumber
+	activationSectors  map[abi.SectorNumber]sectorActivation
+	sectorActivationCh chan WindowPostReq
+	mockProofs         map[abi.SectorNumber]bool
+	proofType          map[abi.SectorNumber]abi.RegisteredSealProof
+}
+
+type sectorActivation struct {
+	SectorNumber abi.SectorNumber
+	RespCh       chan WindowPostResp
+	NextPost     abi.ChainEpoch
+}
+
+type WindowPostReq struct {
+	SectorNumber abi.SectorNumber
+	RespCh       chan WindowPostResp
+}
+
+type WindowPostResp struct {
+	SectorNumber abi.SectorNumber
+	Error        error
 }
 
 func NewTestUnmanagedMiner(t *testing.T, full *TestFullNode, actorAddr address.Address, opts ...NodeOpt) *TestUnmanagedMiner {
@@ -86,26 +106,39 @@ func NewTestUnmanagedMiner(t *testing.T, full *TestFullNode, actorAddr address.A
 	tm := TestUnmanagedMiner{
 		t:                 t,
 		options:           options,
-		cacheDir:          cacheDir,
+		CacheDir:          cacheDir,
 		unsealedSectorDir: unsealedSectorDir,
 		sealedSectorDir:   sealedSectorDir,
 
-		CacheDirPaths:       make(map[abi.SectorNumber]string),
 		UnsealedSectorPaths: make(map[abi.SectorNumber]string),
 		SealedSectorPaths:   make(map[abi.SectorNumber]string),
 		SealedCids:          make(map[abi.SectorNumber]cid.Cid),
 		UnsealedCids:        make(map[abi.SectorNumber]cid.Cid),
 		SealTickets:         make(map[abi.SectorNumber]abi.SealRandomness),
 
-		ActorAddr:        actorAddr,
-		OwnerKey:         options.ownerKey,
-		FullNode:         full,
-		currentSectorNum: 101,
+		ActorAddr:          actorAddr,
+		OwnerKey:           options.ownerKey,
+		FullNode:           full,
+		currentSectorNum:   101,
+		activationSectors:  make(map[abi.SectorNumber]sectorActivation),
+		mockProofs:         make(map[abi.SectorNumber]bool),
+		proofType:          make(map[abi.SectorNumber]abi.RegisteredSealProof),
+		sectorActivationCh: make(chan WindowPostReq),
 	}
 	tm.Libp2p.PeerID = peerId
 	tm.Libp2p.PrivKey = privkey
 
 	return &tm
+}
+
+func (tm *TestUnmanagedMiner) Start(ctx context.Context) {
+	go tm.wdPostScheduler(ctx)
+}
+
+func (tm *TestUnmanagedMiner) AssertNoPower(ctx context.Context) {
+	p := tm.CurrentPower(ctx)
+	tm.t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	require.True(tm.t, p.MinerPower.RawBytePower.IsZero())
 }
 
 func (tm *TestUnmanagedMiner) CurrentPower(ctx context.Context) *api.MinerPower {
@@ -118,93 +151,313 @@ func (tm *TestUnmanagedMiner) CurrentPower(ctx context.Context) *api.MinerPower 
 	return p
 }
 
-func (tm *TestUnmanagedMiner) AssertNoPower(ctx context.Context) {
-	p := tm.CurrentPower(ctx)
-	tm.t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
-	require.True(tm.t, p.MinerPower.RawBytePower.IsZero())
-}
-
 func (tm *TestUnmanagedMiner) AssertPower(ctx context.Context, raw uint64, qa uint64) {
 	req := require.New(tm.t)
 	p := tm.CurrentPower(ctx)
 	tm.t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 	req.Equal(raw, p.MinerPower.RawBytePower.Uint64())
 	req.Equal(qa, p.MinerPower.QualityAdjPower.Uint64())
-
 }
 
-func (tm *TestUnmanagedMiner) OnboardCCSectorWithMockProofs(ctx context.Context, proofType abi.RegisteredSealProof) abi.SectorNumber {
+func (tm *TestUnmanagedMiner) OnboardCCSectorWithMockProofs(ctx context.Context, proofType abi.RegisteredSealProof) (abi.SectorNumber, chan WindowPostResp) {
 	req := require.New(tm.t)
 	sectorNumber := tm.currentSectorNum
 	tm.currentSectorNum++
 
 	tm.SealedCids[sectorNumber] = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
 
-	var sealRandEpoch abi.ChainEpoch
-
-	head, err := tm.FullNode.ChainHead(ctx)
-	require.NoError(tm.t, err)
-
-	if head.Height() > policy.SealRandomnessLookback {
-		sealRandEpoch = head.Height() - policy.SealRandomnessLookback
-	} else {
-		sealRandEpoch = policy.SealRandomnessLookback
-		tm.t.Logf("Waiting for at least epoch %d for seal randomness (current epoch %d) ...", sealRandEpoch+5, head.Height())
-		tm.FullNode.WaitTillChain(ctx, HeightAtLeast(sealRandEpoch+5))
-	}
+	preCommitSealRand := tm.waitPreCommitSealRandomness(ctx)
 
 	// Step 4 : Submit the Pre-Commit to the network
-	r := tm.manualOnboardingSubmitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
+	r := tm.submitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
 		Sectors: []miner14.SectorPreCommitInfo{{
 			Expiration:    2880 * 300,
 			SectorNumber:  sectorNumber,
 			SealProof:     TestSpt,
 			SealedCID:     tm.SealedCids[sectorNumber],
-			SealRandEpoch: sealRandEpoch,
+			SealRandEpoch: preCommitSealRand,
 		}},
 	}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
 	req.True(r.Receipt.ExitCode.IsSuccess())
 
-	_, err = tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, r.TipSet)
-	req.NoError(err)
-
 	sectorProof := []byte{0xde, 0xad, 0xbe, 0xef}
 
-	var seedRandomnessHeight abi.ChainEpoch
+	_ = tm.proveCommitWaitSeed(ctx, sectorNumber)
 
-	head, err = tm.FullNode.ChainHead(ctx)
-	require.NoError(tm.t, err)
-	preCommitInfo, err := tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, head.Key())
-	req.NoError(err)
-	seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
-
-	tm.t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-head.Height(), seedRandomnessHeight, head.Height())
-	tm.FullNode.WaitTillChain(ctx, HeightAtLeast(seedRandomnessHeight+5))
-
-	r = tm.manualOnboardingSubmitMessage(ctx, &miner14.ProveCommitSectors3Params{
+	r = tm.submitMessage(ctx, &miner14.ProveCommitSectors3Params{
 		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: sectorNumber}},
 		SectorProofs:             [][]byte{sectorProof},
 		RequireActivationSuccess: true,
 	}, 0, builtin.MethodsMiner.ProveCommitSectors3)
-	req.NoError(err)
 	req.True(r.Receipt.ExitCode.IsSuccess())
 
-	return sectorNumber
+	tm.mockProofs[sectorNumber] = true
+	tm.proofType[sectorNumber] = proofType
+
+	// schedule WindowPosts for this sector
+	respCh := make(chan WindowPostResp, 1)
+	tm.sectorActivationCh <- WindowPostReq{SectorNumber: sectorNumber, RespCh: respCh}
+
+	return sectorNumber, respCh
 }
 
-func (tm *TestUnmanagedMiner) OnboardCCSectorWithRealProofs(ctx context.Context, proofType abi.RegisteredSealProof) abi.SectorNumber {
+func (tm *TestUnmanagedMiner) createCCSector(ctx context.Context, sectorNumber abi.SectorNumber) {
+	req := require.New(tm.t)
+
+	unsealedSectorPath := filepath.Join(tm.unsealedSectorDir, fmt.Sprintf("%d", sectorNumber))
+	sealedSectorPath := filepath.Join(tm.sealedSectorDir, fmt.Sprintf("%d", sectorNumber))
+	unsealedSize := abi.PaddedPieceSize(tm.sectorSize).Unpadded()
+	req.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
+	req.NoError(os.WriteFile(sealedSectorPath, make([]byte, tm.sectorSize), 0644))
+	tm.t.Logf("Wrote unsealed sector to %s", unsealedSectorPath)
+	tm.t.Logf("Wrote sealed sector to %s", sealedSectorPath)
+
+	tm.UnsealedSectorPaths[sectorNumber] = unsealedSectorPath
+	tm.SealedSectorPaths[sectorNumber] = sealedSectorPath
+
+	return
+}
+
+func (tm *TestUnmanagedMiner) OnboardCCSectorWithRealProofs(ctx context.Context, proofType abi.RegisteredSealProof) (abi.SectorNumber, chan WindowPostResp) {
 	req := require.New(tm.t)
 	sectorNumber := tm.currentSectorNum
 	tm.currentSectorNum++
 
 	// --------------------Create pre-commit for the CC sector -> we'll just pre-commit `sector size` worth of 0s for this CC sector
 
-	// Step 1: Wait for the seal randomness to be available -> we want to draw seal randomess from a tipset that has achieved finality as PoReps are expensive to generate
-	// See if we already have such a epoch and wait if not
+	// Step 1: Wait for the pre-commitseal randomness to be available (we can only draw seal randomness from tipsets that have already achieved finality)
+	preCommitSealRand := tm.waitPreCommitSealRandomness(ctx)
+
+	// Step 2: Write empty 32 bytes that we want to seal i.e. create our CC sector
+	tm.createCCSector(ctx, sectorNumber)
+
+	// Step 3: Generate a Pre-Commit for the CC sector -> this persists the proof on the `TestUnmanagedMiner` Miner State
+	tm.generatePreCommit(ctx, sectorNumber, preCommitSealRand, proofType)
+
+	// Step 4 : Submit the Pre-Commit to the network
+	r := tm.submitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
+		Sectors: []miner14.SectorPreCommitInfo{{
+			Expiration:    2880 * 300,
+			SectorNumber:  sectorNumber,
+			SealProof:     TestSpt,
+			SealedCID:     tm.SealedCids[sectorNumber],
+			SealRandEpoch: preCommitSealRand,
+		}},
+	}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
+	req.True(r.Receipt.ExitCode.IsSuccess())
+
+	// Step 5: Generate a ProveCommit for the CC sector
+	waitSeedRandomness := tm.proveCommitWaitSeed(ctx, sectorNumber)
+
+	proveCommit := tm.generateProveCommit(ctx, sectorNumber, proofType, waitSeedRandomness)
+
+	// Step 6: Submit the ProveCommit to the network
+	tm.t.Log("Submitting ProveCommitSector ...")
+
+	r = tm.submitMessage(ctx, &miner14.ProveCommitSectors3Params{
+		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: sectorNumber}},
+		SectorProofs:             [][]byte{proveCommit},
+		RequireActivationSuccess: true,
+	}, 0, builtin.MethodsMiner.ProveCommitSectors3)
+	req.True(r.Receipt.ExitCode.IsSuccess())
+
+	tm.mockProofs[sectorNumber] = false
+	tm.proofType[sectorNumber] = proofType
+
+	// schedule WindowPosts for this sector
+	tm.t.Logf("Scheduling WindowPost for sector %d", sectorNumber)
+	respCh := make(chan WindowPostResp, 1)
+	tm.sectorActivationCh <- WindowPostReq{SectorNumber: sectorNumber, RespCh: respCh}
+
+	return sectorNumber, respCh
+}
+
+func (tm *TestUnmanagedMiner) wdPostScheduler(ctx context.Context) {
+	for {
+		select {
+		case req := <-tm.sectorActivationCh:
+			currentEpoch, nextPost, err := tm.calculateNextPostEpoch(ctx, req.SectorNumber)
+			tm.t.Logf("Activating sector %d, next post %d, current epoch %d", req.SectorNumber, nextPost, currentEpoch)
+			if err != nil {
+				req.RespCh <- WindowPostResp{SectorNumber: req.SectorNumber, Error: err}
+				close(req.RespCh)
+				delete(tm.activationSectors, req.SectorNumber)
+				continue
+			}
+			nextPost += 5 // give a little buffer
+			tm.activationSectors[req.SectorNumber] = sectorActivation{SectorNumber: req.SectorNumber, RespCh: req.RespCh, NextPost: nextPost}
+
+			go func() {
+				tm.FullNode.WaitTillChain(ctx, HeightAtLeast(nextPost))
+				err := tm.submitWindowPost(ctx, req.SectorNumber)
+				req.RespCh <- WindowPostResp{SectorNumber: req.SectorNumber, Error: err}
+				close(req.RespCh)
+				delete(tm.activationSectors, req.SectorNumber)
+			}()
+
+		case <-ctx.Done():
+			tm.t.Logf("Context cancelled, stopping window post scheduler")
+			for sector, sa := range tm.activationSectors {
+				sa.RespCh <- WindowPostResp{SectorNumber: sector, Error: fmt.Errorf("context cancelled")}
+				close(sa.RespCh)
+			}
+			return
+		}
+	}
+}
+
+func (tm *TestUnmanagedMiner) submitWindowPost(ctx context.Context, sectorNumber abi.SectorNumber) error {
+	fmt.Printf("WindowPoST(%d): Running WindowPoSt ...\n", sectorNumber)
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	// We should be up to the deadline we care about
+	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v, ProvingDeadline: %+v\n", sectorNumber, sp, di)
+	if di.Index != sp.Deadline {
+		return fmt.Errorf("sector %d is not in the deadline %d, but %d", sectorNumber, sp.Deadline, di.Index)
+	}
+
+	var proofBytes []byte
+	if tm.mockProofs[sectorNumber] {
+		proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+	} else {
+		proofBytes, err = tm.generateWindowPost(ctx, sectorNumber)
+		if err != nil {
+			return fmt.Errorf("failed to generate window post: %w", err)
+		}
+	}
+
+	fmt.Printf("WindowedPoSt(%d) Submitting ...\n", sectorNumber)
+
+	chainRandomnessEpoch := di.Challenge
+	chainRandomness, err := tm.FullNode.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, chainRandomnessEpoch,
+		nil, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get chain randomness: %w", err)
+	}
+
+	minerInfo, err := tm.FullNode.StateMinerInfo(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get miner info: %w", err)
+	}
+
+	r := tm.submitMessage(ctx, &miner14.SubmitWindowedPoStParams{
+		ChainCommitEpoch: chainRandomnessEpoch,
+		ChainCommitRand:  chainRandomness,
+		Deadline:         sp.Deadline,
+		Partitions:       []miner14.PoStPartition{{Index: sp.Partition}},
+		Proofs:           []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+	}, 0, builtin.MethodsMiner.SubmitWindowedPoSt)
+
+	fmt.Println("WindowedPoSt(%d) Submitted ...", sectorNumber, r.Receipt.ExitCode)
+
+	if !r.Receipt.ExitCode.IsSuccess() {
+		return fmt.Errorf("submitting PoSt failed: %s", r.Receipt.ExitCode)
+	}
+
+	return nil
+}
+
+func (tm *TestUnmanagedMiner) generateWindowPost(
+	ctx context.Context,
+	sectorNumber abi.SectorNumber,
+) ([]byte, error) {
+	head, err := tm.FullNode.ChainHead(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	minerInfo, err := tm.FullNode.StateMinerInfo(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get miner info: %w", err)
+	}
+
+	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, types.EmptyTSK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+
+	minerAddrBytes := new(bytes.Buffer)
+	if err := tm.ActorAddr.MarshalCBOR(minerAddrBytes); err != nil {
+		return nil, fmt.Errorf("failed to marshal miner address: %w", err)
+	}
+
+	rand, err := tm.FullNode.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_WindowedPoStChallengeSeed, di.Challenge, minerAddrBytes.Bytes(), head.Key())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get randomness: %w", err)
+	}
+	postRand := abi.PoStRandomness(rand)
+	postRand[31] &= 0x3f // make fr32 compatible
+
+	privateSectorInfo := ffi.PrivateSectorInfo{
+		SectorInfo: proof.SectorInfo{
+			SealProof:    tm.proofType[sectorNumber],
+			SectorNumber: sectorNumber,
+			SealedCID:    tm.SealedCids[sectorNumber],
+		},
+		CacheDirPath:     tm.CacheDir,
+		PoStProofType:    minerInfo.WindowPoStProofType,
+		SealedSectorPath: tm.SealedSectorPaths[sectorNumber],
+	}
+
+	actorIdNum, err := address.IDFromAddress(tm.ActorAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get actor ID: %w", err)
+	}
+	actorId := abi.ActorID(actorIdNum)
+
+	windowProofs, faultySectors, err := ffi.GenerateWindowPoSt(actorId, ffi.NewSortedPrivateSectorInfo(privateSectorInfo), postRand)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate window post: %w", err)
+	}
+	if len(faultySectors) > 0 {
+		return nil, fmt.Errorf("post failed for sectors: %v", faultySectors)
+	}
+	if len(windowProofs) != 1 {
+		return nil, fmt.Errorf("expected 1 proof, got %d", len(windowProofs))
+	}
+	if windowProofs[0].PoStProof != minerInfo.WindowPoStProofType {
+		return nil, fmt.Errorf("expected proof type %d, got %d", minerInfo.WindowPoStProofType, windowProofs[0].PoStProof)
+	}
+	proofBytes := windowProofs[0].ProofBytes
+
+	info := proof.WindowPoStVerifyInfo{
+		Randomness:        postRand,
+		Proofs:            []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+		ChallengedSectors: []proof.SectorInfo{{SealProof: tm.proofType[sectorNumber], SectorNumber: sectorNumber, SealedCID: tm.SealedCids[sectorNumber]}},
+		Prover:            actorId,
+	}
+
+	verified, err := ffi.VerifyWindowPoSt(info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify window post: %w", err)
+	}
+	if !verified {
+		return nil, fmt.Errorf("window post verification failed")
+	}
+
+	return proofBytes, nil
+}
+
+func (tm *TestUnmanagedMiner) waitPreCommitSealRandomness(ctx context.Context) abi.ChainEpoch {
+	// we want to draw seal randomess from a tipset that has already achieved finality as PreCommits are expensive to re-generate.
+	// See if we already have an epoch that is already final and wait for such an epoch if we don't have one
 	head, err := tm.FullNode.ChainHead(ctx)
 	require.NoError(tm.t, err)
-	var sealRandEpoch abi.ChainEpoch
 
+	var sealRandEpoch abi.ChainEpoch
 	if head.Height() > policy.SealRandomnessLookback {
 		sealRandEpoch = head.Height() - policy.SealRandomnessLookback
 	} else {
@@ -213,62 +466,53 @@ func (tm *TestUnmanagedMiner) OnboardCCSectorWithRealProofs(ctx context.Context,
 		tm.FullNode.WaitTillChain(ctx, HeightAtLeast(sealRandEpoch+5))
 	}
 
-	// Step 2: Write empty 32 bytes that we want to seal i.e. create our CC sector
-	unsealedSectorPath := filepath.Join(tm.unsealedSectorDir, fmt.Sprintf("%d", sectorNumber))
-	sealedSectorPath := filepath.Join(tm.sealedSectorDir, fmt.Sprintf("%d", sectorNumber))
-
-	unsealedSize := abi.PaddedPieceSize(tm.sectorSize).Unpadded()
-	req.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
-	req.NoError(os.WriteFile(sealedSectorPath, make([]byte, tm.sectorSize), 0644))
-
-	tm.t.Logf("Wrote unsealed sector to %s", unsealedSectorPath)
-	tm.t.Logf("Wrote sealed sector to %s", sealedSectorPath)
-
-	// Step 3: Generate a Pre-Commit for the CC sector -> this persists the proof on the Miner State
-	tm.manualOnboardingGeneratePreCommit(ctx, tm.cacheDir, unsealedSectorPath, sealedSectorPath, sectorNumber, sealRandEpoch, proofType)
-
-	// Step 4 : Submit the Pre-Commit to the network
-	r := tm.manualOnboardingSubmitMessage(ctx, &miner14.PreCommitSectorBatchParams2{
-		Sectors: []miner14.SectorPreCommitInfo{{
-			Expiration:    2880 * 300,
-			SectorNumber:  sectorNumber,
-			SealProof:     TestSpt,
-			SealedCID:     tm.SealedCids[sectorNumber],
-			SealRandEpoch: sealRandEpoch,
-		}},
-	}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
-	req.True(r.Receipt.ExitCode.IsSuccess())
-
-	_, err = tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, r.TipSet)
-	req.NoError(err)
-
-	// Step 5: Generate a ProveCommit for the CC sector
-	proveCommit := tm.manualOnboardingGenerateProveCommit(ctx, sectorNumber, proofType)
-
-	// Step 6: Submit the ProveCommit to the network
-	tm.t.Log("Submitting MinerB ProveCommitSector ...")
-
-	r = tm.manualOnboardingSubmitMessage(ctx, &miner14.ProveCommitSectors3Params{
-		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: sectorNumber}},
-		SectorProofs:             [][]byte{proveCommit},
-		RequireActivationSuccess: true,
-	}, 0, builtin.MethodsMiner.ProveCommitSectors3)
-	req.NoError(err)
-	req.True(r.Receipt.ExitCode.IsSuccess())
-
-	return sectorNumber
+	return sealRandEpoch
 }
 
-func (tm *TestUnmanagedMiner) manualOnboardingGeneratePreCommit(
+// manualOnboardingCalculateNextPostEpoch calculates the first epoch of the deadline proving window
+// that we want for the given sector for the given miner.
+func (tm *TestUnmanagedMiner) calculateNextPostEpoch(
 	ctx context.Context,
-	cacheDirPath string,
-	unsealedSectorPath string,
-	sealedSectorPath string,
+	sectorNumber abi.SectorNumber,
+) (abi.ChainEpoch, abi.ChainEpoch, error) {
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v\n", sectorNumber, sp)
+
+	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): ProvingDeadline: %+v\n", sectorNumber, di)
+
+	// periodStart tells us the first epoch of the current proving period (24h)
+	// although it may be in the future if we don't need to submit post in this period
+	periodStart := di.PeriodStart
+	if di.PeriodStart < di.CurrentEpoch && sp.Deadline <= di.Index {
+		// the deadline we want has past in this current proving period, so wait till the next one
+		periodStart += di.WPoStProvingPeriod
+	}
+	provingEpoch := periodStart + (di.WPoStProvingPeriod/abi.ChainEpoch(di.WPoStPeriodDeadlines))*abi.ChainEpoch(sp.Deadline)
+
+	return di.CurrentEpoch, provingEpoch, nil
+}
+
+func (tm *TestUnmanagedMiner) generatePreCommit(
+	ctx context.Context,
 	sectorNumber abi.SectorNumber,
 	sealRandEpoch abi.ChainEpoch,
 	proofType abi.RegisteredSealProof,
 ) {
-
 	req := require.New(tm.t)
 	tm.t.Logf("Generating proof type %d PreCommit ...", proofType)
 
@@ -290,9 +534,9 @@ func (tm *TestUnmanagedMiner) manualOnboardingGeneratePreCommit(
 
 	pc1, err := ffi.SealPreCommitPhase1(
 		proofType,
-		cacheDirPath,
-		unsealedSectorPath,
-		sealedSectorPath,
+		tm.CacheDir,
+		tm.UnsealedSectorPaths[sectorNumber],
+		tm.SealedSectorPaths[sectorNumber],
 		sectorNumber,
 		actorId,
 		sealTickets,
@@ -305,8 +549,8 @@ func (tm *TestUnmanagedMiner) manualOnboardingGeneratePreCommit(
 
 	sealedCid, unsealedCid, err := ffi.SealPreCommitPhase2(
 		pc1,
-		cacheDirPath,
-		sealedSectorPath,
+		tm.CacheDir,
+		tm.SealedSectorPaths[sectorNumber],
 	)
 	req.NoError(err)
 
@@ -316,44 +560,42 @@ func (tm *TestUnmanagedMiner) manualOnboardingGeneratePreCommit(
 	tm.SealTickets[sectorNumber] = sealTickets
 	tm.SealedCids[sectorNumber] = sealedCid
 	tm.UnsealedCids[sectorNumber] = unsealedCid
-	tm.CacheDirPaths[sectorNumber] = cacheDirPath
-	tm.UnsealedSectorPaths[sectorNumber] = unsealedSectorPath
-	tm.SealedSectorPaths[sectorNumber] = sealedSectorPath
 }
 
-func (tm *TestUnmanagedMiner) manualOnboardingGenerateProveCommit(
-	ctx context.Context,
-	sectorNumber abi.SectorNumber,
-	proofType abi.RegisteredSealProof,
-) []byte {
+func (tm *TestUnmanagedMiner) proveCommitWaitSeed(ctx context.Context, sectorNumber abi.SectorNumber) abi.InteractiveSealRandomness {
 	req := require.New(tm.t)
-
-	tm.t.Logf("Generating proof type %d Sector Proof ...", proofType)
-
 	head, err := tm.FullNode.ChainHead(ctx)
 	req.NoError(err)
 
-	var seedRandomnessHeight abi.ChainEpoch
-
 	preCommitInfo, err := tm.FullNode.StateSectorPreCommitInfo(ctx, tm.ActorAddr, sectorNumber, head.Key())
 	req.NoError(err)
-	seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+	seedRandomnessHeight := preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
 
 	tm.t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-head.Height(), seedRandomnessHeight, head.Height())
 	tm.FullNode.WaitTillChain(ctx, HeightAtLeast(seedRandomnessHeight+5))
 
-	head, err = tm.FullNode.ChainHead(ctx)
-	req.NoError(err)
-
 	minerAddrBytes := new(bytes.Buffer)
 	req.NoError(tm.ActorAddr.MarshalCBOR(minerAddrBytes))
 
-	tm.t.Logf("Getting seed randomness from beacon at epoch %d", seedRandomnessHeight)
-	tm.t.Logf("Getting seed randomness from tickets at epoch %d", head.Height())
+	head, err = tm.FullNode.ChainHead(ctx)
+	req.NoError(err)
 
 	rand, err := tm.FullNode.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, seedRandomnessHeight, minerAddrBytes.Bytes(), head.Key())
 	req.NoError(err)
 	seedRandomness := abi.InteractiveSealRandomness(rand)
+
+	tm.t.Logf("Got seed randomness for sector %d: %x", sectorNumber, seedRandomness)
+	return seedRandomness
+}
+
+func (tm *TestUnmanagedMiner) generateProveCommit(
+	ctx context.Context,
+	sectorNumber abi.SectorNumber,
+	proofType abi.RegisteredSealProof,
+	seedRandomness abi.InteractiveSealRandomness,
+) []byte {
+	tm.t.Logf("Generating proof type %d Sector Proof for sector %d...", proofType, sectorNumber)
+	req := require.New(tm.t)
 
 	actorIdNum, err := address.IDFromAddress(tm.ActorAddr)
 	req.NoError(err)
@@ -365,7 +607,7 @@ func (tm *TestUnmanagedMiner) manualOnboardingGenerateProveCommit(
 		proofType,
 		tm.SealedCids[sectorNumber],
 		tm.UnsealedCids[sectorNumber],
-		tm.CacheDirPaths[sectorNumber],
+		tm.CacheDir,
 		tm.SealedSectorPaths[sectorNumber],
 		sectorNumber,
 		actorId,
@@ -385,13 +627,12 @@ func (tm *TestUnmanagedMiner) manualOnboardingGenerateProveCommit(
 	return sectorProof
 }
 
-func (tm *TestUnmanagedMiner) manualOnboardingSubmitMessage(
+func (tm *TestUnmanagedMiner) submitMessage(
 	ctx context.Context,
 	params cbg.CBORMarshaler,
 	value uint64,
 	method abi.MethodNum,
 ) *api.MsgLookup {
-
 	enc, aerr := actors.SerializeParams(params)
 	require.NoError(tm.t, aerr)
 

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -228,7 +228,6 @@ func (tm *TestUnmanagedMiner) OnboardCCSectorWithRealProofs(ctx context.Context,
 			return
 		}
 
-		nextPost += 5 // Buffer to ensure readiness for submission
 		tm.FullNode.WaitTillChain(ctx, HeightAtLeast(nextPost))
 
 		err = tm.submitWindowPost(ctx, sectorNumber)

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -30,8 +30,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet/key"
 )
 
-const sectorSize = abi.SectorSize(2 << 10) // 2KiB
-
 // TestUnmanagedMiner is a miner that's not managed by the storage/infrastructure, all tasks must be manually executed, managed and scheduled by the test or test kit.
 // Note: `TestUnmanagedMiner` is not thread safe and assumes linear access of it's methods
 type TestUnmanagedMiner struct {
@@ -143,7 +141,7 @@ func (tm *TestUnmanagedMiner) AssertPower(ctx context.Context, raw uint64, qa ui
 }
 
 func (tm *TestUnmanagedMiner) mkAndSavePiecesToOnboard(_ context.Context, sectorNumber abi.SectorNumber, pt abi.RegisteredSealProof) []abi.PieceInfo {
-	paddedPieceSize := abi.PaddedPieceSize(sectorSize)
+	paddedPieceSize := abi.PaddedPieceSize(tm.options.sectorSize)
 	unpaddedPieceSize := paddedPieceSize.Unpadded()
 
 	// Generate random bytes for the piece
@@ -207,14 +205,14 @@ func (tm *TestUnmanagedMiner) makeAndSaveCCSector(_ context.Context, sectorNumbe
 	// Define paths for unsealed and sealed sectors
 	unsealedSectorPath := filepath.Join(tm.unsealedSectorDir, fmt.Sprintf("%d", sectorNumber))
 	sealedSectorPath := filepath.Join(tm.sealedSectorDir, fmt.Sprintf("%d", sectorNumber))
-	unsealedSize := abi.PaddedPieceSize(sectorSize).Unpadded()
+	unsealedSize := abi.PaddedPieceSize(tm.options.sectorSize).Unpadded()
 
 	// Write unsealed sector file
 	requirements.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
 	tm.t.Logf("Miner %s: Sector %d: wrote unsealed CC sector to %s", tm.ActorAddr, sectorNumber, unsealedSectorPath)
 
 	// Write sealed sector file
-	requirements.NoError(os.WriteFile(sealedSectorPath, make([]byte, sectorSize), 0644))
+	requirements.NoError(os.WriteFile(sealedSectorPath, make([]byte, tm.options.sectorSize), 0644))
 	tm.t.Logf("Miner %s: Sector %d: wrote sealed CC sector to %s", tm.ActorAddr, sectorNumber, sealedSectorPath)
 
 	// Update paths in the struct

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -1,6 +1,16 @@
 package kit
 
 import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-state-types/abi"
+	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -23,4 +33,202 @@ type TestUnmanagedMiner struct {
 		PeerID  peer.ID
 		PrivKey libp2pcrypto.PrivKey
 	}
+}
+
+func (tm *TestUnmanagedMiner) StartWindowedPostLoop(ctx context.Context, sectorNumber abi.SectorNumber, proofType abi.RegisteredSealProof) {
+	tm.t.Helper()
+
+	go func() {
+		for ctx.Err() == nil {
+			currentEpoch, nextPost, err := tm.manualOnboardingCalculateNextPostEpoch(ctx, sectorNumber)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			nextPost += 5 // give a little buffer
+			fmt.Printf("WindowPoST(%d) Waiting %d until epoch %d to submit PoSt\n", sectorNumber, nextPost-currentEpoch, nextPost)
+
+			// Create channel to listen for chain head
+			heads, err := tm.FullNode.ChainNotify(ctx)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			// Wait for nextPost epoch
+			for chg := range heads {
+				var ts *types.TipSet
+				for _, c := range chg {
+					if c.Type != "apply" {
+						continue
+					}
+					ts = c.Val
+					if ts.Height() >= nextPost {
+						break
+					}
+				}
+				if ctx.Err() != nil {
+					return
+				}
+				if ts != nil && ts.Height() >= nextPost {
+					break
+				}
+			}
+			if ctx.Err() != nil {
+				return
+			}
+
+			err = manualOnboardingSubmitWindowPost(ctx, withMockProofs, client, miner, sectorNumber, cacheDirPath, sealedSectorPath, sealedCid, proofType)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			// signal first post is done
+			select {
+			case <-first:
+			default:
+				close(first)
+			}
+		}
+	}()
+}
+
+func (tm *TestUnmanagedMiner) manualOnboardingCalculateNextPostEpoch(
+	ctx context.Context,
+	sectorNumber abi.SectorNumber,
+) (abi.ChainEpoch, abi.ChainEpoch, error) {
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v\n", sectorNumber, sp)
+
+	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): ProvingDeadline: %+v\n", sectorNumber, di)
+
+	// periodStart tells us the first epoch of the current proving period (24h)
+	// although it may be in the future if we don't need to submit post in this period
+	periodStart := di.PeriodStart
+	if di.PeriodStart < di.CurrentEpoch && sp.Deadline <= di.Index {
+		// the deadline we want has past in this current proving period, so wait till the next one
+		periodStart += di.WPoStProvingPeriod
+	}
+	provingEpoch := periodStart + (di.WPoStProvingPeriod/abi.ChainEpoch(di.WPoStPeriodDeadlines))*abi.ChainEpoch(sp.Deadline)
+
+	return di.CurrentEpoch, provingEpoch, nil
+}
+
+func (tm *TestUnmanagedMiner) manualOnboardingSubmitWindowPost(
+	ctx context.Context,
+	withMockProofs bool,
+	sectorNumber abi.SectorNumber,
+	cacheDirPath, sealedSectorPath string,
+	sealedCid cid.Cid,
+	proofType abi.RegisteredSealProof,
+) error {
+	fmt.Printf("WindowPoST(%d): Running WindowPoSt ...\n", sectorNumber)
+
+	head, err := tm.FullNode.ChainHead(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := tm.FullNode.StateSectorPartition(ctx, tm.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	// We should be up to the deadline we care about
+	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v, ProvingDeadline: %+v\n", sectorNumber, sp, di)
+	if di.Index != sp.Deadline {
+		return fmt.Errorf("sector %d is not in the deadline %d, but %d", sectorNumber, sp.Deadline, di.Index)
+	}
+
+	var proofBytes []byte
+	if withMockProofs {
+		proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+	} else {
+		proofBytes, err = manualOnboardingGenerateWindowPost(ctx, tm.FullNode, cacheDirPath, sealedSectorPath, tm.ActorAddr, sectorNumber, sealedCid, proofType)
+		if err != nil {
+			return fmt.Errorf("failed to generate window post: %w", err)
+		}
+	}
+
+	fmt.Printf("WindowedPoSt(%d) Submitting ...\n", sectorNumber)
+
+	chainRandomnessEpoch := di.Challenge
+	chainRandomness, err := tm.FullNode.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, chainRandomnessEpoch, nil, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get chain randomness: %w", err)
+	}
+
+	minerInfo, err := tm.FullNode.StateMinerInfo(ctx, tm.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get miner info: %w", err)
+	}
+
+	r, err := manualOnboardingSubmitMessage(ctx, tm.FullNode, miner, &miner14.SubmitWindowedPoStParams{
+		ChainCommitEpoch: chainRandomnessEpoch,
+		ChainCommitRand:  chainRandomness,
+		Deadline:         sp.Deadline,
+		Partitions:       []miner14.PoStPartition{{Index: sp.Partition}},
+		Proofs:           []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+	}, 0, builtin.MethodsMiner.SubmitWindowedPoSt)
+	if err != nil {
+		return fmt.Errorf("failed to submit PoSt: %w", err)
+	}
+	if !r.Receipt.ExitCode.IsSuccess() {
+		return fmt.Errorf("submitting PoSt failed: %s", r.Receipt.ExitCode)
+	}
+
+	if !withMockProofs {
+		// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
+		if err := manualOnboardingDisputeWindowPost(ctx, client, miner, sectorNumber); err != nil {
+			return fmt.Errorf("failed to dispute PoSt: %w", err)
+		}
+	}
+	return nil
+}
+
+func (tm *TestUnmanagedMiner) manualOnboardingSubmitMessage(
+	ctx context.Context,
+	params cbg.CBORMarshaler,
+	value uint64,
+	method abi.MethodNum,
+) (*api.MsgLookup, error) {
+	enc, aerr := actors.SerializeParams(params)
+	if aerr != nil {
+		return nil, fmt.Errorf("failed to serialize params: %w", aerr)
+	}
+
+	m, err := tm.FullNode.MpoolPushMessage(ctx, &types.Message{
+		To:     tm.ActorAddr,
+		From:   tm.OwnerKey.Address,
+		Value:  types.FromFil(value),
+		Method: method,
+		Params: enc,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to push message: %w", err)
+	}
+
+	return tm.FullNode.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
 }

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -1,0 +1,26 @@
+package kit
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/wallet/key"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// TestUnmanagedMiner is a miner that's not managed by the storage/
+// infrastructure, all tasks must be manually executed, managed and scheduled by
+// the test or test kit.
+type TestUnmanagedMiner struct {
+	t       *testing.T
+	options nodeOpts
+
+	ActorAddr address.Address
+	OwnerKey  *key.Key
+	FullNode  *TestFullNode
+	Libp2p    struct {
+		PeerID  peer.ID
+		PrivKey libp2pcrypto.PrivKey
+	}
+}

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -9,24 +9,25 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ipfs/go-cid"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
+
 	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
 	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/proof"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/require"
-	cbg "github.com/whyrusleeping/cbor-gen"
-
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/wallet/key"
-	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // TestUnmanagedMiner is a miner that's not managed by the storage/infrastructure, all tasks must be manually executed, managed and scheduled by the test or test kit.

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -117,8 +117,8 @@ func TestManualCCOnboarding(t *testing.T) {
 				sealedSectorPath = filepath.Join(tmpDir, "sealed")
 
 				sealTickets, sealedCid, unsealedCid = manualOnboardingGeneratePreCommit(
-					t,
 					ctx,
+					t,
 					client,
 					cacheDirPath,
 					unsealedSectorPath,
@@ -171,8 +171,8 @@ func TestManualCCOnboarding(t *testing.T) {
 				sectorProof = []byte{0xde, 0xad, 0xbe, 0xef}
 			} else {
 				sectorProof = manualOnboardingGenerateProveCommit(
-					t,
 					ctx,
+					t,
 					client,
 					cacheDirPath,
 					sealedSectorPath,
@@ -252,7 +252,7 @@ func TestManualCCOnboarding(t *testing.T) {
 			if withMockProofs {
 				proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
 			} else {
-				proofBytes = manualOnboardingGenerateWindowPost(t, ctx, client, cacheDirPath, sealedSectorPath, mAddrB, bSectorNum, sealedCid)
+				proofBytes = manualOnboardingGenerateWindowPost(ctx, t, client, cacheDirPath, sealedSectorPath, mAddrB, bSectorNum, sealedCid)
 			}
 
 			t.Log("Submitting WindowedPoSt...")
@@ -286,7 +286,7 @@ func TestManualCCOnboarding(t *testing.T) {
 
 			if !withMockProofs {
 				// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
-				manualOnboardingDisputeWindowPost(t, ctx, client, mAddrB, bSectorNum)
+				manualOnboardingDisputeWindowPost(ctx, t, client, mAddrB, bSectorNum)
 			}
 
 			t.Log("Checking power after PoSt ...")
@@ -302,8 +302,8 @@ func TestManualCCOnboarding(t *testing.T) {
 }
 
 func manualOnboardingGeneratePreCommit(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	client api.FullNode,
 	cacheDirPath,
 	unsealedSectorPath,
@@ -366,8 +366,8 @@ func manualOnboardingGeneratePreCommit(
 }
 
 func manualOnboardingGenerateProveCommit(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	client api.FullNode,
 	cacheDirPath,
 	sealedSectorPath string,
@@ -424,8 +424,8 @@ func manualOnboardingGenerateProveCommit(
 }
 
 func manualOnboardingGenerateWindowPost(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	client api.FullNode,
 	cacheDirPath string,
 	sealedSectorPath string,
@@ -490,8 +490,8 @@ func manualOnboardingGenerateWindowPost(
 }
 
 func manualOnboardingDisputeWindowPost(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	client kit.TestFullNode,
 	minerAddr address.Address,
 	sectorNumber abi.SectorNumber,

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -1,30 +1,14 @@
 package itests
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-cid"
-	"github.com/stretchr/testify/require"
-	cbg "github.com/whyrusleeping/cbor-gen"
-
-	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/builtin"
-	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
-	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/go-state-types/proof"
-
-	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors"
-	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/stretchr/testify/require"
 )
 
 const sectorSize = abi.SectorSize(2 << 10) // 2KiB
@@ -71,6 +55,7 @@ func TestManualCCOnboarding(t *testing.T) {
 			nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
 			minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
 			ens.Start()
+			minerB.Start(ctx)
 
 			build.Clock.Sleep(time.Second)
 
@@ -87,60 +72,23 @@ func TestManualCCOnboarding(t *testing.T) {
 			minerB.AssertNoPower(ctx)
 
 			var bSectorNum abi.SectorNumber
+			var respCh chan kit.WindowPostResp
 			if withMockProofs {
-				bSectorNum = minerB.OnboardCCSectorWithMockProofs(ctx, kit.TestSpt)
+				bSectorNum, respCh = minerB.OnboardCCSectorWithMockProofs(ctx, kit.TestSpt)
 			} else {
-				bSectorNum = minerB.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
+				bSectorNum, respCh = minerB.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
 			}
 
 			// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 			minerB.AssertNoPower(ctx)
 
-			// start a background PoST scheduler for miner B
-			bFirstCh, bErrCh := manualOnboardingRunWindowPost(
-				ctx,
-				withMockProofs,
-				client,
-				minerB,
-				bSectorNum,
-				minerB.CacheDirPaths[bSectorNum],
-				minerB.SealedSectorPaths[bSectorNum],
-				minerB.SealedCids[bSectorNum],
-				kit.TestSpt,
-			)
-
-			checkPostSchedulers := func() {
-				t.Helper()
-				select {
-				case err, ok := <-bErrCh:
-					if ok {
-						t.Fatalf("Received error from Miner B PoST scheduler: %v", err)
-					}
-				default:
-				}
-			}
-
-			isClosed := func(ch <-chan struct{}) bool {
-				select {
-				case <-ch:
-					return true
-				default:
-				}
-				return false
-			}
-
-			for ctx.Err() == nil {
-				checkPostSchedulers()
-				// wait till the first PoST is submitted for MinerB and check again
-				if isClosed(bFirstCh) {
-					break
-				}
-				t.Log("Waiting for first PoST to be submitted for all miners ...")
-				select {
-				case <-time.After(2 * time.Second):
-				case <-ctx.Done():
-					t.Fatal("Context cancelled")
-				}
+			// wait till sector is activated
+			select {
+			case resp := <-respCh:
+				req.NoError(resp.Error)
+				req.Equal(resp.SectorNumber, bSectorNum)
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for sector activation")
 			}
 
 			// Fetch on-chain sector properties
@@ -153,372 +101,10 @@ func TestManualCCOnboarding(t *testing.T) {
 
 			head = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
 
-			checkPostSchedulers()
-
 			t.Log("Checking power after PoSt ...")
 
 			// Miner B should now have power
 			minerB.AssertPower(ctx, (uint64(2 << 10)), (uint64(2 << 10)))
-
-			checkPostSchedulers()
 		})
 	}
-}
-
-func manualOnboardingGenerateWindowPost(
-	ctx context.Context,
-	client api.FullNode,
-	cacheDirPath string,
-	sealedSectorPath string,
-	minerAddr address.Address,
-	sectorNumber abi.SectorNumber,
-	sealedCid cid.Cid,
-	proofType abi.RegisteredSealProof,
-) ([]byte, error) {
-
-	head, err := client.ChainHead(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain head: %w", err)
-	}
-
-	minerInfo, err := client.StateMinerInfo(ctx, minerAddr, head.Key())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get miner info: %w", err)
-	}
-
-	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, types.EmptyTSK)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-
-	minerAddrBytes := new(bytes.Buffer)
-	if err := minerAddr.MarshalCBOR(minerAddrBytes); err != nil {
-		return nil, fmt.Errorf("failed to marshal miner address: %w", err)
-	}
-
-	rand, err := client.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_WindowedPoStChallengeSeed, di.Challenge, minerAddrBytes.Bytes(), head.Key())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get randomness: %w", err)
-	}
-	postRand := abi.PoStRandomness(rand)
-	postRand[31] &= 0x3f // make fr32 compatible
-
-	privateSectorInfo := ffi.PrivateSectorInfo{
-		SectorInfo: proof.SectorInfo{
-			SealProof:    proofType,
-			SectorNumber: sectorNumber,
-			SealedCID:    sealedCid,
-		},
-		CacheDirPath:     cacheDirPath,
-		PoStProofType:    minerInfo.WindowPoStProofType,
-		SealedSectorPath: sealedSectorPath,
-	}
-
-	actorIdNum, err := address.IDFromAddress(minerAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get actor ID: %w", err)
-	}
-	actorId := abi.ActorID(actorIdNum)
-
-	windowProofs, faultySectors, err := ffi.GenerateWindowPoSt(actorId, ffi.NewSortedPrivateSectorInfo(privateSectorInfo), postRand)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate window post: %w", err)
-	}
-	if len(faultySectors) > 0 {
-		return nil, fmt.Errorf("post failed for sectors: %v", faultySectors)
-	}
-	if len(windowProofs) != 1 {
-		return nil, fmt.Errorf("expected 1 proof, got %d", len(windowProofs))
-	}
-	if windowProofs[0].PoStProof != minerInfo.WindowPoStProofType {
-		return nil, fmt.Errorf("expected proof type %d, got %d", minerInfo.WindowPoStProofType, windowProofs[0].PoStProof)
-	}
-	proofBytes := windowProofs[0].ProofBytes
-
-	info := proof.WindowPoStVerifyInfo{
-		Randomness:        postRand,
-		Proofs:            []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
-		ChallengedSectors: []proof.SectorInfo{{SealProof: proofType, SectorNumber: sectorNumber, SealedCID: sealedCid}},
-		Prover:            actorId,
-	}
-
-	verified, err := ffi.VerifyWindowPoSt(info)
-	if err != nil {
-		return nil, fmt.Errorf("failed to verify window post: %w", err)
-	}
-	if !verified {
-		return nil, fmt.Errorf("window post verification failed")
-	}
-
-	return proofBytes, nil
-}
-
-func manualOnboardingDisputeWindowPost(
-	ctx context.Context,
-	client kit.TestFullNode,
-	miner *kit.TestUnmanagedMiner,
-	sectorNumber abi.SectorNumber,
-) error {
-
-	head, err := client.ChainHead(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get chain head: %w", err)
-	}
-
-	sp, err := client.StateSectorPartition(ctx, miner.ActorAddr, sectorNumber, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get sector partition: %w", err)
-	}
-
-	di, err := client.StateMinerProvingDeadline(ctx, miner.ActorAddr, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-
-	disputeEpoch := di.Close + 5
-	fmt.Printf("WindowPoST(%d): Dispute: Waiting %d until epoch %d to submit dispute\n", sectorNumber, disputeEpoch-head.Height(), disputeEpoch)
-
-	client.WaitTillChain(ctx, kit.HeightAtLeast(disputeEpoch))
-
-	fmt.Printf("WindowPoST(%d): Dispute: Disputing WindowedPoSt to confirm validity...\n", sectorNumber)
-
-	_, err = manualOnboardingSubmitMessage(ctx, client, miner, &miner14.DisputeWindowedPoStParams{
-		Deadline:  sp.Deadline,
-		PoStIndex: 0,
-	}, 0, builtin.MethodsMiner.DisputeWindowedPoSt)
-	if err == nil {
-		return fmt.Errorf("expected dispute to fail")
-	}
-	if !strings.Contains(err.Error(), "failed to dispute valid post") {
-		return fmt.Errorf("expected dispute to fail with 'failed to dispute valid post', got: %w", err)
-	}
-	if !strings.Contains(err.Error(), "(RetCode=16)") {
-		return fmt.Errorf("expected dispute to fail with RetCode=16, got: %w", err)
-	}
-	return nil
-}
-
-func manualOnboardingSubmitMessage(
-	ctx context.Context,
-	client api.FullNode,
-	from *kit.TestUnmanagedMiner,
-	params cbg.CBORMarshaler,
-	value uint64,
-	method abi.MethodNum,
-) (*api.MsgLookup, error) {
-
-	enc, aerr := actors.SerializeParams(params)
-	if aerr != nil {
-		return nil, fmt.Errorf("failed to serialize params: %w", aerr)
-	}
-
-	m, err := client.MpoolPushMessage(ctx, &types.Message{
-		To:     from.ActorAddr,
-		From:   from.OwnerKey.Address,
-		Value:  types.FromFil(value),
-		Method: method,
-		Params: enc,
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to push message: %w", err)
-	}
-
-	return client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
-}
-
-// manualOnboardingCalculateNextPostEpoch calculates the first epoch of the deadline proving window
-// that we want for the given sector for the given miner.
-func manualOnboardingCalculateNextPostEpoch(
-	ctx context.Context,
-	client api.FullNode,
-	minerAddr address.Address,
-	sectorNumber abi.SectorNumber,
-) (abi.ChainEpoch, abi.ChainEpoch, error) {
-
-	head, err := client.ChainHead(ctx)
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get chain head: %w", err)
-	}
-
-	sp, err := client.StateSectorPartition(ctx, minerAddr, sectorNumber, head.Key())
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get sector partition: %w", err)
-	}
-
-	fmt.Printf("WindowPoST(%d): SectorPartition: %+v\n", sectorNumber, sp)
-
-	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, head.Key())
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-
-	fmt.Printf("WindowPoST(%d): ProvingDeadline: %+v\n", sectorNumber, di)
-
-	// periodStart tells us the first epoch of the current proving period (24h)
-	// although it may be in the future if we don't need to submit post in this period
-	periodStart := di.PeriodStart
-	if di.PeriodStart < di.CurrentEpoch && sp.Deadline <= di.Index {
-		// the deadline we want has past in this current proving period, so wait till the next one
-		periodStart += di.WPoStProvingPeriod
-	}
-	provingEpoch := periodStart + (di.WPoStProvingPeriod/abi.ChainEpoch(di.WPoStPeriodDeadlines))*abi.ChainEpoch(sp.Deadline)
-
-	return di.CurrentEpoch, provingEpoch, nil
-}
-
-func manualOnboardingSubmitWindowPost(
-	ctx context.Context,
-	withMockProofs bool,
-	client kit.TestFullNode,
-	miner *kit.TestUnmanagedMiner,
-	sectorNumber abi.SectorNumber,
-	cacheDirPath, sealedSectorPath string,
-	sealedCid cid.Cid,
-	proofType abi.RegisteredSealProof,
-) error {
-	fmt.Printf("WindowPoST(%d): Running WindowPoSt ...\n", sectorNumber)
-
-	head, err := client.ChainHead(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get chain head: %w", err)
-	}
-
-	sp, err := client.StateSectorPartition(ctx, miner.ActorAddr, sectorNumber, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get sector partition: %w", err)
-	}
-
-	// We should be up to the deadline we care about
-	di, err := client.StateMinerProvingDeadline(ctx, miner.ActorAddr, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-	fmt.Printf("WindowPoST(%d): SectorPartition: %+v, ProvingDeadline: %+v\n", sectorNumber, sp, di)
-	if di.Index != sp.Deadline {
-		return fmt.Errorf("sector %d is not in the deadline %d, but %d", sectorNumber, sp.Deadline, di.Index)
-	}
-
-	var proofBytes []byte
-	if withMockProofs {
-		proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
-	} else {
-		proofBytes, err = manualOnboardingGenerateWindowPost(ctx, client, cacheDirPath, sealedSectorPath, miner.ActorAddr, sectorNumber, sealedCid, proofType)
-		if err != nil {
-			return fmt.Errorf("failed to generate window post: %w", err)
-		}
-	}
-
-	fmt.Printf("WindowedPoSt(%d) Submitting ...\n", sectorNumber)
-
-	chainRandomnessEpoch := di.Challenge
-	chainRandomness, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, chainRandomnessEpoch, nil, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get chain randomness: %w", err)
-	}
-
-	minerInfo, err := client.StateMinerInfo(ctx, miner.ActorAddr, head.Key())
-	if err != nil {
-		return fmt.Errorf("failed to get miner info: %w", err)
-	}
-
-	r, err := manualOnboardingSubmitMessage(ctx, client, miner, &miner14.SubmitWindowedPoStParams{
-		ChainCommitEpoch: chainRandomnessEpoch,
-		ChainCommitRand:  chainRandomness,
-		Deadline:         sp.Deadline,
-		Partitions:       []miner14.PoStPartition{{Index: sp.Partition}},
-		Proofs:           []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
-	}, 0, builtin.MethodsMiner.SubmitWindowedPoSt)
-	if err != nil {
-		return fmt.Errorf("failed to submit PoSt: %w", err)
-	}
-	if !r.Receipt.ExitCode.IsSuccess() {
-		return fmt.Errorf("submitting PoSt failed: %s", r.Receipt.ExitCode)
-	}
-
-	if !withMockProofs {
-		// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
-		if err := manualOnboardingDisputeWindowPost(ctx, client, miner, sectorNumber); err != nil {
-			return fmt.Errorf("failed to dispute PoSt: %w", err)
-		}
-	}
-	return nil
-}
-
-// manualOnboardingRunWindowPost runs a goroutine to continually submit PoSTs for the given sector
-// and miner. It will wait until the next proving period for the sector and then submit the PoSt.
-// It will continue to do this until the context is cancelled.
-// It returns a channel that will be closed when the first PoSt is submitted and a channel that will
-// receive any errors that occur.
-func manualOnboardingRunWindowPost(
-	ctx context.Context,
-	withMockProofs bool,
-	client kit.TestFullNode,
-	miner *kit.TestUnmanagedMiner,
-	sectorNumber abi.SectorNumber,
-	cacheDirPath,
-	sealedSectorPath string,
-	sealedCid cid.Cid,
-	proofType abi.RegisteredSealProof,
-) (chan struct{}, chan error) {
-	first := make(chan struct{})
-	errCh := make(chan error)
-
-	go func() {
-		for ctx.Err() == nil {
-			currentEpoch, nextPost, err := manualOnboardingCalculateNextPostEpoch(ctx, client, miner.ActorAddr, sectorNumber)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			nextPost += 5 // give a little buffer
-			fmt.Printf("WindowPoST(%d) Waiting %d until epoch %d to submit PoSt\n", sectorNumber, nextPost-currentEpoch, nextPost)
-
-			// Create channel to listen for chain head
-			heads, err := client.ChainNotify(ctx)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			// Wait for nextPost epoch
-			for chg := range heads {
-				var ts *types.TipSet
-				for _, c := range chg {
-					if c.Type != "apply" {
-						continue
-					}
-					ts = c.Val
-					if ts.Height() >= nextPost {
-						break
-					}
-				}
-				if ctx.Err() != nil {
-					return
-				}
-				if ts != nil && ts.Height() >= nextPost {
-					break
-				}
-			}
-			if ctx.Err() != nil {
-				return
-			}
-
-			err = manualOnboardingSubmitWindowPost(ctx, withMockProofs, client, miner, sectorNumber, cacheDirPath, sealedSectorPath, sealedCid, proofType)
-			if err != nil {
-				errCh <- err
-				return
-			}
-
-			// signal first post is done
-			select {
-			case <-first:
-			default:
-				close(first)
-			}
-		}
-	}()
-
-	return first, errCh
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/itests/kit"
-	"github.com/stretchr/testify/require"
 )
 
 const sectorSize = abi.SectorSize(2 << 10) // 2KiB
@@ -85,7 +87,7 @@ func TestManualCCOnboarding(t *testing.T) {
 	req.NoError(err)
 	t.Logf("Miner B SectorOnChainInfo %d: %+v", bSectorNum, soi)
 
-	head = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
+	_ = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
 
 	t.Log("Checking power after PoSt ...")
 
@@ -93,10 +95,10 @@ func TestManualCCOnboarding(t *testing.T) {
 	minerB.AssertPower(ctx, (uint64(2 << 10)), (uint64(2 << 10)))
 
 	// WindowPost Dispute should fail
-	assertDisputeFails(t, ctx, minerB, bSectorNum)
+	assertDisputeFails(ctx, t, minerB, bSectorNum)
 }
 
-func assertDisputeFails(t *testing.T, ctx context.Context, miner *kit.TestUnmanagedMiner, sector abi.SectorNumber) {
+func assertDisputeFails(ctx context.Context, t *testing.T, miner *kit.TestUnmanagedMiner, sector abi.SectorNumber) {
 	err := miner.SubmitPostDispute(ctx, sector)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to dispute valid post")

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -28,7 +28,6 @@ func TestManualCCOnboarding(t *testing.T) {
 		blocktime = 5 * time.Millisecond
 		client    kit.TestFullNode
 		minerA    kit.TestMiner // A is a standard genesis miner
-		minerA2   kit.TestMiner
 	)
 
 	// Setup and begin mining with a single miner (A)
@@ -38,11 +37,9 @@ func TestManualCCOnboarding(t *testing.T) {
 	ens := kit.NewEnsemble(t, kitOpts...).
 		FullNode(&client, nodeOpts...).
 		Miner(&minerA, &client, nodeOpts...).
-		// TODO: Figure out we need two genesis miners if we want to use two unmanaged miners in the test
-		Miner(&minerA2, &client, nodeOpts...).
 		Start().
 		InterconnectAll()
-	ens.BeginMining(blocktime)
+	ens.BeginMiningMustPost(blocktime)
 
 	// Instantiate MinerB to manually handle sector onboarding and power acquisition through sector activation.
 	// Unlike other miners managed by the Lotus Miner storage infrastructure, MinerB operates independently,

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -705,7 +705,6 @@ func manualOnboardingRunWindowPost(
 	sealedCid cid.Cid,
 	proofType abi.RegisteredSealProof,
 ) (chan struct{}, chan error) {
-
 	first := make(chan struct{})
 	errCh := make(chan error)
 

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -1,0 +1,209 @@
+package itests
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/proof"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+)
+
+// Manually onboard CC sectors, bypassing lotus-miner onboarding pathways
+func TestManualCCOnboarding(t *testing.T) {
+	req := require.New(t)
+
+	kit.QuietMiningLogs()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		blocktime = 2 * time.Millisecond
+
+		client kit.TestFullNode
+		minerA kit.TestMiner // A is a standard genesis miner
+		minerB kit.TestMiner // B is a CC miner we will onboard manually
+	)
+
+	opts := []kit.NodeOpt{kit.WithAllSubsystems()}
+	ens := kit.NewEnsemble(t, kit.MockProofs()).
+		FullNode(&client, opts...).
+		Miner(&minerA, &client, opts...).
+		Start().
+		InterconnectAll()
+	ens.BeginMining(blocktime)
+
+	opts = append(opts, kit.OwnerAddr(client.DefaultKey))
+	ens.Miner(&minerB, &client, opts...).Start()
+
+	maddrA, err := minerA.ActorAddress(ctx)
+	req.NoError(err)
+
+	build.Clock.Sleep(time.Second)
+
+	t.Log("Submitting PreCommitSector...")
+
+	maddrB, err := minerB.ActorAddress(ctx)
+	req.NoError(err)
+
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+
+	minerBInfo, err := client.StateMinerInfo(ctx, maddrB, head.Key())
+	req.NoError(err)
+
+	preCommitParams := &miner.PreCommitSectorBatchParams2{
+		Sectors: []miner.SectorPreCommitInfo{{
+			Expiration:    2880 * 300,
+			SectorNumber:  22,
+			SealProof:     kit.TestSpt,
+			SealedCID:     cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz"),
+			SealRandEpoch: head.Height() - 200,
+		}},
+	}
+
+	enc := new(bytes.Buffer)
+	req.NoError(preCommitParams.MarshalCBOR(enc))
+
+	m, err := client.MpoolPushMessage(ctx, &types.Message{
+		To:     maddrB,
+		From:   minerB.OwnerKey.Address,
+		Value:  types.FromFil(1),
+		Method: builtin.MethodsMiner.PreCommitSectorBatch2,
+		Params: enc.Bytes(),
+	}, nil)
+	req.NoError(err)
+
+	r, err := client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+	req.NoError(err)
+	require.True(t, r.Receipt.ExitCode.IsSuccess())
+
+	client.WaitTillChain(ctx, kit.HeightAtLeast(r.Height+miner14.PreCommitChallengeDelay+5))
+
+	t.Log("Checking initial power...")
+
+	p, err := client.StateMinerPower(ctx, maddrA, r.TipSet)
+	req.NoError(err)
+	t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+
+	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
+	req.NoError(err)
+	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	require.True(t, p.MinerPower.RawBytePower.IsZero())
+
+	t.Log("Submitting ProveCommitSector...")
+
+	bSectorNum := preCommitParams.Sectors[0].SectorNumber
+
+	proveCommitParams := miner14.ProveCommitSectors3Params{
+		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: bSectorNum}},
+		SectorProofs:             [][]byte{{0xde, 0xad, 0xbe, 0xef}},
+		RequireActivationSuccess: true,
+	}
+
+	enc = new(bytes.Buffer)
+	req.NoError(proveCommitParams.MarshalCBOR(enc))
+
+	m, err = client.MpoolPushMessage(ctx, &types.Message{
+		To:     minerB.ActorAddr,
+		From:   minerB.OwnerKey.Address,
+		Value:  types.FromFil(0),
+		Method: builtin.MethodsMiner.ProveCommitSectors3,
+		Params: enc.Bytes(),
+	}, nil)
+	req.NoError(err)
+
+	r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+	req.NoError(err)
+	require.True(t, r.Receipt.ExitCode.IsSuccess())
+
+	soi, err := client.StateSectorGetInfo(ctx, maddrB, bSectorNum, r.TipSet)
+	req.NoError(err)
+	t.Logf("SectorOnChainInfo %d: %+v", bSectorNum, soi)
+
+	sp, err := client.StateSectorPartition(ctx, maddrB, bSectorNum, r.TipSet)
+	req.NoError(err)
+	t.Logf("SectorPartition %d: %+v", bSectorNum, sp)
+	bSectorDeadline := sp.Deadline
+	bSectorPartition := sp.Partition
+
+	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
+	req.NoError(err)
+	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	require.True(t, p.MinerPower.RawBytePower.IsZero())
+
+	di, err := client.StateMinerProvingDeadline(ctx, maddrB, types.EmptyTSK)
+	req.NoError(err)
+	t.Logf("MinerB Deadline Info: %+v", di)
+
+	// Use the current deadline to work out when the deadline we care about (bSectorDeadline) is open
+	// and ready to receive posts
+	deadlineCount := di.WPoStPeriodDeadlines
+	epochsPerDeadline := uint64(di.WPoStChallengeWindow)
+	currentDeadline := di.Index
+	currentDeadlineStart := di.Open
+	waitTillEpoch := abi.ChainEpoch((deadlineCount-currentDeadline+bSectorDeadline)*epochsPerDeadline) + currentDeadlineStart - di.WPoStProvingPeriod + 1
+
+	t.Logf("Waiting %d until epoch %d to get to deadline %d", waitTillEpoch-di.CurrentEpoch, waitTillEpoch, bSectorDeadline)
+	client.WaitTillChain(ctx, kit.HeightAtLeast(waitTillEpoch))
+
+	// We should be up to the deadline we care about
+	di, err = client.StateMinerProvingDeadline(ctx, maddrB, types.EmptyTSK)
+	req.NoError(err)
+	req.Equal(di.Index, bSectorDeadline, "should be in the deadline of the sector to prove")
+
+	t.Log("Submitting WindowedPoSt...")
+
+	head, err = client.ChainHead(ctx)
+	req.NoError(err)
+	rand, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, di.Open, nil, head.Key())
+	require.NoError(t, err)
+
+	postParams := miner.SubmitWindowedPoStParams{
+		ChainCommitEpoch: di.Open,
+		ChainCommitRand:  rand,
+		Deadline:         bSectorDeadline,
+		Partitions:       []miner.PoStPartition{{Index: bSectorPartition}},
+		Proofs: []proof.PoStProof{{
+			PoStProof:  minerBInfo.WindowPoStProofType,
+			ProofBytes: []byte{0x1, 0x2, 0x3, 0x4},
+		}},
+	}
+
+	enc = new(bytes.Buffer)
+	req.NoError(postParams.MarshalCBOR(enc))
+
+	m, err = client.MpoolPushMessage(ctx, &types.Message{
+		To:     maddrB,
+		From:   minerB.OwnerKey.Address,
+		Value:  types.NewInt(0),
+		Method: builtin.MethodsMiner.SubmitWindowedPoSt,
+		Params: enc.Bytes(),
+	}, nil)
+	req.NoError(err)
+
+	r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+	req.NoError(err)
+	require.True(t, r.Receipt.ExitCode.IsSuccess())
+
+	t.Log("Checking power after PoSt...")
+
+	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
+	req.NoError(err)
+	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	req.Equal(uint64(2<<10), p.MinerPower.RawBytePower.Uint64())    // 2kiB RBP
+	req.Equal(uint64(2<<10), p.MinerPower.QualityAdjPower.Uint64()) // 2kiB QaP
+}

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -24,7 +24,8 @@ func TestManualCCOnboarding(t *testing.T) {
 	defer cancel()
 
 	var (
-		blocktime = 2 * time.Millisecond
+		// need to pick a balance value so that the test is not racy on CI by running through it's WindowPostDeadlines too fast
+		blocktime = 5 * time.Millisecond
 		client    kit.TestFullNode
 		minerA    kit.TestMiner // A is a standard genesis miner
 	)

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -3,13 +3,16 @@ package itests
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
@@ -21,11 +24,13 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 )
+
+const sectorSize = abi.SectorSize(2 << 10) // 2KiB
 
 // Manually onboard CC sectors, bypassing lotus-miner onboarding pathways
 func TestManualCCOnboarding(t *testing.T) {
@@ -45,15 +50,38 @@ func TestManualCCOnboarding(t *testing.T) {
 				blocktime = 2 * time.Millisecond
 
 				client kit.TestFullNode
-				minerA kit.TestMiner // A is a standard genesis miner
-				minerB kit.TestMiner // B is a CC miner we will onboard manually
+				minerA kit.TestMiner          // A is a standard genesis miner
+				minerB kit.TestUnmanagedMiner // B is a CC miner we will onboard manually
+				minerC kit.TestUnmanagedMiner // C is a CC miner we will onboard manually (will be used for NI-PoRep)
 
+				// TODO: single sector per miner for now, but this isn't going to scale when refactored into
+				// TestUnmanagedMiner - they'll need their own list of sectors and their own copy of each of
+				// the things below, including per-sector maps of some of these too.
+				//
+				// Misc thoughts:
+				// Each TestUnmanagedMiner should have its own temp dir, within which it can have a cache dir
+				// and a place to put sealed and unsealed sectors. We can't share these between miners.
+				// We should have a way to "add" CC sectors, which will setup the sealed and unsealed files
+				// and can move many of the manualOnboarding*() methods into the TestUnmanagedMiner struct.
+				//
+				// The manualOnboardingRunWindowPost() Go routine should be owned by TestUnmanagedMiner and
+				// a simple "miner.StartWindowPost()" should suffice to make it observe all of the sectors
+				// it knows about and start posting for them. We should be able to ignore most (all?) of the
+				// special cases that lotus-miner currently has to deal with.
+
+				// sector numbers, make them unique for each miner so our maps work
 				bSectorNum = abi.SectorNumber(22)
+				cSectorNum = abi.SectorNumber(33)
 
-				cacheDirPath                         string
-				unsealedSectorPath, sealedSectorPath string
-				sealedCid, unsealedCid               cid.Cid
-				sealTickets                          abi.SealRandomness
+				tmpDir = t.TempDir()
+
+				cacheDirPath                         = map[abi.SectorNumber]string{} // can't share a cacheDir between miners
+				unsealedSectorPath, sealedSectorPath = map[abi.SectorNumber]string{}, map[abi.SectorNumber]string{}
+				sealedCid, unsealedCid               = map[abi.SectorNumber]cid.Cid{}, map[abi.SectorNumber]cid.Cid{}
+
+				// note we'll use the same randEpoch for both miners
+				sealRandEpoch = policy.SealRandomnessLookback
+				sealTickets   = map[abi.SectorNumber]abi.SealRandomness{}
 			)
 
 			// Setup and begin mining with a single miner (A)
@@ -62,7 +90,7 @@ func TestManualCCOnboarding(t *testing.T) {
 			if withMockProofs {
 				kitOpts = append(kitOpts, kit.MockProofs())
 			}
-			nodeOpts := []kit.NodeOpt{kit.WithAllSubsystems()}
+			nodeOpts := []kit.NodeOpt{kit.SectorSize(sectorSize), kit.WithAllSubsystems()}
 			ens := kit.NewEnsemble(t, kitOpts...).
 				FullNode(&client, nodeOpts...).
 				Miner(&minerA, &client, nodeOpts...).
@@ -71,93 +99,74 @@ func TestManualCCOnboarding(t *testing.T) {
 			ens.BeginMining(blocktime)
 
 			nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
-			ens.Miner(&minerB, &client, nodeOpts...).Start()
-
-			maddrA, err := minerA.ActorAddress(ctx)
-			req.NoError(err)
+			ens.UnmanagedMiner(&minerB, &client, nodeOpts...).Start()
+			ens.UnmanagedMiner(&minerC, &client, nodeOpts...).Start()
 
 			build.Clock.Sleep(time.Second)
 
-			mAddrB, err := minerB.ActorAddress(ctx)
-			req.NoError(err)
-			mAddrBBytes := new(bytes.Buffer)
-			req.NoError(mAddrB.MarshalCBOR(mAddrBBytes))
-
 			head, err := client.ChainHead(ctx)
-			req.NoError(err)
-
-			minerBInfo, err := client.StateMinerInfo(ctx, mAddrB, head.Key())
 			req.NoError(err)
 
 			t.Log("Checking initial power ...")
 
 			// Miner A should have power
-			p, err := client.StateMinerPower(ctx, maddrA, head.Key())
+			p, err := client.StateMinerPower(ctx, minerA.ActorAddr, head.Key())
 			req.NoError(err)
 			t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 
 			// Miner B should have no power
-			p, err = client.StateMinerPower(ctx, mAddrB, head.Key())
+			p, err = client.StateMinerPower(ctx, minerB.ActorAddr, head.Key())
 			req.NoError(err)
 			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 			req.True(p.MinerPower.RawBytePower.IsZero())
 
+			// Miner C should have no power
+			p, err = client.StateMinerPower(ctx, minerC.ActorAddr, head.Key())
+			req.NoError(err)
+			t.Logf("MinerC RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.True(p.MinerPower.RawBytePower.IsZero())
+
 			// Run precommit for a sector on miner B
 
-			sealRandEpoch := policy.SealRandomnessLookback
 			t.Logf("Waiting for at least epoch %d for seal randomness (current epoch %d) ...", sealRandEpoch+5, head.Height())
 			client.WaitTillChain(ctx, kit.HeightAtLeast(sealRandEpoch+5))
 
 			if withMockProofs {
-				sealedCid = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
+				sealedCid[bSectorNum] = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
 			} else {
-				cacheDirPath = t.TempDir()
-				tmpDir := t.TempDir()
-				unsealedSectorPath = filepath.Join(tmpDir, "unsealed")
-				sealedSectorPath = filepath.Join(tmpDir, "sealed")
+				cacheDirPath[bSectorNum] = filepath.Join(tmpDir, "cacheb")
+				unsealedSectorPath[bSectorNum] = filepath.Join(tmpDir, "unsealedb")
+				sealedSectorPath[bSectorNum] = filepath.Join(tmpDir, "sealedb")
 
-				sealTickets, sealedCid, unsealedCid = manualOnboardingGeneratePreCommit(
+				sealTickets[bSectorNum], sealedCid[bSectorNum], unsealedCid[bSectorNum] = manualOnboardingGeneratePreCommit(
 					ctx,
 					t,
 					client,
-					cacheDirPath,
-					unsealedSectorPath,
-					sealedSectorPath,
-					mAddrB,
+					cacheDirPath[bSectorNum],
+					unsealedSectorPath[bSectorNum],
+					sealedSectorPath[bSectorNum],
+					minerB.ActorAddr,
 					bSectorNum,
 					sealRandEpoch,
+					kit.TestSpt,
 				)
 			}
 
-			t.Log("Submitting PreCommitSector ...")
+			t.Log("Submitting MinerB PreCommitSector ...")
 
-			preCommitParams := &miner.PreCommitSectorBatchParams2{
-				Sectors: []miner.SectorPreCommitInfo{{
+			r, err := manualOnboardingSubmitMessage(ctx, client, minerB, &miner14.PreCommitSectorBatchParams2{
+				Sectors: []miner14.SectorPreCommitInfo{{
 					Expiration:    2880 * 300,
-					SectorNumber:  22,
+					SectorNumber:  bSectorNum,
 					SealProof:     kit.TestSpt,
-					SealedCID:     sealedCid,
+					SealedCID:     sealedCid[bSectorNum],
 					SealRandEpoch: sealRandEpoch,
 				}},
-			}
-
-			enc := new(bytes.Buffer)
-			req.NoError(preCommitParams.MarshalCBOR(enc))
-
-			m, err := client.MpoolPushMessage(ctx, &types.Message{
-				To:     mAddrB,
-				From:   minerB.OwnerKey.Address,
-				Value:  types.FromFil(1),
-				Method: builtin.MethodsMiner.PreCommitSectorBatch2,
-				Params: enc.Bytes(),
-			}, nil)
-			req.NoError(err)
-
-			r, err := client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
 			req.NoError(err)
 			req.True(r.Receipt.ExitCode.IsSuccess())
 
-			preCommitInfo, err := client.StateSectorPreCommitInfo(ctx, mAddrB, bSectorNum, r.TipSet)
+			preCommitInfo, err := client.StateSectorPreCommitInfo(ctx, minerB.ActorAddr, bSectorNum, r.TipSet)
 			req.NoError(err)
 
 			// Run prove commit for the sector on miner B
@@ -174,129 +183,210 @@ func TestManualCCOnboarding(t *testing.T) {
 					ctx,
 					t,
 					client,
-					cacheDirPath,
-					sealedSectorPath,
-					mAddrB,
+					cacheDirPath[bSectorNum],
+					sealedSectorPath[bSectorNum],
+					minerB.ActorAddr,
 					bSectorNum,
-					sealedCid,
-					unsealedCid,
-					sealTickets,
+					sealedCid[bSectorNum],
+					unsealedCid[bSectorNum],
+					sealTickets[bSectorNum],
+					kit.TestSpt,
 				)
 			}
 
-			t.Log("Submitting ProveCommitSector ...")
+			t.Log("Submitting MinerB ProveCommitSector ...")
 
-			proveCommitParams := miner14.ProveCommitSectors3Params{
+			r, err = manualOnboardingSubmitMessage(ctx, client, minerB, &miner14.ProveCommitSectors3Params{
 				SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: bSectorNum}},
 				SectorProofs:             [][]byte{sectorProof},
 				RequireActivationSuccess: true,
-			}
-
-			enc = new(bytes.Buffer)
-			req.NoError(proveCommitParams.MarshalCBOR(enc))
-
-			m, err = client.MpoolPushMessage(ctx, &types.Message{
-				To:     minerB.ActorAddr,
-				From:   minerB.OwnerKey.Address,
-				Value:  types.FromFil(0),
-				Method: builtin.MethodsMiner.ProveCommitSectors3,
-				Params: enc.Bytes(),
-			}, nil)
-			req.NoError(err)
-
-			r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			}, 0, builtin.MethodsMiner.ProveCommitSectors3)
 			req.NoError(err)
 			req.True(r.Receipt.ExitCode.IsSuccess())
 
 			// Check power after proving, should still be zero until the PoSt is submitted
-			p, err = client.StateMinerPower(ctx, mAddrB, r.TipSet)
+			p, err = client.StateMinerPower(ctx, minerB.ActorAddr, r.TipSet)
 			req.NoError(err)
 			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 			req.True(p.MinerPower.RawBytePower.IsZero())
 
-			// Fetch on-chain sector properties
+			// start a background PoST scheduler for miner B
+			bFirstCh, bErrCh := manualOnboardingRunWindowPost(
+				ctx,
+				withMockProofs,
+				client,
+				minerB,
+				bSectorNum,
+				cacheDirPath[bSectorNum],
+				sealedSectorPath[bSectorNum],
+				sealedCid[bSectorNum],
+				kit.TestSpt,
+			)
 
-			soi, err := client.StateSectorGetInfo(ctx, mAddrB, bSectorNum, r.TipSet)
-			req.NoError(err)
-			t.Logf("SectorOnChainInfo %d: %+v", bSectorNum, soi)
+			// Miner C (will be used for NI-PoRep)
 
-			sp, err := client.StateSectorPartition(ctx, mAddrB, bSectorNum, r.TipSet)
-			req.NoError(err)
-			t.Logf("SectorPartition %d: %+v", bSectorNum, sp)
-			bSectorDeadline := sp.Deadline
-			bSectorPartition := sp.Partition
-
-			// Wait for the deadline to come around and submit a PoSt
-
-			di, err := client.StateMinerProvingDeadline(ctx, mAddrB, types.EmptyTSK)
-			req.NoError(err)
-			t.Logf("MinerB Deadline Info: %+v", di)
-
-			// Use the current deadline to work out when the deadline we care about (bSectorDeadline) is open
-			// and ready to receive posts
-			deadlineCount := di.WPoStPeriodDeadlines
-			epochsPerDeadline := uint64(di.WPoStChallengeWindow)
-			currentDeadline := di.Index
-			currentDeadlineStart := di.Open
-			waitTillEpoch := abi.ChainEpoch((deadlineCount-currentDeadline+bSectorDeadline)*epochsPerDeadline) + currentDeadlineStart + 1
-
-			t.Logf("Waiting %d until epoch %d to get to deadline %d", waitTillEpoch-di.CurrentEpoch, waitTillEpoch, bSectorDeadline)
-			head = client.WaitTillChain(ctx, kit.HeightAtLeast(waitTillEpoch))
-
-			// We should be up to the deadline we care about
-			di, err = client.StateMinerProvingDeadline(ctx, mAddrB, types.EmptyTSK)
-			req.NoError(err)
-			req.Equal(bSectorDeadline, di.Index, "should be in the deadline of the sector to prove")
-
-			var proofBytes []byte
 			if withMockProofs {
-				proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+				sealedCid[cSectorNum] = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
 			} else {
-				proofBytes = manualOnboardingGenerateWindowPost(ctx, t, client, cacheDirPath, sealedSectorPath, mAddrB, bSectorNum, sealedCid)
+				cacheDirPath[cSectorNum] = filepath.Join(tmpDir, "cachec")
+				unsealedSectorPath[cSectorNum] = filepath.Join(tmpDir, "unsealedc")
+				sealedSectorPath[cSectorNum] = filepath.Join(tmpDir, "sealedc")
+
+				sealTickets[cSectorNum], sealedCid[cSectorNum], unsealedCid[cSectorNum] = manualOnboardingGeneratePreCommit(
+					ctx,
+					t,
+					client,
+					cacheDirPath[cSectorNum],
+					unsealedSectorPath[cSectorNum],
+					sealedSectorPath[cSectorNum],
+					minerC.ActorAddr,
+					cSectorNum,
+					sealRandEpoch,
+					kit.TestSpt,
+				)
 			}
 
-			t.Log("Submitting WindowedPoSt...")
+			t.Log("Submitting MinerC PreCommitSector ...")
 
-			rand, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, di.Open, nil, head.Key())
-			req.NoError(err)
-
-			postParams := miner.SubmitWindowedPoStParams{
-				ChainCommitEpoch: di.Open,
-				ChainCommitRand:  rand,
-				Deadline:         bSectorDeadline,
-				Partitions:       []miner.PoStPartition{{Index: bSectorPartition}},
-				Proofs:           []proof.PoStProof{{PoStProof: minerBInfo.WindowPoStProofType, ProofBytes: proofBytes}},
-			}
-
-			enc = new(bytes.Buffer)
-			req.NoError(postParams.MarshalCBOR(enc))
-
-			m, err = client.MpoolPushMessage(ctx, &types.Message{
-				To:     mAddrB,
-				From:   minerB.OwnerKey.Address,
-				Value:  types.NewInt(0),
-				Method: builtin.MethodsMiner.SubmitWindowedPoSt,
-				Params: enc.Bytes(),
-			}, nil)
-			req.NoError(err)
-
-			r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			r, err = manualOnboardingSubmitMessage(ctx, client, minerC, &miner14.PreCommitSectorBatchParams2{
+				Sectors: []miner14.SectorPreCommitInfo{{
+					Expiration:    2880 * 300,
+					SectorNumber:  cSectorNum,
+					SealProof:     kit.TestSpt,
+					SealedCID:     sealedCid[cSectorNum],
+					SealRandEpoch: sealRandEpoch,
+				}},
+			}, 1, builtin.MethodsMiner.PreCommitSectorBatch2)
 			req.NoError(err)
 			req.True(r.Receipt.ExitCode.IsSuccess())
 
-			if !withMockProofs {
-				// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
-				manualOnboardingDisputeWindowPost(ctx, t, client, mAddrB, bSectorNum)
+			preCommitInfo, err = client.StateSectorPreCommitInfo(ctx, minerC.ActorAddr, cSectorNum, r.TipSet)
+			req.NoError(err)
+
+			// Run prove commit for the sector on miner C
+
+			seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+			t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-r.Height, seedRandomnessHeight, r.Height)
+			client.WaitTillChain(ctx, kit.HeightAtLeast(seedRandomnessHeight+5))
+
+			if withMockProofs {
+				sectorProof = []byte{0xde, 0xad, 0xbe, 0xef}
+			} else {
+				sectorProof = manualOnboardingGenerateProveCommit(
+					ctx,
+					t,
+					client,
+					cacheDirPath[cSectorNum],
+					sealedSectorPath[cSectorNum],
+					minerC.ActorAddr,
+					cSectorNum,
+					sealedCid[cSectorNum],
+					unsealedCid[cSectorNum],
+					sealTickets[cSectorNum],
+					kit.TestSpt,
+				)
 			}
+
+			t.Log("Submitting MinerC ProveCommitSector ...")
+
+			r, err = manualOnboardingSubmitMessage(ctx, client, minerC, &miner14.ProveCommitSectors3Params{
+				SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: cSectorNum}},
+				SectorProofs:             [][]byte{sectorProof},
+				RequireActivationSuccess: true,
+			}, 0, builtin.MethodsMiner.ProveCommitSectors3)
+			req.NoError(err)
+			req.True(r.Receipt.ExitCode.IsSuccess())
+
+			// Check power after proving, should still be zero until the PoSt is submitted
+			p, err = client.StateMinerPower(ctx, minerC.ActorAddr, r.TipSet)
+			req.NoError(err)
+			t.Logf("MinerC RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.True(p.MinerPower.RawBytePower.IsZero())
+
+			// start a background PoST scheduler for miner C
+			cFirstCh, cErrCh := manualOnboardingRunWindowPost(
+				ctx,
+				withMockProofs,
+				client,
+				minerC,
+				cSectorNum,
+				cacheDirPath[cSectorNum],
+				sealedSectorPath[cSectorNum],
+				sealedCid[cSectorNum],
+				kit.TestSpt,
+			)
+
+			checkPostSchedulers := func() {
+				t.Helper()
+				select {
+				case err, ok := <-bErrCh:
+					if ok {
+						t.Fatalf("Received error from Miner B PoST scheduler: %v", err)
+					}
+				case err, ok := <-cErrCh:
+					if ok {
+						t.Fatalf("Received error from Miner C PoST scheduler: %v", err)
+					}
+				default:
+				}
+			}
+
+			isClosed := func(ch <-chan struct{}) bool {
+				select {
+				case <-ch:
+					return true
+				default:
+				}
+				return false
+			}
+
+			for ctx.Err() == nil {
+				checkPostSchedulers()
+				// wait till the first PoST is submitted for both by checking if both bFirstCh and cFirstCh are closed, if so, break, otherwise sleep for 500ms and check again
+				if isClosed(bFirstCh) && isClosed(cFirstCh) {
+					break
+				}
+				t.Log("Waiting for first PoST to be submitted for all miners ...")
+				select {
+				case <-time.After(2 * time.Second):
+				case <-ctx.Done():
+					t.Fatal("Context cancelled")
+				}
+			}
+
+			// Fetch on-chain sector properties
+
+			soi, err := client.StateSectorGetInfo(ctx, minerB.ActorAddr, bSectorNum, r.TipSet)
+			req.NoError(err)
+			t.Logf("Miner B SectorOnChainInfo %d: %+v", bSectorNum, soi)
+			soi, err = client.StateSectorGetInfo(ctx, minerC.ActorAddr, cSectorNum, r.TipSet)
+			req.NoError(err)
+			t.Logf("Miner C SectorOnChainInfo %d: %+v", cSectorNum, soi)
+
+			head, err = client.ChainHead(ctx)
+			req.NoError(err)
+
+			head = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
+
+			checkPostSchedulers()
 
 			t.Log("Checking power after PoSt ...")
 
 			// Miner B should now have power
-			p, err = client.StateMinerPower(ctx, mAddrB, r.TipSet)
+			p, err = client.StateMinerPower(ctx, minerB.ActorAddr, head.Key())
 			req.NoError(err)
 			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 			req.Equal(uint64(2<<10), p.MinerPower.RawBytePower.Uint64())    // 2kiB RBP
 			req.Equal(uint64(2<<10), p.MinerPower.QualityAdjPower.Uint64()) // 2kiB QaP
+
+			// Miner C should now have power
+			p, err = client.StateMinerPower(ctx, minerC.ActorAddr, head.Key())
+			req.NoError(err)
+			t.Logf("MinerC RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.Equal(uint64(2<<10), p.MinerPower.RawBytePower.Uint64())    // 2kiB RBP
+			req.Equal(uint64(2<<10), p.MinerPower.QualityAdjPower.Uint64()) // 2kiB QaP
+
+			checkPostSchedulers()
 		})
 	}
 }
@@ -311,15 +401,19 @@ func manualOnboardingGeneratePreCommit(
 	minerAddr address.Address,
 	sectorNumber abi.SectorNumber,
 	sealRandEpoch abi.ChainEpoch,
+	proofType abi.RegisteredSealProof,
 ) (abi.SealRandomness, cid.Cid, cid.Cid) {
 
 	req := require.New(t)
-	t.Log("Generating PreCommit ...")
+	t.Logf("Generating proof type %d PreCommit ...", proofType)
 
-	sectorSize := abi.SectorSize(2 << 10)
+	_ = os.Mkdir(cacheDirPath, 0755)
 	unsealedSize := abi.PaddedPieceSize(sectorSize).Unpadded()
 	req.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
 	req.NoError(os.WriteFile(sealedSectorPath, make([]byte, sectorSize), 0644))
+
+	t.Logf("Wrote unsealed sector to %s", unsealedSectorPath)
+	t.Logf("Wrote sealed sector to %s", sealedSectorPath)
 
 	head, err := client.ChainHead(ctx)
 	req.NoError(err)
@@ -331,14 +425,14 @@ func manualOnboardingGeneratePreCommit(
 	req.NoError(err)
 	sealTickets := abi.SealRandomness(rand)
 
-	t.Logf("Running SealPreCommitPhase1 for sector %d...", sectorNumber)
+	t.Logf("Running proof type %d SealPreCommitPhase1 for sector %d...", proofType, sectorNumber)
 
 	actorIdNum, err := address.IDFromAddress(minerAddr)
 	req.NoError(err)
 	actorId := abi.ActorID(actorIdNum)
 
 	pc1, err := ffi.SealPreCommitPhase1(
-		kit.TestSpt,
+		proofType,
 		cacheDirPath,
 		unsealedSectorPath,
 		sealedSectorPath,
@@ -350,7 +444,7 @@ func manualOnboardingGeneratePreCommit(
 	req.NoError(err)
 	req.NotNil(pc1)
 
-	t.Logf("Running SealPreCommitPhase2 for sector %d...", sectorNumber)
+	t.Logf("Running proof type %d SealPreCommitPhase2 for sector %d...", proofType, sectorNumber)
 
 	sealedCid, unsealedCid, err := ffi.SealPreCommitPhase2(
 		pc1,
@@ -375,18 +469,20 @@ func manualOnboardingGenerateProveCommit(
 	sectorNumber abi.SectorNumber,
 	sealedCid, unsealedCid cid.Cid,
 	sealTickets abi.SealRandomness,
+	proofType abi.RegisteredSealProof,
 ) []byte {
 	req := require.New(t)
 
-	t.Log("Generating Sector Proof ...")
+	t.Logf("Generating proof type %d Sector Proof ...", proofType)
 
 	head, err := client.ChainHead(ctx)
 	req.NoError(err)
 
+	var seedRandomnessHeight abi.ChainEpoch
+
 	preCommitInfo, err := client.StateSectorPreCommitInfo(ctx, minerAddr, sectorNumber, head.Key())
 	req.NoError(err)
-
-	seedRandomnessHeight := preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+	seedRandomnessHeight = preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
 
 	minerAddrBytes := new(bytes.Buffer)
 	req.NoError(minerAddr.MarshalCBOR(minerAddrBytes))
@@ -399,10 +495,10 @@ func manualOnboardingGenerateProveCommit(
 	req.NoError(err)
 	actorId := abi.ActorID(actorIdNum)
 
-	t.Logf("Running SealCommitPhase1 for sector %d...", sectorNumber)
+	t.Logf("Running proof type %d SealCommitPhase1 for sector %d...", proofType, sectorNumber)
 
 	scp1, err := ffi.SealCommitPhase1(
-		kit.TestSpt,
+		proofType,
 		sealedCid,
 		unsealedCid,
 		cacheDirPath,
@@ -415,47 +511,57 @@ func manualOnboardingGenerateProveCommit(
 	)
 	req.NoError(err)
 
-	t.Logf("Running SealCommitPhase2 for sector %d...", sectorNumber)
+	t.Logf("Running proof type %d SealCommitPhase2 for sector %d...", proofType, sectorNumber)
 
 	sectorProof, err := ffi.SealCommitPhase2(scp1, sectorNumber, actorId)
 	req.NoError(err)
+
+	t.Logf("Got proof type %d sector proof of length %d", proofType, len(sectorProof))
 
 	return sectorProof
 }
 
 func manualOnboardingGenerateWindowPost(
 	ctx context.Context,
-	t *testing.T,
 	client api.FullNode,
 	cacheDirPath string,
 	sealedSectorPath string,
 	minerAddr address.Address,
 	sectorNumber abi.SectorNumber,
 	sealedCid cid.Cid,
-) []byte {
-
-	req := require.New(t)
+	proofType abi.RegisteredSealProof,
+) ([]byte, error) {
 
 	head, err := client.ChainHead(ctx)
-	req.NoError(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain head: %w", err)
+	}
 
 	minerInfo, err := client.StateMinerInfo(ctx, minerAddr, head.Key())
-	req.NoError(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get miner info: %w", err)
+	}
 
 	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, types.EmptyTSK)
-	req.NoError(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get proving deadline: %w", err)
+	}
 
 	minerAddrBytes := new(bytes.Buffer)
-	req.NoError(minerAddr.MarshalCBOR(minerAddrBytes))
+	if err := minerAddr.MarshalCBOR(minerAddrBytes); err != nil {
+		return nil, fmt.Errorf("failed to marshal miner address: %w", err)
+	}
 
 	rand, err := client.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_WindowedPoStChallengeSeed, di.Challenge, minerAddrBytes.Bytes(), head.Key())
-	req.NoError(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get randomness: %w", err)
+	}
 	postRand := abi.PoStRandomness(rand)
 	postRand[31] &= 0x3f // make fr32 compatible
 
 	privateSectorInfo := ffi.PrivateSectorInfo{
 		SectorInfo: proof.SectorInfo{
-			SealProof:    kit.TestSpt,
+			SealProof:    proofType,
 			SectorNumber: sectorNumber,
 			SealedCID:    sealedCid,
 		},
@@ -465,70 +571,311 @@ func manualOnboardingGenerateWindowPost(
 	}
 
 	actorIdNum, err := address.IDFromAddress(minerAddr)
-	req.NoError(err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get actor ID: %w", err)
+	}
 	actorId := abi.ActorID(actorIdNum)
 
 	windowProofs, faultySectors, err := ffi.GenerateWindowPoSt(actorId, ffi.NewSortedPrivateSectorInfo(privateSectorInfo), postRand)
-	req.NoError(err)
-	req.Len(faultySectors, 0)
-	req.Len(windowProofs, 1)
-	req.Equal(minerInfo.WindowPoStProofType, windowProofs[0].PoStProof)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate window post: %w", err)
+	}
+	if len(faultySectors) > 0 {
+		return nil, fmt.Errorf("post failed for sectors: %v", faultySectors)
+	}
+	if len(windowProofs) != 1 {
+		return nil, fmt.Errorf("expected 1 proof, got %d", len(windowProofs))
+	}
+	if windowProofs[0].PoStProof != minerInfo.WindowPoStProofType {
+		return nil, fmt.Errorf("expected proof type %d, got %d", minerInfo.WindowPoStProofType, windowProofs[0].PoStProof)
+	}
 	proofBytes := windowProofs[0].ProofBytes
 
 	info := proof.WindowPoStVerifyInfo{
 		Randomness:        postRand,
 		Proofs:            []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
-		ChallengedSectors: []proof.SectorInfo{{SealProof: kit.TestSpt, SectorNumber: sectorNumber, SealedCID: sealedCid}},
+		ChallengedSectors: []proof.SectorInfo{{SealProof: proofType, SectorNumber: sectorNumber, SealedCID: sealedCid}},
 		Prover:            actorId,
 	}
 
 	verified, err := ffi.VerifyWindowPoSt(info)
-	req.NoError(err)
-	req.True(verified, "window post verification failed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify window post: %w", err)
+	}
+	if !verified {
+		return nil, fmt.Errorf("window post verification failed")
+	}
 
-	return proofBytes
+	return proofBytes, nil
 }
 
 func manualOnboardingDisputeWindowPost(
 	ctx context.Context,
-	t *testing.T,
 	client kit.TestFullNode,
-	minerAddr address.Address,
+	miner kit.TestUnmanagedMiner,
 	sectorNumber abi.SectorNumber,
-) {
-
-	req := require.New(t)
+) error {
 
 	head, err := client.ChainHead(ctx)
-	req.NoError(err)
+	if err != nil {
+		return fmt.Errorf("failed to get chain head: %w", err)
+	}
 
-	sp, err := client.StateSectorPartition(ctx, minerAddr, sectorNumber, head.Key())
-	req.NoError(err)
+	sp, err := client.StateSectorPartition(ctx, miner.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get sector partition: %w", err)
+	}
 
-	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, head.Key())
-	req.NoError(err)
+	di, err := client.StateMinerProvingDeadline(ctx, miner.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get proving deadline: %w", err)
+	}
 
 	disputeEpoch := di.Close + 5
-	t.Logf("Waiting %d until epoch %d to submit dispute", disputeEpoch-head.Height(), disputeEpoch)
+	fmt.Printf("WindowPoST(%d): Dispute: Waiting %d until epoch %d to submit dispute\n", sectorNumber, disputeEpoch-head.Height(), disputeEpoch)
 
 	client.WaitTillChain(ctx, kit.HeightAtLeast(disputeEpoch))
 
-	t.Logf("Disputing WindowedPoSt to confirm validity...")
+	fmt.Printf("WindowPoST(%d): Dispute: Disputing WindowedPoSt to confirm validity...\n", sectorNumber)
 
-	disputeParams := &miner14.DisputeWindowedPoStParams{Deadline: sp.Deadline, PoStIndex: 0}
-	enc := new(bytes.Buffer)
-	req.NoError(disputeParams.MarshalCBOR(enc))
+	_, err = manualOnboardingSubmitMessage(ctx, client, miner, &miner14.DisputeWindowedPoStParams{
+		Deadline:  sp.Deadline,
+		PoStIndex: 0,
+	}, 0, builtin.MethodsMiner.DisputeWindowedPoSt)
+	if err == nil {
+		return fmt.Errorf("expected dispute to fail")
+	}
+	if !strings.Contains(err.Error(), "failed to dispute valid post") {
+		return fmt.Errorf("expected dispute to fail with 'failed to dispute valid post', got: %w", err)
+	}
+	if !strings.Contains(err.Error(), "(RetCode=16)") {
+		return fmt.Errorf("expected dispute to fail with RetCode=16, got: %w", err)
+	}
+	return nil
+}
 
-	disputeMsg := &types.Message{
-		To:     minerAddr,
-		Method: builtin.MethodsMiner.DisputeWindowedPoSt,
-		Params: enc.Bytes(),
-		Value:  types.NewInt(0),
-		From:   client.DefaultKey.Address,
+func manualOnboardingSubmitMessage(
+	ctx context.Context,
+	client api.FullNode,
+	from kit.TestUnmanagedMiner,
+	params cbg.CBORMarshaler,
+	value uint64,
+	method abi.MethodNum,
+) (*api.MsgLookup, error) {
+
+	enc, aerr := actors.SerializeParams(params)
+	if aerr != nil {
+		return nil, fmt.Errorf("failed to serialize params: %w", aerr)
 	}
 
-	_, err = client.MpoolPushMessage(ctx, disputeMsg, nil)
-	req.Error(err, "expected dispute to fail")
-	req.Contains(err.Error(), "failed to dispute valid post")
-	req.Contains(err.Error(), "(RetCode=16)")
+	m, err := client.MpoolPushMessage(ctx, &types.Message{
+		To:     from.ActorAddr,
+		From:   from.OwnerKey.Address,
+		Value:  types.FromFil(value),
+		Method: method,
+		Params: enc,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to push message: %w", err)
+	}
+
+	return client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+}
+
+// manualOnboardingCalculateNextPostEpoch calculates the first epoch of the deadline proving window
+// that we want for the given sector for the given miner.
+func manualOnboardingCalculateNextPostEpoch(
+	ctx context.Context,
+	client api.FullNode,
+	minerAddr address.Address,
+	sectorNumber abi.SectorNumber,
+) (abi.ChainEpoch, abi.ChainEpoch, error) {
+
+	head, err := client.ChainHead(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := client.StateSectorPartition(ctx, minerAddr, sectorNumber, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v\n", sectorNumber, sp)
+
+	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, head.Key())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+
+	fmt.Printf("WindowPoST(%d): ProvingDeadline: %+v\n", sectorNumber, di)
+
+	// periodStart tells us the first epoch of the current proving period (24h)
+	// although it may be in the future if we don't need to submit post in this period
+	periodStart := di.PeriodStart
+	if di.PeriodStart < di.CurrentEpoch && sp.Deadline <= di.Index {
+		// the deadline we want has past in this current proving period, so wait till the next one
+		periodStart += di.WPoStProvingPeriod
+	}
+	provingEpoch := periodStart + (di.WPoStProvingPeriod/abi.ChainEpoch(di.WPoStPeriodDeadlines))*abi.ChainEpoch(sp.Deadline)
+
+	return di.CurrentEpoch, provingEpoch, nil
+}
+
+func manualOnboardingSubmitWindowPost(
+	ctx context.Context,
+	withMockProofs bool,
+	client kit.TestFullNode,
+	miner kit.TestUnmanagedMiner,
+	sectorNumber abi.SectorNumber,
+	cacheDirPath, sealedSectorPath string,
+	sealedCid cid.Cid,
+	proofType abi.RegisteredSealProof,
+) error {
+	fmt.Printf("WindowPoST(%d): Running WindowPoSt ...\n", sectorNumber)
+
+	head, err := client.ChainHead(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chain head: %w", err)
+	}
+
+	sp, err := client.StateSectorPartition(ctx, miner.ActorAddr, sectorNumber, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get sector partition: %w", err)
+	}
+
+	// We should be up to the deadline we care about
+	di, err := client.StateMinerProvingDeadline(ctx, miner.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get proving deadline: %w", err)
+	}
+	fmt.Printf("WindowPoST(%d): SectorPartition: %+v, ProvingDeadline: %+v\n", sectorNumber, sp, di)
+	if di.Index != sp.Deadline {
+		return fmt.Errorf("sector %d is not in the deadline %d, but %d", sectorNumber, sp.Deadline, di.Index)
+	}
+
+	var proofBytes []byte
+	if withMockProofs {
+		proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+	} else {
+		proofBytes, err = manualOnboardingGenerateWindowPost(ctx, client, cacheDirPath, sealedSectorPath, miner.ActorAddr, sectorNumber, sealedCid, proofType)
+		if err != nil {
+			return fmt.Errorf("failed to generate window post: %w", err)
+		}
+	}
+
+	fmt.Printf("WindowedPoSt(%d) Submitting ...\n", sectorNumber)
+
+	chainRandomnessEpoch := di.Challenge
+	chainRandomness, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, chainRandomnessEpoch, nil, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get chain randomness: %w", err)
+	}
+
+	minerInfo, err := client.StateMinerInfo(ctx, miner.ActorAddr, head.Key())
+	if err != nil {
+		return fmt.Errorf("failed to get miner info: %w", err)
+	}
+
+	r, err := manualOnboardingSubmitMessage(ctx, client, miner, &miner14.SubmitWindowedPoStParams{
+		ChainCommitEpoch: chainRandomnessEpoch,
+		ChainCommitRand:  chainRandomness,
+		Deadline:         sp.Deadline,
+		Partitions:       []miner14.PoStPartition{{Index: sp.Partition}},
+		Proofs:           []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+	}, 0, builtin.MethodsMiner.SubmitWindowedPoSt)
+	if err != nil {
+		return fmt.Errorf("failed to submit PoSt: %w", err)
+	}
+	if !r.Receipt.ExitCode.IsSuccess() {
+		return fmt.Errorf("submitting PoSt failed: %s", r.Receipt.ExitCode)
+	}
+
+	if !withMockProofs {
+		// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
+		if err := manualOnboardingDisputeWindowPost(ctx, client, miner, sectorNumber); err != nil {
+			return fmt.Errorf("failed to dispute PoSt: %w", err)
+		}
+	}
+	return nil
+}
+
+// manualOnboardingRunWindowPost runs a goroutine to continually submit PoSTs for the given sector
+// and miner. It will wait until the next proving period for the sector and then submit the PoSt.
+// It will continue to do this until the context is cancelled.
+// It returns a channel that will be closed when the first PoSt is submitted and a channel that will
+// receive any errors that occur.
+func manualOnboardingRunWindowPost(
+	ctx context.Context,
+	withMockProofs bool,
+	client kit.TestFullNode,
+	miner kit.TestUnmanagedMiner,
+	sectorNumber abi.SectorNumber,
+	cacheDirPath,
+	sealedSectorPath string,
+	sealedCid cid.Cid,
+	proofType abi.RegisteredSealProof,
+) (chan struct{}, chan error) {
+
+	first := make(chan struct{})
+	errCh := make(chan error)
+
+	go func() {
+		for ctx.Err() == nil {
+			currentEpoch, nextPost, err := manualOnboardingCalculateNextPostEpoch(ctx, client, miner.ActorAddr, sectorNumber)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			nextPost += 5 // give a little buffer
+			fmt.Printf("WindowPoST(%d) Waiting %d until epoch %d to submit PoSt\n", sectorNumber, nextPost-currentEpoch, nextPost)
+
+			// Create channel to listen for chain head
+			heads, err := client.ChainNotify(ctx)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			// Wait for nextPost epoch
+			for chg := range heads {
+				var ts *types.TipSet
+				for _, c := range chg {
+					if c.Type != "apply" {
+						continue
+					}
+					ts = c.Val
+					if ts.Height() >= nextPost {
+						break
+					}
+				}
+				if ctx.Err() != nil {
+					return
+				}
+				if ts != nil && ts.Height() >= nextPost {
+					break
+				}
+			}
+			if ctx.Err() != nil {
+				return
+			}
+
+			err = manualOnboardingSubmitWindowPost(ctx, withMockProofs, client, miner, sectorNumber, cacheDirPath, sealedSectorPath, sealedCid, proofType)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			// signal first post is done
+			select {
+			case <-first:
+			default:
+				close(first)
+			}
+		}
+	}()
+
+	return first, errCh
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -17,94 +17,88 @@ const sectorSize = abi.SectorSize(2 << 10) // 2KiB
 func TestManualCCOnboarding(t *testing.T) {
 	req := require.New(t)
 
-	for _, withMockProofs := range []bool{true, false} {
-		testName := "WithRealProofs"
-		if withMockProofs {
-			testName = "WithMockProofs"
-		}
+	kit.QuietMiningLogs()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-		t.Run(testName, func(t *testing.T) {
-			kit.QuietMiningLogs()
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+	var (
+		blocktime = 2 * time.Millisecond
+		client    kit.TestFullNode
+		minerA    kit.TestMiner // A is a standard genesis miner
+	)
 
-			var (
-				blocktime = 2 * time.Millisecond
-				client    kit.TestFullNode
-				minerA    kit.TestMiner // A is a standard genesis miner
-			)
+	// Setup and begin mining with a single miner (A)
+	// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
+	kitOpts := []kit.EnsembleOpt{}
+	nodeOpts := []kit.NodeOpt{kit.SectorSize(sectorSize), kit.WithAllSubsystems()}
+	ens := kit.NewEnsemble(t, kitOpts...).
+		FullNode(&client, nodeOpts...).
+		Miner(&minerA, &client, nodeOpts...).
+		Start().
+		InterconnectAll()
+	ens.BeginMining(blocktime)
 
-			// Setup and begin mining with a single miner (A)
-			// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
-			kitOpts := []kit.EnsembleOpt{}
-			if withMockProofs {
-				kitOpts = append(kitOpts, kit.MockProofs())
-			}
-			nodeOpts := []kit.NodeOpt{kit.SectorSize(sectorSize), kit.WithAllSubsystems()}
-			ens := kit.NewEnsemble(t, kitOpts...).
-				FullNode(&client, nodeOpts...).
-				Miner(&minerA, &client, nodeOpts...).
-				Start().
-				InterconnectAll()
-			ens.BeginMining(blocktime)
+	// Instantiate MinerB to manually handle sector onboarding and power acquisition through sector activation.
+	// Unlike other miners managed by the Lotus Miner storage infrastructure, MinerB operates independently,
+	// performing all related tasks manually. Managed by the TestKit, MinerB has the capability to utilize actual proofs
+	// for the processes of sector onboarding and activation.
+	nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
+	minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
+	ens.Start()
 
-			// Instantiate MinerB to manually handle sector onboarding and power acquisition through sector activation.
-			// Unlike other miners managed by the Lotus Miner storage infrastructure, MinerB operates independently,
-			// performing all related tasks manually. Managed by the TestKit, MinerB has the capability to utilize actual proofs
-			// for the processes of sector onboarding and activation.
-			nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
-			minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
-			ens.Start()
-			minerB.Start(ctx)
+	build.Clock.Sleep(time.Second)
 
-			build.Clock.Sleep(time.Second)
+	t.Log("Checking initial power ...")
 
-			t.Log("Checking initial power ...")
+	// Miner A should have power as it has already onboarded sectors in the genesis block
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+	p, err := client.StateMinerPower(ctx, minerA.ActorAddr, head.Key())
+	req.NoError(err)
+	t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 
-			// Miner A should have power as it has already onboarded sectors in the genesis block
-			head, err := client.ChainHead(ctx)
-			req.NoError(err)
-			p, err := client.StateMinerPower(ctx, minerA.ActorAddr, head.Key())
-			req.NoError(err)
-			t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+	// Miner B should have no power as it has yet to onboard and activate any sectors
+	minerB.AssertNoPower(ctx)
 
-			// Miner B should have no power as it has yet to onboard and activate any sectors
-			minerB.AssertNoPower(ctx)
+	var bSectorNum abi.SectorNumber
+	var respCh chan kit.WindowPostResp
 
-			var bSectorNum abi.SectorNumber
-			var respCh chan kit.WindowPostResp
-			if withMockProofs {
-				bSectorNum, respCh = minerB.OnboardCCSectorWithMockProofs(ctx, kit.TestSpt)
-			} else {
-				bSectorNum, respCh = minerB.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
-			}
+	bSectorNum, respCh = minerB.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
 
-			// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
-			minerB.AssertNoPower(ctx)
+	// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
+	minerB.AssertNoPower(ctx)
 
-			// wait till sector is activated
-			select {
-			case resp := <-respCh:
-				req.NoError(resp.Error)
-				req.Equal(resp.SectorNumber, bSectorNum)
-			case <-ctx.Done():
-				t.Fatal("timed out waiting for sector activation")
-			}
-
-			// Fetch on-chain sector properties
-			head, err = client.ChainHead(ctx)
-			req.NoError(err)
-
-			soi, err := client.StateSectorGetInfo(ctx, minerB.ActorAddr, bSectorNum, head.Key())
-			req.NoError(err)
-			t.Logf("Miner B SectorOnChainInfo %d: %+v", bSectorNum, soi)
-
-			head = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
-
-			t.Log("Checking power after PoSt ...")
-
-			// Miner B should now have power
-			minerB.AssertPower(ctx, (uint64(2 << 10)), (uint64(2 << 10)))
-		})
+	// wait till sector is activated
+	select {
+	case resp := <-respCh:
+		req.NoError(resp.Error)
+		req.Equal(resp.SectorNumber, bSectorNum)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for sector activation")
 	}
+
+	// Fetch on-chain sector properties
+	head, err = client.ChainHead(ctx)
+	req.NoError(err)
+
+	soi, err := client.StateSectorGetInfo(ctx, minerB.ActorAddr, bSectorNum, head.Key())
+	req.NoError(err)
+	t.Logf("Miner B SectorOnChainInfo %d: %+v", bSectorNum, soi)
+
+	head = client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+5))
+
+	t.Log("Checking power after PoSt ...")
+
+	// Miner B should now have power
+	minerB.AssertPower(ctx, (uint64(2 << 10)), (uint64(2 << 10)))
+
+	// WindowPost Dispute should fail
+	assertDisputeFails(t, ctx, minerB, bSectorNum)
+}
+
+func assertDisputeFails(t *testing.T, ctx context.Context, miner *kit.TestUnmanagedMiner, sector abi.SectorNumber) {
+	err := miner.SubmitPostDispute(ctx, sector)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to dispute valid post")
+	require.Contains(t, err.Error(), "(RetCode=16)")
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -46,6 +46,8 @@ func TestManualCCOnboarding(t *testing.T) {
 	// for the processes of sector onboarding and activation.
 	nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
 	minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
+	minerC, ens := ens.UnmanagedMiner(&client, nodeOpts...)
+
 	ens.Start()
 
 	build.Clock.Sleep(time.Second)
@@ -62,14 +64,15 @@ func TestManualCCOnboarding(t *testing.T) {
 	// Miner B should have no power as it has yet to onboard and activate any sectors
 	minerB.AssertNoPower(ctx)
 
+	// Miner C should have no power as it has yet to onboard and activate any sectors
+	minerC.AssertNoPower(ctx)
+
 	var bSectorNum abi.SectorNumber
 	var respCh chan kit.WindowPostResp
-
 	bSectorNum, respCh = minerB.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
 
 	// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 	minerB.AssertNoPower(ctx)
-
 	// wait till sector is activated
 	select {
 	case resp := <-respCh:

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -19,76 +19,97 @@ const defaultSectorSize = abi.SectorSize(2 << 10) // 2KiB
 func TestManualCCOnboarding(t *testing.T) {
 	req := require.New(t)
 
-	kit.QuietMiningLogs()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	for _, withMockProofs := range []bool{true, false} {
+		testName := "WithRealProofs"
+		if withMockProofs {
+			testName = "WithMockProofs"
+		}
+		t.Run(testName, func(t *testing.T) {
+			kit.QuietMiningLogs()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	var (
-		// need to pick a balance value so that the test is not racy on CI by running through it's WindowPostDeadlines too fast
-		blocktime = 5 * time.Millisecond
-		client    kit.TestFullNode
-		minerA    kit.TestMiner // A is a standard genesis miner
-	)
+			var (
+				// need to pick a balance value so that the test is not racy on CI by running through it's WindowPostDeadlines too fast
+				blocktime = 5 * time.Millisecond
+				client    kit.TestFullNode
+				minerA    kit.TestMiner // A is a standard genesis miner
+			)
 
-	// Setup and begin mining with a single miner (A)
-	// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
-	kitOpts := []kit.EnsembleOpt{}
-	nodeOpts := []kit.NodeOpt{kit.SectorSize(defaultSectorSize), kit.WithAllSubsystems()}
-	ens := kit.NewEnsemble(t, kitOpts...).
-		FullNode(&client, nodeOpts...).
-		Miner(&minerA, &client, nodeOpts...).
-		Start().
-		InterconnectAll()
-	ens.BeginMiningMustPost(blocktime)
+			// Setup and begin mining with a single miner (A)
+			// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
+			kitOpts := []kit.EnsembleOpt{}
+			if withMockProofs {
+				kitOpts = append(kitOpts, kit.MockProofs())
+			}
+			nodeOpts := []kit.NodeOpt{kit.SectorSize(defaultSectorSize), kit.WithAllSubsystems()}
+			ens := kit.NewEnsemble(t, kitOpts...).
+				FullNode(&client, nodeOpts...).
+				Miner(&minerA, &client, nodeOpts...).
+				Start().
+				InterconnectAll()
+			ens.BeginMiningMustPost(blocktime)
 
-	// Instantiate MinerB to manually handle sector onboarding and power acquisition through sector activation.
-	// Unlike other miners managed by the Lotus Miner storage infrastructure, MinerB operates independently,
-	// performing all related tasks manually. Managed by the TestKit, MinerB has the capability to utilize actual proofs
-	// for the processes of sector onboarding and activation.
-	nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
-	minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
-	minerC, ens := ens.UnmanagedMiner(&client, nodeOpts...)
+			// Instantiate MinerB to manually handle sector onboarding and power acquisition through sector activation.
+			// Unlike other miners managed by the Lotus Miner storage infrastructure, MinerB operates independently,
+			// performing all related tasks manually. Managed by the TestKit, MinerB has the capability to utilize actual proofs
+			// for the processes of sector onboarding and activation.
+			nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
+			minerB, ens := ens.UnmanagedMiner(&client, nodeOpts...)
+			minerC, ens := ens.UnmanagedMiner(&client, nodeOpts...)
 
-	ens.Start()
+			ens.Start()
 
-	build.Clock.Sleep(time.Second)
+			build.Clock.Sleep(time.Second)
 
-	t.Log("Checking initial power ...")
+			t.Log("Checking initial power ...")
 
-	// Miner A should have power as it has already onboarded sectors in the genesis block
-	head, err := client.ChainHead(ctx)
-	req.NoError(err)
-	p, err := client.StateMinerPower(ctx, minerA.ActorAddr, head.Key())
-	req.NoError(err)
-	t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			// Miner A should have power as it has already onboarded sectors in the genesis block
+			head, err := client.ChainHead(ctx)
+			req.NoError(err)
+			p, err := client.StateMinerPower(ctx, minerA.ActorAddr, head.Key())
+			req.NoError(err)
+			t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
 
-	// Miner B should have no power as it has yet to onboard and activate any sectors
-	minerB.AssertNoPower(ctx)
+			// Miner B should have no power as it has yet to onboard and activate any sectors
+			minerB.AssertNoPower(ctx)
 
-	// Miner C should have no power as it has yet to onboard and activate any sectors
-	minerC.AssertNoPower(ctx)
+			// Miner C should have no power as it has yet to onboard and activate any sectors
+			minerC.AssertNoPower(ctx)
 
-	// ---- Miner B onboards a CC sector
-	var bSectorNum abi.SectorNumber
-	var respCh chan kit.WindowPostResp
-	bSectorNum, respCh = minerB.OnboardSectorWithPiecesAndRealProofs(ctx, kit.TestSpt)
-	// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
-	minerB.AssertNoPower(ctx)
-	// Activate CC Sector for Miner B and assert power
-	activateAndAssertPower(ctx, t, minerB, respCh, bSectorNum, uint64(defaultSectorSize))
+			// ---- Miner B onboards a CC sector
+			var bSectorNum abi.SectorNumber
+			var respCh chan kit.WindowPostResp
 
-	// --- Miner C onboards sector with data/pieces
-	var cSectorNum abi.SectorNumber
-	var cRespCh chan kit.WindowPostResp
-	cSectorNum, cRespCh = minerC.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
-	// Miner C should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
-	minerC.AssertNoPower(ctx)
-	// Activate CC Sector for Miner C and assert power
-	activateAndAssertPower(ctx, t, minerC, cRespCh, cSectorNum, uint64(defaultSectorSize))
+			if withMockProofs {
+				bSectorNum, respCh = minerB.OnboardSectorWithPiecesAndMockProofs(ctx, kit.TestSpt)
+			} else {
+				bSectorNum, respCh = minerB.OnboardSectorWithPiecesAndRealProofs(ctx, kit.TestSpt)
+			}
+			// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
+			minerB.AssertNoPower(ctx)
+			// Activate CC Sector for Miner B and assert power
+			activateAndAssertPower(ctx, t, minerB, respCh, bSectorNum, uint64(defaultSectorSize), withMockProofs)
+
+			// --- Miner C onboards sector with data/pieces
+			var cSectorNum abi.SectorNumber
+			var cRespCh chan kit.WindowPostResp
+
+			if withMockProofs {
+				cSectorNum, cRespCh = minerC.OnboardCCSectorWithMockProofs(ctx, kit.TestSpt)
+			} else {
+				cSectorNum, cRespCh = minerC.OnboardCCSectorWithRealProofs(ctx, kit.TestSpt)
+			}
+			// Miner C should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
+			minerC.AssertNoPower(ctx)
+			// Activate CC Sector for Miner C and assert power
+			activateAndAssertPower(ctx, t, minerC, cRespCh, cSectorNum, uint64(defaultSectorSize), withMockProofs)
+		})
+	}
 }
 
 func activateAndAssertPower(ctx context.Context, t *testing.T, miner *kit.TestUnmanagedMiner, respCh chan kit.WindowPostResp, sector abi.SectorNumber,
-	sectorSize uint64) {
+	sectorSize uint64, withMockProofs bool) {
 	req := require.New(t)
 	// wait till sector is activated
 	select {
@@ -114,8 +135,15 @@ func activateAndAssertPower(ctx context.Context, t *testing.T, miner *kit.TestUn
 	// Miner B should now have power
 	miner.AssertPower(ctx, sectorSize, sectorSize)
 
-	// WindowPost Dispute should fail
-	assertDisputeFails(ctx, t, miner, sector)
+	if withMockProofs {
+		// WindowPost Dispute should succeed as we are using mock proofs
+		err := miner.SubmitPostDispute(ctx, sector)
+		require.NoError(t, err)
+	} else {
+		// WindowPost Dispute should fail
+		assertDisputeFails(ctx, t, miner, sector)
+	}
+
 }
 
 func assertDisputeFails(ctx context.Context, t *testing.T, miner *kit.TestUnmanagedMiner, sector abi.SectorNumber) {

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -32,7 +32,7 @@ func TestManualCCOnboarding(t *testing.T) {
 	req := require.New(t)
 
 	for _, withMockProofs := range []bool{true, false} {
-		testName := "WithoutMockProofs"
+		testName := "WithRealProofs"
 		if withMockProofs {
 			testName = "WithMockProofs"
 		}
@@ -508,7 +508,7 @@ func manualOnboardingDisputeWindowPost(
 	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, head.Key())
 	req.NoError(err)
 
-	disputeEpoch := di.Challenge + miner14.WPoStDisputeWindow + 5
+	disputeEpoch := di.Close + 5
 	t.Logf("Waiting %d until epoch %d to submit dispute", disputeEpoch-head.Height(), disputeEpoch)
 
 	client.WaitTillChain(ctx, kit.HeightAtLeast(disputeEpoch))

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -3,12 +3,16 @@ package itests
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
+	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
 	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
@@ -18,6 +22,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 )
@@ -26,184 +31,504 @@ import (
 func TestManualCCOnboarding(t *testing.T) {
 	req := require.New(t)
 
-	kit.QuietMiningLogs()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	for _, withMockProofs := range []bool{true, false} {
+		testName := "WithoutMockProofs"
+		if withMockProofs {
+			testName = "WithMockProofs"
+		}
+		t.Run(testName, func(t *testing.T) {
+			kit.QuietMiningLogs()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	var (
-		blocktime = 2 * time.Millisecond
+			var (
+				blocktime = 2 * time.Millisecond
 
-		client kit.TestFullNode
-		minerA kit.TestMiner // A is a standard genesis miner
-		minerB kit.TestMiner // B is a CC miner we will onboard manually
-	)
+				client kit.TestFullNode
+				minerA kit.TestMiner // A is a standard genesis miner
+				minerB kit.TestMiner // B is a CC miner we will onboard manually
 
-	opts := []kit.NodeOpt{kit.WithAllSubsystems()}
-	ens := kit.NewEnsemble(t, kit.MockProofs()).
-		FullNode(&client, opts...).
-		Miner(&minerA, &client, opts...).
-		Start().
-		InterconnectAll()
-	ens.BeginMining(blocktime)
+				bSectorNum = abi.SectorNumber(22)
 
-	opts = append(opts, kit.OwnerAddr(client.DefaultKey))
-	ens.Miner(&minerB, &client, opts...).Start()
+				cacheDirPath                         string
+				unsealedSectorPath, sealedSectorPath string
+				sealedCid, unsealedCid               cid.Cid
+				sealTickets                          abi.SealRandomness
+			)
 
-	maddrA, err := minerA.ActorAddress(ctx)
-	req.NoError(err)
+			// Setup and begin mining with a single miner (A)
 
-	build.Clock.Sleep(time.Second)
+			kitOpts := []kit.EnsembleOpt{}
+			if withMockProofs {
+				kitOpts = append(kitOpts, kit.MockProofs())
+			}
+			nodeOpts := []kit.NodeOpt{kit.WithAllSubsystems()}
+			ens := kit.NewEnsemble(t, kitOpts...).
+				FullNode(&client, nodeOpts...).
+				Miner(&minerA, &client, nodeOpts...).
+				Start().
+				InterconnectAll()
+			ens.BeginMining(blocktime)
 
-	t.Log("Submitting PreCommitSector...")
+			nodeOpts = append(nodeOpts, kit.OwnerAddr(client.DefaultKey))
+			ens.Miner(&minerB, &client, nodeOpts...).Start()
 
-	maddrB, err := minerB.ActorAddress(ctx)
-	req.NoError(err)
+			maddrA, err := minerA.ActorAddress(ctx)
+			req.NoError(err)
+
+			build.Clock.Sleep(time.Second)
+
+			mAddrB, err := minerB.ActorAddress(ctx)
+			req.NoError(err)
+			mAddrBBytes := new(bytes.Buffer)
+			req.NoError(mAddrB.MarshalCBOR(mAddrBBytes))
+
+			head, err := client.ChainHead(ctx)
+			req.NoError(err)
+
+			minerBInfo, err := client.StateMinerInfo(ctx, mAddrB, head.Key())
+			req.NoError(err)
+
+			t.Log("Checking initial power ...")
+
+			// Miner A should have power
+			p, err := client.StateMinerPower(ctx, maddrA, head.Key())
+			req.NoError(err)
+			t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+
+			// Miner B should have no power
+			p, err = client.StateMinerPower(ctx, mAddrB, head.Key())
+			req.NoError(err)
+			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.True(p.MinerPower.RawBytePower.IsZero())
+
+			// Run precommit for a sector on miner B
+
+			sealRandEpoch := policy.SealRandomnessLookback
+			t.Logf("Waiting for at least epoch %d for seal randomness (current epoch %d) ...", sealRandEpoch+5, head.Height())
+			client.WaitTillChain(ctx, kit.HeightAtLeast(sealRandEpoch+5))
+
+			if withMockProofs {
+				sealedCid = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
+			} else {
+				cacheDirPath = t.TempDir()
+				tmpDir := t.TempDir()
+				unsealedSectorPath = filepath.Join(tmpDir, "unsealed")
+				sealedSectorPath = filepath.Join(tmpDir, "sealed")
+
+				sealTickets, sealedCid, unsealedCid = manualOnboardingGeneratePreCommit(
+					t,
+					ctx,
+					client,
+					cacheDirPath,
+					unsealedSectorPath,
+					sealedSectorPath,
+					mAddrB,
+					bSectorNum,
+					sealRandEpoch,
+				)
+			}
+
+			t.Log("Submitting PreCommitSector ...")
+
+			preCommitParams := &miner.PreCommitSectorBatchParams2{
+				Sectors: []miner.SectorPreCommitInfo{{
+					Expiration:    2880 * 300,
+					SectorNumber:  22,
+					SealProof:     kit.TestSpt,
+					SealedCID:     sealedCid,
+					SealRandEpoch: sealRandEpoch,
+				}},
+			}
+
+			enc := new(bytes.Buffer)
+			req.NoError(preCommitParams.MarshalCBOR(enc))
+
+			m, err := client.MpoolPushMessage(ctx, &types.Message{
+				To:     mAddrB,
+				From:   minerB.OwnerKey.Address,
+				Value:  types.FromFil(1),
+				Method: builtin.MethodsMiner.PreCommitSectorBatch2,
+				Params: enc.Bytes(),
+			}, nil)
+			req.NoError(err)
+
+			r, err := client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			req.NoError(err)
+			req.True(r.Receipt.ExitCode.IsSuccess())
+
+			preCommitInfo, err := client.StateSectorPreCommitInfo(ctx, mAddrB, bSectorNum, r.TipSet)
+			req.NoError(err)
+
+			// Run prove commit for the sector on miner B
+
+			seedRandomnessHeight := preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+			t.Logf("Waiting %d epochs for seed randomness at epoch %d (current epoch %d)...", seedRandomnessHeight-r.Height, seedRandomnessHeight, r.Height)
+			client.WaitTillChain(ctx, kit.HeightAtLeast(seedRandomnessHeight+5))
+
+			var sectorProof []byte
+			if withMockProofs {
+				sectorProof = []byte{0xde, 0xad, 0xbe, 0xef}
+			} else {
+				sectorProof = manualOnboardingGenerateProveCommit(
+					t,
+					ctx,
+					client,
+					cacheDirPath,
+					sealedSectorPath,
+					mAddrB,
+					bSectorNum,
+					sealedCid,
+					unsealedCid,
+					sealTickets,
+				)
+			}
+
+			t.Log("Submitting ProveCommitSector ...")
+
+			proveCommitParams := miner14.ProveCommitSectors3Params{
+				SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: bSectorNum}},
+				SectorProofs:             [][]byte{sectorProof},
+				RequireActivationSuccess: true,
+			}
+
+			enc = new(bytes.Buffer)
+			req.NoError(proveCommitParams.MarshalCBOR(enc))
+
+			m, err = client.MpoolPushMessage(ctx, &types.Message{
+				To:     minerB.ActorAddr,
+				From:   minerB.OwnerKey.Address,
+				Value:  types.FromFil(0),
+				Method: builtin.MethodsMiner.ProveCommitSectors3,
+				Params: enc.Bytes(),
+			}, nil)
+			req.NoError(err)
+
+			r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			req.NoError(err)
+			req.True(r.Receipt.ExitCode.IsSuccess())
+
+			// Check power after proving, should still be zero until the PoSt is submitted
+			p, err = client.StateMinerPower(ctx, mAddrB, r.TipSet)
+			req.NoError(err)
+			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.True(p.MinerPower.RawBytePower.IsZero())
+
+			// Fetch on-chain sector properties
+
+			soi, err := client.StateSectorGetInfo(ctx, mAddrB, bSectorNum, r.TipSet)
+			req.NoError(err)
+			t.Logf("SectorOnChainInfo %d: %+v", bSectorNum, soi)
+
+			sp, err := client.StateSectorPartition(ctx, mAddrB, bSectorNum, r.TipSet)
+			req.NoError(err)
+			t.Logf("SectorPartition %d: %+v", bSectorNum, sp)
+			bSectorDeadline := sp.Deadline
+			bSectorPartition := sp.Partition
+
+			// Wait for the deadline to come around and submit a PoSt
+
+			di, err := client.StateMinerProvingDeadline(ctx, mAddrB, types.EmptyTSK)
+			req.NoError(err)
+			t.Logf("MinerB Deadline Info: %+v", di)
+
+			// Use the current deadline to work out when the deadline we care about (bSectorDeadline) is open
+			// and ready to receive posts
+			deadlineCount := di.WPoStPeriodDeadlines
+			epochsPerDeadline := uint64(di.WPoStChallengeWindow)
+			currentDeadline := di.Index
+			currentDeadlineStart := di.Open
+			waitTillEpoch := abi.ChainEpoch((deadlineCount-currentDeadline+bSectorDeadline)*epochsPerDeadline) + currentDeadlineStart + 1
+
+			t.Logf("Waiting %d until epoch %d to get to deadline %d", waitTillEpoch-di.CurrentEpoch, waitTillEpoch, bSectorDeadline)
+			head = client.WaitTillChain(ctx, kit.HeightAtLeast(waitTillEpoch))
+
+			// We should be up to the deadline we care about
+			di, err = client.StateMinerProvingDeadline(ctx, mAddrB, types.EmptyTSK)
+			req.NoError(err)
+			req.Equal(bSectorDeadline, di.Index, "should be in the deadline of the sector to prove")
+
+			var proofBytes []byte
+			if withMockProofs {
+				proofBytes = []byte{0xde, 0xad, 0xbe, 0xef}
+			} else {
+				proofBytes = manualOnboardingGenerateWindowPost(t, ctx, client, cacheDirPath, sealedSectorPath, mAddrB, bSectorNum, sealedCid)
+			}
+
+			t.Log("Submitting WindowedPoSt...")
+
+			rand, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, di.Open, nil, head.Key())
+			req.NoError(err)
+
+			postParams := miner.SubmitWindowedPoStParams{
+				ChainCommitEpoch: di.Open,
+				ChainCommitRand:  rand,
+				Deadline:         bSectorDeadline,
+				Partitions:       []miner.PoStPartition{{Index: bSectorPartition}},
+				Proofs:           []proof.PoStProof{{PoStProof: minerBInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+			}
+
+			enc = new(bytes.Buffer)
+			req.NoError(postParams.MarshalCBOR(enc))
+
+			m, err = client.MpoolPushMessage(ctx, &types.Message{
+				To:     mAddrB,
+				From:   minerB.OwnerKey.Address,
+				Value:  types.NewInt(0),
+				Method: builtin.MethodsMiner.SubmitWindowedPoSt,
+				Params: enc.Bytes(),
+			}, nil)
+			req.NoError(err)
+
+			r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
+			req.NoError(err)
+			req.True(r.Receipt.ExitCode.IsSuccess())
+
+			if !withMockProofs {
+				// Dispute the PoSt to confirm the validity of the PoSt since PoSt acceptance is optimistic
+				manualOnboardingDisputeWindowPost(t, ctx, client, mAddrB, bSectorNum)
+			}
+
+			t.Log("Checking power after PoSt ...")
+
+			// Miner B should now have power
+			p, err = client.StateMinerPower(ctx, mAddrB, r.TipSet)
+			req.NoError(err)
+			t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
+			req.Equal(uint64(2<<10), p.MinerPower.RawBytePower.Uint64())    // 2kiB RBP
+			req.Equal(uint64(2<<10), p.MinerPower.QualityAdjPower.Uint64()) // 2kiB QaP
+		})
+	}
+}
+
+func manualOnboardingGeneratePreCommit(
+	t *testing.T,
+	ctx context.Context,
+	client api.FullNode,
+	cacheDirPath,
+	unsealedSectorPath,
+	sealedSectorPath string,
+	minerAddr address.Address,
+	sectorNumber abi.SectorNumber,
+	sealRandEpoch abi.ChainEpoch,
+) (abi.SealRandomness, cid.Cid, cid.Cid) {
+
+	req := require.New(t)
+	t.Log("Generating PreCommit ...")
+
+	sectorSize := abi.SectorSize(2 << 10)
+	unsealedSize := abi.PaddedPieceSize(sectorSize).Unpadded()
+	req.NoError(os.WriteFile(unsealedSectorPath, make([]byte, unsealedSize), 0644))
+	req.NoError(os.WriteFile(sealedSectorPath, make([]byte, sectorSize), 0644))
 
 	head, err := client.ChainHead(ctx)
 	req.NoError(err)
 
-	minerBInfo, err := client.StateMinerInfo(ctx, maddrB, head.Key())
+	minerAddrBytes := new(bytes.Buffer)
+	req.NoError(minerAddr.MarshalCBOR(minerAddrBytes))
+
+	rand, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_SealRandomness, sealRandEpoch, minerAddrBytes.Bytes(), head.Key())
+	req.NoError(err)
+	sealTickets := abi.SealRandomness(rand)
+
+	t.Logf("Running SealPreCommitPhase1 for sector %d...", sectorNumber)
+
+	actorIdNum, err := address.IDFromAddress(minerAddr)
+	req.NoError(err)
+	actorId := abi.ActorID(actorIdNum)
+
+	pc1, err := ffi.SealPreCommitPhase1(
+		kit.TestSpt,
+		cacheDirPath,
+		unsealedSectorPath,
+		sealedSectorPath,
+		sectorNumber,
+		actorId,
+		sealTickets,
+		[]abi.PieceInfo{},
+	)
+	req.NoError(err)
+	req.NotNil(pc1)
+
+	t.Logf("Running SealPreCommitPhase2 for sector %d...", sectorNumber)
+
+	sealedCid, unsealedCid, err := ffi.SealPreCommitPhase2(
+		pc1,
+		cacheDirPath,
+		sealedSectorPath,
+	)
 	req.NoError(err)
 
-	preCommitParams := &miner.PreCommitSectorBatchParams2{
-		Sectors: []miner.SectorPreCommitInfo{{
-			Expiration:    2880 * 300,
-			SectorNumber:  22,
-			SealProof:     kit.TestSpt,
-			SealedCID:     cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz"),
-			SealRandEpoch: head.Height() - 200,
-		}},
+	t.Logf("Unsealed CID: %s", unsealedCid)
+	t.Logf("Sealed CID: %s", sealedCid)
+
+	return sealTickets, sealedCid, unsealedCid
+}
+
+func manualOnboardingGenerateProveCommit(
+	t *testing.T,
+	ctx context.Context,
+	client api.FullNode,
+	cacheDirPath,
+	sealedSectorPath string,
+	minerAddr address.Address,
+	sectorNumber abi.SectorNumber,
+	sealedCid, unsealedCid cid.Cid,
+	sealTickets abi.SealRandomness,
+) []byte {
+	req := require.New(t)
+
+	t.Log("Generating Sector Proof ...")
+
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+
+	preCommitInfo, err := client.StateSectorPreCommitInfo(ctx, minerAddr, sectorNumber, head.Key())
+	req.NoError(err)
+
+	seedRandomnessHeight := preCommitInfo.PreCommitEpoch + policy.GetPreCommitChallengeDelay()
+
+	minerAddrBytes := new(bytes.Buffer)
+	req.NoError(minerAddr.MarshalCBOR(minerAddrBytes))
+
+	rand, err := client.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, seedRandomnessHeight, minerAddrBytes.Bytes(), head.Key())
+	req.NoError(err)
+	seedRandomness := abi.InteractiveSealRandomness(rand)
+
+	actorIdNum, err := address.IDFromAddress(minerAddr)
+	req.NoError(err)
+	actorId := abi.ActorID(actorIdNum)
+
+	t.Logf("Running SealCommitPhase1 for sector %d...", sectorNumber)
+
+	scp1, err := ffi.SealCommitPhase1(
+		kit.TestSpt,
+		sealedCid,
+		unsealedCid,
+		cacheDirPath,
+		sealedSectorPath,
+		sectorNumber,
+		actorId,
+		sealTickets,
+		seedRandomness,
+		[]abi.PieceInfo{},
+	)
+	req.NoError(err)
+
+	t.Logf("Running SealCommitPhase2 for sector %d...", sectorNumber)
+
+	sectorProof, err := ffi.SealCommitPhase2(scp1, sectorNumber, actorId)
+	req.NoError(err)
+
+	return sectorProof
+}
+
+func manualOnboardingGenerateWindowPost(
+	t *testing.T,
+	ctx context.Context,
+	client api.FullNode,
+	cacheDirPath string,
+	sealedSectorPath string,
+	minerAddr address.Address,
+	sectorNumber abi.SectorNumber,
+	sealedCid cid.Cid,
+) []byte {
+
+	req := require.New(t)
+
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+
+	minerInfo, err := client.StateMinerInfo(ctx, minerAddr, head.Key())
+	req.NoError(err)
+
+	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, types.EmptyTSK)
+	req.NoError(err)
+
+	minerAddrBytes := new(bytes.Buffer)
+	req.NoError(minerAddr.MarshalCBOR(minerAddrBytes))
+
+	rand, err := client.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_WindowedPoStChallengeSeed, di.Challenge, minerAddrBytes.Bytes(), head.Key())
+	req.NoError(err)
+	postRand := abi.PoStRandomness(rand)
+	postRand[31] &= 0x3f // make fr32 compatible
+
+	privateSectorInfo := ffi.PrivateSectorInfo{
+		SectorInfo: proof.SectorInfo{
+			SealProof:    kit.TestSpt,
+			SectorNumber: sectorNumber,
+			SealedCID:    sealedCid,
+		},
+		CacheDirPath:     cacheDirPath,
+		PoStProofType:    minerInfo.WindowPoStProofType,
+		SealedSectorPath: sealedSectorPath,
 	}
 
+	actorIdNum, err := address.IDFromAddress(minerAddr)
+	req.NoError(err)
+	actorId := abi.ActorID(actorIdNum)
+
+	windowProofs, faultySectors, err := ffi.GenerateWindowPoSt(actorId, ffi.NewSortedPrivateSectorInfo(privateSectorInfo), postRand)
+	req.NoError(err)
+	req.Len(faultySectors, 0)
+	req.Len(windowProofs, 1)
+	req.Equal(minerInfo.WindowPoStProofType, windowProofs[0].PoStProof)
+	proofBytes := windowProofs[0].ProofBytes
+
+	info := proof.WindowPoStVerifyInfo{
+		Randomness:        postRand,
+		Proofs:            []proof.PoStProof{{PoStProof: minerInfo.WindowPoStProofType, ProofBytes: proofBytes}},
+		ChallengedSectors: []proof.SectorInfo{{SealProof: kit.TestSpt, SectorNumber: sectorNumber, SealedCID: sealedCid}},
+		Prover:            actorId,
+	}
+
+	verified, err := ffi.VerifyWindowPoSt(info)
+	req.NoError(err)
+	req.True(verified, "window post verification failed")
+
+	return proofBytes
+}
+
+func manualOnboardingDisputeWindowPost(
+	t *testing.T,
+	ctx context.Context,
+	client kit.TestFullNode,
+	minerAddr address.Address,
+	sectorNumber abi.SectorNumber,
+) {
+
+	req := require.New(t)
+
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+
+	sp, err := client.StateSectorPartition(ctx, minerAddr, sectorNumber, head.Key())
+	req.NoError(err)
+
+	di, err := client.StateMinerProvingDeadline(ctx, minerAddr, head.Key())
+	req.NoError(err)
+
+	disputeEpoch := di.Challenge + miner14.WPoStDisputeWindow + 5
+	t.Logf("Waiting %d until epoch %d to submit dispute", disputeEpoch-head.Height(), disputeEpoch)
+
+	client.WaitTillChain(ctx, kit.HeightAtLeast(disputeEpoch))
+
+	t.Logf("Disputing WindowedPoSt to confirm validity...")
+
+	disputeParams := &miner14.DisputeWindowedPoStParams{Deadline: sp.Deadline, PoStIndex: 0}
 	enc := new(bytes.Buffer)
-	req.NoError(preCommitParams.MarshalCBOR(enc))
+	req.NoError(disputeParams.MarshalCBOR(enc))
 
-	m, err := client.MpoolPushMessage(ctx, &types.Message{
-		To:     maddrB,
-		From:   minerB.OwnerKey.Address,
-		Value:  types.FromFil(1),
-		Method: builtin.MethodsMiner.PreCommitSectorBatch2,
+	disputeMsg := &types.Message{
+		To:     minerAddr,
+		Method: builtin.MethodsMiner.DisputeWindowedPoSt,
 		Params: enc.Bytes(),
-	}, nil)
-	req.NoError(err)
-
-	r, err := client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
-	req.NoError(err)
-	require.True(t, r.Receipt.ExitCode.IsSuccess())
-
-	client.WaitTillChain(ctx, kit.HeightAtLeast(r.Height+miner14.PreCommitChallengeDelay+5))
-
-	t.Log("Checking initial power...")
-
-	p, err := client.StateMinerPower(ctx, maddrA, r.TipSet)
-	req.NoError(err)
-	t.Logf("MinerA RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
-
-	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
-	req.NoError(err)
-	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
-	require.True(t, p.MinerPower.RawBytePower.IsZero())
-
-	t.Log("Submitting ProveCommitSector...")
-
-	bSectorNum := preCommitParams.Sectors[0].SectorNumber
-
-	proveCommitParams := miner14.ProveCommitSectors3Params{
-		SectorActivations:        []miner14.SectorActivationManifest{{SectorNumber: bSectorNum}},
-		SectorProofs:             [][]byte{{0xde, 0xad, 0xbe, 0xef}},
-		RequireActivationSuccess: true,
-	}
-
-	enc = new(bytes.Buffer)
-	req.NoError(proveCommitParams.MarshalCBOR(enc))
-
-	m, err = client.MpoolPushMessage(ctx, &types.Message{
-		To:     minerB.ActorAddr,
-		From:   minerB.OwnerKey.Address,
-		Value:  types.FromFil(0),
-		Method: builtin.MethodsMiner.ProveCommitSectors3,
-		Params: enc.Bytes(),
-	}, nil)
-	req.NoError(err)
-
-	r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
-	req.NoError(err)
-	require.True(t, r.Receipt.ExitCode.IsSuccess())
-
-	soi, err := client.StateSectorGetInfo(ctx, maddrB, bSectorNum, r.TipSet)
-	req.NoError(err)
-	t.Logf("SectorOnChainInfo %d: %+v", bSectorNum, soi)
-
-	sp, err := client.StateSectorPartition(ctx, maddrB, bSectorNum, r.TipSet)
-	req.NoError(err)
-	t.Logf("SectorPartition %d: %+v", bSectorNum, sp)
-	bSectorDeadline := sp.Deadline
-	bSectorPartition := sp.Partition
-
-	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
-	req.NoError(err)
-	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
-	require.True(t, p.MinerPower.RawBytePower.IsZero())
-
-	di, err := client.StateMinerProvingDeadline(ctx, maddrB, types.EmptyTSK)
-	req.NoError(err)
-	t.Logf("MinerB Deadline Info: %+v", di)
-
-	// Use the current deadline to work out when the deadline we care about (bSectorDeadline) is open
-	// and ready to receive posts
-	deadlineCount := di.WPoStPeriodDeadlines
-	epochsPerDeadline := uint64(di.WPoStChallengeWindow)
-	currentDeadline := di.Index
-	currentDeadlineStart := di.Open
-	waitTillEpoch := abi.ChainEpoch((deadlineCount-currentDeadline+bSectorDeadline)*epochsPerDeadline) + currentDeadlineStart - di.WPoStProvingPeriod + 1
-
-	t.Logf("Waiting %d until epoch %d to get to deadline %d", waitTillEpoch-di.CurrentEpoch, waitTillEpoch, bSectorDeadline)
-	client.WaitTillChain(ctx, kit.HeightAtLeast(waitTillEpoch))
-
-	// We should be up to the deadline we care about
-	di, err = client.StateMinerProvingDeadline(ctx, maddrB, types.EmptyTSK)
-	req.NoError(err)
-	req.Equal(di.Index, bSectorDeadline, "should be in the deadline of the sector to prove")
-
-	t.Log("Submitting WindowedPoSt...")
-
-	head, err = client.ChainHead(ctx)
-	req.NoError(err)
-	rand, err := client.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, di.Open, nil, head.Key())
-	require.NoError(t, err)
-
-	postParams := miner.SubmitWindowedPoStParams{
-		ChainCommitEpoch: di.Open,
-		ChainCommitRand:  rand,
-		Deadline:         bSectorDeadline,
-		Partitions:       []miner.PoStPartition{{Index: bSectorPartition}},
-		Proofs: []proof.PoStProof{{
-			PoStProof:  minerBInfo.WindowPoStProofType,
-			ProofBytes: []byte{0x1, 0x2, 0x3, 0x4},
-		}},
-	}
-
-	enc = new(bytes.Buffer)
-	req.NoError(postParams.MarshalCBOR(enc))
-
-	m, err = client.MpoolPushMessage(ctx, &types.Message{
-		To:     maddrB,
-		From:   minerB.OwnerKey.Address,
 		Value:  types.NewInt(0),
-		Method: builtin.MethodsMiner.SubmitWindowedPoSt,
-		Params: enc.Bytes(),
-	}, nil)
-	req.NoError(err)
+		From:   client.DefaultKey.Address,
+	}
 
-	r, err = client.StateWaitMsg(ctx, m.Cid(), 2, api.LookbackNoLimit, true)
-	req.NoError(err)
-	require.True(t, r.Receipt.ExitCode.IsSuccess())
-
-	t.Log("Checking power after PoSt...")
-
-	p, err = client.StateMinerPower(ctx, maddrB, r.TipSet)
-	req.NoError(err)
-	t.Logf("MinerB RBP: %v, QaP: %v", p.MinerPower.QualityAdjPower.String(), p.MinerPower.RawBytePower.String())
-	req.Equal(uint64(2<<10), p.MinerPower.RawBytePower.Uint64())    // 2kiB RBP
-	req.Equal(uint64(2<<10), p.MinerPower.QualityAdjPower.Uint64()) // 2kiB QaP
+	_, err = client.MpoolPushMessage(ctx, disputeMsg, nil)
+	req.Error(err, "expected dispute to fail")
+	req.Contains(err.Error(), "failed to dispute valid post")
+	req.Contains(err.Error(), "(RetCode=16)")
 }


### PR DESCRIPTION
## Related Issues
This PR aims to refactor https://github.com/filecoin-project/lotus/pull/12017 by creating a generic testkit manual miner that can be used to onboard CC sectors and Snap deal sectors. It does not have any of the NI-PoRep tests introduced in https://github.com/filecoin-project/lotus/pull/12045. 

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
