### PR TITLE
fix: eth_getBlockReceipts should work similarly as geth

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -1045,6 +1045,16 @@ func (e *EthBlockNumberOrHash) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	// check if input is a block hash (66 characters long)
+	if len(str) == 66 && strings.HasPrefix(str, "0x") {
+		hash, err := ParseEthHash(str)
+		if err != nil {
+			return err
+		}
+		e.BlockHash = &hash
+		return nil
+	}
+
 	// check if block param is a number (decimal or hex)
 	var num EthUint64
 	if err := num.UnmarshalJSON(b); err == nil {

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -2,6 +2,7 @@ package ethtypes
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -530,6 +531,103 @@ func TestFilecoinAddressToEthAddressParams(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, params)
+		})
+	}
+}
+
+func TestEthBlockNumberOrHashUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected func() EthBlockNumberOrHash
+		wantErr  bool
+	}{
+		{
+			name:  "Valid block number",
+			input: `{"blockNumber": "0x1234"}`,
+			expected: func() EthBlockNumberOrHash {
+				v := uint64(0x1234)
+				return EthBlockNumberOrHash{BlockNumber: (*EthUint64)(&v)}
+			},
+		},
+		{
+			name:  "Valid block hash",
+			input: `{"blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234"}`,
+			expected: func() EthBlockNumberOrHash {
+				h, _ := ParseEthHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+				return EthBlockNumberOrHash{BlockHash: &h}
+			},
+		},
+		{
+			name:  "Valid block number as string",
+			input: `"0x1234"`,
+			expected: func() EthBlockNumberOrHash {
+				v := uint64(0x1234)
+				return EthBlockNumberOrHash{BlockNumber: (*EthUint64)(&v)}
+			},
+		},
+		{
+			name:  "Valid block hash as string",
+			input: `"0x1234567890123456789012345678901234567890123456789012345678901234"`,
+			expected: func() EthBlockNumberOrHash {
+				h, _ := ParseEthHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+				return EthBlockNumberOrHash{BlockHash: &h}
+			},
+		},
+		{
+			name:  "Valid 'latest' string",
+			input: `"latest"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("latest")}
+			},
+		},
+		{
+			name:  "Valid 'earliest' string",
+			input: `"earliest"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("earliest")}
+			},
+		},
+		{
+			name:  "Valid 'pending' string",
+			input: `"pending"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("pending")}
+			},
+		},
+		{
+			name:    "Invalid: both block number and hash",
+			input:   `{"blockNumber": "0x1234", "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid block number",
+			input:   `{"blockNumber": "invalid"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid block hash",
+			input:   `{"blockHash": "invalid"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid string",
+			input:   `"invalid"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got EthBlockNumberOrHash
+			err := got.UnmarshalJSON([]byte(tc.input))
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err, fmt.Sprintf("did not expect error but got %s", err))
+				require.Equal(t, tc.expected(), got)
+			}
 		})
 	}
 }

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1162,6 +1162,16 @@ func TestEthGetBlockReceipts(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, txReceipt, receipt)
 	}
+
+	// try with the geth request format for `EthBlockNumberOrHash`
+	var req ethtypes.EthBlockNumberOrHash
+	reqStr := fmt.Sprintf(`"%s"`, lastReceipt.BlockHash.String())
+	err = req.UnmarshalJSON([]byte(reqStr))
+	require.NoError(t, err)
+
+	gethBlockReceipts, err := client.EthGetBlockReceipts(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, gethBlockReceipts, 3)
 }
 
 func deployContractWithEth(ctx context.Context, t *testing.T, client *kit.TestFullNode, ethAddr ethtypes.EthAddress,


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/12530 AND https://github.com/filecoin-project/lotus/issues/12536.

Tested on a local node as well:

```
curl --location --request POST 'http://localhost:1234/rpc/v1' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["0xc6b5584814d4872c4050c725fa2bdc2b1d23e8d63ae10db6ce7e6aeef5f4623d"],"id":1}'
{"id":1,"jsonrpc":"2.0","result":[]}
```

```
curl --location --request POST 'http://localhost:1234/rpc/v1' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["0xdc7c0197634c7c03adf6c3b44559009bc81278269183e97be4974b65c6425ccf"],"id":1}'
{"error":{"code":1,"message":"failed to get tipset: cannot get tipset by hash: cannot find tipset with cid bafy2bzacedohyamxmnghya5n63b3irkzacn4qetye2iyh2l34sluwzogijom6: ipld: could not find bafy2bzacedohyamxmnghya5n63b3irkzacn4qetye2iyh2l34sluwzogijom6"},"id":1,"jsonrpc":"2.0"}
```