### PR TITLE
docs: update release issue template with pointers to network upgrade info

### DIFF
--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -22,6 +22,8 @@
 * Scope: Node|Miner MINOR|PATCH
 * Is this linked with a network upgrade, and thus mandatory? Yes|No
 * Related network upgrade version: nvXX|n/a
+   * (network upgrade) Scope, dates, and epochs: <link to post in https://github.com/filecoin-project/community/discussions/74>
+   * (network upgrade) Lotus changelog with Lotus specifics: <link to section in https://github.com/filecoin-project/lotus/blob/master/CHANGELOG.md with more details>
 
 ## 🚢 Estimated shipping date
 


### PR DESCRIPTION
The goal is to get rid of posts like https://github.com/filecoin-project/lotus/discussions/12187 because we're just linking to other sources of truth.

This allows the removal of the "Lotus announcement upgrade" rows in the network upgrade template: https://docs.google.com/document/d/1KKJj2COb0vIqAQh-4F7fflJjxiTgGrU9oT9B461nsgg/edit


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] CI is green
