### PR TITLE
src: lint: bump golangci-lint to 1.59, address unchecked fmt.Fprint*

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
-      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2
+      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
       - run: make deps
       - run: golangci-lint run -v --timeout 10m --concurrency 4
   check-fmt:

--- a/chain/types/fil.go
+++ b/chain/types/fil.go
@@ -68,7 +68,7 @@ func (f FIL) Nano() string {
 func (f FIL) Format(s fmt.State, ch rune) {
 	switch ch {
 	case 's', 'v':
-		fmt.Fprint(s, f.String())
+		_, _ = fmt.Fprint(s, f.String())
 	default:
 		f.Int.Format(s, ch)
 	}

--- a/cli/helper.go
+++ b/cli/helper.go
@@ -76,15 +76,15 @@ func NewAppFmt(a *ufcli.App) *AppFmt {
 }
 
 func (a *AppFmt) Print(args ...interface{}) {
-	fmt.Fprint(a.app.Writer, args...)
+	_, _ = fmt.Fprint(a.app.Writer, args...)
 }
 
 func (a *AppFmt) Println(args ...interface{}) {
-	fmt.Fprintln(a.app.Writer, args...)
+	_, _ = fmt.Fprintln(a.app.Writer, args...)
 }
 
 func (a *AppFmt) Printf(fmtstr string, args ...interface{}) {
-	fmt.Fprintf(a.app.Writer, fmtstr, args...)
+	_, _ = fmt.Fprintf(a.app.Writer, fmtstr, args...)
 }
 
 func (a *AppFmt) Scan(args ...interface{}) (int, error) {

--- a/cli/info.go
+++ b/cli/info.go
@@ -160,8 +160,18 @@ func infoCmdAct(cctx *cli.Context) error {
 	}
 
 	fmt.Printf("Bandwidth:\n")
-	fmt.Fprintf(tw, "\tTotalIn\tTotalOut\tRateIn\tRateOut\n")
-	fmt.Fprintf(tw, "\t%s\t%s\t%s/s\t%s/s\n", humanize.Bytes(uint64(s.TotalIn)), humanize.Bytes(uint64(s.TotalOut)), humanize.Bytes(uint64(s.RateIn)), humanize.Bytes(uint64(s.RateOut)))
+	if _, err := fmt.Fprintf(tw, "\tTotalIn\tTotalOut\tRateIn\tRateOut\n"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(
+		tw,
+		"\t%s\t%s\t%s/s\t%s/s\n",
+		humanize.Bytes(uint64(s.TotalIn)),
+		humanize.Bytes(uint64(s.TotalOut)),
+		humanize.Bytes(uint64(s.RateIn)),
+		humanize.Bytes(uint64(s.RateOut))); err != nil {
+		return err
+	}
 	return tw.Flush()
 
 }

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -168,7 +168,7 @@ var msigCreateCmd = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "actor creation failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "actor creation failed!")
 			return err
 		}
 
@@ -178,7 +178,7 @@ var msigCreateCmd = &cli.Command{
 		if err := execreturn.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
 			return err
 		}
-		fmt.Fprintln(cctx.App.Writer, "Created new multisig: ", execreturn.IDAddress, execreturn.RobustAddress)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Created new multisig: ", execreturn.IDAddress, execreturn.RobustAddress)
 
 		// TODO: maybe register this somewhere
 		return nil
@@ -242,25 +242,25 @@ var msigInspectCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "Balance: %s\n", types.FIL(act.Balance))
-		fmt.Fprintf(cctx.App.Writer, "Spendable: %s\n", types.FIL(types.BigSub(act.Balance, locked)))
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Balance: %s\n", types.FIL(act.Balance))
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Spendable: %s\n", types.FIL(types.BigSub(act.Balance, locked)))
 
 		if cctx.Bool("vesting") {
 			ib, err := mstate.InitialBalance()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cctx.App.Writer, "InitialBalance: %s\n", types.FIL(ib))
+			_, _ = fmt.Fprintf(cctx.App.Writer, "InitialBalance: %s\n", types.FIL(ib))
 			se, err := mstate.StartEpoch()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cctx.App.Writer, "StartEpoch: %d\n", se)
+			_, _ = fmt.Fprintf(cctx.App.Writer, "StartEpoch: %d\n", se)
 			ud, err := mstate.UnlockDuration()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cctx.App.Writer, "UnlockDuration: %d\n", ud)
+			_, _ = fmt.Fprintf(cctx.App.Writer, "UnlockDuration: %d\n", ud)
 		}
 
 		signers, err := mstate.Signers()
@@ -271,17 +271,17 @@ var msigInspectCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cctx.App.Writer, "Threshold: %d / %d\n", threshold, len(signers))
-		fmt.Fprintln(cctx.App.Writer, "Signers:")
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Threshold: %d / %d\n", threshold, len(signers))
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Signers:")
 
 		signerTable := tabwriter.NewWriter(cctx.App.Writer, 8, 4, 2, ' ', 0)
