### PR TITLE
feat(shed): check command for FIP-0081 pledge calculation

### DIFF
--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -1140,14 +1140,13 @@ func preFip0081StateMinerInitialPledgeForSector(ctx context.Context, t *testing.
 		VelocityEstimate: networkQAPower.VelocityEstimate,
 	}
 
-	initialPledge, err := miner14.InitialPledgeForPower(
+	initialPledge := miner14.InitialPledgeForPower(
 		sectorWeight,
 		thisEpochBaselinePower,
 		rewardEstimate,
 		networkQAPowerEstimate,
 		circSupply.FilCirculating,
-	), nil
-	req.NoError(err)
+	)
 
 	var initialPledgeNum = types.NewInt(110)
 	var initialPledgeDen = types.NewInt(100)


### PR DESCRIPTION
```
lotus-shed audits fip0081-pledge
```

```
Calculating at epoch 4462564
 Sector Size | Verified % | Duration  | Actual                   | Pre-FIP-0081             | Difference
---------------------------------------------------------------------------------------------------------
 2KiB        |  100%      | 1 year(s) | 0.000000082694866747 FIL | 0.000000082694866747 FIL | 0
 2KiB        |   50%      | 1 year(s) | 0.000000045482176711 FIL | 0.000000045482176711 FIL | 0
 2KiB        |    0%      | 1 year(s) | 0.000000008269486673 FIL | 0.000000008269486673 FIL | 0
 2KiB        |  100%      | 3 year(s) | 0.000000082694866747 FIL | 0.000000082694866747 FIL | 0
 2KiB        |   50%      | 3 year(s) | 0.000000045482176711 FIL | 0.000000045482176711 FIL | 0
 2KiB        |    0%      | 3 year(s) | 0.000000008269486673 FIL | 0.000000008269486673 FIL | 0
 32GiB       |  100%      | 1 year(s) | 1.387389641535528066 FIL | 1.387389641535528066 FIL | 0
 32GiB       |   50%      | 1 year(s) | 0.763064302844540436 FIL | 0.763064302844540436 FIL | 0
 32GiB       |    0%      | 1 year(s) | 0.138738964153552805 FIL | 0.138738964153552805 FIL | 0
 32GiB       |  100%      | 3 year(s) | 1.387389641535528066 FIL | 1.387389641535528066 FIL | 0
 32GiB       |   50%      | 3 year(s) | 0.763064302844540436 FIL | 0.763064302844540436 FIL | 0
 32GiB       |    0%      | 3 year(s) | 0.138738964153552805 FIL | 0.138738964153552805 FIL | 0
 64GiB       |  100%      | 1 year(s) | 2.774779283071056134 FIL | 2.774779283071056134 FIL | 0
 64GiB       |   50%      | 1 year(s) | 1.526128605689080873 FIL | 1.526128605689080873 FIL | 0
 64GiB       |    0%      | 1 year(s) | 0.277477928307105612 FIL | 0.277477928307105612 FIL | 0
 64GiB       |  100%      | 3 year(s) | 2.774779283071056134 FIL | 2.774779283071056134 FIL | 0
 64GiB       |   50%      | 3 year(s) | 1.526128605689080873 FIL | 1.526128605689080873 FIL | 0
 64GiB       |    0%      | 3 year(s) | 0.277477928307105612 FIL | 0.277477928307105612 FIL | 0
---------------------------------------------------------------------------------------------------------
```

Currently not a measurable difference. Will keep on checking and if there remains no difference then I'll do more digging. The ramp time is a year so it should be very gradual.

Also .. TIL pledge is the same for different durations even though the functions take a duration value for spacetime calculation?