### PR TITLE
chore: set Calibration upgrade epoch for nv24

### DIFF
--- a/build/buildconstants/params_calibnet.go
+++ b/build/buildconstants/params_calibnet.go
@@ -99,8 +99,8 @@ const UpgradeCalibrationDragonFixHeight = 1493854
 // 2024-07-11T12:00:00Z
 const UpgradeWaffleHeight = 1779094
 
-// ??????
-const UpgradeTuktukHeight = 999999999999999
+// 2024-10-23T13:30:00Z
+const UpgradeTuktukHeight = 2078794
 
 // FIP-0081: for the power actor state for pledge calculations.
 // UpgradeTuktukPowerRampDurationEpochs ends up in the power actor state after
@@ -162,7 +162,8 @@ var F3ManifestServerID = MustParseID("12D3KooWS9vD9uwm8u2uPyJV32QBAhKAmPYwmziAgr
 // The initial F3 power table CID.
 var F3InitialPowerTableCID cid.Cid = cid.Undef
 
-const F3BootstrapEpoch abi.ChainEpoch = UpgradeWaffleHeight + 100
+// Calibnet F3 activation epoch is 2024-10-24T13:30:00Z - Epoch 2081674
+const F3BootstrapEpoch abi.ChainEpoch = UpgradeTuktukHeight + 2880
 
 // F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
 // flag has no effect if F3 is not enabled.


### PR DESCRIPTION
## Proposed Changes
Set the Calibration nv24 upgrade epoch and the F3BootstrapEpoch, as outlined by: https://github.com/filecoin-project/community/discussions/74#discussioncomment-10881951

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
