### PR TITLE
chore: remove redundant `F3Consensus` build parameter

### DIFF
--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -210,7 +210,3 @@ var F3ManifestServerID = MustParseID("12D3KooWHcNBkqXEBrsjoveQvj6zDF3vK5S9tAfqyY
 var F3InitialPowerTableCID cid.Cid = cid.Undef
 
 var F3BootstrapEpoch abi.ChainEpoch = 1000
-
-// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-// flag has no effect if F3 is not enabled.
-const F3Consensus = true

--- a/build/buildconstants/params_butterfly.go
+++ b/build/buildconstants/params_butterfly.go
@@ -113,7 +113,3 @@ var F3ManifestServerID = MustParseID("12D3KooWJr9jy4ngtJNR7JC1xgLFra3DjEtyxskRYW
 var F3InitialPowerTableCID cid.Cid = cid.Undef
 
 const F3BootstrapEpoch abi.ChainEpoch = 1000
-
-// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-// flag has no effect if F3 is not enabled.
-const F3Consensus = true

--- a/build/buildconstants/params_calibnet.go
+++ b/build/buildconstants/params_calibnet.go
@@ -164,7 +164,3 @@ var F3InitialPowerTableCID cid.Cid = cid.Undef
 
 // Calibnet F3 activation epoch is 2024-10-24T13:30:00Z - Epoch 2081674
 const F3BootstrapEpoch abi.ChainEpoch = UpgradeTuktukHeight + 2880
-
-// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-// flag has no effect if F3 is not enabled.
-const F3Consensus = true

--- a/build/buildconstants/params_interop.go
+++ b/build/buildconstants/params_interop.go
@@ -151,7 +151,3 @@ var F3ManifestServerID = MustParseID("12D3KooWQJ2rdVnG4okDUB6yHQhAjNutGNemcM7Xzq
 var F3InitialPowerTableCID cid.Cid = cid.Undef
 
 const F3BootstrapEpoch abi.ChainEpoch = 1000
-
-// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-// flag has no effect if F3 is not enabled.
-const F3Consensus = true

--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -189,7 +189,3 @@ var F3InitialPowerTableCID = cid.Undef
 
 const F3Enabled = true
 const F3BootstrapEpoch abi.ChainEpoch = -1
-
-// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-// flag has no effect if F3 is not enabled.
-const F3Consensus = false

--- a/build/buildconstants/params_testground.go
+++ b/build/buildconstants/params_testground.go
@@ -131,10 +131,6 @@ var (
 	F3ManifestServerID     peer.ID        = ""
 	F3BootstrapEpoch       abi.ChainEpoch = -1
 	F3InitialPowerTableCID                = cid.Undef
-
-	// F3Consensus set whether F3 should checkpoint tipsets finalized by F3. This
-	// flag has no effect if F3 is not enabled.
-	F3Consensus = true
 )
 
 func init() {


### PR DESCRIPTION


## Related Issues
* Relates to: https://github.com/filecoin-project/lotus/pull/12547

## Proposed Changes
Upgrade to `go-f3` `v0.4.0` removed the option to disable checkpointing by F3. As a result this build parameter no longer has any effect. Remove it.



## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