-		fmt.Fprintf(signerTable, "ID\tAddress\n")
+		_, _ = fmt.Fprintf(signerTable, "ID\tAddress\n")
 		for _, s := range signers {
 			signerActor, err := api.StateAccountKey(ctx, s, types.EmptyTSK)
 			if err != nil {
-				fmt.Fprintf(signerTable, "%s\t%s\n", s, "N/A")
+				_, _ = fmt.Fprintf(signerTable, "%s\t%s\n", s, "N/A")
 			} else {
-				fmt.Fprintf(signerTable, "%s\t%s\n", s, signerActor)
+				_, _ = fmt.Fprintf(signerTable, "%s\t%s\n", s, signerActor)
 			}
 		}
 		if err := signerTable.Flush(); err != nil {
@@ -297,7 +297,7 @@ var msigInspectCmd = &cli.Command{
 		}
 
 		decParams := cctx.Bool("decode-params")
-		fmt.Fprintln(cctx.App.Writer, "Transactions: ", len(pending))
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Transactions: ", len(pending))
 		if len(pending) > 0 {
 			var txids []int64
 			for txid := range pending {
@@ -308,7 +308,7 @@ var msigInspectCmd = &cli.Command{
 			})
 
 			w := tabwriter.NewWriter(cctx.App.Writer, 8, 4, 2, ' ', 0)
-			fmt.Fprintf(w, "ID\tState\tApprovals\tTo\tValue\tMethod\tParams\n")
+			_, _ = fmt.Fprintf(w, "ID\tState\tApprovals\tTo\tValue\tMethod\tParams\n")
 			for _, txid := range txids {
 				tx := pending[txid]
 				target := tx.To.String()
@@ -320,9 +320,31 @@ var msigInspectCmd = &cli.Command{
 
 				if err != nil {
 					if tx.Method == 0 {
-						fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n", txid, "pending", len(tx.Approved), target, types.FIL(tx.Value), "Send", tx.Method, paramStr)
+						_, _ = fmt.Fprintf(
+							w,
+							"%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n",
+							txid,
+							"pending",
+							len(tx.Approved),
+							target,
+							types.FIL(tx.Value),
+							"Send",
+							tx.Method,
+							paramStr,
+						)
 					} else {
-						fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n", txid, "pending", len(tx.Approved), target, types.FIL(tx.Value), "new account, unknown method", tx.Method, paramStr)
+						_, _ = fmt.Fprintf(
+							w,
+							"%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n",
+							txid,
+							"pending",
+							len(tx.Approved),
+							target,
+							types.FIL(tx.Value),
+							"new account, unknown method",
+							tx.Method,
+							paramStr,
+						)
 					}
 				} else {
 					method := consensus.NewActorRegistry().Methods[targAct.Code][tx.Method] // TODO: use remote map
@@ -341,7 +363,18 @@ var msigInspectCmd = &cli.Command{
 						paramStr = string(b)
 					}
 
-					fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n", txid, "pending", len(tx.Approved), target, types.FIL(tx.Value), method.Name, tx.Method, paramStr)
+					_, _ = fmt.Fprintf(
+						w,
+						"%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n",
+						txid,
+						"pending",
+						len(tx.Approved),
+						target,
+						types.FIL(tx.Value),
+						method.Name,
+						tx.Method,
+						paramStr,
+					)
 				}
 			}
 			if err := w.Flush(); err != nil {
@@ -923,7 +956,7 @@ var msigAddProposeCmd = &cli.Command{
 
 		msgCid := sm.Cid()
 
-		fmt.Fprintln(cctx.App.Writer, "sent add proposal in message: ", msgCid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "sent add proposal in message: ", msgCid)
 
 		wait, err := api.StateWaitMsg(ctx, msgCid, uint64(cctx.Int("confidence")), build.Finality, true)
 		if err != nil {

--- a/cli/net.go
+++ b/cli/net.go
@@ -479,7 +479,7 @@ var NetBandwidthCmd = &cli.Command{
 
 		tw := tabwriter.NewWriter(os.Stdout, 4, 4, 2, ' ', 0)
 
-		fmt.Fprintf(tw, "Segment\tTotalIn\tTotalOut\tRateIn\tRateOut\n")
+		_, _ = fmt.Fprintf(tw, "Segment\tTotalIn\tTotalOut\tRateIn\tRateOut\n")
 
 		if bypeer {
 			bw, err := api.NetBandwidthStatsByPeer(ctx)
@@ -498,7 +498,15 @@ var NetBandwidthCmd = &cli.Command{
 
 			for _, p := range peers {
 				s := bw[p]
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s/s\t%s/s\n", p, humanize.Bytes(uint64(s.TotalIn)), humanize.Bytes(uint64(s.TotalOut)), humanize.Bytes(uint64(s.RateIn)), humanize.Bytes(uint64(s.RateOut)))
+				_, _ = fmt.Fprintf(
+					tw,
+					"%s\t%s\t%s\t%s/s\t%s/s\n",
+					p,
+					humanize.Bytes(uint64(s.TotalIn)),
+					humanize.Bytes(uint64(s.TotalOut)),
+					humanize.Bytes(uint64(s.RateIn)),
+					humanize.Bytes(uint64(s.RateOut)),
+				)
 			}
 		} else if byproto {
 			bw, err := api.NetBandwidthStatsByProtocol(ctx)
@@ -520,7 +528,15 @@ var NetBandwidthCmd = &cli.Command{
 				if p == "" {
 					p = "<unknown>"
 				}
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s/s\t%s/s\n", p, humanize.Bytes(uint64(s.TotalIn)), humanize.Bytes(uint64(s.TotalOut)), humanize.Bytes(uint64(s.RateIn)), humanize.Bytes(uint64(s.RateOut)))
+				_, _ = fmt.Fprintf(
+					tw,
+					"%s\t%s\t%s\t%s/s\t%s/s\n",
+					p,
+					humanize.Bytes(uint64(s.TotalIn)),
+					humanize.Bytes(uint64(s.TotalOut)),
+					humanize.Bytes(uint64(s.RateIn)),
+					humanize.Bytes(uint64(s.RateOut)),
+				)
 			}
 		} else {
 
@@ -529,7 +545,14 @@ var NetBandwidthCmd = &cli.Command{
 				return err
 			}
 
-			fmt.Fprintf(tw, "Total\t%s\t%s\t%s/s\t%s/s\n", humanize.Bytes(uint64(s.TotalIn)), humanize.Bytes(uint64(s.TotalOut)), humanize.Bytes(uint64(s.RateIn)), humanize.Bytes(uint64(s.RateOut)))
+			_, _ = fmt.Fprintf(
+				tw,
+				"Total\t%s\t%s\t%s/s\t%s/s\n",
+				humanize.Bytes(uint64(s.TotalIn)),
+				humanize.Bytes(uint64(s.TotalOut)),
+				humanize.Bytes(uint64(s.RateIn)),
+				humanize.Bytes(uint64(s.RateOut)),
+			)
 		}
 
 		return tw.Flush()

--- a/cli/paych.go
+++ b/cli/paych.go
@@ -93,7 +93,7 @@ var paychAddFundsCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Fprintln(cctx.App.Writer, chAddr)
+		_, _ = fmt.Fprintln(cctx.App.Writer, chAddr)
 		return nil
 	},
 }
@@ -168,23 +168,23 @@ var paychStatusCmd = &cli.Command{
 func paychStatus(writer io.Writer, avail *lapi.ChannelAvailableFunds) {
 	if avail.Channel == nil {
 		if avail.PendingWaitSentinel != nil {
-			fmt.Fprint(writer, "Creating channel\n")
-			fmt.Fprintf(writer, "  From:          %s\n", avail.From)
-			fmt.Fprintf(writer, "  To:            %s\n", avail.To)
-			fmt.Fprintf(writer, "  Pending Amt:   %s\n", types.FIL(avail.PendingAmt))
-			fmt.Fprintf(writer, "  Wait Sentinel: %s\n", avail.PendingWaitSentinel)
+			_, _ = fmt.Fprint(writer, "Creating channel\n")
+			_, _ = fmt.Fprintf(writer, "  From:          %s\n", avail.From)
+			_, _ = fmt.Fprintf(writer, "  To:            %s\n", avail.To)
+			_, _ = fmt.Fprintf(writer, "  Pending Amt:   %s\n", types.FIL(avail.PendingAmt))
+			_, _ = fmt.Fprintf(writer, "  Wait Sentinel: %s\n", avail.PendingWaitSentinel)
 			return
 		}
-		fmt.Fprint(writer, "Channel does not exist\n")
-		fmt.Fprintf(writer, "  From: %s\n", avail.From)
-		fmt.Fprintf(writer, "  To:   %s\n", avail.To)
+		_, _ = fmt.Fprint(writer, "Channel does not exist\n")
+		_, _ = fmt.Fprintf(writer, "  From: %s\n", avail.From)
+		_, _ = fmt.Fprintf(writer, "  To:   %s\n", avail.To)
 		return
 	}
 
 	if avail.PendingWaitSentinel != nil {
-		fmt.Fprint(writer, "Adding Funds to channel\n")
+		_, _ = fmt.Fprint(writer, "Adding Funds to channel\n")
 	} else {
-		fmt.Fprint(writer, "Channel exists\n")
+		_, _ = fmt.Fprint(writer, "Channel exists\n")
 	}
 
 	nameValues := [][]string{
@@ -204,7 +204,7 @@ func paychStatus(writer io.Writer, avail *lapi.ChannelAvailableFunds) {
 			avail.PendingWaitSentinel.String(),
 		})
 	}
-	fmt.Fprint(writer, formatNameValues(nameValues))
+	_, _ = fmt.Fprint(writer, formatNameValues(nameValues))
 }
 
 func formatNameValues(nameValues [][]string) string {
@@ -240,7 +240,7 @@ var paychListCmd = &cli.Command{
 		}
 
 		for _, v := range chs {
-			fmt.Fprintln(cctx.App.Writer, v.String())
+			_, _ = fmt.Fprintln(cctx.App.Writer, v.String())
 		}
 		return nil
 	},
@@ -281,7 +281,7 @@ var paychSettleCmd = &cli.Command{
 			return fmt.Errorf("settle message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "Settled channel %s\n", ch)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Settled channel %s\n", ch)
 		return nil
 	},
 }
@@ -321,7 +321,7 @@ var paychCloseCmd = &cli.Command{
 			return fmt.Errorf("collect message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "Collected funds for channel %s\n", ch)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Collected funds for channel %s\n", ch)
 		return nil
 	},
 }
@@ -381,7 +381,7 @@ var paychVoucherCreateCmd = &cli.Command{
 		}
 
 		if v.Voucher == nil {
-			return fmt.Errorf("Could not create voucher: insufficient funds in channel, shortfall: %d", v.Shortfall)
+			return fmt.Errorf("could not create voucher: insufficient funds in channel, shortfall: %d", v.Shortfall)
 		}
 
 		enc, err := EncodedString(v.Voucher)
@@ -389,7 +389,7 @@ var paychVoucherCreateCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Fprintln(cctx.App.Writer, enc)
+		_, _ = fmt.Fprintln(cctx.App.Writer, enc)
 		return nil
 	},
 }
@@ -425,7 +425,7 @@ var paychVoucherCheckCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "voucher is valid")
+		_, _ = fmt.Fprintln(cctx.App.Writer, "voucher is valid")
 		return nil
 	},
 }
