### PR TITLE
chore: go mod: revert go version change as it breaks Docker build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/filecoin-project/lotus
 
-go 1.22
-
-toolchain go1.22.1
+go 1.21
 
 retract v1.14.0 // Accidentally force-pushed tag, use v1.14.1+ instead.
 


### PR DESCRIPTION
## Related Issues
We don't want to upgrade the go version in the Curio docker build and so let's not upgrade the go version for now. It got accidentally updated in https://github.com/filecoin-project/lotus/commit/6302607650f9191bcc471547c595d712875b2f0f.

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
