### PR TITLE
fix: fix F3 JSON RPC error pass through across API boundary

### DIFF
--- a/api/api_errors.go
+++ b/api/api_errors.go
@@ -23,22 +23,22 @@ var (
 	RPCErrors = jsonrpc.NewErrors()
 
 	// ErrF3Disabled signals that F3 consensus process is disabled.
-	ErrF3Disabled = errF3Disabled{}
+	ErrF3Disabled = &errF3Disabled{}
 	// ErrF3ParticipationTicketInvalid signals that F3ParticipationTicket cannot be decoded.
-	ErrF3ParticipationTicketInvalid = errF3ParticipationTicketInvalid{}
+	ErrF3ParticipationTicketInvalid = &errF3ParticipationTicketInvalid{}
 	// ErrF3ParticipationTicketExpired signals that the current GPBFT instance as surpassed the expiry of the ticket.
-	ErrF3ParticipationTicketExpired = errF3ParticipationTicketExpired{}
+	ErrF3ParticipationTicketExpired = &errF3ParticipationTicketExpired{}
 	// ErrF3ParticipationIssuerMismatch signals that the ticket is not issued by the current node.
-	ErrF3ParticipationIssuerMismatch = errF3ParticipationIssuerMismatch{}
+	ErrF3ParticipationIssuerMismatch = &errF3ParticipationIssuerMismatch{}
 	// ErrF3ParticipationTooManyInstances signals that participation ticket cannot be
 	// issued because it asks for too many instances.
-	ErrF3ParticipationTooManyInstances = errF3ParticipationTooManyInstances{}
+	ErrF3ParticipationTooManyInstances = &errF3ParticipationTooManyInstances{}
 	// ErrF3ParticipationTicketStartBeforeExisting signals that participation ticket
 	// is before the start instance of an existing lease held by the miner.
-	ErrF3ParticipationTicketStartBeforeExisting = errF3ParticipationTicketStartBeforeExisting{}
+	ErrF3ParticipationTicketStartBeforeExisting = &errF3ParticipationTicketStartBeforeExisting{}
 	// ErrF3NotReady signals that the F3 instance isn't ready for participation yet. The caller
 	// should back off and try again later.
-	ErrF3NotReady = errF3NotReady{}
+	ErrF3NotReady = &errF3NotReady{}
 
 	_ error = (*ErrOutOfGas)(nil)
 	_ error = (*ErrActorNotFound)(nil)


### PR DESCRIPTION

## Related Issues
* Fixes #12630
## Proposed Changes

Fix the issue by instantiating pointers to sentinel F3 error values and assert that errors indeed pass through via an integration test.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
