### PR TITLE
fix(f3): handle a case where we might receive no manifest

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -491,7 +491,11 @@ func (p *f3Participator) awaitLeaseExpiry(ctx context.Context, lease api.F3Parti
 			}
 			log.Errorw("Failed to check F3 progress while awaiting lease expiry. Retrying after backoff.", "attempts", p.backoff.Attempt(), "backoff", p.backoff.Duration(), "err", err)
 			p.backOff(ctx)
-		case manifest.NetworkName != lease.Network:
+		case manifest == nil || manifest.NetworkName != lease.Network:
+			// If we got an unexpected manifest, or no manifest, go back to the
+			// beginning and try to get another ticket. Switching from having a manifest
+			// to having no manifest can theoretically happen if the lotus node reboots
+			// and has no static manifest.
 			return nil
 		}
 		switch progress, err := p.node.F3GetProgress(ctx); {


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

In _theory_ a lotus node can return no manifest from `F3Manifest`. I don't think that happens in practice but we should handle the case and start over at the top (try to get another lease). If we really have no manifest, lotus will tell us that F3 isn't ready yet and we'll backoff for a bit.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green