### PR TITLE
fix: ETH getLogs: fix slowness at head and ignore null blocks

### DIFF
--- a/chain/events/filter/index.go
+++ b/chain/events/filter/index.go
@@ -698,11 +698,12 @@ func (ei *EventIndex) GetMaxHeightInIndex(ctx context.Context) (uint64, error) {
 	return maxHeight, err
 }
 
-func (ei *EventIndex) IsHeightProcessed(ctx context.Context, height uint64) (bool, error) {
-	row := ei.stmtIsHeightProcessed.QueryRowContext(ctx, height)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
+func (ei *EventIndex) IsHeightPast(ctx context.Context, height uint64) (bool, error) {
+	maxHeight, err := ei.GetMaxHeightInIndex(ctx)
+	if err != nil {
+		return false, err
+	}
+	return height <= maxHeight, nil
 }
 
 func (ei *EventIndex) IsTipsetProcessed(ctx context.Context, tipsetKeyCid []byte) (bool, error) {

--- a/chain/events/filter/index_test.go
+++ b/chain/events/filter/index_test.go
@@ -94,17 +94,17 @@ func TestEventIndexPrefillFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(14000), mh)
 
-	b, err := ei.IsHeightProcessed(context.Background(), 14000)
+	b, err := ei.IsHeightPast(context.Background(), 14000)
 	require.NoError(t, err)
 	require.True(t, b)
 
-	b, err = ei.IsHeightProcessed(context.Background(), 14001)
+	b, err = ei.IsHeightPast(context.Background(), 14001)
 	require.NoError(t, err)
 	require.False(t, b)
 
-	b, err = ei.IsHeightProcessed(context.Background(), 13000)
+	b, err = ei.IsHeightPast(context.Background(), 13000)
 	require.NoError(t, err)
-	require.False(t, b)
+	require.True(t, b)
 
 	tsKey := events14000.msgTs.Key()
 	tsKeyCid, err := tsKey.Cid()


### PR DESCRIPTION
Temporary patch for the v1.28 release to fix some of the issues mentioned in https://github.com/filecoin-project/lotus/issues/12205.

- Event Index is not aware of null blocks because it is never invoked for null blocks. 
- If user does not explicitly specify "latest", eth_getlogs should inly block will "latest"-1 as the events for the "latest" block will only be available after the block is executed (deferred execution).

The right thing to do here is revisit how all the ETH RPC APIs deal with the "latest" flag and ensure they are "deferred execution-safe". We also need to make the Event Index aware of null blocks(or atleast have a way to ensure that a given height resulted in a null block and so it has already "processed" the events for that height). Let's prioritise this as part of our ETH RPC work.