### PR TITLE
feat(tx_index): fill transaction index gap on enabling automatic backfill

### DIFF
--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -112,7 +112,7 @@ func (ei *EthTxHashLookup) UpsertUniqueHash(txHash ethtypes.EthHash, c cid.Cid) 
 		return xerrors.New("db closed")
 	}
 
-	result, err := ei.stmtInsertTxHash.Exec(txHash.String(), c.String())
+	result, err := ei.stmtInsertUniqueTxHash.Exec(txHash.String(), c.String())
 	if err != nil {
 		return err
 	}

--- a/chain/ethhashlookup/index.go
+++ b/chain/ethhashlookup/index.go
@@ -1,0 +1,117 @@
+package ethhashlookup
+
+import (
+	"context"
+	"os"
+
+	"github.com/filecoin-project/lotus/chain/store"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+	"github.com/filecoin-project/lotus/lib/sqlite"
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+)
+
+var log = logging.Logger("txhashindex")
+
+// ChainStore interface; we could use store.ChainStore directly,
+// but this simplifies unit testing.
+type ChainStore interface {
+	SubscribeHeadChanges(f store.ReorgNotifee)
+	GetSecpkMessagesForTipset(ctx context.Context, ts *types.TipSet) ([]*types.SignedMessage, error)
+	GetHeaviestTipSet() *types.TipSet
+	GetTipSetFromKey(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
+}
+
+var _ ChainStore = (*store.ChainStore)(nil)
+
+// PopulateAfterSnapshot populates the tx hash index after a snapshot is restored.
+func PopulateAfterSnapshot(ctx context.Context, path string, cs ChainStore) error {
+	// if a database already exists, we try to delete it and create a new one
+	if _, err := os.Stat(path); err == nil {
+		if err = os.Remove(path); err != nil {
+			return xerrors.Errorf("tx hash index already exists at %s and can't be deleted", path)
+		}
+	}
+
+	db, _, err := sqlite.Open(path)
+	if err != nil {
+		return xerrors.Errorf("failed to setup tx hash index db: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Errorf("error closing tx hash database: %s", err)
+		}
+	}()
+
+	if err = sqlite.InitDb(ctx, "message index", db, ddls, []sqlite.MigrationFunc{}); err != nil {
+		_ = db.Close()
+		return xerrors.Errorf("error creating tx hash index database: %w", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return xerrors.Errorf("error when starting transaction: %w", err)
+	}
+
+	rollback := func() {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf("error in rollback: %s", err)
+		}
+	}
+
+	insertStmt, err := tx.Prepare(insertTxHash)
+	if err != nil {
+		rollback()
+		return xerrors.Errorf("error preparing insertStmt: %w", err)
+	}
+
+	defer insertStmt.Close()
+
+	var (
+		curTs       = cs.GetHeaviestTipSet()
+		startHeight = curTs.Height()
+		msgs        []*types.SignedMessage
+	)
+
+	for curTs != nil {
+		msgs, err = cs.GetSecpkMessagesForTipset(ctx, curTs)
+		if err != nil {
+			log.Infof("stopping import after %d tipsets", startHeight-curTs.Height())
+			break
+		}
+
+		for _, m := range msgs {
+			ethTx, err := ethtypes.EthTransactionFromSignedFilecoinMessage(m)
+			if err != nil {
+				rollback()
+				return err
+			}
+
+			txHash, err := ethTx.TxHash()
+			if err != nil {
+				rollback()
+				return err
+			}
+
+			_, err = insertStmt.Exec(txHash.String(), m.Cid().String())
+			if err != nil {
+				rollback()
+				return err
+			}
+		}
+
+		curTs, err = cs.GetTipSetFromKey(ctx, curTs.Parents())
+		if err != nil {
+			rollback()
+			return xerrors.Errorf("error walking chain: %w", err)
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return xerrors.Errorf("error committing transaction: %w", err)
+	}
+
+	return nil
+}

--- a/chain/ethhashlookup/index.go
+++ b/chain/ethhashlookup/index.go
@@ -66,7 +66,9 @@ func PopulateAfterSnapshot(ctx context.Context, path string, cs ChainStore) erro
 		return xerrors.Errorf("error preparing insertStmt: %w", err)
 	}
 
-	defer insertStmt.Close()
+	defer func() {
+		_ = insertStmt.Close()
+	}()
 
 	var (
 		curTs       = cs.GetHeaviestTipSet()

--- a/chain/store/messages.go
+++ b/chain/store/messages.go
@@ -350,3 +350,18 @@ func (cs *ChainStore) LoadSignedMessagesFromCids(ctx context.Context, cids []cid
 
 	return msgs, nil
 }
+
+// GetSecpkMessagesForTipset returns all the secpk messages for a tipset
+func (cs *ChainStore) GetSecpkMessagesForTipset(ctx context.Context, ts *types.TipSet) ([]*types.SignedMessage, error) {
+	msgs := make([]*types.SignedMessage, 0)
+	for _, b := range ts.Blocks() {
+		secpkmsgs, err := cs.SecpkMessagesForBlock(ctx, b)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get secpk messages for block: %w", err)
+		}
+
+		msgs = append(msgs, secpkmsgs...)
+	}
+
+	return msgs, nil
+}

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -36,6 +36,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/beacon/drand"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/ethhashlookup"
 	"github.com/filecoin-project/lotus/chain/index"
 	proofsffi "github.com/filecoin-project/lotus/chain/proofs/ffi"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -650,6 +651,19 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 		log.Info("populating message index done")
 	}
 
