### PR TITLE
fix: fix address network override via env var

### DIFF
--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -137,9 +137,13 @@ var PropagationDelaySecs = uint64(10)
 var EquivocationDelaySecs = uint64(2)
 
 func init() {
+	var addrNetwork address.Network
 	if os.Getenv("LOTUS_USE_TEST_ADDRESSES") != "1" {
-		SetAddressNetwork(address.Mainnet)
+		addrNetwork = address.Mainnet
+	} else {
+		addrNetwork = address.Testnet
 	}
+	SetAddressNetwork(addrNetwork)
 
 	if os.Getenv("LOTUS_DISABLE_TUKTUK") == "1" {
 		UpgradeTuktukHeight = math.MaxInt64 - 1


### PR DESCRIPTION


## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Default address.CurrentNetwork was changed to mainnet. As a result if `LOTUS_USE_TEST_ADDRESSES` is set we need to explicitly use testnet address.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
