### PR TITLE
chore: docs: add changelog upgrade warning for events db migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 # UNRELEASED
 
+## ☢️ Upgrade Warnings ☢️
+
+- This Lotus release includes some correctness improvements to the events subsystem, impacting RPC APIs including `GetActorEventsRaw`, `SubscribeActorEventsRaw`, `eth_getLogs` and the `eth` filter APIs. Part of these improvements involve an events database migration that may take some time to complete on nodes with extensive event databases. See [filecoin-project/lotus#12080](https://github.com/filecoin-project/lotus/pull/12080) for details.
+
 ## New features
+
 - feat: Add trace transaction API supporting RPC method `trace_transaction` ([filecoin-project/lotus#12068](https://github.com/filecoin-project/lotus/pull/12068))
 
 ## Improvements


### PR DESCRIPTION
Similar to the one we added for 1.27.1, but we have yet another migration worth mentioning.