### PR TITLE
feat(f3): resolve finality for eth APIs according to F3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 # UNRELEASED v.1.32.0
 
-
 See https://github.com/filecoin-project/lotus/blob/release/v1.32.0/CHANGELOG.md
 
 # Node and Miner v1.31.0 / 2024-12-02

--- a/chain/lf3/disabled.go
+++ b/chain/lf3/disabled.go
@@ -1,0 +1,42 @@
+package lf3
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+type DisabledF3 struct{}
+
+var _ F3API = DisabledF3{}
+
+func (DisabledF3) GetOrRenewParticipationTicket(_ context.Context, _ uint64, _ api.F3ParticipationTicket, _ uint64) (api.F3ParticipationTicket, error) {
+	return api.F3ParticipationTicket{}, api.ErrF3Disabled
+}
+func (DisabledF3) Participate(_ context.Context, _ api.F3ParticipationTicket) (api.F3ParticipationLease, error) {
+	return api.F3ParticipationLease{}, api.ErrF3Disabled
+}
+func (DisabledF3) GetCert(_ context.Context, _ uint64) (*certs.FinalityCertificate, error) {
+	return nil, api.ErrF3Disabled
+}
+func (DisabledF3) GetLatestCert(_ context.Context) (*certs.FinalityCertificate, error) {
+	return nil, api.ErrF3Disabled
+}
+func (DisabledF3) GetManifest(_ context.Context) (*manifest.Manifest, error) {
+	return nil, api.ErrF3Disabled
+}
+func (DisabledF3) GetPowerTable(_ context.Context, _ types.TipSetKey) (gpbft.PowerEntries, error) {
+	return nil, api.ErrF3Disabled
+}
+func (DisabledF3) GetF3PowerTable(_ context.Context, _ types.TipSetKey) (gpbft.PowerEntries, error) {
+	return nil, api.ErrF3Disabled
+}
+func (DisabledF3) IsEnabled() bool                                { return false }
+func (DisabledF3) IsRunning() (bool, error)                       { return false, api.ErrF3Disabled }
+func (DisabledF3) Progress() (gpbft.Instant, error)               { return gpbft.Instant{}, api.ErrF3Disabled }
+func (DisabledF3) ListParticipants() ([]api.F3Participant, error) { return nil, api.ErrF3Disabled }

