### PR TITLE
fix: set address current network for non-mainnet since default is changed

### DIFF
--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
 )
@@ -98,6 +99,7 @@ var ConsensusMinerMinPower = abi.NewStoragePower(2048)
 var PreCommitChallengeDelay = abi.ChainEpoch(10)
 
 func init() {
+	SetAddressNetwork(address.Testnet)
 	getGenesisNetworkVersion := func(ev string, def network.Version) network.Version {
 		hs, found := os.LookupEnv(ev)
 		if found {

--- a/build/buildconstants/params_2k_test.go
+++ b/build/buildconstants/params_2k_test.go
@@ -1,0 +1,16 @@
+//go:build debug || 2k
+// +build debug 2k
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Testnet)
+}

--- a/build/buildconstants/params_butterfly_test.go
+++ b/build/buildconstants/params_butterfly_test.go
@@ -1,0 +1,16 @@
+//go:build butterflynet
+// +build butterflynet
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Testnet)
+}

--- a/build/buildconstants/params_calibnet_test.go
+++ b/build/buildconstants/params_calibnet_test.go
@@ -1,0 +1,16 @@
+//go:build calibnet
+// +build calibnet
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Testnet)
+}

--- a/build/buildconstants/params_interop_test.go
+++ b/build/buildconstants/params_interop_test.go
@@ -1,0 +1,16 @@
+//go:build interopnet
+// +build interopnet
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Testnet)
+}

--- a/build/buildconstants/params_mainnet_test.go
+++ b/build/buildconstants/params_mainnet_test.go
@@ -1,0 +1,16 @@
+//go:build !debug && !2k && !testground && !calibnet && !butterflynet && !interopnet
+// +build !debug,!2k,!testground,!calibnet,!butterflynet,!interopnet
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Mainnet)
+}

--- a/build/buildconstants/params_testground.go
+++ b/build/buildconstants/params_testground.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/network"
 	builtin2 "github.com/filecoin-project/specs-actors/v2/actors/builtin"
@@ -137,6 +138,7 @@ var (
 )
 
 func init() {
+	SetAddressNetwork(address.Testnet)
 	Devnet = true
 }
 

--- a/build/buildconstants/params_testground_test.go
+++ b/build/buildconstants/params_testground_test.go
@@ -1,0 +1,16 @@
+//go:build testground
+// +build testground
+
+package buildconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+)
+
+func Test_NetworkName(t *testing.T) {
+	require.Equal(t, address.CurrentNetwork, address.Testnet)
+}


### PR DESCRIPTION


## Related Issues
* https://github.com/filecoin-project/go-address/commit/e08728680fb

## Proposed Changes
Default `address.CurrentNetwork` was changed in an upstream dependency. Update the build constants for non-mainnet to explicitly set it to `Testnet`.

Add tests to assert it.
## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
