### PR TITLE
refactor(shed): improve termination-estimate CLI for delegated owner addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bug Fixes
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
 - Event APIs (Eth events and actor events) should only return reverted events if client queries by specific block hash / tipset. Eth and actor event subscription APIs should always return reverted events to enable accurate observation of real-time changes. ([filecoin-project/lotus#12585](https://github.com/filecoin-project/lotus/pull/12585))
+- Add logic to check if the miner's owner address is delegated(f4 address). If it is delegated, the `lotus-shed sectors termination-estimate` command now sends the termination state call using the worker ID. This fix resolves the issue where termination-estimate did not function correctly for miners with delegated owner addresses. ([filecoin-project/lotus#12569](https://github.com/filecoin-project/lotus/pull/12569))
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ## Bug Fixes
 
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
+- Add logic to check if the miner's owner address is delegated(f4 address). If it is delegated, the `lotus-shed sectors termination-estimate` command now sends the termination state call using the worker ID. This fix resolves the issue where termination-estimate did not function correctly for miners with delegated owner addresses. ([filecoin-project/lotus#12569](https://github.com/filecoin-project/lotus/pull/12569))
+
 
 ## Deps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## Bug Fixes
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
 - Event APIs (Eth events and actor events) should only return reverted events if client queries by specific block hash / tipset. Eth and actor event subscription APIs should always return reverted events to enable accurate observation of real-time changes. ([filecoin-project/lotus#12585](https://github.com/filecoin-project/lotus/pull/12585))
-- Add logic to check if the miner's owner address is delegated(f4 address). If it is delegated, the `lotus-shed sectors termination-estimate` command now sends the termination state call using the worker ID. This fix resolves the issue where termination-estimate did not function correctly for miners with delegated owner addresses. ([filecoin-project/lotus#12569](https://github.com/filecoin-project/lotus/pull/12569))
+- Add logic to check if the miner's owner address is delegated (f4 address). If it is delegated, the `lotus-shed sectors termination-estimate` command now sends the termination state call using the worker ID. This fix resolves the issue where termination-estimate did not function correctly for miners with delegated owner addresses. ([filecoin-project/lotus#12569](https://github.com/filecoin-project/lotus/pull/12569))
 
 ## Improvements
 

--- a/cmd/lotus-shed/sectors.go
+++ b/cmd/lotus-shed/sectors.go
@@ -124,6 +124,18 @@ var terminateSectorPenaltyEstimationCmd = &cli.Command{
 			return err
 		}
 
+		ownerAddr, err := nodeApi.StateAccountKey(ctx, mi.Owner, types.EmptyTSK)
+		if err != nil {
+			ownerAddr = mi.Owner
+		}
+
+		var fromAddr address.Address
+		if ownerAddr.Protocol() == address.Delegated {
+			fromAddr = mi.Worker
+		} else {
+			fromAddr = mi.Owner
+		}
+
 		terminationDeclarationParams := []miner2.TerminationDeclaration{}
 
 		for _, sn := range cctx.Args().Slice() {
@@ -159,7 +171,7 @@ var terminateSectorPenaltyEstimationCmd = &cli.Command{
 		}
 
 		msg := &types.Message{
-			From:   mi.Owner,
+			From:   fromAddr,
 			To:     maddr,
 			Method: builtin.MethodsMiner.TerminateSectors,
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
### AS-IS
The `termination-estimate` CLI command fails to function correctly under specific conditions:

- When the owner address is a delegated address (F4 address), the existing code cannot send the Termination State Call.
- This results in the `termination-estimate` command not working for miners with delegated owner addresses.

### TO-BE
- Added a check to determine if the owner's address is delegated.
- If the owner's address is delegated, the code now uses the worker address to make the State Call.
- This modification allows the `termination-estimate` command to function correctly for miners with delegated owner addresses.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
### Case Study of Failure Scenarios

#### Case 1: Normal Operation

- Scenario: Miner's owner address is not delegated
- Miner Address: f01083914
- Account overview (From filfox)
![image](https://github.com/user-attachments/assets/20654668-3497-4b0a-9bf4-9b062de783ba)

- Output of command `lotus state active-sectors f01083914` (Last 5 result)
~~~bash
328942: bagboea4b5abcbfmobbo3eohmpe6ttau22doqcilddximppemx763j2rqz6afcnrh
328943: bagboea4b5abcapzk7al4mfvmh2mzpaq3mfexqaeck2ybbeoacljdqbywuli4fgiz
328944: bagboea4b5abcariha7m3boweimn5jr7wnk2ypaygogzmusposu6qlszinltri6ye
328945: bagboea4b5abcakn5qru3yse5lqa2aq4ekzznqjwb6mkqrpapoyjhz72ro4afhsbp
328946: bagboea4b5abcao3nq57q42aplr576no4lg3lp5lslwgs6yfc773oxqpzmikg6qzr
~~~
- Output of command `termination-estimate` with one of the above result : `./lotus-shed sectors termination-estimate --actor f01083914 328946`
~~~bash
./lotus-shed sectors termination-estimate --actor f01083914 328946
Estimated termination penalty: 134421027270868758 attoFIL
~~~

#### Case 1: Malfunction Operation

- Scenario: Miner's owner address is delegated (f4)
- Miner Address: f01697248
- Account overview (From filfox)
![image](https://github.com/user-attachments/assets/f52c2809-d9d3-4696-95ce-11f251d3c1e9)

- Output of command `lotus state active-sectors f01083914` (Last 5 result)
~~~bash
507031: bagboea4b5abcbgtonlgb5pcnrc6qdy47t6zj2zj6bm6vf45da2mrbmviotdti4sx
507032: bagboea4b5abcansneufjgctgy45ntlrc3ropoxvieh742sdemdqesbb77kt4qd2g
507033: bagboea4b5abcay25dtlgbmnvtqtv6ruf2n2qtbz52nqrt2sqllhowqkidvxt7oiu
507034: bagboea4b5abcakbe3xed3jf6z5rmoqurnqglzvak2ijjbvbffdzcjdtxwd532dql
507035: bagboea4b5abcbawfiaunopdmdd5otfj4wdempvuthz5tnug5fjvfa2yaal7hejr3
~~~
- Output of command `termination-estimate` with one of the above result : `./lotus-shed sectors termination-estimate --actor f01697248 507035`. -> **does not print any result.** 

## Checklist

refactor(shed): improve termination-estimate CLI for delegated owner addresses

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions) 
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
