### PR TITLE
chore: cache `make deps` when running CI checks

### DIFF
--- a/.github/actions/make-deps/action.yml
+++ b/.github/actions/make-deps/action.yml
@@ -1,0 +1,38 @@
+name: Make Deps
+description: Runs `make deps` with caching
+
+inputs:
+  working-directory:
+    description: Specifies the working directory where the command is run.
+    required: false
+  github-token:
+    description: Specifies the token to use when calling GitHub APIs while building FFI.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - id: cache-ffi
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ runner.os }}-${{ runner.arch }}-ffi-${{ hashFiles('./.git/modules/extern/filecoin-ffi/HEAD') }}
+        path: |
+          ./extern/filecoin-ffi/filcrypto.h
+          ./extern/filecoin-ffi/libfilcrypto.a
+          ./extern/filecoin-ffi/filcrypto.pc
+          ./build/.filecoin-install
+    - if: steps.cache-ffi.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory || github.workspace }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+      run: FFI_PORTABLE=1 make deps
+    - if: steps.cache-ffi.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ runner.os }}-${{ runner.arch }}-ffi-${{ hashFiles('./.git/modules/extern/filecoin-ffi/HEAD') }}
+        path: |
+          ./extern/filecoin-ffi/filcrypto.h
+          ./extern/filecoin-ffi/libfilcrypto.a
+          ./extern/filecoin-ffi/filcrypto.pc
+          ./build/.filecoin-install

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
-      - run: make deps lotus
+      - uses: ./.github/actions/make-deps
       - run: make gen
       - run: git diff --exit-code
       - run: make docsgen-cli
@@ -43,8 +43,8 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
+      - uses: ./.github/actions/make-deps
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
-      - run: make deps
       - run: golangci-lint run -v --timeout 10m --concurrency 4
   check-fmt:
     name: Check (gofmt)


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Over 90% of time running CI check gen is spent on `make deps`. Define a composite GitHub Action that caches the ffi dependencies and makes this reusable across other actions.

Note that the changes remove `make lotus` from the gen-check CI workflow since it is not required for `make gen` to execute.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
