### PR TITLE
chore: use DEBUG level log when F3 is not ready for participation

### DIFF
--- a/chain/lf3/participation.go
+++ b/chain/lf3/participation.go
@@ -193,7 +193,7 @@ func (p *Participant) tryParticipate(ctx context.Context, ticket api.F3Participa
 			log.Debugw("Reattempting F3 participation with the same ticket.", "attempts", p.backoff.Attempt())
 			continue
 		case errors.Is(err, api.ErrF3NotReady):
-			log.Warnw("F3 is not ready. Retrying F3 participation after backoff.", "backoff", p.backoff.Duration(), "err", err)
+			log.Debugw("F3 is not ready. Retrying F3 participation after backoff.", "backoff", p.backoff.Duration(), "err", err)
 			p.backOff(ctx)
 			continue
 		case err != nil:


### PR DESCRIPTION




## Related Issues
* Fixes #12688

## Proposed Changes
To reduce log verbosity change the log level for message indicating that F3 is not ready for participation yet. Because, the participation logic will reattempt after some backoff and these logs may at times become too verbose.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
