### PR TITLE
fix(sync): do not allow to expand checkpointed tipsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 
 - Add Market PendingProposals API / CLI. ([filecoin-project/lotus#12724](https://github.com/filecoin-project/lotus/pull/12724))
+- Fix checkpointed tipsets being expanded #12747
 
 ## Improvements
 

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -531,7 +531,7 @@ func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
 	if maybeHead.Height() == hts.Height() {
 		// check if maybeHead is fully contained in headTipSet
 		// if that is the case, there is nothing for us to do
-		// we need to exit out early, otherwise checkpoint-fork logic will reject it
+		// we need to exit out early, otherwise checkpoint-fork logic might wrongly reject it
 		fullyContained := true
 		for _, c := range maybeHead.Cids() {
 			if !hts.Contains(c) {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -530,6 +530,7 @@ func (syncer *Syncer) Sync(ctx context.Context, maybeHead *types.TipSet) error {
 
 	if maybeHead.Height() == hts.Height() {
 		// check if maybeHead is fully contained in headTipSet
+		// meaning we already synced all the blocks that are a part of maybeHead
 		// if that is the case, there is nothing for us to do
 		// we need to exit out early, otherwise checkpoint-fork logic might wrongly reject it
 		fullyContained := true

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -845,6 +845,14 @@ loop:
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load next local tipset: %w", err)
 	}
+
+	if chkpt := syncer.store.GetCheckpoint(); !ignoreCheckpoint && chkpt != nil {
+		// don't allow us to expand the tipset beyond the checkpoint
+		if known.Equals(chkpt) && base.IsChildOf(knownParent) {
+			return nil, xerrors.Errorf("tispet expanding fork: %w", ErrForkCheckpoint)
+		}
+	}
+
 	if base.IsChildOf(knownParent) {
 		// common case: receiving a block that's potentially part of the same tipset as our best block
 		return blockSet, nil

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -1064,7 +1064,7 @@ func TestSyncCheckpointPartial(t *testing.T) {
 	}
 	tu.waitUntilSyncTarget(p1, a.TipSet())
 
-	tu.pushFtsAndWait(p2, aPartial, true)
+	tu.pushFtsAndWait(p2, a, true)
 	tu.checkpointTs(p2, aPartial.TipSet().Key())
 	t.Logf("p1 head: %v, p2 head: %v, a: %v", tu.getHead(p1), tu.getHead(p2), a.TipSet())
 	tu.pushTsExpectErr(p2, aPartial2, true)


### PR DESCRIPTION
Resolves a bug in sync by preventing checkpoint expansion.