### PR TITLE
fix: api itest panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - This Lotus release includes some correctness improvements to the events subsystem, impacting RPC APIs including `GetActorEventsRaw`, `SubscribeActorEventsRaw`, `eth_getLogs` and the `eth` filter APIs. Part of these improvements involve an events database migration that may take some time to complete on nodes with extensive event databases. See [filecoin-project/lotus#12080](https://github.com/filecoin-project/lotus/pull/12080) for details.
 
+- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher` and `storage/pipeline.New`. They now have an additional error return to deal with errors arising from fetching the sealing config.
+
 ## New features
 
 - feat: Add trace transaction API supporting RPC method `trace_transaction` ([filecoin-project/lotus#12068](https://github.com/filecoin-project/lotus/pull/12068))

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -173,6 +173,8 @@ func (ts *apiSuite) testOutOfGasError(t *testing.T) {
 		buildconstants.BlockGasLimit = originalLimit
 	}()
 
+	t.Logf("BlockGasLimit changed: %d", buildconstants.BlockGasLimit)
+
 	msg := &types.Message{
 		From:  senderAddr,
 		To:    senderAddr,
@@ -289,6 +291,7 @@ func (ts *apiSuite) testNonGenesisMiner(t *testing.T) {
 	ctx := context.Background()
 
 	full, genesisMiner, ens := kit.EnsembleMinimal(t, append(ts.opts, kit.MockProofs())...)
+
 	ens.InterconnectAll().BeginMining(4 * time.Millisecond)
 
 	time.Sleep(1 * time.Second)

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -255,7 +255,10 @@ func SealingPipeline(fc config.MinerFeeConfig) func(params SealingPipelineParams
 		provingBuffer := md.WPoStProvingPeriod * 2
 		pcp := sealing.NewBasicPreCommitPolicy(api, gsd, provingBuffer)
 
-		pipeline := sealing.New(ctx, api, fc, evts, maddr, ds, sealer, verif, prover, &pcp, gsd, j, as)
+		pipeline, err := sealing.New(ctx, api, fc, evts, maddr, ds, sealer, verif, prover, &pcp, gsd, j, as)
+		if err != nil {
+			return nil, xerrors.Errorf("creating sealing pipeline: %w", err)
+		}
 
 		lc.Append(fx.Hook{
 			OnStart: func(context.Context) error {


### PR DESCRIPTION
1) Fixes flakiness in `testNonGenesisMiner` in `api_test` by de-racing the closing of the miner repo and the sealer reading it in a go-routine. If the go-routine gets scheduled after the miner repo is closed in the test, this causes a panic which fails the test. The right thing to do here is for the sealer to read the repo when it is instantiated and pass the config to the go-routine.

2) Adds some logging to the `testOutOfGasError` itest to see what's going on when it fails (very very rare). 