### PR TITLE
chore: bump `MinerBuildVersion` in master to v1.28.3-dev

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -18,7 +18,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.28.2-dev"
+const MinerBuildVersion = "1.28.3-dev"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.2-dev
+   1.28.3-dev
 
 COMMANDS:
    init          Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -7,7 +7,7 @@ USAGE:
    lotus-worker [global options] command [command options] [arguments...]
 
 VERSION:
-   1.28.2-dev
+   1.28.3-dev
 
 COMMANDS:
    run        Start lotus worker


### PR DESCRIPTION
## Related Issues
#12379 

## Proposed Changes
As part of the release checklist, bump the `MinerBuildVersion` in master.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
~~- [ ] New features have usage guidelines and / or documentation updates in~~
  ~~- [ ] [Lotus Documentation](https://lotus.filecoin.io)~~
 ~~- [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)~~
~~- [ ] Tests exist for new functionality or change in behavior~~
- [ ] CI is green
