### PR TITLE
chore(test): unflake TestTraceFilter

### DIFF
--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -876,12 +876,17 @@ func TestTraceFilter(t *testing.T) {
 	hc := <-ch // current
 	require.Equal(t, store.HCCurrent, hc[0].Type)
 	beforeNullHeight := hc[0].Val.Height()
-	hc = <-ch // wait for next block
-	require.Equal(t, store.HCApply, hc[0].Type)
-	afterNullHeight := hc[0].Val.Height()
-	require.Greater(t, afterNullHeight, beforeNullHeight+1)
-	hc = <-ch // one more, so "latest" points to the block after nulls
-	require.Equal(t, store.HCApply, hc[0].Type)
+	var blocks int
+	for {
+		hc = <-ch // wait for next block
+		require.Equal(t, store.HCApply, hc[0].Type)
+		if hc[0].Val.Height() > beforeNullHeight {
+			blocks++
+			if blocks == 2 { // two blocks, so "latest" points to the block after nulls
+				break
+			}
+		}
+	}
 
 	// define filter criteria that spans a null round so it has to at lest consider it
 	toBlock = "latest"


### PR DESCRIPTION
Failure @ https://github.com/filecoin-project/lotus/actions/runs/12173008490/job/33952695031#step:9:4808

Two applies with the same height, I assume this is a reorg at head; although that seems a bit sus since I think we're only supposed to have one miner here. 🤷 the point of the test is to get 2 beyond head and ChainNotify was just a way of ticking that over.