### PR TITLE
ci: automate release issue creation from v1.32.0 learnings

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -329,7 +329,7 @@ func main() {
 					if err != nil {
 						return fmt.Errorf("failed to read issue template: %w", err)
 					}
-					// Spring used for String contains and Lists
+					// Sprig used for String contains and Lists
 					tmpl, err := template.New("issue").Funcs(sprig.FuncMap()).Parse(string(issueTemplate))
 					if err != nil {
 						return fmt.Errorf("failed to parse issue template: %w", err)
@@ -347,6 +347,8 @@ func main() {
 					// Remove duplicate newlines before headers and list items since the templating leaves a lot extra newlines around.
 					// Extra newlines are present because go formatting control statements done within HTML comments rather than using {{- -}}.
 					// HTML comments are used instead so that the template file parses as clean markdown on its own.
+					// In addition, HTML comments were also required within "ranges" in the template.  
+					// Using HTML comments everywhere keeps things consistent.  
 					re := regexp.MustCompile(`\n\n+([^#*\[\|])`)
 					issueBody = re.ReplaceAllString(issueBody, "\n$1")
 

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -347,8 +347,8 @@ func main() {
 					// Remove duplicate newlines before headers and list items since the templating leaves a lot extra newlines around.
 					// Extra newlines are present because go formatting control statements done within HTML comments rather than using {{- -}}.
 					// HTML comments are used instead so that the template file parses as clean markdown on its own.
-					// In addition, HTML comments were also required within "ranges" in the template.  
-					// Using HTML comments everywhere keeps things consistent.  
+					// In addition, HTML comments were also required within "ranges" in the template.
+					// Using HTML comments everywhere keeps things consistent.
 					re := regexp.MustCompile(`\n\n+([^#*\[\|])`)
 					issueBody = re.ReplaceAllString(issueBody, "\n$1")
 

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -9,11 +9,12 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	masterminds "github.com/Masterminds/semver/v3"
+	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/google/go-github/v66/github"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -133,6 +134,8 @@ func getProject(name, version string) project {
 	}
 }
 
+const releaseDateStringPattern = `^(Week of )?\d{4}-\d{2}-\d{2}( \(estimate\))?$`
+
 func main() {
 	app := &cli.App{
 		Name:  "release",
@@ -176,26 +179,31 @@ func main() {
 				Name:  "create-issue",
 				Usage: "Create a new release issue from the template",
 				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "create-on-github",
+						Usage: "Whether to create the issue on github rather than print the issue content. $GITHUB_TOKEN must be set.",
+						Value: false,
+					},
 					&cli.StringFlag{
 						Name:     "type",
-						Usage:    "What's the type of the release? (node, miner, both)",
+						Usage:    "What's the type of the release? (Options: node, miner, both)",
 						Value:    "both",
 						Required: true,
 					},
 					&cli.StringFlag{
 						Name:     "tag",
-						Usage:    "What's the tag of the release? (e.g. 1.30.1)",
+						Usage:    "What's the tag of the release? (e.g., 1.30.1)",
 						Required: true,
 					},
 					&cli.StringFlag{
 						Name:     "level",
-						Usage:    "What's the level of the release? (major, minor, patch)",
+						Usage:    "What's the level of the release? (Options: major, minor, patch)",
 						Value:    "patch",
 						Required: true,
 					},
 					&cli.StringFlag{
 						Name:     "network-upgrade",
-						Usage:    "What's the version of the network upgrade this release is related to? (e.g. 23)",
+						Usage:    "What's the version of the network upgrade this release is related to? (e.g., 25)",
 						Required: false,
 					},
 					&cli.StringFlag{
@@ -210,61 +218,52 @@ func main() {
 					},
 					&cli.StringFlag{
 						Name:     "rc1-date",
-						Usage:    "What's the expected shipping date for RC1 (YYYY-MM-DD)?",
-						Required: false,
-					},
-					&cli.StringFlag{
-						Name:     "rc1-precision",
-						Usage:    "How precise is the RC1 date? (day, week)",
-						Required: false,
-					},
-					&cli.StringFlag{
-						Name:     "rc1-confidence",
-						Usage:    "How confident is the RC1 date? (estimated, confirmed)",
+						Usage:    fmt.Sprintf("What's the expected shipping date for RC1? (Pattern: '%s'))", releaseDateStringPattern),
+						Value:    "TBD",
 						Required: false,
 					},
 					&cli.StringFlag{
 						Name:     "stable-date",
-						Usage:    "What's the expected shipping date for the stable release (YYYY-MM-DD)?",
+						Usage:    fmt.Sprintf("What's the expected shipping date for the stable release? (Pattern: '%s'))", releaseDateStringPattern),
+						Value:    "TBD",
 						Required: false,
 					},
 					&cli.StringFlag{
-						Name:     "stable-precision",
-						Usage:    "How precise is the stable release date? (day, week)",
-						Required: false,
-					},
-					&cli.StringFlag{
-						Name:     "stable-confidence",
-						Usage:    "How confident is the stable release date? (estimated, confirmed)",
+						Name:     "repo",
+						Usage:    "Which full repository name (i.e., OWNER/REPOSITORY) to create the issue under.",
+						Value:    "filecoin-project/lotus",
 						Required: false,
 					},
 				},
 				Action: func(c *cli.Context) error {
-					// Read the flag values
-					releaseType := c.String("type")
-					releaseTag := c.String("tag")
-					releaseLevel := c.String("level")
-					networkUpgrade := c.String("network-upgrade")
-					discussionLink := c.String("discussion-link")
-					changelogLink := c.String("changelog-link")
-					rc1Date := c.String("rc1-date")
-					rc1Precision := c.String("rc1-precision")
-					rc1Confidence := c.String("rc1-confidence")
-					stableDate := c.String("stable-date")
-					stablePrecision := c.String("stable-precision")
-					stableConfidence := c.String("stable-confidence")
+					// Read and validate the flag values
+					createOnGitHub := c.Bool("create-on-github")
 
-					// Validate the flag values
-					if releaseType != "node" && releaseType != "miner" && releaseType != "both" {
+					releaseType := c.String("type")
+					// releaseType gets special formatting
+					if releaseType == "node" {
+						releaseType = "Node"
+					} else if releaseType == "miner" {
+						releaseType = "Miner"
+					} else if releaseType == "both" {
+						releaseType = "Node and Miner"
+					} else {
 						return fmt.Errorf("invalid value for the 'type' flag. Allowed values are 'node', 'miner', and 'both'")
 					}
+
+					releaseTag := c.String("tag")
 					releaseVersion, err := masterminds.StrictNewVersion(releaseTag)
 					if err != nil {
 						return fmt.Errorf("invalid value for the 'tag' flag. Must be a valid semantic version (e.g. 1.30.1)")
 					}
+
+					releaseLevel := c.String("level")
 					if releaseLevel != "major" && releaseLevel != "minor" && releaseLevel != "patch" {
 						return fmt.Errorf("invalid value for the 'level' flag. Allowed values are 'major', 'minor', and 'patch'")
 					}
+
+					networkUpgrade := c.String("network-upgrade")
+					discussionLink := c.String("discussion-link")
 					if networkUpgrade != "" {
 						_, err := strconv.ParseUint(networkUpgrade, 10, 64)
 						if err != nil {
@@ -276,48 +275,45 @@ func main() {
 								return fmt.Errorf("invalid value for the 'discussion-link' flag. Must be a valid URL")
 							}
 						}
-						if changelogLink != "" {
-							_, err := url.ParseRequestURI(changelogLink)
-							if err != nil {
-								return fmt.Errorf("invalid value for the 'changelog-link' flag. Must be a valid URL")
-							}
-						}
 					}
-					if rc1Date != "" {
-						_, err := time.Parse("2006-01-02", rc1Date)
+
+					changelogLink := c.String("changelog-link")
+					if changelogLink != "" {
+						_, err := url.ParseRequestURI(changelogLink)
 						if err != nil {
-							return fmt.Errorf("invalid value for the 'rc1-date' flag. Must be a valid date (YYYY-MM-DD)")
-						}
-						if rc1Precision != "" {
-							if rc1Precision != "day" && rc1Precision != "week" {
-								return fmt.Errorf("invalid value for the 'rc1-precision' flag. Allowed values are 'day' and 'week'")
-							}
-						}
-						if rc1Confidence != "" {
-							if rc1Confidence != "estimated" && rc1Confidence != "confirmed" {
-								return fmt.Errorf("invalid value for the 'rc1-confidence' flag. Allowed values are 'estimated' and 'confirmed'")
-							}
-						}
-					}
-					if stableDate != "" {
-						_, err := time.Parse("2006-01-02", stableDate)
-						if err != nil {
-							return fmt.Errorf("invalid value for the 'stable-date' flag. Must be a valid date (YYYY-MM-DD)")
-						}
-						if stablePrecision != "" {
-							if stablePrecision != "day" && stablePrecision != "week" {
-								return fmt.Errorf("invalid value for the 'stable-precision' flag. Allowed values are 'day' and 'week'")
-							}
-						}
-						if stableConfidence != "" {
-							if stableConfidence != "estimated" && stableConfidence != "confirmed" {
-								return fmt.Errorf("invalid value for the 'stable-confidence' flag. Allowed values are 'estimated' and 'confirmed'")
-							}
+							return fmt.Errorf("invalid value for the 'changelog-link' flag. Must be a valid URL")
 						}
 					}
 
+					rc1Date := c.String("rc1-date")
+					releaseDateStringRegexp := regexp.MustCompile(releaseDateStringPattern)
+					if rc1Date != "TBD" {
+						matches := releaseDateStringRegexp.FindStringSubmatch(rc1Date)
+						if matches == nil {
+							return fmt.Errorf("rc1-date must be of form %s", releaseDateStringPattern)
+						}
+					}
+
+					stableDate := c.String("stable-date")
+					if stableDate != "TBD" {
+						matches := releaseDateStringRegexp.FindStringSubmatch(stableDate)
+						if matches == nil {
+							return fmt.Errorf("stable-date must be of form %s", releaseDateStringPattern)
+						}
+					}
+
+					repoFullName := c.String("repo")
+					repoRegexp := regexp.MustCompile(`^([^/]+)/([^/]+)$`)
+					matches := repoRegexp.FindStringSubmatch(repoFullName)
+					if matches == nil {
+						return fmt.Errorf("invalid repository name format. Must be 'owner/repo'")
+					}
+					repoOwner := matches[1]
+					repoName := matches[2]
+
 					// Prepare template data
 					data := make(map[string]interface{})
+					data["CreateOnGitHub"] = createOnGitHub
 					data["Type"] = releaseType
 					data["Tag"] = releaseVersion.String()
 					data["NextTag"] = releaseVersion.IncPatch().String()
@@ -325,19 +321,16 @@ func main() {
 					data["NetworkUpgrade"] = networkUpgrade
 					data["NetworkUpgradeDiscussionLink"] = discussionLink
 					data["NetworkUpgradeChangelogEntryLink"] = changelogLink
-					data["ReleaseCandidateDate"] = rc1Date
-					data["ReleaseCandidatePrecision"] = rc1Precision
-					data["ReleaseCandidateConfidence"] = rc1Confidence
-					data["StableDate"] = stableDate
-					data["StablePrecision"] = stablePrecision
-					data["StableConfidence"] = stableConfidence
+					data["RC1DateString"] = rc1Date
+					data["StableDateString"] = stableDate
 
 					// Render the issue template
 					issueTemplate, err := os.ReadFile("documentation/misc/RELEASE_ISSUE_TEMPLATE.md")
 					if err != nil {
 						return fmt.Errorf("failed to read issue template: %w", err)
 					}
-					tmpl, err := template.New("issue").Parse(string(issueTemplate))
+					// Spring used for String contains and Lists
+					tmpl, err := template.New("issue").Funcs(sprig.FuncMap()).Parse(string(issueTemplate))
 					if err != nil {
 						return fmt.Errorf("failed to parse issue template: %w", err)
 					}
@@ -351,30 +344,62 @@ func main() {
 					issueTitle := fmt.Sprintf("Lotus %s v%s Release", releaseType, releaseTag)
 					issueBody := issueBodyBuffer.String()
 
-					// Set up the GitHub client
-					client := github.NewClient(nil).WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+					// Remove duplicate newlines before headers and list items since the templating leaves a lot extra newlines around.
+					// Extra newlines are present because go formatting control statements done within HTML comments rather than using {{- -}}.
+					// HTML comments are used instead so that the template file parses as clean markdown on its own.
+					re := regexp.MustCompile(`\n\n+([^#*\[\|])`)
+					issueBody = re.ReplaceAllString(issueBody, "\n$1")
 
-					// Check if the issue already exists
-					issues, _, err := client.Search.Issues(context.Background(), issueTitle+" in:title state:open", &github.SearchOptions{})
-					if err != nil {
-						return fmt.Errorf("failed to list issues: %w", err)
-					}
-					if issues.GetTotal() > 0 {
-						return fmt.Errorf("issue already exists: %s", issues.Issues[0].GetHTMLURL())
-					}
+					if !createOnGitHub {
+						// Create the URL-encoded parameters
+						params := url.Values{}
+						params.Add("title", issueTitle)
+						params.Add("body", issueBody)
+						params.Add("labels", "tpm")
 
-					// Create the issue
-					issue, _, err := client.Issues.Create(context.Background(), "filecoin", "lotus", &github.IssueRequest{
-						Title: &issueTitle,
-						Body:  &issueBody,
-						Labels: &[]string{
-							"tpm",
-						},
-					})
-					if err != nil {
-						return fmt.Errorf("failed to create issue: %w", err)
+						// Construct the URL
+						issueURL := fmt.Sprintf("https://github.com/%s/issues/new?%s", repoFullName, params.Encode())
+
+						debugFormat := `
+Issue Details:
+=============
+Title: %s
+
+Body:
+-----
+%s
+
+URL to create issue:
+-------------------
+%s
+`
+						fmt.Printf(debugFormat, issueTitle, issueBody, issueURL)
+					} else {
+						// Set up the GitHub client
+						client := github.NewClient(nil).WithAuthToken(os.Getenv("GITHUB_TOKEN"))
+
+						// Check if the issue already exists
+						issues, _, err := client.Search.Issues(context.Background(), fmt.Sprintf("%s in:title state:open repo:%s is:issue", issueTitle, repoFullName), &github.SearchOptions{})
+						if err != nil {
+							return fmt.Errorf("failed to list issues: %w", err)
+						}
+						if issues.GetTotal() > 0 {
+							return fmt.Errorf("issue already exists: %s", issues.Issues[0].GetHTMLURL())
+						}
+
+						// Create the issue
+						issue, _, err := client.Issues.Create(context.Background(), repoOwner, repoName, &github.IssueRequest{
+							Title: &issueTitle,
+							Body:  &issueBody,
+							Labels: &[]string{
+								"tpm",
+							},
+						})
+						if err != nil {
+							return fmt.Errorf("failed to create issue: %w", err)
+						}
+						fmt.Println("Issue created: ", issue.GetHTMLURL())
 					}
-					fmt.Println("Issue created:", issue.GetHTMLURL())
 
 					return nil
 				},

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -1,58 +1,52 @@
-# Lotus {{.Type}} {{.Tag}} Release
-
 [//]: # (Below are non-visible steps intended for the issue creator)
 [//]: # (❗️ Complete the steps below as part of creating a release issue and mark them complete with an X or ✅ when done.)
-[//]: # ([ ] Start an issue with title "[WIP] Lotus {{.Type}} v{{.Tag}} Release" and adjust the title for whether it's a Node or Miner release.)
+<!--{{if not .CreateOnGitHub}}-->
+[//]: # ([ ] Start an issue with title "Lotus {{.Type}} v{{.Tag}} Release" and adjust the title for whether it's a Node or Miner release.)
 [//]: # ([ ] Copy in the content of https://github.com/filecoin-project/lotus/blob/master/documentation/misc/RELEASE_ISSUE_TEMPLATE.md)
-[//]: # ([ ] Find/Replace "{{.NextTag}}" with the actual values e.g., v1.30.1)
-[//]: # ([ ] Find/Replace "{{.Tag}}" with the actual values)
-[//]: # ([ ] If this isn't a release tied to a network upgrade, remove all items conditional on ne .NetworkUpgrade "")
-[//]: # ([ ] If this is a patch release, remove all items conditional on ne .Level "patch")
-[//]: # ([ ] If this is a minor release, remove all items conditional on ne .Level "minor")
-[//]: # ([ ] Copy/paste the "Release Checklist > rcX" section to "Release Checklist > Stable \(non-RC\) Release" and apply the "diff" called out there.)
-[//]: # ([ ] Find/Replace "rcX" with "rc1")
+[//]: # ([ ] Find all the "go templating" "control" logic that is in \{\{ \}\} blocks and mimic the logic manually.)
 [//]: # ([ ] Adjust the "Meta" section values)
 [//]: # ([ ] Apply the `tpm` label to the issue)
 [//]: # ([ ] Create the issue)
+<!--{{end}}-->
+<!-- At least as of 2024-12-02, it isn't possible to programmatically pin issues. -->
 [//]: # ([ ] Pin the issue on GitHub)
 
-## 😶‍🌫 Meta
-* Scope: {{.Type}} {{.Level}}
-<!--{{if ne .NetworkUpgrade ""}}-->
-* (network upgrade) This release is related to a network upgrade and thus mandatory.
-* (network upgrade) Related network upgrade version: nv{{.NetworkUpgrade}}
+# 😶‍🌫 Meta
+* Type: {{.Type}} 
+* Level: {{.Level}}
+* Related network upgrade version: <!--{{if not .NetworkUpgrade}}-->n/a<!--{{else}}-->nv{{.NetworkUpgrade}}
    * Scope, dates, and epochs: {{.NetworkUpgradeDiscussionLink}}
    * Lotus changelog with Lotus specifics: {{.NetworkUpgradeChangelogEntryLink}}
 <!--{{end}}-->
 
-## 🚢 Estimated shipping date
+# 🚢 Estimated shipping date
 
 [//]: # (If/when we know an exact date, remove the "week of".)
 [//]: # (If a date week is an estimate, annotate with "estimate".)
 
-| Candidate | Date | Precision (day or week) | Confidence(estimated or confirmed) | Release URL |
-|-----------|------|-------------------------|------------------------------------|-------------|
-| RC1 | {{or .ReleaseCandidateDate "unknown"}} | {{or .ReleaseCandidatePrecision "unknown"}} | {{or .ReleaseCandidateConfidence "unknown"}} | |
-| Stable (non-RC) | {{or .StableDate "unknown"}} | {{or .StablePrecision "unknown"}} | {{or .StableConfidence "unknown"}} | |
+| Candidate | Expected Release Date | Release URL |
+|-----------|-----------------------|-------------|
+| RC1 | {{.RC1DateString}} | |
+| Stable (non-RC) | {{.StableDateString}} | |
 
-## 🪢 Dependencies for releases
+# 🪢 Dependencies for releases
 > [!NOTE]
 > 1. This is the set of changes that need to make it in for a given RC.  This is effectively the set of changes to cherry-pick from master.
 > 2. They can be checked as done once they land in `master`.
 > 3. They are presented here for quick reference, but backporting is tracked in each `Release Checklist`.
 
-[//]: # (Copy/paste this for each RC, and increment "X")
-### rcX
+<!--{{/* Sprig is used for defining a list per https://stackoverflow.com/a/57959333 */}}-->
+<!--{{$rcVersions := list "rc1" "rcX" "Stable Release (non-RC)"}}-->
+<!--{{range $rc := $rcVersions}}-->
+## {{$rc}}
 - [ ] To Be Added
 
-### Stable (non-RC)
-- [ ] To Be Added
+<!--{{end}}-->
+# ✅ Release Checklist
 
-## ✅ Release Checklist
-
-### Before RC1
+## ⬅️  Before RC1
 <!--{{if ne .NetworkUpgrade ""}}-->
-- [ ] (network upgrade) Make sure all [Lotus dependencies are updated to the correct versions for the network upgrade](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/Update_Dependencies_Lotus.md)
+- [ ] Make sure all [Lotus dependencies are updated to the correct versions for the network upgrade](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/Update_Dependencies_Lotus.md)
    - Link to Lotus PR:
 <!--{{end}}-->
 - [ ] Open PR against [RELEASE_ISSUE_TEMPLATE.md](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/RELEASE_ISSUE_TEMPLATE.md) with title `docs(release): v{{.Tag}} release template improvements` for improving future releases.
@@ -60,15 +54,30 @@
    - There likely aren't any changes at this point, but this can be opened with a small whitespace change so the PR is open and we can more easily hold the standard of making improvements incrementally since improvements are usually better done by collecting changes/notes along the way rather than just thinking about it at the end.
    - This will get merged in a `Post Release` step.
 <!--{{if eq .Level "patch"}})-->
-- [ ] (patch release) Fork a new branch (`release/v{{.Tag}}` or `release/miner/v{{.Tag}}`) from the last stable `release/vX.Y.x` or `release/miner/vX.Y.x` and make any further release-related changes to this branch.
+<!--  {{if contains .Type "Node"}}-->
+- [ ] Fork a new `release/v{{.Tag}}` branch from the last stable `release/vX.Y.x` and make any further release-related changes to this branch.
+<!--  {{end}}-->
+<!--  {{if contains .Type "Miner"}}-->
+- [ ] Fork a new `release/miner/v{{.Tag}}` branch from the last stable `release/miner/vX.Y.x` and make any further release-related changes to this branch.
+<!--  {{end}}-->
 <!--{{end}}-->
 <!--{{if eq .Level "minor"}}-->
-- [ ] (minor release) Fork a new branch (`release/v{{.Tag}}` or `release/miner/v{{.Tag}}`) from `master` and make any further release-related changes to this branch.
+<!--  {{if contains .Type "Node"}}-->
+- [ ] Fork a new `release/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
+<!--  {{end}}-->
+<!--  {{if contains .Type "Miner"}}-->
+- [ ] Fork a new `release/miner/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
+<!--  {{end}}-->
 <!--{{end}}-->
+<!--{{if ne .Level "patch"}}-->
 - `master` branch Version string updates
-   - Skip this set of steps if you are patching a previous minor release.
    - [ ] bump the version(s) in `build/version.go` to `v{{.NextTag}}-dev`.
-      - Ensure to update the appropriate version string based on whether you are creating a node release (`NodeBuildVersion`), a miner release (`MinerBuildVersion`), or both.
+<!--{{  if contains .Type "Node"}}-->
+      - Ensure to update `NodeBuildVersion`
+<!--{{  end}}-->
+<!--{{  if contains .Type "Miner"}}-->
+      - Ensure to update `MinerBuildVersion`
+<!--{{  end}}-->
    - [ ] Run `make gen && make docsgen-cli` before committing changes.
    - [ ] Update the CHANGELOG
      - [ ] Change the `UNRELEASED` section header to `UNRELEASED v{{.Tag}}`
@@ -77,42 +86,53 @@
    - [ ] Create a PR with title `build: update Lotus {{.Type}} version to v{{.NextTag}}-dev in master`
      - Link to PR:
    - [ ] Merge PR
+<!--{{end}}-->
 
-### RCs
+## 🏎️  RCs
 
-[//]: # (Copy/paste this whole "rcX" section for each additional RC, and increment "X")
-#### rcX
+<!--{{range $rc := $rcVersions}}-->
+<!--  {{$tagSuffix := ""}}-->
+<!--  {{if contains "rc" $rc}}-->
+<!--    {{$tagSuffix = printf "-%s" $rc}}-->
+<!--  {{end}}-->
+### {{$rc}}
 > [!IMPORTANT]
-> These PRs should be done in and target the `release/v{{.Tag}}` or `release/miner/v{{.Tag}}` branch.
+> These PRs should be done in and target the `release/v{{$.Tag}}` or `release/miner/v{{$.Tag}}` branch.
 
-**Backport PR**
-
-[//]: # (For RC1 there likely isn't any backporting to do and thus no PR which reduces the steps.)
-[//]: # (We do need all these steps for RC2 onwards though.)
-[//]: # (If steps are removed for the RC1 checklist, they need to be preserved for future RCs/stable.)
-[//]: # (For RC1 we still need to make sure the tracked items land though.)
+#### Backport PR for {{$rc}}
 - [ ] All explicitly tracked items from `Dependencies for releases` have landed
+<!--  {{if ne $rc "rc1"}}-->
 - [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
 - [ ] Removed the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
-- [ ] Create a PR with title `build: backport changes for {{.Type}} v{{.Tag}}-rcX`
+- [ ] Create a PR with title `build: backport changes for {{$.Type}} v{{$.Tag}}{{$tagSuffix}}`
    - Link to PR:
 - [ ] Merge PR
+<!--  {{end}}-->
 
-**Release PR**
+#### Release PR for {{$rc}}
 
-- [ ] Update the version string(s) in `build/version.go` to one ending with '-rcX'.
-    - Ensure to update the appropriate version string based on whether you are creating a node release (`NodeBuildVersion`), a miner release (`MinerBuildVersion`), or both.
+- [ ] Update the version string(s) in `build/version.go` to one {{if contains "rc" $rc}}ending with '-{{$rc}}'{{else}}**NOT* ending with 'rcX'{{end}}.
+<!--  {{if contains "Node" $.Type}}-->
+    - Ensure to update `NodeBuildVersion`
+<!--  {{end}}-->
+<!--  {{if contains "Miner" $.Type}}-->
+    - Ensure to update `MinerBuildVersion`
+<!--  {{end}}-->
 - [ ] Run `make gen && make docsgen-cli` to generate documentation
-- [ ] Create a draft PR with title `build: release Lotus {{.Type}} v{{.Tag}}-rcX`
+- [ ] Create a draft PR with title `build: release Lotus {{$.Type}} v{{$.Tag}}{{$tagSuffix}}`
    - Link to PR:
    - Opening a PR will trigger a CI run that will build assets, create a draft GitHub release, and attach the assets.
 - [ ] Changelog prep
    - [ ] Go to the [releases page](https://github.com/filecoin-project/lotus/releases) and copy the auto-generated release notes into the CHANGELOG
    - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
-<!--{{if ne .NetworkUpgrade ""}}-->
+<!--  {{if ne $.NetworkUpgrade ""}}-->
+<!--    {{if contains "rc" $rc}}-->
    - [ ] (network upgrade) Specify whether the Calibration or Mainnet upgrade epoch has been specified or not yet.
       - Example where these weren't specified yet: [PR #12169](https://github.com/filecoin-project/lotus/pull/12169)
-<!--{{end}}-->
+<!--    {{else}}-->
+   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
+<!--    {{end}}-->
+<!--  {{end}}-->
    - [ ] Ensure no missing content when spot checking git history
       - Example command looking at git commits: `git log --oneline --graph vA.B.C..`, where A.B.C correspond to the previous release.
       - Example GitHub UI search looking at merged PRs into master: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
@@ -125,39 +145,23 @@
  - [ ] Comment on this issue announcing the RC
     - Link to issue comment:
 
-**Testing**
+#### Testing for {{$rc}}
 > [!NOTE]
 > Link to any special steps for testing releases beyond ensuring CI is green.  Steps can be inlined here or tracked elsewhere.
 
-### Stable (non-RC) Release
+<!--{{end}}-->
 
-[//]: # (This "NOTE" below with the "diff" to apply to the "rcX copy/pasted content" is here to avoid the duplication in the template itself.)
-[//]: # (This is done as a visible NOTE rather than a comment to make sure it's clear what needs to be added to this section.)
-[//]: # (These comments ^^^ can be removed once the NOTE steps below are completed.)
-> [!NOTE]
-> 1️⃣ Copy/paste in the `rcX` section above to below this `[!Note]`
->
-> 2️⃣ make these changes:
-> 1. Release PR > Update the version string...
->    * Update the version string in `build/version.go` to one **NOT** ending with '-rcX'
-> 2. Release PR > Changelog prep...
->    * Add "(network upgrade) Ensure the Mainnet upgrade epoch is specified."
-> 3. Release PR > Create a draft PR...
->    * Create a PR with title `build: release Lotus {{.Type}} v{{.Tag}}`
->
-> 3️⃣ Remove this `[!Note]` and the related invisible comments.
-
-### Post-Release
+## ➡ Post-Release
 
 - [ ] Open a PR against `master` cherry-picking the CHANGELOG commits from the `release/v{{.Tag}}` branch. Title it `chore(release): cherry-pick v{{.Tag}} changelog back to master`
    - Link to PR:
    - Assuming we followed [the process of merging changes into `master` first before backporting to the release branch](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#branch-and-tag-strategy), the only changes should be CHANGELOG updates.
 - [ ] Finish updating/merging the [RELEASE_ISSUE_TEMPLATE.md](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/RELEASE_ISSUE_TEMPLATE.md) PR from `Before RC1` with any improvements determined from this latest release iteration.
 
-## ❤️ Contributors
+# ❤️ Contributors
 
 See the final release notes!
 
-## ⁉️ Do you have questions?
+# ⁉️ Do you have questions?
 
 Leave a comment in this ticket!

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -54,28 +54,28 @@
    - There likely aren't any changes at this point, but this can be opened with a small whitespace change so the PR is open and we can more easily hold the standard of making improvements incrementally since improvements are usually better done by collecting changes/notes along the way rather than just thinking about it at the end.
    - This will get merged in a `Post Release` step.
 <!--{{if eq .Level "patch"}})-->
-<!--  {{if contains .Type "Node"}}-->
+<!--  {{if contains "Node" .Type}}-->
 - [ ] Fork a new `release/v{{.Tag}}` branch from the last stable `release/vX.Y.x` and make any further release-related changes to this branch.
 <!--  {{end}}-->
-<!--  {{if contains .Type "Miner"}}-->
+<!--  {{if contains "Miner" .Type}}-->
 - [ ] Fork a new `release/miner/v{{.Tag}}` branch from the last stable `release/miner/vX.Y.x` and make any further release-related changes to this branch.
 <!--  {{end}}-->
 <!--{{end}}-->
 <!--{{if eq .Level "minor"}}-->
-<!--  {{if contains .Type "Node"}}-->
+<!--  {{if contains "Node" .Type}}-->
 - [ ] Fork a new `release/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
 <!--  {{end}}-->
-<!--  {{if contains .Type "Miner"}}-->
+<!--  {{if contains "Miner" .Type}}-->
 - [ ] Fork a new `release/miner/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
 <!--  {{end}}-->
 <!--{{end}}-->
 <!--{{if ne .Level "patch"}}-->
 - `master` branch Version string updates
    - [ ] bump the version(s) in `build/version.go` to `v{{.NextTag}}-dev`.
-<!--{{  if contains .Type "Node"}}-->
+<!--{{  if contains "Node" .Type}}-->
       - Ensure to update `NodeBuildVersion`
 <!--{{  end}}-->
-<!--{{  if contains .Type "Miner"}}-->
+<!--{{  if contains "Miner" .Type}}-->
       - Ensure to update `MinerBuildVersion`
 <!--{{  end}}-->
    - [ ] Run `make gen && make docsgen-cli` before committing changes.

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/Gurpartap/async v0.0.0-20180927173644-4f7f499dd9ee
 	github.com/Kubuxu/imtui v0.0.0-20210401140320-41663d68d0fa
 	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/jsonschema v0.0.0-20200530073317-71f438968921
 	github.com/cheggaaa/pb/v3 v3.1.5
@@ -169,8 +170,10 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/GeertJohan/go.incremental v1.0.0 // indirect
 	github.com/Jorropo/jsync v1.0.1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
@@ -225,6 +228,7 @@ require (
 	github.com/google/pprof v0.0.0-20240509144519-723abb6459b7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/iancoleman/orderedmap v0.1.0 // indirect
 	github.com/ipfs/go-blockservice v0.5.2 // indirect
@@ -272,6 +276,8 @@ require (
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
@@ -314,7 +320,9 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/spf13/cast v1.7.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
@@ -62,9 +64,13 @@ github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETF
 github.com/Kubuxu/imtui v0.0.0-20210401140320-41663d68d0fa h1:1PPxEyGdIGVkX/kqMvLJ95a1dGS1Sz7tpNEgehEYYt0=
 github.com/Kubuxu/imtui v0.0.0-20210401140320-41663d68d0fa/go.mod h1:WUmMvh9wMtqj1Xhf1hf3kp9RvL+y6odtdYxpyZjb90U=
 github.com/Masterminds/glide v0.13.2/go.mod h1:STyF5vcenH/rUqTEv+/hBXlSTo7KYwg2oc2f4tzPWic=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
+github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -547,6 +553,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
+github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
@@ -943,9 +951,13 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
@@ -1180,6 +1192,8 @@ github.com/sercand/kuberesolver/v4 v4.0.0/go.mod h1:F4RGyuRmMAjeXHKL+w4P7AwUnPce
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
@@ -1229,6 +1243,8 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
+github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
This is followup to https://github.com/filecoin-project/lotus/pull/12741 after using the script to create the Lotus release issue for v1.32.0 for Node and Miner.  

The following changes were made:
1. `create-on-github` flag that when not set prints out formatted output to STDOUT.  This was really useful for development and debugging.
2. Simplified rc1 and stable release date to just take a single string that conforms to a likely pattern.  I found the template table with precision/confidence was too much as well as specifying all the options before.
3. `repo` option so can create an issue outside of `filecoin-project/lotus`.  This was useful for development/debugging.
4. For each CLI argument, I'm reading in the value and validating/processing it before moving to the next.
5. Introduced Mastermind Sprig library for template formatting convenience utilities like String contains and inline list generation.
6. Did post processing on the formatted output to remove extra unnecessary newlines which were adding undesired vertical spacing.
7. Removed template setup steps that are no longer applicable if the issue was created with the script.
8. Reduced heading level of all headings so that get better distinction between headings.
9. More clearly handle a "Node and Miner" release where steps for both are listed out.
10. Removed a lot of the manual copy/paste steps/comments and instead let the template syntax describe what needs to be done.  This allowed for reduction in copy/pasting.

Example: created https://github.com/filecoin-project/lotus/pull/12749 with `./release create-issue --create-on-github --type both --tag 1.32.0 --level minor --network-upgrade 25 --rc1-date "Week of 2024-12-02" --stable-date "Week of 2024-12-16"`

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
