### PR TITLE
feat: implement F3 CLI to list power table and proportional power at instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+## New Features
+
+* Implement F3 utility CLIs to list the power table for a given instance and sum the proportional power of a set of actors that participate in a given instance. See: https://github.com/filecoin-project/lotus/pull/12698.
+
 # UNRELEASED v1.31.0
 
 See https://github.com/filecoin-project/lotus/blob/release/v1.31.0/CHANGELOG.md

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -85,12 +85,9 @@ var f3SubCmdPowerTable = &cli.Command{
 	Aliases: []string{"pt"},
 	Subcommands: []*cli.Command{
 		{
-			Name:    "get",
-			Aliases: []string{"g"},
-			Usage: `Get F3 power table at a specific instance ID or latest instance if none is specified.
-
-The instance may be specified as the first argument. If unspecified,
-the latest instance is used.`,
+			Name:      "get",
+			Aliases:   []string{"g"},
+			Usage:     `Get F3 power table at a specific instance ID or latest instance if none is specified.`,
 			ArgsUsage: "[instance]",
 			Flags:     []cli.Flag{f3FlagPowerTableFromEC},
 			Before: func(cctx *cli.Context) error {
@@ -179,16 +176,9 @@ the latest instance is used.`,
 			},
 		},
 		{
-			Name:    "get-proportion",
-			Aliases: []string{"gp"},
-			Usage: `Gets the total proportion of power for a list of actors at a given instance.
-
-The instance may be specified via --instance flag. If unspecified, the
-latest instance is used.
-
-The list of actors may be specified as Actor ID or miner address, space
-separated, via arguments. Example:
-  $ lotus f3 powertable get-proportion -i 42 1413 t01234 f12345`,
+			Name:      "get-proportion",
+			Aliases:   []string{"gp"},
+			Usage:     `Gets the total proportion of power for a list of actors at a given instance.`,
 			ArgsUsage: "<actor-id> [actor-id] ...",
 			Flags: []cli.Flag{
 				f3FlagPowerTableFromEC,

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -34,11 +34,7 @@ var (
 			{
 				Name:    "list-miners",
 				Aliases: []string{"lm"},
-				Usage: `Lists the miners that currently participate in F3 via this node.
-
-The instance may be specified as the first argument. If unspecified,
-the latest instance is used.
-`,
+				Usage:   `Lists the miners that currently participate in F3 via this node.`,
 				Action: func(cctx *cli.Context) error {
 					api, closer, err := GetFullNodeAPIV1(cctx)
 					if err != nil {
@@ -84,9 +80,12 @@ the latest instance is used.
 				Aliases: []string{"pt"},
 				Subcommands: []*cli.Command{
 					{
-						Name:      "get",
-						Aliases:   []string{"g"},
-						Usage:     "Get F3 power table at a specific instance ID or latest instance if none is specified.",
+						Name:    "get",
+						Aliases: []string{"g"},
+						Usage: `Get F3 power table at a specific instance ID or latest instance if none is specified.
+
+The instance may be specified as the first argument. If unspecified,
+the latest instance is used.`,
 						ArgsUsage: "[instance]",
 						Flags:     []cli.Flag{f3FlagPowerTableFromEC},
 						Before: func(cctx *cli.Context) error {
@@ -184,8 +183,7 @@ the latest instance is used.
 
 The list of actors may be specified as Actor ID or miner address, space
 separated, pied to STDIN. Example:
-  $ echo "1413 t01234 f12345" | lotus f3 powertable get-proportion 42
-`,
+  $ echo "1413 t01234 f12345" | lotus f3 powertable get-proportion 42`,
 						ArgsUsage: "[instance]",
 						Flags:     []cli.Flag{f3FlagPowerTableFromEC},
 						Before: func(cctx *cli.Context) error {

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -295,9 +295,8 @@ separated, pied to STDIN. Example:
 								// Prune duplicate IDs.
 								if _, ok := seenIDs[actorID]; ok {
 									continue
-								} else {
-									seenIDs[actorID] = struct{}{}
 								}
+								seenIDs[actorID] = struct{}{}
 								scaled, key := pt.Get(actorID)
 								if key == nil {
 									return fmt.Errorf("actor ID %q not found in power table", actorID)

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2799,10 +2799,6 @@ USAGE:
 
 COMMANDS:
    list-miners, lm  Lists the miners that currently participate in F3 via this node.
-
-                    The instance may be specified as the first argument. If unspecified,
-                    the latest instance is used.
-
    powertable, pt   
    certs, c         Manages interactions with F3 finality certificates.
    manifest         Gets the current manifest used by F3.
@@ -2818,12 +2814,191 @@ OPTIONS:
 NAME:
    lotus f3 list-miners - Lists the miners that currently participate in F3 via this node.
 
-                          The instance may be specified as the first argument. If unspecified,
-                          the latest instance is used.
+USAGE:
+   lotus f3 list-miners [command options] [arguments...]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+### lotus f3 powertable
+```
+NAME:
+   lotus f3 powertable
+
+USAGE:
+   lotus f3 powertable command [command options] [arguments...]
+
+COMMANDS:
+   get, g              Get F3 power table at a specific instance ID or latest instance if none is specified.
+
+                       The instance may be specified as the first argument. If unspecified,
+                       the latest instance is used.
+   get-proportion, gp  Gets the total proportion of power for a list of actors at a given instance.
+
+                       The instance may be specified as the first argument. If unspecified,
+                       the latest instance is used.
+
+                       The list of actors may be specified as Actor ID or miner address, space
+                       separated, pied to STDIN. Example:
+                         $ echo "1413 t01234 f12345" | lotus f3 powertable get-proportion 42
+   help, h             Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help
+```
+
+#### lotus f3 powertable get
+```
+NAME:
+   lotus f3 powertable get - Get F3 power table at a specific instance ID or latest instance if none is specified.
+
+                             The instance may be specified as the first argument. If unspecified,
+                             the latest instance is used.
+
+USAGE:
+   lotus f3 powertable get [command options] [instance]
+
+OPTIONS:
+   --ec        Whether to get the power table from EC. (default: false)
+   --help, -h  show help
+```
+
+### lotus f3 certs
+```
+NAME:
+   lotus f3 certs - Manages interactions with F3 finality certificates.
+
+USAGE:
+   lotus f3 certs command [command options] [arguments...]
+
+COMMANDS:
+   get      Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
+   list     Lists a range of F3 finality certificates.
+
+            By default the certificates are listed in newest to oldest order,
+            i.e. descending instance IDs. The order may be reversed using the
+            '--reverse' flag.
+
+            A range may optionally be specified as the first argument to indicate 
+            inclusive range of 'from' and 'to' instances in following notation:
+            '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
+            An omitted <from> value is always interpreted as 0, and an omitted
+            <to> value indicates the latest instance. If both are specified, <from>
+            must never exceed <to>.
+
+            If no range is specified, the latest 10 certificates are listed, i.e. 
+            the range of '0..' with limit of 10. Otherwise, all certificates in
+            the specified range are listed unless limit is explicitly specified.
+
+            Examples:
+              * All certificates from newest to oldest:
+                  $ lotus f3 certs list 0..
+
+              * Three newest certificates:
+                  $ lotus f3 certs list --limit 3 0..
+
+              * Three oldest certificates:
+                  $ lotus f3 certs list --limit 3 --reverse 0..
+
+              * Up to three certificates starting from instance 1413 to the oldest:
+                  $ lotus f3 certs list --limit 3 ..1413
+
+              * Up to 3 certificates starting from instance 1413 to the newest:
+                  $ lotus f3 certs list --limit 3 --reverse 1413..
+
+              * All certificates from instance 3 to 1413 in order of newest to oldest:
+                  $ lotus f3 certs list 3..1413
+
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help
+```
+
+#### lotus f3 certs get
+```
+NAME:
+   lotus f3 certs get - Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
+
+USAGE:
+   lotus f3 certs get [command options] [instance]
+
+OPTIONS:
+   --output value  The output format. Supported formats: text, json (default: "text")
+   --help, -h      show help
+```
+
+#### lotus f3 certs list
+```
+NAME:
+   lotus f3 certs list - Lists a range of F3 finality certificates.
+
+                         By default the certificates are listed in newest to oldest order,
+                         i.e. descending instance IDs. The order may be reversed using the
+                         '--reverse' flag.
+
+                         A range may optionally be specified as the first argument to indicate 
+                         inclusive range of 'from' and 'to' instances in following notation:
+                         '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
+                         An omitted <from> value is always interpreted as 0, and an omitted
+                         <to> value indicates the latest instance. If both are specified, <from>
+                         must never exceed <to>.
+
+                         If no range is specified, the latest 10 certificates are listed, i.e. 
+                         the range of '0..' with limit of 10. Otherwise, all certificates in
+                         the specified range are listed unless limit is explicitly specified.
+
+                         Examples:
+                           * All certificates from newest to oldest:
+                               $ lotus f3 certs list 0..
+
+                           * Three newest certificates:
+                               $ lotus f3 certs list --limit 3 0..
+
+                           * Three oldest certificates:
+                               $ lotus f3 certs list --limit 3 --reverse 0..
+
+                           * Up to three certificates starting from instance 1413 to the oldest:
+                               $ lotus f3 certs list --limit 3 ..1413
+
+                           * Up to 3 certificates starting from instance 1413 to the newest:
+                               $ lotus f3 certs list --limit 3 --reverse 1413..
+
+                           * All certificates from instance 3 to 1413 in order of newest to oldest:
+                               $ lotus f3 certs list 3..1413
 
 
 USAGE:
-   lotus f3 list-miners [command options] [arguments...]
+   lotus f3 certs list [command options] [range]
+
+OPTIONS:
+   --output value  The output format. Supported formats: text, json (default: "text")
+   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: 10 when no range is specified. Otherwise, unlimited.)
+   --reverse       Reverses the default order of output.  (default: false)
+   --help, -h      show help
+```
+
+### lotus f3 manifest
+```
+NAME:
+   lotus f3 manifest - Gets the current manifest used by F3.
+
+USAGE:
+   lotus f3 manifest [command options] [arguments...]
+
+OPTIONS:
+   --output value  The output format. Supported formats: text, json (default: "text")
+   --help, -h      show help
+```
+
+### lotus f3 status
+```
+NAME:
+   lotus f3 status - Checks the F3 status.
+
+USAGE:
+   lotus f3 status [command options] [arguments...]
 
 OPTIONS:
    --help, -h  show help

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2836,12 +2836,12 @@ COMMANDS:
                        the latest instance is used.
    get-proportion, gp  Gets the total proportion of power for a list of actors at a given instance.
 
-                       The instance may be specified as the first argument. If unspecified,
-                       the latest instance is used.
+                       The instance may be specified via --instance flag. If unspecified, the
+                       latest instance is used.
 
                        The list of actors may be specified as Actor ID or miner address, space
-                       separated, pied to STDIN. Example:
-                         $ echo "1413 t01234 f12345" | lotus f3 powertable get-proportion 42
+                       separated, via arguments. Example:
+                         $ lotus f3 powertable get-proportion -i 42 1413 t01234 f12345
    help, h             Shows a list of commands or help for one command
 
 OPTIONS:

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2831,17 +2831,7 @@ USAGE:
 
 COMMANDS:
    get, g              Get F3 power table at a specific instance ID or latest instance if none is specified.
-
-                       The instance may be specified as the first argument. If unspecified,
-                       the latest instance is used.
    get-proportion, gp  Gets the total proportion of power for a list of actors at a given instance.
-
-                       The instance may be specified via --instance flag. If unspecified, the
-                       latest instance is used.
-
-                       The list of actors may be specified as Actor ID or miner address, space
-                       separated, via arguments. Example:
-                         $ lotus f3 powertable get-proportion -i 42 1413 t01234 f12345
    help, h             Shows a list of commands or help for one command
 
 OPTIONS:
@@ -2853,15 +2843,26 @@ OPTIONS:
 NAME:
    lotus f3 powertable get - Get F3 power table at a specific instance ID or latest instance if none is specified.
 
-                             The instance may be specified as the first argument. If unspecified,
-                             the latest instance is used.
-
 USAGE:
    lotus f3 powertable get [command options] [instance]
 
 OPTIONS:
    --ec        Whether to get the power table from EC. (default: false)
    --help, -h  show help
+```
+
+#### lotus f3 powertable get-proportion
+```
+NAME:
+   lotus f3 powertable get-proportion - Gets the total proportion of power for a list of actors at a given instance.
+
+USAGE:
+   lotus f3 powertable get-proportion [command options] <actor-id> [actor-id] ...
+
+OPTIONS:
+   --ec                        Whether to get the power table from EC. (default: false)
+   --instance value, -i value  The F3 instance ID. (default: Latest Instance)
+   --help, -h                  show help
 ```
 
 ### lotus f3 certs

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -2799,6 +2799,11 @@ USAGE:
 
 COMMANDS:
    list-miners, lm  Lists the miners that currently participate in F3 via this node.
+
+                    The instance may be specified as the first argument. If unspecified,
+                    the latest instance is used.
+
+   powertable, pt   
    certs, c         Manages interactions with F3 finality certificates.
    manifest         Gets the current manifest used by F3.
    status           Checks the F3 status.
@@ -2813,148 +2818,12 @@ OPTIONS:
 NAME:
    lotus f3 list-miners - Lists the miners that currently participate in F3 via this node.
 
+                          The instance may be specified as the first argument. If unspecified,
+                          the latest instance is used.
+
+
 USAGE:
    lotus f3 list-miners [command options] [arguments...]
-
-OPTIONS:
-   --help, -h  show help
-```
-
-### lotus f3 certs
-```
-NAME:
-   lotus f3 certs - Manages interactions with F3 finality certificates.
-
-USAGE:
-   lotus f3 certs command [command options] [arguments...]
-
-COMMANDS:
-   get      Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
-   list     Lists a range of F3 finality certificates.
-
-            By default the certificates are listed in newest to oldest order,
-            i.e. descending instance IDs. The order may be reversed using the
-            '--reverse' flag.
-
-            A range may optionally be specified as the first argument to indicate 
-            inclusive range of 'from' and 'to' instances in following notation:
-            '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
-            An omitted <from> value is always interpreted as 0, and an omitted
-            <to> value indicates the latest instance. If both are specified, <from>
-            must never exceed <to>.
-
-            If no range is specified, the latest 10 certificates are listed, i.e. 
-            the range of '0..' with limit of 10. Otherwise, all certificates in
-            the specified range are listed unless limit is explicitly specified.
-
-            Examples:
-              * All certificates from newest to oldest:
-                  $ lotus f3 certs list 0..
-
-              * Three newest certificates:
-                  $ lotus f3 certs list --limit 3 0..
-
-              * Three oldest certificates:
-                  $ lotus f3 certs list --limit 3 --reverse 0..
-
-              * Up to three certificates starting from instance 1413 to the oldest:
-                  $ lotus f3 certs list --limit 3 ..1413
-
-              * Up to 3 certificates starting from instance 1413 to the newest:
-                  $ lotus f3 certs list --limit 3 --reverse 1413..
-
-              * All certificates from instance 3 to 1413 in order of newest to oldest:
-                  $ lotus f3 certs list 3..1413
-
-   help, h  Shows a list of commands or help for one command
-
-OPTIONS:
-   --help, -h  show help
-```
-
-#### lotus f3 certs get
-```
-NAME:
-   lotus f3 certs get - Gets an F3 finality certificate to a given instance ID, or the latest certificate if no instance is specified.
-
-USAGE:
-   lotus f3 certs get [command options] [instance]
-
-OPTIONS:
-   --output value  The output format. Supported formats: text, json (default: "text")
-   --help, -h      show help
-```
-
-#### lotus f3 certs list
-```
-NAME:
-   lotus f3 certs list - Lists a range of F3 finality certificates.
-
-                         By default the certificates are listed in newest to oldest order,
-                         i.e. descending instance IDs. The order may be reversed using the
-                         '--reverse' flag.
-
-                         A range may optionally be specified as the first argument to indicate 
-                         inclusive range of 'from' and 'to' instances in following notation:
-                         '<from>..<to>'. Either <from> or <to> may be omitted, but not both.
-                         An omitted <from> value is always interpreted as 0, and an omitted
-                         <to> value indicates the latest instance. If both are specified, <from>
-                         must never exceed <to>.
-
-                         If no range is specified, the latest 10 certificates are listed, i.e. 
-                         the range of '0..' with limit of 10. Otherwise, all certificates in
-                         the specified range are listed unless limit is explicitly specified.
-
-                         Examples:
-                           * All certificates from newest to oldest:
-                               $ lotus f3 certs list 0..
-
-                           * Three newest certificates:
-                               $ lotus f3 certs list --limit 3 0..
-
-                           * Three oldest certificates:
-                               $ lotus f3 certs list --limit 3 --reverse 0..
-
-                           * Up to three certificates starting from instance 1413 to the oldest:
-                               $ lotus f3 certs list --limit 3 ..1413
-
-                           * Up to 3 certificates starting from instance 1413 to the newest:
-                               $ lotus f3 certs list --limit 3 --reverse 1413..
-
-                           * All certificates from instance 3 to 1413 in order of newest to oldest:
-                               $ lotus f3 certs list 3..1413
-
-
-USAGE:
-   lotus f3 certs list [command options] [range]
-
-OPTIONS:
-   --output value  The output format. Supported formats: text, json (default: "text")
-   --limit value   The maximum number of instances. A value less than 0 indicates no limit. (default: 10 when no range is specified. Otherwise, unlimited.)
-   --reverse       Reverses the default order of output.  (default: false)
-   --help, -h      show help
-```
-
-### lotus f3 manifest
-```
-NAME:
-   lotus f3 manifest - Gets the current manifest used by F3.
-
-USAGE:
-   lotus f3 manifest [command options] [arguments...]
-
-OPTIONS:
-   --output value  The output format. Supported formats: text, json (default: "text")
-   --help, -h      show help
-```
-
-### lotus f3 status
-```
-NAME:
-   lotus f3 status - Checks the F3 status.
-
-USAGE:
-   lotus f3 status [command options] [arguments...]
 
 OPTIONS:
    --help, -h  show help


### PR DESCRIPTION



## Related Issues



## Proposed Changes
Implement utility CLIs to:
* get the power table used by F3 at a given instance ID.
* get total proportional power of a list of actors at a given instance ID.

These utilities allow us to debug the exact participation power for an instance without having to manually calculate it or estimate it from the latest power.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