--- a/chain/lf3/mock/mock_f3.go
+++ b/chain/lf3/mock/mock_f3.go
@@ -1,0 +1,162 @@
+package mock
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/lf3"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+type MockF3API struct {
+	lk sync.Mutex
+
+	latestCert *certs.FinalityCertificate
+	manifest   *manifest.Manifest
+	enabled    bool
+	running    bool
+}
+
+func (m *MockF3API) GetOrRenewParticipationTicket(ctx context.Context, minerID uint64, previous api.F3ParticipationTicket, instances uint64) (api.F3ParticipationTicket, error) {
+	if !m.IsEnabled() {
+		return api.F3ParticipationTicket{}, api.ErrF3Disabled
+	}
+	return api.F3ParticipationTicket{}, nil
+}
+
+func (m *MockF3API) Participate(ctx context.Context, ticket api.F3ParticipationTicket) (api.F3ParticipationLease, error) {
+	if !m.IsEnabled() {
+		return api.F3ParticipationLease{}, api.ErrF3Disabled
+	}
+	return api.F3ParticipationLease{}, nil
+}
+
+func (m *MockF3API) GetCert(ctx context.Context, instance uint64) (*certs.FinalityCertificate, error) {
+	if !m.IsEnabled() {
+		return nil, api.ErrF3Disabled
+	}
+	return nil, nil
+}
+
+// SetLatestCert sets the latest certificate to be returned by GetLatestCert. If GetLatestCert is
+// called before this method, it will return an error.
+func (m *MockF3API) SetLatestCert(cert *certs.FinalityCertificate) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	m.latestCert = cert
+}
+
+func (m *MockF3API) GetLatestCert(ctx context.Context) (*certs.FinalityCertificate, error) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	if !m.enabled {
+		return nil, api.ErrF3Disabled
+	}
+
+	if m.latestCert == nil {
+		return nil, xerrors.Errorf("no latest cert set in test, did you mean to?")
+	}
+
+	return m.latestCert, nil
+}
+
+// SetManifest sets the manifest to be returned by GetManifest. If GetManifest is called before this
+// method, it will return an error.
+//
+// Use manifest.LocalDevnetManifest() for a convenient manifest to use in tests.
+func (m *MockF3API) SetManifest(manifest *manifest.Manifest) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	m.manifest = manifest
+}
+
+func (m *MockF3API) GetManifest(ctx context.Context) (*manifest.Manifest, error) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	if !m.enabled {
+		return nil, api.ErrF3Disabled
+	}
+
+	if m.manifest == nil {
+		return nil, xerrors.Errorf("no manifest set in test, did you mean to?")
+	}
+
+	return m.manifest, nil
+}
+
+func (m *MockF3API) GetPowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error) {
+	if !m.IsEnabled() {
+		return nil, api.ErrF3Disabled
+	}
+
+	return nil, nil
+}
+
+func (m *MockF3API) GetF3PowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error) {
+	if !m.IsEnabled() {
+		return nil, api.ErrF3Disabled
+	}
+
+	return nil, nil
+}
+
+func (m *MockF3API) SetEnabled(enabled bool) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	m.enabled = enabled
+}
+
+func (m *MockF3API) IsEnabled() bool {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	return m.enabled
+}
+
+func (m *MockF3API) SetRunning(running bool) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	m.running = running
+}
+
+func (m *MockF3API) IsRunning() (bool, error) {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	if !m.enabled {
+		return false, api.ErrF3Disabled
+	}
+
+	return m.running, nil
+}
+
+func (m *MockF3API) Progress() (gpbft.Instant, error) {
+	if !m.IsEnabled() {
+		return gpbft.Instant{}, api.ErrF3Disabled
+	}
+
+	return gpbft.Instant{}, nil
+}
+
+func (m *MockF3API) ListParticipants() ([]api.F3Participant, error) {
+	if !m.IsEnabled() {
+		return nil, api.ErrF3Disabled
+	}
+
+	return nil, nil
+}
+
+var _ lf3.F3API = (*MockF3API)(nil)

