### PR TITLE
fix(f3): don't return an error on stop if our context was canceled

### DIFF
--- a/chain/lf3/participation.go
+++ b/chain/lf3/participation.go
@@ -3,6 +3,7 @@ package lf3
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -82,8 +83,12 @@ func (p *Participant) Stop(ctx context.Context) error {
 
 func (p *Participant) run(ctx context.Context) (_err error) {
 	defer func() {
-		if ctx.Err() == nil && _err != nil {
-			log.Errorw("F3 participation stopped unexpectedly", "error", _err)
+		if ctx.Err() != nil {
+			_err = nil
+		}
+		if _err != nil {
+			_err = fmt.Errorf("F3 participant stopped unexpectedly: %w", _err)
+			log.Error(_err)
 		}
 	}()
 


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->

Don't return an error on stop if our context was canceled. Otherwise, the node's `stop` function returns an error and the splitstore and window post dispute tests randomly fail.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green