### PR TITLE
feat: update EthGetTransactionCount test for earliest, latest, and `pending` block parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Add `EthGetBlockReceipts` RPC method to retrieve transaction receipts for a spec
 
 ## Improvements
 
+- Update `TestEthGetTransactionCount` to test for `earliest`, `pending` and `finalized` and refactor `EthGetTransactionCount` to return empty block for `earliest`.
 - Reduce size of embedded genesis CAR files by removing WASM actor blocks and compressing with zstd. This reduces the `lotus` binary size by approximately 10 MiB. ([filecoin-project/lotus#12439](https://github.com/filecoin-project/lotus/pull/12439))
 - Add ChainSafe operated Calibration archival node to the bootstrap list ([filecoin-project/lotus#12517](https://github.com/filecoin-project/lotus/pull/12517))
 - Legacy/historical Drand lookups via `StateGetBeaconEntry` now work again for all historical epochs. `StateGetBeaconEntry` now uses the on-chain beacon entries and follows the same rules for historical Drand round matching as `StateGetRandomnessFromBeacon` and the `get_beacon_randomness` FVM syscall. Be aware that there will be some some variance in matching Filecoin epochs to Drand rounds where null Filecoin rounds are involved prior to network version 14. ([filecoin-project/lotus#12428](https://github.com/filecoin-project/lotus/pull/12428)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Add `EthGetBlockReceipts` RPC method to retrieve transaction receipts for a spec
 
 ## Improvements
 
-- Update `TestEthGetTransactionCount` to test for `earliest`, `pending` and `finalized` and refactor `EthGetTransactionCount` to return empty block for `earliest`.  ([filecoin-project/lotus#12448](https://github.com/filecoin-project/lotus/pull/12448))
+- Update `TestEthGetTransactionCount` to test for `earliest`, `pending` and `finalized`.  ([filecoin-project/lotus#12448](https://github.com/filecoin-project/lotus/pull/12448))
 - Reduce size of embedded genesis CAR files by removing WASM actor blocks and compressing with zstd. This reduces the `lotus` binary size by approximately 10 MiB. ([filecoin-project/lotus#12439](https://github.com/filecoin-project/lotus/pull/12439))
 - Add ChainSafe operated Calibration archival node to the bootstrap list ([filecoin-project/lotus#12517](https://github.com/filecoin-project/lotus/pull/12517))
 - Legacy/historical Drand lookups via `StateGetBeaconEntry` now work again for all historical epochs. `StateGetBeaconEntry` now uses the on-chain beacon entries and follows the same rules for historical Drand round matching as `StateGetRandomnessFromBeacon` and the `get_beacon_randomness` FVM syscall. Be aware that there will be some some variance in matching Filecoin epochs to Drand rounds where null Filecoin rounds are involved prior to network version 14. ([filecoin-project/lotus#12428](https://github.com/filecoin-project/lotus/pull/12428)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Add `EthGetBlockReceipts` RPC method to retrieve transaction receipts for a spec
 
 ## Improvements
 
-- Update `TestEthGetTransactionCount` to test for `earliest`, `pending` and `finalized` and refactor `EthGetTransactionCount` to return empty block for `earliest`.
+- Update `TestEthGetTransactionCount` to test for `earliest`, `pending` and `finalized` and refactor `EthGetTransactionCount` to return empty block for `earliest`.  ([filecoin-project/lotus#12448](https://github.com/filecoin-project/lotus/pull/12448))
 - Reduce size of embedded genesis CAR files by removing WASM actor blocks and compressing with zstd. This reduces the `lotus` binary size by approximately 10 MiB. ([filecoin-project/lotus#12439](https://github.com/filecoin-project/lotus/pull/12439))
 - Add ChainSafe operated Calibration archival node to the bootstrap list ([filecoin-project/lotus#12517](https://github.com/filecoin-project/lotus/pull/12517))
 - Legacy/historical Drand lookups via `StateGetBeaconEntry` now work again for all historical epochs. `StateGetBeaconEntry` now uses the on-chain beacon entries and follows the same rules for historical Drand round matching as `StateGetRandomnessFromBeacon` and the `get_beacon_randomness` FVM syscall. Be aware that there will be some some variance in matching Filecoin epochs to Drand rounds where null Filecoin rounds are involved prior to network version 14. ([filecoin-project/lotus#12428](https://github.com/filecoin-project/lotus/pull/12428)).

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1260,9 +1260,8 @@ func TestEthGetTransactionCount(t *testing.T) {
 		lastHash = client.EVM().SubmitTransaction(ctx, tx)
 
 		// Check counts for "earliest", "latest", and "pending"
-		earliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
-		require.NoError(t, err)
-		require.Zero(t, earliestCount, "Earliest transaction count should always be zero")
+		_, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+		require.Error(t, err) // earliest is not supported
 
 		latestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
 		require.NoError(t, err)
@@ -1279,9 +1278,8 @@ func TestEthGetTransactionCount(t *testing.T) {
 	}
 
 	// Get the final counts for "earliest", "latest", and "pending"
-	finalEarliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
-	require.NoError(t, err)
-	require.Zero(t, finalEarliestCount, "Final earliest transaction count should still be zero")
+	_, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+	require.Error(t, err) // earliest is not supported
 
 	finalLatestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
 	require.NoError(t, err)
@@ -1290,7 +1288,6 @@ func TestEthGetTransactionCount(t *testing.T) {
 	finalPendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
 	require.NoError(t, err)
 	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
-	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount, "Final latest transaction count should equal the number of transactions sent")
 
 	// Test with a contract
 	createReturn := client.EVM().DeployContract(ctx, client.DefaultKey.Address, contract)

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1268,6 +1268,15 @@ func TestEthGetTransactionCount(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ethtypes.EthUint64(i), latestCount, "Latest transaction count should be equal to the number of mined transactions")
 
+		// Check counts for "earliest", "latest", and "pending"
+		earliestCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+		require.NoError(t, err)
+		require.Zero(t, earliestCount, "Earliest transaction count should always be zero")
+
+		latestCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
+		require.NoError(t, err)
+		require.Equal(t, ethtypes.EthUint64(i), latestCount, "Latest transaction count should be equal to the number of mined transactions")
+
 		pendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
 		require.NoError(t, err)
 		require.True(t, int(pendingCount) == i+1 || int(pendingCount) == i+2,
@@ -1279,15 +1288,20 @@ func TestEthGetTransactionCount(t *testing.T) {
 	}
 
 	// Get the final counts for "earliest", "latest", and "pending"
-	// finalEarliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
-	// require.NoError(t, err)
-	// require.Zero(t, finalEarliestCount, "Final earliest transaction count should still be zero")
+	finalEarliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+	require.NoError(t, err)
+	require.Zero(t, finalEarliestCount, "Final earliest transaction count should still be zero")
 
 	finalLatestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
 	require.NoError(t, err)
 	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount, "Final latest transaction count should equal the number of transactions sent")
 
 	finalPendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
+	require.NoError(t, err)
+	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
+	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount, "Final latest transaction count should equal the number of transactions sent")
+
+	finalPendingCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
 	require.NoError(t, err)
 	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
 

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1268,19 +1268,10 @@ func TestEthGetTransactionCount(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ethtypes.EthUint64(i), latestCount, "Latest transaction count should be equal to the number of mined transactions")
 
-		// Check counts for "earliest", "latest", and "pending"
-		earliestCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
-		require.NoError(t, err)
-		require.Zero(t, earliestCount, "Earliest transaction count should always be zero")
-
-		latestCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
-		require.NoError(t, err)
-		require.Equal(t, ethtypes.EthUint64(i), latestCount, "Latest transaction count should be equal to the number of mined transactions")
-
 		pendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
 		require.NoError(t, err)
-		require.True(t, int(pendingCount) == i+1 || int(pendingCount) == i+2,
-			fmt.Sprintf("Pending transaction count should be either %d or %d, but got %d", i+1, i+2, pendingCount))
+		require.True(t, int(pendingCount) == i || int(pendingCount) == i+1,
+			fmt.Sprintf("Pending transaction count should be either %d or %d, but got %d", i, i+1, pendingCount))
 
 		// Wait for the transaction to be mined
 		_, err = client.EVM().WaitTransaction(ctx, lastHash)
@@ -1300,10 +1291,6 @@ func TestEthGetTransactionCount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
 	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount, "Final latest transaction count should equal the number of transactions sent")
-
-	finalPendingCount, err = client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
-	require.NoError(t, err)
-	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
 
 	// Test with a contract
 	createReturn := client.EVM().DeployContract(ctx, client.DefaultKey.Address, contract)

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1259,26 +1259,37 @@ func TestEthGetTransactionCount(t *testing.T) {
 		client.EVM().SignTransaction(tx, key.PrivateKey)
 		lastHash = client.EVM().SubmitTransaction(ctx, tx)
 
-		// Check pending transaction count immediately after submission
+		// Check counts for "earliest", "latest", and "pending"
+		earliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+		require.NoError(t, err)
+		require.Zero(t, earliestCount, "Earliest transaction count should always be zero")
+
+		latestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
+		require.NoError(t, err)
+		require.Equal(t, ethtypes.EthUint64(i), latestCount, "Latest transaction count should be equal to the number of mined transactions")
+
 		pendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
 		require.NoError(t, err)
-		require.True(t, int(pendingCount) == i || int(pendingCount) == i+1,
-			fmt.Sprintf("Pending transaction count should be either %d or %d, but got %d", i, i+1, pendingCount))
+		require.True(t, int(pendingCount) == i+1 || int(pendingCount) == i+2,
+			fmt.Sprintf("Pending transaction count should be either %d or %d, but got %d", i+1, i+2, pendingCount))
 
 		// Wait for the transaction to be mined
 		_, err = client.EVM().WaitTransaction(ctx, lastHash)
 		require.NoError(t, err)
-
-		// Check latest transaction count after the transaction is mined
-		latestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
-		require.NoError(t, err)
-		require.Equal(t, ethtypes.EthUint64(i+1), latestCount, "Latest transaction count should increment after mining")
 	}
 
-	// Get the final latest transaction count
+	// Get the final counts for "earliest", "latest", and "pending"
+	// finalEarliestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("earliest"))
+	// require.NoError(t, err)
+	// require.Zero(t, finalEarliestCount, "Final earliest transaction count should still be zero")
+
 	finalLatestCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("latest"))
 	require.NoError(t, err)
-	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount)
+	require.Equal(t, ethtypes.EthUint64(numTx), finalLatestCount, "Final latest transaction count should equal the number of transactions sent")
+
+	finalPendingCount, err := client.EVM().EthGetTransactionCount(ctx, ethAddr, ethtypes.NewEthBlockNumberOrHashFromPredefined("pending"))
+	require.NoError(t, err)
+	require.Equal(t, ethtypes.EthUint64(numTx), finalPendingCount, "Final pending transaction count should equal the number of transactions sent")
 
 	// Test with a contract
 	createReturn := client.EVM().DeployContract(ctx, client.DefaultKey.Address, contract)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -474,6 +474,10 @@ func (a *EthModule) EthGetTransactionCount(ctx context.Context, sender ethtypes.
 		return ethtypes.EthUint64(nonce), nil
 	}
 
+	if blkParam.PredefinedBlock != nil && *blkParam.PredefinedBlock == "earliest" {
+		return ethtypes.EthUint64(0), nil
+	}
+
 	// For all other cases, get the tipset based on the block parameter
 	ts, err := getTipsetByEthBlockNumberOrHash(ctx, a.Chain, blkParam)
 	if err != nil {

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -474,10 +474,6 @@ func (a *EthModule) EthGetTransactionCount(ctx context.Context, sender ethtypes.
 		return ethtypes.EthUint64(nonce), nil
 	}
 
-	if blkParam.PredefinedBlock != nil && *blkParam.PredefinedBlock == "earliest" {
-		return ethtypes.EthUint64(0), nil
-	}
-
 	// For all other cases, get the tipset based on the block parameter
 	ts, err := getTipsetByEthBlockNumberOrHash(ctx, a.Chain, blkParam)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
#12543

## Proposed Changes
Update `TestEthGetTransactionCount` to test for `earliest`, `pending`, and `finalized` and refactor `EthGetTransactionCount` to return an empty block for `earliest`.

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
