### PR TITLE
fix(f3): fix hot loop in F3 participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update `EthGetBlockByNumber` to return a pointer to ethtypes.EthBlock or nil for null rounds. ([filecoin-project/lotus#12529](https://github.com/filecoin-project/lotus/pull/12529))
 - Reduce size of embedded genesis CAR files by removing WASM actor blocks and compressing with zstd. This reduces the `lotus` binary size by approximately 10 MiB. ([filecoin-project/lotus#12439](https://github.com/filecoin-project/lotus/pull/12439))
 - Add ChainSafe operated Calibration archival node to the bootstrap list ([filecoin-project/lotus#12517](https://github.com/filecoin-project/lotus/pull/12517))
+- Fix hotloop in F3 pariticpation API ([filecoin-project/lotus#12575](https://github.com/filecoin-project/lotus/pull/12575))
 
 ## Bug Fixes
 

--- a/itests/f3_test.go
+++ b/itests/f3_test.go
@@ -46,7 +46,7 @@ func TestF3_Enabled(t *testing.T) {
 	blocktime := 100 * time.Millisecond
 	e := setup(t, blocktime)
 
-	e.waitTillF3Instance(3, 25*time.Second)
+	e.waitTillF3Instance(modules.F3LeaseTerm+1, 40*time.Second)
 }
 
 // Test that checks that F3 can be rebootsrapped by changing the manifest

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -462,7 +462,7 @@ func (p *f3Participator) tryF3Participate(ctx context.Context, ticket api.F3Part
 			p.backOff(ctx)
 			continue
 		default:
-			log.Infow("Successfully acquired F3 participation lease.", "issuer", lease.Issuer, "expiry", lease.ValidityTerm)
+			log.Infow("Successfully acquired F3 participation lease.", "issuer", lease.Issuer, "expiry", lease.FromInstance+lease.ValidityTerm)
 			p.previousTicket = ticket
 			return lease, true, nil
 		}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -462,7 +462,11 @@ func (p *f3Participator) tryF3Participate(ctx context.Context, ticket api.F3Part
 			p.backOff(ctx)
 			continue
 		default:
-			log.Infow("Successfully acquired F3 participation lease.", "issuer", lease.Issuer, "expiry", lease.FromInstance+lease.ValidityTerm)
+			log.Infow("Successfully acquired F3 participation lease.",
+				"issuer", lease.Issuer,
+				"not-before", lease.FromInstance,
+				"not-after", lease.FromInstance+lease.ValidityTerm,
+			)
 			p.previousTicket = ticket
 			return lease, true, nil
 		}

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -47,6 +47,9 @@ import (
 	"github.com/filecoin-project/lotus/storage/wdpost"
 )
 
+// F3LeaseTerm The number of instances the miner will attempt to lease from nodes.
+const F3LeaseTerm = 5
+
 type UuidWrapper struct {
 	v1api.FullNode
 }
@@ -546,8 +549,6 @@ func F3Participation(mctx helpers.MetricsCtx, lc fx.Lifecycle, node v1api.FullNo
 		// checkProgressInterval defines the duration between progress checks in normal operation mode.
 		// This interval is used when there are no errors in retrieving the current progress.
 		checkProgressInterval = 10 * time.Second
-		// leaseTerm The number of instances the miner will attempt to lease from nodes.
-		leaseTerm = 5
 	)
 
 	participator := newF3Participator(
@@ -560,7 +561,7 @@ func F3Participation(mctx helpers.MetricsCtx, lc fx.Lifecycle, node v1api.FullNo
 		},
 		checkProgressMaxAttempts,
 		checkProgressInterval,
-		leaseTerm,
+		F3LeaseTerm,
 	)
 
 	ctx, cancel := context.WithCancel(mctx)


### PR DESCRIPTION
Due to a bug in the `awaitLeaseExpiry`, we would retry immediately, which then would cause a hot loop.
Fix the bug and add a bit of hot-loop protection.