### PR TITLE
ci: tests: adds tooling to run very expensive tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,9 @@ Before you mark the PR ready for review, please make sure that:
   - If the change does not require a CHANGELOG.md entry, do one of the following:
     - Add `[skip changelog]` to the PR title
     - Add the label `skip/changelog` to the PR
+- [ ] Add the label `need/very-expensive-tests` if the PR requires running very expensive tests
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
 - [ ] Tests exist for new functionality or change in behavior
 - [ ] CI is green
-- [ ] Add the label `run-very-expensive-tests` if the PR requires running very expensive tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,3 +26,4 @@ Before you mark the PR ready for review, please make sure that:
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
 - [ ] Tests exist for new functionality or change in behavior
 - [ ] CI is green
+- [ ] Add the label `run-very-expensive-tests` if the PR requires running very expensive tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,9 @@ Before you mark the PR ready for review, please make sure that:
   - If the change does not require a CHANGELOG.md entry, do one of the following:
     - Add `[skip changelog]` to the PR title
     - Add the label `skip/changelog` to the PR
-- [ ] Add the label `need/very-expensive-tests` if the PR requires running very expensive tests
+- [ ] Run [very expensive tests](https://github.com/search?q=repo%3Afilecoin-project%2Flotus+VeryExpensive&type=code) if useful or skip
+   - If touching codepaths affecting "very expensive tests", add the label `need/very-expensive-tests`.
+   - Otherwise skip (do nothing)
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
 
       - id: test
         env:
+          LOTUS_RUN_VERY_EXPENSIVE_TESTS: ${{ steps.envs.outputs.run_very_expensive_tests }}
           # Unit test groups other than unit-rest
           utests: |
             [
@@ -75,6 +76,11 @@ jobs:
                 "go_test_flags": "-run=TestConformance",
                 "skip_conformance": "0"
               }
+            ]
+          # Tests that are very expensive to run and need a higher timeout when activated
+          very_expensive_tests: |
+            [
+              "itest-niporep_manual"
             ]
           # Mapping from test group names to custom runner labels
           # The jobs default to running on the default hosted runners (4 CPU, 16 RAM).
@@ -189,6 +195,21 @@ jobs:
 
           # Apply the needs_parameters flag to the groups
           groups="$(jq -n --argjson g "$groups" --argjson p "$parameters" '$g | map(. + {"needs_parameters": ([.name] | inside($p)) })')"
+
+          # Update the timeout for very expensive tests
+          if [ "${LOTUS_RUN_VERY_EXPENSIVE_TESTS}" == "1" ]; then
+            groups="$(jq -n --argjson g "$groups" --argjson e "$very_expensive_tests" '$g | map(
+              if ([.name] | inside($e)) then
+                if .go_test_flags then
+                  .go_test_flags += " -timeout=60m"
+                else
+                  . + {"go_test_flags": "-timeout=60m"}
+                end
+              else
+                .
+              end
+            )')"
+          fi
 
           # Output the groups
           echo "groups=$groups"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,13 @@ name: Test
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
   push:
     branches:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,10 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           HAS_RUN_VERY_EXPENSIVE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'need/very-expensive-tests') }}
+        # set the run_very_expensive_tests flag based on a few criteras:
+        # - if we're in a PR with the label 'need/very-expensive-tests'
+        # - if we're in the nightly cron job (schedule)
+        # this flag is used later to setup the env variable LOTUS_RUN_VERY_EXPENSIVE_TESTS
         run: |
           if [[ "${GITHUB_EVENT_NAME}" = "pull_request" && "${HAS_RUN_VERY_EXPENSIVE_LABEL}" = "true" ]]; then
             echo "run_very_expensive_tests=1" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - id: envs
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          HAS_RUN_VERY_EXPENSIVE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-very-expensive-tests') }}
+          HAS_RUN_VERY_EXPENSIVE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'need/very-expensive-tests') }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" = "pull_request" && "${HAS_RUN_VERY_EXPENSIVE_LABEL}" = "true" ]]; then
             echo "run_very_expensive_tests=1" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
 
       - id: test
         env:
-          LOTUS_RUN_VERY_EXPENSIVE_TESTS: ${{ steps.envs.outputs.run_very_expensive_tests }}
           # Unit test groups other than unit-rest
           utests: |
             [
@@ -76,11 +75,6 @@ jobs:
                 "go_test_flags": "-run=TestConformance",
                 "skip_conformance": "0"
               }
-            ]
-          # Tests that are very expensive to run and need a higher timeout when activated
-          very_expensive_tests: |
-            [
-              "itest-niporep_manual"
             ]
           # Mapping from test group names to custom runner labels
           # The jobs default to running on the default hosted runners (4 CPU, 16 RAM).
@@ -196,21 +190,6 @@ jobs:
           # Apply the needs_parameters flag to the groups
           groups="$(jq -n --argjson g "$groups" --argjson p "$parameters" '$g | map(. + {"needs_parameters": ([.name] | inside($p)) })')"
 
