### PR TITLE
fix(f3): send the last gpbft message for each new participant

### DIFF
--- a/chain/lf3/participation_lease.go
+++ b/chain/lf3/participation_lease.go
@@ -23,6 +23,8 @@ type leaser struct {
 	issuer               peer.ID
 	status               f3Status
 	maxLeasableInstances uint64
+	// Signals that a lease was created and/or updated.
+	notifyParticipation chan struct{}
 }
 
 func newParticipationLeaser(nodeId peer.ID, status f3Status, maxLeasedInstances uint64) *leaser {
@@ -30,6 +32,7 @@ func newParticipationLeaser(nodeId peer.ID, status f3Status, maxLeasedInstances 
 		leases:               make(map[uint64]api.F3ParticipationLease),
 		issuer:               nodeId,
 		status:               status,
+		notifyParticipation:  make(chan struct{}, 1),
 		maxLeasableInstances: maxLeasedInstances,
 	}
 }
@@ -102,6 +105,10 @@ func (l *leaser) participate(ticket api.F3ParticipationTicket) (api.F3Participat
 		log.Infof("started participating in F3 for miner %d", newLease.MinerID)
 	}
 	l.leases[newLease.MinerID] = newLease
+	select {
+	case l.notifyParticipation <- struct{}{}:
+	default:
+	}
 	return newLease, nil
 }
 


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Send the last gpbft message for each new participant.

Otherwise, we can get into a situation where everyone is waiting for the next round to participate, but we'll never get there because not enough participants acted in the current round.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green