### PR TITLE
fix: Eth Tx Events Bloom Filter: fix slice modification bug and flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+- https://github.com/filecoin-project/lotus/pull/12203: Fix slice modification bug in ETH Tx Events Bloom Filter
+
 ## ☢️ Upgrade Warnings ☢️
 
 - This Lotus release includes some correctness improvements to the events subsystem, impacting RPC APIs including `GetActorEventsRaw`, `SubscribeActorEventsRaw`, `eth_getLogs` and the `eth` filter APIs. Part of these improvements involve an events database migration that may take some time to complete on nodes with extensive event databases. See [filecoin-project/lotus#12080](https://github.com/filecoin-project/lotus/pull/12080) for details.

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -188,8 +188,6 @@ type EthBlock struct {
 const EthBloomSize = 2048
 
 var (
-	EmptyEthBloom  = [EthBloomSize / 8]byte{}
-	FullEthBloom   = [EthBloomSize / 8]byte{}
 	EmptyEthHash   = EthHash{}
 	EmptyUncleHash = must.One(ParseEthHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")) // Keccak-256 of an RLP of an empty array
 	EmptyRootHash  = must.One(ParseEthHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")) // Keccak-256 hash of the RLP of null
@@ -197,22 +195,17 @@ var (
 	EmptyEthNonce  = [8]byte{0, 0, 0, 0, 0, 0, 0, 0}
 )
 
-func init() {
-	for i := range FullEthBloom {
-		FullEthBloom[i] = 0xff
-	}
-}
-
 func NewEmptyEthBloom() []byte {
-	b := make([]byte, len(EmptyEthBloom))
-	copy(b, EmptyEthBloom[:])
-	return b
+	eb := [EthBloomSize / 8]byte{}
+	return eb[:]
 }
 
 func NewFullEthBloom() []byte {
-	b := make([]byte, len(FullEthBloom))
-	copy(b, FullEthBloom[:])
-	return b
+	fb := [EthBloomSize / 8]byte{}
+	for i := range fb {
+		fb[i] = 0xff
+	}
+	return fb[:]
 }
 
 func NewEthBlock(hasTransactions bool, tipsetLen int) EthBlock {

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -204,13 +204,17 @@ func init() {
 }
 
 func NewEthBlock(hasTransactions bool, tipsetLen int) EthBlock {
+	// make a copy of FullEthBloom
+	LogsBloom := make([]byte, len(FullEthBloom))
+	copy(LogsBloom, FullEthBloom[:])
+
 	b := EthBlock{
 		Sha3Uncles:       EmptyUncleHash, // Sha3Uncles set to a hardcoded value which is used by some clients to determine if has no uncles.
 		StateRoot:        EmptyEthHash,
 		TransactionsRoot: EmptyRootHash, // TransactionsRoot set to a hardcoded value which is used by some clients to determine if has no transactions.
 		ReceiptsRoot:     EmptyEthHash,
 		Difficulty:       EmptyEthInt,
-		LogsBloom:        FullEthBloom[:],
+		LogsBloom:        LogsBloom,
 		Extradata:        []byte{},
 		MixHash:          EmptyEthHash,
 		Nonce:            EmptyEthNonce,

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -203,18 +203,26 @@ func init() {
 	}
 }
 
-func NewEthBlock(hasTransactions bool, tipsetLen int) EthBlock {
-	// make a copy of FullEthBloom
-	LogsBloom := make([]byte, len(FullEthBloom))
-	copy(LogsBloom, FullEthBloom[:])
+func NewEmptyEthBloom() []byte {
+	b := make([]byte, len(EmptyEthBloom))
+	copy(b, EmptyEthBloom[:])
+	return b
+}
 
+func NewFullEthBloom() []byte {
+	b := make([]byte, len(FullEthBloom))
+	copy(b, FullEthBloom[:])
+	return b
+}
+
+func NewEthBlock(hasTransactions bool, tipsetLen int) EthBlock {
 	b := EthBlock{
 		Sha3Uncles:       EmptyUncleHash, // Sha3Uncles set to a hardcoded value which is used by some clients to determine if has no uncles.
 		StateRoot:        EmptyEthHash,
 		TransactionsRoot: EmptyRootHash, // TransactionsRoot set to a hardcoded value which is used by some clients to determine if has no transactions.
 		ReceiptsRoot:     EmptyEthHash,
 		Difficulty:       EmptyEthInt,
-		LogsBloom:        LogsBloom,
+		LogsBloom:        NewFullEthBloom(),
 		Extradata:        []byte{},
 		MixHash:          EmptyEthHash,
 		Nonce:            EmptyEthNonce,

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -593,7 +593,7 @@ func TestTxReceiptBloom(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, th)
 
-	receipt, err := client.EthGetTransactionReceipt(ctx, *th)
+	receipt, err := client.EVM().WaitTransaction(ctx, *th)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 	require.Len(t, receipt.Logs, 1)

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -690,8 +690,6 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 	if tx.BlockNumber != nil {
 		blockNumber = *tx.BlockNumber
 	}
-	LogsBloom := make([]byte, len(ethtypes.EmptyEthBloom))
-	copy(LogsBloom, ethtypes.EmptyEthBloom[:])
 
 	receipt := api.EthTxReceipt{
 		TransactionHash:  tx.Hash,
@@ -702,7 +700,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 		BlockNumber:      blockNumber,
 		Type:             ethtypes.EthUint64(2),
 		Logs:             []ethtypes.EthLog{}, // empty log array is compulsory when no logs, or libraries like ethers.js break
-		LogsBloom:        LogsBloom,
+		LogsBloom:        ethtypes.NewEmptyEthBloom(),
 	}
 
 	if lookup.Receipt.ExitCode.IsSuccess() {

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -690,6 +690,8 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 	if tx.BlockNumber != nil {
 		blockNumber = *tx.BlockNumber
 	}
+	LogsBloom := make([]byte, len(ethtypes.EmptyEthBloom))
+	copy(LogsBloom, ethtypes.EmptyEthBloom[:])
 
 	receipt := api.EthTxReceipt{
 		TransactionHash:  tx.Hash,
@@ -700,7 +702,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 		BlockNumber:      blockNumber,
 		Type:             ethtypes.EthUint64(2),
 		Logs:             []ethtypes.EthLog{}, // empty log array is compulsory when no logs, or libraries like ethers.js break
-		LogsBloom:        ethtypes.EmptyEthBloom[:],
+		LogsBloom:        LogsBloom,
 	}
 
 	if lookup.Receipt.ExitCode.IsSuccess() {


### PR DESCRIPTION
This fixes a  bug in the Bloom Filter for events that is part of ETH Tx receipts.  The issue is that all receipts reference the same underlying backing empty array for it's events bloom filter during initialisation. However, modification to the bloom filter then also modifies the backing array... which is then used to initialise other bloom filters.

**_This also fixes the eth_filters flaky itest._**