### PR TITLE
fix: skip checking the initial power table CID if undefined

### DIFF
--- a/cli/f3.go
+++ b/cli/f3.go
@@ -162,7 +162,7 @@ var f3SubCmdPowerTable = &cli.Command{
 				if err != nil {
 					return fmt.Errorf("gettingh power table CID at instance %d: %w", instance, err)
 				}
-				if !expectedPowerTableCID.Equals(actualPowerTableCID) {
+				if !cid.Undef.Equals(expectedPowerTableCID) && !expectedPowerTableCID.Equals(actualPowerTableCID) {
 					return fmt.Errorf("expected power table CID %s at instance %d, got: %s", expectedPowerTableCID, instance, actualPowerTableCID)
 				}
 				result.PowerTable.CID = actualPowerTableCID.String()
@@ -247,7 +247,7 @@ var f3SubCmdPowerTable = &cli.Command{
 				if err != nil {
 					return fmt.Errorf("gettingh power table CID at instance %d: %w", instance, err)
 				}
-				if !expectedPowerTableCID.Equals(actualPowerTableCID) {
+				if !cid.Undef.Equals(expectedPowerTableCID) && !expectedPowerTableCID.Equals(actualPowerTableCID) {
 					return fmt.Errorf("expected power table CID %s at instance %d, got: %s", expectedPowerTableCID, instance, actualPowerTableCID)
 				}
 				result.PowerTable.CID = actualPowerTableCID.String()


### PR DESCRIPTION

## Related Issues
* #12698

## Proposed Changes
In Lotus F3 cli Only check the expected power table CID when it is present.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
