### PR TITLE
[skip changelog] fix(cli): print RebroadcastBackoffExponent in lotus f3 manifest

### DIFF
--- a/cli/templates/f3_manifest.go.tmpl
+++ b/cli/templates/f3_manifest.go.tmpl
@@ -9,12 +9,13 @@ Manifest:
   Committee Lookback:   {{.CommitteeLookback}}
   Catch Up Alignment:   {{.CatchUpAlignment}}
 
-  GPBFT Delta:                       {{.Gpbft.Delta}}
-  GPBFT Delta BackOff Exponent:      {{.Gpbft.DeltaBackOffExponent}}
-  GPBFT Max Lookahead Rounds:        {{.Gpbft.MaxLookaheadRounds}}
-  GPBFT Rebroadcast Backoff Base:    {{.Gpbft.RebroadcastBackoffBase}}
-  GPBFT Rebroadcast Backoff Spread:  {{.Gpbft.RebroadcastBackoffSpread}}
-  GPBFT Rebroadcast Backoff Max:     {{.Gpbft.RebroadcastBackoffMax}}
+  GPBFT Delta:                        {{.Gpbft.Delta}}
+  GPBFT Delta BackOff Exponent:       {{.Gpbft.DeltaBackOffExponent}}
+  GPBFT Max Lookahead Rounds:         {{.Gpbft.MaxLookaheadRounds}}
+  GPBFT Rebroadcast Backoff Base:     {{.Gpbft.RebroadcastBackoffBase}}
+  GPBFT Rebroadcast Backoff Exponent: {{.Gpbft.RebroadcastBackoffExponent}}
+  GPBFT Rebroadcast Backoff Spread:   {{.Gpbft.RebroadcastBackoffSpread}}
+  GPBFT Rebroadcast Backoff Max:      {{.Gpbft.RebroadcastBackoffMax}}
 
   EC Period:            {{.EC.Period}}
   EC Finality:          {{.EC.Finality}}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

(Came across this while implementing https://github.com/ChainSafe/forest/pull/4937)
 `RebroadcastBackoffExponent` seems to be dropped in `lotus f3 manifest` output. 

## Proposed Changes
<!-- A clear list of the changes being made -->

Print `GPBFT Rebroadcast Backoff Exponent: 1.3` line in `lotus f3 manifest` output

## Additional Info
<!-- Callouts, links to documentation, and etc -->

Output with the change
```
➜  lotus git:(master) ✗ ./lotus f3 manifest
Manifest:
  Protocol Version:     4
  Paused:               false
  Initial Instance:     0
  Initial Power Table:  bafy2bzaceab236vmmb3n4q4tkvua2n4dphcbzzxerxuey3mot4g3cov5j3r2c
  Bootstrap Epoch:      2081674
  Network Name:         calibrationnet
  Ignore EC Power:      false
  Committee Lookback:   10
  Catch Up Alignment:   15s

  GPBFT Delta:                        6s
  GPBFT Delta BackOff Exponent:       2
  GPBFT Max Lookahead Rounds:         5
  GPBFT Rebroadcast Backoff Base:     6s
  GPBFT Rebroadcast Backoff Exponent: 1.3
  GPBFT Rebroadcast Backoff Spread:   0.1
  GPBFT Rebroadcast Backoff Max:      1m0s

  EC Period:            30s
  EC Finality:          900
  EC Delay Multiplier:  2
  EC Head Lookback:     0
  EC Finalize:          true

  Certificate Exchange Client Timeout:    10s
  Certificate Exchange Server Timeout:    1m0s
  Certificate Exchange Min Poll Interval: 30s
  Certificate Exchange Max Poll Interval: 2m0s
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
