### PR TITLE
SealProofVariant and lotus-bench NI-PoRep additions

### DIFF
--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -136,7 +136,11 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 		i := i
 		m := m
 
-		spt, err := miner.SealProofTypeFromSectorSize(m.SectorSize, nv, synthetic)
+		variant := miner.SealProofVariant_Standard
+		if synthetic {
+			variant = miner.SealProofVariant_Synthetic
+		}
+		spt, err := miner.SealProofTypeFromSectorSize(m.SectorSize, nv, variant)
 		if err != nil {
 			return cid.Undef, err
 		}

--- a/cmd/lotus-bench/bench-sectors.sh
+++ b/cmd/lotus-bench/bench-sectors.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# This is an example of how a full sector lifecycle can be benchmarked using `lotus-bench`. The
+# script generates an unsealed sector, runs PC1, PC2, C1, and C2, and prints the duration of each
+# step. The script also prints the proof length and total duration of the lifecycle.
+#
+# Change `flags` to `--non-interactive` to run NI-PoRep, and switch `sector_size` to the desired
+# sector size. The script assumes that the `lotus-bench` binary is in the same directory as the
+# script.
+#
+# Note that for larger sector sizes, /tmp may not have enough space for the full lifecycle.
+
+set -e
+set -o pipefail
+
+tmpdir=/tmp
+
+flags=""
+# flags="--non-interactive"
+sector_size=2KiB
+# sector_size=8MiB
+# sector_size=512MiB
+# sector_size=32GiB
+# sector_size=64GiB
+
+unsealed_file=${tmpdir}/unsealed${sector_size}
+sealed_file=${tmpdir}/sealed${sector_size}
+cache_dir=${tmpdir}/cache${sector_size}
+c1_file=${tmpdir}/c1_${sector_size}.json
+proof_out=${tmpdir}/proof_${sector_size}.hex
+rm -rf $unsealed_file $sealed_file $cache_dir $c1_file
+
+echo "Generating unsealed sector ..."
+read -r unsealed_cid unsealed_size <<< $(./lotus-bench simple addpiece --sector-size $sector_size /dev/zero $unsealed_file | tail -1)
+if [ $? -ne 0 ]; then exit 1; fi
+echo "Unsealed CID: $unsealed_cid"
+echo "Unsealed Size: $unsealed_size"
+
+start_total=$(date +%s%3N)
+
+echo "Running PC1 ..."
+echo "./lotus-bench simple precommit1 --sector-size $sector_size $flags $unsealed_file $sealed_file $cache_dir $unsealed_cid $unsealed_size"
+start_pc1=$(date +%s%3N)
+pc1_output=$(./lotus-bench simple precommit1 --sector-size $sector_size $flags $unsealed_file $sealed_file $cache_dir $unsealed_cid $unsealed_size | tail -1)
+if [ $? -ne 0 ]; then exit 1; fi
+end_pc1=$(date +%s%3N)
+pc1_duration=$((end_pc1 - start_pc1))
+
+echo "Running PC2 ..."
+echo "./lotus-bench simple precommit2 --sector-size $sector_size $flags $sealed_file $cache_dir $pc1_output"
+start_pc2=$(date +%s%3N)
+read -r commd commr <<< $(./lotus-bench simple precommit2 --sector-size $sector_size $flags $sealed_file $cache_dir $pc1_output | tail -1 | sed -E 's/[dr]://g')
+if [ $? -ne 0 ]; then exit 1; fi
+end_pc2=$(date +%s%3N)
+pc2_duration=$((end_pc2 - start_pc2))
+
+echo "CommD CID: $commd"
+echo "CommR CID: $commr"
+
+echo "Running C1 ..."
+echo "./lotus-bench simple commit1 --sector-size $sector_size $flags $sealed_file $cache_dir ${commd} ${commr} $c1_file"
+start_c1=$(date +%s%3N)
+./lotus-bench simple commit1 --sector-size $sector_size $flags $sealed_file $cache_dir ${commd} ${commr} $c1_file
+end_c1=$(date +%s%3N)
+c1_duration=$((end_c1 - start_c1))
+
+echo "Running C2 ..."
+echo "./lotus-bench simple commit2 $flags $c1_file"
+start_c2=$(date +%s%3N)
+proof=$(./lotus-bench simple commit2 $flags $c1_file | tail -1 | sed 's/^proof: //')
+if [ $? -ne 0 ]; then exit 1; fi
+end_c2=$(date +%s%3N)
+c2_duration=$((end_c2 - start_c2))
+
+echo $proof > $proof_out
+echo "Wrote proof to $proof_out"
+
+# $proof is hex, calculate the length of it in bytes
+proof_len=$(echo "scale=0; ${#proof}/2" | bc)
+echo "Proof length: $proof_len"
+
+end_total=$(date +%s%3N)
+total_duration=$((end_total - start_total))
+
+echo "PC1 duration: $((pc1_duration / 1000)).$((pc1_duration % 1000)) seconds"
+echo "PC2 duration: $((pc2_duration / 1000)).$((pc2_duration % 1000)) seconds"
+echo "C1 duration: $((c1_duration / 1000)).$((c1_duration % 1000)) seconds"
+echo "C2 duration: $((c2_duration / 1000)).$((c2_duration % 1000)) seconds"
+echo "Total duration: $((total_duration / 1000)).$((total_duration % 1000)) seconds"

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -338,7 +338,7 @@ var sealBenchCmd = &cli.Command{
 
 		if !skipc2 {
 			log.Info("generating winning post candidates")
-			wipt, err := spt(sectorSize, false, false).RegisteredWinningPoStProof()
+			wipt, err := spt(sectorSize, miner.SealProofVariant_Standard).RegisteredWinningPoStProof()
 			if err != nil {
 				return err
 			}
@@ -556,7 +556,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 				Miner:  mid,
 				Number: i,
 			},
-			ProofType: spt(sectorSize, false, false),
+			ProofType: spt(sectorSize, miner.SealProofVariant_Standard),
 		}
 
 		start := time.Now()
