### PR TITLE
chore: remove duplicate `docsgen` CI check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,19 +20,6 @@ permissions:
   contents: read
 
 jobs:
-  check-docsgen:
-    name: Check (docs-check)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-      - uses: ./.github/actions/install-system-dependencies
-      - uses: ./.github/actions/install-go
-      - run: go install golang.org/x/tools/cmd/goimports
-      - run: make deps
-      - run: make docsgen
-      - run: git diff --exit-code
   check-gen:
     name: Check (gen-check)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Issues
* Fixes #12498

## Proposed Changes
`docsgen` make target is already a dependency of `gen` which has a CI check. We do not need to check `docsgen` separately for conformance.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
