### PR TITLE
feat(ci): add PR title check workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,10 +12,10 @@
 Before you mark the PR ready for review, please make sure that:
 
 - [ ] Commits have a clear commit message.
-- [ ] PR title is in the form of of `<PR type>: <area>: <change being made>`
+- [ ] PR title is in the form of of `<type> (<scope>): <subject>`
   - example: ` fix: mempool: Introduce a cache for valid signatures`
-  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
-  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
+  - `type`: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+  - `scope`: api, chain, deps, mempool, multisig, networking, paych, proving, sealing, state, wallet
 - [ ] Update CHANGELOG.md or signal that this change does not need it.
   - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
   - If the change does not require a CHANGELOG.md entry, do one of the following:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,15 +12,8 @@
 Before you mark the PR ready for review, please make sure that:
 
 - [ ] Commits have a clear commit message.
-- [ ] PR title is in the form of of `<type> (<scope>): <subject>`
-  - example: ` fix: mempool: Introduce a cache for valid signatures`
-  - `type`: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
-  - `scope`: api, chain, deps, mempool, multisig, networking, paych, proving, sealing, state, wallet
-- [ ] Update CHANGELOG.md or signal that this change does not need it.
-  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
-  - If the change does not require a CHANGELOG.md entry, do one of the following:
-    - Add `[skip changelog]` to the PR title
-    - Add the label `skip/changelog` to the PR
+- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions)
+- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#changelog-management)
 - [ ] New features have usage guidelines and / or documentation updates in
   - [ ] [Lotus Documentation](https://lotus.filecoin.io)
   - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,10 +30,7 @@ jobs:
       - if: steps.changelog.outputs.modified == '0'
         env:
           MESSAGE: |
-            docs/changelogs/ was not modified in this PR. Please do one of the following:
-            - add a changelog entry
-            - add `[skip changelog]` to the PR title
-            - label the PR with `skip/changelog`
+            docs/changelogs/ was not modified in this PR. Please do one of the options in [changelog management conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#changelog-management)
         run: |
           echo "::error::${MESSAGE//$'\n'/%0A}"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:
@@ -13,8 +12,7 @@ jobs:
     name: Check PR Title
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR Title
-        id: check_title
+      - name: Check PR Title and Manage Review
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -23,48 +21,30 @@ jobs:
             const pattern = /^(feat|fix|docs|style|refactor|test|chore):\s\w+:\s.+/;
             
             if (!pattern.test(title)) {
-              core.setOutput('result', 'invalid');
-              throw new Error('PR title does not match the required format');
-            }
-            core.setOutput('result', 'valid');
-
-      - name: Request changes
-        if: failure()
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              body: 'Please update the PR title to match the required format: `<type>: <scope>: <subject>`\n\nTypes: feat, fix, docs, style, refactor, test, chore\nScope: required\nSubject: start with lowercase',
-              event: 'REQUEST_CHANGES'
-            })
-
-      - name: Dismiss previous review if title is now valid
-        if: success()
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            });
-            
-            const botReview = reviews.data.find(review => 
-              review.user.type === 'Bot' && 
-              review.state === 'CHANGES_REQUESTED'
-            );
-            
-            if (botReview) {
-              await github.rest.pulls.dismissReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+              await github.rest.pulls.createReview({
+                ...context.repo,
                 pull_number: context.payload.pull_request.number,
-                review_id: botReview.id,
-                message: 'PR title now matches the required format.'
+                body: 'Please update the PR title to match the required format: `<type>: <scope>: <subject>`\n\nTypes: feat, fix, docs, style, refactor, test, chore\nScope: required\nSubject: start with lowercase',
+                event: 'REQUEST_CHANGES'
               });
+              core.setFailed('PR title does not match the required format');
+            } else {
+              const reviews = await github.rest.pulls.listReviews({
+                ...context.repo,
+                pull_number: context.payload.pull_request.number
+              });
+              
+              const botReview = reviews.data.find(review => 
+                review.user.type === 'Bot' && 
+                review.state === 'CHANGES_REQUESTED'
+              );
+              
+              if (botReview) {
+                await github.rest.pulls.dismissReview({
+                  ...context.repo,
+                  pull_number: context.payload.pull_request.number,
+                  review_id: botReview.id,
+                  message: 'PR title now matches the required format.'
+                });
+              }
             }

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -20,7 +20,7 @@ jobs:
             const title = context.payload.pull_request.title;
             // This should match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions
             // 202408: Beyond Conventional Commit conventions, we also optionally suport the "scope" outside of paranenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
-            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?:?\s(\w+:)?\s?[a-z].+$/;
+            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?!?:?\s(\w+:)?\s?[a-z].+$/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,13 +18,13 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test):\s\w+:\s[a-z].+/;
+            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?:?\s(\w+:)?\s[a-z].+$/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.payload.pull_request.number,
-                body: 'Please update the PR title to match the required format: `<type>: <area>: <subject>`\n\nTypes: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test, chore\nArea: e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps\nSubject: start with lowercase',
+                body: 'Please update the PR title to match one of the required formats:\n\n1. `<type>: <scope>: <subject>`\n2. `<type>(<scope>): <subject>`\n\nTypes: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test\nArea/Scope: api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps\nSubject: start with lowercase\n\nOptionally, you can add "[skip changelog]" at the start of the title if the change does not require a CHANGELOG.md entry.',
                 event: 'REQUEST_CHANGES'
               });
               core.setFailed('PR title does not match the required format');

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -24,12 +24,12 @@ jobs:
             
             if (!pattern.test(title)) {
               core.setOutput('result', 'invalid');
-              return;
+              throw new Error('PR title does not match the required format');
             }
             core.setOutput('result', 'valid');
 
       - name: Request changes