-          # Update the timeout for very expensive tests
-          if [ "${LOTUS_RUN_VERY_EXPENSIVE_TESTS}" == "1" ]; then
-            groups="$(jq -n --argjson g "$groups" --argjson e "$very_expensive_tests" '$g | map(
-              if ([.name] | inside($e)) then
-                if .go_test_flags then
-                  .go_test_flags += " -timeout=60m"
-                else
-                  . + {"go_test_flags": "-timeout=60m"}
-                end
-              else
-                .
-              end
-            )')"
-          fi
-
           # Output the groups
           echo "groups=$groups"
           echo "groups=$(jq -nc --argjson g "$groups" '$g')" >> $GITHUB_OUTPUT
@@ -325,13 +304,18 @@ jobs:
           TEST_RUSTPROOFS_LOGS: ${{ matrix.test_rustproofs_logs || '0' }}
           FORMAT: ${{ matrix.format || 'standard-verbose' }}
           PACKAGES: ${{ join(matrix.packages, ' ') }}
+          GO_TEST_FLAGS: ${{ matrix.go_test_flags || '' }}
         run: |
+          if [ "$LOTUS_RUN_VERY_EXPENSIVE_TESTS" == "1" ] && [[ ! "$GO_TEST_FLAGS" =~ "-timeout" ]]; then
+            GO_TEST_FLAGS="$GO_TEST_FLAGS -timeout 30m"
+          fi
+
           gotestsum \
             --format "$FORMAT" \
             --junitfile "$REPORTS_PATH/$NAME.xml" \
             --jsonfile "$REPORTS_PATH/$NAME.json" \
             --packages="$PACKAGES" \
-            -- ${{ matrix.go_test_flags || '' }}
+            -- ${GO_TEST_FLAGS}
       - if: success() || failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
       - master
       - release/*
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs nightly at 0AM UTC
 
 defaults:
   run:
@@ -25,10 +27,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       groups: ${{ steps.test.outputs.groups }}
+      run_very_expensive_tests: ${{ steps.envs.outputs.run_very_expensive_tests }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+      - id: envs
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          HAS_RUN_VERY_EXPENSIVE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-very-expensive-tests') }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" && "${HAS_RUN_VERY_EXPENSIVE_LABEL}" = "true" ]]; then
+            echo "run_very_expensive_tests=1" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" = "schedule" ]]; then
+            echo "run_very_expensive_tests=1" >> $GITHUB_OUTPUT
+          else
+            echo "run_very_expensive_tests=0" >> $GITHUB_OUTPUT
+          fi
+
       - id: test
         env:
           # Unit test groups other than unit-rest
@@ -242,6 +258,9 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.discover.outputs.groups) }}
+    env:
+      LOTUS_RUN_EXPENSIVE_TESTS: 1
+      LOTUS_RUN_VERY_EXPENSIVE_TESTS: ${{ needs.discover.outputs.run_very_expensive_tests }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -311,7 +311,7 @@ jobs:
           GO_TEST_FLAGS: ${{ matrix.go_test_flags || '' }}
         run: |
           if [ "$LOTUS_RUN_VERY_EXPENSIVE_TESTS" == "1" ] && [[ ! "$GO_TEST_FLAGS" =~ "-timeout" ]]; then
-            GO_TEST_FLAGS="$GO_TEST_FLAGS -timeout 30m"
+            GO_TEST_FLAGS="$GO_TEST_FLAGS -timeout 60m"
           fi
 
           gotestsum \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,9 +332,9 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: ipdxco/create-or-update-issue@0265e9148d6c26f6cdb0abb9c47df048a585c2fe # v1.0.0
+        uses: ipdxco/create-or-update-issue@1c3635e06dd2f09272e49c6f1ad4619ba949120b # v1.0.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           title: "Fix Expensive Tests"
-          label: "expensive-test-failure"
+          label: "area/expensive-test-failure"
           body: "During a scheduled run, the test ${{ matrix.name }} failed."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   discover:
@@ -328,3 +329,12 @@ jobs:
             ${{ steps.reports.outputs.path }}/${{ matrix.name }}.xml
             ${{ steps.reports.outputs.path }}/${{ matrix.name }}.json
         continue-on-error: true
+
+      - name: Create issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: ipdxco/create-or-update-issue@0265e9148d6c26f6cdb0abb9c47df048a585c2fe # v1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          title: "Fix Expensive Tests"
+          label: "expensive-test-failure"
+          body: "During a scheduled run, the test ${{ matrix.name }} failed."


### PR DESCRIPTION
## Related Issues
Closes https://github.com/filecoin-project/lotus/issues/12136

## Proposed Changes

- [x] Keep the `LOTUS_RUN_EXPENSIVE_TESTS` flag unchanged, but make it explicit in CI
- [x] Adds the `LOTUS_RUN_VERY_EXPENSIVE_TESTS` flag based on a few signals (wip)
    - [x] If a PR contains the label `need/very-expensive-tests`
    - [x] During a nightly run
- [x] Adds a `very_expensive_tests` array in the `test.yml` settings (similar to how test are configured for custom runners, etc).
    - [x] Tests in that array will run with `-timeout=60m`

## Additional Info

Currently the test using VERY EXPENSIVE is `niporep_manual_test.go`.

Example of a regular run:
https://github.com/filecoin-project/lotus/actions/runs/9908341740/job/27439500093?pr=12225
You'll find `skipping test` logs in the `gotestsum` step.

Adding the `need/very-expensive-tests` label should toggle those on.
 
## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip/changelog` to the PR
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