--- a/chain/tsresolver/tipset_resolver.go
+++ b/chain/tsresolver/tipset_resolver.go
@@ -1,0 +1,191 @@
+package tsresolver
+
+import (
+	"context"
+	"errors"
+
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/manifest"
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors/policy"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+)
+
+var log = logging.Logger("chain/tsresolver")
+
+const (
+	EthBlockSelectorEarliest  = "earliest"
+	EthBlockSelectorPending   = "pending"
+	EthBlockSelectorLatest    = "latest"
+	EthBlockSelectorSafe      = "safe"
+	EthBlockSelectorFinalized = "finalized"
+)
+
+type TipSetLoader interface {
+	GetHeaviestTipSet() (ts *types.TipSet)
+	LoadTipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
+	GetTipsetByHeight(ctx context.Context, h abi.ChainEpoch, anchor *types.TipSet, prev bool) (*types.TipSet, error)
+}
+
+type F3 interface {
+	GetManifest(ctx context.Context) (*manifest.Manifest, error)
+	GetLatestCert(ctx context.Context) (*certs.FinalityCertificate, error)
+}
+
+type TipSetResolver interface {
+	ResolveEthBlockSelector(ctx context.Context, selector string, strict bool) (*types.TipSet, error)
+}
+
+type tipSetResolver struct {
+	loader TipSetLoader
+	f3     F3
+}
+
+var _ TipSetResolver = (*tipSetResolver)(nil)
+
+func NewTipSetResolver(loader TipSetLoader, f3 F3) TipSetResolver {
+	return &tipSetResolver{
+		loader: loader,
+		f3:     f3,
+	}
+}
+
+// ResolveEthBlockSelector resolves an Ethereum block selector string to a TipSet.
+//
+// The selector can be one of:
+//   - "pending": the chain head
+//   - "latest": the TipSet with the latest executed messages (head - 1)
+//   - "safe": the TipSet with messages executed at least eth.SafeEpochDelay (30) epochs ago or the
+//     latest F3 finalized TipSet
+//   - "finalized": the TipSet with messages executed at least policy.ChainFinality (900) epochs ago
+//     or the latest F3 finalized TipSet
+//   - a decimal block number: the TipSet at the given height
+//   - a 0x-prefixed hex block number: the TipSet at the given height
+//
+// If a specific block number is specified and `strict` is true, an error is returned if the block
+// number resolves to a null round, otherwise in the case of a null round the first non-null TipSet
+// immediately before the null round is returned.
+func (tsr *tipSetResolver) ResolveEthBlockSelector(ctx context.Context, selector string, strict bool) (*types.TipSet, error) {
+	switch selector {
+	case EthBlockSelectorEarliest:
+		return nil, xerrors.Errorf(`block param "%s" is not supported`, EthBlockSelectorEarliest)
+
+	case EthBlockSelectorPending:
+		return tsr.loader.GetHeaviestTipSet(), nil
+
+	case EthBlockSelectorLatest:
+		return tsr.loader.LoadTipSet(ctx, tsr.loader.GetHeaviestTipSet().Parents())
+
+	case EthBlockSelectorSafe:
+		return tsr.loadFinalizedTipSet(ctx, ethtypes.SafeEpochDelay)
+
+	case EthBlockSelectorFinalized:
+		return tsr.loadFinalizedTipSet(ctx, policy.ChainFinality)
+
+	default:
+		// likely an 0x hex block number or a decimal block number
+		return tsr.resolveEthBlockNumberSelector(ctx, selector, strict)
+	}
+}
+
+// loadFinalizedTipSet will use F3 to load and return the latest finalized tipset.
+//
+//   - If it can't load a finalized tipset from F3, it will return the tipset fallbackDelay epochs
+//     behind the chain head (-1).
+//   - If the finalized tipset from F3 is older than fallbackDelay epochs, it will return the tipset
+//     fallbackDelay epochs behind the chain head (-1).
+func (tsr *tipSetResolver) loadFinalizedTipSet(ctx context.Context, fallbackDelay abi.ChainEpoch) (*types.TipSet, error) {
+	head := tsr.loader.GetHeaviestTipSet()
+	latestHeight := head.Height() - 1 // always one behind for Eth compatibility due to deferred execution
+	fallbackHeight := latestHeight - fallbackDelay
+
+	f3TipSet, err := tsr.maybeF3FinalizedTipSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if f3TipSet != nil && f3TipSet.Height() > fallbackHeight {
+		// return the parent of the finalized tipset, which will be >= fallbackHeight
+		return tsr.loader.LoadTipSet(ctx, f3TipSet.Parents())
+	} // else F3 is disabled, not running, or behind the default safe or finalized height
+
+	ts, err := tsr.loader.GetTipsetByHeight(ctx, fallbackHeight, head, true)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset at height %v: %w", fallbackHeight, err)
+	}
+	return ts, nil
+}
+
+// maybeF3FinalizedTipSet returns the latest F3 finalized tipset if F3 is enabled and the latest
+// certificate indicates that the tipset is finalized on top of the EC chain. If F3 is disabled or
+// or the current manifest is not finalizing tipsets on top of the EC chain, or we can't load a
+// certificate with a finalized tipset, it returns nil. This method will only return errors that
+// arise from dealing with the chain store, not from F3.
+func (tsr *tipSetResolver) maybeF3FinalizedTipSet(ctx context.Context) (*types.TipSet, error) {
+	// TODO: switch the order of GetManifest and GetLatestCert the former won't panic on
+	// a fresh F3 instance: https://github.com/filecoin-project/lotus/issues/12772
+	cert, err := tsr.f3.GetLatestCert(ctx)
+	if err != nil {
+		if !errors.Is(err, api.ErrF3Disabled) {
+			log.Warnf("loading latest F3 certificate: %s", err)
+		}
+		return nil, nil
+	}
+	if cert == nil {
+		return nil, nil
+	}
+
+	if manifest, err := tsr.f3.GetManifest(ctx); err != nil {
+		log.Warnf("loading F3 manifest: %s", err)
+		return nil, nil
+	} else if !manifest.EC.Finalize {
+		// F3 is not finalizing tipsets on top of EC, ignore it
+		return nil, nil
+	}
+
+	if len(cert.ECChain) == 0 || cert.ECChain.IsZero() {
+		// defensive; finality certs are supposed to have a guarantee of at least one tipset
+		return nil, nil
+	}
+
+	tsk, err := types.TipSetKeyFromBytes(cert.ECChain.Head().Key)
+	if err != nil {
+		return nil, xerrors.Errorf("decoding tipset key reported by F3: %w", err)
+	}
+
+	finalizedTipSet, err := tsr.loader.LoadTipSet(ctx, tsk)
+	if err != nil {
+		return nil, xerrors.Errorf("loading tipset reported as finalized by F3 %s: %w", tsk, err)
+	}
+
+	return finalizedTipSet, nil
+}
+
+func (tsr *tipSetResolver) resolveEthBlockNumberSelector(ctx context.Context, selector string, strict bool) (*types.TipSet, error) {
+	var num ethtypes.EthUint64
+	if err := num.UnmarshalJSON([]byte(`"` + selector + `"`)); err != nil {
+		return nil, xerrors.Errorf("cannot parse block number: %v", err)
+	}
+
+	head := tsr.loader.GetHeaviestTipSet()
+	if abi.ChainEpoch(num) > head.Height()-1 {
+		return nil, xerrors.New("requested a future epoch (beyond 'latest')")
+	}
+
+	ts, err := tsr.loader.GetTipsetByHeight(ctx, abi.ChainEpoch(num), head, true)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot get tipset at height: %v", num)
+	}
+
+	if strict && ts.Height() != abi.ChainEpoch(num) {
+		return nil, api.NewErrNullRound(abi.ChainEpoch(num))
+	}
+
+	return ts, nil
+}

