### PR TITLE
chore: remove build dependency to `goimports` cli

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
       - run: make deps lotus
-      - run: go install golang.org/x/tools/cmd/goimports
       - run: make gen
       - run: git diff --exit-code
       - run: make docsgen-cli

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ endif
 
 GOFLAGS+=-ldflags="$(ldflags)"
 
+FIX_IMPORTS = $(GOCC) run ./scripts/fiximports
 
 ## FFI
 
@@ -295,7 +296,7 @@ dist-clean:
 type-gen: api-gen
 	$(GOCC) run ./gen/main.go
 	$(GOCC) generate -x ./...
-	goimports -w api/
+	$(FIX_IMPORTS)
 
 actors-code-gen:
 	$(GOCC) run ./gen/inline-gen . gen/inlinegen-data.json
@@ -313,8 +314,7 @@ bundle-gen:
 
 api-gen:
 	$(GOCC) run ./gen/api
-	goimports -w api
-	goimports -w api
+	$(FIX_IMPORTS)
 .PHONY: api-gen
 
 cfgdoc-gen:
@@ -334,7 +334,7 @@ docsgen: fiximports
 .PHONY: docsgen
 
 fiximports:
-	$(GOCC) run ./scripts/fiximports
+	$(FIX_IMPORTS)
 .PHONY: fiximports
 
 gen: actors-code-gen type-gen cfgdoc-gen docsgen api-gen


### PR DESCRIPTION

## Related Issues
  * https://github.com/filecoin-project/lotus/pull/11695

## Proposed Changes
Lotus imports fixing was optimised to run as a go script for a faster turnaround. The changes here remove the leftover direct calls to `goimports` such that all imports are now fixed with the same script. This removes the need for installing `goimports` during CI workflows or in local development environment.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
