### PR TITLE
feat: itest: minor UnmanagedMiner refactor for reusability and simplicity

### DIFF
--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -327,7 +327,7 @@ func (n *Ensemble) UnmanagedMiner(full *TestFullNode, opts ...NodeOpt) (*TestUnm
 	actorAddr, err := address.NewIDAddress(genesis2.MinerStart + n.minerCount())
 	require.NoError(n.t, err)
 
-	minerNode := NewTestUnmanagedMiner(n.t, full, actorAddr, opts...)
+	minerNode := NewTestUnmanagedMiner(n.t, full, actorAddr, n.options.mockProofs, opts...)
 	n.AddInactiveUnmanagedMiner(minerNode)
 	return minerNode, n
 }


### PR DESCRIPTION
* move some utility methods into UnmanagedMiner so they can be used from other itests
* make UnmanagedMiner aware of mock proofs so we can remove a lot of branching
