### PR TITLE
ETH RPC: receipts: use correct txtype in receipts

### DIFF
--- a/itests/eth_legacy_transactions_test.go
+++ b/itests/eth_legacy_transactions_test.go
@@ -81,6 +81,7 @@ func TestLegacyValueTransferValidSignature(t *testing.T) {
 	require.EqualValues(t, ethAddr, receipt.From)
 	require.EqualValues(t, ethAddr2, *receipt.To)
 	require.EqualValues(t, hash, receipt.TransactionHash)
+	require.EqualValues(t, ethtypes.EthLegacyTxType, receipt.Type)
 
 	// Success.
 	require.EqualValues(t, ethtypes.EthUint64(0x1), receipt.Status)
@@ -227,6 +228,7 @@ func TestLegacyEIP155ValueTransferValidSignature(t *testing.T) {
 	require.EqualValues(t, ethAddr, receipt.From)
 	require.EqualValues(t, ethAddr2, *receipt.To)
 	require.EqualValues(t, hash, receipt.TransactionHash)
+	require.EqualValues(t, ethtypes.EthLegacyTxType, receipt.Type)
 
 	// Success.
 	require.EqualValues(t, ethtypes.EthUint64(0x1), receipt.Status)

--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -98,6 +98,7 @@ func TestValueTransferValidSignature(t *testing.T) {
 	require.EqualValues(t, ethAddr, receipt.From)
 	require.EqualValues(t, ethAddr2, *receipt.To)
 	require.EqualValues(t, hash, receipt.TransactionHash)
+	require.EqualValues(t, ethtypes.EIP1559TxType, receipt.Type)
 
 	// Success.
 	require.EqualValues(t, ethtypes.EthUint64(0x1), receipt.Status)

--- a/node/impl/full/eth_utils.go
+++ b/node/impl/full/eth_utils.go
@@ -699,7 +699,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, lookup *api.MsgLook
 		TransactionIndex: transactionIndex,
 		BlockHash:        blockHash,
 		BlockNumber:      blockNumber,
-		Type:             ethtypes.EthUint64(2),
+		Type:             tx.Type,
 		Logs:             []ethtypes.EthLog{}, // empty log array is compulsory when no logs, or libraries like ethers.js break
 		LogsBloom:        ethtypes.NewEmptyEthBloom(),
 	}


### PR DESCRIPTION
Fixes a bug in `EthGetReceipts` where it always assumes `TxType` is `EIP-1559` which is no longer true after adding support for legacy txns.