### PR TITLE
[skip changelog] feat(f3): move F3 pubsub topics to F3 module

### DIFF
--- a/build/buildconstants/shared_funcs.go
+++ b/build/buildconstants/shared_funcs.go
@@ -2,6 +2,7 @@ package buildconstants
 
 import (
 	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -30,4 +31,12 @@ func IsNearUpgrade(epoch, upgradeEpoch abi.ChainEpoch) bool {
 		return false
 	}
 	return epoch > upgradeEpoch-policy.ChainFinality && epoch < upgradeEpoch+policy.ChainFinality
+}
+
+func MustParseID(id string) peer.ID {
+	p, err := peer.Decode(id)
+	if err != nil {
+		panic(err)
+	}
+	return p
 }

--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -3,6 +3,8 @@ package build
 import (
 	"os"
 
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/filecoin-project/lotus/build/buildconstants"
@@ -23,6 +25,9 @@ func IndexerIngestTopic(netName dtypes.NetworkName) string {
 	}
 
 	return "/indexer/ingest/" + nn
+}
+func F3TopicName(netName dtypes.NetworkName) string {
+	return manifest.PubSubTopicFromNetworkName(gpbft.NetworkName(netName))
 }
 func DhtProtocolName(netName dtypes.NetworkName) protocol.ID {
 	return protocol.ID("/fil/kad/" + string(netName))

--- a/chain/lf3/manifest.go
+++ b/chain/lf3/manifest.go
@@ -1,12 +1,14 @@
 package lf3
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/fx"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
@@ -16,7 +18,54 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
-func NewManifestProvider(nn dtypes.NetworkName, ps *pubsub.PubSub, mds dtypes.MetadataDS) manifest.ManifestProvider {
+// Determines the max. number of configuration changes
+// that are allowed for the dynamic manifest.
+// If the manifest changes more than this number, the F3
+// message topic will be filtered
+var MaxDynamicManifestChangesAllowed = 1000
+
+type ManifestOut struct {
+	fx.Out
+
+	ManifestProvider manifest.ManifestProvider
+	PubsubTopics     []string `group:"pubsub-topic,flatten"`
+}
+
+func NewManifestProvider(provider peer.ID) any {
+	if provider == "" {
+		return manifest.NewStaticManifestProvider
+	}
+	return func(m *manifest.Manifest, ps *pubsub.PubSub, mds dtypes.MetadataDS) ManifestOut {
+		var out ManifestOut
+		ds := namespace.Wrap(mds, datastore.NewKey("/f3-dynamic-manifest"))
+		f3BaseTopicName := manifest.PubSubTopicFromNetworkName(gpbft.NetworkName(m.NetworkName))
+		out.ManifestProvider = manifest.NewDynamicManifestProvider(m, ds, ps, provider)
+		out.PubsubTopics = append(out.PubsubTopics, manifest.ManifestPubSubTopicName)
+
+		// allow dynamic manifest topic and the new topic names after a reconfiguration.
+		// Note: This is pretty ugly, but I tried to use a regex subscription filter
+		// as the commented code below, but unfortunately it overwrites previous filters. A simple fix would
+		// be to allow combining several topic filters, but for now this works.
+		//
+		// 	pattern := fmt.Sprintf(`^\/f3\/%s\/0\.0\.1\/?[0-9]*$`, in.Nn)
+		// 	rx, err := regexp.Compile(pattern)
+		// 	if err != nil {
+		// 		return nil, xerrors.Errorf("failed to compile manifest topic regex: %w", err)
+		// 	}
+		// 	options = append(options,
+		// 		pubsub.WithSubscriptionFilter(
+		// 			pubsub.WrapLimitSubscriptionFilter(
+		// 				pubsub.NewRegexpSubscriptionFilter(rx),
+		// 				100)))
+		for i := 0; i < MaxDynamicManifestChangesAllowed; i++ {
+			out.PubsubTopics = append(out.PubsubTopics, fmt.Sprintf("%s/%d", f3BaseTopicName, i))
+		}
+
+		return out
+	}
+}
+
+func NewManifest(nn dtypes.NetworkName) *manifest.Manifest {
 	m := manifest.LocalDevnetManifest()
 	m.NetworkName = gpbft.NetworkName(nn)
 	m.EC.Period = time.Duration(buildconstants.BlockDelaySecs) * time.Second
@@ -33,13 +82,5 @@ func NewManifestProvider(nn dtypes.NetworkName, ps *pubsub.PubSub, mds dtypes.Me
 	// TODO: We're forcing this to start paused for now. We need to remove this for the final
 	// mainnet launch.
 	m.Pause = true
-
-	switch manifestServerID, err := peer.Decode(buildconstants.ManifestServerID); {
-	case err != nil:
-		log.Warnw("Cannot decode F3 manifest sever identity; falling back on static manifest provider", "err", err)
-		return manifest.NewStaticManifestProvider(m)
-	default:
-		ds := namespace.Wrap(mds, datastore.NewKey("/f3-dynamic-manifest"))
-		return manifest.NewDynamicManifestProvider(m, ds, ps, manifestServerID)
-	}
+	return m
 }

--- a/node/builder.go
+++ b/node/builder.go
@@ -56,19 +56,20 @@ type special struct{ id int }
 
 //nolint:golint
 var (
-	DefaultTransportsKey = special{0}  // Libp2p option
-	DiscoveryHandlerKey  = special{2}  // Private type
-	AddrsFactoryKey      = special{3}  // Libp2p option
-	SmuxTransportKey     = special{4}  // Libp2p option
-	RelayKey             = special{5}  // Libp2p option
-	SecurityKey          = special{6}  // Libp2p option
-	BaseRoutingKey       = special{7}  // fx groups + multiret
-	NatPortMapKey        = special{8}  // Libp2p option
-	ConnectionManagerKey = special{9}  // Libp2p option
-	AutoNATSvcKey        = special{10} // Libp2p option
-	BandwidthReporterKey = special{11} // Libp2p option
-	ConnGaterKey         = special{12} // Libp2p option
-	ResourceManagerKey   = special{14} // Libp2p option
+	DefaultTransportsKey  = special{0}  // Libp2p option
+	DiscoveryHandlerKey   = special{2}  // Private type
+	AddrsFactoryKey       = special{3}  // Libp2p option
+	SmuxTransportKey      = special{4}  // Libp2p option
+	RelayKey              = special{5}  // Libp2p option
+	SecurityKey           = special{6}  // Libp2p option
+	BaseRoutingKey        = special{7}  // fx groups + multiret
+	NatPortMapKey         = special{8}  // Libp2p option
+	ConnectionManagerKey  = special{9}  // Libp2p option
+	AutoNATSvcKey         = special{10} // Libp2p option
+	BandwidthReporterKey  = special{11} // Libp2p option
+	ConnGaterKey          = special{12} // Libp2p option
+	ResourceManagerKey    = special{14} // Libp2p option
+	F3ManifestProviderKey = special{15} // F3 Manifest Provider + pubsub topics
 )
 
 type invoke int

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -163,7 +163,8 @@ var ChainNode = Options(
 	),
 
 	If(build.IsF3Enabled(),
-		Override(new(manifest.ManifestProvider), lf3.NewManifestProvider),
+		Override(new(*manifest.Manifest), lf3.NewManifest),
+		Override(F3ManifestProviderKey, lf3.NewManifestProvider(buildconstants.F3ManifestServerID)),
 		Override(new(*lf3.F3), lf3.New),
 	),
 )


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Pre-requisite for #12204


## Proposed Changes
<!-- A clear list of the changes being made -->

Move F3 pubsub topics to F3 module. This way, we don't have to rely on a global variable to determine if F3 is enabled, which will make testing easier. Instead, we can provide the pubsub topics when we provide the F3 manifest provider and service.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green