### PR TITLE
feat(f3): remove lease-check interval constants

### DIFF
--- a/node/modules/storageminer.go
+++ b/node/modules/storageminer.go
@@ -366,17 +366,15 @@ type f3Participator struct {
 	backoff                  *backoff.Backoff
 	maxCheckProgressAttempts int
 	previousTicket           api.F3ParticipationTicket
-	checkProgressInterval    time.Duration
 	leaseTerm                uint64
 }
 
-func newF3Participator(node v1api.FullNode, participant dtypes.MinerAddress, backoff *backoff.Backoff, maxCheckProgress int, checkProgressInterval time.Duration, leaseTerm uint64) *f3Participator {
+func newF3Participator(node v1api.FullNode, participant dtypes.MinerAddress, backoff *backoff.Backoff, maxCheckProgress int, leaseTerm uint64) *f3Participator {
 	return &f3Participator{
 		node:                     node,
 		participant:              address.Address(participant),
 		backoff:                  backoff,
 		maxCheckProgressAttempts: maxCheckProgress,
-		checkProgressInterval:    checkProgressInterval,
 		leaseTerm:                leaseTerm,
 	}
 }
@@ -479,8 +477,10 @@ func (p *f3Participator) tryF3Participate(ctx context.Context, ticket api.F3Part
 
 func (p *f3Participator) awaitLeaseExpiry(ctx context.Context, lease api.F3ParticipationLease) error {
 	p.backoff.Reset()
+	renewLeaseWithin := p.leaseTerm / 2
 	for ctx.Err() == nil {
-		switch manifest, err := p.node.F3GetManifest(ctx); {
+		manifest, err := p.node.F3GetManifest(ctx)
+		switch {
 		case errors.Is(err, api.ErrF3Disabled):
 			log.Errorw("Cannot await F3 participation lease expiry as F3 is disabled.", "err", err)
 			return xerrors.Errorf("awaiting F3 participation lease expiry: %w", err)
@@ -505,13 +505,17 @@ func (p *f3Participator) awaitLeaseExpiry(ctx context.Context, lease api.F3Parti
 			}
 			log.Errorw("Failed to check F3 progress while awaiting lease expiry. Retrying after backoff.", "attempts", p.backoff.Attempt(), "backoff", p.backoff.Duration(), "err", err)
 			p.backOff(ctx)
-		case progress.ID+2 >= lease.ToInstance():
-			log.Infof("F3 progressed (%d) to within two instances of lease expiry (%d). Renewing participation.", progress.ID, lease.ToInstance())
+		case progress.ID+renewLeaseWithin >= lease.ToInstance():
+			log.Infof("F3 progressed (%d) to within %d instances of lease expiry (%d). Renewing participation.", progress.ID, renewLeaseWithin, lease.ToInstance())
 			return nil
 		default:
 			remainingInstanceLease := lease.ToInstance() - progress.ID
-			log.Debugf("F3 participation lease is valid for further %d instances. Re-checking after %s.", remainingInstanceLease, p.checkProgressInterval)
-			p.backOffFor(ctx, p.checkProgressInterval)
+			waitTime := time.Duration(remainingInstanceLease-renewLeaseWithin) * manifest.CatchUpAlignment
+			if waitTime == 0 {
+				waitTime = 100 * time.Millisecond
+			}
+			log.Debugf("F3 participation lease is valid for further %d instances. Re-checking after %s.", remainingInstanceLease, waitTime)
+			p.backOffFor(ctx, waitTime)
 		}
 	}
 	return ctx.Err()
@@ -546,9 +550,6 @@ func F3Participation(mctx helpers.MetricsCtx, lc fx.Lifecycle, node v1api.FullNo
 		// typically when we would try to renew the participation ticket. Hence, the value
 		// to 13.
 		checkProgressMaxAttempts = 13
-		// checkProgressInterval defines the duration between progress checks in normal operation mode.
-		// This interval is used when there are no errors in retrieving the current progress.
-		checkProgressInterval = 10 * time.Second
 	)
 
 	participator := newF3Participator(
@@ -560,7 +561,6 @@ func F3Participation(mctx helpers.MetricsCtx, lc fx.Lifecycle, node v1api.FullNo
 			Factor: 1.5,
 		},
 		checkProgressMaxAttempts,
-		checkProgressInterval,
 		F3LeaseTerm,
 	)
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

I expect this may help with some of the flaky tests as those may have been timing out because we weren't renewing the lease fast enough.

https://github.com/filecoin-project/lotus/issues/12519

## Proposed Changes
<!-- A clear list of the changes being made -->

1. Instead of hard-coding the renewal to be within 2 instances of the end of the lease, specify the renewal to be within 1/2th of the end of the lease, rounded up (towards the end of the lease).
2. Instead of hard-coding the lease check interval to be 10s (problematic for tests where the block time is 100ms), set it to be the minimum amount of time we expect to have to wait for the remaining
instances to complete.

I've configured a hard-coded minimum of renewing the lease once every 100ms in case a manifest doesn't have a configured catch-up alignment interval, but I don't expect us to hit that in practice.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green