### PR TITLE
test(chain): test forking before/after finality

### DIFF
--- a/chain/store/checkpoint_test.go
+++ b/chain/store/checkpoint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/gen"
 )
 
@@ -20,6 +21,7 @@ func TestChainCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	cg.AdvanceState = false
 
 	// Let the first miner mine some blocks.
 	last := cg.CurTipset.TipSet()
@@ -83,4 +85,41 @@ func TestChainCheckpoint(t *testing.T) {
 
 	head = cs.GetHeaviestTipSet()
 	require.True(t, head.Equals(checkpoint))
+
+	// Now extend the fork 900 epochs into the future.
+	for i := 0; i < int(policy.ChainFinality)+10; i++ {
+		ts, err := cg.NextTipSetFromMiners(last, cg.Miners[1:], 0)
+		require.NoError(t, err)
+
+		last = ts.TipSet.TipSet()
+	}
+
+	// Try to re-checkpoint to the long fork. This will work because we only have to revert a
+	// single epoch.
+	err = cs.SetCheckpoint(ctx, last)
+	require.NoError(t, err)
+
+	head = cs.GetHeaviestTipSet()
+	require.True(t, head.Equals(last))
+
+	// Now try to go back to the checkpoint. This should fail because it's too far in the past
+	// on the wrong fork.
+	err = cs.SetCheckpoint(ctx, checkpoint)
+	require.Error(t, err)
+
+	// Now extend the checkpoint chain to the same tipset.
+	for checkpoint.Height() < last.Height() {
+		ts, err := cg.NextTipSetFromMiners(checkpoint, cg.Miners[1:], 0)
+		require.NoError(t, err)
+
+		checkpoint = ts.TipSet.TipSet()
+	}
+
+	// We should still refuse to switch.
+	err = cs.SetCheckpoint(ctx, checkpoint)
+	require.Error(t, err)
+
+	// But it should be possible to set a checkpoint on a common chain
+	err = cs.SetCheckpoint(ctx, checkpointParents)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

tests for #12650

## Proposed Changes
<!-- A clear list of the changes being made -->

Test checkpoints beyond finality. Specifically, ensure:

1. We can checkpoint before finality.
2. We cannot fork more than finality epochs.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

I had to add a bit of a hack to the chain-gen logic to optionally prevent time (state) from moving forwards. Otherwise, we'd lose all power and actually providing window posts was going to be too much trouble.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green