### PR TITLE
fix(events): event index unique for tipset during backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ## Bug Fixes
 
+- Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
+
 ## Deps
 
 # Node v1.29.2 / 2024-10-03

--- a/cmd/lotus-shed/indexes.go
+++ b/cmd/lotus-shed/indexes.go
@@ -212,6 +212,7 @@ var backfillEventsCmd = &cli.Command{
 				return fmt.Errorf("failed to get tipset key cid: %w", err)
 			}
 
+			eventCount := 0
 			// loop over each message receipt and backfill the events
 			for idx, receipt := range receipts {
 				msg := msgs[idx]
@@ -229,7 +230,7 @@ var backfillEventsCmd = &cli.Command{
 					return fmt.Errorf("failed to load events for tipset %s: %w", currTs, err)
 				}
 
-				for eventIdx, event := range events {
+				for _, event := range events {
 					addr, found := addressLookups[event.Emitter]
 					if !found {
 						var ok bool
@@ -248,7 +249,7 @@ var backfillEventsCmd = &cli.Command{
 						currTs.Key().Bytes(),
 						tsKeyCid.Bytes(),
 						addr.Bytes(),
-						eventIdx,
+						eventCount,
 						msg.Cid.Bytes(),
 						idx,
 					).Scan(&entryID)
@@ -267,7 +268,7 @@ var backfillEventsCmd = &cli.Command{
 						currTs.Key().Bytes(), // tipset_key
 						tsKeyCid.Bytes(),     // tipset_key_cid
 						addr.Bytes(),         // emitter_addr
-						eventIdx,             // event_index
+						eventCount,           // event_index
 						msg.Cid.Bytes(),      // message_cid
 						idx,                  // message_index
 						false,                // reverted
@@ -307,6 +308,7 @@ var backfillEventsCmd = &cli.Command{
 						}
 						entriesAffected += rowsAffected
 					}
+					eventCount++
 				}
 			}
 


### PR DESCRIPTION
This was left undone as part of the original fix for unique event indexes and shows up as a bug (e.g. "duplicate logIndex" for ETH APIs) where backfilling is involved.

I think this might also be implicated in the duplicate-events bugs we are seeing because we use the index in the "exists" check.

Ref: https://github.com/filecoin-project/lotus/pull/11952
Ref: https://github.com/filecoin-project/lotus/issues/12549
