### PR TITLE
fix: niporep: unflake provecommit failure for niporep

### DIFF
--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -1148,6 +1148,6 @@ func (tm *TestUnmanagedMiner) IsImmutableDeadline(ctx context.Context, deadlineI
 	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, types.EmptyTSK)
 	require.NoError(tm.t, err)
 	// don't rely on di.Index because if we haven't enrolled in cron it won't be ticking
-	currentDeadline := uint64((di.CurrentEpoch - di.PeriodStart) / di.WPoStChallengeWindow)
-	return currentDeadline == deadlineIndex || currentDeadline == deadlineIndex-1
+	currentDeadlineIdx := uint64(math.Abs(float64((di.CurrentEpoch - di.PeriodStart) / di.WPoStChallengeWindow)))
+	return currentDeadlineIdx == deadlineIndex || currentDeadlineIdx == deadlineIndex-1
 }


### PR DESCRIPTION
Flaky noticed here: https://github.com/filecoin-project/lotus/actions/runs/9673748140/job/26688221640

I'm pretty sure this is it - miner isn't enrolled in cron, `di.CurrentEpoch - di.PeriodStart` is negative, our deadline index is a uint64 overflow to some massive number which doesn't match what we want so it's always false.

There's 2 other places in the code I've done this same calculation but this one is missing the abs().