### PR TITLE
chore(eth): minor optimisation in EthHashFromCid

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -529,7 +529,13 @@ func handleHexStringPrefix(s string) string {
 }
 
 func EthHashFromCid(c cid.Cid) (EthHash, error) {
-	return ParseEthHash(c.Hash().HexString()[8:])
+	b := c.Hash()
+	if len(b) != EthHashLength+4 {
+		return EthHash{}, fmt.Errorf("CID hash length is not 32 bytes")
+	}
+	var h EthHash
+	copy(h[:], b[4:])
+	return h, nil
 }
 
 func ParseEthHash(s string) (EthHash, error) {

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
@@ -105,6 +106,15 @@ func TestEthHash(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, hash, string(jm))
 	}
+
+	_, err := EthHashFromCid(cid.Undef)
+	require.ErrorContains(t, err, "not 32 bytes")
+
+	_, err = EthHashFromCid(cid.MustParse("bafkqaaa"))
+	require.ErrorContains(t, err, "not 32 bytes")
+
+	_, err = EthHashFromCid(cid.MustParse("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk"))
+	require.ErrorContains(t, err, "not 32 bytes")
 }
 
 func TestEthFilterID(t *testing.T) {
@@ -524,4 +534,15 @@ func TestFilecoinAddressToEthAddressParams(t *testing.T) {
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func BenchmarkEthHashFromCid(b *testing.B) {
+	c := cid.MustParse("bafy2bzacedwviarjtjraqakob5pslltmuo5n3xev3nt5zylezofkbbv5jclyu")
+
+	for i := 0; i < b.N; i++ {
+		_, err := EthHashFromCid(c)
+		if err != nil {
+			b.Fatalf("Error in EthHashFromCid: %v", err)
+		}
+	}
 }

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -107,14 +107,16 @@ func TestEthHash(t *testing.T) {
 		require.Equal(t, hash, string(jm))
 	}
 
-	_, err := EthHashFromCid(cid.Undef)
-	require.ErrorContains(t, err, "not 32 bytes")
-
-	_, err = EthHashFromCid(cid.MustParse("bafkqaaa"))
-	require.ErrorContains(t, err, "not 32 bytes")
-
-	_, err = EthHashFromCid(cid.MustParse("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk"))
-	require.ErrorContains(t, err, "not 32 bytes")
+	for _, c := range []cid.Cid{
+		cid.Undef,
+		cid.MustParse("bafy2bzacaa"),
+		cid.MustParse("bafkqaaa"),
+		cid.MustParse("bafy2bzacidqenpags5upxuhzpynnbhaojm5cy6dfoiojibz4gk2u4degs4qiclksacibt65ogzfjqionu7o25nl3y4ayzsizwbc32crqgnrqntqv"),
+		cid.MustParse("bafyrgqhai26anf3i7pips7q22coa4sz2fr4gk4q4sqdtymvvjyginfzaqewveaeqdh524nsktaq43j65v22xxrybrtertmcfxufdam3da3hbk"),
+	} {
+		_, err := EthHashFromCid(c)
+		require.ErrorContains(t, err, "CID does not have the expected prefix")
+	}
 }
 
 func TestEthFilterID(t *testing.T) {

--- a/itests/eth_hash_lookup_test.go
+++ b/itests/eth_hash_lookup_test.go
@@ -324,7 +324,7 @@ func TestTransactionHashLookupNonexistentMessage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	cid := cid.MustParse("bafk2bzacecapjnxnyw4talwqv5ajbtbkzmzqiosztj5cb3sortyp73ndjl76e")
+	cid := cid.MustParse("bafy2bzacecapjnxnyw4talwqv5ajbtbkzmzqiosztj5cb3sortyp73ndjl76e")
 
 	// We shouldn't be able to return a hash for this fake cid
 	chainHash, err := client.EthGetTransactionHashByCid(ctx, cid)


### PR DESCRIPTION
Very minor, but it bothers me each time I have to look at it so I may as well fix it.

`BenchmarkEthHashFromCid-32       5629081               216.2 ns/op`

vs

`BenchmarkEthHashFromCid-32      29226618                41.58 ns/op`


