### PR TITLE
chore: backport #12054 to release/v1.27.0 branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
-      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2
       - run: make deps
       - run: golangci-lint run -v --timeout 10m --concurrency 4
   check-fmt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4071,6 +4071,7 @@ This is a  **highly recommended** but optional Lotus v1.11.1 release that introd
 - Release Template: remove binary validation step ([filecoin-project/lotus#6709](https://github.com/filecoin-project/lotus/pull/6709))
 - Reset of the interop network ([filecoin-project/lotus#6689](https://github.com/filecoin-project/lotus/pull/6689))
 - Update version.go to 1.11.1 ([filecoin-project/lotus#6621](https://github.com/filecoin-project/lotus/pull/6621))
+- chore: pin golanglint-ci to v1.58.2 ([filecoin-project/lotus#12054](https://github.com/filecoin-project/lotus/pull/12054))
 
 ## Contributors
 


### PR DESCRIPTION
## Proposed Changes
Backport #12054 to `release/v1.27.0` branch to make the lint-checker happy, so that we can get all the checks 🟢

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
