### PR TITLE
fix: handle negative value for `LOTUS_DISABLE_F3` env var gracefully

### DIFF
--- a/build/params_shared_funcs.go
+++ b/build/params_shared_funcs.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"os"
+	"strings"
 
 	"github.com/libp2p/go-libp2p/core/protocol"
 
@@ -36,5 +37,21 @@ var MustParseAddress = buildconstants.MustParseAddress
 
 func IsF3Enabled() bool {
 	const F3DisableEnvKey = "LOTUS_DISABLE_F3"
-	return buildconstants.F3Enabled && len(os.Getenv(F3DisableEnvKey)) == 0
+	if !buildconstants.F3Enabled {
+		// Build constant takes precedence over environment variable.
+		return false
+	}
+	v, disableEnvVarSet := os.LookupEnv(F3DisableEnvKey)
+	if !disableEnvVarSet {
+		// Environment variable to disable F3 is not set.
+		return true
+	}
+	switch strings.TrimSpace(strings.ToLower(v)) {
+	case "", "0", "false", "no":
+		// Consider these values as "do not disable".
+		return true
+	default:
+		// Consider any other value as disable.
+		return false
+	}
 }


### PR DESCRIPTION

## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Accept any of "", "0", "false", "no" as negative value for `LOTUS_DISABLE_F3` in which case F3 should remain enabled.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
