### PR TITLE
build: release: v1.28.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 # v1.28.0-rc3 / 2024-07-04
 
-This is the second release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
+This is the third release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
 **This release candidate sets the calibration network to upgrade at epoch 1779094, corresponding to 2024-07-11T12:00:00Z.** This release does NOT set the mainnet upgrade epoch yet, in which will be updated in the final release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Improvements
 
-# v1.28.0-rc2 / 2024-07-04
+# v1.28.0-rc3 / 2024-07-04
 
 This is the second release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
@@ -90,7 +90,7 @@ For certain node operators, such as full archival nodes or systems that need to 
 - Ignore market balance after nv23 (https://github.com/filecoin-project/lotus/pull/11976)
 - Add finality-related params for `eth_getBlockByNumber` (https://github.com/filecoin-project/lotus/pull/12110)
 - rename `Actor.Address` to `Actor.DelegatedAddress` and only use it for f4 addresses (https://github.com/filecoin-project/lotus/pull/12155)
-
+- feat:ec: integrate F3 dynamic manifest #12185
 
 # v1.27.1 / 2024-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This is the third release candidate of the upcoming MANDATORY Lotus v1.28.0 rele
 
 **This release candidate sets the calibration network to upgrade at epoch 1779094, corresponding to 2024-07-11T12:00:00Z.** This release does NOT set the mainnet upgrade epoch yet, in which will be updated in the final release.
 
+Compared to `Lotus v1.28.0-rc2`, the `Lotus v1.28.0-rc3` introduces the manifest for the "control" nodes for F3 passive testing. This change shouldn't have any impact on production nodes.
+
 ☢️ Upgrade Warnings ☢️
 
 If you are running the `v1.26.0` or an earlier version of Lotus, please go through the `Upgrade Warnings` section for the `v1.27.*` releases, before upgrading to this RC.

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.0-rc2"
+const NodeBuildVersion string = "1.28.0-rc3"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.0-rc2"
+const MinerBuildVersion = "1.28.0-rc3"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
diff with v1.28.0-rc2 
- #12185

Orjan was very quick at clicking!! This change introduces the manifest for the "control" nodes for F3 passive testing. This change shouldnt have any impact on actual production nodes.