### PR TITLE
fix(f3): log the correct number of instances remaining

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -989,6 +989,10 @@ type F3ParticipationLease struct {
 	ValidityTerm uint64
 }
 
+func (l *F3ParticipationLease) ToInstance() uint64 {
+	return l.FromInstance + l.ValidityTerm
+}
+
 // EthSubscriber is the reverse interface to the client, called after EthSubscribe
 type EthSubscriber interface {
 	// note: the parameter is ethtypes.EthSubscriptionResponse serialized as json object

--- a/chain/lf3/participation_lease.go
+++ b/chain/lf3/participation_lease.go
@@ -107,7 +107,7 @@ func (l *leaser) getParticipantsByInstance(instance uint64) []uint64 {
 	defer l.mutex.Unlock()
 	var participants []uint64
 	for id, lease := range l.leases {
-		if instance > lease.FromInstance+lease.ValidityTerm {
+		if instance > lease.ToInstance() {
 			// Lazily delete the expired leases.
 			delete(l.leases, id)
 		} else {
@@ -145,7 +145,7 @@ func (l *leaser) validate(currentNetwork gpbft.NetworkName, currentInstance uint
 	// Combine the errors to remove significance of the order by which they are
 	// checked outside if this function.
 	var err error
-	if currentNetwork != lease.Network || currentInstance > lease.FromInstance+lease.ValidityTerm {
+	if currentNetwork != lease.Network || currentInstance > lease.ToInstance() {
 		err = multierr.Append(err, api.ErrF3ParticipationTicketExpired)
 	}
 	if l.issuer != lease.Issuer {

--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -468,7 +468,7 @@ func (p *f3Participator) tryF3Participate(ctx context.Context, ticket api.F3Part
 			log.Infow("Successfully acquired F3 participation lease.",
 				"issuer", lease.Issuer,
 				"not-before", lease.FromInstance,
-				"not-after", lease.FromInstance+lease.ValidityTerm,
+				"not-after", lease.ToInstance(),
 			)
 			p.previousTicket = ticket
 			return lease, true, nil
@@ -505,11 +505,11 @@ func (p *f3Participator) awaitLeaseExpiry(ctx context.Context, lease api.F3Parti
 			}
 			log.Errorw("Failed to check F3 progress while awaiting lease expiry. Retrying after backoff.", "attempts", p.backoff.Attempt(), "backoff", p.backoff.Duration(), "err", err)
 			p.backOff(ctx)
-		case progress.ID+2 >= lease.FromInstance+lease.ValidityTerm:
-			log.Infof("F3 progressed (%d) to within two instances of lease expiry (%d+%d). Renewing participation.", progress.ID, lease.FromInstance, lease.ValidityTerm)
+		case progress.ID+2 >= lease.ToInstance():
+			log.Infof("F3 progressed (%d) to within two instances of lease expiry (%d). Renewing participation.", progress.ID, lease.ToInstance())
 			return nil
 		default:
-			remainingInstanceLease := lease.ValidityTerm - progress.ID
+			remainingInstanceLease := lease.ToInstance() - progress.ID
 			log.Debugf("F3 participation lease is valid for further %d instances. Re-checking after %s.", remainingInstanceLease, p.checkProgressInterval)
 			p.backOffFor(ctx, p.checkProgressInterval)
 		}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

1. Add a `ToInstance()` to the lease so we can stop repeating code.
2. Use it to correctly log the number of remaining instances.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green