### PR TITLE
fix: Eth Trace Block: nil access panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 
 - https://github.com/filecoin-project/lotus/pull/12203: Fix slice modification bug in ETH Tx Events Bloom Filter
+- https://github.com/filecoin-project/lotus/pull/12221: Fix a nil reference panic in the ETH Trace API
 
 ## ☢️ Upgrade Warnings ☢️
 

--- a/node/impl/full/eth_trace.go
+++ b/node/impl/full/eth_trace.go
@@ -446,7 +446,7 @@ func decodeCreateViaEAM(et *types.ExecutionTrace) (initcode []byte, addr *ethtyp
 	}
 	ret, err := decodeReturn[eam12.CreateReturn](&et.MsgRct)
 	if err != nil {
-		return nil, (*ethtypes.EthAddress)(&ret.EthAddress), err
+		return nil, nil, err
 	}
 	return initcode, (*ethtypes.EthAddress)(&ret.EthAddress), nil
 }


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/12209.

Fixes a panic the ETH TRACE API.