### PR TITLE
fix: ci: publish correct docker tags on workflow dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,15 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ inputs.ref || github.ref }}
+      - id: git
+        env:
+          REF: ${{ inputs.ref || github.ref }}
+        run: |
+          ref="${REF#refs/heads/}"
+          ref="${ref#refs/tags/}"
+          sha="$(git rev-parse --short HEAD)"
+          echo "ref=$ref" | tee -a "$GITHUB_OUTPUT"
+          echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -76,10 +85,9 @@ jobs:
         with:
           images: filecoin/${{ matrix.image }}
           tags: |
-            type=schedule
-            type=raw,enable=${{ github.event_name != 'schedule' && steps.channel.outputs.channel != '' }},value=${{ steps.channel.outputs.channel }}
-            type=ref,event=tag
-            type=sha,prefix=
+            type=raw,enable=${{ steps.channel.outputs.channel != '' }},value=${{ steps.channel.outputs.channel }}
+            type=raw,enable=${{ startsWith(inputs.ref || github.ref, 'refs/tags/') }},value=${{ steps.git.outputs.ref }}
+            type=raw,value=${{ steps.git.outputs.sha }}
           flavor: |
             latest=false
             suffix=${{ matrix.network != 'mainnet' && format('-{0}', matrix.network) || '' }}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://ipdx-workspace.slack.com/archives/CP50PPW2X/p1716967567670129

## Proposed Changes
<!-- A clear list of the changes being made -->
When the workflow is triggered manually, infer the `sha` and `ref` to use for generating Docker metadata from the git checkout instead of relying on the `github` context (which points to the git info of the version of the workflow we're using).

## Additional Info
<!-- Callouts, links to documentation, and etc -->
We didn't release the tag before because the tag release was tied to the tag push trigger only. I have now run the workflow again (from this branch) and verified the tag is being correctly pushed:
- https://github.com/filecoin-project/lotus/actions/runs/9283617669/job/25544197664
- e.g. https://hub.docker.com/layers/filecoin/lotus-all-in-one/v1.27.0/images/sha256-975685469d3785934d767d97c3a4a7275a273fdd1fe0a73ebdc51e7a9bf032bd?context=explore

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
