### PR TITLE
refactor(eth): attach ToFilecoinMessage converter to EthCall type

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -23,6 +23,8 @@ import (
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/must"
 )
 
@@ -226,6 +228,64 @@ type EthCall struct {
 	GasPrice EthBigInt   `json:"gasPrice"`
 	Value    EthBigInt   `json:"value"`
 	Data     EthBytes    `json:"data"`
+}
+
+func (c *EthCall) ToFilecoinMessage() (*types.Message, error) {
+	var from address.Address
+	if c.From == nil || *c.From == (EthAddress{}) {
+		// Send from the filecoin "system" address.
+		var err error
+		from, err = (EthAddress{}).ToFilecoinAddress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct the ethereum system address: %w", err)
+		}
+	} else {
+		// The from address must be translatable to an f4 address.
+		var err error
+		from, err = c.From.ToFilecoinAddress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to translate sender address (%s): %w", c.From.String(), err)
+		}
+		if p := from.Protocol(); p != address.Delegated {
+			return nil, fmt.Errorf("expected a class 4 address, got: %d: %w", p, err)
+		}
+	}
+
+	var params []byte
+	if len(c.Data) > 0 {
+		initcode := abi.CborBytes(c.Data)
+		params2, err := actors.SerializeParams(&initcode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize params: %w", err)
+		}
+		params = params2
+	}
+
+	var to address.Address
+	var method abi.MethodNum
+	if c.To == nil {
+		// this is a contract creation
+		to = builtintypes.EthereumAddressManagerActorAddr
+		method = builtintypes.MethodsEAM.CreateExternal
+	} else {
+		addr, err := c.To.ToFilecoinAddress()
+		if err != nil {
+			return nil, xerrors.Errorf("cannot get Filecoin address: %w", err)
+		}
+		to = addr
+		method = builtintypes.MethodsEVM.InvokeContract
+	}
+
+	return &types.Message{
+		From:       from,
+		To:         to,
+		Value:      big.Int(c.Value),
+		Method:     method,
+		Params:     params,
+		GasLimit:   build.BlockGasLimit,
+		GasFeeCap:  big.Zero(),
+		GasPremium: big.Zero(),
+	}, nil
 }
 
 func (c *EthCall) UnmarshalJSON(b []byte) error {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multicodec"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -18,7 +19,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
@@ -1012,7 +1012,7 @@ func (a *EthModule) EthEstimateGas(ctx context.Context, p jsonrpc.RawParams) (et
 		return ethtypes.EthUint64(0), xerrors.Errorf("decoding params: %w", err)
 	}
 
-	msg, err := ethCallToFilecoinMessage(ctx, params.Tx)
+	msg, err := params.Tx.ToFilecoinMessage()
 	if err != nil {
 		return ethtypes.EthUint64(0), err
 	}
@@ -1179,7 +1179,7 @@ func ethGasSearch(
 }
 
 func (a *EthModule) EthCall(ctx context.Context, tx ethtypes.EthCall, blkParam ethtypes.EthBlockNumberOrHash) (ethtypes.EthBytes, error) {
-	msg, err := ethCallToFilecoinMessage(ctx, tx)
+	msg, err := tx.ToFilecoinMessage()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to convert ethcall to filecoin message: %w", err)
 	}

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multicodec"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -19,6 +18,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -132,64 +131,6 @@ func getTipsetByEthBlockNumberOrHash(ctx context.Context, chain *store.ChainStor
 	}
 
 	return nil, errors.New("invalid block param")
-}
-
-func ethCallToFilecoinMessage(ctx context.Context, tx ethtypes.EthCall) (*types.Message, error) {
-	var from address.Address
-	if tx.From == nil || *tx.From == (ethtypes.EthAddress{}) {
-		// Send from the filecoin "system" address.
-		var err error
-		from, err = (ethtypes.EthAddress{}).ToFilecoinAddress()
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct the ethereum system address: %w", err)
-		}
-	} else {
-		// The from address must be translatable to an f4 address.
-		var err error
-		from, err = tx.From.ToFilecoinAddress()
-		if err != nil {
-			return nil, fmt.Errorf("failed to translate sender address (%s): %w", tx.From.String(), err)
-		}
-		if p := from.Protocol(); p != address.Delegated {
-			return nil, fmt.Errorf("expected a class 4 address, got: %d: %w", p, err)
-		}
-	}
-
-	var params []byte
-	if len(tx.Data) > 0 {
-		initcode := abi.CborBytes(tx.Data)
-		params2, err := actors.SerializeParams(&initcode)
-		if err != nil {
-			return nil, fmt.Errorf("failed to serialize params: %w", err)
-		}
-		params = params2
-	}
-
-	var to address.Address
-	var method abi.MethodNum
-	if tx.To == nil {
-		// this is a contract creation
-		to = builtintypes.EthereumAddressManagerActorAddr
-		method = builtintypes.MethodsEAM.CreateExternal
-	} else {
-		addr, err := tx.To.ToFilecoinAddress()
-		if err != nil {
-			return nil, xerrors.Errorf("cannot get Filecoin address: %w", err)
-		}
-		to = addr
-		method = builtintypes.MethodsEVM.InvokeContract
-	}
-
-	return &types.Message{
-		From:       from,
-		To:         to,
-		Value:      big.Int(tx.Value),
-		Method:     method,
-		Params:     params,
-		GasLimit:   build.BlockGasLimit,
-		GasFeeCap:  big.Zero(),
-		GasPremium: big.Zero(),
-	}, nil
 }
 
 func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTxInfo bool, cs *store.ChainStore, sa StateAPI) (ethtypes.EthBlock, error) {


### PR DESCRIPTION
Small refactor to clean things up.

* This converter is better placed as an EthCall method instead of a package-level function.
* The resulting package/module import graph is sane.
* Exporting this as a public method is very helpful for those who use Lotus as a library.