### PR TITLE
fix(events): order events consistently when querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Upgrade go-f3 to 0.7.1 to resolve Tipset not found errors when trying to establish instance start time ([filecoin-project/lotus#12651](https://github.com/filecoin-project/lotus/pull/12651)).
 - Try harder in the F3 participation loop to participate using the same lotus node ([filecoin-project/lotus#12664](https://github.com/filecoin-project/lotus/pull/12664)).
 - The mining loop will now correctly "stick" to the same upstream lotus node for all operations pertaining to mining a single block ([filecoin-project/lotus#12665](https://github.com/filecoin-project/lotus/pull/12665)).
+- Make the ordering of event output for `eth_` APIs and `GetActorEventsRaw` consistent, sorting ascending on: epoch, message index, event index and original event entry order. ([filecoin-project/lotus#12623](https://github.com/filecoin-project/lotus/pull/12623))
 
 ## Deps
 

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 
 	"github.com/ipfs/go-cid"
@@ -418,10 +417,6 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 			return nil, nil
 		}
 
-		// collected event list is in inverted order since we selected only the most recent events
-		// sort it into height order
-		sort.Slice(ces, func(i, j int) bool { return ces[i].Height < ces[j].Height })
-
 		return ces, nil
 	}
 
@@ -597,6 +592,6 @@ func makePrefillFilterQuery(f *EventFilter) ([]any, string, error) {
 	}
 
 	// retain insertion order of event_entry rows
-	s += " ORDER BY tm.height DESC, ee._rowid_ ASC"
+	s += " ORDER BY tm.height ASC, tm.message_index ASC, e.event_index ASC, ee._rowid_ ASC"
 	return values, s, nil
 }


### PR DESCRIPTION
(This PR is against https://github.com/filecoin-project/lotus/pull/12421 until it's merged)

In ChainIndexer and the existing master version of this same code, we do an `ORDER BY` when querying for events but then we do a `slices.Sort` on the output, only sorting by epoch.

1. The sort is not stable, so it can end up with events jumbled up even if the epoch is properly sorted
2. We're not making use of the `ORDER BY`, in fact we do the reverse of what we ask for, so we should just do it there
3. The existing `ORDER BY` relies on insertion order (`_rowid_`) of the event entries, which should mostly be fine (aside from reverts perhaps), but we have `event_index` that we use for `logIndex` on Eth output and we're not making use of that or properly ordering by it.

Here's a list of eth events from epoch `4374648`, just listing their blockNumber, transactionIndex and logIndex:

```
  [ '0x42c078', '0x49', '0x80' ],
  [ '0x42c078', '0x35', '0x62' ],
  [ '0x42c078', '0x35', '0x61' ],
  [ '0x42c078', '0x35', '0x60' ],
  [ '0x42c078', '0x49', '0x81' ],
  [ '0x42c078', '0x49', '0x82' ]
```

They should be nicely ordered. Here is the same but with this fix:

```
  [ '0x42c078', '0x35', '0x60' ],
  [ '0x42c078', '0x35', '0x61' ],
  [ '0x42c078', '0x35', '0x62' ],
  [ '0x42c078', '0x49', '0x80' ],
  [ '0x42c078', '0x49', '0x81' ],
  [ '0x42c078', '0x49', '0x82' ]
```

Note that in the process here we're going with `ASC` for all of the fields - epochs, messages, events and event entries.

This is the query now for a from/to query of eth_getLogs:

```
SELECT e.id,
  tm.height, tm.tipset_key_cid,
  e.emitter_id, e.emitter_addr,
  e.event_index, tm.message_cid,
  tm.message_index, e.reverted,
  ee.flags, ee.key,
  ee.codec, ee.value
FROM event e  JOIN tipset_message tm ON e.message_id = tm.id
JOIN event_entry ee ON e.id = ee.event_id
HERE tm.height BETWEEN ? AND ? AND e.reverted=?
ORDER BY tm.height ASC, tm.message_index ASC, e.event_index ASC, ee._rowid_ ASC
```

And here's what the query plan looks like for that:

```
QUERY PLAN
|--SEARCH tm USING INDEX idx_height (height>? AND height<?)
|--SEARCH e USING INDEX idx_event_message_id (message_id=?)
|--SEARCH ee USING INDEX event_entry_event_id (event_id=?)
`--USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```

As long as we're hitting the height index first then we should be good.

Here's a larger range of epochs to see that it's doing ordering across epochs:

```
  [ '0x42c0db', '0x35', '0x78' ],
  [ '0x42c0de', '0x3c', '0x7c' ],
  [ '0x42c0e1', '0x37', '0x61' ],
  [ '0x42c0e4', '0x37', '0x63' ],
  [ '0x42c0e4', '0x39', '0x65' ],
  [ '0x42c0e7', '0x39', '0x6e' ],
  [ '0x42c0e9', '0x54', '0x9f' ],
  [ '0x42c0ec', '0x3b', '0x64' ],
  [ '0x42c0ee', '0x29', '0x58' ],
  [ '0x42c0ee', '0x29', '0x59' ],
  [ '0x42c0ee', '0x29', '0x5a' ],
  [ '0x42c0ee', '0x29', '0x5b' ],
  [ '0x42c0ee', '0x29', '0x5c' ],
  [ '0x42c0ee', '0x29', '0x5d' ],
  [ '0x42c0ee', '0x29', '0x5e' ],
  [ '0x42c0ee', '0x29', '0x5f' ]
```