### PR TITLE
feat!: gateway: fix rate limiting, better stateful handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
 
 - fix: add datacap balance to circ supply internal accounting as unCirc #12348
 
+## Improvements
+
+- fix!: gateway: fix rate limiting, general cleanup ([filecoin-project/lotus#12315](https://github.com/filecoin-project/lotus/pull/12315)).
+  - CLI usage documentation has been improved for `lotus-gateway`
+  - `--per-conn-rate-limit` now works as advertised.
+  - Some APIs have changed which may impact users consuming Lotus Gateway code as a library.
+
 # v1.28.1 / 2024-07-24
 
 This is the MANDATORY Lotus v1.28.1 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇. v1.28.1 is also the minimal version that supports nv23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - https://github.com/filecoin-project/lotus/pull/12332: fix: ETH RPC: receipts: use correct txtype in receipts
 - https://github.com/filecoin-project/lotus/pull/12335: fix: lotus-shed: store processed tipset after backfilling events
 
+## ☢️ Upgrade Warnings ☢️
+
+- lotus-gateway behaviour, CLI arguments and APIs have received minor changes. See the improvements section below.
+
 ## New features
 
 - feat: Add trace filter API supporting RPC method `trace_filter` ([filecoin-project/lotus#12123](https://github.com/filecoin-project/lotus/pull/12123)). Configuring `EthTraceFilterMaxResults` sets a limit on how many results are returned in any individual `trace_filter` RPC API call.
@@ -32,10 +36,15 @@
 
 ## Improvements
 
-- fix!: gateway: fix rate limiting, general cleanup ([filecoin-project/lotus#12315](https://github.com/filecoin-project/lotus/pull/12315)).
+- feat!: gateway: fix rate limiting, better stateful handling ([filecoin-project/lotus#12315](https://github.com/filecoin-project/lotus/pull/12315)).
   - CLI usage documentation has been improved for `lotus-gateway`
   - `--per-conn-rate-limit` now works as advertised.
+  - `--eth-max-filters-per-conn` is new and allows you to set the maximum number of filters and subscription per connection, it defaults to 16.
+    - Previously, this limit was set to `16` and applied separately to filters and subscriptions. This limit is now unified and applies to both filters and subscriptions.
+  - Stateful Ethereum APIs (those involving filters and subscriptions) are now disabled for plain HTTP connections. A client must be using websockets to access these APIs.
+    - These APIs are also now automatically removed from the node by the gateway when a client disconnects.
   - Some APIs have changed which may impact users consuming Lotus Gateway code as a library.
+  - The default value for the `Events.FilterTTL` config option has been reduced from 24h to 1h. This means that filters will expire on a Lotus node after 1 hour of not being accessed by the client.
 
 # v1.28.1 / 2024-07-24
 

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -268,13 +268,17 @@
   #EnableActorEventsAPI = false
 
   # FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
-  # this time become eligible for automatic deletion.
+  # this time become eligible for automatic deletion. Filters consume resources, so if they are unused they
+  # should not be retained.
   #
   # type: Duration
   # env var: LOTUS_EVENTS_FILTERTTL
-  #FilterTTL = "24h0m0s"
+  #FilterTTL = "1h0m0s"
 
   # MaxFilters specifies the maximum number of filters that may exist at any one time.
+  # Multi-tenant environments may want to increase this value to serve a larger number of clients. If using
+  # lotus-gateway, this global limit can be coupled with --eth-max-filters-per-conn which limits the number
+  # of filters per connection.
   #
   # type: int
   # env var: LOTUS_EVENTS_MAXFILTERS

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -1,0 +1,42 @@
+package gateway_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/gateway"
+)
+
+func TestRequestRateLimiterHandler(t *testing.T) {
+	var callCount int
+	h := gateway.NewRateLimitHandler(
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			callCount++
+		}),
+		0, // api rate
+		2, // request rate (per minute)
+		0, // cleanup interval
+	)
+
+	runRequest := func(host string, expectedStatus, expectedCallCount int) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = host + ":1234"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		require.Equal(t, expectedStatus, w.Code, "expected status %v, got %v", expectedStatus, w.Code)
+		require.Equal(t, expectedCallCount, callCount, "expected callCount to be %v, got %v", expectedCallCount, callCount)
+	}
+
+	// Test that the handler allows up to 2 requests per minute per host.
+	runRequest("boop", http.StatusOK, 1)
+	runRequest("boop", http.StatusOK, 2)
+	runRequest("beep", http.StatusOK, 3)
+	runRequest("boop", http.StatusTooManyRequests, 3)
+	runRequest("beep", http.StatusOK, 4)
+	runRequest("boop", http.StatusTooManyRequests, 4)
+	runRequest("beep", http.StatusTooManyRequests, 4)
+}

--- a/gateway/handler_test.go
+++ b/gateway/handler_test.go
@@ -13,7 +13,7 @@ import (
 func TestRequestRateLimiterHandler(t *testing.T) {
 	var callCount int
 	h := gateway.NewRateLimitHandler(
-		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 			callCount++
 		}),
 		0, // api rate

--- a/gateway/node.go
+++ b/gateway/node.go
@@ -7,6 +7,7 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	logger "github.com/ipfs/go-log/v2"
 	"go.opencensus.io/stats"
 	"golang.org/x/time/rate"
 
@@ -30,6 +31,8 @@ import (
 	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
+
+var log = logger.Logger("gateway")
 
 const (
 	DefaultLookbackCap            = time.Hour * 24

--- a/gateway/node_test.go
+++ b/gateway/node_test.go
@@ -23,7 +23,7 @@ import (
 func TestGatewayAPIChainGetTipSetByHeight(t *testing.T) {
 	ctx := context.Background()
 
-	lookbackTimestamp := uint64(time.Now().Unix()) - uint64(DefaultLookbackCap.Seconds())
+	lookbackTimestamp := uint64(time.Now().Unix()) - uint64(DefaultMaxLookbackDuration.Seconds())
 	type args struct {
 		h         abi.ChainEpoch
 		tskh      abi.ChainEpoch
@@ -264,7 +264,7 @@ func TestGatewayLimitTokensRate(t *testing.T) {
 	ctx := context.Background()
 	mock := &mockGatewayDepsAPI{}
 	tokens := 3
-	var rateLimit = 200
+	rateLimit := 200
 	rateLimitTimeout := time.Second / time.Duration(rateLimit/3) // large enough to not be hit
 	a := NewNode(mock, WithRateLimit(rateLimit), WithRateLimitTimeout(rateLimitTimeout))
 

--- a/gateway/proxy_fil.go
+++ b/gateway/proxy_fil.go
@@ -413,10 +413,10 @@ func (gw *Node) StateSearchMsg(ctx context.Context, from types.TipSetKey, msg ci
 		return nil, err
 	}
 	if limit == api.LookbackNoLimit {
-		limit = gw.stateWaitLookbackLimit
+		limit = gw.maxMessageLookbackEpochs
 	}
-	if gw.stateWaitLookbackLimit != api.LookbackNoLimit && limit > gw.stateWaitLookbackLimit {
-		limit = gw.stateWaitLookbackLimit
+	if gw.maxMessageLookbackEpochs != api.LookbackNoLimit && limit > gw.maxMessageLookbackEpochs {
+		limit = gw.maxMessageLookbackEpochs
 	}
 	if err := gw.checkTipsetKey(ctx, from); err != nil {
 		return nil, err
@@ -429,10 +429,10 @@ func (gw *Node) StateWaitMsg(ctx context.Context, msg cid.Cid, confidence uint64
 		return nil, err
 	}
 	if limit == api.LookbackNoLimit {
-		limit = gw.stateWaitLookbackLimit
+		limit = gw.maxMessageLookbackEpochs
 	}
-	if gw.stateWaitLookbackLimit != api.LookbackNoLimit && limit > gw.stateWaitLookbackLimit {
-		limit = gw.stateWaitLookbackLimit
+	if gw.maxMessageLookbackEpochs != api.LookbackNoLimit && limit > gw.maxMessageLookbackEpochs {
+		limit = gw.maxMessageLookbackEpochs
 	}
 	return gw.target.StateWaitMsg(ctx, msg, confidence, limit, allowReplaced)
 }

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/filecoin-project/go-f3 v0.0.7
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.4.0
-	github.com/filecoin-project/go-jsonrpc v0.3.2
+	github.com/filecoin-project/go-jsonrpc v0.6.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
 	github.com/filecoin-project/go-state-types v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1/go.mod h1:gXpNmr3oQx8l3o7qkGy
 github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0/go.mod h1:bxmzgT8tmeVQA1/gvBwFmYdT8SOFUwB3ovSUfG1Ux0g=
 github.com/filecoin-project/go-hamt-ipld/v3 v3.4.0 h1:nYs6OPUF8KbZ3E8o9p9HJnQaE8iugjHR5WYVMcicDJc=
 github.com/filecoin-project/go-hamt-ipld/v3 v3.4.0/go.mod h1:s0qiHRhFyrgW0SvdQMSJFQxNa4xEIG5XvqCBZUEgcbc=
-github.com/filecoin-project/go-jsonrpc v0.3.2 h1:uuAWTZe6B3AUUta+O26HlycGoej/yiaI1fXp3Du+D3I=
-github.com/filecoin-project/go-jsonrpc v0.3.2/go.mod h1:jBSvPTl8V1N7gSTuCR4bis8wnQnIjHbRPpROol6iQKM=
+github.com/filecoin-project/go-jsonrpc v0.6.0 h1:/fFJIAN/k6EgY90m7qbyfY28woMwyseZmh2gVs5sYjY=
+github.com/filecoin-project/go-jsonrpc v0.6.0/go.mod h1:/n/niXcS4ZQua6i37LcVbY1TmlJR0UIK9mDFQq2ICek=
 github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=
 github.com/filecoin-project/go-padreader v0.0.1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -91,7 +91,7 @@ func DefaultFullNode() *FullNode {
 			DisableRealTimeFilterAPI: false,
 			DisableHistoricFilterAPI: false,
 			EnableActorEventsAPI:     false,
-			FilterTTL:                Duration(time.Hour * 24),
+			FilterTTL:                Duration(time.Hour * 1),
 			MaxFilters:               100,
 			MaxFilterResults:         10000,
 			MaxFilterHeightRange:     2880, // conservative limit of one day

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -143,13 +143,17 @@ disabled by setting their respective Disable* options.`,
 			Type: "Duration",
 
 			Comment: `FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
-this time become eligible for automatic deletion.`,
+this time become eligible for automatic deletion. Filters consume resources, so if they are unused they
+should not be retained.`,
 		},
 		{
 			Name: "MaxFilters",
 			Type: "int",
 
-			Comment: `MaxFilters specifies the maximum number of filters that may exist at any one time.`,
+			Comment: `MaxFilters specifies the maximum number of filters that may exist at any one time.
+Multi-tenant environments may want to increase this value to serve a larger number of clients. If using
+lotus-gateway, this global limit can be coupled with --eth-max-filters-per-conn which limits the number
+of filters per connection.`,
 		},
 		{
 			Name: "MaxFilterResults",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -592,10 +592,14 @@ type EventsConfig struct {
 	EnableActorEventsAPI bool
 
 	// FilterTTL specifies the time to live for actor event filters. Filters that haven't been accessed longer than
-	// this time become eligible for automatic deletion.
+	// this time become eligible for automatic deletion. Filters consume resources, so if they are unused they
+	// should not be retained.
 	FilterTTL Duration
 
 	// MaxFilters specifies the maximum number of filters that may exist at any one time.
+	// Multi-tenant environments may want to increase this value to serve a larger number of clients. If using
+	// lotus-gateway, this global limit can be coupled with --eth-max-filters-per-conn which limits the number
+	// of filters per connection.
 	MaxFilters int
 
 	// MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/go-jsonrpc/pull/118
Ref: https://github.com/filecoin-project/lotus/issues/11589
Ref: https://github.com/filecoin-project/lotus/issues/11153

---

API changes and breakage:

* Plain HTTP connections now can't use stateful ethereum APIs (they couldn't really before, but they allowed addition of filters and subs in a dangerous way), you have to be using WebSockets
* `gateway.NewNode` now only takes 1 argument (the api) and a list of options to override defaults
* `gateway.NewRateLimiterHandler` and `gateway.NewConnectionRateLimiterHandler` have been replaced with `gateway.NewRateLimitHandler`.
* The handlers returned by both `gateway.NewRateLimitHandler` and the primary `gateway.Handler` return an `http.Handler` augmented with a `Shutdown(ctx)` method to be used for graceful cleanup of resources.
* The default for the config option `Events.FilterTTL` has been reduced from 24h to 1h. It's a measure of "how long since this thing was last used", and 24h is way too long for that IMO.

Fix:

* `--per-conn-rate-limit` was previously applied as a global rate limiter,
  effectively making it have the same impact as `--rate-limit`. This change fixes
  the behaviour such that `--per-conn-rate-limit` is applied as a API call
  limiter within a single connection (i.e. a WebSocket connection). The rate
  is specified as tokens-per-second, where tokens are relative to the expense
  of the API call being made.

Improve:

* Auto-clean-up of stateful resources when a WebSockets connection ends, so we close down subscriptions and remove filters if the user didn't do so themselves.
* Added `--eth-max-filters-per-conn` to override the default (16) and it now applies to the combined total of eth subs and filters, not separately
* Replace the `--conn-per-minute` limit mechanism to a standard `rate.Limiter` instead of the custom rate limit implementation. There is a slight change of behaviour with this in that I allow a burst, which the original doesn't. It also has a different cleanup mechanism with a separate goroutine dedicated to this task instead of a goroutine per request that decrements and may cleanup if zero. 