@@ -586,7 +586,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 							Miner:  mid,
 							Number: i,
 						},
-						ProofType: spt(sectorSize, false, false),
+						ProofType: spt(sectorSize, miner.SealProofVariant_Standard),
 					}
 
 					start := time.Now()
@@ -797,7 +797,7 @@ var proveCmd = &cli.Command{
 				Miner:  abi.ActorID(mid),
 				Number: abi.SectorNumber(c2in.SectorNum),
 			},
-			ProofType: spt(abi.SectorSize(c2in.SectorSize), false, false),
+			ProofType: spt(abi.SectorSize(c2in.SectorSize), miner.SealProofVariant_Standard),
 		}
 
 		fmt.Printf("----\nstart proof computation\n")
@@ -828,8 +828,8 @@ func bps(sectorSize abi.SectorSize, sectorNum int, d time.Duration) string {
 	return types.SizeStr(types.BigInt{Int: bps}) + "/s"
 }
 
-func spt(ssize abi.SectorSize, synth bool, ni bool) abi.RegisteredSealProof {
-	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion, synth, ni)
+func spt(ssize abi.SectorSize, variant miner.SealProofVariant) abi.RegisteredSealProof {
+	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion, variant)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/lotus-bench/main.go
+++ b/cmd/lotus-bench/main.go
@@ -338,7 +338,7 @@ var sealBenchCmd = &cli.Command{
 
 		if !skipc2 {
 			log.Info("generating winning post candidates")
-			wipt, err := spt(sectorSize, false).RegisteredWinningPoStProof()
+			wipt, err := spt(sectorSize, false, false).RegisteredWinningPoStProof()
 			if err != nil {
 				return err
 			}
@@ -556,7 +556,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 				Miner:  mid,
 				Number: i,
 			},
-			ProofType: spt(sectorSize, false),
+			ProofType: spt(sectorSize, false, false),
 		}
 
 		start := time.Now()
@@ -586,7 +586,7 @@ func runSeals(sb *ffiwrapper.Sealer, sbfs *basicfs.Provider, numSectors int, par
 							Miner:  mid,
 							Number: i,
 						},
-						ProofType: spt(sectorSize, false),
+						ProofType: spt(sectorSize, false, false),
 					}
 
 					start := time.Now()
@@ -797,7 +797,7 @@ var proveCmd = &cli.Command{
 				Miner:  abi.ActorID(mid),
 				Number: abi.SectorNumber(c2in.SectorNum),
 			},
-			ProofType: spt(abi.SectorSize(c2in.SectorSize), false),
+			ProofType: spt(abi.SectorSize(c2in.SectorSize), false, false),
 		}
 
 		fmt.Printf("----\nstart proof computation\n")
@@ -828,8 +828,8 @@ func bps(sectorSize abi.SectorSize, sectorNum int, d time.Duration) string {
 	return types.SizeStr(types.BigInt{Int: bps}) + "/s"
 }
 
-func spt(ssize abi.SectorSize, synth bool) abi.RegisteredSealProof {
-	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion, synth)
+func spt(ssize abi.SectorSize, synth bool, ni bool) abi.RegisteredSealProof {
+	spt, err := miner.SealProofTypeFromSectorSize(ssize, build.TestNetworkVersion, synth, ni)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/lotus-bench/simple.go
+++ b/cmd/lotus-bench/simple.go
@@ -186,7 +186,7 @@ var simpleAddPiece = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, false),
+			ProofType: spt(sectorSize, false, false),
 		}
 
 		data, err := os.Open(cctx.Args().First())
