### PR TITLE
[skip changelog] chore: drand: cleanup legacy and unused configs

### DIFF
--- a/build/buildconstants/drand.go
+++ b/build/buildconstants/drand.go
@@ -30,22 +30,6 @@ type DrandPoint struct {
 }
 
 var DrandConfigs = map[DrandEnum]DrandConfig{
-	DrandMainnet: {
-		Servers: []string{
-			"https://api.drand.sh",
-			"https://api2.drand.sh",
-			"https://api3.drand.sh",
-			"https://drand.cloudflare.com",
-			"https://api.drand.secureweb3.com:6875", // Storswift
-		},
-		Relays: []string{
-			"/dnsaddr/api.drand.sh/",
-			"/dnsaddr/api2.drand.sh/",
-			"/dnsaddr/api3.drand.sh/",
-		},
-		IsChained:     true,
-		ChainInfoJSON: `{"public_key":"868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31","period":30,"genesis_time":1595431050,"hash":"8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce","groupHash":"176f93498eac9ca337150b46d21dd58673ea4e3581185f869672e59fa4cb390a"}`,
-	},
 	DrandQuicknet: {
 		Servers: []string{
 			"https://api.drand.sh",
@@ -74,9 +58,16 @@ var DrandConfigs = map[DrandEnum]DrandConfig{
 		IsChained:     true,
 		ChainInfoJSON: `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"84b2234fb34e835dccd048255d7ad3194b81af7d978c3bf157e3469592ae4e02","groupHash":"4dd408e5fdff9323c76a9b6f087ba8fdc5a6da907bd9217d9d10f2287d081957"}`,
 	},
+
+	// legacy randomness sources, their ChainInfo must remain here forever
+	// to allow validating randomness from past epochs
 	DrandIncentinet: {
 		IsChained:     true,
 		ChainInfoJSON: `{"public_key":"8cad0c72c606ab27d36ee06de1d5b2db1faf92e447025ca37575ab3a8aac2eaae83192f846fc9e158bc738423753d000","period":30,"genesis_time":1595873820,"hash":"80c8b872c714f4c00fdd3daa465d5514049f457f01f85a4caf68cdcd394ba039","groupHash":"d9406aaed487f7af71851b4399448e311f2328923d454e971536c05398ce2d9b"}`,
+	},
+	DrandMainnet: {
+		IsChained:     true,
+		ChainInfoJSON: `{"public_key":"868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31","period":30,"genesis_time":1595431050,"hash":"8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce","groupHash":"176f93498eac9ca337150b46d21dd58673ea4e3581185f869672e59fa4cb390a"}`,
 	},
 }
 

--- a/build/buildconstants/drand.go
+++ b/build/buildconstants/drand.go
@@ -11,8 +11,8 @@ type DrandEnum int
 const (
 	DrandMainnet DrandEnum = iota + 1
 	DrandTestnet
-	unusedDrandDevnet   // kept to retain iota numbering
-	unusedDrandLocalnet // kept to retain iota numbering
+	_ // kept to retain iota numbering, used to be Devnet
+	_ // kept to retain iota numbering, used to be Localnet
 	DrandIncentinet
 	DrandQuicknet
 )

--- a/build/buildconstants/drand.go
+++ b/build/buildconstants/drand.go
@@ -11,8 +11,8 @@ type DrandEnum int
 const (
 	DrandMainnet DrandEnum = iota + 1
 	DrandTestnet
-	DrandDevnet
-	DrandLocalnet
+	unusedDrandDevnet   // kept to retain iota numbering
+	unusedDrandLocalnet // kept to retain iota numbering
 	DrandIncentinet
 	DrandQuicknet
 )
@@ -73,18 +73,6 @@ var DrandConfigs = map[DrandEnum]DrandConfig{
 		},
 		IsChained:     true,
 		ChainInfoJSON: `{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"84b2234fb34e835dccd048255d7ad3194b81af7d978c3bf157e3469592ae4e02","groupHash":"4dd408e5fdff9323c76a9b6f087ba8fdc5a6da907bd9217d9d10f2287d081957"}`,
-	},
-	DrandDevnet: {
-		Servers: []string{
-			"https://dev1.drand.sh",
-			"https://dev2.drand.sh",
-		},
-		Relays: []string{
-			"/dnsaddr/dev1.drand.sh/",
-			"/dnsaddr/dev2.drand.sh/",
-		},
-		IsChained:     true,
-		ChainInfoJSON: `{"public_key":"8cda589f88914aa728fd183f383980b35789ce81b274e5daee1f338b77d02566ef4d3fb0098af1f844f10f9c803c1827","period":25,"genesis_time":1595348225,"hash":"e73b7dc3c4f6a236378220c0dd6aa110eb16eed26c11259606e07ee122838d4f","groupHash":"567d4785122a5a3e75a9bc9911d7ea807dd85ff76b78dc4ff06b075712898607"}`,
 	},
 	DrandIncentinet: {
 		IsChained:     true,

--- a/build/drand.go
+++ b/build/drand.go
@@ -6,8 +6,6 @@ import (
 
 var DrandMainnet = buildconstants.DrandMainnet       // Deprecated: Use buildconstants.DrandMainnet instead
 var DrandTestnet = buildconstants.DrandTestnet       // Deprecated: Use buildconstants.DrandTestnet instead
-var DrandDevnet = buildconstants.DrandDevnet         // Deprecated: Use buildconstants.DrandDevnet instead
-var DrandLocalnet = buildconstants.DrandLocalnet     // Deprecated: Use buildconstants.DrandLocalnet instead
 var DrandIncentinet = buildconstants.DrandIncentinet // Deprecated: Use buildconstants.DrandIncentinet instead
 var DrandQuicknet = buildconstants.DrandQuicknet     // Deprecated: Use buildconstants.DrandQuicknet instead
 


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/pull/10476

## Proposed Changes

- Remove the network-portion of `mainnet` just like it was done for `incentinet` in https://github.com/filecoin-project/lotus/pull/10476. This will stop network clients being built for the unused network and will resolve spurious errors like:
```
{"level":"info","ts":"2024-07-09T15:36:34.379+1000","logger":"drand","caller":"client/optimizing.go:194","msg":"","optimizing_client":"endpoint down when speed tested","client":"HT
TP(\"https://api.drand.secureweb3.com:6875/\").(+verifier)","err":"decoding response: EOF"}
``` 

- [As per ](https://filecoinproject.slack.com/archives/C047Z15JNEA/p1721656072094789?thread_ts=1720504044.538999&cid=C047Z15JNEA) @AnomalRoil remove unused `devnet` config

## Additional Info
