### PR TITLE
fix: api: add datacap balance to circ supply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 ([filecoin-project/lotus#12324](https://github.com/filecoin-project/lotus/pull/12324)).
 - feat: Added `lotus-shed indexes inspect-events` health-check command ([filecoin-project/lotus#12346](https://github.com/filecoin-project/lotus/pull/12346)).
 
+## Enhancements
+
+- fix: add datacap balance to circ supply internal accounting as unCirc #12348
+
 # v1.28.1 / 2024-07-24
 
 This is the MANDATORY Lotus v1.28.1 release, which will deliver the Filecoin network version 23, codenamed Waffle 🧇. v1.28.1 is also the minimal version that supports nv23.

--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -27,6 +27,7 @@ var InitActorAddr = builtin.InitActorAddr
 var SystemActorAddr = builtin.SystemActorAddr
 var BurntFundsActorAddr = builtin.BurntFundsActorAddr
 var CronActorAddr = builtin.CronActorAddr
+var DatacapActorAddr = builtin.DatacapActorAddr
 var EthereumAddressManagerActorAddr = builtin.EthereumAddressManagerActorAddr
 var SaftAddress = makeAddress("t0122")
 var ReserveAddress = makeAddress("t090")

--- a/chain/actors/builtin/builtin.go.template
+++ b/chain/actors/builtin/builtin.go.template
@@ -27,6 +27,7 @@ var InitActorAddr = builtin.InitActorAddr
 var SystemActorAddr = builtin.SystemActorAddr
 var BurntFundsActorAddr = builtin.BurntFundsActorAddr
 var CronActorAddr = builtin.CronActorAddr
+var DatacapActorAddr = builtin.DatacapActorAddr
 var EthereumAddressManagerActorAddr = builtin.EthereumAddressManagerActorAddr
 var SaftAddress = makeAddress("t0122")
 var ReserveAddress = makeAddress("t090")

--- a/chain/stmgr/supply.go
+++ b/chain/stmgr/supply.go
@@ -417,7 +417,8 @@ func (sm *StateManager) GetCirculatingSupply(ctx context.Context, height abi.Cha
 			a == builtin.BurntFundsActorAddr ||
 			a == builtin.SaftAddress ||
 			a == builtin.ReserveAddress ||
-			a == builtin.EthereumAddressManagerActorAddr:
+			a == builtin.EthereumAddressManagerActorAddr ||
+			a == builtin.DatacapActorAddr:
 
 			unCirc = big.Add(unCirc, actor.Balance)
 


### PR DESCRIPTION
while datacap actor is not expected to be receiving funds, however, it did https://filfox.info/en/message/bafy2bzacebszh56u7lqkooszlmoszfumiq4zztgavsbgnxs2t7cmimpp656cs?t=1 . which is uncovered for circulating supply APIs internal accounting.


