### PR TITLE
[skip changelog] chore: blockstore_gc: minor cleanups

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -627,7 +627,18 @@ func (b *Blockstore) Flush(context.Context) error {
 	b.lockDB()
 	defer b.unlockDB()
 
-	return b.db.Sync()
+	// fsync the new db first
+	if b.dbNext != nil {
+		if err := b.dbNext.Sync(); err != nil {
+			return err
+		}
+	}
+
+	if err := b.db.Sync(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Has implements Blockstore.Has.


### PR DESCRIPTION
## Proposed Changes
Two standalone fixes around GC - a forgotten `flush()` and lack of `ctx` propagation.

The refator separating the iteration into its own function allows "walking the store with a function", moving a lot of the complexity a step down, leaving [just the logic in place for easier read](https://github.com/filecoin-project/lotus/blob/d6fe66d8280a7c/blockstore/badger/blockstore.go#L393-L416).

cc @ZenGround0 to review, as this used to be their domain