### PR TITLE
fix: chain: use instance-local verifier to VerifyWinningPoSt

### DIFF
--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -30,7 +30,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/proofs"
-	proofsffi "github.com/filecoin-project/lotus/chain/proofs/ffi"
 	"github.com/filecoin-project/lotus/chain/rand"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -369,8 +368,7 @@ func (filec *FilecoinEC) VerifyWinningPoStProof(ctx context.Context, nv network.
 		}
 	}
 
-	// TODO(rvagg): why is this using proofsffi.ProofVerifier.VerifyWinningPoSt directly and not filec.verifier.VerifyWinningPoSt?
-	ok, err := proofsffi.ProofVerifier.VerifyWinningPoSt(ctx, proof.WinningPoStVerifyInfo{
+	ok, err := filec.verifier.VerifyWinningPoSt(ctx, proof.WinningPoStVerifyInfo{
 		Randomness:        rand,
 		Proofs:            h.WinPoStProof,
 		ChallengedSectors: sectors,


### PR DESCRIPTION
This was likely a mistake in the implementation, instead of using the verifier attached to the instance it reached directly into ffi.

The only place, other than the DI builder that we make a new `FilecoinEC` is where we just use it to `CreateBlock`, where we don't insert a verifier, but this doesn't touch this pathway. https://github.com/filecoin-project/lotus/blob/ee00791d9b49278b42ae4f3eb1bf85852da32ca8/chain/gen/gen.go#L511

`VerifyBlock` does go here but we're only doing that in the syncer and it's setup by DI properly.

The only other explanation I have for this, if not a mistake, is that it was done for testing purposes but I can't see anything failing.
