### PR TITLE
Merge 1.28.2 to master

### DIFF
--- a/build/bootstrap/butterflynet.pi
+++ b/build/bootstrap/butterflynet.pi
@@ -1,2 +1,2 @@
-/dns4/bootstrap-0.butterfly.fildev.network/tcp/1347/p2p/12D3KooWL5bactqSPNTw5tqyWgaAFDFXBF4vskdcPHZDTQSsqPVY
-/dns4/bootstrap-1.butterfly.fildev.network/tcp/1347/p2p/12D3KooWD4LgpLFUmHdjABn3sdXMYJ6we1H65hKTGwA9XWbgd3hx
+/dns4/bootstrap-0.butterfly.fildev.network/tcp/1347/p2p/12D3KooWGW6xMTpjEBqndYkqytbu8PWfJmpK4wKLLLNSkXL2QZtD
+/dns4/bootstrap-1.butterfly.fildev.network/tcp/1347/p2p/12D3KooWFGz9HegR3Rjrtm8b9WXTM6E3kN1sdd6X1JztuCgQaZSB

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.1-dev"
+        "version": "1.28.2-dev"
     },
     "methods": [
         {
@@ -6546,7 +6546,7 @@
                         [
                             {
                                 "ID": 1000,
-                                "Power": 0,
+                                "Power": "0",
                                 "PubKey": "Bw=="
                             }
                         ]
@@ -6629,7 +6629,7 @@
                         [
                             {
                                 "ID": 1000,
-                                "Power": 0,
+                                "Power": "0",
                                 "PubKey": "Bw=="
                             }
                         ]

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.1-dev"
+        "version": "1.28.2-dev"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.1-dev"
+        "version": "1.28.2-dev"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.28.1-dev"
+        "version": "1.28.2-dev"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.28.1-dev"
+const NodeBuildVersion string = "1.28.2-dev"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -18,7 +18,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.1-dev"
+const MinerBuildVersion = "1.28.2-dev"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/chain/lf3/ec.go
+++ b/chain/lf3/ec.go
@@ -172,7 +172,7 @@ func (ec *ecWrapper) getPowerTableLotusTSK(ctx context.Context, tsk types.TipSet
 
 		pe := gpbft.PowerEntry{
 			ID:    gpbft.ActorID(id),
-			Power: claim.QualityAdjPower.Int,
+			Power: claim.QualityAdjPower,
 		}
 
 		act, err := state.GetActor(minerAddr)

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -2304,7 +2304,7 @@ Response:
 [
   {
     "ID": 1000,
-    "Power": 0,
+    "Power": "0",
     "PubKey": "Bw=="
   }
 ]
@@ -2335,7 +2335,7 @@ Response:
 [
   {
     "ID": 1000,
-    "Power": 0,
+    "Power": "0",
     "PubKey": "Bw=="
   }
 ]

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.1-dev
+   1.28.2-dev
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.1-dev
+   1.28.2-dev
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -7,7 +7,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.1-dev
+   1.28.2-dev
 
 COMMANDS:
    daemon   Start a lotus daemon process

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ retract v1.14.0 // Accidentally force-pushed tag, use v1.14.1+ instead.
 
 retract v1.20.2 // Wrongfully cherry picked PR, use v1.20.2+ instead.
 
-retract v1.28.0 // miss some bug fixes and featires, use v1.28.1+ instead
+retract v1.28.0 // misses some bug fixes and features, use v1.28.1+ instead
 
 replace github.com/filecoin-project/test-vectors => ./extern/test-vectors // provided via a git submodule
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ retract v1.14.0 // Accidentally force-pushed tag, use v1.14.1+ instead.
 
 retract v1.20.2 // Wrongfully cherry picked PR, use v1.20.2+ instead.
 
+retract v1.28.0 // miss some bug fixes and featires, use v1.28.1+ instead
+
 replace github.com/filecoin-project/test-vectors => ./extern/test-vectors // provided via a git submodule
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi // provided via a git submodule
@@ -41,7 +43,7 @@ require (
 	github.com/filecoin-project/go-commp-utils v0.1.3
 	github.com/filecoin-project/go-commp-utils/nonffi v0.0.0-20220905160352-62059082a837
 	github.com/filecoin-project/go-crypto v0.0.1
-	github.com/filecoin-project/go-f3 v0.0.6
+	github.com/filecoin-project/go-f3 v0.0.7
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0
 	github.com/filecoin-project/go-jsonrpc v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/filecoin-project/go-commp-utils/nonffi v0.0.0-20220905160352-62059082
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-crypto v0.0.1 h1:AcvpSGGCgjaY8y1az6AMfKQWreF/pWO2JJGLl6gCq6o=
 github.com/filecoin-project/go-crypto v0.0.1/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
-github.com/filecoin-project/go-f3 v0.0.6 h1:j+HfGT8OMxq/Y7GhT2B7FTcM4ci7i5AV27OFog5sIwI=
-github.com/filecoin-project/go-f3 v0.0.6/go.mod h1:oO+Ch7aa6GRp9xRRLbdQBsrte0oGg7+hsA8PZ9Zy6xc=
+github.com/filecoin-project/go-f3 v0.0.7 h1:dqmxtQXfX1r3hhFZvCszqryg80MZJmfcPFL3nhyHCVA=
+github.com/filecoin-project/go-f3 v0.0.7/go.mod h1:ihW5IGLBEuW8pVc9t5MQiAhdzv95EBBfnnrGfMfEbTY=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-fil-commcid v0.1.0 h1:3R4ds1A9r6cr8mvZBfMYxTS88OqLYEo6roi+GiIeOh8=
 github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=


### PR DESCRIPTION
Replacement of #12306 but with current master; let's get this done before anything else moves into master so we can just have the one merge commit and nothing else.

It's a bit different to #12306, but the differences are mostly non-overlapping with `master`, i.e. this is basically master but with what's in #12306 overlaid.

```
$ git diff --stat origin/jen/v1.28.1releasetomaster
 .github/workflows/docker.yml                 |  28 ++++++++++---------
 .github/workflows/release.yml                | 360 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------------------
 .gitignore                                   |   6 ++++
 .goreleaser.yaml                             | 113 --------------------------------------------------------------------------
 CHANGELOG.md                                 |   1 +
 blockstore/badger/blockstore.go              |  69 ++--------------------------------------------
 build/bootstrap.go                           |   9 ++++++
 cli/wallet.go                                |   2 +-
 cmd/release/README.md                        |  42 ++++++++++++++++++++++++++++
 cmd/release/main.go                          | 172 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 documentation/en/cli-lotus.md                |   2 +-
 documentation/misc/RELEASE_ISSUE_TEMPLATE.md |  37 ++++++++++++-------------
 go.mod                                       |   4 +--
 node/modules/lp2p/host.go                    |  20 ++++++++++++--
 scripts/publish-checksums.sh                 |  87 ---------------------------------------------------------
 scripts/version-check.sh                     |  39 --------------------------
 16 files changed, 562 insertions(+), 429 deletions(-)

$ git diff --stat origin/master 
 CHANGELOG.md                                |  23 ++++++++++++++++-------
 build/bootstrap/butterflynet.pi             |   4 ++--
 build/genesis/butterflynet.car              | Bin 8768237 -> 8768236 bytes
 build/openrpc/full.json                     |   6 +++---
 build/openrpc/gateway.json                  |   2 +-
 build/openrpc/miner.json                    |   2 +-
 build/openrpc/worker.json                   |   2 +-
 build/version.go                            |   4 ++--
 chain/lf3/ec.go                             |   2 +-
 documentation/en/api-v1-unstable-methods.md |   4 ++--
 documentation/en/cli-lotus-miner.md         |   2 +-
 documentation/en/cli-lotus-worker.md        |   2 +-
 documentation/en/cli-lotus.md               |   2 +-
 go.mod                                      |   4 +++-
 go.sum                                      |   4 ++--
 15 files changed, 37 insertions(+), 26 deletions(-)
```

* CHANGELOG.md just adds the entry from #12292
* go.mod adds github.com/sirupsen/logrus and golang.org/x/mod which were pulled in for #12096

Diff in this PR should make it clear that it's all pretty minimal, the CHANGELOG.md gets updated with what's in 1.28.1, go-f3 gets bumped and the internal version is bumped to 1.28.2-dev. It leaves filecoin-ffi on master as d041c9ab85e68cfb which is the latest release.