### PR TITLE
feat(index): add lotus shed commands to prune all indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - https://github.com/filecoin-project/lotus/pull/12332: fix: ETH RPC: receipts: use correct txtype in receipts
 - https://github.com/filecoin-project/lotus/pull/12335: fix: lotus-shed: store processed tipset after backfilling events
 - https://github.com/filecoin-project/lotus/pull/12341: fix: miner: Fix DDO pledge math
+- https://github.com/filecoin-project/lotus/pull/12393: feat(index): add lotus shed commands to prune all indexes
 
 ## ☢️ Upgrade Warnings ☢️
 

--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
+
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/lib/sqlite"

--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -10,10 +10,6 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/builtin"
-
-	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/lib/sqlite"
 )
@@ -132,14 +128,12 @@ func (ei *EthTxHashLookup) DeleteEntriesOlderThan(days int) (int64, error) {
 		return 0, xerrors.New("db closed")
 	}
 
-	epochs := abi.ChainEpoch(buildconstants.BlockDelaySecs * builtin.SecondsInDay * uint64(days))
-	return DeleteEntriesOlderThan(ei.db, epochs)
+	return DeleteEntriesOlderThan(ei.db, days)
 }
 
 // DeleteEntriesOlderThan deletes entries older than the given number of epochs from now.
-func DeleteEntriesOlderThan(db *sql.DB, epochs abi.ChainEpoch) (int64, error) {
-	secondsAgo := int64(epochs) * int64(buildconstants.BlockDelaySecs)
-	res, err := db.Exec(deleteOlderThan, "-"+strconv.FormatInt(secondsAgo, 10)+" seconds")
+func DeleteEntriesOlderThan(db *sql.DB, days int) (int64, error) {
+	res, err := db.Exec(deleteOlderThan, "-"+strconv.Itoa(days)+" day")
 	if err != nil {
 		return 0, err
 	}

--- a/chain/ethhashlookup/eth_transaction_hash_lookup.go
+++ b/chain/ethhashlookup/eth_transaction_hash_lookup.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/builtin"
-	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/ipfs/go-cid"
 	_ "github.com/mattn/go-sqlite3"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/lib/sqlite"
 )

--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -653,7 +653,7 @@ var backfillMsgIndexCmd = &cli.Command{
 			return err
 		}
 
-		defer closer()
+		defer closer() //nolint:errcheck
 		ctx := lcli.ReqContext(cctx)
 
 		curTs, err := api.ChainHead(ctx)
@@ -753,7 +753,7 @@ var pruneMsgIndexCmd = &cli.Command{
 		api := srvc.FullNodeAPI()
 		closer := srvc.Close
 
-		defer closer()
+		defer closer() //nolint:errcheck
 		ctx := lcli.ReqContext(cctx)
 
 		basePath, startHeight, err := parsePruneArgs(ctx, cctx, api)
@@ -790,7 +790,8 @@ var backfillTxHashCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		defer closer()
+
+		defer closer() //nolint:errcheck
 
 		ctx := lcli.ReqContext(cctx)
 

--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -816,7 +816,7 @@ var backfillTxHashCmd = &cli.Command{
 			return err
 		}
 
-		var totalRowsAffected int64 = 0
+		var totalRowsAffected int64
 		for i := 0; i < epochs; i++ {
 			epoch := abi.ChainEpoch(startHeight - int64(i))
 
@@ -1083,7 +1083,7 @@ func pruneEventsIndex(_ context.Context, basePath string, startHeight int64) err
 		return xerrors.Errorf("error deleting event: %w", err)
 	}
 
-	var totalRowsAffected int64 = 0
+	var totalRowsAffected int64
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
 		return xerrors.Errorf("error getting rows affected: %w", err)
@@ -1157,7 +1157,7 @@ func pruneTxIndex(ctx context.Context, api lapi.FullNode, basePath string, start
 		return err
 	}
 
-	var totalRowsAffected int64 = 0
+	var totalRowsAffected int64
 	for currTs != nil {
 		select {
 		case <-ctx.Done():

--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -757,7 +757,7 @@ var pruneMsgIndexCmd = &cli.Command{
 			return xerrors.Errorf("error parsing prune args: %w", err)
 		}
 
-		err = pruneMsgIndex(ctx, basePath, startHeight)
+		err = pruneMsgIndex(basePath, startHeight)
 		if err != nil {
 			return xerrors.Errorf("error pruning msgindex: %w", err)
 		}
@@ -992,7 +992,7 @@ var pruneAllIndexesCmd = &cli.Command{
 		var g = new(errgroup.Group)
 
 		g.Go(func() error {
-			if err := pruneMsgIndex(ctx, basePath, startHeight); err != nil {
+			if err := pruneMsgIndex(basePath, startHeight); err != nil {
 				return xerrors.Errorf("error pruning msgindex: %w", err)
 			}
 
@@ -1127,7 +1127,7 @@ func pruneTxIndex(basePath string, startHeight int64) error {
 }
 
 // pruneMsgIndex is a helper function that prunes the msgindex.db for messages older than a given height
-func pruneMsgIndex(_ context.Context, basePath string, startHeight int64) error {
+func pruneMsgIndex(basePath string, startHeight int64) error {
 	log.Infof("pruning msgindex")
 
 	dbPath := path.Join(basePath, indexesDBDir, index.DefaultDbFilename)

--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -44,8 +44,6 @@ const (
 const (
 	deleteMsgIndexFromStartHeight = `DELETE FROM messages WHERE epoch < ?`
 
-	deleteTxHashIndexByCID = `DELETE FROM eth_tx_hashes WHERE cid = ?`
-
 	deleteEventFromStartHeight   = `DELETE FROM event WHERE height < ?;`
 	deleteEventEntriesByEventIDs = `DELETE FROM event_entry WHERE event_id IN (SELECT id FROM event WHERE height < ?);`
 	deleteEventsSeenByHeight     = `DELETE FROM events_seen WHERE height < ?;`


### PR DESCRIPTION
## Related Issues
Fixes: #12377 

## Proposed Changes
- Add a `lotus-shed` command to prune the indexes, other 
  - Add a `prune-txhash` command to prune tx hash index
  - Add a `prune-events` command
  - refactor `prune-msgindex` command to prune the msg index
  - Add `prune-all-indexes` command to prune all the indexes (msg, events, tx hash)at once
 
- Use `older-than` flag to get the height to start pruning indexes older than the provided height