### PR TITLE
feat: calib: enable f3 by default

### DIFF
--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -152,5 +152,5 @@ const Eip155ChainId = 314159
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = false
-const F3BootstrapEpoch abi.ChainEpoch = -1
+const F3Enabled = true
+const F3BootstrapEpoch abi.ChainEpoch = UpgradeWaffleHeight + 100


### PR DESCRIPTION
bootstrap f3 at 100 epoch after nv23 is activated.
enable f3 by default for calib nodes for [passive testing](https://docs.google.com/document/d/14hMFN95_AsByBh7iMc4r_czUgg8tfjHQ1gTsmmHZ8jI/edit) purpose 