### PR TITLE
[skip changelog] chore: types: fix type mismatches missed in #12246

### DIFF
--- a/build/buildconstants/params_shared_vals.go
+++ b/build/buildconstants/params_shared_vals.go
@@ -97,8 +97,8 @@ const BlockMessageLimit = 10000
 var BlockGasLimit = int64(10_000_000_000)
 var BlockGasTarget = BlockGasLimit / 2
 
-const BaseFeeMaxChangeDenom = 8 // 12.5%
-const InitialBaseFee = 100e6
-const MinimumBaseFee = 100
-const PackingEfficiencyNum = 4
-const PackingEfficiencyDenom = 5
+const BaseFeeMaxChangeDenom int64 = 8 // 12.5%
+const InitialBaseFee int64 = 100e6
+const MinimumBaseFee int64 = 100
+const PackingEfficiencyNum int64 = 4
+const PackingEfficiencyDenom int64 = 5

--- a/build/params_shared_vals.go
+++ b/build/params_shared_vals.go
@@ -58,11 +58,11 @@ var BlockMessageLimit = buildconstants.BlockMessageLimit // Deprecated: Use buil
 var BlockGasLimit = buildconstants.BlockGasLimit   // Deprecated: Use buildconstants.BlockGasLimit instead
 var BlockGasTarget = buildconstants.BlockGasTarget // Deprecated: Use buildconstants.BlockGasTarget instead
 
-var BaseFeeMaxChangeDenom int64 = buildconstants.BaseFeeMaxChangeDenom   // Deprecated: Use buildconstants.BaseFeeMaxChangeDenom instead
-var InitialBaseFee int64 = buildconstants.InitialBaseFee                 // Deprecated: Use buildconstants.InitialBaseFee instead
-var MinimumBaseFee int64 = buildconstants.MinimumBaseFee                 // Deprecated: Use buildconstants.MinimumBaseFee instead
-var PackingEfficiencyNum int64 = buildconstants.PackingEfficiencyNum     // Deprecated: Use buildconstants.PackingEfficiencyNum instead
-var PackingEfficiencyDenom int64 = buildconstants.PackingEfficiencyDenom // Deprecated: Use buildconstants.PackingEfficiencyDenom instead
+var BaseFeeMaxChangeDenom = buildconstants.BaseFeeMaxChangeDenom   // Deprecated: Use buildconstants.BaseFeeMaxChangeDenom instead
+var InitialBaseFee = buildconstants.InitialBaseFee                 // Deprecated: Use buildconstants.InitialBaseFee instead
+var MinimumBaseFee = buildconstants.MinimumBaseFee                 // Deprecated: Use buildconstants.MinimumBaseFee instead
+var PackingEfficiencyNum = buildconstants.PackingEfficiencyNum     // Deprecated: Use buildconstants.PackingEfficiencyNum instead
+var PackingEfficiencyDenom = buildconstants.PackingEfficiencyDenom // Deprecated: Use buildconstants.PackingEfficiencyDenom instead
 
 const TestNetworkVersion = buildconstants.TestNetworkVersion // Deprecated: Use buildconstants.TestNetworkVersion instead
 

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -54,7 +54,7 @@ var rbfDenomBig = types.NewInt(100)
 
 var RepublishInterval = time.Duration(10*buildconstants.BlockDelaySecs+buildconstants.PropagationDelaySecs) * time.Second
 
-var minimumBaseFee = types.NewInt(buildconstants.MinimumBaseFee)
+var minimumBaseFee = types.NewInt(uint64(buildconstants.MinimumBaseFee))
 var baseFeeLowerBoundFactor = types.NewInt(10)
 var baseFeeLowerBoundFactorConservative = types.NewInt(100)
 


### PR DESCRIPTION
Makes testground build again, namely:

 `for d in ./cmd/lotus*; do go build -tags testground -o /dev/null $d || break ; done`
 
 Missed due to https://github.com/filecoin-project/lotus/issues/12239 