--- a/chain/tsresolver/tipset_resolver_test.go
+++ b/chain/tsresolver/tipset_resolver_test.go
@@ -1,0 +1,247 @@
+package tsresolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/crypto"
+
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	f3mock "github.com/filecoin-project/lotus/chain/lf3/mock"
+	"github.com/filecoin-project/lotus/chain/tsresolver"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var dummyCid = cid.MustParse("bafkqaaa")
+
+func TestResolveEthBlockSelector(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("basic selectors", func(t *testing.T) {
+		req := require.New(t)
+
+		parent := makeTestTipSet(t, 99, nil)
+		head := makeTestTipSet(t, 100, parent.Cids())
+
+		loader := &mockTipSetLoader{
+			head: head,
+			tipsets: map[types.TipSetKey]*types.TipSet{
+				parent.Key(): parent,
+			},
+		}
+
+		resolver := tsresolver.NewTipSetResolver(loader, &f3mock.MockF3API{})
+
+		ts, err := resolver.ResolveEthBlockSelector(ctx, "pending", true)
+		req.NoError(err)
+		req.Equal(head, ts)
+
+		ts, err = resolver.ResolveEthBlockSelector(ctx, "latest", true)
+		req.NoError(err)
+		req.Equal(parent, ts)
+
+		ts, err = resolver.ResolveEthBlockSelector(ctx, "earliest", true)
+		req.ErrorContains(err, "not supported")
+		req.Nil(ts)
+	})
+
+	for _, f3Status := range []string{"disabled", "stopped", "nonfinalizing"} {
+		t.Run("safe/finalized with F3 "+f3Status, func(t *testing.T) {
+			req := require.New(t)
+
+			head := makeTestTipSet(t, 1000, nil)
+			safe := makeTestTipSet(t, 969, nil) // head - 31
+			final := makeTestTipSet(t, 99, nil) // head - 901
+			// setup f3 such that if the checks for disabled/running/non-finalized slip through
+			// that it will return a tipset that `"finalized"` would return - we should never see
+			// this in these tests
+			f3finalzedParent := makeTestTipSet(t, 960, nil)
+			f3finalzed := makeTestTipSet(t, 961, f3finalzedParent.Cids())
+
+			loader := &mockTipSetLoader{
+				head: head,
+				byHeight: map[abi.ChainEpoch]*types.TipSet{
+					969: safe,
+					99:  final,
+				},
+				tipsets: map[types.TipSetKey]*types.TipSet{
+					f3finalzedParent.Key(): f3finalzedParent,
+					f3finalzed.Key():       f3finalzed,
+				},
+			}
+
+			f3 := &f3mock.MockF3API{}
+			// setup f3 as if it's operational, then selectively turn off what we are testing
+			f3.SetManifest(manifest.LocalDevnetManifest())
+			f3.SetLatestCert(&certs.FinalityCertificate{
+				ECChain: gpbft.ECChain{
+					gpbft.TipSet{Key: f3finalzed.Key().Bytes()},
+				},
+			})
+
+			switch f3Status {
+			case "disabled":
+				f3.SetEnabled(false)
+			case "stopped":
+				f3.SetLatestCert(nil) // no cert as a proxy for not running
+			case "nonfinalizing":
+				m := manifest.LocalDevnetManifest()
+				m.EC.Finalize = false
+				f3.SetManifest(m)
+			}
+
+			resolver := tsresolver.NewTipSetResolver(loader, f3)
+
+			ts, err := resolver.ResolveEthBlockSelector(ctx, "safe", true)
+			req.NoError(err)
+			req.Equal(safe, ts)
+
+			ts, err = resolver.ResolveEthBlockSelector(ctx, "finalized", true)
+			req.NoError(err)
+			req.Equal(final, ts)
+		})
+	}
+
+	t.Run("safe/finalized with F3 enabled and close to head", func(t *testing.T) {
+		// normal F3 operation, closer to head than default "safe"
+
+		req := require.New(t)
+
+		head := makeTestTipSet(t, 1000, nil)
+		finalzedParent := makeTestTipSet(t, 994, nil)
+		finalzed := makeTestTipSet(t, 995, finalzedParent.Cids())
+
+		loader := &mockTipSetLoader{
+			head: head,
+			tipsets: map[types.TipSetKey]*types.TipSet{
+				finalzedParent.Key(): finalzedParent,
+				finalzed.Key():       finalzed,
+			},
+		}
+
+		f3 := &f3mock.MockF3API{}
+		f3.SetEnabled(true)
+		f3.SetRunning(true)
+		f3.SetManifest(manifest.LocalDevnetManifest())
+		f3.SetLatestCert(&certs.FinalityCertificate{
+			ECChain: gpbft.ECChain{
+				gpbft.TipSet{Key: finalzed.Key().Bytes()},
+			},
+		})
+
+		resolver := tsresolver.NewTipSetResolver(loader, f3)
+
+		ts, err := resolver.ResolveEthBlockSelector(ctx, "safe", true)
+		req.NoError(err)
+		req.Equal(finalzedParent, ts)
+
+		ts, err = resolver.ResolveEthBlockSelector(ctx, "finalized", true)
+		req.NoError(err)
+		req.Equal(finalzedParent, ts)
+	})
+
+	t.Run("safe/finalized with F3 enabled and far from head", func(t *testing.T) {
+		// F3 is running, but delayed longer than EC, so expect fall-back to EC behaviour
+
+		req := require.New(t)
+
+		head := makeTestTipSet(t, 1000, nil)
+		safe := makeTestTipSet(t, 969, nil)    // head - 31
+		final := makeTestTipSet(t, 99, nil)    // head - 901
+		finalzed := makeTestTipSet(t, 10, nil) // head - 990
+
+		loader := &mockTipSetLoader{
+			head: head,
+			tipsets: map[types.TipSetKey]*types.TipSet{
+				finalzed.Key(): finalzed,
+			},
+			byHeight: map[abi.ChainEpoch]*types.TipSet{
+				969: safe,
+				99:  final,
+			},
+		}
+
+		f3 := &f3mock.MockF3API{}
+		f3.SetEnabled(true)
+		f3.SetRunning(true)
+		f3.SetManifest(manifest.LocalDevnetManifest())
+		f3.SetLatestCert(&certs.FinalityCertificate{
+			ECChain: gpbft.ECChain{
+				gpbft.TipSet{Key: finalzed.Key().Bytes()},
+			},
+		})
+
+		resolver := tsresolver.NewTipSetResolver(loader, f3)
+
+		ts, err := resolver.ResolveEthBlockSelector(ctx, "safe", true)
+		req.NoError(err)
+		req.Equal(safe, ts)
+
+		ts, err = resolver.ResolveEthBlockSelector(ctx, "finalized", true)
+		req.NoError(err)
+		req.Equal(final, ts)
+	})
+
+	t.Run("block number resolution", func(t *testing.T) {
+		req := require.New(t)
+
+		head := makeTestTipSet(t, 100, nil)
+		target := makeTestTipSet(t, 42, nil)
+
+		loader := &mockTipSetLoader{
+			head: head,
+			byHeight: map[abi.ChainEpoch]*types.TipSet{
+				42: target,
+			},
+		}
+
+		resolver := tsresolver.NewTipSetResolver(loader, &f3mock.MockF3API{})
+
+		ts, err := resolver.ResolveEthBlockSelector(ctx, "42", true)
+		req.NoError(err)
+		req.Equal(target, ts)
+
+		ts, err = resolver.ResolveEthBlockSelector(ctx, "0x2a", true)
+		req.NoError(err)
+		req.Equal(target, ts)
+	})
+}
+
+func makeTestTipSet(t *testing.T, height int64, parents []cid.Cid) *types.TipSet {
+	if parents == nil {
+		parents = []cid.Cid{dummyCid, dummyCid}
+	}
+	ts, err := types.NewTipSet([]*types.BlockHeader{{
+		Miner:                 builtin.SystemActorAddr,
+		Height:                abi.ChainEpoch(height),
+		ParentStateRoot:       dummyCid,
+		Messages:              dummyCid,
+		ParentMessageReceipts: dummyCid,
+		BlockSig:              &crypto.Signature{Type: crypto.SigTypeBLS},
+		BLSAggregate:          &crypto.Signature{Type: crypto.SigTypeBLS},
+		Parents:               parents,
+	}})
+	require.NoError(t, err)
+	return ts
+}
+
+type mockTipSetLoader struct {
+	head     *types.TipSet
+	tipsets  map[types.TipSetKey]*types.TipSet
+	byHeight map[abi.ChainEpoch]*types.TipSet
+}
+
+func (m *mockTipSetLoader) GetHeaviestTipSet() *types.TipSet { return m.head }
+func (m *mockTipSetLoader) LoadTipSet(_ context.Context, tsk types.TipSetKey) (*types.TipSet, error) {
+	return m.tipsets[tsk], nil
+}
+func (m *mockTipSetLoader) GetTipsetByHeight(_ context.Context, h abi.ChainEpoch, _ *types.TipSet, _ bool) (*types.TipSet, error) {
+	return m.byHeight[h], nil
+}

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -264,6 +264,11 @@ func F3Enabled(cfg *lf3.Config) NodeOpt {
 	)
 }
 
