### PR TITLE
feat: improve semantics for returning reverted events to event API users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ## Bug Fixes
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
+- Event APIs (Eth events and actor events) should only return reverted events if client queries by specific block hash / tipset. Eth and actor event subscription APIs should always return reverted events to enable accurate observation of real-time changes. ([filecoin-project/lotus#12585](https://github.com/filecoin-project/lotus/pull/12585))
+
+## Improvements
 
 ## Improvements
 

--- a/node/impl/full/actor_events.go
+++ b/node/impl/full/actor_events.go
@@ -32,13 +32,19 @@ type ChainAccessor interface {
 }
 
 type EventFilterManager interface {
+	Fill(
+		ctx context.Context,
+		minHeight, maxHeight abi.ChainEpoch,
+		tipsetCid cid.Cid,
+		addresses []address.Address,
+		keysWithCodec map[string][]types.ActorEventBlock,
+	) (filter.EventFilter, error)
 	Install(
 		ctx context.Context,
 		minHeight, maxHeight abi.ChainEpoch,
 		tipsetCid cid.Cid,
 		addresses []address.Address,
 		keysWithCodec map[string][]types.ActorEventBlock,
-		excludeReverted bool,
 	) (filter.EventFilter, error)
 	Remove(ctx context.Context, id types.FilterID) error
 }
@@ -102,22 +108,15 @@ func (a *ActorEventHandler) GetActorEventsRaw(ctx context.Context, evtFilter *ty
 		return nil, err
 	}
 
-	// Install a filter just for this call, collect events, remove the filter
+	// Fill a filter and collect events
 	tipSetCid, err := params.GetTipSetCid()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tipset cid: %w", err)
 	}
-	excludeReverted := tipSetCid == cid.Undef
-	f, err := a.eventFilterManager.Install(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields, excludeReverted)
+	f, err := a.eventFilterManager.Fill(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		// Remove the temporary filter regardless of the original context.
-		if err := a.eventFilterManager.Remove(context.Background(), f.ID()); err != nil {
-			log.Warnf("failed to remove filter: %s", err)
-		}
-	}()
 	return getCollected(ctx, f), nil
 }
 
@@ -218,7 +217,7 @@ func (a *ActorEventHandler) SubscribeActorEventsRaw(ctx context.Context, evtFilt
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tipset cid: %w", err)
 	}
-	fm, err := a.eventFilterManager.Install(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields, false)
+	fm, err := a.eventFilterManager.Install(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields)
 	if err != nil {
 		return nil, err
 	}

--- a/node/impl/full/actor_events.go
+++ b/node/impl/full/actor_events.go
@@ -107,7 +107,8 @@ func (a *ActorEventHandler) GetActorEventsRaw(ctx context.Context, evtFilter *ty
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tipset cid: %w", err)
 	}
-	f, err := a.eventFilterManager.Install(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields, false)
+	excludeReverted := tipSetCid == cid.Undef
+	f, err := a.eventFilterManager.Install(ctx, params.MinHeight, params.MaxHeight, tipSetCid, evtFilter.Addresses, evtFilter.Fields, excludeReverted)
 	if err != nil {
 		return nil, err
 	}

