### PR TITLE
fix: build: Ensure Quicknet is used when spinning up 2k/butterfly networks

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -160,8 +160,7 @@ func init() {
 
 	UpgradePhoenixHeight = getUpgradeHeight("LOTUS_PHOENIX_HEIGHT", UpgradePhoenixHeight)
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
-		0:                    DrandMainnet,
-		UpgradePhoenixHeight: DrandQuicknet,
+		0: DrandQuicknet,
 	}
 
 	BuildType |= Build2k

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -83,8 +83,7 @@ const UpgradeWatermelonFix2Height = -101
 const UpgradeCalibrationDragonFixHeight = -102
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
-	0:                    DrandMainnet,
-	UpgradePhoenixHeight: DrandQuicknet,
+	0: DrandQuicknet,
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -16,8 +16,7 @@ import (
 )
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
-	0:                    DrandMainnet,
-	UpgradePhoenixHeight: DrandQuicknet,
+	0: DrandQuicknet,
 }
 
 const GenesisNetworkVersion = network.Version21

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -69,8 +69,7 @@ const UpgradeWatermelonFix2Height = -2
 const UpgradeCalibrationDragonFixHeight = -3
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
-	0:                    DrandMainnet,
-	UpgradePhoenixHeight: DrandQuicknet,
+	0: DrandQuicknet,
 }
 
 var SupportedProofTypes = []abi.RegisteredSealProof{


### PR DESCRIPTION
## Proposed Changes
Since `GenesisNetworkVersion?` is set to network.Version22, and the upgrade `UpgradePhoenixHeight = abi.ChainEpoch(-25)` - we are never triggering the switch Quicknet in 2k-networks and butterfly-networks.

This ensure that we start using Quicknet from start.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
