### PR TITLE
fix(f3): try again when we fail to fetch the manifest

### DIFF
--- a/chain/lf3/participation.go
+++ b/chain/lf3/participation.go
@@ -203,6 +203,7 @@ func (p *Participant) awaitLeaseExpiry(ctx context.Context, lease api.F3Particip
 			}
 			log.Errorw("Failed to check F3 progress while awaiting lease expiry. Retrying after backoff.", "attempts", p.backoff.Attempt(), "backoff", p.backoff.Duration(), "err", err)
 			p.backOff(ctx)
+			continue
 		case manifest == nil || manifest.NetworkName != lease.Network:
 			// If we got an unexpected manifest, or no manifest, go back to the
 			// beginning and try to get another ticket. Switching from having a manifest

--- a/chain/lf3/participation_test.go
+++ b/chain/lf3/participation_test.go
@@ -1,0 +1,75 @@
+package lf3_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jpillora/backoff"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/lf3"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+)
+
+type manifestFailAPI struct {
+	manifestRequested chan struct{}
+}
+
+func (m *manifestFailAPI) F3GetManifest(ctx context.Context) (*manifest.Manifest, error) {
+	select {
+	case m.manifestRequested <- struct{}{}:
+	default:
+	}
+	return nil, errors.New("test error")
+}
+
+func (m *manifestFailAPI) F3GetOrRenewParticipationTicket(ctx context.Context, minerID address.Address, previous api.F3ParticipationTicket, instances uint64) (api.F3ParticipationTicket, error) {
+	switch string(previous) {
+	case "good ticket":
+		return api.F3ParticipationTicket("bad ticket"), nil
+	case "":
+		return api.F3ParticipationTicket("good ticket"), nil
+	default:
+		panic("unexpected ticket")
+	}
+}
+
+func (m *manifestFailAPI) F3GetProgress(ctx context.Context) (gpbft.Instant, error) {
+	return gpbft.Instant{}, nil
+}
+
+func (m *manifestFailAPI) F3Participate(ctx context.Context, ticket api.F3ParticipationTicket) (api.F3ParticipationLease, error) {
+	return api.F3ParticipationLease{
+		Network:      "test",
+		Issuer:       "foobar",
+		MinerID:      0,
+		FromInstance: 0,
+		ValidityTerm: 10,
+	}, nil
+}
+
+// Test that we correctly handle failed requests for the manifest and keep trying to get it.
+func TestParticipantManifestFailure(t *testing.T) {
+	api := &manifestFailAPI{manifestRequested: make(chan struct{}, 5)}
+	addr, err := address.NewIDAddress(1000)
+	require.NoError(t, err)
+
+	p := lf3.NewParticipant(context.Background(), api, dtypes.MinerAddress(addr),
+		&backoff.Backoff{
+			Min:    1 * time.Second,
+			Max:    1 * time.Minute,
+			Factor: 1.5,
+		}, 13, 5)
+	require.NoError(t, p.Start(context.Background()))
+	<-api.manifestRequested
+	<-api.manifestRequested
+	<-api.manifestRequested
+	require.NoError(t, p.Stop(context.Background()))
+}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

Try again when we fail to fetch the manifest (reported via Antithesis). Continuing with the function here will lead to a panic. This can happen, e.g., if the lotus node stops and/or returns an error while the participant is waiting for its lease to expire.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green