### PR TITLE
fix(pubsub): Switch to a last-seen cache strategy

### DIFF
--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -9,6 +9,7 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p-pubsub/timecache"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/minio/blake2b-simd"
@@ -485,6 +486,10 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		options = append(options, pubsub.WithEventTracer(trw))
 		options = append(options, pubsub.WithPeerScoreInspect(pst.UpdatePeerScore, 10*time.Second))
 	}
+
+	// This way, we stop propegating a message until it drops off the network. Otherwise, we'll
+	// ignore the message for 2m then start broadcasting it again.
+	options = append(options, pubsub.WithSeenMessagesStrategy(timecache.Strategy_LastSeen))
 
 	return pubsub.NewGossipSub(helpers.LifecycleCtx(in.Mctx, in.Lc), in.Host, options...)
 }


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

We were using the default first-seen strategy which means we'd loop messages every 2 minutes (when they expire from the cache). This new strategy keeps the message in the cache until we haven't seen it for 2 minutes, ensuring that it eventually drops off the network (with high likelihood).

The downside to this change, and a reason to potentially not include it, is that it may significantly harm message propegation. Specifically:

1. Node sends a message.
2. Node's peers propegate it.
3. Peer re-sends it.
4. Nodes peers (the same peers) have already seen the message so they _don't_ propagate it. But some other nodes on the network didn't get it, so the message is censored.

In practice, we've configured our re-broadcast interval to be greater than the cache time so this may not be an issue? But this still isn't a straight-forward merge.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

The correct fix is message expiration: https://github.com/libp2p/go-libp2p-pubsub/issues/573, but that requires deeper protocol changes.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green