### PR TITLE
chore(deps): update go-state-types, adapt to QAP API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+## Improvements
+
+- The miner actor builtin `QAPowerForWeight` no longer accepts the unused "dealWeight" parameter, the function signature now only takes 3 arguments: sectorSize, sectorDuration, verifiedWeight. ([filecoin-project/lotus#12445](https://github.com/filecoin-project/lotus/pull/12445))
+
 ## Bug Fixes
 
 - Make `EthTraceFilter` / `trace_filter` skip null rounds instead of erroring. ([filecoin-project/lotus#12702](https://github.com/filecoin-project/lotus/pull/12702))

--- a/chain/actors/builtin/builtin.go
+++ b/chain/actors/builtin/builtin.go
@@ -8,8 +8,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
+	minertypes "github.com/filecoin-project/go-state-types/builtin/v15/miner"
 	smoothingtypes "github.com/filecoin-project/go-state-types/builtin/v8/util/smoothing"
-	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/manifest"
 	"github.com/filecoin-project/go-state-types/proof"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -56,8 +56,8 @@ type ExtendedSectorInfo = proof.ExtendedSectorInfo
 type PoStProof = proof.PoStProof
 type FilterEstimate = smoothingtypes.FilterEstimate
 
-func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, verifiedWeight abi.DealWeight) abi.StoragePower {
-	return minertypes.QAPowerForWeight(size, duration, dealWeight, verifiedWeight)
+func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, verifiedWeight abi.DealWeight) abi.StoragePower {
+	return minertypes.QAPowerForWeight(size, duration, verifiedWeight)
 }
 
 func ActorNameByCode(c cid.Cid) string {

--- a/chain/actors/builtin/builtin.go.template
+++ b/chain/actors/builtin/builtin.go.template
@@ -19,7 +19,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/actors"
 
-	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
+	minertypes "github.com/filecoin-project/go-state-types/builtin/v15/miner"
 	smoothingtypes "github.com/filecoin-project/go-state-types/builtin/v8/util/smoothing"
 )
 
@@ -56,8 +56,8 @@ type ExtendedSectorInfo = proof.ExtendedSectorInfo
 type PoStProof = proof.PoStProof
 type FilterEstimate = smoothingtypes.FilterEstimate
 
-func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, verifiedWeight abi.DealWeight) abi.StoragePower {
-	return minertypes.QAPowerForWeight(size, duration, dealWeight, verifiedWeight)
+func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, verifiedWeight abi.DealWeight) abi.StoragePower {
+	return minertypes.QAPowerForWeight(size, duration, verifiedWeight)
 }
 
 func ActorNameByCode(c cid.Cid) string {

--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -90,7 +90,7 @@ type State interface {
 	Proposals() (DealProposals, error)
 	VerifyDealsForActivation(
 		minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-	) (weight, verifiedWeight abi.DealWeight, err error)
+	) (verifiedWeight abi.DealWeight, err error)
 	NextID() (abi.DealID, error)
 	GetState() interface{}
 	GetAllocationIdForPendingDeal(dealId abi.DealID) (verifregtypes.AllocationId, error)

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -167,7 +167,7 @@ type State interface {
 	Proposals() (DealProposals, error)
 	VerifyDealsForActivation(
 		minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-	) (weight, verifiedWeight abi.DealWeight, err error)
+	) (verifiedWeight abi.DealWeight, err error)
 	NextID() (abi.DealID, error)
 	GetState() interface{}
 	GetAllocationIdForPendingDeal(dealId abi.DealID) (verifregtypes.AllocationId, error)

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -146,9 +146,9 @@ func (s *state{{.v}}) LockedTable() (BalanceTable, error) {
 
 func (s *state{{.v}}) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw{{if (ge .v 2)}}, _{{end}}, err := market{{.v}}.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw{{if (ge .v 2)}}, _{{end}}, err := market{{.v}}.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state{{.v}}) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v0.go
+++ b/chain/actors/builtin/market/v0.go
@@ -125,9 +125,9 @@ func (s *state0) LockedTable() (BalanceTable, error) {
 
 func (s *state0) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, err := market0.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, err := market0.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state0) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v10.go
+++ b/chain/actors/builtin/market/v10.go
@@ -124,9 +124,9 @@ func (s *state10) LockedTable() (BalanceTable, error) {
 
 func (s *state10) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market10.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market10.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state10) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v11.go
+++ b/chain/actors/builtin/market/v11.go
@@ -124,9 +124,9 @@ func (s *state11) LockedTable() (BalanceTable, error) {
 
 func (s *state11) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market11.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market11.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state11) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v12.go
+++ b/chain/actors/builtin/market/v12.go
@@ -124,9 +124,9 @@ func (s *state12) LockedTable() (BalanceTable, error) {
 
 func (s *state12) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market12.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market12.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state12) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v13.go
+++ b/chain/actors/builtin/market/v13.go
@@ -124,9 +124,9 @@ func (s *state13) LockedTable() (BalanceTable, error) {
 
 func (s *state13) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market13.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market13.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state13) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v14.go
+++ b/chain/actors/builtin/market/v14.go
@@ -124,9 +124,9 @@ func (s *state14) LockedTable() (BalanceTable, error) {
 
 func (s *state14) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market14.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market14.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state14) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v15.go
+++ b/chain/actors/builtin/market/v15.go
@@ -124,9 +124,9 @@ func (s *state15) LockedTable() (BalanceTable, error) {
 
 func (s *state15) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market15.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market15.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state15) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v2.go
+++ b/chain/actors/builtin/market/v2.go
@@ -125,9 +125,9 @@ func (s *state2) LockedTable() (BalanceTable, error) {
 
 func (s *state2) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market2.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market2.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state2) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v3.go
+++ b/chain/actors/builtin/market/v3.go
@@ -120,9 +120,9 @@ func (s *state3) LockedTable() (BalanceTable, error) {
 
 func (s *state3) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market3.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market3.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state3) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v4.go
+++ b/chain/actors/builtin/market/v4.go
@@ -120,9 +120,9 @@ func (s *state4) LockedTable() (BalanceTable, error) {
 
 func (s *state4) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market4.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market4.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state4) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v5.go
+++ b/chain/actors/builtin/market/v5.go
@@ -120,9 +120,9 @@ func (s *state5) LockedTable() (BalanceTable, error) {
 
 func (s *state5) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market5.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market5.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state5) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v6.go
+++ b/chain/actors/builtin/market/v6.go
@@ -122,9 +122,9 @@ func (s *state6) LockedTable() (BalanceTable, error) {
 
 func (s *state6) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market6.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market6.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state6) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v7.go
+++ b/chain/actors/builtin/market/v7.go
@@ -122,9 +122,9 @@ func (s *state7) LockedTable() (BalanceTable, error) {
 
 func (s *state7) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market7.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market7.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state7) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v8.go
+++ b/chain/actors/builtin/market/v8.go
@@ -123,9 +123,9 @@ func (s *state8) LockedTable() (BalanceTable, error) {
 
 func (s *state8) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market8.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market8.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state8) NextID() (abi.DealID, error) {

--- a/chain/actors/builtin/market/v9.go
+++ b/chain/actors/builtin/market/v9.go
@@ -124,9 +124,9 @@ func (s *state9) LockedTable() (BalanceTable, error) {
 
 func (s *state9) VerifyDealsForActivation(
 	minerAddr address.Address, deals []abi.DealID, currEpoch, sectorExpiry abi.ChainEpoch,
-) (weight, verifiedWeight abi.DealWeight, err error) {
-	w, vw, _, err := market9.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
-	return w, vw, err
+) (verifiedWeight abi.DealWeight, err error) {
+	_, vw, _, err := market9.ValidateDealsForActivation(&s.State, s.store, deals, minerAddr, sectorExpiry, currEpoch)
+	return vw, err
 }
 
 func (s *state9) NextID() (abi.DealID, error) {

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -293,7 +293,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 				}
 
 				rawPow = big.Add(rawPow, big.NewInt(int64(m.SectorSize)))
-				sectorWeight := builtin.QAPowerForWeight(m.SectorSize, minerInfos[i].presealExp, big.Zero(), markettypes.DealWeight(&preseal.Deal))
+				sectorWeight := builtin.QAPowerForWeight(m.SectorSize, minerInfos[i].presealExp, markettypes.DealWeight(&preseal.Deal))
 				minerInfos[i].sectorWeight = append(minerInfos[i].sectorWeight, sectorWeight)
 				qaPow = big.Add(qaPow, sectorWeight)
 			}

--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -1120,7 +1120,7 @@ func preFip0081StateMinerInitialPledgeForSector(ctx context.Context, t *testing.
 	req.NoError(err)
 
 	verifiedWeight := big.Mul(big.NewIntUnsigned(verifiedSize), big.NewInt(int64(sectorDuration)))
-	sectorWeight := builtin2.QAPowerForWeight(sectorSize, sectorDuration, big.Zero(), verifiedWeight)
+	sectorWeight := builtin2.QAPowerForWeight(sectorSize, sectorDuration, verifiedWeight)
 
 	thisEpochBaselinePower, err := rewardState.(interface {
 		ThisEpochBaselinePower() (abi.StoragePower, error)

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1449,12 +1449,12 @@ func (a *StateAPI) calculateSectorWeight(ctx context.Context, maddr address.Addr
 		return types.EmptyInt, xerrors.Errorf("loading market actor: %w", err)
 	} else if s, err := market.Load(store, act); err != nil {
 		return types.EmptyInt, xerrors.Errorf("loading market actor state: %w", err)
-	} else if w, vw, err := s.VerifyDealsForActivation(maddr, pci.DealIDs, height, pci.Expiration); err != nil {
+	} else if vw, err := s.VerifyDealsForActivation(maddr, pci.DealIDs, height, pci.Expiration); err != nil {
 		return types.EmptyInt, xerrors.Errorf("verifying deals for activation: %w", err)
 	} else {
 		// NB: not exactly accurate, but should always lead us to *over* estimate, not under
 		duration := pci.Expiration - height
-		sectorWeight = builtin.QAPowerForWeight(ssize, duration, w, vw)
+		sectorWeight = builtin.QAPowerForWeight(ssize, duration, vw)
 	}
 
 	return sectorWeight, nil
@@ -1640,7 +1640,7 @@ func (a *StateAPI) StateMinerInitialPledgeForSector(ctx context.Context, sectorD
 	}
 
 	verifiedWeight := big.Mul(big.NewIntUnsigned(verifiedSize), big.NewInt(int64(sectorDuration)))
-	sectorWeight := builtin.QAPowerForWeight(sectorSize, sectorDuration, big.Zero(), verifiedWeight)
+	sectorWeight := builtin.QAPowerForWeight(sectorSize, sectorDuration, verifiedWeight)
 
 	epochsSinceRampStart, rampDurationEpochs, err := a.getPledgeRampParams(ctx, ts.Height(), state)
 	if err != nil {


### PR DESCRIPTION
Updates go-state-types and incorporates https://github.com/filecoin-project/go-state-types/pull/308 which removes "deal weight" entirely from QAP calculation since it's unnecessary. So, we inherit a signature change here for `QAPowerForWeight` which drops the deal weight argument.

This is on top of https://github.com/filecoin-project/lotus/pull/12384 because it touches pledge calculation too. I'll leave this as draft until that merges. We also don't have a tagged gst with this change, and it might be best to leave this commit until @rjan90 cuts a second prerelease and pulls that in for nv24.