### PR TITLE
chore: upgrade: Update codename for NV23

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -191,7 +191,7 @@ type ForkUpgradeParams struct {
 	UpgradeWatermelonHeight  abi.ChainEpoch
 	UpgradeDragonHeight      abi.ChainEpoch
 	UpgradePhoenixHeight     abi.ChainEpoch
-	UpgradeAussieHeight      abi.ChainEpoch
+	UpgradeWaffleHeight      abi.ChainEpoch
 }
 
 // ChainExportConfig holds configuration for chain ranged exports.

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -17971,7 +17971,7 @@
                                 "UpgradeWatermelonHeight": 10101,
                                 "UpgradeDragonHeight": 10101,
                                 "UpgradePhoenixHeight": 10101,
-                                "UpgradeAussieHeight": 10101
+                                "UpgradeWaffleHeight": 10101
                             },
                             "Eip155ChainID": 123
                         }
@@ -17998,10 +17998,6 @@
                                     "type": "number"
                                 },
                                 "UpgradeAssemblyHeight": {
-                                    "title": "number",
-                                    "type": "number"
-                                },
-                                "UpgradeAussieHeight": {
                                     "title": "number",
                                     "type": "number"
                                 },
@@ -18098,6 +18094,10 @@
                                     "type": "number"
                                 },
                                 "UpgradeTurboHeight": {
+                                    "title": "number",
+                                    "type": "number"
+                                },
+                                "UpgradeWaffleHeight": {
                                     "title": "number",
                                     "type": "number"
                                 },

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -71,7 +71,7 @@ var UpgradeDragonHeight = abi.ChainEpoch(-24)
 
 var UpgradePhoenixHeight = abi.ChainEpoch(-25)
 
-var UpgradeAussieHeight = abi.ChainEpoch(200)
+var UpgradeWaffleHeight = abi.ChainEpoch(200)
 
 // This fix upgrade only ran on calibrationnet
 const UpgradeWatermelonFixHeight = -100
