### PR TITLE
fix: flaky wdPost dispute itest

### DIFF
--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -297,7 +297,6 @@ waitForProof:
 
 		deadlines, err := client.StateMinerDeadlines(ctx, maddr, types.EmptyTSK)
 		require.NoError(t, err)
-
 		for dlIdx, dl := range deadlines {
 			nonEmpty, err := dl.PostSubmissions.IsEmpty()
 			require.NoError(t, err)
@@ -319,6 +318,7 @@ waitForProof:
 			Deadline:  targetDeadline,
 			PoStIndex: 0,
 		}
+
 		enc, aerr := actors.SerializeParams(params)
 		require.NoError(t, aerr)
 


### PR DESCRIPTION
Fixes the flaky wdPost dispute itest.
See https://github.com/filecoin-project/lotus/actions/runs/9468130894/job/26083829500 for an example failed run.