### PR TITLE
feat(f3): log when gaining/losing participation leases

### DIFF
--- a/chain/lf3/participation_lease.go
+++ b/chain/lf3/participation_lease.go
@@ -98,6 +98,9 @@ func (l *leaser) participate(ticket api.F3ParticipationTicket) (api.F3Participat
 		// For safety, strictly require lease start instance to never decrease.
 		return api.F3ParticipationLease{}, api.ErrF3ParticipationTicketStartBeforeExisting
 	}
+	if !found {
+		log.Infof("started participating in F3 for miner %d", newLease.MinerID)
+	}
 	l.leases[newLease.MinerID] = newLease
 	return newLease, nil
 }
@@ -110,6 +113,7 @@ func (l *leaser) getParticipantsByInstance(instance uint64) []uint64 {
 		if instance > lease.ToInstance() {
 			// Lazily delete the expired leases.
 			delete(l.leases, id)
+			log.Warnf("lost F3 participation lease for miner %d", id)
 		} else {
 			participants = append(participants, id)
 		}


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Log whenever we start/stop participating for a storage miner in F3. Given that we use overlapping leases, we expect that we'll start participating for a miner on start then continue to participate over time.

This could get a bit noisy for setups that constantly switch between different lotus nodes but there's not much I can do about that and this will really help with debugging.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green