@@ -156,7 +156,7 @@ func init() {
 	UpgradeThunderHeight = getUpgradeHeight("LOTUS_THUNDER_HEIGHT", UpgradeThunderHeight)
 	UpgradeWatermelonHeight = getUpgradeHeight("LOTUS_WATERMELON_HEIGHT", UpgradeWatermelonHeight)
 	UpgradeDragonHeight = getUpgradeHeight("LOTUS_DRAGON_HEIGHT", UpgradeDragonHeight)
-	UpgradeAussieHeight = getUpgradeHeight("LOTUS_AUSSIE_HEIGHT", UpgradeAussieHeight)
+	UpgradeWaffleHeight = getUpgradeHeight("LOTUS_WAFFLE_HEIGHT", UpgradeWaffleHeight)
 
 	UpgradePhoenixHeight = getUpgradeHeight("LOTUS_PHOENIX_HEIGHT", UpgradePhoenixHeight)
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -59,7 +59,7 @@ const UpgradeWatermelonHeight = -24
 const UpgradeDragonHeight = -25
 const UpgradePhoenixHeight = -26
 
-const UpgradeAussieHeight = 400
+const UpgradeWaffleHeight = 400
 
 // This fix upgrade only ran on calibrationnet
 const UpgradeWatermelonFixHeight = -100

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -99,7 +99,7 @@ const UpgradePhoenixHeight = UpgradeDragonHeight + 120
 const UpgradeCalibrationDragonFixHeight = 1493854
 
 // ?????
-const UpgradeAussieHeight = 999999999999999
+const UpgradeWaffleHeight = 999999999999999
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -56,7 +56,7 @@ var UpgradeThunderHeight = abi.ChainEpoch(-23)
 var UpgradeWatermelonHeight = abi.ChainEpoch(-24)
 var UpgradeDragonHeight = abi.ChainEpoch(-25)
 
-const UpgradeAussieHeight = 50
+const UpgradeWaffleHeight = 50
 
 const UpgradePhoenixHeight = UpgradeDragonHeight + 100
 

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -107,7 +107,7 @@ const UpgradeDragonHeight = 3855360
 const UpgradePhoenixHeight = UpgradeDragonHeight + 120
 
 // ??????
-var UpgradeAussieHeight = abi.ChainEpoch(9999999999)
+var UpgradeWaffleHeight = abi.ChainEpoch(9999999999)
 
 // This fix upgrade only ran on calibrationnet
 const UpgradeWatermelonFixHeight = -1
@@ -133,8 +133,8 @@ func init() {
 		SetAddressNetwork(address.Mainnet)
 	}
 
-	if os.Getenv("LOTUS_DISABLE_AUSSIE") == "1" {
-		UpgradeAussieHeight = math.MaxInt64 - 1
+	if os.Getenv("LOTUS_DISABLE_WAFFLE") == "1" {
+		UpgradeWaffleHeight = math.MaxInt64 - 1
 	}
 
 	// NOTE: DO NOT change this unless you REALLY know what you're doing. This is not consensus critical, however,

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -115,7 +115,7 @@ var (
 	UpgradeDragonHeight               abi.ChainEpoch = -26
 	UpgradePhoenixHeight              abi.ChainEpoch = -27
 	UpgradeCalibrationDragonFixHeight abi.ChainEpoch = -28
-	UpgradeAussieHeight               abi.ChainEpoch = -29
+	UpgradeWaffleHeight               abi.ChainEpoch = -29
 
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 		0:                    DrandMainnet,

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -304,7 +304,7 @@ func DefaultUpgradeSchedule() stmgr.UpgradeSchedule {
 		Network:   network.Version22,
 		Migration: upgradeActorsV13VerifregFix(calibnetv13BuggyVerifregCID1, calibnetv13CorrectManifestCID1),
 	}, {
-		Height:    build.UpgradeAussieHeight,
+		Height:    build.UpgradeWaffleHeight,
 		Network:   network.Version23,
 		Migration: UpgradeActorsV14,
 		PreMigrations: []stmgr.PreMigration{{

--- a/documentation/en/api-v0-methods.md
+++ b/documentation/en/api-v0-methods.md
@@ -4483,7 +4483,7 @@ Response:
     "UpgradeWatermelonHeight": 10101,
     "UpgradeDragonHeight": 10101,
     "UpgradePhoenixHeight": 10101,
-    "UpgradeAussieHeight": 10101
+    "UpgradeWaffleHeight": 10101
   },
   "Eip155ChainID": 123
 }

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -6185,7 +6185,7 @@ Response:
     "UpgradeWatermelonHeight": 10101,
     "UpgradeDragonHeight": 10101,
     "UpgradePhoenixHeight": 10101,
-    "UpgradeAussieHeight": 10101
+    "UpgradeWaffleHeight": 10101
   },
   "Eip155ChainID": 123
 }

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1962,7 +1962,7 @@ func (a *StateAPI) StateGetNetworkParams(ctx context.Context) (*api.NetworkParam
 			UpgradeWatermelonHeight:  build.UpgradeWatermelonHeight,
 			UpgradeDragonHeight:      build.UpgradeDragonHeight,
 			UpgradePhoenixHeight:     build.UpgradePhoenixHeight,
-			UpgradeAussieHeight:      build.UpgradeAussieHeight,
+			UpgradeWaffleHeight:      build.UpgradeWaffleHeight,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Proposed Changes
This PR updates the codename for NetworkVersion23 to reflect that Waffle has been choosen for the codename of NV23: https://metropolis.vote/dashboard/c/6pnapz4axv.

Slack-thread asking for clarification here: https://filecoinproject.slack.com/archives/CEHTVSEG6/p1718632500744349?thread_ts=1717005618.376869&cid=CEHTVSEG6

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
