### PR TITLE
Implement snap deals test for manual sector onboarding

### DIFF
--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -349,7 +349,7 @@ func (tm *TestUnmanagedMiner) OnboardSectorWithPiecesAndMockProofs(ctx context.C
 	return sectorNumber, respCh
 }
 
-func (tm *TestUnmanagedMiner) mkStagedFileWithPieces(_ context.Context, sectorNumber abi.SectorNumber, pt abi.RegisteredSealProof) ([]abi.PieceInfo, string) {
+func (tm *TestUnmanagedMiner) mkStagedFileWithPieces(sectorNumber abi.SectorNumber, pt abi.RegisteredSealProof) ([]abi.PieceInfo, string) {
 	paddedPieceSize := abi.PaddedPieceSize(tm.options.sectorSize)
 	unpaddedPieceSize := paddedPieceSize.Unpadded()
 
@@ -402,9 +402,9 @@ func (tm *TestUnmanagedMiner) SnapDealWithRealProofs(ctx context.Context, proofT
 	require.NoError(tm.t, err)
 
 	updatePath := requireTempFile(tm.t, bytes.NewReader(randomBytes), uint64(s.Size()))
-	_ = updatePath.Close()
+	require.NoError(tm.t, updatePath.Close())
 	updateDir := filepath.Join(tm.t.TempDir(), fmt.Sprintf("update-%d", sectorNumber))
-	_ = os.MkdirAll(updateDir, 0700)
+	require.NoError(tm.t, os.MkdirAll(updateDir, 0700))
 
 	newSealed, newUnsealed, err := ffi.SectorUpdate.EncodeInto(updateProofType, updatePath.Name(), updateDir,
 		tm.sealedSectorPaths[sectorNumber], tm.cacheDirPaths[sectorNumber], unsealedPath, pieces)

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -16,7 +16,7 @@ import (
 const defaultSectorSize = abi.SectorSize(2 << 10) // 2KiB
 
 // Manually onboard CC sectors, bypassing lotus-miner onboarding pathways
-func TestManualCCOnboarding(t *testing.T) {
+func TestManualSectorOnboarding(t *testing.T) {
 	req := require.New(t)
 
 	for _, withMockProofs := range []bool{true, false} {
@@ -115,6 +115,13 @@ func TestManualCCOnboarding(t *testing.T) {
 			// Wait till both miners' sectors have had their first post and are activated and check that this is reflected in miner power
 			waitTillActivatedAndAssertPower(ctx, t, minerB, bRespCh, bSectorNum, uint64(defaultSectorSize), withMockProofs)
 			waitTillActivatedAndAssertPower(ctx, t, minerC, cRespCh, cSectorNum, uint64(defaultSectorSize), withMockProofs)
+
+			// Miner B has activated the CC sector -> upgrade it with snapdeals
+			// Note: We can't activate a sector with mock proofs as the WdPost is successfully disputed and so no point
+			// in snapping it as snapping is only for activated sectors
+			if !withMockProofs {
+				minerB.SnapDealWithRealProofs(ctx, kit.TestSpt, bSectorNum)
+			}
 		})
 	}
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -19,7 +19,7 @@ const defaultSectorSize = abi.SectorSize(2 << 10) // 2KiB
 func TestManualSectorOnboarding(t *testing.T) {
 	req := require.New(t)
 
-	for _, withMockProofs := range []bool{false, true} {
+	for _, withMockProofs := range []bool{true, false} {
 		testName := "WithRealProofs"
 		if withMockProofs {
 			testName = "WithMockProofs"


### PR DESCRIPTION
## Related Issues
Implements a test for Snap Deals (by upgrading an active CC sector with actual pieces and then using DDO for sector upgrade) with real proofs.

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, market, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
