### PR TITLE
fix: daemon: ensure imports are unaffected by remote-EOF

### DIFF
--- a/lib/httpreader/resumable.go
+++ b/lib/httpreader/resumable.go
@@ -78,6 +78,7 @@ func NewResumableReader(ctx context.Context, url string) (*ResumableReader, erro
 func (r *ResumableReader) ContentLength() int64 {
 	return r.contentLength
 }
+
 func (r *ResumableReader) Close() error {
 	if r.reader != nil {
 		return r.reader.Close()

--- a/lib/httpreader/resumable.go
+++ b/lib/httpreader/resumable.go
@@ -24,6 +24,8 @@ type ResumableReader struct {
 	reader        io.ReadCloser
 }
 
+var _ io.ReadCloser = &ResumableReader{}
+
 func NewResumableReader(ctx context.Context, url string) (*ResumableReader, error) {
 	finalURL := ""
 
@@ -75,6 +77,12 @@ func NewResumableReader(ctx context.Context, url string) (*ResumableReader, erro
 
 func (r *ResumableReader) ContentLength() int64 {
 	return r.contentLength
+}
+func (r *ResumableReader) Close() error {
+	if r.reader != nil {
+		return r.reader.Close()
+	}
+	return nil
 }
 
 func (r *ResumableReader) Read(p []byte) (n int, err error) {

--- a/lib/httpreader/resumable.go
+++ b/lib/httpreader/resumable.go
@@ -24,7 +24,7 @@ type ResumableReader struct {
 	reader        io.ReadCloser
 }
 
-var _ io.ReadCloser = &ResumableReader{}
+var _ io.ReadCloser = (*ResumableReader)(nil)
 
 func NewResumableReader(ctx context.Context, url string) (*ResumableReader, error) {
 	finalURL := ""


### PR DESCRIPTION
While testing snapshot imports from a cold-start
```
lotus daemon --remove-existing-chain=true --import-snapshot https://forest-archive.chainsafe.dev/latest/calibnet
```

I encountered the process aborting with an unexpected
```
...
2024-10-02T12:10:57.487+0200	INFO	badgerbs	v2@v2.2007.4/levels.go:1010	[Compactor: 0] Compaction for level: 1 DONE
4.38 GiB / 4.38 GiB [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24.52 MiB p/s 3m3s
2024-10-02T12:11:09.056+0200	WARN	chainstore	store/store.go:670	reorgWorker quit
2024-10-02T12:11:09.058+0200	INFO	badgerbs	v2@v2.2007.4/db.go:1027	Storing value log head: {Fid:8 Len:32 Offset:276003168}

2024-10-02T12:11:09.190+0200	INFO	badgerbs	v2@v2.2007.4/levels.go:1000	[Compactor: 173] Running compaction: {level:0 score:1.73 dropPrefixes:[]} for level: 0

2024-10-02T12:11:10.036+0200	INFO	badgerbs	v2@v2.2007.4/levels.go:962	LOG Compact 0->1, del 5 tables, add 5 tables, took 846.318625ms

2024-10-02T12:11:10.036+0200	INFO	badgerbs	v2@v2.2007.4/levels.go:1010	[Compactor: 173] Compaction for level: 0 DONE
2024-10-02T12:11:10.036+0200	INFO	badgerbs	v2@v2.2007.4/db.go:550	Force compaction on level 0 done
ERROR: importing chain failed: failed to read from underlying reader: http2: response body closed

```

see in-code comment explaining the fix