### PR TITLE
feat: recompute tipset to generate missing events if event indexing is enabled

### DIFF
--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -163,7 +163,21 @@ func (si *SqliteIndexer) loadExecutedMessages(ctx context.Context, msgTs, rctTs 
 
 		eventsArr, err := amt4.LoadAMT(ctx, st, *rct.EventsRoot, amt4.UseTreeBitWidth(types.EventAMTBitwidth))
 		if err != nil {
-			return nil, xerrors.Errorf("error loading events amt: %w", err)
+			if si.tipsetExecutorFnc == nil {
+				return nil, xerrors.Errorf("failed to load events amt for message %s: %w", ems[i].msg.Cid(), err)
+			}
+			log.Warnf("failed to load events amt for message %s: %s; recomputing tipset state to regenerate events", ems[i].msg.Cid(), err)
+
+			_, _, err = si.tipsetExecutorFnc(ctx, msgTs)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to recompute missing events; failed to recompute tipset state: %w", err)
+			}
+
+			eventsArr, err = amt4.LoadAMT(ctx, st, *rct.EventsRoot, amt4.UseTreeBitWidth(types.EventAMTBitwidth))
+			if err != nil {
+				return nil, xerrors.Errorf("failed to load events amt for message %s: %w", ems[i].msg.Cid(), err)
+			}
+			log.Infof("successfully recomputed tipset state and loaded events amt for message %s", ems[i].msg.Cid())
 		}
 
 		ems[i].evs = make([]types.Event, eventsArr.Len())

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -163,13 +163,12 @@ func (si *SqliteIndexer) loadExecutedMessages(ctx context.Context, msgTs, rctTs 
 
 		eventsArr, err := amt4.LoadAMT(ctx, st, *rct.EventsRoot, amt4.UseTreeBitWidth(types.EventAMTBitwidth))
 		if err != nil {
-			if si.tipsetExecutorFnc == nil {
+			if si.recomputeTipSetStateFunc == nil {
 				return nil, xerrors.Errorf("failed to load events amt for message %s: %w", ems[i].msg.Cid(), err)
 			}
 			log.Warnf("failed to load events amt for message %s: %s; recomputing tipset state to regenerate events", ems[i].msg.Cid(), err)
 
-			_, _, err = si.tipsetExecutorFnc(ctx, msgTs)
-			if err != nil {
+			if err := si.recomputeTipSetStateFunc(ctx, msgTs); err != nil {
 				return nil, xerrors.Errorf("failed to recompute missing events; failed to recompute tipset state: %w", err)
 			}
 

--- a/chain/index/indexer.go
+++ b/chain/index/indexer.go
@@ -21,6 +21,7 @@ var _ Indexer = (*SqliteIndexer)(nil)
 
 // IdToRobustAddrFunc is a function type that resolves an actor ID to a robust address
 type IdToRobustAddrFunc func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool)
+type tipsetExecutorFnc func(ctx context.Context, ts *types.TipSet) (cid.Cid, cid.Cid, error)
 
 type preparedStatements struct {
 	insertEthTxHashStmt                   *sql.Stmt
@@ -53,6 +54,7 @@ type SqliteIndexer struct {
 	cs ChainStore
 
 	idToRobustAddrFunc IdToRobustAddrFunc
+	tipsetExecutorFnc  tipsetExecutorFnc
 
 	stmts *preparedStatements
 
@@ -118,6 +120,10 @@ func (si *SqliteIndexer) Start() error {
 
 func (si *SqliteIndexer) SetIdToRobustAddrFunc(idToRobustAddrFunc IdToRobustAddrFunc) {
 	si.idToRobustAddrFunc = idToRobustAddrFunc
+}
+
+func (si *SqliteIndexer) SetTipsetExecutorFnc(tipsetExecutorFnc tipsetExecutorFnc) {
+	si.tipsetExecutorFnc = tipsetExecutorFnc
 }
 
 func (si *SqliteIndexer) Close() error {

--- a/chain/index/indexer.go
+++ b/chain/index/indexer.go
@@ -21,7 +21,7 @@ var _ Indexer = (*SqliteIndexer)(nil)
 
 // IdToRobustAddrFunc is a function type that resolves an actor ID to a robust address
 type IdToRobustAddrFunc func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool)
-type tipsetExecutorFnc func(ctx context.Context, ts *types.TipSet) (cid.Cid, cid.Cid, error)
+type recomputeTipSetStateFunc func(ctx context.Context, ts *types.TipSet) error
 
 type preparedStatements struct {
 	insertEthTxHashStmt                   *sql.Stmt
@@ -53,8 +53,8 @@ type SqliteIndexer struct {
 	db *sql.DB
 	cs ChainStore
 
-	idToRobustAddrFunc IdToRobustAddrFunc
-	tipsetExecutorFnc  tipsetExecutorFnc
+	idToRobustAddrFunc       IdToRobustAddrFunc
+	recomputeTipSetStateFunc recomputeTipSetStateFunc
 
 	stmts *preparedStatements
 
@@ -122,8 +122,8 @@ func (si *SqliteIndexer) SetIdToRobustAddrFunc(idToRobustAddrFunc IdToRobustAddr
 	si.idToRobustAddrFunc = idToRobustAddrFunc
 }
 
-func (si *SqliteIndexer) SetTipsetExecutorFnc(tipsetExecutorFnc tipsetExecutorFnc) {
-	si.tipsetExecutorFnc = tipsetExecutorFnc
+func (si *SqliteIndexer) SetRecomputeTipSetStateFunc(recomputeTipSetStateFunc recomputeTipSetStateFunc) {
+	si.recomputeTipSetStateFunc = recomputeTipSetStateFunc
 }
 
 func (si *SqliteIndexer) Close() error {

--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -56,6 +56,7 @@ type Indexer interface {
 	IndexEthTxHash(ctx context.Context, txHash ethtypes.EthHash, c cid.Cid) error
 
 	SetIdToRobustAddrFunc(idToRobustAddrFunc IdToRobustAddrFunc)
+	SetTipsetExecutorFnc(tipsetExecutorFnc tipsetExecutorFnc)
 	Apply(ctx context.Context, from, to *types.TipSet) error
 	Revert(ctx context.Context, from, to *types.TipSet) error
 

--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -56,7 +56,7 @@ type Indexer interface {
 	IndexEthTxHash(ctx context.Context, txHash ethtypes.EthHash, c cid.Cid) error
 
 	SetIdToRobustAddrFunc(idToRobustAddrFunc IdToRobustAddrFunc)
-	SetTipsetExecutorFnc(tipsetExecutorFnc tipsetExecutorFnc)
+	SetRecomputeTipSetStateFunc(recomputeTipSetStateFunc recomputeTipSetStateFunc)
 	Apply(ctx context.Context, from, to *types.TipSet) error
 	Revert(ctx context.Context, from, to *types.TipSet) error
 

--- a/node/modules/chainindex.go
+++ b/node/modules/chainindex.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
@@ -71,8 +70,9 @@ func InitChainIndexer(lc fx.Lifecycle, mctx helpers.MetricsCtx, indexer index.In
 				return *actor.DelegatedAddress, true
 			})
 
-			indexer.SetTipsetExecutorFnc(func(ctx context.Context, ts *types.TipSet) (cid.Cid, cid.Cid, error) {
-				return sm.RecomputeTipSetState(ctx, ts)
+			indexer.SetRecomputeTipSetStateFunc(func(ctx context.Context, ts *types.TipSet) error {
+				_, _, err := sm.RecomputeTipSetState(ctx, ts)
+				return err
 			})
 
 			ch, err := mp.Updates(ctx)

--- a/node/modules/chainindex.go
+++ b/node/modules/chainindex.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/index"
@@ -68,6 +69,10 @@ func InitChainIndexer(lc fx.Lifecycle, mctx helpers.MetricsCtx, indexer index.In
 				}
 
 				return *actor.DelegatedAddress, true
+			})
+
+			indexer.SetTipsetExecutorFnc(func(ctx context.Context, ts *types.TipSet) (cid.Cid, cid.Cid, error) {
+				return sm.RecomputeTipSetState(ctx, ts)
 			})
 
 			ch, err := mp.Updates(ctx)

--- a/node/modules/chainindex.go
+++ b/node/modules/chainindex.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/ipfs/go-cid"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/index"


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/issues/12453.

If we're unable to find events for a given receipt, we recompute the tipset to generate events and re-read the events true to enable auto-repair for events. This will work during reconciliation as well.