### PR TITLE
chore: docs: Update label to `skip/changelog` in the PR-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Before you mark the PR ready for review, please make sure that:
   - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
   - If the change does not require a CHANGELOG.md entry, do one of the following:
     - Add `[skip changelog]` to the PR title
-    - Add the label `skip-changelog` to the PR
+    - Add the label `skip/changelog` to the PR
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)


### PR DESCRIPTION
## Proposed Changes
chore: docs: Update label for `skip/changelog` in the PR-template

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip-changelog` to the PR
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
