### PR TITLE
chore: market tests: remove non-existent market tests from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
           #   to support resource intensive jobs.
           runners: |
             {
-              "itest-deals_concurrent": ["self-hosted", "linux", "x64", "4xlarge"],
               "itest-sector_pledge": ["self-hosted", "linux", "x64", "4xlarge"],
               "itest-worker": ["self-hosted", "linux", "x64", "4xlarge"],
 
@@ -71,15 +70,8 @@ jobs:
               "itest-wdpost": ["self-hosted", "linux", "x64", "2xlarge"],
               "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"],
 
-              "itest-batch_deal": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-cli": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_512mb": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_anycid": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_max_staging_deals": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_partial_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_publish": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_remote_retrieval": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-decode_params": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "xlarge"],
               "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "xlarge"],
@@ -123,19 +115,12 @@ jobs:
             [
               "conformance",
               "itest-api",
-              "itest-deals_offline",
-              "itest-deals_padding",
-              "itest-deals_partial_retrieval_dm-level",
-              "itest-deals_pricing",
-              "itest-deals",
               "itest-direct_data_onboard_verified",
               "itest-direct_data_onboard",
               "itest-manual_onboarding",
               "itest-net",
               "itest-path_detach_redeclare",
-              "itest-path_type_filters",
               "itest-sealing_resources",
-              "itest-sector_finalize_early",
               "itest-sector_import_full",
               "itest-sector_import_simple",
               "itest-sector_pledge",
@@ -143,7 +128,6 @@ jobs:
               "itest-wdpost_no_miner_storage",
               "itest-wdpost_worker_config",
               "itest-wdpost",
-              "itest-worker_upgrade",
               "itest-worker",
               "multicore-sdr",
               "unit-cli",


### PR DESCRIPTION
There's a bunch of itests that were removed as part of https://github.com/filecoin-project/lotus/pull/11999 that we also need to remove from the CI workflow.