### PR TITLE
fix: ci: update concurrency group settings of the sorted pr checks workflow

### DIFF
--- a/.github/workflows/sorted-pr-checks.yml
+++ b/.github/workflows/sorted-pr-checks.yml
@@ -22,8 +22,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.pull_number }}-${{ github.event.workflow_run.id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.inputs.pull_number }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 jobs:
   comment:


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
n/a

## Proposed Changes
<!-- A clear list of the changes being made -->
1. Use `workflow_run.head_repository` + `workflow_run.head_branch` in the concurrency group name instead of `workflow_run.id`. This way, the concurrency group should work across all the workflows associated with a single PR.
2. Do not `cancel_in_progress` workflow runs of the sorted PR checks workflow. This should minimise the number of notifications users receive about cancelled workflows.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
