### PR TITLE
feat: Lotus Send CLI: Lotus send should work with ETH address receipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - https://github.com/filecoin-project/lotus/pull/12279 Upgrade to go-f3 v0.0.5
 - https://github.com/filecoin-project/lotus/pull/12295 Upgrade to go-f3 v0.0.6
 - https://github.com/filecoin-project/lotus/pull/12292: feat: p2p: allow overriding bootstrap nodes with environmemnt variable
+- https://github.com/filecoin-project/lotus/pull/12319: feat: `lotus send CLI`: allow sending to ETH addresses
 
 ## New features
 

--- a/cli/send.go
+++ b/cli/send.go
@@ -131,9 +131,7 @@ var SendCmd = &cli.Command{
 			}
 			fmt.Println("f4 addr: ", faddr)
 			params.From = faddr
-		}
-
-		if params.From == address.Undef {
+		} else {
 			defaddr, err := srv.FullNodeAPI().WalletDefaultAddress(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get default address: %w", err)

--- a/cli/send.go
+++ b/cli/send.go
@@ -90,7 +90,20 @@ var SendCmd = &cli.Command{
 
 		params.To, err = address.NewFromString(cctx.Args().Get(0))
 		if err != nil {
-			return ShowHelp(cctx, fmt.Errorf("failed to parse target address: %w", err))
+			// could be an ETH address
+			ea, err := ethtypes.ParseEthAddress(cctx.Args().Get(0))
+			if err != nil {
+				return ShowHelp(cctx, fmt.Errorf("failed to parse target address; address must be a valid FIL address or an ETH address: %w", err))
+			}
+			// this will be either "f410f..." or "f0..."
+			params.To, err = ea.ToFilecoinAddress()
+			if err != nil {
+				return ShowHelp(cctx, fmt.Errorf("failed to convert ETH address to FIL address: %w", err))
+			}
+			// ideally, this should never happen
+			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
+				return ShowHelp(cctx, fmt.Errorf("ETH addresses can only map to a FIL addresses starting with f410f or f0"))
+			}
 		}
 
 		val, err := types.ParseFIL(cctx.Args().Get(1))
@@ -119,6 +132,17 @@ var SendCmd = &cli.Command{
 			fmt.Println("f4 addr: ", faddr)
 			params.From = faddr
 		}
+
+		if params.From == address.Undef {
+			defaddr, err := srv.FullNodeAPI().WalletDefaultAddress(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get default address: %w", err)
+			}
+			params.From = defaddr
+		}
+
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Sending message from: %s\n", params.From.String())
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Sending message to: %s\n", params.To.String())
 
 		if cctx.IsSet("params-hex") {
 			decparams, err := hex.DecodeString(cctx.String("params-hex"))
@@ -166,6 +190,7 @@ var SendCmd = &cli.Command{
 		} else {
 			params.Method = abi.MethodNum(cctx.Uint64("method"))
 		}
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Using Method: %d\n", params.Method)
 
 		if cctx.IsSet("gas-premium") {
 			gp, err := types.BigFromString(cctx.String("gas-premium"))

--- a/cli/send.go
+++ b/cli/send.go
@@ -141,9 +141,6 @@ var SendCmd = &cli.Command{
 			params.From = defaddr
 		}
 
-		_, _ = fmt.Fprintf(cctx.App.Writer, "Sending message from: %s\n", params.From.String())
-		_, _ = fmt.Fprintf(cctx.App.Writer, "Sending message to: %s\n", params.To.String())
-
 		if cctx.IsSet("params-hex") {
 			decparams, err := hex.DecodeString(cctx.String("params-hex"))
 			if err != nil {
@@ -152,7 +149,7 @@ var SendCmd = &cli.Command{
 			params.Params = decparams
 		}
 
-		if ethtypes.IsEthAddress(params.From) {
+		if ethtypes.IsEthAddress(params.From) || ethtypes.IsEthAddress(params.To) {
 			// Method numbers don't make sense from eth accounts.
 			if cctx.IsSet("method") {
 				return xerrors.Errorf("messages from f410f addresses may not specify a method number")
@@ -190,7 +187,8 @@ var SendCmd = &cli.Command{
 		} else {
 			params.Method = abi.MethodNum(cctx.Uint64("method"))
 		}
-		_, _ = fmt.Fprintf(cctx.App.Writer, "Using Method: %d\n", params.Method)
+
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Sending message from: %s\nSending message to: %s\nUsing Method: %d\n", params.From.String(), params.To.String(), params.Method)
 
 		if cctx.IsSet("gas-premium") {
 			gp, err := types.BigFromString(cctx.String("gas-premium"))

--- a/cli/send_test.go
+++ b/cli/send_test.go
@@ -59,16 +59,17 @@ func TestSendCLI(t *testing.T) {
 
 		gomock.InOrder(
 			mockSrvcs.EXPECT().MessageForSend(gomock.Any(), SendParams{
-				To:  mustAddr(address.NewIDAddress(1)),
-				Val: oneFil,
+				From: mustAddr(address.NewIDAddress(1)),
+				To:   mustAddr(address.NewIDAddress(1)),
+				Val:  oneFil,
 			}).Return(arbtProto, nil),
 			mockSrvcs.EXPECT().PublishMessage(gomock.Any(), arbtProto, false).
 				Return(sigMsg, nil, nil),
 			mockSrvcs.EXPECT().Close(),
 		)
-		err := app.Run([]string{"lotus", "send", "t01", "1"})
+		err := app.Run([]string{"lotus", "send", "--from", "t01", "t01", "1"})
 		require.NoError(t, err)
-		require.EqualValues(t, sigMsg.Cid().String()+"\n", buf.String())
+		require.Contains(t, buf.String(), sigMsg.Cid().String()+"\n")
 	})
 }
 
@@ -112,6 +113,6 @@ func TestSendEthereum(t *testing.T) {
 		)
 		err = app.Run([]string{"lotus", "send", "--from-eth-addr", testEthAddr.String(), "--params-hex", "01020304", "f01", "1"})
 		require.NoError(t, err)
-		require.EqualValues(t, sigMsg.Cid().String()+"\n", buf.String())
+		require.Contains(t, buf.String(), sigMsg.Cid().String()+"\n")
 	})
 }


### PR DESCRIPTION
This fixes the Lotus send CLI to work with ETH address recipients (both `0xff...` corresponding to Filecoin `f0` addresses and `0xabcd` corresponding to Filecoin `f410f` addresses).

Have tested this locally on a local devnet.

```
./lotus send --from-eth-addr 0x4582e0a8f02f45dfb6cca081b1cb82fcf0508c34 0xff000000000000000000000000000000000003ed 10

f4 addr:  t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message from: t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message to: t01005
Using Method: 3844450837
bafy2bzacec3lcrfevp4wsuya65t2nien2cjselbmqd3cnr2w32hukbwxg57zy
```

```
./lotus send 0xff000000000000000000000000000000000003ed 10
Sending message from: t3uhfeeespjbuhde6vfxvgyuhoj4danwv3fdsk3m3t46p2kpegm76jpvukgnlb2w7aucldnmq2j4un3nlxs73a
Sending message to: t01005
Using Method: 0
bafy2bzacedwvhrfdopwr7azpjcjvjw22orirulikewdpw6zgc3tg5bgspv3vu
```

```
./lotus send 0x4582e0a8f02f45dfb6cca081b1cb82fcf0508c34 100
Sending message from: t3uhfeeespjbuhde6vfxvgyuhoj4danwv3fdsk3m3t46p2kpegm76jpvukgnlb2w7aucldnmq2j4un3nlxs73a
Sending message to: t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Using Method: 0
bafy2bzacebnj45yttbtcd75rajfwkqpc27tsru6brfhufolnjtvhsixltitqo
```

```
./lotus send --from-eth-addr 0x4582e0a8f02f45dfb6cca081b1cb82fcf0508c34 0xff000000000000000000000000000000000003ec  0.2
f4 addr:  t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message from: t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message to: t01004
Using Method: 3844450837
bafy2bzacedk25ku4sny272z6erhha4bx5pymbfued4wu6434z4yoaka2n6rvu
```

```
./lotus send --from-eth-addr 0x4582e0a8f02f45dfb6cca081b1cb82fcf0508c34 0x28dfd8668534e9caa8fb0b77577c8b78831d0d07 0.2
f4 addr:  t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message from: t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message to: t410ffdp5qzufgtu4vkh3bn3vo7elpcbr2dih4tfslca
Using Method: 3844450837
bafy2bzacedrwb75aagtwl74krto7aym5ato7vwqtg6cc4wlgzvmf3wiwrp7ik
```

```
 ./lotus send --from-eth-addr 0x4582e0a8f02f45dfb6cca081b1cb82fcf0508c34 t01005 10
f4 addr:  t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message from: t410fiwbobkhqf5c57nwmuca3ds4c7tyfbdbun3hxwmi
Sending message to: t01005
Using Method: 3844450837
bafy2bzaceaijk7lflnkt3l6s6irnxsmmoennfj57jpjgn3zi4e53t6qbokkae
```

```
./lotus send --from t410ffdp5qzufgtu4vkh3bn3vo7elpcbr2dih4tfslca t01005 0.2
Sending message from: t410ffdp5qzufgtu4vkh3bn3vo7elpcbr2dih4tfslca
Sending message to: t01005
Using Method: 3844450837
bafy2bzaceb5o4uqbktypwpiabxmqycxku6lcz5yace4hxkvlkhyd424shpdhg
```

```
./lotus send --from t410ffdp5qzufgtu4vkh3bn3vo7elpcbr2dih4tfslca 0xff000000000000000000000000000000000003ed  0.1
Sending message from: t410ffdp5qzufgtu4vkh3bn3vo7elpcbr2dih4tfslca
Sending message to: t01005
Using Method: 3844450837
bafy2bzacecqggccw43b455eady3fdv2apk7tybfi5ua2qrcaox33eo3la4yna
```