### PR TITLE
fix: storage: Fix a race in GenerateWindowPoStAdv

### DIFF
--- a/storage/sealer/worker_local.go
+++ b/storage/sealer/worker_local.go
@@ -675,6 +675,8 @@ func (l *LocalWorker) GenerateWindowPoStAdv(ctx context.Context, ppt abi.Registe
 
 		go func(i int, s storiface.PostSectorChallenge) {
 			defer wg.Done()
+			ctx := ctx
+
 			defer func() {
 				if l.challengeThrottle != nil {
 					<-l.challengeThrottle


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR fixes multiple issues in GenerateWindowPoStAdv
* Data race assigning ctx to a shared value
* Fairly severe data race when a ladder of contexts are cancelled from multiple goroutines
  * That data race could make some goroutines hang, leading to slow or missed PoSts, also leading to incorrectly skipped sectors

## Additional Info
This issue led to incorrect PoSts being produced in Curio. This was not a huge deal in lotus-miner thanks to multiple layers of checks and retires, just caused slower PoSts.

Afaict this bug is here since 2022.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