+	if cfg.Index.EnableAutomaticBackFillTxIndex {
+		log.Info("back-filling tx index...")
+		basePath, err := lr.SqlitePath()
+		if err != nil {
+			return err
+		}
+
+		if err = ethhashlookup.PopulateAfterSnapshot(ctx, filepath.Join(basePath, ethhashlookup.DefaultDbFilename), cst); err != nil {
+			return err
+		}
+
+		log.Info("populating tx index done")
+	}
 	return nil
 }
 

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -261,7 +261,7 @@ func ConfigFullNode(c interface{}) Option {
 
 			If(cfg.Fevm.EnableEthRPC,
 				Override(new(*full.EthEventHandler), modules.EthEventHandler(cfg.Events, cfg.Fevm.EnableEthRPC)),
-				Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm)),
+				Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm, cfg.Index.EnableAutomaticBackFill)),
 				Override(new(full.EthEventAPI), From(new(*full.EthEventHandler))),
 			),
 			If(!cfg.Fevm.EnableEthRPC,

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -261,7 +261,7 @@ func ConfigFullNode(c interface{}) Option {
 
 			If(cfg.Fevm.EnableEthRPC,
 				Override(new(*full.EthEventHandler), modules.EthEventHandler(cfg.Events, cfg.Fevm.EnableEthRPC)),
-				Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm, cfg.Index.EnableAutomaticBackFill)),
+				Override(new(full.EthModuleAPI), modules.EthModuleAPI(cfg.Fevm, cfg.Index.EnableAutomaticBackFillTxIndex, cfg.Index.MaxAutomaticBackFillTxIndexHeight)),
 				Override(new(full.EthEventAPI), From(new(*full.EthEventHandler))),
 			),
 			If(!cfg.Fevm.EnableEthRPC,

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -97,6 +97,10 @@ func DefaultFullNode() *FullNode {
 			MaxFilterResults:         10000,
 			MaxFilterHeightRange:     2880, // conservative limit of one day
 		},
+		Index: IndexConfig{
+			EnableAutomaticBackFillTxIndex:    false,
+			MaxAutomaticBackFillTxIndexHeight: 5760, // total epochs in 2 days, (30 seconds per epoch)
+		},
 	}
 }
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -71,7 +71,7 @@ type ApisConfig struct {
 }
 
 type JournalConfig struct {
-	//Events of the form: "system1:event1,system1:event2[,...]"
+	// Events of the form: "system1:event1,system1:event2[,...]"
 	DisabledEvents string
 }
 
