### PR TITLE
fix: test: use parents instead of height-1 to calculate sector activation epoch

### DIFF
--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -796,7 +796,12 @@ func (tm *TestUnmanagedMiner) submitProveCommit(
 		if exitCodes[i].IsSuccess() {
 			req.NoError(err)
 			req.Equal(si.SectorNumber, sector.sectorNumber)
-			req.Equal(si.Activation, msgReturn.Height-1)
+			// To check the activation epoch, we use Parents() rather than Height-1 to account for null rounds
+			ts, err := tm.FullNode.ChainGetTipSet(tm.ctx, msgReturn.TipSet)
+			req.NoError(err)
+			parent, err := tm.FullNode.ChainGetTipSet(tm.ctx, ts.Parents())
+			req.NoError(err)
+			req.Equal(si.Activation, parent.Height())
 		} else {
 			req.Nil(si, "sector should not be on chain")
 		}


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lotus/issues/12001
Ref: https://github.com/filecoin-project/lotus/actions/runs/9887807887/job/27310358031?pr=12207