### PR TITLE
feat:ec:f3: add env var to disable F3

### DIFF
--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -189,5 +189,5 @@ const Eip155ChainId = 31415926
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = true
+const f3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = 100

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -106,5 +106,5 @@ const Eip155ChainId = 3141592
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = true
+const f3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = 200

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -152,5 +152,5 @@ const Eip155ChainId = 314159
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = true
+const f3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = UpgradeWaffleHeight + 100

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -145,5 +145,5 @@ const Eip155ChainId = 3141592
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = true
+const f3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = 1000

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -169,5 +169,5 @@ const Eip155ChainId = 314
 // WhitelistedBlock skips checks on message validity in this block to sidestep the zero-bls signature
 var WhitelistedBlock = MustParseCid("bafy2bzaceapyg2uyzk7vueh3xccxkuwbz3nxewjyguoxvhx77malc2lzn2ybi")
 
-const F3Enabled = false
+const f3Enabled = false
 const F3BootstrapEpoch abi.ChainEpoch = -1

--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"os"
+
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/protocol"
 
@@ -48,4 +50,9 @@ func MustParseCid(c string) cid.Cid {
 	}
 
 	return ret
+}
+
+func IsF3Enabled() bool {
+	const F3DisableEnvKey = "LOTUS_DISABLE_F3"
+	return f3Enabled && len(os.Getenv(F3DisableEnvKey)) == 0
 }

--- a/chain/lf3/f3.go
+++ b/chain/lf3/f3.go
@@ -3,7 +3,6 @@ package lf3
 import (
 	"context"
 	"errors"
-	"os"
 	"time"
 
 	"github.com/ipfs/go-datastore"
@@ -47,12 +46,6 @@ type F3Params struct {
 
 var log = logging.Logger("f3")
 
-const (
-	F3DisableEnvKey      = "DISABLE_F3"
-	F3DisableEnvValue    = "1"
-	F3DisableCheckPeriod = 2 * time.Duration(build.BlockDelaySecs)
-)
-
 func New(mctx helpers.MetricsCtx, lc fx.Lifecycle, params F3Params) (*F3, error) {
 	manifest := f3.LocalnetManifest()
 	manifest.NetworkName = gpbft.NetworkName(params.NetworkName)
@@ -88,23 +81,6 @@ func New(mctx helpers.MetricsCtx, lc fx.Lifecycle, params F3Params) (*F3, error)
 				err := fff.inner.Run(lCtx)
 				if err != nil {
 					log.Errorf("running f3: %+v", err)
-				}
-			}()
-			go func() {
-				ticker := time.NewTicker(F3DisableCheckPeriod)
-				for {
-					select {
-					case <-ticker.C:
-						if os.Getenv(F3DisableEnvKey) == F3DisableEnvValue {
-							// TODO: Once https://github.com/filecoin-project/lotus/pull/12173 is merged
-							// we can use fff.inner.Stop() instead of calling cancel()
-							cancel()
-							log.Errorf("F3 has been disabled in runtime")
-							return
-						}
-					case <-lCtx.Done():
-						return
-					}
 				}
 			}()
 		}, cancel))

--- a/chain/lf3/f3.go
+++ b/chain/lf3/f3.go
@@ -49,7 +49,7 @@ var log = logging.Logger("f3")
 
 const (
 	F3DisableEnvKey      = "DISABLE_F3"
-	F3DisableEnvValue    = "_yes_"
+	F3DisableEnvValue    = "1"
 	F3DisableCheckPeriod = 2 * time.Duration(build.BlockDelaySecs)
 )
 

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -151,7 +151,7 @@ var ChainNode = Options(
 		Override(HandleIncomingBlocksKey, modules.HandleIncomingBlocks),
 	),
 
-	If(build.F3Enabled, Override(new(*lf3.F3), lf3.New)),
+	If(build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue, Override(new(*lf3.F3), lf3.New)),
 )
 
 func ConfigFullNode(c interface{}) Option {

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -151,7 +151,7 @@ var ChainNode = Options(
 		Override(HandleIncomingBlocksKey, modules.HandleIncomingBlocks),
 	),
 
-	If(build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue, Override(new(*lf3.F3), lf3.New)),
+	If(build.IsF3Enabled(), Override(new(*lf3.F3), lf3.New)),
 )
 
 func ConfigFullNode(c interface{}) Option {

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"errors"
-	"os"
 
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
@@ -14,7 +13,6 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node/config"
@@ -143,7 +141,7 @@ func ConfigStorageMiner(c interface{}) Option {
 		Override(new(config.HarmonyDB), cfg.HarmonyDB),
 		Override(new(harmonydb.ITestID), harmonydb.ITestID("")),
 		Override(new(*ctladdr.AddressSelector), modules.AddressSelector(&cfg.Addresses)),
-		If(build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue, Override(F3Participation, modules.F3Participation)),
+		If(build.IsF3Enabled(), Override(F3Participation, modules.F3Participation)),
 	)
 }
 

--- a/node/builder_miner.go
+++ b/node/builder_miner.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"os"
 
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
@@ -13,6 +14,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/gen/slashfilter"
+	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/lib/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/miner"
 	"github.com/filecoin-project/lotus/node/config"
@@ -141,7 +143,7 @@ func ConfigStorageMiner(c interface{}) Option {
 		Override(new(config.HarmonyDB), cfg.HarmonyDB),
 		Override(new(harmonydb.ITestID), harmonydb.ITestID("")),
 		Override(new(*ctladdr.AddressSelector), modules.AddressSelector(&cfg.Addresses)),
-		If(build.F3Enabled, Override(F3Participation, modules.F3Participation)),
+		If(build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue, Override(F3Participation, modules.F3Participation)),
 	)
 }
 

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -19,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-f3/gpbft"
 
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/metrics"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
@@ -381,7 +383,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		build.IndexerIngestTopic(in.Nn),
 	}
 
-	if build.F3Enabled {
+	if build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue {
 		allowTopics = append(allowTopics, gpbft.NetworkName(in.Nn).PubSubTopic())
 	}
 

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net"
-	"os"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -20,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-f3/gpbft"
 
 	"github.com/filecoin-project/lotus/build"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/metrics"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
@@ -383,7 +381,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		build.IndexerIngestTopic(in.Nn),
 	}
 
-	if build.F3Enabled && os.Getenv(lf3.F3DisableEnvKey) != lf3.F3DisableEnvValue {
+	if build.IsF3Enabled() {
 		allowTopics = append(allowTopics, gpbft.NetworkName(in.Nn).PubSubTopic())
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Closes https://github.com/filecoin-project/go-f3/issues/388 

## Proposed Changes
<!-- A clear list of the changes being made -->
This PR:
* Does not run F3 if the `DISABLE_F3` env variable is set.
* Stops F3 in runtime if the `DISABLE_F3` env var is set. The process is currently polling this env variable every 5 minutes, we can poll more often if needed.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
To test it you can run Lotus normally with F3 enabled and then set `DISABLE_F3 = 1  on your environment, this should output a log saying that F3 has been disabled.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
