### PR TITLE
fix: update actor code ID in lotus-shed invariant check

### DIFF
--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -636,7 +636,7 @@ func checkNv24Invariants(ctx context.Context, oldStateRootCid cid.Cid, newStateR
 		return xerrors.Errorf("failed to decode state root: %w", err)
 	}
 
-	actorCodeCids, err := actors.GetActorCodeIDs(actorstypes.Version14)
+	actorCodeCids, err := actors.GetActorCodeIDs(actorstypes.Version15)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Related Issues
When running the invariant check after running a bench migration (`./lotus-shed migrate-state --check-invariants=true ..`) it failed with:

```
main.checkNv24Invariants
     /home/filoz/lotus/cmd/lotus-shed/migrations.go:649
  - unexpected actor code CID bafk2bzaceabq3zagn4ee2wbagarxf7xgbrqgqgm55xydanxik2bifztqgynts for address t094151:
```

This is because the `checkNv24Invariants` was wrongly set to Version 14 actors.

## Proposed Changes
This PR updates `actors.GetActorCodeIDs` to Version 15 in the `checkNv24Invariants` function.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
