### PR TITLE
fix: getMsgInfo returns an ErrNotFound when there are no rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Implement `EthGetTransactionByBlockNumberAndIndex` (`eth_getTransactionByBlockNumberAndIndex`) and `EthGetTransactionByBlockHashAndIndex` (`eth_getTransactionByBlockHashAndIndex`) methods. ([filecoin-project/lotus#12618](https://github.com/filecoin-project/lotus/pull/12618))
 
 ## Bug Fixes
+- GetMsgInfo returns an ErrNotFound when there are no rows ([filecoin-project/lotus#12680](https://github.com/filecoin-project/lotus/pull/12680))
 - Fix a bug in the `lotus-shed indexes backfill-events` command that may result in either duplicate events being backfilled where there are existing events (such an operation *should* be idempotent) or events erroneously having duplicate `logIndex` values when queried via ETH APIs. ([filecoin-project/lotus#12567](https://github.com/filecoin-project/lotus/pull/12567))
 - Event APIs (Eth events and actor events) should only return reverted events if client queries by specific block hash / tipset. Eth and actor event subscription APIs should always return reverted events to enable accurate observation of real-time changes. ([filecoin-project/lotus#12585](https://github.com/filecoin-project/lotus/pull/12585))
 - Add logic to check if the miner's owner address is delegated (f4 address). If it is delegated, the `lotus-shed sectors termination-estimate` command now sends the termination state call using the worker ID. This fix resolves the issue where termination-estimate did not function correctly for miners with delegated owner addresses. ([filecoin-project/lotus#12569](https://github.com/filecoin-project/lotus/pull/12569))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - Make `EthTraceFilter` / `trace_filter` skip null rounds instead of erroring. ([filecoin-project/lotus#12702](https://github.com/filecoin-project/lotus/pull/12702))
 - Event APIs (`GetActorEventsRaw`, `SubscribeActorEventsRaw`, `eth_getLogs`, `eth_newFilter`, etc.) will now return an error when a request matches more than `MaxFilterResults` (default: 10,000) rather than silently truncating the results. Also apply an internal event matcher for `eth_getLogs` (etc.) to avoid builtin actor events on database query so as not to include them in `MaxFilterResults` calculation. ([filecoin-project/lotus#12671](https://github.com/filecoin-project/lotus/pull/12671))
-- GetMsgInfo returns an ErrNotFound when there are no rows ([filecoin-project/lotus#12680](https://github.com/filecoin-project/lotus/pull/12680))
+- `ChainIndexer#GetMsgInfo` returns an `ErrNotFound` when there are no rows. ([filecoin-project/lotus#12680](https://github.com/filecoin-project/lotus/pull/12680))
 
 ## New Features
 

--- a/chain/index/read.go
+++ b/chain/index/read.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -48,10 +49,8 @@ func (si *SqliteIndexer) GetMsgInfo(ctx context.Context, messageCid cid.Cid) (*M
 	var tipsetKeyCidBytes []byte
 	var height int64
 
-	if err := si.readWithHeadIndexWait(ctx, func() error {
-		return si.queryMsgInfo(ctx, messageCid, &tipsetKeyCidBytes, &height)
-	}); err != nil {
-		if err == sql.ErrNoRows {
+	if err := si.queryMsgInfo(ctx, messageCid, &tipsetKeyCidBytes, &height); err != nil {
+		if strings.Contains(err.Error(), "no rows in result set") {
 			return nil, ErrNotFound
 		}
 		return nil, err

--- a/chain/index/read.go
+++ b/chain/index/read.go
@@ -3,7 +3,6 @@ package index
 import (
 	"context"
 	"database/sql"
-	"strings"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -50,7 +49,7 @@ func (si *SqliteIndexer) GetMsgInfo(ctx context.Context, messageCid cid.Cid) (*M
 	var height int64
 
 	if err := si.queryMsgInfo(ctx, messageCid, &tipsetKeyCidBytes, &height); err != nil {
-		if strings.Contains(err.Error(), "no rows in result set") {
+		if err == sql.ErrNoRows {
 			return nil, ErrNotFound
 		}
 		return nil, err

--- a/chain/index/read.go
+++ b/chain/index/read.go
@@ -48,7 +48,12 @@ func (si *SqliteIndexer) GetMsgInfo(ctx context.Context, messageCid cid.Cid) (*M
 	var tipsetKeyCidBytes []byte
 	var height int64
 
-	if err := si.queryMsgInfo(ctx, messageCid, &tipsetKeyCidBytes, &height); err != nil {
+	if err := si.readWithHeadIndexWait(ctx, func() error {
+		return si.queryMsgInfo(ctx, messageCid, &tipsetKeyCidBytes, &height)
+	}); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/chain/index/read_test.go
+++ b/chain/index/read_test.go
@@ -82,7 +82,7 @@ func TestGetMsgInfo(t *testing.T) {
 		nonExistentMsgCid := randomCid(t, rng)
 		mi, err := s.GetMsgInfo(ctx, nonExistentMsgCid)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrNotFound))
+		require.ErrorIs(t, err, ErrNotFound)
 		require.Nil(t, mi)
 	})
 }


### PR DESCRIPTION
## Related Issues
Closes #12674

## Proposed Changes
GetMsgInfo returns an ErrNotFound when there are no rows.


## Checklist


- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
