### PR TITLE
chore: conditionally change the limit of F3 certs listed via CLI

### DIFF
--- a/cli/f3.go
+++ b/cli/f3.go
@@ -135,8 +135,9 @@ An omitted <from> value is always interpreted as 0, and an omitted
 <to> value indicates the latest instance. If both are specified, <from>
 must never exceed <to>.
 
-If no range is specified all certificates are listed, i.e. the range
-of '0..'.
+If no range is specified, the latest 10 certificates are listed, i.e. 
+the range of '0..' with limit of 10. Otherwise, all certificates in
+the specified range are listed unless limit is explicitly specified.
 
 Examples:
   * All certificates from newest to oldest:
@@ -181,6 +182,10 @@ Examples:
 							fromTo := cctx.Args().First()
 							if fromTo == "" {
 								fromTo = "0.."
+								if !cctx.IsSet(f3FlagInstanceLimit.Name) {
+									// Default to limit of 10 if no explicit range and limit is given.
+									limit = 10
+								}
 							}
 							r, err := newRanger(fromTo, limit, reverse, func() (uint64, error) {
 								latest, err := api.F3GetLatestCertificate(cctx.Context)
@@ -306,7 +311,7 @@ Examples:
 	f3FlagInstanceLimit = &cli.IntFlag{
 		Name:        "limit",
 		Usage:       "The maximum number of instances. A value less than 0 indicates no limit.",
-		DefaultText: "No limit",
+		DefaultText: "10 when no range is specified. Otherwise, unlimited.",
 		Value:       -1,
 	}
 	f3FlagReverseOrder = &cli.BoolFlag{

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2774,8 +2774,9 @@ COMMANDS:
             <to> value indicates the latest instance. If both are specified, <from>
             must never exceed <to>.
 
-            If no range is specified all certificates are listed, i.e. the range
-            of '0..'.
+            If no range is specified, the latest 10 certificates are listed, i.e. 
+            the range of '0..' with limit of 10. Otherwise, all certificates in
+            the specified range are listed unless limit is explicitly specified.
 
             Examples:
               * All certificates from newest to oldest:
@@ -2831,8 +2832,9 @@ NAME:
                          <to> value indicates the latest instance. If both are specified, <from>
                          must never exceed <to>.
 
-                         If no range is specified all certificates are listed, i.e. the range
-                         of '0..'.
+                         If no range is specified, the latest 10 certificates are listed, i.e. 
+                         the range of '0..' with limit of 10. Otherwise, all certificates in
+                         the specified range are listed unless limit is explicitly specified.
 
                          Examples:
                            * All certificates from newest to oldest:
@@ -2859,7 +2861,7 @@ USAGE:
 
 OPTIONS:
    --output value  The output format. Supported formats: text, json (default: "text")
-   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: No limit)
+   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: 10 when no range is specified. Otherwise, unlimited.)
    --reverse       Reverses the default order of output.  (default: false)
    --help, -h      show help
 ```


### PR DESCRIPTION




## Related Issues
Addresses https://github.com/filecoin-project/lotus/pull/12627#discussion_r1815426539

## Proposed Changes
* When no range is given, default limit to 10
* Otherwise default to unlimited.

This is better than the current default of always unlimited because:
* there are a lot of certs, and
* when range is given the chances are the user wants all of them.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
