### PR TITLE
feat: use dnsaddr for butterflynet bootstrap addresses

### DIFF
--- a/build/bootstrap/butterflynet.pi
+++ b/build/bootstrap/butterflynet.pi
@@ -1,2 +1,1 @@
-/dns4/bootstrap-0.butterfly.fildev.network/tcp/1347/p2p/12D3KooWF76a8Avv74CV55noqKd5rHsM8uwFYhaW4PhMhuE4PQsP
-/dns4/bootstrap-1.butterfly.fildev.network/tcp/1347/p2p/12D3KooWCN1G8gK5HXQNDFKxAVmF6bpg436uVyNYFgiX94ZHCPjj
+/dnsaddr/bootstrap.butterfly.fildev.network


### PR DESCRIPTION


## Related Issues
https://github.com/filecoin-project/lotus-infra/issues/1598

## Proposed Changes
Further to work done on the butterflynet infrastructure improvements, a dnsaddr link is created with up-to-date bootstrap node addresses whenever butterflynet is reset/spawn up. This means we no longer need to update the bootstrap addresses in lotus. Instead, we can simply use `/dnsaddr/bootstrap.butterfly.fildev.network`.

## Additional Info
See:
- https://github.com/libp2p/specs/blob/master/addressing/README.md#dnsaddr-links


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