@@ -580,12 +580,16 @@ func outputVoucher(w io.Writer, v *paych.SignedVoucher, export bool) error {
 		}
 	}
 
-	fmt.Fprintf(w, "Lane %d, Nonce %d: %s", v.Lane, v.Nonce, types.FIL(v.Amount))
-	if export {
-		fmt.Fprintf(w, "; %s", enc)
+	if _, err := fmt.Fprintf(w, "Lane %d, Nonce %d: %s", v.Lane, v.Nonce, types.FIL(v.Amount)); err != nil {
+		return err
 	}
-	fmt.Fprintln(w)
-	return nil
+	if export {
+		if _, err := fmt.Fprintf(w, "; %s", enc); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
 }
 
 var paychVoucherSubmitCmd = &cli.Command{
@@ -629,7 +633,7 @@ var paychVoucherSubmitCmd = &cli.Command{
 			return fmt.Errorf("message execution failed (exit code %d)", mwait.Receipt.ExitCode)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "channel updated successfully")
+		_, _ = fmt.Fprintln(cctx.App.Writer, "channel updated successfully")
 
 		return nil
 	},

--- a/cli/send.go
+++ b/cli/send.go
@@ -217,7 +217,7 @@ var SendCmd = &cli.Command{
 			return err
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "%s\n", sm.Cid())
+		_, _ = fmt.Fprintf(cctx.App.Writer, "%s\n", sm.Cid())
 		return nil
 	},
 }

