### PR TITLE
ci: improve stalebot behavior/language

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,16 +17,16 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ github.token }}
-        stale-issue-message: 'Oops, seems like we needed more information for this issue, please comment with more details or this issue will be closed in 24 hours.'
+        stale-issue-message: 'We needed more information for this issue, please comment with more details or this issue will be closed in 72 hours.'
         close-issue-message: 'This issue was closed because it is missing author input.'
-        stale-pr-message: 'Thank you for submitting the PR and contributing to lotus! Lotus maintainers need more of your input before merging it, please address the suggested changes or reply to the comments or this PR will be closed in 48 hours. You are always more than welcome to reopen the PR later as well!'
+        stale-pr-message: 'Thank you for submitting the PR and contributing to lotus! Lotus maintainers need more of your input before merging it, please address the suggested changes or reply to the comments or this PR will be closed in 72 hours. You are always more than welcome to reopen the PR later as well!'
         close-pr-message: 'This PR was closed because it is missing author input. Please feel free to reopen the PR when you get to it! Thank you for your interest in contributing to lotus!'
         stale-issue-label: 'kind/stale'
         stale-pr-label: 'kind/stale'
         any-of-labels: 'need/author-input '
         days-before-issue-stale: 3
-        days-before-issue-close: 1
+        days-before-issue-close: 3
         days-before-pr-stale: 5
-        days-before-pr-close: 2
+        days-before-pr-close: 3
         remove-stale-when-updated: true
         enable-statistics: true


### PR DESCRIPTION
1. Remove the cutesy language, it's kind of insulting. Happy to revert this change if people feel strongly, but I _really_ don't like it when companies do this kind of thing.
2. Extend the close delay for both PRs and issues to 72 hours. We don't really need a response within a day and requiring a response within a day is pretty demanding.