--- a/node/impl/full/actor_events_test.go
+++ b/node/impl/full/actor_events_test.go
@@ -146,6 +146,11 @@ func TestGetActorEventsRaw(t *testing.T) {
 	minerAddr, err := address.NewIDAddress(uint64(rng.Int63()))
 	req.NoError(err)
 
+	c := mkCid(t, "c")
+	tskey := types.NewTipSetKey(c)
+	tsKeyCid, err := tskey.Cid()
+	req.NoError(err)
+
 	testCases := []struct {
 		name                   string
 		filter                 *types.ActorEventFilter
@@ -159,16 +164,18 @@ func TestGetActorEventsRaw(t *testing.T) {
 		expectErr              string
 	}{
 		{
-			name:             "nil filter",
-			filter:           nil,
-			installMinHeight: -1,
-			installMaxHeight: -1,
+			name:                   "nil filter",
+			filter:                 nil,
+			installMinHeight:       -1,
+			installMaxHeight:       -1,
+			installExcludeReverted: true,
 		},
 		{
-			name:             "empty filter",
-			filter:           &types.ActorEventFilter{},
-			installMinHeight: -1,
-			installMaxHeight: -1,
+			name:                   "empty filter",
+			filter:                 &types.ActorEventFilter{},
+			installMinHeight:       -1,
+			installMaxHeight:       -1,
+			installExcludeReverted: true,
 		},
 		{
 			name: "basic height range filter",
@@ -176,25 +183,38 @@ func TestGetActorEventsRaw(t *testing.T) {
 				FromHeight: epochPtr(0),
 				ToHeight:   epochPtr(maxFilterHeightRange),
 			},
-			installMinHeight: 0,
-			installMaxHeight: maxFilterHeightRange,
+			installMinHeight:       0,
+			installMaxHeight:       maxFilterHeightRange,
+			installExcludeReverted: true,
+		},
+		{
+			name: "query for tipset key",
+			filter: &types.ActorEventFilter{
+				TipSetKey: &tskey,
+			},
+			installTipSetKey:       tsKeyCid,
+			installMinHeight:       0,
+			installMaxHeight:       0,
+			installExcludeReverted: false,
 		},
 		{
 			name: "from, no to height",
 			filter: &types.ActorEventFilter{
 				FromHeight: epochPtr(0),
 			},
-			currentHeight:    maxFilterHeightRange - 1,
-			installMinHeight: 0,
-			installMaxHeight: -1,
+			currentHeight:          maxFilterHeightRange - 1,
+			installMinHeight:       0,
+			installMaxHeight:       -1,
+			installExcludeReverted: true,
 		},
 		{
 			name: "to, no from height",
 			filter: &types.ActorEventFilter{
 				ToHeight: epochPtr(maxFilterHeightRange - 1),
 			},
-			installMinHeight: -1,
-			installMaxHeight: maxFilterHeightRange - 1,
+			installMinHeight:       -1,
+			installMaxHeight:       maxFilterHeightRange - 1,
+			installExcludeReverted: true,
 		},
 		{
 			name: "from, no to height, too far",

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1727,15 +1727,12 @@ func (e *EthEventHandler) ethGetEventsForFilter(ctx context.Context, filterSpec 
 		}
 	}
 
-	// Create a temporary filter
-	excludeReverted := pf.tipsetCid == cid.Undef
-	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, excludeReverted)
+	// Fill a filter and collect events
+	f, err := e.EventFilterManager.Fill(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to install event filter: %w", err)
 	}
 	ces := f.TakeCollectedEvents(ctx)
-
-	_ = e.uninstallFilter(ctx, f)
 
 	return ces, nil
 }
@@ -1958,8 +1955,7 @@ func (e *EthEventHandler) EthNewFilter(ctx context.Context, filterSpec *ethtypes
 		return ethtypes.EthFilterID{}, err
 	}
 
-	excludeReverted := pf.tipsetCid == cid.Undef
-	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, excludeReverted)
+	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys)
 	if err != nil {
 		return ethtypes.EthFilterID{}, xerrors.Errorf("failed to install event filter: %w", err)
 	}
@@ -2125,7 +2121,7 @@ func (e *EthEventHandler) EthSubscribe(ctx context.Context, p jsonrpc.RawParams)
 			}
 		}
 
-		f, err := e.EventFilterManager.Install(ctx, -1, -1, cid.Undef, addresses, keysToKeysWithCodec(keys), false)
+		f, err := e.EventFilterManager.Install(ctx, -1, -1, cid.Undef, addresses, keysToKeysWithCodec(keys))
 		if err != nil {
 			// clean up any previous filters added and stop the sub
 			_, _ = e.EthUnsubscribe(ctx, sub.id)

--- a/node/impl/full/eth.go
+++ b/node/impl/full/eth.go
@@ -1728,7 +1728,8 @@ func (e *EthEventHandler) ethGetEventsForFilter(ctx context.Context, filterSpec 
 	}
 
 	// Create a temporary filter
-	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, false)
+	excludeReverted := pf.tipsetCid == cid.Undef
+	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, excludeReverted)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to install event filter: %w", err)
 	}
@@ -1957,7 +1958,8 @@ func (e *EthEventHandler) EthNewFilter(ctx context.Context, filterSpec *ethtypes
 		return ethtypes.EthFilterID{}, err
 	}
 
-	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, true)
+	excludeReverted := pf.tipsetCid == cid.Undef
+	f, err := e.EventFilterManager.Install(ctx, pf.minHeight, pf.maxHeight, pf.tipsetCid, pf.addresses, pf.keys, excludeReverted)
 	if err != nil {
 		return ethtypes.EthFilterID{}, xerrors.Errorf("failed to install event filter: %w", err)
 	}
@@ -2123,7 +2125,7 @@ func (e *EthEventHandler) EthSubscribe(ctx context.Context, p jsonrpc.RawParams)
 			}
 		}
 
-		f, err := e.EventFilterManager.Install(ctx, -1, -1, cid.Undef, addresses, keysToKeysWithCodec(keys), true)
+		f, err := e.EventFilterManager.Install(ctx, -1, -1, cid.Undef, addresses, keysToKeysWithCodec(keys), false)
 		if err != nil {
 			// clean up any previous filters added and stop the sub
 			_, _ = e.EthUnsubscribe(ctx, sub.id)


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/issues/12584.

-Event APIs should only returns reverted events if client has queries by block hash rather than epoch.
- The Subscribe API should always return reverted events for an accurate observation of real time changes.