### PR TITLE
fix: ethhashlookup: clean-up query management and lifecycle

### DIFF
--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -29,61 +29,19 @@ var ddls = []string{
 }
 
 const (
-	insertTxHash = `INSERT INTO eth_tx_hashes
-	(hash, cid)
-	VALUES(?, ?)
-	ON CONFLICT (hash) DO UPDATE SET insertion_time = CURRENT_TIMESTAMP`
+	insertTxHash    = `INSERT INTO eth_tx_hashes (hash, cid) VALUES(?, ?) ON CONFLICT (hash) DO UPDATE SET insertion_time = CURRENT_TIMESTAMP`
+	getCidFromHash  = `SELECT cid FROM eth_tx_hashes WHERE hash = ?`
+	getHashFromCid  = `SELECT hash FROM eth_tx_hashes WHERE cid = ?`
+	deleteOlderThan = `DELETE FROM eth_tx_hashes WHERE insertion_time < datetime('now', ?);`
 )
 
 type EthTxHashLookup struct {
 	db *sql.DB
-}
 
-func (ei *EthTxHashLookup) UpsertHash(txHash ethtypes.EthHash, c cid.Cid) error {
-	hashEntry, err := ei.db.Prepare(insertTxHash)
-	if err != nil {
-		return xerrors.Errorf("prepare insert event: %w", err)
-	}
-
-	_, err = hashEntry.Exec(txHash.String(), c.String())
-	return err
-}
-
-func (ei *EthTxHashLookup) GetCidFromHash(txHash ethtypes.EthHash) (cid.Cid, error) {
-	row := ei.db.QueryRow("SELECT cid FROM eth_tx_hashes WHERE hash = :hash;", sql.Named("hash", txHash.String()))
-
-	var c string
-	err := row.Scan(&c)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return cid.Undef, ErrNotFound
-		}
-		return cid.Undef, err
-	}
-	return cid.Decode(c)
-}
-
-func (ei *EthTxHashLookup) GetHashFromCid(c cid.Cid) (ethtypes.EthHash, error) {
-	row := ei.db.QueryRow("SELECT hash FROM eth_tx_hashes WHERE cid = :cid;", sql.Named("cid", c.String()))
-
-	var hashString string
-	err := row.Scan(&c)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return ethtypes.EmptyEthHash, ErrNotFound
-		}
-		return ethtypes.EmptyEthHash, err
-	}
-	return ethtypes.ParseEthHash(hashString)
-}
-
-func (ei *EthTxHashLookup) DeleteEntriesOlderThan(days int) (int64, error) {
-	res, err := ei.db.Exec("DELETE FROM eth_tx_hashes WHERE insertion_time < datetime('now', ?);", "-"+strconv.Itoa(days)+" day")
-	if err != nil {
-		return 0, err
-	}
-
-	return res.RowsAffected()
+	stmtInsertTxHash    *sql.Stmt
+	stmtGetCidFromHash  *sql.Stmt
+	stmtGetHashFromCid  *sql.Stmt
+	stmtDeleteOlderThan *sql.Stmt
 }
 
 func NewTransactionHashLookup(ctx context.Context, path string) (*EthTxHashLookup, error) {
@@ -97,12 +55,96 @@ func NewTransactionHashLookup(ctx context.Context, path string) (*EthTxHashLooku
 		return nil, xerrors.Errorf("failed to init eth transaction hash lookup db: %w", err)
 	}
 
-	return &EthTxHashLookup{db: db}, nil
+	ei := &EthTxHashLookup{db: db}
+
+	if err = ei.initStatements(); err != nil {
+		_ = ei.Close()
+		return nil, xerrors.Errorf("error preparing eth transaction hash lookup db statements: %w", err)
+	}
+
+	return ei, nil
 }
 
-func (ei *EthTxHashLookup) Close() error {
+func (ei *EthTxHashLookup) initStatements() (err error) {
+	ei.stmtInsertTxHash, err = ei.db.Prepare(insertTxHash)
+	if err != nil {
+		return xerrors.Errorf("prepare stmtInsertTxHash: %w", err)
+	}
+	ei.stmtGetCidFromHash, err = ei.db.Prepare(getCidFromHash)
+	if err != nil {
+		return xerrors.Errorf("prepare stmtGetCidFromHash: %w", err)
+	}
+	ei.stmtGetHashFromCid, err = ei.db.Prepare(getHashFromCid)
+	if err != nil {
+		return xerrors.Errorf("prepare stmtGetHashFromCid: %w", err)
+	}
+	ei.stmtDeleteOlderThan, err = ei.db.Prepare(deleteOlderThan)
+	if err != nil {
+		return xerrors.Errorf("prepare stmtDeleteOlderThan: %w", err)
+	}
+	return nil
+}
+
+func (ei *EthTxHashLookup) UpsertHash(txHash ethtypes.EthHash, c cid.Cid) error {
+	if ei.db == nil {
+		return xerrors.New("db closed")
+	}
+
+	_, err := ei.stmtInsertTxHash.Exec(txHash.String(), c.String())
+	return err
+}
+
+func (ei *EthTxHashLookup) GetCidFromHash(txHash ethtypes.EthHash) (cid.Cid, error) {
+	if ei.db == nil {
+		return cid.Undef, xerrors.New("db closed")
+	}
+
+	row := ei.stmtGetCidFromHash.QueryRow(txHash.String())
+	var c string
+	err := row.Scan(&c)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return cid.Undef, ErrNotFound
+		}
+		return cid.Undef, err
+	}
+	return cid.Decode(c)
+}
+
+func (ei *EthTxHashLookup) GetHashFromCid(c cid.Cid) (ethtypes.EthHash, error) {
+	if ei.db == nil {
+		return ethtypes.EmptyEthHash, xerrors.New("db closed")
+	}
+
+	row := ei.stmtGetHashFromCid.QueryRow(c.String())
+	var hashString string
+	err := row.Scan(&c)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ethtypes.EmptyEthHash, ErrNotFound
+		}
+		return ethtypes.EmptyEthHash, err
+	}
+	return ethtypes.ParseEthHash(hashString)
+}
+
+func (ei *EthTxHashLookup) DeleteEntriesOlderThan(days int) (int64, error) {
+	if ei.db == nil {
+		return 0, xerrors.New("db closed")
+	}
+
+	res, err := ei.stmtDeleteOlderThan.Exec("-" + strconv.Itoa(days) + " day")
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (ei *EthTxHashLookup) Close() (err error) {
 	if ei.db == nil {
 		return nil
 	}
-	return ei.db.Close()
+	db := ei.db
+	ei.db = nil
+	return db.Close()
 }


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/lotus/issues/12171

Prompted because I'm noticing that my WAL for both calibnet and mainnet nodes is ~32M, even with my calibnet node running master which has https://github.com/filecoin-project/lotus/pull/12098 which should result in it being compacted earlier than that (suggests that queries may be remaining open?).

The main thing that stands out in this file is the use of the preparedstatement that's prepared each time it's used, and not closed. So that's what's probably retaining memory and perhaps it's also responsible for the WAL size (I'm not sure how though tbh).

This refactor makes all queries use preparedstatements that persist for the lifecycle of the index, so we get the efficiency gains from that.