### PR TITLE
feat: ETH RPC: Use Block Cache for `EthGetBlockByHash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## Enhancements
 
 - fix: add datacap balance to circ supply internal accounting as unCirc #12348
+- feat: Use a block cache to speed up the `EthGetBlockByHash` API: https://github.com/filecoin-project/lotus/pull/12359
 
 # v1.28.1 / 2024-07-24
 

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -241,6 +241,16 @@
   # env var: LOTUS_FEVM_ETHTRACEFILTERMAXRESULTS
   #EthTraceFilterMaxResults = 500
 
+  # EthBlkCacheSize specifies the size of the cache used for caching Ethereum blocks.
+  # This cache enhances the performance of the eth_getBlockByHash RPC call by minimizing the need to access chain state for
+  # recently requested blocks that are already cached.
+  # The default size of the cache is 500 blocks.
+  # Note: Setting this value to 0 disables the cache.
+  #
+  # type: int
+  # env var: LOTUS_FEVM_ETHBLKCACHESIZE
+  #EthBlkCacheSize = 500
+
 
 [Events]
   # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -306,6 +306,13 @@ func WithEthRPC() NodeOpt {
 	})
 }
 
+func DisableETHBlockCache() NodeOpt {
+	return WithCfgOpt(func(cfg *config.FullNode) error {
+		cfg.Fevm.EthBlkCacheSize = 0
+		return nil
+	})
+}
+
 func DisableEthRPC() NodeOpt {
 	return WithCfgOpt(func(cfg *config.FullNode) error {
 		cfg.Fevm.EnableEthRPC = false

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -86,6 +86,7 @@ func DefaultFullNode() *FullNode {
 			EnableEthRPC:                 false,
 			EthTxHashMappingLifetimeDays: 0,
 			EthTraceFilterMaxResults:     500,
+			EthBlkCacheSize:              500,
 		},
 		Events: EventsConfig{
 			DisableRealTimeFilterAPI: false,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -238,6 +238,16 @@ Set to 0 to keep all mappings`,
 
 			Comment: ``,
 		},
+		{
+			Name: "EthBlkCacheSize",
+			Type: "int",
+
+			Comment: `EthBlkCacheSize specifies the size of the cache used for caching Ethereum blocks.
+This cache enhances the performance of the eth_getBlockByHash RPC call by minimizing the need to access chain state for
+recently requested blocks that are already cached.
+The default size of the cache is 500 blocks.
+Note: Setting this value to 0 disables the cache.`,
+		},
 	},
 	"FullNode": {
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -550,6 +550,13 @@ type FevmConfig struct {
 	EthTraceFilterMaxResults uint64
 
 	Events DeprecatedEvents `toml:"Events,omitempty"`
+
+	// EthBlkCacheSize specifies the size of the cache used for caching Ethereum blocks.
+	// This cache enhances the performance of the eth_getBlockByHash RPC call by minimizing the need to access chain state for
+	// recently requested blocks that are already cached.
+	// The default size of the cache is 500 blocks.
+	// Note: Setting this value to 0 disables the cache.
+	EthBlkCacheSize int
 }
 
 type DeprecatedEvents struct {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -140,8 +140,8 @@ type EthModule struct {
 	EthTraceFilterMaxResults uint64
 	EthEventHandler          *EthEventHandler
 
-	EthBlkCache   *arc.ARCCache[cid.Cid, *ethtypes.EthBlock]
-	EthBlkTxCache *arc.ARCCache[cid.Cid, *ethtypes.EthBlock]
+	EthBlkCache   *arc.ARCCache[cid.Cid, *ethtypes.EthBlock] // caches blocks by their CID but blocks only have the transaction hashes
+	EthBlkTxCache *arc.ARCCache[cid.Cid, *ethtypes.EthBlock] // caches blocks along with full transaction payload by their CID
 
 	ChainAPI
 	MpoolAPI
@@ -322,7 +322,7 @@ func (a *EthModule) EthGetBlockByHash(ctx context.Context, blkHash ethtypes.EthH
 	// Fetch the tipset using the block hash
 	ts, err := a.Chain.GetTipSetByCid(ctx, cid)
 	if err != nil {
-		return ethtypes.EthBlock{}, xerrors.Errorf("failed to load tipset by CID %s: %w", blkHash.String(), err)
+		return ethtypes.EthBlock{}, xerrors.Errorf("failed to load tipset by CID %s: %w", cid, err)
 	}
 
 	// Generate an Ethereum block from the Filecoin tipset


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/10520.

Part of https://github.com/filecoin-project/lotus/issues/12293.