### PR TITLE
feat: implement Lotus F3 CLI finality cert get and list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `lotus chain head` now supports a `--height` flag to print just the epoch number of the current chain head ([filecoin-project/lotus#12609](https://github.com/filecoin-project/lotus/pull/12609))
 - `lotus-shed indexes inspect-indexes` now performs a comprehensive comparison of the event index data for each message by comparing the AMT root CID from the message receipt with the root of a reconstructed AMT. Previously `inspect-indexes` simply compared event counts, comparing AMT roots confirms all the event data is byte-perfect. ([filecoin-project/lotus#12570](https://github.com/filecoin-project/lotus/pull/12570))
 - Expose APIs to list the miner IDs that are currently participating in F3 via node. ([filecoin-project/lotus#12608](https://github.com/filecoin-project/lotus/pull/12608))
-- Implement new `lotus f3` CLI commands to list F3 participants, dump manifest and check the F3 status. ([filecoin-project/lotus#12617](https://github.com/filecoin-project/lotus/pull/12617))
+- Implement new `lotus f3` CLI commands to list F3 participants, dump manifest, get/list finality certificates and check the F3 status. ([filecoin-project/lotus#12617](https://github.com/filecoin-project/lotus/pull/12617), [filecoin-project/lotus#12627](https://github.com/filecoin-project/lotus/pull/12627))
 
 ## Bug Fixes
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,8 +11,14 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
 
+	"github.com/filecoin-project/lotus/api/v1api"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 )
 
@@ -21,7 +29,7 @@ var (
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list-miners",
-				Aliases: []string{"lp"},
+				Aliases: []string{"lm"},
 				Usage:   "Lists the miners that currently participate in F3 via this node.",
 				Action: func(cctx *cli.Context) error {
 					api, closer, err := GetFullNodeAPIV1(cctx)
@@ -39,23 +47,119 @@ var (
 						return err
 					}
 					const (
-						idColumn   = "ID"
-						fromColumn = "From"
-						ToColumn   = "To"
+						miner = "Miner"
+						from  = "From"
+						to    = "To"
 					)
 					tw := tablewriter.New(
-						tablewriter.Col(idColumn),
-						tablewriter.Col(fromColumn),
-						tablewriter.Col(ToColumn),
+						tablewriter.Col(miner),
+						tablewriter.Col(from),
+						tablewriter.Col(to),
 					)
 					for _, participant := range miners {
+						addr, err := address.NewIDAddress(participant.MinerID)
+						if err != nil {
+							return fmt.Errorf("converting miner ID to address: %w", err)
+						}
+
 						tw.Write(map[string]interface{}{
-							idColumn:   participant.MinerID,
-							fromColumn: participant.FromInstance,
-							ToColumn:   participant.FromInstance + participant.ValidityTerm,
+							miner: addr,
+							from:  participant.FromInstance,
+							to:    participant.FromInstance + participant.ValidityTerm,
 						})
 					}
 					return tw.Flush(cctx.App.Writer)
+				},
+			},
+			{
+				Name:    "certs",
+				Aliases: []string{"fc", "c", "cert"},
+				Usage:   "Manages interactions with F3 finality certificates.",
+				Flags:   []cli.Flag{f3FlagOutput},
+				Subcommands: []*cli.Command{
+					{
+						Name:  "get",
+						Usage: "Gets an F3 finality certificate.",
+						Flags: []cli.Flag{
+							f3FlagOutput,
+							f3FlagInstanceID,
+						},
+						After: func(cctx *cli.Context) error {
+							api, closer, err := GetFullNodeAPIV1(cctx)
+							if err != nil {
+								return err
+							}
+							defer closer()
+
+							// Get the certificate, either for the given instance or the latest if no
+							// instance is specified.
+							var cert *certs.FinalityCertificate
+							if cctx.IsSet(f3FlagInstanceID.Name) {
+								cert, err = api.F3GetCertificate(cctx.Context, cctx.Uint64(f3FlagInstanceID.Name))
+							} else {
+								cert, err = api.F3GetLatestCertificate(cctx.Context)
+							}
+							if err != nil {
+								return fmt.Errorf("getting finality certificate: %w", err)
+							}
+							if cert == nil {
+								_, _ = fmt.Fprintln(cctx.App.Writer, "No certificate.")
+								return nil
+							}
+
+							return outputFinalityCertificate(cctx, api, cert)
+						},
+					},
+					{
+						Name:  "list",
+						Usage: "Lists a set of F3 finality certificates.",
+						Flags: []cli.Flag{
+							f3FlagOutput,
+							f3FlagInstanceFrom,
+							f3FlagInstanceLimit,
+						},
+						Before: nil,
+						After: func(cctx *cli.Context) error {
+							api, closer, err := GetFullNodeAPIV1(cctx)
+							if err != nil {
+								return err
+							}
+							defer closer()
+
+							var count int
+							limit := cctx.Int(f3FlagInstanceLimit.Name)
+							var cert *certs.FinalityCertificate
+							for cctx.Context.Err() == nil && count <= limit {
+								if cert == nil {
+									if cctx.IsSet(f3FlagInstanceFrom.Name) {
+										cert, err = api.F3GetCertificate(cctx.Context, cctx.Uint64(f3FlagInstanceFrom.Name))
+									} else {
+										cert, err = api.F3GetLatestCertificate(cctx.Context)
+									}
+									if err != nil {
+										return fmt.Errorf("getting finality certificate: %w", err)
+									}
+								} else if cert.GPBFTInstance > 0 {
+									cert, err = api.F3GetCertificate(cctx.Context, cert.GPBFTInstance-1)
+									if err != nil {
+										return fmt.Errorf("getting finality certificate for instance %d: %w", cert.GPBFTInstance-1, err)
+									}
+								} else {
+									return nil
+								}
+
+								if cert == nil {
+									_, _ = fmt.Fprintln(cctx.App.Writer, "No certificate.")
+									return nil
+								}
+								if err := outputFinalityCertificate(cctx, api, cert); err != nil {
+									return err
+								}
+								count++
+							}
+							return nil
+						},
+					},
 				},
 			},
 			{
@@ -140,7 +244,46 @@ var (
 			}
 		},
 	}
+	f3FlagInstanceID = &cli.Uint64Flag{
+		Name:        "instance",
+		Aliases:     []string{"i", "id"},
+		Usage:       "The instance ID for which to get the finality certificate.",
+		DefaultText: "Latest instance.",
+	}
+	f3FlagInstanceFrom = &cli.Uint64Flag{
+		Name:        "fromInstance",
+		Usage:       "The start instance ID.",
+		DefaultText: "Latest instance.",
+	}
+	f3FlagInstanceLimit = &cli.IntFlag{
+		Name:  "limit",
+		Usage: "The maximum number of instances. A value less than 0 indicates no limit.",
+		Value: 10,
+	}
 )
+
+func outputFinalityCertificate(cctx *cli.Context, api v1api.FullNode, cert *certs.FinalityCertificate) error {
+	// Get the power table used by the GPBFT instance that resulted in the cert, i.e.
+	// the power table corresponding the base of the finalised chin.
+	ltsk, err := types.TipSetKeyFromBytes(cert.ECChain.Base().Key)
+	if err != nil {
+		return fmt.Errorf("decoding latest certificate tipset key: %w", err)
+	}
+	pt, err := api.F3GetF3PowerTable(cctx.Context, ltsk)
+	if err != nil {
+		return fmt.Errorf("getting F3 power table: %w", err)
+	}
+	switch output := cctx.String(f3FlagOutput.Name); strings.ToLower(output) {
+	case "text":
+		return prettyPrintFinalityCertificate(cctx.App.Writer, cert, pt)
+	case "json":
+		encoder := json.NewEncoder(cctx.App.Writer)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(cert)
+	default:
+		return fmt.Errorf("unknown output format: %s", output)
+	}
+}
 
 func prettyPrintManifest(out io.Writer, manifest *manifest.Manifest) error {
 	if manifest == nil {
@@ -148,7 +291,7 @@ func prettyPrintManifest(out io.Writer, manifest *manifest.Manifest) error {
 		return err
 	}
 
-	const manifestTemplate = `Manifest: 
+	const manifestTemplate = `Manifest:
   Protocol Version:     {{.ProtocolVersion}}
   Paused:               {{.Pause}}
   Initial Instance:     {{.InitialInstance}}
@@ -182,4 +325,112 @@ func prettyPrintManifest(out io.Writer, manifest *manifest.Manifest) error {
 		return fmt.Errorf("failed to parse manifest template: %w", err)
 	}
 	return t.ExecuteTemplate(out, "manifest", manifest)
+}
+
+func prettyPrintFinalityCertificate(out io.Writer, cert *certs.FinalityCertificate, entries gpbft.PowerEntries) error {
+	if cert == nil {
+		_, _ = fmt.Fprintln(out, "Certificate: None")
+		return nil
+	}
+
+	const certificateTemplate = `---
+Instance: {{.GPBFTInstance}}
+Finalized Chain:
+  {{ .ECChain }}
+
+Supplemental Data:
+  Commitments:          {{printf "%X" .SupplementalData.Commitments}}
+  Power Table CID:      {{.SupplementalData.PowerTable}}
+
+Power Table Delta:
+{{ptDiffToString .PowerTableDelta}}
+Signers:
+{{ signersToString .Signers }}
+Signature (base64 encoded):
+  {{ base64 .Signature }}
+`
+
+	t, err := template.New("certificate").
+		Funcs(template.FuncMap{
+			"ptDiffToString": func(diff certs.PowerTableDiff) (string, error) {
+				var buf bytes.Buffer
+				if err := prettyPrintPowerTableDiffs(&buf, diff); err != nil {
+					return "", err
+				}
+				return buf.String(), nil
+			},
+			"signersToString": func(signers bitfield.BitField) (string, error) {
+				var buf bytes.Buffer
+				if err := prettyPrintSigners(&buf, signers, entries); err != nil {
+					return "", err
+				}
+				return buf.String(), nil
+			},
+			"base64": base64.StdEncoding.EncodeToString,
+		}).Parse(certificateTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse certificate template: %w", err)
+	}
+	return t.Execute(out, cert)
+}
+
+func prettyPrintPowerTableDiffs(out io.Writer, diff certs.PowerTableDiff) error {
+	if len(diff) == 0 {
+		_, _ = fmt.Fprintln(out, "[]")
+		return nil
+	}
+	const (
+		miner       = "Miner"
+		deltaColumn = "Power Delta"
+	)
+	tw := tablewriter.New(
+		tablewriter.Col(miner),
+		tablewriter.Col(deltaColumn),
+	)
+	for _, delta := range diff {
+		addr, err := address.NewIDAddress(uint64(delta.ParticipantID))
+		if err != nil {
+			return fmt.Errorf("getting ID address: %w", err)
+		}
+		tw.Write(map[string]interface{}{
+			miner:       addr,
+			deltaColumn: delta.PowerDelta,
+		})
+	}
+	return tw.Flush(out)
+}
+
+func prettyPrintSigners(out io.Writer, signers bitfield.BitField, entries gpbft.PowerEntries) error {
+	pt := gpbft.NewPowerTable()
+	if err := pt.Add(entries...); err != nil {
+		return fmt.Errorf("populating power table from entries: %w", err)
+	}
+
+	const (
+		miner        = "Miner"
+		powerScaled  = "Scaled Power"
+		powerPercent = "Power %"
+	)
+	tw := tablewriter.New(
+		tablewriter.Col(miner),
+		tablewriter.Col(powerScaled),
+		tablewriter.Col(powerPercent),
+	)
+	if err := signers.ForEach(func(index uint64) error {
+		entry := pt.Entries[index]
+		addr, err := address.NewIDAddress(uint64(entry.ID))
+		if err != nil {
+			return fmt.Errorf("getting ID address: %w", err)
+		}
+		signerPowerPercent := (float64(pt.ScaledPower[index]) / float64(pt.ScaledTotal)) * 100
+		tw.Write(map[string]interface{}{
+			miner:        addr,
+			powerScaled:  pt.ScaledPower[index],
+			powerPercent: fmt.Sprintf("%.2f%%", signerPowerPercent),
+		})
+		return nil
+	}); err != nil {
+		return err
+	}
+	return tw.Flush(out)
 }

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -75,7 +75,6 @@ var (
 				Name:    "certs",
 				Aliases: []string{"fc", "c", "cert"},
 				Usage:   "Manages interactions with F3 finality certificates.",
-				Flags:   []cli.Flag{f3FlagOutput},
 				Subcommands: []*cli.Command{
 					{
 						Name:  "get",
@@ -118,7 +117,6 @@ var (
 							f3FlagInstanceFrom,
 							f3FlagInstanceLimit,
 						},
-						Before: nil,
 						After: func(cctx *cli.Context) error {
 							api, closer, err := GetFullNodeAPIV1(cctx)
 							if err != nil {
@@ -129,7 +127,7 @@ var (
 							var count int
 							limit := cctx.Int(f3FlagInstanceLimit.Name)
 							var cert *certs.FinalityCertificate
-							for cctx.Context.Err() == nil && count <= limit {
+							for cctx.Context.Err() == nil && count < limit {
 								if cert == nil {
 									if cctx.IsSet(f3FlagInstanceFrom.Name) {
 										cert, err = api.F3GetCertificate(cctx.Context, cctx.Uint64(f3FlagInstanceFrom.Name))

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -100,7 +100,8 @@ var (
 							// instance is specified.
 							var cert *certs.FinalityCertificate
 							if cctx.Args().Present() {
-								instance, err := strconv.ParseUint(cctx.Args().First(), 10, 64)
+								var instance uint64
+								instance, err = strconv.ParseUint(cctx.Args().First(), 10, 64)
 								if err != nil {
 									return fmt.Errorf("parsing instance: %w", err)
 								}

--- a/cli/templates/f3_finality_cert.go.tmpl
+++ b/cli/templates/f3_finality_cert.go.tmpl
@@ -1,0 +1,37 @@
+Instance:     {{.GPBFTInstance}}
+Power Table:
+  Next:       {{.SupplementalData.PowerTable}}
+  Delta:      {{ptDiffToString .PowerTableDelta}}
+Finalized Chain:
+  Length:     {{ $chainLength := len .ECChain -}}{{ $chainLength }}
+  Epochs:     {{ .ECChain.Base.Epoch -}}-{{ .ECChain.Head.Epoch }}
+  Chain:
+{{- $maxTipSets := 10 -}}
+{{- $maxTipSetKeys := 2 -}}
+{{- range $i, $tipset := .ECChain -}}
+    {{- if lt $i $maxTipSets -}}
+        {{- if lt (add $i 1) $chainLength }}
+    ├──
+        {{- else }}
+    └──
+        {{- end -}}
+        {{- $ltsk := tipSetKeyToLotusTipSetKey $tipset.Key -}}
+        {{- $ltskLength := len $ltsk.Cids -}}
+        {{ $tipset.Epoch }} (length: {{ $ltskLength }}): [
+        {{- range $j, $cid := $ltsk.Cids -}}
+            {{- if lt $j $maxTipSetKeys -}}
+                {{- if lt (add $j 1) $ltskLength -}}
+                    {{- $cid -}}, {{ else -}}
+                    {{- $cid -}}
+                {{- end -}}
+            {{- else -}}
+                ...
+                {{- break -}}
+            {{- end -}}
+        {{- end -}}]
+    {{- else }}
+    └──...omitted the remaining {{ sub $chainLength $maxTipSets }} tipsets.
+        {{- break -}}
+    {{- end -}}
+{{- end }}
+Signed by {{ .Signers.Count }} miner(s).

--- a/cli/templates/f3_manifest.go.tmpl
+++ b/cli/templates/f3_manifest.go.tmpl
@@ -1,0 +1,28 @@
+Manifest:
+  Protocol Version:     {{.ProtocolVersion}}
+  Paused:               {{.Pause}}
+  Initial Instance:     {{.InitialInstance}}
+  Initial Power Table:  {{if .InitialPowerTable.Defined}}{{.InitialPowerTable}}{{else}}unknown{{end}}
+  Bootstrap Epoch:      {{.BootstrapEpoch}}
+  Network Name:         {{.NetworkName}}
+  Ignore EC Power:      {{.IgnoreECPower}}
+  Committee Lookback:   {{.CommitteeLookback}}
+  Catch Up Alignment:   {{.CatchUpAlignment}}
+
+  GPBFT Delta:                       {{.Gpbft.Delta}}
+  GPBFT Delta BackOff Exponent:      {{.Gpbft.DeltaBackOffExponent}}
+  GPBFT Max Lookahead Rounds:        {{.Gpbft.MaxLookaheadRounds}}
+  GPBFT Rebroadcast Backoff Base:    {{.Gpbft.RebroadcastBackoffBase}}
+  GPBFT Rebroadcast Backoff Spread:  {{.Gpbft.RebroadcastBackoffSpread}}
+  GPBFT Rebroadcast Backoff Max:     {{.Gpbft.RebroadcastBackoffMax}}
+
+  EC Period:            {{.EC.Period}}
+  EC Finality:          {{.EC.Finality}}
+  EC Delay Multiplier:  {{.EC.DelayMultiplier}}
+  EC Head Lookback:     {{.EC.HeadLookback}}
+  EC Finalize:          {{.EC.Finalize}}
+
+  Certificate Exchange Client Timeout:    {{.CertificateExchange.ClientRequestTimeout}}
+  Certificate Exchange Server Timeout:    {{.CertificateExchange.ServerRequestTimeout}}
+  Certificate Exchange Min Poll Interval: {{.CertificateExchange.MinimumPollInterval}}
+  Certificate Exchange Max Poll Interval: {{.CertificateExchange.MaximumPollInterval}}

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2729,10 +2729,11 @@ USAGE:
    lotus f3 command [command options] [arguments...]
 
 COMMANDS:
-   list-miners, lp  Lists the miners that currently participate in F3 via this node.
-   manifest         Gets the current manifest used by F3.
-   status           Checks the F3 status.
-   help, h          Shows a list of commands or help for one command
+   list-miners, lm     Lists the miners that currently participate in F3 via this node.
+   certs, fc, c, cert  Manages interactions with F3 finality certificates.
+   manifest            Gets the current manifest used by F3.
+   status              Checks the F3 status.
+   help, h             Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -2748,6 +2749,53 @@ USAGE:
 
 OPTIONS:
    --help, -h  show help
+```
+
+### lotus f3 certs
+```
+NAME:
+   lotus f3 certs - Manages interactions with F3 finality certificates.
+
+USAGE:
+   lotus f3 certs command [command options] [arguments...]
+
+COMMANDS:
+   get      Gets an F3 finality certificate.
+   list     Lists a set of F3 finality certificates.
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --output value  The output format. Supported formats: text, json (default: "text")
+   --help, -h      show help
+```
+
+#### lotus f3 certs get
+```
+NAME:
+   lotus f3 certs get - Gets an F3 finality certificate.
+
+USAGE:
+   lotus f3 certs get [command options] [arguments...]
+
+OPTIONS:
+   --output value                          The output format. Supported formats: text, json (default: "text")
+   --instance value, -i value, --id value  The instance ID for which to get the finality certificate. (default: Latest instance.)
+   --help, -h                              show help
+```
+
+#### lotus f3 certs list
+```
+NAME:
+   lotus f3 certs list - Lists a set of F3 finality certificates.
+
+USAGE:
+   lotus f3 certs list [command options] [arguments...]
+
+OPTIONS:
+   --output value        The output format. Supported formats: text, json (default: "text")
+   --fromInstance value  The start instance ID. (default: Latest instance.)
+   --limit value         The maximum number of instances. A value less than 0 indicates no limit. (default: 10)
+   --help, -h            show help
 ```
 
 ### lotus f3 manifest

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2763,20 +2763,38 @@ COMMANDS:
    get      Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
    list     Lists a range of F3 finality certificates.
 
+            By default the certificates are listed in newest to oldest order,
+            i.e. descending instance IDs. The order may be reversed using the
+            '--reverse' flag.
+
             A range may optionally be specified as the first argument to indicate 
             inclusive range of 'from' and 'to' instances in following notation:
             '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
-            An omitted instance is interpreted as the latest instance.
+            An omitted <from> value is always interpreted as 0, and an omitted
+            <to> value indicates the latest instance. If both are specified, <from>
+            must never exceed <to>.
 
-            If no range is specified, certificates are listed in descending order
-            of instance, starting from the latest until the limit is reached, i.e.
-            the default range of '..0'.
+            If no range is specified all certificates are listed, i.e. the range
+            of '0..'.
 
             Examples:
-              * '5..': from instance 5 to the latest instance.
-              * '..0': from the latest instance to instance 0.
-              * '3..2': from instance 3 to instance 2.
-              * '2..3': from instance 2 to instance 3.
+              * All certificates from newest to oldest:
+                  $ lotus f3 certs list 0..
+
+              * Three newest certificates:
+                  $ lotus f3 certs list --limit 3 0..
+
+              * Three oldest certificates:
+                  $ lotus f3 certs list --limit 3 --reverse 0..
+
+              * Up to three certificates starting from instance 1413 to the oldest:
+                  $ lotus f3 certs list --limit 3 ..1413
+
+              * Up to 3 certificates starting from instance 1413 to the newest:
+                  $ lotus f3 certs list --limit 3 --reverse 1413..
+
+              * All certificates from instance 3 to 1413 in order of newest to oldest:
+                  $ lotus f3 certs list 3..1413
 
    help, h  Shows a list of commands or help for one command
 
@@ -2802,20 +2820,38 @@ OPTIONS:
 NAME:
    lotus f3 certs list - Lists a range of F3 finality certificates.
 
+                         By default the certificates are listed in newest to oldest order,
+                         i.e. descending instance IDs. The order may be reversed using the
+                         '--reverse' flag.
+
                          A range may optionally be specified as the first argument to indicate 
                          inclusive range of 'from' and 'to' instances in following notation:
                          '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
-                         An omitted instance is interpreted as the latest instance.
+                         An omitted <from> value is always interpreted as 0, and an omitted
+                         <to> value indicates the latest instance. If both are specified, <from>
+                         must never exceed <to>.
 
-                         If no range is specified, certificates are listed in descending order
-                         of instance, starting from the latest until the limit is reached, i.e.
-                         the default range of '..0'.
+                         If no range is specified all certificates are listed, i.e. the range
+                         of '0..'.
 
                          Examples:
-                           * '5..': from instance 5 to the latest instance.
-                           * '..0': from the latest instance to instance 0.
-                           * '3..2': from instance 3 to instance 2.
-                           * '2..3': from instance 2 to instance 3.
+                           * All certificates from newest to oldest:
+                               $ lotus f3 certs list 0..
+
+                           * Three newest certificates:
+                               $ lotus f3 certs list --limit 3 0..
+
+                           * Three oldest certificates:
+                               $ lotus f3 certs list --limit 3 --reverse 0..
+
+                           * Up to three certificates starting from instance 1413 to the oldest:
+                               $ lotus f3 certs list --limit 3 ..1413
+
+                           * Up to 3 certificates starting from instance 1413 to the newest:
+                               $ lotus f3 certs list --limit 3 --reverse 1413..
+
+                           * All certificates from instance 3 to 1413 in order of newest to oldest:
+                               $ lotus f3 certs list 3..1413
 
 
 USAGE:
@@ -2823,7 +2859,8 @@ USAGE:
 
 OPTIONS:
    --output value  The output format. Supported formats: text, json (default: "text")
-   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: 10)
+   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: No limit)
+   --reverse       Reverses the default order of output.  (default: false)
    --help, -h      show help
 ```
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2729,11 +2729,11 @@ USAGE:
    lotus f3 command [command options] [arguments...]
 
 COMMANDS:
-   list-miners, lm     Lists the miners that currently participate in F3 via this node.
-   certs, fc, c, cert  Manages interactions with F3 finality certificates.
-   manifest            Gets the current manifest used by F3.
-   status              Checks the F3 status.
-   help, h             Shows a list of commands or help for one command
+   list-miners, lm  Lists the miners that currently participate in F3 via this node.
+   certs, c         Manages interactions with F3 finality certificates.
+   manifest         Gets the current manifest used by F3.
+   status           Checks the F3 status.
+   help, h          Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help
@@ -2760,42 +2760,71 @@ USAGE:
    lotus f3 certs command [command options] [arguments...]
 
 COMMANDS:
-   get      Gets an F3 finality certificate.
-   list     Lists a set of F3 finality certificates.
+   get      Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
+   list     Lists a range of F3 finality certificates.
+
+            A range may optionally be specified as the first argument to indicate 
+            inclusive range of 'from' and 'to' instances in following notation:
+            '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
+            An omitted instance is interpreted as the latest instance.
+
+            If no range is specified, certificates are listed in descending order
+            of instance, starting from the latest until the limit is reached, i.e.
+            the default range of '..0'.
+
+            Examples:
+              * '5..': from instance 5 to the latest instance.
+              * '..0': from the latest instance to instance 0.
+              * '3..2': from instance 3 to instance 2.
+              * '2..3': from instance 2 to instance 3.
+
    help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help
+```
+
+#### lotus f3 certs get
+```
+NAME:
+   lotus f3 certs get - Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
+
+USAGE:
+   lotus f3 certs get [command options] [instance]
 
 OPTIONS:
    --output value  The output format. Supported formats: text, json (default: "text")
    --help, -h      show help
 ```
 
-#### lotus f3 certs get
-```
-NAME:
-   lotus f3 certs get - Gets an F3 finality certificate.
-
-USAGE:
-   lotus f3 certs get [command options] [arguments...]
-
-OPTIONS:
-   --output value                          The output format. Supported formats: text, json (default: "text")
-   --instance value, -i value, --id value  The instance ID for which to get the finality certificate. (default: Latest instance.)
-   --help, -h                              show help
-```
-
 #### lotus f3 certs list
 ```
 NAME:
-   lotus f3 certs list - Lists a set of F3 finality certificates.
+   lotus f3 certs list - Lists a range of F3 finality certificates.
+
+                         A range may optionally be specified as the first argument to indicate 
+                         inclusive range of 'from' and 'to' instances in following notation:
+                         '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
+                         An omitted instance is interpreted as the latest instance.
+
+                         If no range is specified, certificates are listed in descending order
+                         of instance, starting from the latest until the limit is reached, i.e.
+                         the default range of '..0'.
+
+                         Examples:
+                           * '5..': from instance 5 to the latest instance.
+                           * '..0': from the latest instance to instance 0.
+                           * '3..2': from instance 3 to instance 2.
+                           * '2..3': from instance 2 to instance 3.
+
 
 USAGE:
-   lotus f3 certs list [command options] [arguments...]
+   lotus f3 certs list [command options] [range]
 
 OPTIONS:
-   --output value        The output format. Supported formats: text, json (default: "text")
-   --fromInstance value  The start instance ID. (default: Latest instance.)
-   --limit value         The maximum number of instances. A value less than 0 indicates no limit. (default: 10)
-   --help, -h            show help
+   --output value  The output format. Supported formats: text, json (default: "text")
+   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: 10)
+   --help, -h      show help
 ```
 
 ### lotus f3 manifest


### PR DESCRIPTION




## Related Issues
* Part of #12607

## Proposed Changes
Implement `lotus f3` CLI sub commands to:
* Get a specific finality certificate, either latest or by instance ID.
* List a range of finality certificates

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
