### PR TITLE
fix: fix minor bugs in lotus shed datastore subcommand

### DIFF
--- a/cmd/lotus-shed/datastore.go
+++ b/cmd/lotus-shed/datastore.go
@@ -133,8 +133,8 @@ var datastoreClearCmd = &cli.Command{
 	},
 	ArgsUsage: "[namespace]",
 	Action: func(cctx *cli.Context) (_err error) {
-		if cctx.NArg() != 2 {
-			return xerrors.Errorf("requires 2 arguments: the datastore prefix")
+		if cctx.NArg() != 1 {
+			return xerrors.Errorf("requires 1 argument: the datastore prefix")
 		}
 		namespace := cctx.Args().Get(0)
 
@@ -157,7 +157,7 @@ var datastoreClearCmd = &cli.Command{
 		}
 		defer lr.Close() //nolint:errcheck
 
-		ds, err := lr.Datastore(cctx.Context, namespace)
+		ds, err := lr.Datastore(cctx.Context, datastore.NewKey(namespace).String())
 		if err != nil {
 			return err
 		}
@@ -306,7 +306,7 @@ var datastoreExportCmd = &cli.Command{
 		}
 		defer lr.Close() //nolint:errcheck
 
-		ds, err := lr.Datastore(cctx.Context, namespace)
+		ds, err := lr.Datastore(cctx.Context, datastore.NewKey(namespace).String())
 		if err != nil {
 			return err
 		}
@@ -389,7 +389,7 @@ var datastoreImportCmd = &cli.Command{
 		}
 		defer lr.Close() //nolint:errcheck
 
-		ds, err := lr.Datastore(cctx.Context, namespace)
+		ds, err := lr.Datastore(cctx.Context, datastore.NewKey(namespace).String())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
* Use consistent pattern to pick `namespace`: the cleaned datastore key vs. direct user input. This way `metadata` for example would work consistently. Otherwise, `clear`, `export` and `import` wont work unless `/metadata` is specified.

* Fix minor bug on number of arguments required for `clear` command.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
