### PR TITLE
feat(f3): display the initial power table CID in the F3 manifest

### DIFF
--- a/chain/lf3/f3.go
+++ b/chain/lf3/f3.go
@@ -184,8 +184,20 @@ func (fff *F3) GetLatestCert(ctx context.Context) (*certs.FinalityCertificate, e
 	return fff.inner.GetLatestCert(ctx)
 }
 
-func (fff *F3) GetManifest() *manifest.Manifest {
-	return fff.inner.Manifest()
+func (fff *F3) GetManifest(ctx context.Context) *manifest.Manifest {
+	m := fff.inner.Manifest()
+	if m.InitialPowerTable.Defined() {
+		return m
+	}
+	cert0, err := fff.inner.GetCert(ctx, 0)
+	if err != nil {
+		return m
+	}
+
+	var mCopy = *m
+	m = &mCopy
+	m.InitialPowerTable = cert0.ECChain.Base().PowerTable
+	return m
 }
 
 func (fff *F3) GetPowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error) {

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -152,13 +152,14 @@ func prettyPrintManifest(out io.Writer, manifest *manifest.Manifest) error {
   Protocol Version:     {{.ProtocolVersion}}
   Paused:               {{.Pause}}
   Initial Instance:     {{.InitialInstance}}
+  Initial Power Table:  {{if .InitialPowerTable.Defined}}{{.InitialPowerTable}}{{else}}unknown{{end}}
   Bootstrap Epoch:      {{.BootstrapEpoch}}
   Network Name:         {{.NetworkName}}
   Ignore EC Power:      {{.IgnoreECPower}}
   Committee Lookback:   {{.CommitteeLookback}}
   Catch Up Alignment:   {{.CatchUpAlignment}}
 
-  GPBFT Delta:                      {{.Gpbft.Delta}}
+  GPBFT Delta:                       {{.Gpbft.Delta}}
   GPBFT Delta BackOff Exponent:      {{.Gpbft.DeltaBackOffExponent}}
   GPBFT Max Lookahead Rounds:        {{.Gpbft.MaxLookaheadRounds}}
   GPBFT Rebroadcast Backoff Base:    {{.Gpbft.RebroadcastBackoffBase}}
@@ -171,8 +172,8 @@ func prettyPrintManifest(out io.Writer, manifest *manifest.Manifest) error {
   EC Head Lookback:     {{.EC.HeadLookback}}
   EC Finalize:          {{.EC.Finalize}}
 
-  Certificate Exchange Client Timeout:  {{.CertificateExchange.ClientRequestTimeout}}
-  Certificate Exchange Server Timeout:  {{.CertificateExchange.ServerRequestTimeout}}
+  Certificate Exchange Client Timeout:    {{.CertificateExchange.ClientRequestTimeout}}
+  Certificate Exchange Server Timeout:    {{.CertificateExchange.ServerRequestTimeout}}
   Certificate Exchange Min Poll Interval: {{.CertificateExchange.MinimumPollInterval}}
   Certificate Exchange Max Poll Interval: {{.CertificateExchange.MaximumPollInterval}}
 `

--- a/node/impl/full/f3.go
+++ b/node/impl/full/f3.go
@@ -57,11 +57,11 @@ func (f3api *F3API) F3GetLatestCertificate(ctx context.Context) (*certs.Finality
 	return f3api.F3.GetLatestCert(ctx)
 }
 
-func (f3api *F3API) F3GetManifest(context.Context) (*manifest.Manifest, error) {
+func (f3api *F3API) F3GetManifest(ctx context.Context) (*manifest.Manifest, error) {
 	if f3api.F3 == nil {
 		return nil, api.ErrF3Disabled
 	}
-	return f3api.F3.GetManifest(), nil
+	return f3api.F3.GetManifest(ctx), nil
 }
 
 func (f3api *F3API) F3IsRunning(context.Context) (bool, error) {


### PR DESCRIPTION
## Related Issues

This will make it easier to tell users how to set/verify `F3_INITIAL_POWERTABLE_CID`.

## Proposed Changes
<!-- A clear list of the changes being made -->

Display the initial power table CID in the `lotus f3 manifest` command output, and make sure it's set if available.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green