+// WithF3API replaces the node's F3API with the provided one. Useful for mocking F3 behavior.
+func WithF3API(f3 lf3.F3API) NodeOpt {
+	return ConstructorOpts(node.Override(new(lf3.F3API), func() lf3.F3API { return f3 }))
+}
+
 // SectorSize sets the sector size for this miner. Start() will populate the
 // corresponding proof type depending on the network version (genesis network
 // version if the Ensemble is unstarted, or the current network version

--- a/node/impl/full/f3.go
+++ b/node/impl/full/f3.go
@@ -19,11 +19,11 @@ import (
 type F3API struct {
 	fx.In
 
-	F3 *lf3.F3 `optional:"true"`
+	F3 lf3.F3API
 }
 
 func (f3api *F3API) F3GetOrRenewParticipationTicket(ctx context.Context, miner address.Address, previous api.F3ParticipationTicket, instances uint64) (api.F3ParticipationTicket, error) {
-	if f3api.F3 == nil {
+	if !f3api.F3.IsEnabled() {
 		log.Infof("F3GetParticipationTicket called for %v, F3 is disabled", miner)
 		return nil, api.ErrF3Disabled
 	}
@@ -35,8 +35,7 @@ func (f3api *F3API) F3GetOrRenewParticipationTicket(ctx context.Context, miner a
 }
 
 func (f3api *F3API) F3Participate(ctx context.Context, ticket api.F3ParticipationTicket) (api.F3ParticipationLease, error) {
-
-	if f3api.F3 == nil {
+	if !f3api.F3.IsEnabled() {
 		log.Infof("F3Participate called, F3 is disabled")
 		return api.F3ParticipationLease{}, api.ErrF3Disabled
 	}
@@ -44,57 +43,33 @@ func (f3api *F3API) F3Participate(ctx context.Context, ticket api.F3Participatio
 }
 
 func (f3api *F3API) F3GetCertificate(ctx context.Context, instance uint64) (*certs.FinalityCertificate, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
 	return f3api.F3.GetCert(ctx, instance)
 }
 
 func (f3api *F3API) F3GetLatestCertificate(ctx context.Context) (*certs.FinalityCertificate, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
 	return f3api.F3.GetLatestCert(ctx)
 }
 
 func (f3api *F3API) F3GetManifest(ctx context.Context) (*manifest.Manifest, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
 	return f3api.F3.GetManifest(ctx)
 }
 
 func (f3api *F3API) F3IsRunning(context.Context) (bool, error) {
-	if f3api.F3 == nil {
-		return false, api.ErrF3Disabled
-	}
-	return f3api.F3.IsRunning(), nil
+	return f3api.F3.IsRunning()
 }
 
 func (f3api *F3API) F3GetECPowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
 	return f3api.F3.GetPowerTable(ctx, tsk)
 }
 
 func (f3api *F3API) F3GetF3PowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
 	return f3api.F3.GetF3PowerTable(ctx, tsk)
 }
 
 func (f3api *F3API) F3GetProgress(context.Context) (gpbft.Instant, error) {
-	if f3api.F3 == nil {
-		return gpbft.Instant{}, api.ErrF3Disabled
-	}
-	return f3api.F3.Progress(), nil
+	return f3api.F3.Progress()
 }
 
 func (f3api *F3API) F3ListParticipants(context.Context) ([]api.F3Participant, error) {
-	if f3api.F3 == nil {
-		return nil, api.ErrF3Disabled
-	}
-	return f3api.F3.ListParticipants(), nil
+	return f3api.F3.ListParticipants()
 }

--- a/node/modules/ethmodule.go
+++ b/node/modules/ethmodule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
+	"github.com/filecoin-project/lotus/chain/tsresolver"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/node/impl/full"
@@ -21,11 +22,39 @@ import (
 	"github.com/filecoin-project/lotus/node/repo"
 )
 
-func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRepo, fx.Lifecycle, *store.ChainStore, *stmgr.StateManager,
-	EventHelperAPI, *messagepool.MessagePool, full.StateAPI, full.ChainAPI, full.MpoolAPI, full.SyncAPI, *full.EthEventHandler, index.Indexer) (*full.EthModule, error) {
-	return func(mctx helpers.MetricsCtx, r repo.LockedRepo, lc fx.Lifecycle, cs *store.ChainStore, sm *stmgr.StateManager, evapi EventHelperAPI,
-		mp *messagepool.MessagePool, stateapi full.StateAPI, chainapi full.ChainAPI, mpoolapi full.MpoolAPI, syncapi full.SyncAPI,
-		ethEventHandler *full.EthEventHandler, chainIndexer index.Indexer) (*full.EthModule, error) {
+func EthModuleAPI(cfg config.FevmConfig) func(
+	helpers.MetricsCtx,
+	repo.LockedRepo,
+	fx.Lifecycle,
+	*store.ChainStore,
+	*stmgr.StateManager,
+	EventHelperAPI,
+	*messagepool.MessagePool,
+	full.StateAPI,
+	full.ChainAPI,
+	full.MpoolAPI,
+	full.SyncAPI,
+	*full.EthEventHandler,
+	index.Indexer,
+	tsresolver.TipSetResolver,
+) (*full.EthModule, error) {
+
+	return func(
+		mctx helpers.MetricsCtx,
+		r repo.LockedRepo,
+		lc fx.Lifecycle,
+		cs *store.ChainStore,
+		sm *stmgr.StateManager,
+		evapi EventHelperAPI,
+		mp *messagepool.MessagePool,
+		stateapi full.StateAPI,
+		chainapi full.ChainAPI,
+		mpoolapi full.MpoolAPI,
+		syncapi full.SyncAPI,
+		ethEventHandler *full.EthEventHandler,
+		chainIndexer index.Indexer,
+		tipsetResolver tsresolver.TipSetResolver,
+	) (*full.EthModule, error) {
 
 		// prefill the whole skiplist cache maintained internally by the GetTipsetByHeight
 		go func() {
@@ -69,7 +98,8 @@ func EthModuleAPI(cfg config.FevmConfig) func(helpers.MetricsCtx, repo.LockedRep
 			EthBlkCache:   blkCache,
 			EthBlkTxCache: blkTxCache,
 
-			ChainIndexer: chainIndexer,
+			ChainIndexer:   chainIndexer,
+			TipSetResolver: tipsetResolver,
 		}, nil
 	}
 }


### PR DESCRIPTION
From CHANGELOG:

> **Ethereum APIs meet F3!** When F3 is enabled and running, Ethereum APIs that accept block descriptors `"finalized"` and `"safe"` will use F3 to determine the block to select instead of the default 30 block delay for `"safe"` and 900 block delay for `"finalized"`.

* Introduced an `lf3.F3API` interface that I can mock and replace the default `lf3.F3`
* Added an `IsEnabled()` to the F3 interface, `lf3.F3` returns `true`
* Added a `lf3.DisabledF3` implementation that gets loaded when F3 isn't enabled, it returns `false` for `IsEnabled()`. All methods now have an error return and they'll return `api.ErrF3Disabled`; so this simplifies `node/impl/full/f3.go` which just has to pass through the calls instead of checking whether `fff` is `nil`.
* Added a `MockF3API` that can be used as a replacement to modify some of its behaviour (focused on the changes in here fore now).
* Added a `TipSetResolver`, which for now, just exposes `ResolveEthBlockSelector` for the Ethereum APIs. But this will be the extension point for the additional non-eth API work (I'll rebase https://github.com/filecoin-project/lotus/pull/12719 ontop of this). This replaces the eth utility function `getTipsetByBlockNumber` and integrates with F3.

So, now when you resolve `"safe"` or `"finalized"`, we first query F3, then:

1. If F3 is disabled or not running, fall back to EC behaviour (`"safe"` = head-30-1, `"finalized"` = head-900-1) (we always -1 for the Eth APIs because the queries are transaction-centric and care about transaction execution).
2. If F3 reports its latest epoch is later than EC finality, we fall back to EC behaviour
3. If F3 is closer to head than the default EC variant (31, or 901), use the F3 epoch (-1) instead

@Kubuxu @masih PTAL

@Stebalien I'm pinging you because I wouldn't mind you additional sanity checking on the eth tipset-1 behaviour in here.