@@ -201,7 +201,7 @@ var simpleAddPiece = &cli.Command{
 			return xerrors.Errorf("add piece: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("AddPiece %s (%s)\n", took, bps(abi.SectorSize(pi.Size), 1, took))
 		fmt.Printf("%s %d\n", pi.PieceCID, pi.Size)
@@ -226,6 +226,10 @@ var simplePreCommit1 = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "synthetic",
 			Usage: "generate synthetic PoRep proofs",
+		},
+		&cli.BoolFlag{
+			Name:  "non-interactive",
+			Usage: "generate NI-PoRep proofs",
 		},
 	},
 	ArgsUsage: "[unsealed] [sealed] [cache] [[piece cid] [piece size]]...",
@@ -263,7 +267,7 @@ var simplePreCommit1 = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, cctx.Bool("synthetic")),
+			ProofType: spt(sectorSize, cctx.Bool("synthetic"), cctx.Bool("non-interactive")),
 		}
 
 		ticket := [32]byte{}
@@ -283,7 +287,7 @@ var simplePreCommit1 = &cli.Command{
 			return xerrors.Errorf("precommit1: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("PreCommit1 %s (%s)\n", took, bps(sectorSize, 1, took))
 		fmt.Println(base64.StdEncoding.EncodeToString(p1o))
@@ -307,6 +311,10 @@ var simplePreCommit2 = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "synthetic",
 			Usage: "generate synthetic PoRep proofs",
+		},
+		&cli.BoolFlag{
+			Name:  "non-interactive",
+			Usage: "generate NI-PoRep proofs",
 		},
 		&cli.StringFlag{
 			Name:  "external-pc2",
@@ -388,7 +396,7 @@ Example invocation of lotus-bench as external executor:
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, cctx.Bool("synthetic")),
+			ProofType: spt(sectorSize, cctx.Bool("synthetic"), cctx.Bool("non-interactive")),
 		}
 
 		start := time.Now()
@@ -398,7 +406,7 @@ Example invocation of lotus-bench as external executor:
 			return xerrors.Errorf("precommit2: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("PreCommit2 %s (%s)\n", took, bps(sectorSize, 1, took))
 		fmt.Printf("d:%s r:%s\n", p2o.Unsealed, p2o.Sealed)
@@ -422,6 +430,10 @@ var simpleCommit1 = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "synthetic",
 			Usage: "generate synthetic PoRep proofs",
+		},
+		&cli.BoolFlag{
+			Name:  "non-interactive",
+			Usage: "generate NI-PoRep proofs",
 		},
 	},
 	ArgsUsage: "[sealed] [cache] [comm D] [comm R] [c1out.json]",
@@ -458,7 +470,7 @@ var simpleCommit1 = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, cctx.Bool("synthetic")),
+			ProofType: spt(sectorSize, cctx.Bool("synthetic"), cctx.Bool("non-interactive")),
 		}
 
 		start := time.Now()
