### PR TITLE
docs: pr title check fix to link to right doc

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
       - if: steps.changelog.outputs.modified == '0'
         env:
           MESSAGE: |
-            docs/changelogs/ was not modified in this PR. Please do one of the options in [changelog management conventions](https://github.com/filecoin-project/lotus/blob/master/README.md#changelog-management)
+            docs/changelogs/ was not modified in this PR. Please do one of the options in [changelog management conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
         run: |
           echo "::error::${MESSAGE//$'\n'/%0A}"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -26,7 +26,7 @@ jobs:
               await github.rest.pulls.createReview({
                 ...context.repo,
                 pull_number: context.payload.pull_request.number,
-                body: 'Please update the PR title to match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions',
+                body: 'Please update the PR title to match https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions',
                 event: 'REQUEST_CHANGES'
               });
               core.setFailed('PR title does not match the required format');


### PR DESCRIPTION
Linking to https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions instead of README.

I used the wrong URLs in https://github.com/filecoin-project/lotus/pull/12361