### PR TITLE
feat: eth: FilecoinAddressToEthAddress can take a complex argument

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -727,7 +727,7 @@ type FullNode interface {
 	// EthAddressToFilecoinAddress converts an EthAddress into an f410 Filecoin Address
 	EthAddressToFilecoinAddress(ctx context.Context, ethAddress ethtypes.EthAddress) (address.Address, error) //perm:read
 	// FilecoinAddressToEthAddress converts an f410 or f0 Filecoin Address to an EthAddress
-	FilecoinAddressToEthAddress(ctx context.Context, filecoinAddress address.Address) (ethtypes.EthAddress, error) //perm:read
+	FilecoinAddressToEthAddress(ctx context.Context, addressSpec ethtypes.StateAddressSpec) (ethtypes.EthAddress, error) //perm:read
 	// EthBlockNumber returns the height of the latest (heaviest) TipSet
 	EthBlockNumber(ctx context.Context) (ethtypes.EthUint64, error) //perm:read
 	// EthGetBlockTransactionCountByNumber returns the number of messages in the TipSet

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -40,6 +40,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+	"github.com/filecoin-project/lotus/lib/must"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	sealing "github.com/filecoin-project/lotus/storage/pipeline"
 	"github.com/filecoin-project/lotus/storage/sealer/sealtasks"
@@ -385,6 +386,10 @@ func init() {
 	}
 	addExample(&ethTraceFilterCriteria)
 	addExample(ethTraceFilterCriteria)
+
+	addExample(&ethtypes.StateAddressSpec{Address: must.One(address.NewIDAddress(1010))})
+	addExample(&ethtypes.StateAddressSpec{Address: must.One(address.NewFromString("f1xc3hws5n6y5m3m44gzb3gyjzhups6wzmhe663ji")), Block: pstring("finalized")})
+	addExample(&ethtypes.StateAddressSpec{Address: must.One(address.NewFromString("f3tcgq5scpfhdwh4dbalwktzf6mbv3ng2nw7tyzni5cyrsgvineid6jybnweecpa6misa6lk4tvwtxj2gkwpzq")), Block: pstring("0x3f15dd")})
 
 	percent := types.Percent(123)
 	addExample(percent)

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -263,7 +263,7 @@ type FullNodeMethods struct {
 
 	F3Participate func(p0 context.Context, p1 address.Address, p2 time.Time, p3 time.Time) (bool, error) `perm:"sign"`
 
-	FilecoinAddressToEthAddress func(p0 context.Context, p1 address.Address) (ethtypes.EthAddress, error) `perm:"read"`
+	FilecoinAddressToEthAddress func(p0 context.Context, p1 ethtypes.StateAddressSpec) (ethtypes.EthAddress, error) `perm:"read"`
 
 	GasEstimateFeeCap func(p0 context.Context, p1 *types.Message, p2 int64, p3 types.TipSetKey) (types.BigInt, error) `perm:"read"`
 
@@ -2145,14 +2145,14 @@ func (s *FullNodeStub) F3Participate(p0 context.Context, p1 address.Address, p2 
 	return false, ErrNotSupported
 }
 
-func (s *FullNodeStruct) FilecoinAddressToEthAddress(p0 context.Context, p1 address.Address) (ethtypes.EthAddress, error) {
+func (s *FullNodeStruct) FilecoinAddressToEthAddress(p0 context.Context, p1 ethtypes.StateAddressSpec) (ethtypes.EthAddress, error) {
 	if s.Internal.FilecoinAddressToEthAddress == nil {
 		return *new(ethtypes.EthAddress), ErrNotSupported
 	}
 	return s.Internal.FilecoinAddressToEthAddress(p0, p1)
 }
 
-func (s *FullNodeStub) FilecoinAddressToEthAddress(p0 context.Context, p1 address.Address) (ethtypes.EthAddress, error) {
+func (s *FullNodeStub) FilecoinAddressToEthAddress(p0 context.Context, p1 ethtypes.StateAddressSpec) (ethtypes.EthAddress, error) {
 	return *new(ethtypes.EthAddress), ErrNotSupported
 }
 

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -6922,19 +6922,28 @@
         },
         {
             "name": "Filecoin.FilecoinAddressToEthAddress",
-            "description": "```go\nfunc (s *FullNodeStruct) FilecoinAddressToEthAddress(p0 context.Context, p1 address.Address) (ethtypes.EthAddress, error) {\n\tif s.Internal.FilecoinAddressToEthAddress == nil {\n\t\treturn *new(ethtypes.EthAddress), ErrNotSupported\n\t}\n\treturn s.Internal.FilecoinAddressToEthAddress(p0, p1)\n}\n```",
+            "description": "```go\nfunc (s *FullNodeStruct) FilecoinAddressToEthAddress(p0 context.Context, p1 ethtypes.StateAddressSpec) (ethtypes.EthAddress, error) {\n\tif s.Internal.FilecoinAddressToEthAddress == nil {\n\t\treturn *new(ethtypes.EthAddress), ErrNotSupported\n\t}\n\treturn s.Internal.FilecoinAddressToEthAddress(p0, p1)\n}\n```",
             "summary": "FilecoinAddressToEthAddress converts an f410 or f0 Filecoin Address to an EthAddress\n",
             "paramStructure": "by-position",
             "params": [
                 {
                     "name": "p1",
-                    "description": "address.Address",
+                    "description": "ethtypes.StateAddressSpec",
                     "summary": "",
                     "schema": {
                         "examples": [
                             "f01234"
                         ],
                         "additionalProperties": false,
+                        "properties": {
+                            "address": {
+                                "additionalProperties": false,
+                                "type": "object"
+                            },
+                            "block": {
+                                "type": "string"
+                            }
+                        },
                         "type": [
                             "object"
                         ]


### PR DESCRIPTION
This is just a demonstration of what we could do with the existing API to extend it to have additional parameters to allow for more complex specification. If you supply something other than an f410 or f0 then you need to supply it with a `"block"` argument too which tells the node what tipset to use to look the address up. Optionally we could just accept all the fX address types and default to something, `"safe"` (probably 30 behind head), but this also allows you to specify `"finalized"` or some specific height, using the standard eth block number method of supplying it as a hex string.

Thread in slack @ https://filecoinproject.slack.com/archives/CP50PPW2X/p1722328160720429