### PR TITLE
fix(ci): don't PR or changelog check for draft PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - labeled
       - unlabeled
+      - ready_for_review
     paths:
       - '**.go'
       - '**/go.mod'
@@ -17,7 +18,8 @@ on:
 jobs:
   changelog:
     if: contains(github.event.pull_request.title, '[skip changelog]') == false &&
-        contains(github.event.pull_request.labels.*.name, 'skip/changelog') == false
+        contains(github.event.pull_request.labels.*.name, 'skip/changelog') == false &&
+        github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: Changelog
     steps:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,13 +2,19 @@ name: PR Title Check
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   pull-requests: write
 
 jobs:
   check-pr-title:
+    if: github.event.pull_request.draft == false
     name: Check PR Title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
       - reopened
       - ready_for_review
 


### PR DESCRIPTION
I was just noticing in https://github.com/filecoin-project/lotus/pull/12388 how unnecessary the GHA spam is for a Draft, so this should prevent that until you mark as ready-for-review, I think.