### PR TITLE
test(f3): fix test flakes

### DIFF
--- a/itests/f3_test.go
+++ b/itests/f3_test.go
@@ -14,13 +14,14 @@ import (
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-state-types/abi"
 
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/modules"
 )
 
 const (
-	DefaultBootsrapEpoch = 15
+	DefaultBootsrapEpoch = 20
 	DefaultFinality      = 5
 )
 
@@ -36,6 +37,8 @@ type testEnv struct {
 // Test that checks that F3 is enabled successfully,
 // and miners are able to bootstrap and make progress
 func TestF3_Enabled(t *testing.T) {
+	kit.QuietMiningLogs()
+
 	blocktime := 100 * time.Millisecond
 	e := setup(t, blocktime)
 
@@ -44,12 +47,11 @@ func TestF3_Enabled(t *testing.T) {
 
 // Test that checks that F3 can be rebootsrapped by changing the manifest
 func TestF3_Rebootstrap(t *testing.T) {
+	kit.QuietMiningLogs()
+
 	blocktime := 100 * time.Millisecond
 	e := setup(t, blocktime)
 	n := e.minerFullNodes[0]
-
-	prevManifest, err := n.F3GetManifest(e.testCtx)
-	require.NoError(t, err)
 
 	newInstance := uint64(2)
 	e.waitTillF3Instance(newInstance, 20*time.Second)
@@ -62,32 +64,29 @@ func TestF3_Rebootstrap(t *testing.T) {
 	cpy.NetworkName += "/1"
 	e.ms.UpdateManifest(&cpy)
 
-	newManifest := e.waitTillManifestChange(prevManifest, 20*time.Second)
+	newManifest := e.waitTillManifestChange(&cpy, 20*time.Second)
 	require.True(t, newManifest.Equal(&cpy))
-	t.Log(newManifest)
 	e.waitTillF3Rebootstrap(20 * time.Second)
 	e.waitTillF3Instance(prevCert.GPBFTInstance+1, 20*time.Second)
 }
 
 // Tests that pause/resume and rebootstrapping F3 works
 func TestF3_PauseAndRebootstrap(t *testing.T) {
+	kit.QuietMiningLogs()
+
 	blocktime := 100 * time.Millisecond
 	e := setup(t, blocktime)
-	n := e.minerFullNodes[0]
-
-	ctx := context.Background()
-	prevManifest, err := n.F3GetManifest(ctx)
-	require.NoError(t, err)
 
 	newInstance := uint64(2)
 	e.waitTillF3Instance(newInstance, 20*time.Second)
 
-	pausedManifest := *prevManifest
+	origManifest := *e.m
+	pausedManifest := origManifest
 	pausedManifest.Pause = true
 	e.ms.UpdateManifest(&pausedManifest)
 	e.waitTillF3Pauses(30 * time.Second)
 
-	e.ms.UpdateManifest(prevManifest)
+	e.ms.UpdateManifest(&origManifest)
 	e.waitTillF3Runs(30 * time.Second)
 
 	cpy := *e.m
@@ -95,7 +94,7 @@ func TestF3_PauseAndRebootstrap(t *testing.T) {
 	cpy.BootstrapEpoch = 25
 	e.ms.UpdateManifest(&cpy)
 
-	e.waitTillManifestChange(prevManifest, 20*time.Second)
+	e.waitTillManifestChange(&cpy, 20*time.Second)
 	e.waitTillF3Rebootstrap(20 * time.Second)
 }
 
@@ -107,11 +106,17 @@ func (e *testEnv) waitTillF3Rebootstrap(timeout time.Duration) {
 		if err != nil || cert == nil {
 			return false
 		}
-		e.t.Log("here")
 		m, err := n.F3GetManifest(e.testCtx)
 		require.NoError(e.t, err)
-		e.t.Log("got manifest", cert.ECChain.Base().Epoch, m.BootstrapEpoch-m.EC.Finality)
-		return cert.ECChain.Base().Epoch == m.BootstrapEpoch-m.EC.Finality
+
+		// Find the first non-null block at or before the target height, that's the bootstrap block.
+		targetEpoch := m.BootstrapEpoch - m.EC.Finality
+		ts, err := n.ChainGetTipSetByHeight(e.testCtx, abi.ChainEpoch(targetEpoch), types.EmptyTSK)
+		if err != nil {
+			return false
+		}
+
+		return cert.ECChain.Base().Epoch == int64(ts.Height())
 	}, timeout)
 }
 
@@ -142,12 +147,12 @@ func (e *testEnv) waitTillF3Instance(i uint64, timeout time.Duration) {
 	}, timeout)
 }
 
-func (e *testEnv) waitTillManifestChange(prevManifest *manifest.Manifest, timeout time.Duration) (m *manifest.Manifest) {
+func (e *testEnv) waitTillManifestChange(newManifest *manifest.Manifest, timeout time.Duration) (m *manifest.Manifest) {
 	e.waitFor(func(n *kit.TestFullNode) bool {
 		var err error
 		m, err = n.F3GetManifest(e.testCtx)
 		require.NoError(e.t, err)
-		return !prevManifest.Equal(m)
+		return newManifest.Equal(m)
 	}, timeout)
 	return m
 
@@ -171,11 +176,11 @@ func (e *testEnv) waitFor(f func(n *kit.TestFullNode) bool, timeout time.Duratio
 // and the second full-node is an observer that is not directly connected to
 // a miner. The last return value is the manifest sender for the network.
 func setup(t *testing.T, blocktime time.Duration) *testEnv {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, stopServices := context.WithCancel(context.Background())
 	errgrp, ctx := errgroup.WithContext(ctx)
 
 	t.Cleanup(func() {
-		cancel()
+		stopServices()
 		require.NoError(t, errgrp.Wait())
 	})
 
@@ -192,13 +197,13 @@ func setup(t *testing.T, blocktime time.Duration) *testEnv {
 	)
 
 	ens := kit.NewEnsemble(t, kit.MockProofs()).
-		FullNode(&n1, kit.ThroughRPC(), kit.WithAllSubsystems(), f3NOpt).
-		FullNode(&n2, kit.ThroughRPC(), kit.WithAllSubsystems(), f3NOpt).
-		FullNode(&n3, kit.ThroughRPC(), kit.WithAllSubsystems(), f3NOpt).
-		Miner(&m1, &n1, kit.ThroughRPC(), kit.WithAllSubsystems(), f3MOpt).
-		Miner(&m2, &n2, kit.ThroughRPC(), kit.WithAllSubsystems(), f3MOpt).
-		Miner(&m3, &n3, kit.ThroughRPC(), kit.WithAllSubsystems(), f3MOpt).
-		Miner(&m4, &n3, kit.ThroughRPC(), kit.WithAllSubsystems(), f3MOpt).
+		FullNode(&n1, kit.WithAllSubsystems(), f3NOpt).
+		FullNode(&n2, kit.WithAllSubsystems(), f3NOpt).
+		FullNode(&n3, kit.WithAllSubsystems(), f3NOpt).
+		Miner(&m1, &n1, kit.WithAllSubsystems(), f3MOpt).
+		Miner(&m2, &n2, kit.WithAllSubsystems(), f3MOpt).
+		Miner(&m3, &n3, kit.WithAllSubsystems(), f3MOpt).
+		Miner(&m4, &n3, kit.WithAllSubsystems(), f3MOpt).
 		Start()
 
 	ens.InterconnectAll().BeginMining(blocktime)

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -220,6 +220,7 @@ func F3Enabled(bootstrapEpoch abi.ChainEpoch, blockDelay time.Duration, finality
 			c := lf3.NewConfig(manifestProvider, true, cid.Undef)(nn)
 			c.InitialManifest.Pause = false
 			c.InitialManifest.EC.Period = blockDelay
+			c.InitialManifest.Gpbft.Delta = blockDelay / 5
 			c.InitialManifest.EC.Finality = int64(finality)
 			c.InitialManifest.BootstrapEpoch = int64(bootstrapEpoch)
 			c.InitialManifest.EC.HeadLookback = 0


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Failed test run https://github.com/filecoin-project/lotus/actions/runs/11046427121/job/30685760550?pr=12505

## Proposed Changes
<!-- A clear list of the changes being made -->

1. Reduce GPBFT delta to blockdelay/5 to match the expected mainnet config and avoid timing out tests.
2. Make waiting for rebootstrap work in the presence of null tipsets.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green