@@ -632,6 +632,9 @@ type IndexConfig struct {
 	// EXPERIMENTAL FEATURE. USE WITH CAUTION
 	// EnableMsgIndex enables indexing of messages on chain.
 	EnableMsgIndex bool
+
+	// EnableAutomaticBackFill enables automatic index back-filling
+	EnableAutomaticBackFill bool
 }
 
 type HarmonyDB struct {

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -633,8 +633,11 @@ type IndexConfig struct {
 	// EnableMsgIndex enables indexing of messages on chain.
 	EnableMsgIndex bool
 
-	// EnableAutomaticBackFill enables automatic index back-filling
-	EnableAutomaticBackFill bool
+	// EnableAutomaticBackFillTxIndex enables automatic index back-filling
+	EnableAutomaticBackFillTxIndex bool
+
+	// Maximum number of blocks to process during a single back-fill operation
+	MaxAutomaticBackFillTxIndexHeight uint64
 }
 
 type HarmonyDB struct {

--- a/node/impl/full/txhashmanager.go
+++ b/node/impl/full/txhashmanager.go
@@ -26,7 +26,7 @@ func (m *EthTxHashManager) Revert(_ context.Context, _, _ *types.TipSet) error {
 
 // FillIndexGap populates the Ethereum transaction hash lookup database with missing entries
 // by processing blocks until we reach the maximum number of automatic back-fill epochs or the message is already indexed.
-func (m *EthTxHashManager) FillIndexGap(currHead *types.TipSet, ctx context.Context, maxAutomaticBackFillBlocks abi.ChainEpoch) error {
+func (m *EthTxHashManager) FillIndexGap(ctx context.Context, currHead *types.TipSet, maxAutomaticBackFillBlocks abi.ChainEpoch) error {
 	log.Info("Start back-filling transaction index from current head: %d", currHead.Height())
 
 	var (

--- a/node/impl/full/txhashmanager.go
+++ b/node/impl/full/txhashmanager.go
@@ -2,11 +2,11 @@ package full
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
-
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/ethhashlookup"
@@ -16,56 +16,63 @@ import (
 
 type EthTxHashManager struct {
 	StateAPI              StateAPI
+	ChainAPI              ChainAPI
 	TransactionHashLookup *ethhashlookup.EthTxHashLookup
 }
 
-func (m *EthTxHashManager) Revert(ctx context.Context, from, to *types.TipSet) error {
+func (m *EthTxHashManager) Revert(_ context.Context, _, _ *types.TipSet) error {
 	return nil
 }
 
-// FillIndexGap back-fills the gap between the current head and the last populated transaction index
-func (m *EthTxHashManager) FillIndexGap(ctx context.Context) error {
-	lastTxHash, lastTxCid, err := m.TransactionHashLookup.GetLastTransaction()
-	if err != nil {
-		return err
-	}
+// FillIndexGap populates the Ethereum transaction hash lookup database with missing entries
+// by processing blocks until we reach the maximum number of automatic back-fill epochs or the message is already indexed.
+func (m *EthTxHashManager) FillIndexGap(currHead *types.TipSet, ctx context.Context, maxAutomaticBackFillBlocks abi.ChainEpoch) error {
+	log.Info("Start back-filling transaction index from current head: %d", currHead.Height())
 
-	log.Infof("Start filling transaction index gap from: %s", lastTxHash)
+	var (
+		fromTs          = currHead
+		processedBlocks = uint64(0)
+	)
 
-	totalProcessedBlock := 0
-	ts := m.StateAPI.Chain.GetHeaviestTipSet()
-	for _, block := range ts.Blocks() {
-		msgs, err := m.StateAPI.Chain.SecpkMessagesForBlock(ctx, block)
-		if err != nil {
-			// If we can't find the messages, we've either imported from snapshot or pruned the store
-			log.Debug("exiting message mapping population at epoch ", ts.Height())
-			return nil
-		}
-
-		for _, msg := range msgs {
-			if msg.Cid() == lastTxCid {
-				// We've reached the last indexed transaction
+	for i := abi.ChainEpoch(0); i < maxAutomaticBackFillBlocks && fromTs.Height() > 0; i++ {
+		for _, block := range fromTs.Blocks() {
+			msgs, err := m.StateAPI.Chain.SecpkMessagesForBlock(ctx, block)
+			if err != nil {
+				log.Debugf("Exiting back-filling at epoch %d: %s", currHead.Height(), err)
 				return nil
 			}
 
-			// process the message
-			m.ProcessSignedMessage(ctx, msg)
+			for _, msg := range msgs {
+				err = m.StoreMsg(ctx, msg)
+				if err != nil {
+					if errors.Is(err, ethhashlookup.ErrAlreadyIndexed) {
+						log.Infof("Reached already indexed transaction at height %d. ", fromTs.Height())
+
+						log.Info("Stop back-filling tx index, Total processed blocks: %d", processedBlocks)
+						return nil
+					}
+
+					return err
+				}
+			}
+
+			processedBlocks++
 		}
 
-		totalProcessedBlock++
+		// Move to the previous tipset
+		var err error
+		fromTs, err = m.ChainAPI.ChainGetTipSet(ctx, fromTs.Parents())
+		if err != nil {
+			return err
+		}
 	}
 
-	ts, err = m.StateAPI.Chain.GetTipSetFromKey(ctx, ts.Parents())
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Finished filling transaction index gap. Total processed block: %d", totalProcessedBlock)
+	log.Info("Finished back-filling tx index, Total processed blocks: %d", processedBlocks)
 
 	return nil
 }
 
-// PopulateExistingMappings walk back from the current head to the minimum height and populate the eth transaction hash lookup database
+// PopulateExistingMappings walks back from the current head to the minimum height and populates the eth transaction hash lookup database
 func (m *EthTxHashManager) PopulateExistingMappings(ctx context.Context, minHeight abi.ChainEpoch) error {
 	if minHeight < buildconstants.UpgradeHyggeHeight {
 		minHeight = buildconstants.UpgradeHyggeHeight
@@ -96,7 +103,7 @@ func (m *EthTxHashManager) PopulateExistingMappings(ctx context.Context, minHeig
 	return nil
 }
 
-func (m *EthTxHashManager) Apply(ctx context.Context, from, to *types.TipSet) error {
+func (m *EthTxHashManager) Apply(ctx context.Context, _, to *types.TipSet) error {
 	for _, blk := range to.Blocks() {
 		_, smsgs, err := m.StateAPI.Chain.MessagesForBlock(ctx, blk)
 		if err != nil {
@@ -123,20 +130,34 @@ func (m *EthTxHashManager) Apply(ctx context.Context, from, to *types.TipSet) er
 	return nil
 }
 
-func (m *EthTxHashManager) ProcessSignedMessage(ctx context.Context, msg *types.SignedMessage) {
+// StoreMsg is similar to ProcessSignedMessage, but it returns an error if the message is already indexed
+// and does not attempt to index the message again.
+func (m *EthTxHashManager) StoreMsg(_ context.Context, msg *types.SignedMessage) error {
 	if msg.Signature.Type != crypto.SigTypeDelegated {
-		return
+		return nil
 	}
 
+	txHash, err := m.getEthTxHash(msg)
+	if err != nil {
+		return err
+	}
+
+	return m.TransactionHashLookup.UpsertUniqueHash(txHash, msg.Cid())
+}
+
+func (m *EthTxHashManager) getEthTxHash(msg *types.SignedMessage) (ethtypes.EthHash, error) {
 	ethTx, err := ethtypes.EthTransactionFromSignedFilecoinMessage(msg)
 	if err != nil {
-		log.Errorf("error converting filecoin message to eth tx: %s", err)
-		return
+		return ethtypes.EthHash{}, err
 	}
 
-	txHash, err := ethTx.TxHash()
+	return ethTx.TxHash()
+}
+
+func (m *EthTxHashManager) ProcessSignedMessage(_ context.Context, msg *types.SignedMessage) {
+	txHash, err := m.getEthTxHash(msg)
 	if err != nil {
-		log.Errorf("error hashing transaction: %s", err)
+		log.Errorf("error converting filecoin message to eth tx: %s", err)
 		return
 	}
 
@@ -162,7 +183,7 @@ func WaitForMpoolUpdates(ctx context.Context, ch <-chan api.MpoolUpdate, manager
 	}
 }
 
-func EthTxHashGC(ctx context.Context, retentionDays int, manager *EthTxHashManager) {
+func EthTxHashGC(_ context.Context, retentionDays int, manager *EthTxHashManager) {
 	if retentionDays == 0 {
 		return
 	}

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -86,7 +86,7 @@ func EthModuleAPI(cfg config.FevmConfig, enableAutomaticBackFill bool, maxAutoma
 
 				if enableAutomaticBackFill { // If the db exists and back-fill is enabled, we'll back-fill missing entries
 					go func() { // since there is only one DB connection, so we can do this in a goroutine without worrying about concurrent write issues
-						err = ethTxHashManager.FillIndexGap(head, mctx, abi.ChainEpoch(maxAutomaticBackFillBlocks))
+						err = ethTxHashManager.FillIndexGap(mctx, head, abi.ChainEpoch(maxAutomaticBackFillBlocks))
 						if err != nil {
 							log.Warnf("error when back-filling transaction index gap: %w", err)
 						}

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/filecoin-project/go-state-types/abi"
-
 	"github.com/filecoin-project/lotus/chain/ethhashlookup"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/messagepool"
@@ -22,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/modules/helpers"
 	"github.com/filecoin-project/lotus/node/repo"
+	"golang.org/x/xerrors"
 )
 
 func EthModuleAPI(cfg config.FevmConfig, enableAutomaticBackFill bool, maxAutomaticBackFillBlocks uint64) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *store.ChainStore, *stmgr.StateManager, EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI, full.MpoolAPI, full.SyncAPI, *full.EthEventHandler) (*full.EthModule, error) {

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -25,7 +25,7 @@ import (
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
-func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *store.ChainStore, *stmgr.StateManager, EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI, full.MpoolAPI, full.SyncAPI, *full.EthEventHandler) (*full.EthModule, error) {
+func EthModuleAPI(cfg config.FevmConfig, enableAutomaticBackFill bool) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *store.ChainStore, *stmgr.StateManager, EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI, full.MpoolAPI, full.SyncAPI, *full.EthEventHandler) (*full.EthModule, error) {
 	return func(mctx helpers.MetricsCtx, r repo.LockedRepo, lc fx.Lifecycle, cs *store.ChainStore, sm *stmgr.StateManager, evapi EventHelperAPI, mp *messagepool.MessagePool, stateapi full.StateAPI, chainapi full.ChainAPI, mpoolapi full.MpoolAPI, syncapi full.SyncAPI, ethEventHandler *full.EthEventHandler) (*full.EthModule, error) {
 		ctx := helpers.LifecycleCtx(mctx, lc)
 
@@ -61,6 +61,11 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 			if err != nil {
 				return nil, err
 			}
+		} else if enableAutomaticBackFill { // If the db exists and back-fill is enabled, we'll back-fill missing entries
+			err = ethTxHashManager.FillIndexGap(mctx)
+			if err != nil {
+				return nil, xerrors.Errorf("error when back-filling transaction index gap: %w", err)
+			}
 		}
 
 		// prefill the whole skiplist cache maintained internally by the GetTipsetByHeight
@@ -82,7 +87,7 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 				}
 
 				// Tipset listener
-				_ = ev.Observe(&ethTxHashManager)
+				ev.Observe(&ethTxHashManager)
 
 				ch, err := mp.Updates(ctx)
 				if err != nil {


### PR DESCRIPTION
## Related Issues
Fixes part of: #11007 

## Proposed Changes
- Adds `EnableAutomaticBackFill` in index config in `fullNode`
- Adds `MaxAutomaticBackFillTxIndexHeight` in index config in `fullnode`
- Tries to fill the gap between the last populated from `current tipset tx hashes` till:
  - we reach `MaxAutomaticBackFillTxIndexHeight` or
  - we reach a conflict in the `eth tx hash index` database
- Adds `PopulateAfterSnapshot` for eth tx hash index to populate data for while loading from snapshot