### PR TITLE
feat: support "safe" param for eth_getBlockByNumber for 30 blocks

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -28,6 +28,10 @@ import (
 
 var ErrInvalidAddress = errors.New("invalid Filecoin Eth address")
 
+// Research into Filecoin chain behaviour suggests that probabilistic finality generally approaches the intended stability guarantee at, or near, 30 epochs. Although a strictly "finalized" safe recommendation remains 900 epochs.
+// See https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
+const SafeEpochDelay = abi.ChainEpoch(30)
+
 type EthUint64 uint64
 
 func (e EthUint64) MarshalJSON() ([]byte, error) {

--- a/gateway/proxy_eth.go
+++ b/gateway/proxy_eth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/events/filter"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
@@ -143,8 +144,9 @@ func (gw *Node) checkBlkParam(ctx context.Context, blkParam string, lookback eth
 		}
 		num = ethtypes.EthUint64(head.Height()) - lookback
 	case "safe":
-		safeEpochDelay := 30 // https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
-		num = ethtypes.EthUint64(head.Height()) - lookback - ethtypes.EthUint64(safeEpochDelay)
+		num = ethtypes.EthUint64(head.Height()) - lookback - ethtypes.EthUint64(ethtypes.SafeEpochDelay)
+	case "finalized":
+		num = ethtypes.EthUint64(head.Height()) - lookback - ethtypes.EthUint64(build.Finality)
 	default:
 		if err := num.UnmarshalJSON([]byte(`"` + blkParam + `"`)); err != nil {
 			return fmt.Errorf("cannot parse block number: %v", err)

--- a/gateway/proxy_eth.go
+++ b/gateway/proxy_eth.go
@@ -142,6 +142,9 @@ func (gw *Node) checkBlkParam(ctx context.Context, blkParam string, lookback eth
 			break
 		}
 		num = ethtypes.EthUint64(head.Height()) - lookback
+	case "safe":
+		safeEpochDelay := 30 // https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
+		num = ethtypes.EthUint64(head.Height()) - lookback - ethtypes.EthUint64(safeEpochDelay)
 	default:
 		if err := num.UnmarshalJSON([]byte(`"` + blkParam + `"`)); err != nil {
 			return fmt.Errorf("cannot parse block number: %v", err)

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -61,7 +61,7 @@ func getTipsetByBlockNumber(ctx context.Context, chain *store.ChainStore, blkPar
 		safeEpochDelay := abi.ChainEpoch(30) // https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
 		latestHeight := head.Height() - 1
 		safeHeight := latestHeight - safeEpochDelay
-		ts, err := chain.GetTipsetByHeight(ctx, abi.ChainEpoch(safeHeight), head, true)
+		ts, err := chain.GetTipsetByHeight(ctx, safeHeight, head, true)
 		if err != nil {
 			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)
 		}

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -57,6 +57,15 @@ func getTipsetByBlockNumber(ctx context.Context, chain *store.ChainStore, blkPar
 			return nil, fmt.Errorf("cannot get parent tipset")
 		}
 		return parent, nil
+	case "safe":
+		safeEpochDelay := abi.ChainEpoch(30) // https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
+		latestHeight := head.Height() - 1
+		safeHeight := latestHeight - safeEpochDelay
+		ts, err := chain.GetTipsetByHeight(ctx, abi.ChainEpoch(safeHeight), head, true)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)
+		}
+		return ts, nil
 	default:
 		var num ethtypes.EthUint64
 		err := num.UnmarshalJSON([]byte(`"` + blkParam + `"`))

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -58,9 +58,16 @@ func getTipsetByBlockNumber(ctx context.Context, chain *store.ChainStore, blkPar
 		}
 		return parent, nil
 	case "safe":
-		safeEpochDelay := abi.ChainEpoch(30) // https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
 		latestHeight := head.Height() - 1
-		safeHeight := latestHeight - safeEpochDelay
+		safeHeight := latestHeight - ethtypes.SafeEpochDelay
+		ts, err := chain.GetTipsetByHeight(ctx, safeHeight, head, true)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)
+		}
+		return ts, nil
+	case "finalized":
+		latestHeight := head.Height() - 1
+		safeHeight := latestHeight - build.Finality
 		ts, err := chain.GetTipsetByHeight(ctx, safeHeight, head, true)
 		if err != nil {
 			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/12083


```
$ curl  -s -X POST localhost:1234/rpc/v1   -H "Content-Type: application/json"   -d '{
    "jsonrpc":"2.0",
    "method":"eth_getBlockByNumber",
    "params":["safe", true],
    "id":1
}'  | jq -r '.result.number' | xargs printf "%d\n"
1714033

$ curl  -s -X POST localhost:1234/rpc/v1   -H "Content-Type: application/json"   -d '{
    "jsonrpc":"2.0",
    "method":"eth_getBlockByNumber",
    "params":["latest", true],
    "id":1
}'  | jq -r '.result.number' | xargs printf "%d\n"
1714063
```

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
