### PR TITLE
chore(events): remove unnecessary DisableRealTimeFilterAPI

### DIFF
--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -246,13 +246,6 @@
 
 
 [Events]
-  # DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
-  # The API is enabled when Fevm.EnableEthRPC or EnableActorEventsAPI is true, but can be disabled selectively with this flag.
-  #
-  # type: bool
-  # env var: LOTUS_EVENTS_DISABLEREALTIMEFILTERAPI
-  #DisableRealTimeFilterAPI = false
-
   # EnableActorEventsAPI enables the Actor events API that enables clients to consume events
   # emitted by (smart contracts + built-in Actors).
   # This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -88,12 +88,11 @@ func DefaultFullNode() *FullNode {
 			EthBlkCacheSize:          500,
 		},
 		Events: EventsConfig{
-			DisableRealTimeFilterAPI: false,
-			EnableActorEventsAPI:     false,
-			FilterTTL:                Duration(time.Hour * 1),
-			MaxFilters:               100,
-			MaxFilterResults:         10000,
-			MaxFilterHeightRange:     2880, // conservative limit of one day
+			EnableActorEventsAPI: false,
+			FilterTTL:            Duration(time.Hour * 1),
+			MaxFilters:           100,
+			MaxFilterResults:     10000,
+			MaxFilterHeightRange: 2880, // conservative limit of one day
 		},
 		ChainIndexer: ChainIndexerConfig{
 			EnableIndexer:       false,

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -174,13 +174,6 @@ may increase startup time.`,
 	},
 	"EventsConfig": {
 		{
-			Name: "DisableRealTimeFilterAPI",
-			Type: "bool",
-
-			Comment: `DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
-The API is enabled when Fevm.EnableEthRPC or EnableActorEventsAPI is true, but can be disabled selectively with this flag.`,
-		},
-		{
 			Name: "EnableActorEventsAPI",
 			Type: "bool",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -554,10 +554,6 @@ type FevmConfig struct {
 }
 
 type EventsConfig struct {
-	// DisableRealTimeFilterAPI will disable the RealTimeFilterAPI that can create and query filters for actor events as they are emitted.
-	// The API is enabled when Fevm.EnableEthRPC or EnableActorEventsAPI is true, but can be disabled selectively with this flag.
-	DisableRealTimeFilterAPI bool
-
 	// EnableActorEventsAPI enables the Actor events API that enables clients to consume events
 	// emitted by (smart contracts + built-in Actors).
 	// This will also enable the RealTimeFilterAPI and HistoricFilterAPI by default, but they can be
@@ -581,11 +577,6 @@ type EventsConfig struct {
 	// MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying
 	// the entire chain)
 	MaxFilterHeightRange uint64
-
-	// Others, not implemented yet:
-	// Set a limit on the number of active websocket subscriptions (may be zero)
-	// Set a timeout for subscription clients
-	// Set upper bound on index size
 }
 
 type ChainIndexerConfig struct {

--- a/node/modules/actorevent.go
+++ b/node/modules/actorevent.go
@@ -42,7 +42,7 @@ func EthEventHandler(cfg config.EventsConfig, enableEthRPC bool) func(helpers.Me
 			SubscribtionCtx:      ctx,
 		}
 
-		if !enableEthRPC || cfg.DisableRealTimeFilterAPI {
+		if !enableEthRPC {
 			// all event functionality is disabled
 			// the historic filter API relies on the real time one
 			return ee, nil
@@ -141,7 +141,7 @@ func EventFilterManager(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.L
 
 func ActorEventHandler(cfg config.EventsConfig) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *filter.EventFilterManager, *store.ChainStore, *stmgr.StateManager, EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI) (*full.ActorEventHandler, error) {
 	return func(mctx helpers.MetricsCtx, r repo.LockedRepo, lc fx.Lifecycle, fm *filter.EventFilterManager, cs *store.ChainStore, sm *stmgr.StateManager, evapi EventHelperAPI, mp *messagepool.MessagePool, stateapi full.StateAPI, chainapi full.ChainAPI) (*full.ActorEventHandler, error) {
-		if !cfg.EnableActorEventsAPI || cfg.DisableRealTimeFilterAPI {
+		if !cfg.EnableActorEventsAPI {
 			return full.NewActorEventHandler(
 				cs,
 				nil, // no EventFilterManager disables API calls


### PR DESCRIPTION
This one's always felt awkward to me and IMO is confusing to describe, so let's just remove it while we're simplifying options.