### PR TITLE
chore: ci: request contents read permissions explicitly in gha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/builtin-actor-tests.yml
+++ b/.github/workflows/builtin-actor-tests.yml
@@ -8,7 +8,8 @@ on:
     branches:
       - release/*
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   release:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   check-docsgen:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,8 @@ defaults:
   run:
     shell: bash
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ defaults:
   run:
     shell: bash
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -17,6 +17,8 @@ on:
       - completed
 
 permissions:
+  actions: read
+  checks: read
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,8 @@ on:
   schedule:
   - cron: '0 12 * * *'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   stale:

--- a/.github/workflows/sync-master-main.yaml
+++ b/.github/workflows/sync-master-main.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   sync:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   discover:


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
n/a

## Proposed Changes
<!-- A clear list of the changes being made -->
Request contents read permissions explicitly in GitHub Actions.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
This permissions are granted implicitly in public repositories (like lotus), but need to be requested explicitly in private repositories (like lotus-priv). This change will allow us to finish the migration of lotus-priv to GHA.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
