### PR TITLE
[skip changelog] feat(f3): override F3BootstrapEpoch on 2k devnet with environment variable

### DIFF
--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -6,6 +6,7 @@ package buildconstants
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 
@@ -106,6 +107,15 @@ func init() {
 
 	GenesisNetworkVersion = getGenesisNetworkVersion("LOTUS_GENESIS_NETWORK_VERSION", GenesisNetworkVersion)
 
+	getBoolean := func(ev string, def bool) bool {
+		hs, found := os.LookupEnv(ev)
+		if found {
+			return hs == "1" || strings.ToLower(hs) == "true"
+		}
+
+		return def
+	}
+
 	getUpgradeHeight := func(ev string, def abi.ChainEpoch) abi.ChainEpoch {
 		hs, found := os.LookupEnv(ev)
 		if found {
@@ -152,6 +162,9 @@ func init() {
 		0: DrandQuicknet,
 	}
 
+	F3Enabled = getBoolean("LOTUS_F3_ENABLED", F3Enabled)
+	F3BootstrapEpoch = getUpgradeHeight("LOTUS_F3_BOOTSTRAP_EPOCH", F3BootstrapEpoch)
+
 	BuildType |= Build2k
 
 }
@@ -179,6 +192,8 @@ const Eip155ChainId = 31415926
 
 var WhitelistedBlock = cid.Undef
 
-const F3Enabled = true
+var F3Enabled = true
+
 const ManifestServerID = "12D3KooWHcNBkqXEBrsjoveQvj6zDF3vK5S9tAfqyYaQF1LGSJwG"
-const F3BootstrapEpoch abi.ChainEpoch = 1000
+
+var F3BootstrapEpoch abi.ChainEpoch = 1000


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

To facilitate local and CI testing for F3 on forest side, this PR adds environment variables to override `F3Enabled` and `F3BootstrapEpcoh` on 2k devnet. (just like how network upgrade epochs can be overridden with environment variables)

(Skipping changelog as similar `LOTUS_{NETWORK}_HEIGHT` changes do not present in CHANGELOG.md)

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title is in the form of of `<PR type>: <area>: <change being made>`
  - example: ` fix: mempool: Introduce a cache for valid signatures`
  - `PR type`: fix, feat, build, chore, ci, docs, perf, refactor, revert, style, test
  - `area`, e.g. api, chain, state, mempool, multisig, networking, paych, proving, sealing, wallet, deps
- [x] Update CHANGELOG.md or signal that this change does not need it.
  - If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
  - If the change does not require a CHANGELOG.md entry, do one of the following:
    - Add `[skip changelog]` to the PR title
    - Add the label `skip/changelog` to the PR
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
