### PR TITLE
fix: f3: panic on unset manifest properties

### DIFF
--- a/chain/lf3/manifest.go
+++ b/chain/lf3/manifest.go
@@ -19,6 +19,13 @@ import (
 func NewManifestProvider(nn dtypes.NetworkName, cs *store.ChainStore, sm *stmgr.StateManager, ps *pubsub.PubSub) manifest.ManifestProvider {
 	m := manifest.LocalDevnetManifest()
 	m.NetworkName = gpbft.NetworkName(nn)
+	m.GpbftConfig = manifest.DefaultGpbftConfig
+	m.CxConfig = &manifest.CxConfig{
+		ClientRequestTimeout: 10 * time.Second,
+		ServerRequestTimeout: time.Minute,
+		MinimumPollInterval:  time.Duration(build.BlockDelaySecs) * time.Second,
+		MaximumPollInterval:  4 * time.Duration(build.BlockDelaySecs) * time.Second,
+	}
 	m.ECDelayMultiplier = 2.
 	m.ECPeriod = time.Duration(build.BlockDelaySecs) * time.Second
 	m.BootstrapEpoch = int64(buildconstants.F3BootstrapEpoch)


### PR DESCRIPTION
Failing when running off master.

`GpbftConfig` is now set in go-f3's `main` branch when calling `LocalDevnetManifest()`, but `CxConfig` isn't. Perhaps we can have that set as well and then have an updated tag @masih?

```
Jul 15 20:05:10 fletcher lotus-calibnet[385671]: github.com/filecoin-project/go-f3.(*F3).resumeInternal(0xc022820790, {0x8b393d0, 0xc022c30f50})
Jul 15 20:05:10 fletcher lotus-calibnet[385671]:         /home/rvagg/go/pkg/mod/github.com/filecoin-project/go-f3@v0.0.3/f3.go:314 +0x1fa
Jul 15 20:05:10 fletcher lotus-calibnet[385671]: github.com/filecoin-project/go-f3.(*F3).reconfigure(0xc022820790, {0x8b393d0?, 0xc022c30fa0?}, 0xc022c31d10)
Jul 15 20:05:10 fletcher lotus-calibnet[385671]:         /home/rvagg/go/pkg/mod/github.com/filecoin-project/go-f3@v0.0.3/f3.go:254 +0x21c
Jul 15 20:05:10 fletcher lotus-calibnet[385671]: github.com/filecoin-project/go-f3.(*F3).Start(0xc022820790, {0x8b393d0, 0xc022c30fa0})
Jul 15 20:05:10 fletcher lotus-calibnet[385671]:         /home/rvagg/go/pkg/mod/github.com/filecoin-project/go-f3@v0.0.3/f3.go:177 +0x193
Jul 15 20:05:10 fletcher lotus-calibnet[385671]: github.com/filecoin-project/lotus/chain/lf3.New.func1()
Jul 15 20:05:10 fletcher lotus-calibnet[385671]:         /home/rvagg/go/src/github.com/filecoin-project/lotus/chain/lf3/f3.go:79 +0x35
Jul 15 20:05:10 fletcher lotus-calibnet[385671]: go.uber.org/fx/internal/lifecycle.Wrap[...].func1()
```