### PR TITLE
fix(miner): fix scary verified power miscalculation upon extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Lotus changelog
 
 # UNRELEASED
+
+- Correct erroneous sector qap calculation upon sector extension in lotus-miner cli. ([filecoin-project/lotus#12698](https://github.com/filecoin-project/lotus/pull/12720))
+
 - Improve eth filter performance for nodes serving many clients. ([filecoin-project/lotus#12603](https://github.com/filecoin-project/lotus/pull/12603))
+
+
 
 ## Improvements
 

--- a/cmd/lotus-miner/sectors.go
+++ b/cmd/lotus-miner/sectors.go
@@ -220,9 +220,11 @@ var sectorsListCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
+		powerBaseEpochs := make(map[abi.SectorNumber]abi.ChainEpoch, len(sset))
 		commitedIDs := make(map[abi.SectorNumber]struct{}, len(sset))
 		for _, info := range sset {
 			commitedIDs[info.SectorNumber] = struct{}{}
+			powerBaseEpochs[info.SectorNumber] = info.PowerBaseEpoch
 		}
 
 		sort.Slice(list, func(i, j int) bool {
@@ -290,7 +292,8 @@ var sectorsListCmd = &cli.Command{
 			estimate := (st.Expiration-st.Activation <= 0) || sealing.IsUpgradeState(sealing.SectorState(st.State))
 			if !estimate {
 				rdw := big.Add(st.DealWeight, st.VerifiedDealWeight)
-				dw = float64(big.Div(rdw, big.NewInt(int64(st.Expiration-st.Activation))).Uint64())
+				powerBaseEpoch := powerBaseEpochs[st.SectorID]
+				dw = float64(big.Div(rdw, big.NewInt(int64(st.Expiration-powerBaseEpoch))).Uint64())
 				vp = float64(big.Div(big.Mul(st.VerifiedDealWeight, big.NewInt(verifiedPowerGainMul)), big.NewInt(int64(st.Expiration-st.Activation))).Uint64())
 			} else {
 				for _, piece := range st.Pieces {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
They probably exist but I couldn't find them

## Proposed Changes
<!-- A clear list of the changes being made -->
Fix sectors display to calculate verified power against correct power base epoch.  This way we don't divide by an incorrect denominator and scare SPs into thinking extensions will dilute their power (i.e. lets not let the whole point of FIP 0045 go to waste)

## Additional Info
<!-- Callouts, links to documentation, and etc -->
slack thread here: https://filecoinproject.slack.com/archives/C015KQQLQQ1/p1728479245409819
## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
