### PR TITLE
fix: test: trace_filter test can't be called on head

### DIFF
--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -688,6 +688,8 @@ func TestTraceFilter(t *testing.T) {
 	require.EqualValues(t, tracesx[0].TransactionHash, hash)
 	require.EqualValues(t, tracesx[0].BlockNumber, receipt.BlockNumber)
 
+	_ = client.WaitTillChain(ctx, kit.HeightAtLeast(abi.ChainEpoch(receipt.BlockNumber+1)))
+
 	// Define filter criteria
 	fromBlock := "0x1"
 	toBlock := fmt.Sprint(receipt.BlockNumber)


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lotus/blob/4a4ddaaeccc56bbd1e86db404726415921695da7/node/impl/full/eth_utils.go#L117-L121
Ref: https://github.com/filecoin-project/lotus/actions/runs/10665372320/job/29558625838
Ref: https://github.com/filecoin-project/lotus/issues/12001#issuecomment-2325209394
