### PR TITLE
chore: set Mainnet upgrade epoch for NV24

### DIFF
--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -109,8 +109,8 @@ const UpgradePhoenixHeight abi.ChainEpoch = UpgradeDragonHeight + 120
 // 2024-08-06T12:00:00Z
 const UpgradeWaffleHeight abi.ChainEpoch = 4154640
 
-// ??????
-var UpgradeTuktukHeight = abi.ChainEpoch(9999999999)
+// 2024-11-20T23:00:00Z
+var UpgradeTuktukHeight = abi.ChainEpoch(4461240)
 
 // FIP-0081: for the power actor state for pledge calculations.
 // UpgradeTuktukPowerRampDurationEpochs ends up in the power actor state after
@@ -188,4 +188,6 @@ var F3ManifestServerID = MustParseID("12D3KooWENMwUF9YxvQxar7uBWJtZkA6amvK4xWmKX
 var F3InitialPowerTableCID = cid.Undef
 
 const F3Enabled = true
-const F3BootstrapEpoch abi.ChainEpoch = -1
+
+// 2024-12-04T23:00:00Z
+const F3BootstrapEpoch abi.ChainEpoch = 4501560


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/12480

## Proposed Changes
- Sets UpgradeTuktukHeight to epoch 4461240. This should be equivalent to:
   - 23:00 in London
   - 15:00 in Los Angeles
   - 07:00 in Beijing (NB: 2024-11-21 in CST)

- Sets F3BootstrapEpoch to epoch 4501560. This should be equivalent to:
   - 23:00 in London
   - 15:00 in Los Angeles
   - 07:00 in Beijing (NB: 2024-12-05 in CST)

## Additional Info
Slack conversation: [link](https://filecoinproject.slack.com/archives/C05P37R9KQD/p1730128669893169)

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