@@ -493,7 +505,7 @@ var simpleCommit1 = &cli.Command{
 			return xerrors.Errorf("commit1: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("Commit1 %s (%s)\n", took, bps(sectorSize, 1, took))
 
@@ -532,6 +544,10 @@ var simpleCommit2 = &cli.Command{
 		&cli.BoolFlag{
 			Name:  "synthetic",
 			Usage: "generate synthetic PoRep proofs",
+		},
+		&cli.BoolFlag{
+			Name:  "non-interactive",
+			Usage: "generate NI-PoRep proofs",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -579,7 +595,7 @@ var simpleCommit2 = &cli.Command{
 				Miner:  abi.ActorID(mid),
 				Number: abi.SectorNumber(c2in.SectorNum),
 			},
-			ProofType: spt(abi.SectorSize(c2in.SectorSize), c.Bool("synthetic")),
+			ProofType: spt(abi.SectorSize(c2in.SectorSize), c.Bool("synthetic"), c.Bool("non-interactive")),
 		}
 
 		start := time.Now()
@@ -637,7 +653,7 @@ var simpleWindowPost = &cli.Command{
 			return xerrors.Errorf("parse commr: %w", err)
 		}
 
-		wpt, err := spt(sectorSize, false).RegisteredWindowPoStProof()
+		wpt, err := spt(sectorSize, false, false).RegisteredWindowPoStProof()
 		if err != nil {
 			return err
 		}
@@ -657,7 +673,7 @@ var simpleWindowPost = &cli.Command{
 
 		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
 			SectorInfo: prf.SectorInfo{
-				SealProof:    spt(sectorSize, false),
+				SealProof:    spt(sectorSize, false, false),
 				SectorNumber: sn,
 				SealedCID:    commr,
 			},
@@ -728,7 +744,7 @@ var simpleWinningPost = &cli.Command{
 			return xerrors.Errorf("parse commr: %w", err)
 		}
 
-		wpt, err := spt(sectorSize, false).RegisteredWinningPoStProof()
+		wpt, err := spt(sectorSize, false, false).RegisteredWinningPoStProof()
 		if err != nil {
 			return err
 		}
@@ -748,7 +764,7 @@ var simpleWinningPost = &cli.Command{
 
 		vp, err := ffi.GenerateSingleVanillaProof(ffi.PrivateSectorInfo{
 			SectorInfo: prf.SectorInfo{
-				SealProof:    spt(sectorSize, false),
+				SealProof:    spt(sectorSize, false, false),
 				SectorNumber: sn,
 				SealedCID:    commr,
 			},
@@ -842,7 +858,7 @@ var simpleReplicaUpdate = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, false),
+			ProofType: spt(sectorSize, false, false),
 		}
 
 		start := time.Now()
@@ -852,7 +868,7 @@ var simpleReplicaUpdate = &cli.Command{
 			return xerrors.Errorf("replica update: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("ReplicaUpdate %s (%s)\n", took, bps(sectorSize, 1, took))
 		fmt.Printf("d:%s r:%s\n", ruo.NewUnsealed, ruo.NewSealed)
@@ -910,7 +926,7 @@ var simpleProveReplicaUpdate1 = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, false),
+			ProofType: spt(sectorSize, false, false),
 		}
 
 		start := time.Now()
@@ -935,7 +951,7 @@ var simpleProveReplicaUpdate1 = &cli.Command{
 			return xerrors.Errorf("replica update: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("ProveReplicaUpdate1 %s (%s)\n", took, bps(sectorSize, 1, took))
 
@@ -997,7 +1013,7 @@ var simpleProveReplicaUpdate2 = &cli.Command{
 				Miner:  mid,
 				Number: 1,
 			},
-			ProofType: spt(sectorSize, false),
+			ProofType: spt(sectorSize, false, false),
 		}
 
 		start := time.Now()
@@ -1032,7 +1048,7 @@ var simpleProveReplicaUpdate2 = &cli.Command{
 			return xerrors.Errorf("prove replica update2: %w", err)
 		}
 
-		took := time.Now().Sub(start)
+		took := time.Since(start)
 
 		fmt.Printf("ProveReplicaUpdate2 %s (%s)\n", took, bps(sectorSize, 1, took))
 		fmt.Println("p:", base64.StdEncoding.EncodeToString(p))

--- a/cmd/lotus-seed/main.go
+++ b/cmd/lotus-seed/main.go
@@ -137,9 +137,8 @@ var preSealCmd = &cli.Command{
 			nv = network.Version(c.Uint64("network-version"))
 		}
 
-		var synthetic = false // there's little reason to have this for a seed.
-
-		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, nv, synthetic)
+		var variant = miner.SealProofVariant_Standard // there's little reason to have this for a seed.
+		spt, err := miner.SealProofTypeFromSectorSize(sectorSize, nv, variant)
 		if err != nil {
 			return err
 		}

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -260,7 +260,7 @@ func (n *Ensemble) MinerEnroll(minerNode *TestMiner, full *TestFullNode, opts ..
 		)
 
 		// Will use 2KiB sectors by default (default value of sectorSize).
-		proofType, err := miner.SealProofTypeFromSectorSize(options.sectorSize, n.genesis.version, false)
+		proofType, err := miner.SealProofTypeFromSectorSize(options.sectorSize, n.genesis.version, miner.SealProofVariant_Standard)
 		require.NoError(n.t, err)
 
 		// Create the preseal commitment.

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -25,6 +25,7 @@ import (
 const DefaultPresealsPerBootstrapMiner = 2
 
 const TestSpt = abi.RegisteredSealProof_StackedDrg2KiBV1_1
+const TestSptNi = abi.RegisteredSealProof_StackedDrg2KiBV1_2_Feat_NiPoRep
 
 // nodeOpts is an options accumulating struct, where functional options are
 // merged into.

--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -302,7 +302,7 @@ func TestMigrationNV17(t *testing.T) {
 	minerInfo, err := testClient.StateMinerInfo(ctx, testMiner.ActorAddr, types.EmptyTSK)
 	require.NoError(t, err)
 
-	spt, err := miner.SealProofTypeFromSectorSize(minerInfo.SectorSize, network.Version17, false)
+	spt, err := miner.SealProofTypeFromSectorSize(minerInfo.SectorSize, network.Version17, miner.SealProofVariant_Standard)
 	require.NoError(t, err)
 
 	preCommitParams := miner9.PreCommitSectorParams{


### PR DESCRIPTION
* Introduce a `SealProofVariant` type with standard, synthetic and non-interactive forms so we can do simpler switching between the variants
* Wire up ni-porep to lotus-bench `simple` and add a configurable bash script that can run through the whole sealing process