### PR TITLE
docs: fix command for getting latest release tag in LOTUS_RELEASE_FLOW

### DIFF
--- a/LOTUS_RELEASE_FLOW.md
+++ b/LOTUS_RELEASE_FLOW.md
@@ -150,8 +150,8 @@ Given Lotus Miner is being actively replaced by [Curio](https://github.com/filec
 `releases` goal was to point to the latest stable tagged release of Lotus software for convenience and script.  This worked when Lotus Node and Miner were released together, but with the [2024Q3 split of releasing Lotus Node and Miner separately](https://github.com/filecoin-project/lotus/issues/12010), there isn't necessarily a single commit to track for the latest released software of both. Rather than having ambiguity by tracking Lotus Node or Lotus Miner releases, we [decided it was clearer to deprecate the branch](https://github.com/filecoin-project/lotus/issues/12374). 
 
 That said, one can still programmatically get the latest release based on the [Branch and Tag Strategy](#branch-and-tag-strategy) with:
-* Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1` 
-* Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1` 
+* Lotus Node: `git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1` 
+* Lotus Miner: `git tag -l 'miner/v*' | grep -v "-" | sort -V -r | head -n 1` 
 
 ## Related Items
 


### PR DESCRIPTION
Reported in https://filecoinproject.slack.com/archives/CP50PPW2X/p1726016827303709

Output now:

```
git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 10
v1.29.0
v1.28.2
v1.28.1
v1.28.0
v1.27.2
v1.27.1
v1.27.0
v1.26.3
v1.26.2
v1.26.1
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
