### PR TITLE
chore: update link to the correct sub-section in the Lotus Release Flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL=/usr/bin/env bash
 %:
 	@echo -e "### ⚠️⚠️⚠️ NOTICE ⚠️⚠️⚠️ ###\n" \
 	         "The 'releases' branch has been deprecated with the 202408 split of 'Lotus Node' and 'Lotus Miner'.\n" \
-		     "See https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md for more info and alternatives.\n" \
+		     "See https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives for more info and alternatives.\n" \
 		     "----------------------" | tee /dev/stderr
 	@exit 1
 


### PR DESCRIPTION
## Related Issues
#12374

## Proposed Changes
Update link when trying to `make clean / make all` in the `releases` branch to go directly to the https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives. 

This was applied in https://github.com/filecoin-project/lotus/pull/12375/commits/e6b35fe408671e4ebe1e129e4d17496b2f8c3574, but got overwritten by a later commit when adding a exit non-zero status code: https://github.com/filecoin-project/lotus/pull/12375/commits/9174306a0852ae0768f2a633940c7f36cf220c30.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
