### PR TITLE
feat(f3): add a build parameter specifying F3's initial power table cid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ## New features
 
 * Add `EthSendRawTransactionUntrusted` RPC method to be used for the gateway when accepting `EthSendRawTransaction` and `eth_sendRawTransaction`. Applies a tighter limit on the number of messages in the queue from a single sender and applies additional restrictions on nonce increments. ([filecoin-project/lotus#12431](https://github.com/filecoin-project/lotus/pull/12431))
-* [Checkpoint TipSets finalized by F3](https://github.com/filecoin-project/lotus/pull/12460): Once a decision is made by F3, the TipSet is check-pointed in `ChainStore`. As part of this change, any missing TipSets are asynchronously synced as required by the `ChainStore` checkpointing mechanism. 
+* [Checkpoint TipSets finalized by F3](https://github.com/filecoin-project/lotus/pull/12460): Once a decision is made by F3, the TipSet is check-pointed in `ChainStore`. As part of this change, any missing TipSets are asynchronously synced as required by the `ChainStore` checkpointing mechanism.
+* Add an environment variable, `F3_INITIAL_POWERTABLE_CID` to allow specifying the initial power table used by F3 ([filecoin-project/lotus#12502](https://github.com/filecoin-project/lotus/pull/12502)). This may be used to help a lotus node re-sync the F3 chain when syncing from a snapshot after the F3 upgrade epoch. The precise CID to use here won't be known until the F3 is officially "live".
 
 ## Improvements
 

--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -199,6 +199,9 @@ var F3Enabled = true
 
 var F3ManifestServerID = MustParseID("12D3KooWHcNBkqXEBrsjoveQvj6zDF3vK5S9tAfqyYaQF1LGSJwG")
 
+// The initial F3 power table CID.
+var F3InitialPowerTableCID cid.Cid = cid.Undef
+
 var F3BootstrapEpoch abi.ChainEpoch = 1000
 
 // F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This

--- a/build/buildconstants/params_butterfly.go
+++ b/build/buildconstants/params_butterfly.go
@@ -102,6 +102,9 @@ const F3Enabled = true
 
 var F3ManifestServerID = MustParseID("12D3KooWJr9jy4ngtJNR7JC1xgLFra3DjEtyxskRYWvBK9TC3Yn6")
 
+// The initial F3 power table CID.
+var F3InitialPowerTableCID cid.Cid = cid.Undef
+
 const F3BootstrapEpoch abi.ChainEpoch = 1000
 
 // F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This

--- a/build/buildconstants/params_calibnet.go
+++ b/build/buildconstants/params_calibnet.go
@@ -149,6 +149,9 @@ const F3Enabled = true
 
 var F3ManifestServerID = MustParseID("12D3KooWS9vD9uwm8u2uPyJV32QBAhKAmPYwmziAgr3Xzk2FU1Mr")
 
+// The initial F3 power table CID.
+var F3InitialPowerTableCID cid.Cid = cid.Undef
+
 const F3BootstrapEpoch abi.ChainEpoch = UpgradeWaffleHeight + 100
 
 // F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This

--- a/build/buildconstants/params_interop.go
+++ b/build/buildconstants/params_interop.go
@@ -140,6 +140,9 @@ const F3Enabled = true
 
 var F3ManifestServerID = MustParseID("12D3KooWQJ2rdVnG4okDUB6yHQhAjNutGNemcM7XzqC9Eo4z9Jce")
 
+// The initial F3 power table CID.
+var F3InitialPowerTableCID cid.Cid = cid.Undef
+
 const F3BootstrapEpoch abi.ChainEpoch = 1000
 
 // F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This

--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -173,6 +173,9 @@ var WhitelistedBlock = cid.MustParse("bafy2bzaceapyg2uyzk7vueh3xccxkuwbz3nxewjyg
 // The F3 manifest server ID, if any.
 var F3ManifestServerID = MustParseID("12D3KooWENMwUF9YxvQxar7uBWJtZkA6amvK4xWmKXfSiHUo2Qq7")
 
+// The initial F3 power table CID.
+var F3InitialPowerTableCID cid.Cid = cid.Undef
+
 const F3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = -1
 

--- a/build/buildconstants/params_shared_vals.go
+++ b/build/buildconstants/params_shared_vals.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"os"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -75,6 +77,16 @@ func init() {
 
 	if os.Getenv("LOTUS_ADDRESS_TYPE") == AddressMainnetEnvVar {
 		SetAddressNetwork(address.Mainnet)
+	}
+
+	if ptCid := os.Getenv("F3_INITIAL_POWERTABLE_CID"); ptCid != "" {
+		if k, err := cid.Parse(ptCid); err != nil {
+			log.Errorf("failed to parse F3_INITIAL_POWERTABLE_CID %q: %s", ptCid, err)
+		} else if F3InitialPowerTableCID.Defined() && k != F3InitialPowerTableCID {
+			log.Errorf("ignoring F3_INITIAL_POWERTABLE_CID as lotus has a hard-coded initial F3 power table")
+		} else {
+			F3InitialPowerTableCID = k
+		}
 	}
 }
 

--- a/build/buildconstants/params_testground.go
+++ b/build/buildconstants/params_testground.go
@@ -121,12 +121,13 @@ var (
 
 	ZeroAddress = MustParseAddress("f3yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaby2smx7a")
 
-	WhitelistedBlock                  = cid.Undef
-	BootstrappersFile                 = ""
-	GenesisFile                       = ""
-	F3Enabled                         = false
-	F3ManifestServerID peer.ID        = ""
-	F3BootstrapEpoch   abi.ChainEpoch = -1
+	WhitelistedBlock                      = cid.Undef
+	BootstrappersFile                     = ""
+	GenesisFile                           = ""
+	F3Enabled                             = false
+	F3ManifestServerID     peer.ID        = ""
+	F3BootstrapEpoch       abi.ChainEpoch = -1
+	F3InitialPowerTableCID                = cid.Undef
 
 	// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
 	// flag has no effect if F3 is not enabled.

--- a/chain/lf3/config.go
+++ b/chain/lf3/config.go
@@ -3,6 +3,7 @@ package lf3
 import (
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -19,7 +20,7 @@ type Config struct {
 	F3ConsensusEnabled      bool
 }
 
-func NewConfig(manifestProvider peer.ID, consensusEnabled bool) func(dtypes.NetworkName) *Config {
+func NewConfig(manifestProvider peer.ID, consensusEnabled bool, initialPowerTable cid.Cid) func(dtypes.NetworkName) *Config {
 	return func(nn dtypes.NetworkName) *Config {
 		m := manifest.LocalDevnetManifest()
 		m.NetworkName = gpbft.NetworkName(nn)
@@ -33,6 +34,7 @@ func NewConfig(manifestProvider peer.ID, consensusEnabled bool) func(dtypes.Netw
 		}
 		m.EC.Finality = int64(policy.ChainFinality)
 		m.CommitteeLookback = 5
+		m.InitialPowerTable = initialPowerTable
 
 		// TODO: We're forcing this to start paused for now. We need to remove this for the final
 		// mainnet launch.

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/filecoin-project/go-f3/manifest"
@@ -216,7 +217,7 @@ func MutateSealingConfig(mut func(sc *config.SealingConfig)) NodeOpt {
 func F3Enabled(bootstrapEpoch abi.ChainEpoch, blockDelay time.Duration, finality abi.ChainEpoch, manifestProvider peer.ID) NodeOpt {
 	return ConstructorOpts(
 		node.Override(new(*lf3.Config), func(nn dtypes.NetworkName) *lf3.Config {
-			c := lf3.NewConfig(manifestProvider, true)(nn)
+			c := lf3.NewConfig(manifestProvider, true, cid.Undef)(nn)
 			c.InitialManifest.Pause = false
 			c.InitialManifest.EC.Period = blockDelay
 			c.InitialManifest.EC.Finality = int64(finality)

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -165,7 +165,11 @@ var ChainNode = Options(
 	),
 
 	If(build.IsF3Enabled(),
-		Override(new(*lf3.Config), lf3.NewConfig(buildconstants.F3ManifestServerID, buildconstants.F3Consensus)),
+		Override(new(*lf3.Config), lf3.NewConfig(
+			buildconstants.F3ManifestServerID,
+			buildconstants.F3Consensus,
+			buildconstants.F3InitialPowerTableCID,
+		)),
 		Override(new(manifest.ManifestProvider), lf3.NewManifestProvider),
 		Override(new(*lf3.F3), lf3.New),
 	),


### PR DESCRIPTION
## Related Issues

https://github.com/filecoin-project/go-f3/issues/596

## Proposed Changes

This PR adds a build parameter specifying the initial power table cid.

This will be used post-bootstrap to hard-code the initial F3's initial power table CID. This will remain unset until F3 successfully bootstraps after which it'll be set to the CID of the committee used to create the first finality certificate.

Additionally, if and only if this CID is not already hard-coded, it can be specified by setting the `F3_INITIAL_POWERTABLE_CID` environment variable. That way users can specify it after the F3 bootstrap epoch without upgrading.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green