-        if: steps.check_title.outputs.result == 'invalid'
+        if: failure()
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -42,12 +42,8 @@ jobs:
               event: 'REQUEST_CHANGES'
             })
 
-      - name: Fail if title is invalid
-        if: steps.check_title.outputs.result == 'invalid'
-        run: exit 1
-
       - name: Dismiss previous review if title is now valid
-        if: steps.check_title.outputs.result == 'valid'
+        if: success()
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -42,6 +42,10 @@ jobs:
               event: 'REQUEST_CHANGES'
             })
 
+      - name: Fail if title is invalid
+        if: steps.check_title.outputs.result == 'invalid'
+        run: exit 1
+
       - name: Dismiss previous review if title is now valid
         if: steps.check_title.outputs.result == 'valid'
         uses: actions/github-script@v6

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?:?\s(\w+:)?\s[a-z].+$/;
+            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?:?\s(\w+:)?\s?[a-z].+$/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,10 +23,10 @@ jobs:
             const pattern = /^(feat|fix|docs|style|refactor|test|chore):\s\w+:\s.+/;
             
             if (!pattern.test(title)) {
-              core.setFailed('PR title does not match the required format: <type>: <scope>: <subject>');
-              return 'invalid';
+              core.setOutput('result', 'invalid');
+              return;
             }
-            return 'valid';
+            core.setOutput('result', 'valid');
 
       - name: Request changes
         if: steps.check_title.outputs.result == 'invalid'

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,13 +18,13 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|docs|style|refactor|test|chore):\s\w+:\s.+/;
+            const pattern = /^(feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test):\s\w+:\s.+/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.payload.pull_request.number,
-                body: 'Please update the PR title to match the required format: `<type>: <scope>: <subject>`\n\nTypes: feat, fix, docs, style, refactor, test, chore\nScope: required\nSubject: start with lowercase',
+                body: 'Please update the PR title to match the required format: `<type>: <area>: <subject>`\n\nTypes: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test, chore\nArea: e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps\nSubject: start with lowercase',
                 event: 'REQUEST_CHANGES'
               });
               core.setFailed('PR title does not match the required format');

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test):\s\w+:\s.+/;
+            const pattern = /^(feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test):\s\w+:\s[a-z].+/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,70 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        id: check_title
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const title = context.payload.pull_request.title;
+            const pattern = /^(feat|fix|docs|style|refactor|test|chore):\s\w+:\s.+/;
+            
+            if (!pattern.test(title)) {
+              core.setFailed('PR title does not match the required format: <type>: <scope>: <subject>');
+              return 'invalid';
+            }
+            return 'valid';
+
+      - name: Request changes
+        if: steps.check_title.outputs.result == 'invalid'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              body: 'Please update the PR title to match the required format: `<type>: <scope>: <subject>`\n\nTypes: feat, fix, docs, style, refactor, test, chore\nScope: required\nSubject: start with lowercase',
+              event: 'REQUEST_CHANGES'
+            })
+
+      - name: Dismiss previous review if title is now valid
+        if: steps.check_title.outputs.result == 'valid'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            
+            const botReview = reviews.data.find(review => 
+              review.user.type === 'Bot' && 
+              review.state === 'CHANGES_REQUESTED'
+            );
+            
+            if (botReview) {
+              await github.rest.pulls.dismissReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                review_id: botReview.id,
+                message: 'PR title now matches the required format.'
+              });
+            }

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,13 +18,15 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
+            // This should match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions
+            // 202408: Beyond Conventional Commit conventions, we also optionally suport the "scope" outside of paranenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
             const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?:?\s(\w+:)?\s?[a-z].+$/;
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.payload.pull_request.number,
-                body: 'Please update the PR title to match one of the required formats:\n\n1. `<type>: <scope>: <subject>`\n2. `<type>(<scope>): <subject>`\n\nTypes: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test\nArea/Scope: api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps\nSubject: start with lowercase\n\nOptionally, you can add "[skip changelog]" at the start of the title if the change does not require a CHANGELOG.md entry.',
+                body: 'Please update the PR title to match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions',
                 event: 'REQUEST_CHANGES'
               });
               core.setFailed('PR title does not match the required format');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+> 2024-08-08: this will get flushed out more soon as part of https://github.com/filecoin-project/lotus/issues/12360
+
+### PR Title Conventions
+PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
+This means the PR title should be in the form of `<type>(<scope>): <description>`
+  - example: `fix(mempool): introduce a cache for valid signatures`
+  - `type`: MUST be one of _build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test_
+  - `scope`: OPTIONAL arbitrary string that is usually one of _api, chain, deps, mempool, multisig, networking, paych, proving, sealing, state, wallet_
+  - Breaking changes must add a `!`
+  - Optionally the PR title can be prefixed with `[skip changelog]` if no changelog edits should be made for this change.
+Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/pr-title-check.yml
+
+### CHANGELOG Management
+To expedite the release process, the CHANGELOG is built-up incrementally.  
+We enforce that each PR updates CHANGELOG.md or signals that the change doesn't need it.
+If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
+If the change does not require a CHANGELOG.md entry, do one of the following:
+- Add `[skip changelog]` to the PR title
+- Add the label `skip/changelog` to the PR
+Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/changelog.yml


### PR DESCRIPTION
## Related Issues
Closes: #12148

## Proposed Changes
- A GitHub Actions workflow to automatically check and enforce a consistent format for PR titles
- Started work on `CONTRIBUTING.md` doc that consolidates contributing expectations in one place. https://github.com/filecoin-project/lotus/issues/12360

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [ ] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip/changelog` to the PR
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
