### PR TITLE
fix: use numerical formatting when printing F3 CLI error message

### DIFF
--- a/cli/f3.go
+++ b/cli/f3.go
@@ -287,7 +287,7 @@ var f3SubCmdPowerTable = &cli.Command{
 					seenIDs[actorID] = struct{}{}
 					scaled, key := pt.Get(actorID)
 					if key == nil {
-						return fmt.Errorf("actor ID %q not found in power table", actorID)
+						return fmt.Errorf("actor ID %d not found in power table", actorID)
 					}
 					result.ScaledSum += scaled
 				}


### PR DESCRIPTION

## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
Use numerical format to print actor IDs not found. Otherwise, `%q` will print special character.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
