### PR TITLE
ci: add changelog check workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,9 @@ Before you mark the PR ready for review, please make sure that:
   - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
   - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
 - [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
+- [ ] If the change does not require a changelog entry, please do one of the following:
+  - [ ] Add `[skip changelog]` to the PR title
+  - [ ] Add the label `skip-changelog` to the PR
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,10 +16,11 @@ Before you mark the PR ready for review, please make sure that:
   - example: ` fix: mempool: Introduce a cache for valid signatures`
   - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
   - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
-- [ ] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
-- [ ] If the change does not require a changelog entry, please do one of the following:
-  - [ ] Add `[skip changelog]` to the PR title
-  - [ ] Add the label `skip-changelog` to the PR
+- [ ] Update CHANGELOG.md or signal that this change does not need it.
+  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
+  - If the change does not require a CHANGELOG.md entry, do one of the following:
+    - Add `[skip changelog]` to the PR title
+    - Add the label `skip-changelog` to the PR
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,39 @@
+name: Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+
+jobs:
+  changelog:
+    if: contains(github.event.pull_request.title, '[skip changelog]') == false &&
+        contains(github.event.pull_request.labels.*.name, 'skip/changelog') == false
+    runs-on: ubuntu-latest
+    name: Changelog
+    steps:
+      - id: changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ENDPOINT: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+          SELECTOR: 'map(select(.filename == "CHANGELOG.md")) | length'
+        run: gh api "$ENDPOINT" --jq "$SELECTOR" | xargs -I{} echo "modified={}" | tee -a $GITHUB_OUTPUT
+      - if: steps.changelog.outputs.modified == '0'
+        env:
+          MESSAGE: |
+            docs/changelogs/ was not modified in this PR. Please do one of the following:
+            - add a changelog entry
+            - add `[skip changelog]` to the PR title
+            - label the PR with `skip/changelog`
+        run: |
+          echo "::error::${MESSAGE//$'\n'/%0A}"
+          exit 1


### PR DESCRIPTION
## Related Issues

Closes #12069 

## Proposed Changes

This PR adds a CI workflow that checks whether the PR contains CHANGELOG.md modifications.

The check can be skipped by adding [skip changelog] to the PR title or labeling the PR with skip/changelog. These instructions are included in the PR template and the workflow failure message.

The checks succeed if CHANGELOG.md is modified and fail otherwise.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
