### PR TITLE
chore: merge `release/v1.28.0` / v1.28.0-rc4 back to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,65 @@
 
 ## Improvements
 
+# v1.28.0-rc1 / 2024-07-01
+
+This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle.
+
+**This release does NOT set a calibration network upgrade epoch yet, which will be included in the subsequent release candidate. This release does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
+
+## The Filecoin network version 23 delivers the following FIPs:
+
+- [FIP-0065: Ignore built-in market locked balance in circulating supply calculation](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md)
+- [FIP-0079: Add BLS Aggregate Signatures to FVM](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0079.md)
+- [FIP-0084: Remove Storage Miner Actor Method ProveCommitSectors](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md)
+- [FIP-0085: Convert f090 Mining Reserve Actor to Keyless Account Actor](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md)
+- [FIP-0091: Add support for legacy Ethereum transactions](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0091.md)
+- [FIP-0092: NI-PoRep](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md)
+- [F3 (Fast Finality) Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
+
+## v14 Builtin Actor Bundle
+The actor bundles for the **calibration network** can be checked as follows:
+
+```
+lotus state actor-cids --network-version=23
+Network Version: 23
+Actor Version: 14
+Manifest CID: bafy2bzacebq3hncszqpojglh2dkwekybq4zn6qpc4gceqbx36wndps5qehtau
+
+Actor             CID  
+account           bafk2bzaced5ecfm56dvtw26q56j4d32yoccyd7ggxn3qdki2enxpqqav45ths
+cron              bafk2bzacedpbtttpyvtjncqoyobr63mhqqtlrygbnudhxyp2vha56f626dkfs
+datacap           bafk2bzacecded3lcvo7ndsk66samyecw2trnhrgzi7jxsary3sqgopxlk6rku
+eam               bafk2bzacecsda4uw7dcu76a27gnrrdcm73tgms7wrte6jbou63vloktkqc5ne
+ethaccount        bafk2bzacebu2lcxfmohomjj3umslnylwugf5gssywdq3575tjarta7o227dls
+evm               bafk2bzacea4xnekruhfmdnzvzeo6cbf7jsfgco6x5wje2ckwc2ui2ojzcrlgu
+init              bafk2bzacedfmsdlewihdcrkdepnfata26nj7akbvexzs3chicujhjf2uxsazc
+multisig          bafk2bzacedwx4svscsp6wqqu2vlcunjihvvm4u2jnsqjkwutjhir7dwtl7z6m
+paymentchannel    bafk2bzacedbit7oo6lryhbo64uikvtjtfcth6oxwy3eebxerenu2h7rj44n24
+placeholder       bafk2bzacedfvut2myeleyq67fljcrw4kkmn5pb5dpyozovj7jpoez5irnc3ro
+reward            bafk2bzaced5rlycj7fzpscfc7p3wwxarngwqylqshj7te3uffey5tevunz4we
+storagemarket     bafk2bzaceatwbyrec2nnwggxc2alpqve7rl52fmbhqflebuxmmnvg3qckjb7c
+storageminer      bafk2bzacecr7ozkdz7l2pq3ig5qxae2ysivbnojhsn4gw3o57ov4mhksma7me
+storagepower      bafk2bzacedgeolvjtnw7fkji5kqmx322abv6uls2v34fuml6nw36dvfcw4mtu
+system            bafk2bzacederl6tlpieldsn6mkndqwd4wj5orfoqgab6p2klswfn3cjagxwla
+verifiedregistry  bafk2bzaceczw2kp6gjjdcjbso7mewp7guik7gr525pal6dotdja2lrct6ok3c
+```
+
+## Migration
+The NV23 upgrade migration is expected to be extremely light as only the FIP-0085 migration will be executed which will be very light. With don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have ran the final benchmarks.
+
+## Dependencies
+- github.com/filecoin-project/go-state-types (`v0.14.0-dev` -> `v0.14.0-rc5`)
+- github.com/filecoin-project/filecoin-ffi (`v1.27.0-rc2` -> `v1.28.0-rc2`)
+- `ref-fvm4` (as part of `filecoin-ffi`) (`4.2.0` -> `4.3.1`)
+- A new `github.com/filecoin-project/go-f3` dependency for F3 soft launch (`v0.0.2`)
+
+## Others
+
+- Soft launch for Filecoin F3 (https://github.com/filecoin-project/lotus/pull/12119)  
+- NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
+- Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
+
 # v1.27.1 / 2024-06-24
 
 This release, v1.27.1, is an OPTIONAL lotus release. It is HIGHLY RECOMMENDED for node operators that are building Filecoin index off lotus!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,17 @@
 
 ## Improvements
 
-# v1.28.0-rc1 / 2024-07-01
+# v1.28.0-rc2 / 2024-07-04
 
-This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
+This is the second release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
-**This release canidate does NOT set a calibration network upgrade epoch, it will be added in the second release candidate, expected to be released July 4th. This release candidate does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
+**This release candidate sets the calibration network to upgrade at epoch 1779094, corresponding to 2024-07-11T12:00:00Z.** This release does NOT set the mainnet upgrade epoch yet, in which will be updated in the final release.
 
 ☢️ Upgrade Warnings ☢️
 
 If you are running the `v1.26.0` or an earlier version of Lotus, please go through the `Upgrade Warnings` section for the `v1.27.*` releases, before upgrading to this RC.
+
+- This upgrade includes an additional migration to the events database. Node operators running Lotus with events turned on (off by default) may experience some delay in initial start-up of Lotus as a minor database migration takes place. See [filecoin-project/lotus#12080](https://github.com/filecoin-project/lotus/pull/12080) for full details.
 
 ## The Filecoin network version 23 delivers the following FIPs:
 
@@ -65,7 +67,15 @@ verifiedregistry  bafk2bzaceczw2kp6gjjdcjbso7mewp7guik7gr525pal6dotdja2lrct6ok3c
 ```
 
 ## Migration
-The NV23 upgrade migration is expected to be extremely light as only FIP-0085 requires a migration. We don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have run the final benchmarks.
+
+All node operators, including storage providers, should be aware that ONE pre-migration is being scheduled 120 epochs before the network upgrade. The migration for the NV23 upgrade is expected to be light with no heavy pre-migrations, here are some expected timings and resource consumption numbers:
+
+- Pre-Migration is expected to take less then 1 minute
+- The migration is expected to take less then 30 seconds on a node with a NVMe-drive and a newer CPU. For nodes running on slower disks/CPU, it is still expected to take less then 1 minute.
+
+We recommend node operators (who haven't enabled splitstore discard mode) that do not care about historical chain states, to prune the chain blockstore by syncing from a snapshot 1-2 days before the upgrade.
+
+For certain node operators, such as full archival nodes or systems that need to keep large amounts of state (RPC providers), we recommend skipping the pre-migration and run the non-cached migration (i.e., just running the migration at the network upgrade epoch), and schedule for some additional downtime. Operators of such nodes can read the [How to disable premigration in network upgrade tutorial.](https://lotus.filecoin.io/kb/disable-premigration/)
 
 ## Dependencies
 - github.com/filecoin-project/go-state-types (`v0.14.0-dev` -> `v0.14.0-rc5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
-**This release does NOT set a calibration network upgrade epoch yet, which will be included in the subsequent release candidate. This release does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
+**This release canidate does NOT set a calibration network upgrade epoch, it will be added in the second release candidate, expected to be released July 4th. This release candidate does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
 
 ☢️ Upgrade Warnings ☢️
 
@@ -63,7 +63,7 @@ verifiedregistry  bafk2bzaceczw2kp6gjjdcjbso7mewp7guik7gr525pal6dotdja2lrct6ok3c
 ```
 
 ## Migration
-The NV23 upgrade migration is expected to be extremely light as only the FIP-0085 migration will be executed which will be very light. With don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have ran the final benchmarks.
+The NV23 upgrade migration is expected to be extremely light as only FIP-0085 requires a migration. With don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have ran the final benchmarks.
 
 ## Dependencies
 - github.com/filecoin-project/go-state-types (`v0.14.0-dev` -> `v0.14.0-rc5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 # v1.28.0-rc1 / 2024-07-01
 
-This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle.
+This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
 **This release does NOT set a calibration network upgrade epoch yet, which will be included in the subsequent release candidate. This release does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
 
@@ -77,6 +77,9 @@ The NV23 upgrade migration is expected to be extremely light as only the FIP-008
 - NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
 - Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
 - Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)
+- Ignore market balance after nv23 (https://github.com/filecoin-project/lotus/pull/11976)
+- Add finality-related params for `eth_getBlockByNumber` (https://github.com/filecoin-project/lotus/pull/12110)
+
 
 # v1.27.1 / 2024-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ If you are running the `v1.26.0` or an earlier version of Lotus, please go throu
 - [FIP-0085: Convert f090 Mining Reserve Actor to Keyless Account Actor](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md)
 - [FIP-0091: Add support for legacy Ethereum transactions](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0091.md)
 - [FIP-0092: NI-PoRep](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md)
-- [F3 (Fast Finality) Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
+- [FIP-0086: Fast Finality Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
 
 ## v14 Builtin Actor Bundle
 The actor bundles for the **calibration network** can be checked as follows:
@@ -73,7 +73,7 @@ The NV23 upgrade migration is expected to be extremely light as only FIP-0085 re
 
 ## Others
 
-- Soft launch for Filecoin F3 (https://github.com/filecoin-project/lotus/pull/12119)  
+- Soft launch of F3 (https://github.com/filecoin-project/lotus/pull/12119)  
 - NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
 - Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
 - Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@
 
 ## Improvements
 
-# v1.28.0-rc2 / 2024-07-04
+# v1.28.0-rc3 / 2024-07-04
 
-This is the second release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
+This is the third release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
 **This release candidate sets the calibration network to upgrade at epoch 1779094, corresponding to 2024-07-11T12:00:00Z.** This release does NOT set the mainnet upgrade epoch yet, in which will be updated in the final release.
+
+Compared to `Lotus v1.28.0-rc2`, the `Lotus v1.28.0-rc3` introduces the manifest for the "control" nodes for F3 passive testing. This change shouldn't have any impact on production nodes.
 
 ☢️ Upgrade Warnings ☢️
 
@@ -92,7 +94,7 @@ For certain node operators, such as full archival nodes or systems that need to 
 - Ignore market balance after nv23 (https://github.com/filecoin-project/lotus/pull/11976)
 - Add finality-related params for `eth_getBlockByNumber` (https://github.com/filecoin-project/lotus/pull/12110)
 - rename `Actor.Address` to `Actor.DelegatedAddress` and only use it for f4 addresses (https://github.com/filecoin-project/lotus/pull/12155)
-
+- feat:ec: integrate F3 dynamic manifest #12185
 
 # v1.27.1 / 2024-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The NV23 upgrade migration is expected to be extremely light as only the FIP-008
 - Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)
 - Ignore market balance after nv23 (https://github.com/filecoin-project/lotus/pull/11976)
 - Add finality-related params for `eth_getBlockByNumber` (https://github.com/filecoin-project/lotus/pull/12110)
+- rename `Actor.Address` to `Actor.DelegatedAddress` and only use it for f4 addresses (https://github.com/filecoin-project/lotus/pull/12155)
 
 
 # v1.27.1 / 2024-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ If you are running the `v1.26.0` or an earlier version of Lotus, please go throu
 - [FIP-0085: Convert f090 Mining Reserve Actor to Keyless Account Actor](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md)
 - [FIP-0091: Add support for legacy Ethereum transactions](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0091.md)
 - [FIP-0092: NI-PoRep](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md)
-- [FIP-0086: Fast Finality Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
+- [F3 (Fast Finality) Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
+
+Note that we are only doing a "soft launch"/"passive testing" for F3 (Fast Finality) i.e. FIP-0086 in NV23. Please see [this doc](https://docs.google.com/document/d/14hMFN95_AsByBh7iMc4r_czUgg8tfjHQ1gTsmmHZ8jI/edit#heading=h.dhzqs3lisv24) for more details.
 
 ## v14 Builtin Actor Bundle
 The actor bundles for the **calibration network** can be checked as follows:
@@ -73,7 +75,7 @@ The NV23 upgrade migration is expected to be extremely light as only FIP-0085 re
 
 ## Others
 
-- Soft launch of F3 (https://github.com/filecoin-project/lotus/pull/12119)  
+- Soft launch for Filecoin F3 (https://github.com/filecoin-project/lotus/pull/12119)  
 - NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
 - Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
 - Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ If you are running the `v1.26.0` or an earlier version of Lotus, please go throu
 - [FIP-0085: Convert f090 Mining Reserve Actor to Keyless Account Actor](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md)
 - [FIP-0091: Add support for legacy Ethereum transactions](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0091.md)
 - [FIP-0092: NI-PoRep](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md)
-- [F3 (Fast Finality) Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
+- [FIP-0086: Fast Finality Soft Launch](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md)
 
 Note that we are only doing a "soft launch"/"passive testing" for F3 (Fast Finality) i.e. FIP-0086 in NV23. Please see [this doc](https://docs.google.com/document/d/14hMFN95_AsByBh7iMc4r_czUgg8tfjHQ1gTsmmHZ8jI/edit#heading=h.dhzqs3lisv24) for more details.
 
@@ -75,7 +75,7 @@ The NV23 upgrade migration is expected to be extremely light as only FIP-0085 re
 
 ## Others
 
-- Soft launch for Filecoin F3 (https://github.com/filecoin-project/lotus/pull/12119)  
+- Soft launch of F3 (https://github.com/filecoin-project/lotus/pull/12119)
 - NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
 - Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
 - Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
 
 ## Improvements
 
-# v1.28.0-rc3 / 2024-07-04
+# v1.28.0-rc4 / 2024-07-04
 
-This is the third release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
+This is the fourth release candidate of the upcoming MANDATORY Lotus v1.28.0 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇.
 
 **This release candidate sets the calibration network to upgrade at epoch 1779094, corresponding to 2024-07-11T12:00:00Z.** This release does NOT set the mainnet upgrade epoch yet, in which will be updated in the final release.
 
-Compared to `Lotus v1.28.0-rc2`, the `Lotus v1.28.0-rc3` introduces the manifest for the "control" nodes for F3 passive testing. This change shouldn't have any impact on production nodes.
+Compared to `Lotus v1.28.0-rc3`, the `Lotus v1.28.0-rc4` release addresses an issue that allows us to publish Docker builds.
 
 ☢️ Upgrade Warnings ☢️
 
@@ -95,6 +95,7 @@ For certain node operators, such as full archival nodes or systems that need to 
 - Add finality-related params for `eth_getBlockByNumber` (https://github.com/filecoin-project/lotus/pull/12110)
 - rename `Actor.Address` to `Actor.DelegatedAddress` and only use it for f4 addresses (https://github.com/filecoin-project/lotus/pull/12155)
 - feat:ec: integrate F3 dynamic manifest #12185
+- fix: f3: Fix F3 build parameters for testground target (#12189) ([filecoin-project/lotus#12189](https://github.com/filecoin-project/lotus/pull/12189))
 
 # v1.27.1 / 2024-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ verifiedregistry  bafk2bzaceczw2kp6gjjdcjbso7mewp7guik7gr525pal6dotdja2lrct6ok3c
 ```
 
 ## Migration
-The NV23 upgrade migration is expected to be extremely light as only FIP-0085 requires a migration. With don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have ran the final benchmarks.
+The NV23 upgrade migration is expected to be extremely light as only FIP-0085 requires a migration. We don't expect null tipsets after the upgrade epoch or heavy block validation times. We will updated this sections once we have run the final benchmarks.
 
 ## Dependencies
 - github.com/filecoin-project/go-state-types (`v0.14.0-dev` -> `v0.14.0-rc5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This is the first release candidate of the upcoming MANDATORY Lotus v1.28.0 rele
 
 **This release does NOT set a calibration network upgrade epoch yet, which will be included in the subsequent release candidate. This release does NOT set the mainnet upgrade epoch yet, which will be updated in the final release.**
 
+☢️ Upgrade Warnings ☢️
+
+If you are running the `v1.26.0` or an earlier version of Lotus, please go through the `Upgrade Warnings` section for the `v1.27.*` releases, before upgrading to this RC.
+
 ## The Filecoin network version 23 delivers the following FIPs:
 
 - [FIP-0065: Ignore built-in market locked balance in circulating supply calculation](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md)
@@ -72,6 +76,7 @@ The NV23 upgrade migration is expected to be extremely light as only the FIP-008
 - Soft launch for Filecoin F3 (https://github.com/filecoin-project/lotus/pull/12119)  
 - NI-PoRep changes (https://github.com/filecoin-project/lotus/pull/12130)
 - Fixes for the ETH events API (https://github.com/filecoin-project/lotus/pull/12080)
+- Support for legacy Ethereum transactions (https://github.com/filecoin-project/lotus/pull/11969)
 
 # v1.27.1 / 2024-06-24
 

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc3"
+        "version": "1.28.0-rc4"
     },
     "methods": [
         {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc1"
+        "version": "1.28.0-rc2"
     },
     "methods": [
         {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.27.2-dev"
+        "version": "1.28.0-rc1"
     },
     "methods": [
         {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc4"
+        "version": "1.28.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc3"
+        "version": "1.28.0-rc4"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc1"
+        "version": "1.28.0-rc2"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.27.2-dev"
+        "version": "1.28.0-rc1"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc4"
+        "version": "1.28.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc3"
+        "version": "1.28.0-rc4"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc1"
+        "version": "1.28.0-rc2"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.27.2-dev"
+        "version": "1.28.0-rc1"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc4"
+        "version": "1.28.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc3"
+        "version": "1.28.0-rc4"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc1"
+        "version": "1.28.0-rc2"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.27.2-dev"
+        "version": "1.28.0-rc1"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc2"
+        "version": "1.28.0-rc3"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.0-rc4"
+        "version": "1.28.1-dev"
     },
     "methods": [
         {

--- a/build/params_butterfly.go
+++ b/build/params_butterfly.go
@@ -19,7 +19,7 @@ var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandQuicknet,
 }
 
-const GenesisNetworkVersion = network.Version21
+const GenesisNetworkVersion = network.Version22
 
 var NetworkBundle = "butterflynet"
 var BundleOverrides map[actorstypes.Version]string
@@ -58,7 +58,7 @@ const UpgradeWatermelonHeight = -24
 const UpgradeDragonHeight = -25
 const UpgradePhoenixHeight = -26
 
-const UpgradeWaffleHeight = 400
+const UpgradeWaffleHeight = 100
 
 // This fix upgrade only ran on calibrationnet
 const UpgradeWatermelonFixHeight = -100

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -98,8 +98,8 @@ const UpgradePhoenixHeight = UpgradeDragonHeight + 120
 // 2024-04-03T11:00:00Z
 const UpgradeCalibrationDragonFixHeight = 1493854
 
-// ?????
-const UpgradeWaffleHeight = 999999999999999
+// 2024-07-11T12:00:00Z
+const UpgradeWaffleHeight = 1779094
 
 var SupportedProofTypes = []abi.RegisteredSealProof{
 	abi.RegisteredSealProof_StackedDrg32GiBV1,

--- a/build/params_interop.go
+++ b/build/params_interop.go
@@ -25,7 +25,7 @@ var ActorDebugging = false
 const BootstrappersFile = "interopnet.pi"
 const GenesisFile = "interopnet.car"
 
-const GenesisNetworkVersion = network.Version16
+const GenesisNetworkVersion = network.Version22
 
 var UpgradeBreezeHeight = abi.ChainEpoch(-1)
 

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.27.2-dev"
+const NodeBuildVersion string = "1.28.0-rc1"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.27.2-dev"
+const MinerBuildVersion = "1.28.0-rc1"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.0-rc2"
+const NodeBuildVersion string = "1.28.0-rc3"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.0-rc2"
+const MinerBuildVersion = "1.28.0-rc3"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.0-rc3"
+const NodeBuildVersion string = "1.28.0-rc4"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.0-rc3"
+const MinerBuildVersion = "1.28.0-rc4"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.0-rc4"
+const NodeBuildVersion string = "1.28.1-dev"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.0-rc4"
+const MinerBuildVersion = "1.28.1-dev"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/build/version.go
+++ b/build/version.go
@@ -39,7 +39,7 @@ func BuildTypeString() string {
 }
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.0-rc1"
+const NodeBuildVersion string = "1.28.0-rc2"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -50,7 +50,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.0-rc1"
+const MinerBuildVersion = "1.28.0-rc2"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc4
+   1.28.1-dev
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc1
+   1.28.0-rc2
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc3
+   1.28.0-rc4
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.27.2-dev
+   1.28.0-rc1
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc3
+   1.28.0-rc4
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc1
+   1.28.0-rc2
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.27.2-dev
+   1.28.0-rc1
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc4
+   1.28.1-dev
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc4
+   1.28.1-dev
 
 COMMANDS:
    daemon   Start a lotus daemon process

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc3
+   1.28.0-rc4
 
 COMMANDS:
    daemon   Start a lotus daemon process

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc2
+   1.28.0-rc3
 
 COMMANDS:
    daemon   Start a lotus daemon process

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.27.2-dev
+   1.28.0-rc1
 
 COMMANDS:
    daemon   Start a lotus daemon process

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.0-rc1
+   1.28.0-rc2
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
During the prep of shipping Lotus v1.28.0-rc2/rc3/rc4 we added the Calibration network upgrade epoch, but we did not land this change in master.

## Proposed Changes
- Merge `release/v1.28.0` branch back into master.
- Update version to v1.28.1-dev in master.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip/changelog` to the PR
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
