### PR TITLE
fix(ci): support checking forks in PR-title check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,7 +1,7 @@
 name: PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Related Issues
Encountered this workflow-failure when looking at merging: https://github.com/filecoin-project/lotus/pull/12354#issuecomment-2277613048

## Proposed Changes
- Use `pull_request_target` event trigger in `pr-title-check-yml` in order to support checking PRs from forks.

## Additional Info
Creating this PR from my Lotus-fork to confirm that it now succeeds

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
