### PR TITLE
chore: docs: Update step in skeleton guide

### DIFF
--- a/documentation/misc/Building_a_network_skeleton.md
+++ b/documentation/misc/Building_a_network_skeleton.md
@@ -101,7 +101,7 @@ You can take a look at this [Filecoin-FFI PR as a reference](https://github.com/
 
 ## Lotus Checklist
 
-1. To integrate the network skeleton into Lotus, ensure that the relevant releases for ref-fvm, filecoin-ffi, and Go-State-Types are bubbled up to Lotus.
+1. To integrate the network skeleton into Lotus, ensure that the relevant releases for ref-fvm, filecoin-ffi, and go-state-types are bubbled up to Lotus.
     - Refer to the [Update Dependencies Lotus tutorial](Update_Dependencies_Lotus.md) for detailed instructions on updating these dependencies in Lotus.
 
 1. Import new actors:

--- a/documentation/misc/Building_a_network_skeleton.md
+++ b/documentation/misc/Building_a_network_skeleton.md
@@ -101,8 +101,8 @@ You can take a look at this [Filecoin-FFI PR as a reference](https://github.com/
 
 ## Lotus Checklist
 
-1. In your Lotus repository, add `replace github.com/filecoin-project/go-state-types => ../go-state-types` to the very end of your Lotus `go.mod` file.
-    - This ensures that your local clone copy of `go-state-types` is used. Any changes you make there will be reflected in your Lotus project.
+1. To integrate the network skeleton into Lotus, ensure that the relevant releases for ref-fvm, filecoin-ffi, and Go-State-Types are bubbled up to Lotus.
+    - Refer to the [Update Dependencies Lotus tutorial](Update_Dependencies_Lotus.md) for detailed instructions on updating these dependencies in Lotus.
 
 1. Import new actors:
 


### PR DESCRIPTION
## Proposed Changes
Updating the instructions for integrating the network skeleton into Lotus. Instead of manually modifying the go.mod file to use a local clone of go-state-types, the updated instructions now direct to the "Update Dependencies Lotus" tutorial for steps on updating dependencies that has been released

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip/changelog` to the PR
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