--- a/cli/sending_ui.go
+++ b/cli/sending_ui.go
@@ -28,7 +28,7 @@ func InteractiveSend(ctx context.Context, cctx *cli.Context, srv ServicesAPI,
 	printer := cctx.App.Writer
 	if xerrors.Is(err, ErrCheckFailed) {
 		if !cctx.Bool("interactive") {
-			fmt.Fprintf(printer, "Following checks have failed:\n")
+			_, _ = fmt.Fprintf(printer, "Following checks have failed:\n")
 			printChecks(printer, checks, proto.Message.Cid())
 		} else {
 			proto, err = resolveChecks(ctx, srv, cctx.App.Writer, proto, checks)
@@ -75,11 +75,11 @@ func resolveChecks(ctx context.Context, s ServicesAPI, printer io.Writer,
 	proto *api.MessagePrototype, checkGroups [][]api.MessageCheckStatus,
 ) (*api.MessagePrototype, error) {
 
-	fmt.Fprintf(printer, "Following checks have failed:\n")
+	_, _ = fmt.Fprintf(printer, "Following checks have failed:\n")
 	printChecks(printer, checkGroups, proto.Message.Cid())
 
 	if feeCapBad, baseFee := isFeeCapProblem(checkGroups, proto.Message.Cid()); feeCapBad {
-		fmt.Fprintf(printer, "Fee of the message can be adjusted\n")
+		_, _ = fmt.Fprintf(printer, "Fee of the message can be adjusted\n")
 		if askUser(printer, "Do you wish to do that? [Yes/no]: ", true) {
 			var err error
 			proto, err = runFeeCapAdjustmentUI(proto, baseFee)
@@ -91,7 +91,7 @@ func resolveChecks(ctx context.Context, s ServicesAPI, printer io.Writer,
 		if err != nil {
 			return nil, err
 		}
-		fmt.Fprintf(printer, "Following checks still failed:\n")
+		_, _ = fmt.Fprintf(printer, "Following checks still failed:\n")
 		printChecks(printer, checks, proto.Message.Cid())
 	}
 
@@ -114,14 +114,14 @@ func printChecks(printer io.Writer, checkGroups [][]api.MessageCheckStatus, prot
 			if !aboutProto {
 				msgName = c.Cid.String()
 			}
-			fmt.Fprintf(printer, "%s message failed a check %s: %s\n", msgName, c.Code, c.Err)
+			_, _ = fmt.Fprintf(printer, "%s message failed a check %s: %s\n", msgName, c.Code, c.Err)
 		}
 	}
 }
 
 func askUser(printer io.Writer, q string, def bool) bool {
 	var resp string
-	fmt.Fprint(printer, q)
+	_, _ = fmt.Fprint(printer, q)
 	_, _ = fmt.Scanln(&resp)
 	resp = strings.ToLower(resp)
 	if len(resp) == 0 {

--- a/cli/spcli/actor.go
+++ b/cli/spcli/actor.go
@@ -670,7 +670,7 @@ func ActorProposeChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 			}
 
 			if !cctx.Bool("really-do-it") {
-				fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
+				_, _ = fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
 				return nil
 			}
 
@@ -695,7 +695,7 @@ func ActorProposeChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 				return xerrors.Errorf("mpool push: %w", err)
 			}
 
-			fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", smsg.Cid())
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", smsg.Cid())
 
 			// wait for it to get mined into a block
 			wait, err := api.StateWaitMsg(ctx, smsg.Cid(), build.MessageConfidence)
@@ -716,8 +716,8 @@ func ActorProposeChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 				return fmt.Errorf("Proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
 			}
 
-			fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully sent, change happens at height %d.\n", na, mi.WorkerChangeEpoch)
-			fmt.Fprintf(cctx.App.Writer, "If you have no active deadlines, call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
+			_, _ = fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully sent, change happens at height %d.\n", na, mi.WorkerChangeEpoch)
+			_, _ = fmt.Fprintf(cctx.App.Writer, "If you have no active deadlines, call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
 
 			return nil
 		},
@@ -942,7 +942,7 @@ func ActorConfirmChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 
 			// check it executed successfully
 			if wait.Receipt.ExitCode.IsError() {
-				fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
+				_, _ = fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
 				return err
 			}
 

--- a/cmd/lotus-bench/cli.go
+++ b/cmd/lotus-bench/cli.go
@@ -304,9 +304,9 @@ func (c *CMD) Stop() {
 
 func (c *CMD) Report() {
 	total := time.Since(c.start)
-	fmt.Fprintf(c.w, "[%s]:\n", c.cmd)
-	fmt.Fprintf(c.w, "- Options:\n")
-	fmt.Fprintf(c.w, "  - concurrency: %d\n", c.concurrency)
-	fmt.Fprintf(c.w, "  - qps: %d\n", c.qps)
+	fmt.Fprintf(c.w, "[%s]:\n", c.cmd)                       //nolint:errcheck
+	fmt.Fprintf(c.w, "- Options:\n")                         //nolint:errcheck
+	fmt.Fprintf(c.w, "  - concurrency: %d\n", c.concurrency) //nolint:errcheck
+	fmt.Fprintf(c.w, "  - qps: %d\n", c.qps)                 //nolint:errcheck
 	c.reporter.Print(total, c.w)
 }

--- a/cmd/lotus-bench/reporter.go
+++ b/cmd/lotus-bench/reporter.go
@@ -93,16 +93,16 @@ func (r *Reporter) Print(elapsed time.Duration, w io.Writer) {
 		totalLatency += latency
 	}
 
-	fmt.Fprintf(w, "- Total Requests: %d\n", nrReq)
-	fmt.Fprintf(w, "- Total Duration: %dms\n", elapsed.Milliseconds())
-	fmt.Fprintf(w, "- Requests/sec: %f\n", float64(nrReq)/elapsed.Seconds())
-	fmt.Fprintf(w, "- Avg latency: %dms\n", totalLatency/nrReq)
-	fmt.Fprintf(w, "- Median latency: %dms\n", r.latencies[nrReq/2])
-	fmt.Fprintf(w, "- Latency distribution:\n")
+	fmt.Fprintf(w, "- Total Requests: %d\n", nrReq)                          //nolint:errcheck
+	fmt.Fprintf(w, "- Total Duration: %dms\n", elapsed.Milliseconds())       //nolint:errcheck
+	fmt.Fprintf(w, "- Requests/sec: %f\n", float64(nrReq)/elapsed.Seconds()) //nolint:errcheck
+	fmt.Fprintf(w, "- Avg latency: %dms\n", totalLatency/nrReq)              //nolint:errcheck
+	fmt.Fprintf(w, "- Median latency: %dms\n", r.latencies[nrReq/2])         //nolint:errcheck
+	fmt.Fprintf(w, "- Latency distribution:\n")                              //nolint:errcheck
 	percentiles := []float64{0.1, 0.5, 0.9, 0.95, 0.99, 0.999}
 	for _, p := range percentiles {
 		idx := int64(p * float64(nrReq))
-		fmt.Fprintf(w, "    %s%% in %dms\n", fmt.Sprintf("%.2f", p*100.0), r.latencies[idx])
+		_, _ = fmt.Fprintf(w, "    %s%% in %dms\n", fmt.Sprintf("%.2f", p*100.0), r.latencies[idx])
 	}
 
 	// create a simple histogram with 10 buckets spanning the range of latency
@@ -135,19 +135,19 @@ func (r *Reporter) Print(elapsed time.Duration, w io.Writer) {
 	}
 
 	// print the histogram using a tabwriter which will align the columns nicely
-	fmt.Fprintf(w, "- Histogram:\n")
+	_, _ = fmt.Fprintf(w, "- Histogram:\n")
 	const padding = 2
 	tabWriter := tabwriter.NewWriter(w, 0, 0, padding, ' ', tabwriter.AlignRight|tabwriter.Debug)
 	for i := 0; i < nrBucket; i++ {
 		ratio := float64(buckets[i].cnt) / float64(nrReq)
 		bars := strings.Repeat("#", int(ratio*100))
-		fmt.Fprintf(tabWriter, "  %d-%dms\t%d\t%s (%s%%)\n", buckets[i].start, buckets[i].end, buckets[i].cnt, bars, fmt.Sprintf("%.2f", ratio*100))
+		_, _ = fmt.Fprintf(tabWriter, "  %d-%dms\t%d\t%s (%s%%)\n", buckets[i].start, buckets[i].end, buckets[i].cnt, bars, fmt.Sprintf("%.2f", ratio*100))
 	}
 	tabWriter.Flush() //nolint:errcheck
 
-	fmt.Fprintf(w, "- Status codes:\n")
+	_, _ = fmt.Fprintf(w, "- Status codes:\n")
 	for code, cnt := range r.statusCodes {
-		fmt.Fprintf(w, "    [%d]: %d\n", code, cnt)
+		_, _ = fmt.Fprintf(w, "    [%d]: %d\n", code, cnt)
 	}
 
 	// print the 10 most occurring errors (in case error values are not unique)
@@ -163,12 +163,12 @@ func (r *Reporter) Print(elapsed time.Duration, w io.Writer) {
 	sort.Slice(sortedErrors, func(i, j int) bool {
 		return sortedErrors[i].cnt > sortedErrors[j].cnt
 	})
-	fmt.Fprintf(w, "- Errors (top 10):\n")
+	_, _ = fmt.Fprintf(w, "- Errors (top 10):\n")
 	for i, se := range sortedErrors {
 		if i > 10 {
 			break
 		}
-		fmt.Fprintf(w, "    [%s]: %d\n", se.err, se.cnt)
+		_, _ = fmt.Fprintf(w, "    [%s]: %d\n", se.err, se.cnt)
 	}
 }
 

--- a/cmd/lotus-bench/rpc.go
+++ b/cmd/lotus-bench/rpc.go
@@ -395,10 +395,10 @@ func (rpc *RPCMethod) Stop() {
 
 func (rpc *RPCMethod) Report() {
 	total := time.Since(rpc.start)
-	fmt.Fprintf(rpc.w, "[%s]:\n", rpc.method)
-	fmt.Fprintf(rpc.w, "- Options:\n")
-	fmt.Fprintf(rpc.w, "  - concurrency: %d\n", rpc.concurrency)
-	fmt.Fprintf(rpc.w, "  - params: %s\n", rpc.params)
-	fmt.Fprintf(rpc.w, "  - qps: %d\n", rpc.qps)
+	fmt.Fprintf(rpc.w, "[%s]:\n", rpc.method)                    //nolint:errcheck
+	fmt.Fprintf(rpc.w, "- Options:\n")                           //nolint:errcheck
+	fmt.Fprintf(rpc.w, "  - concurrency: %d\n", rpc.concurrency) //nolint:errcheck
+	fmt.Fprintf(rpc.w, "  - params: %s\n", rpc.params)           //nolint:errcheck
+	fmt.Fprintf(rpc.w, "  - qps: %d\n", rpc.qps)                 //nolint:errcheck
 	rpc.reporter.Print(total, rpc.w)
 }

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -719,12 +719,12 @@ var actorControlSet = &cli.Command{
 				return err
 			}
 
-			fmt.Fprintln(cctx.App.Writer, hex.EncodeToString(msgBytes))
+			_, _ = fmt.Fprintln(cctx.App.Writer, hex.EncodeToString(msgBytes))
 			return nil
 		}
 
 		if !cctx.Bool("really-do-it") {
-			fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
 			return nil
 		}
 
@@ -760,7 +760,7 @@ var actorProposeChangeWorker = &cli.Command{
 		}
 
 		if !cctx.Bool("really-do-it") {
-			fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
 			return nil
 		}
 
@@ -840,7 +840,7 @@ var actorProposeChangeWorker = &cli.Command{
 			return xerrors.Errorf("mpool push: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", smsg.Cid())
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", smsg.Cid())
 
 		// wait for it to get mined into a block
 		wait, err := nodeAPI.StateWaitMsg(ctx, smsg.Cid(), build.MessageConfidence)
@@ -850,7 +850,7 @@ var actorProposeChangeWorker = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose worker change failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose worker change failed!")
 			return err
 		}
 
@@ -862,8 +862,8 @@ var actorProposeChangeWorker = &cli.Command{
 			return fmt.Errorf("Proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
-		fmt.Fprintf(cctx.App.Writer, "Call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
 
 		return nil
 	},
@@ -890,7 +890,7 @@ var actorConfirmChangeWorker = &cli.Command{
 		}
 
 		if !cctx.Bool("really-do-it") {
-			fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Pass --really-do-it to actually execute this action")
 			return nil
 		}
 
@@ -961,7 +961,7 @@ var actorConfirmChangeWorker = &cli.Command{
 			return xerrors.Errorf("mpool push: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Confirm Message CID:", smsg.Cid())
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Confirm Message CID:", smsg.Cid())
 
 		// wait for it to get mined into a block
 		wait, err := nodeAPI.StateWaitMsg(ctx, smsg.Cid(), build.MessageConfidence)
@@ -971,7 +971,7 @@ var actorConfirmChangeWorker = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Worker change failed!")
 			return err
 		}
 

--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -93,7 +93,7 @@ var mmProposeWithdrawBalance = &cli.Command{
 			return xerrors.Errorf("proposing message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
@@ -103,7 +103,7 @@ var mmProposeWithdrawBalance = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
 			return err
 		}
 
@@ -172,7 +172,7 @@ var mmApproveWithdrawBalance = &cli.Command{
 			return xerrors.Errorf("approving message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Approve Message CID:", acid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Approve Message CID:", acid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, acid, build.MessageConfidence)
@@ -182,7 +182,7 @@ var mmApproveWithdrawBalance = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
 			return err
 		}
 
@@ -253,7 +253,7 @@ var mmProposeChangeOwner = &cli.Command{
 			return xerrors.Errorf("proposing message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
@@ -263,7 +263,7 @@ var mmProposeChangeOwner = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose owner change tx failed!")
 			return err
 		}
 
@@ -343,7 +343,7 @@ var mmApproveChangeOwner = &cli.Command{
 			return xerrors.Errorf("approving message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Approve Message CID:", acid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Approve Message CID:", acid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, acid, build.MessageConfidence)
@@ -353,7 +353,7 @@ var mmApproveChangeOwner = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Approve owner change tx failed!")
 			return err
 		}
 
@@ -416,8 +416,8 @@ var mmProposeChangeWorker = &cli.Command{
 			}
 		} else {
 			if mi.NewWorker == newAddr {
-				fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
-				fmt.Fprintf(cctx.App.Writer, "Call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
+				_, _ = fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
+				_, _ = fmt.Fprintf(cctx.App.Writer, "Call 'confirm-change-worker' at or after height %d to complete.\n", mi.WorkerChangeEpoch)
 				return fmt.Errorf("change to worker address %s already pending", na)
 			}
 		}
@@ -427,8 +427,8 @@ var mmProposeChangeWorker = &cli.Command{
 			NewControlAddrs: mi.ControlAddresses,
 		}
 
-		fmt.Fprintf(cctx.App.Writer, "newAddr: %s\n", newAddr)
-		fmt.Fprintf(cctx.App.Writer, "NewControlAddrs: %s\n", mi.ControlAddresses)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "newAddr: %s\n", newAddr)
+		_, _ = fmt.Fprintf(cctx.App.Writer, "NewControlAddrs: %s\n", mi.ControlAddresses)
 
 		sp, err := actors.SerializeParams(cwp)
 		if err != nil {
@@ -440,7 +440,7 @@ var mmProposeChangeWorker = &cli.Command{
 			return xerrors.Errorf("proposing message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
@@ -450,7 +450,7 @@ var mmProposeChangeWorker = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}
 
@@ -632,7 +632,7 @@ var mmConfirmChangeWorker = &cli.Command{
 			return xerrors.Errorf("proposing message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
@@ -642,7 +642,7 @@ var mmConfirmChangeWorker = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}
 
@@ -839,7 +839,7 @@ var mmProposeControlSet = &cli.Command{
 			return xerrors.Errorf("proposing message: %w", err)
 		}
 
-		fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
+		_, _ = fmt.Fprintln(cctx.App.Writer, "Propose Message CID:", pcid)
 
 		// wait for it to get mined into a block
 		wait, err := api.StateWaitMsg(ctx, pcid, build.MessageConfidence)
@@ -849,7 +849,7 @@ var mmProposeControlSet = &cli.Command{
 
 		// check it executed successfully
 		if wait.Receipt.ExitCode.IsError() {
-			fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
+			_, _ = fmt.Fprintln(cctx.App.Writer, "Propose worker change tx failed!")
 			return err
 		}
 

--- a/cmd/lotus-sim/info.go
+++ b/cmd/lotus-sim/info.go
@@ -66,17 +66,17 @@ func printInfo(ctx context.Context, sim *simulation.Simulation, out io.Writer) e
 	startTime := time.Unix(int64(start.MinTimestamp()), 0)
 	duration := headTime.Sub(startTime)
 
-	fmt.Fprintf(tw, "Num:\t%s\n", sim.Name())
-	fmt.Fprintf(tw, "Head:\t%s\n", head)
-	fmt.Fprintf(tw, "Start Epoch:\t%d\n", firstEpoch)
-	fmt.Fprintf(tw, "End Epoch:\t%d\n", headEpoch)
-	fmt.Fprintf(tw, "Length:\t%d\n", headEpoch-firstEpoch)
-	fmt.Fprintf(tw, "Start Date:\t%s\n", startTime)
-	fmt.Fprintf(tw, "End Date:\t%s\n", headTime)
-	fmt.Fprintf(tw, "Duration:\t%.2f day(s)\n", duration.Hours()/24)
-	fmt.Fprintf(tw, "Capacity:\t%s\n", types.SizeStr(powerNow.RawBytePower))
-	fmt.Fprintf(tw, "Daily Capacity Growth:\t%s/day\n", types.SizeStr(growthRate))
-	fmt.Fprintf(tw, "Network Version:\t%d\n", sim.GetNetworkVersion())
+	fmt.Fprintf(tw, "Num:\t%s\n", sim.Name())                                      //nolint:errcheck
+	fmt.Fprintf(tw, "Head:\t%s\n", head)                                           //nolint:errcheck
+	fmt.Fprintf(tw, "Start Epoch:\t%d\n", firstEpoch)                              //nolint:errcheck
+	fmt.Fprintf(tw, "End Epoch:\t%d\n", headEpoch)                                 //nolint:errcheck
+	fmt.Fprintf(tw, "Length:\t%d\n", headEpoch-firstEpoch)                         //nolint:errcheck
+	fmt.Fprintf(tw, "Start Date:\t%s\n", startTime)                                //nolint:errcheck
+	fmt.Fprintf(tw, "End Date:\t%s\n", headTime)                                   //nolint:errcheck
+	fmt.Fprintf(tw, "Duration:\t%.2f day(s)\n", duration.Hours()/24)               //nolint:errcheck
+	fmt.Fprintf(tw, "Capacity:\t%s\n", types.SizeStr(powerNow.RawBytePower))       //nolint:errcheck
+	fmt.Fprintf(tw, "Daily Capacity Growth:\t%s/day\n", types.SizeStr(growthRate)) //nolint:errcheck
+	fmt.Fprintf(tw, "Network Version:\t%d\n", sim.GetNetworkVersion())             //nolint:errcheck
 	return tw.Flush()
 }
 

--- a/cmd/lotus-sim/info_capacity.go
+++ b/cmd/lotus-sim/info_capacity.go
@@ -60,7 +60,7 @@ var infoCapacityGrowthSimCommand = &cli.Command{
 			)
 			lastPower = newPower
 			lastHeight = newEpoch
-			fmt.Fprintf(cctx.App.Writer, "%s/day\n", types.SizeStr(growthRate))
+			_, _ = fmt.Fprintf(cctx.App.Writer, "%s/day\n", types.SizeStr(growthRate))
 		}
 		return cctx.Err()
 	},

--- a/cmd/lotus-sim/info_state.go
+++ b/cmd/lotus-sim/info_state.go
@@ -128,7 +128,7 @@ var infoStateGrowthSimCommand = &cli.Command{
 					return err
 				}
 
-				fmt.Fprintf(cctx.App.Writer, "%d: %s\n", ts.Height(), types.SizeStr(types.NewInt(parentStateSize)))
+				_, _ = fmt.Fprintf(cctx.App.Writer, "%d: %s\n", ts.Height(), types.SizeStr(types.NewInt(parentStateSize)))
 			}
 
 			ts, err = sim.Node.Chainstore.LoadTipSet(cctx.Context, ts.Parents())

--- a/cmd/lotus-sim/info_wdpost.go
+++ b/cmd/lotus-sim/info_wdpost.go
@@ -35,7 +35,7 @@ var infoWindowPostBandwidthSimCommand = &cli.Command{
 
 		var postGas, totalGas int64
 		printStats := func() {
-			fmt.Fprintf(cctx.App.Writer, "%.4f%%\n", float64(100*postGas)/float64(totalGas))
+			_, _ = fmt.Fprintf(cctx.App.Writer, "%.4f%%\n", float64(100*postGas)/float64(totalGas))
 		}
 		idx := 0
 		err = sim.Walk(cctx.Context, 0, func(

--- a/cmd/lotus-sim/list.go
+++ b/cmd/lotus-sim/list.go
@@ -31,7 +31,7 @@ var listSimCommand = &cli.Command{
 				return err
 			}
 			head := sim.GetHead()
-			fmt.Fprintf(tw, "%s\t%s\t%s\n", name, head.Height(), head.Key())
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", name, head.Height(), head.Key())
 		}
 		return tw.Flush()
 	},

--- a/cmd/lotus-sim/profile.go
+++ b/cmd/lotus-sim/profile.go
@@ -83,9 +83,9 @@ func profileOnSignal(cctx *cli.Context, signals ...os.Signal) {
 			case context.Canceled:
 				return
 			case nil:
-				fmt.Fprintf(cctx.App.ErrWriter, "Wrote profile to %q\n", fname)
+				_, _ = fmt.Fprintf(cctx.App.ErrWriter, "Wrote profile to %q\n", fname)
 			default:
-				fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to write profile: %s\n", err)
+				_, _ = fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to write profile: %s\n", err)
 			}
 		case <-cctx.Done():
 			return

--- a/cmd/lotus-sim/run.go
+++ b/cmd/lotus-sim/run.go
@@ -51,22 +51,22 @@ Signals:
 				return err
 			}
 
-			fmt.Fprintf(cctx.App.Writer, "advanced to %d %s\n", ts.Height(), ts.Key())
+			_, _ = fmt.Fprintf(cctx.App.Writer, "advanced to %d %s\n", ts.Height(), ts.Key())
 
 			// Print
 			select {
 			case <-ch:
-				fmt.Fprintln(cctx.App.Writer, "---------------------")
+				_, _ = fmt.Fprintln(cctx.App.Writer, "---------------------")
 				if err := printInfo(cctx.Context, sim, cctx.App.Writer); err != nil {
-					fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to print info: %s\n", err)
+					_, _ = fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to print info: %s\n", err)
 				}
-				fmt.Fprintln(cctx.App.Writer, "---------------------")
+				_, _ = fmt.Fprintln(cctx.App.Writer, "---------------------")
 			case <-cctx.Context.Done():
 				return cctx.Err()
 			default:
 			}
 		}
-		fmt.Fprintln(cctx.App.Writer, "simulation done")
+		_, _ = fmt.Fprintln(cctx.App.Writer, "simulation done")
 		return err
 	},
 }

--- a/cmd/lotus-sim/upgrade.go
+++ b/cmd/lotus-sim/upgrade.go
@@ -48,10 +48,10 @@ var upgradeList = &cli.Command{
 		}
 
 		tw := tabwriter.NewWriter(cctx.App.Writer, 8, 8, 0, ' ', 0)
-		fmt.Fprintf(tw, "version\theight\tepochs\tmigration\texpensive")
+		_, _ = fmt.Fprintf(tw, "version\theight\tepochs\tmigration\texpensive")
 		epoch := sim.GetHead().Height()
 		for _, upgrade := range upgrades {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				tw, "%d\t%d\t%+d\t%t\t%t",
 				upgrade.Network, upgrade.Height, upgrade.Height-epoch,
 				upgrade.Migration != nil,

--- a/cmd/lotus-sim/util.go
+++ b/cmd/lotus-sim/util.go
@@ -10,9 +10,8 @@ import (
 )
 
 func open(cctx *cli.Context) (*simulation.Node, error) {
-	_, _, err := ulimit.ManageFdLimit()
-	if err != nil {
-		fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to raise ulimit: %s\n", err)
+	if _, _, err := ulimit.ManageFdLimit(); err != nil {
+		_, _ = fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to raise ulimit: %s\n", err)
 	}
 	return simulation.OpenNode(cctx.Context, cctx.String("repo"))
 }

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -81,7 +81,7 @@ func FromReader(reader io.Reader, def interface{}, opts ...LoadCfgOpt) (interfac
 	}
 	for _, d := range movedFields {
 		if md.IsDefined(d.Field...) {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				warningOut,
 				"WARNING: Use of deprecated configuration option '%s' will be removed in a future release, use '%s' instead\n",
 				strings.Join(d.Field, "."),


### PR DESCRIPTION
Another attempt at bumping the linter.

In 1.59, they removed a blanket `Ignore: "fmt:.*",` and instead now rely on a more targeted ignore set of rules based on the types that `fmt.Fprint*()` prints into. The main reason this bites us hard here is because when we print from `urfave/cli` `Command` runners, we use the built-in context `AppWriter` and `ErrWriter`. `AppWriter` is _usually_ `os.Stdout` which is not excluded in the new rules, `ErrWriter` is _usually_ `os.Stderr` but it could also be something else and the new rules can't differentiate and neither can we.

I'm fine with the more targeted ruleset. It means having to opt-in to ignores if you have good reason to. Mostly I've gone with `_, _ = ` ignores, but there's a few places of blocks of `fmt.Fprintf` lines where I've gone with `//nolint:errcheck`.

In terms of landing this, it will have conflicts with the markets removal PRs, notably there's a big change set in paych.go which is disappearing with those PRs. This PR isn't urgent and it may be easier to rebase this on those changes once they land than the other way around.