### PR TITLE
fix(f3): when returning a partially used lease, trim its ValidityTerm

### DIFF
--- a/chain/lf3/participation_lease.go
+++ b/chain/lf3/participation_lease.go
@@ -104,6 +104,8 @@ func (l *leaser) participate(ticket api.F3ParticipationTicket) (api.F3Participat
 	if found {
 		// short-circuite for reparticipation.
 		if currentLease == newLease {
+			newLease.ValidityTerm = newLease.ToInstance() - instant.ID
+			newLease.FromInstance = instant.ID
 			return newLease, nil
 		}
 		if currentLease.Network == newLease.Network && currentLease.FromInstance > newLease.FromInstance {

--- a/chain/lf3/participation_lease_test.go
+++ b/chain/lf3/participation_lease_test.go
@@ -34,6 +34,15 @@ func TestLeaser(t *testing.T) {
 		require.Equal(t, issuer.String(), lease.Issuer)
 		require.Equal(t, uint64(10), lease.FromInstance) // Current instance (10) + offset (5)
 		require.Equal(t, uint64(5), lease.ValidityTerm)  // Current instance (10) + offset (5)
+
+		progress.currentInstance += 2
+
+		lease, err = subject.participate(ticket)
+		require.NoError(t, err)
+		require.Equal(t, uint64(123), lease.MinerID)
+		require.Equal(t, issuer.String(), lease.Issuer)
+		require.Equal(t, uint64(12), lease.FromInstance) // Current instance (10) + offset (5)
+		require.Equal(t, uint64(3), lease.ValidityTerm)  // Current instance (10) + offset (5)
 	})
 	t.Run("get participants", func(t *testing.T) {
 		progress.currentInstance = 11


### PR DESCRIPTION
Otherwise the early renew logic will never trigger.