### PR TITLE
fix(chainindexer): backfilling should halt when chain state data is missing and not backfill parents

### DIFF
--- a/chain/index/api.go
+++ b/chain/index/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -285,12 +286,6 @@ func (si *SqliteIndexer) verifyIndexedData(ctx context.Context, ts *types.TipSet
 }
 
 func (si *SqliteIndexer) backfillMissingTipset(ctx context.Context, ts *types.TipSet) (*types.IndexValidation, error) {
-	// backfill the tipset in the Index
-	parentTs, err := si.cs.GetTipSetFromKey(ctx, ts.Parents())
-	if err != nil {
-		return nil, xerrors.Errorf("failed to get parent tipset at height %d: %w", ts.Height(), err)
-	}
-
 	executionTs, err := si.getNextTipset(ctx, ts)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get next tipset at height %d: %w", ts.Height(), err)
@@ -298,20 +293,15 @@ func (si *SqliteIndexer) backfillMissingTipset(ctx context.Context, ts *types.Ti
 
 	backfillFunc := func() error {
 		return withTx(ctx, si.db, func(tx *sql.Tx) error {
-			if err := si.indexTipsetWithParentEvents(ctx, tx, ts, executionTs); err != nil {
-				return xerrors.Errorf("error indexing (ts, executionTs): %w", err)
-			}
-
-			if err := si.indexTipsetWithParentEvents(ctx, tx, parentTs, ts); err != nil {
-				return xerrors.Errorf("error indexing (parentTs, ts): %w", err)
-			}
-
-			return nil
+			return si.indexTipsetWithParentEvents(ctx, tx, ts, executionTs)
 		})
 	}
 
 	if err := backfillFunc(); err != nil {
-		return nil, xerrors.Errorf("failed to backfill tipset: %w", err)
+		if ipld.IsNotFound(err) {
+			return nil, xerrors.Errorf("failed to backfill tipset at epoch %d: chain store does not contain data", ts.Height())
+		}
+		return nil, xerrors.Errorf("failed to backfill tipset at epoch %d; err: %w", ts.Height(), err)
 	}
 
 	indexedData, err := si.getIndexedTipSetData(ctx, ts)

--- a/chain/index/api.go
+++ b/chain/index/api.go
@@ -299,7 +299,7 @@ func (si *SqliteIndexer) backfillMissingTipset(ctx context.Context, ts *types.Ti
 
 	if err := backfillFunc(); err != nil {
 		if ipld.IsNotFound(err) {
-			return nil, xerrors.Errorf("failed to backfill tipset at epoch %d: chain store does not contain data", ts.Height())
+			return nil, xerrors.Errorf("failed to backfill tipset at epoch %d: chain store does not contain data: %w", ts.Height(), err)
 		}
 		return nil, xerrors.Errorf("failed to backfill tipset at epoch %d; err: %w", ts.Height(), err)
 	}

--- a/cmd/lotus-shed/chain_index.go
+++ b/cmd/lotus-shed/chain_index.go
@@ -137,7 +137,6 @@ number of failed RPC calls. Otherwise, it will exit with a zero status.
 				fromEpoch, toEpoch, backfill, logGood)
 		}
 		totalEpochs := fromEpoch - toEpoch + 1
-		haltNoData := false
 		haltHeight := -1
 
 		for epoch := fromEpoch; epoch >= toEpoch; epoch-- {
@@ -158,7 +157,6 @@ number of failed RPC calls. Otherwise, it will exit with a zero status.
 			if err != nil {
 				if strings.Contains(err.Error(), "chain store does not contain data") {
 					haltHeight = epoch
-					haltNoData = true
 					break
 				}
 
@@ -199,7 +197,7 @@ number of failed RPC calls. Otherwise, it will exit with a zero status.
 			_, _ = fmt.Fprintf(cctx.App.Writer, "Total successful Null round validations: %d\n", successfulNullRounds)
 		}
 
-		if haltNoData {
+		if haltHeight >= 0 {
 			return fmt.Errorf("chain index validation and backfilled halted at height %d as chain state does contain data for that height", haltHeight)
 		} else if failedRPCs > 0 {
 			return fmt.Errorf("chain index validation failed with %d RPC errors", failedRPCs)


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/pull/12421#discussion_r1805860944 AND https://filecoinproject.slack.com/archives/CP50PPW2X/p1729486344066509?thread_ts=1729485320.287299&cid=CP50PPW2X

**_Tested it on a calibnet node:_**

<img width="1405" alt="Screenshot 2024-10-21 at 11 56 53 AM" src="https://github.com/user-attachments/assets/75fdad57-d75f-4cce-91b6-c54c441d84c5">
