### PR TITLE
Backport pledge fixes to 1.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This patch release backports [PR #12341](https://github.com/filecoin-project/lot
 
 ## ☢️ Upgrade Warnings ☢️
 - The `releases` branch has been deprecated with the 202408 split of 'Lotus Node' and 'Lotus Miner'. See https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives for more info and alternatives for getting the latest release for both the 'Lotus Node' and 'Lotus Miner' based on the [Branch and Tag Strategy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#branch-and-tag-strategy).
-- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher` and `storage/pipeline.New`. They now have an additional error return to deal with errors arising from fetching the sealing config.
+- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher` and `storage/pipeline.New` and `sealing.NewCommitBatcher`. They now have an additional error return to deal with errors arising from fetching the sealing config.
 
 # v1.28.1 / 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This patch release backports [PR #12341](https://github.com/filecoin-project/lot
 
 ## ☢️ Upgrade Warnings ☢️
 - The `releases` branch has been deprecated with the 202408 split of 'Lotus Node' and 'Lotus Miner'. See https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives for more info and alternatives for getting the latest release for both the 'Lotus Node' and 'Lotus Miner' based on the [Branch and Tag Strategy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#branch-and-tag-strategy).
-- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher` and `storage/pipeline.New` and `sealing.NewCommitBatcher`. They now have an additional error return to deal with errors arising from fetching the sealing config.
+- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher`, `sealing.NewCommitBatcher` and `storage/pipeline.New`. They now have an additional error return to deal with errors arising from fetching the sealing config.
 
 # v1.28.1 / 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This patch release backports [PR #12341](https://github.com/filecoin-project/lot
 
 ## ☢️ Upgrade Warnings ☢️
 - The `releases` branch has been deprecated with the 202408 split of 'Lotus Node' and 'Lotus Miner'. See https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives for more info and alternatives for getting the latest release for both the 'Lotus Node' and 'Lotus Miner' based on the [Branch and Tag Strategy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#branch-and-tag-strategy).
+- Breaking change in public APIs `storage/pipeline.NewPreCommitBatcher` and `storage/pipeline.New`. They now have an additional error return to deal with errors arising from fetching the sealing config.
 
 # v1.28.1 / 2024-07-24
 

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -172,6 +172,8 @@ func (ts *apiSuite) testOutOfGasError(t *testing.T) {
 		build.BlockGasLimit = originalLimit
 	}()
 
+	t.Logf("BlockGasLimit changed: %d", build.BlockGasLimit)
+
 	msg := &types.Message{
 		From:  senderAddr,
 		To:    senderAddr,
@@ -288,6 +290,7 @@ func (ts *apiSuite) testNonGenesisMiner(t *testing.T) {
 	ctx := context.Background()
 
 	full, genesisMiner, ens := kit.EnsembleMinimal(t, append(ts.opts, kit.MockProofs())...)
+
 	ens.InterconnectAll().BeginMining(4 * time.Millisecond)
 
 	time.Sleep(1 * time.Second)

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -255,7 +255,10 @@ func SealingPipeline(fc config.MinerFeeConfig) func(params SealingPipelineParams
 		provingBuffer := md.WPoStProvingPeriod * 2
 		pcp := sealing.NewBasicPreCommitPolicy(api, gsd, provingBuffer)
 
-		pipeline := sealing.New(ctx, api, fc, evts, maddr, ds, sealer, verif, prover, &pcp, gsd, j, as)
+		pipeline, err := sealing.New(ctx, api, fc, evts, maddr, ds, sealer, verif, prover, &pcp, gsd, j, as)
+		if err != nil {
+			return nil, xerrors.Errorf("creating sealing pipeline: %w", err)
+		}
 
 		lc.Append(fx.Hook{
 			OnStart: func(context.Context) error {

--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -81,7 +81,7 @@ type CommitBatcher struct {
 	lk                    sync.Mutex
 }
 
-func NewCommitBatcher(mctx context.Context, maddr address.Address, api CommitBatcherApi, addrSel AddressSelector, feeCfg config.MinerFeeConfig, getConfig dtypes.GetSealingConfigFunc, prov storiface.Prover) *CommitBatcher {
+func NewCommitBatcher(mctx context.Context, maddr address.Address, api CommitBatcherApi, addrSel AddressSelector, feeCfg config.MinerFeeConfig, getConfig dtypes.GetSealingConfigFunc, prov storiface.Prover) (*CommitBatcher, error) {
 	b := &CommitBatcher{
 		api:       api,
 		maddr:     maddr,
@@ -101,19 +101,19 @@ func NewCommitBatcher(mctx context.Context, maddr address.Address, api CommitBat
 		stopped: make(chan struct{}),
 	}
 
-	go b.run()
-
-	return b
-}
-
-func (b *CommitBatcher) run() {
-	var forceRes chan []sealiface.CommitBatchRes
-	var lastMsg []sealiface.CommitBatchRes
-
 	cfg, err := b.getConfig()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
+
+	go b.run(cfg)
+
+	return b, nil
+}
+
+func (b *CommitBatcher) run(cfg sealiface.Config) {
+	var forceRes chan []sealiface.CommitBatchRes
+	var lastMsg []sealiface.CommitBatchRes
 
 	timer := time.NewTimer(b.batchWait(cfg.CommitBatchWait, cfg.CommitBatchSlack))
 	for {

--- a/storage/pipeline/mocks/mock_commit_batcher.go
+++ b/storage/pipeline/mocks/mock_commit_batcher.go
@@ -164,21 +164,6 @@ func (mr *MockCommitBatcherApiMockRecorder) StateMinerInfo(arg0, arg1, arg2 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateMinerInfo", reflect.TypeOf((*MockCommitBatcherApi)(nil).StateMinerInfo), arg0, arg1, arg2)
 }
 
-// StateMinerInitialPledgeCollateral mocks base method.
-func (m *MockCommitBatcherApi) StateMinerInitialPledgeCollateral(arg0 context.Context, arg1 address.Address, arg2 miner.SectorPreCommitInfo, arg3 types.TipSetKey) (big.Int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateMinerInitialPledgeCollateral", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(big.Int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StateMinerInitialPledgeCollateral indicates an expected call of StateMinerInitialPledgeCollateral.
-func (mr *MockCommitBatcherApiMockRecorder) StateMinerInitialPledgeCollateral(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateMinerInitialPledgeCollateral", reflect.TypeOf((*MockCommitBatcherApi)(nil).StateMinerInitialPledgeCollateral), arg0, arg1, arg2, arg3)
-}
-
 // StateNetworkVersion mocks base method.
 func (m *MockCommitBatcherApi) StateNetworkVersion(arg0 context.Context, arg1 types.TipSetKey) (network.Version, error) {
 	m.ctrl.T.Helper()

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -258,9 +258,7 @@ func New(mctx context.Context, sapi SealingAPI, fc config.MinerFeeConfig, events
 		addrSel: addrSel,
 
 		terminator: NewTerminationBatcher(mctx, maddr, sapi, addrSel, fc, gc),
-		commiter:   NewCommitBatcher(mctx, maddr, sapi, addrSel, fc, gc, prov),
-
-		getConfig: gc,
+		getConfig:  gc,
 
 		legacySc: storedcounter.New(ds, datastore.NewKey(StorageCounterDSPrefix)),
 
@@ -274,6 +272,12 @@ func New(mctx context.Context, sapi SealingAPI, fc config.MinerFeeConfig, events
 		return nil, err
 	}
 	s.precommiter = pc
+
+	cc, err := NewCommitBatcher(mctx, maddr, sapi, addrSel, fc, gc, prov)
+	if err != nil {
+		return nil, err
+	}
+	s.commiter = cc
 
 	s.notifee = func(before, after SectorInfo) {
 		s.journal.RecordEvent(s.sealingEvtType, func() interface{} {

--- a/storage/pipeline/sealing.go
+++ b/storage/pipeline/sealing.go
@@ -273,7 +273,7 @@ func New(mctx context.Context, sapi SealingAPI, fc config.MinerFeeConfig, events
 	}
 	s.precommiter = pc
 
-	cc, err := NewCommitBatcher(mctx, maddr, sapi, addrSel, fc, gc, prov)
+	cc, err := NewCommitBatcher(mctx, maddr, sapi, addrSel, fc, gc, prov, s)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/pipeline/states_replica_update.go
+++ b/storage/pipeline/states_replica_update.go
@@ -143,6 +143,13 @@ func (m *Sealing) handleSubmitReplicaUpdate(ctx statemachine.Context, sector Sec
 		return ctx.Send(SectorSubmitReplicaUpdateFailed{})
 	}
 
+	log.Infow("submitting replica update",
+		"sector", sector.SectorNumber,
+		"weight", types.FIL(weightUpdate),
+		"totalPledge", types.FIL(collateral),
+		"initialPledge", types.FIL(onChainInfo.InitialPledge),
+		"toPledge", types.FIL(big.Sub(collateral, onChainInfo.InitialPledge)))
+
 	collateral = big.Sub(collateral, onChainInfo.InitialPledge)
 	if collateral.LessThan(big.Zero()) {
 		collateral = big.Zero()

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -780,6 +780,16 @@ func (m *Sealing) handleSubmitCommitAggregate(ctx statemachine.Context, sector S
 		return err
 	}
 
+	pci, err := m.Api.StateSectorPreCommitInfo(ctx.Context(), m.maddr, sector.SectorNumber, types.EmptyTSK)
+	if err != nil {
+		return xerrors.Errorf("getting precommit info: %w", err)
+	}
+
+	weight, err := m.sectorWeight(ctx.Context(), sector, pci.Info.Expiration)
+	if err != nil {
+		return xerrors.Errorf("getting sector weight: %w", err)
+	}
+
 	res, err := m.commiter.AddCommit(ctx.Context(), sector, AggregateInput{
 		Info: proof.AggregateSealVerifyInfo{
 			Number:                sector.SectorNumber,
@@ -788,8 +798,9 @@ func (m *Sealing) handleSubmitCommitAggregate(ctx statemachine.Context, sector S
 			SealedCID:             *sector.CommR,
 			UnsealedCID:           *sector.CommD,
 		},
-		Proof: sector.Proof,
-		Spt:   sector.SectorType,
+		Proof:  sector.Proof,
+		Spt:    sector.SectorType,
+		Weight: weight,
 
 		ActivationManifest: miner2.SectorActivationManifest{
 			SectorNumber: sector.SectorNumber,


### PR DESCRIPTION
PR into @rjan90 's branch @ https://github.com/filecoin-project/lotus/pull/12385

Includes https://github.com/filecoin-project/lotus/pull/12238, https://github.com/filecoin-project/lotus/pull/12244, and the desired https://github.com/filecoin-project/lotus/pull/12341.

We could alternatively just do https://github.com/filecoin-project/lotus/pull/12341 but it's a little bit messier after the flaky test fixes from the other 2 PRs. But those PRs do break the storage/pipeline API a bit, as mentioned in the CHANGELOG, I just don't know anyone uses them externally or will really care.