### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -1252,11 +1252,11 @@ var ChainExportRangeCmd = &cli.Command{
 		}
 
 		if head.Height() < tail.Height() {
-			return errors.New("Height of --head tipset must be greater or equal to the height of the --tail tipset")
+			return errors.New("height of --head tipset must be greater or equal to the height of the --tail tipset")
 		}
 
 		if !cctx.Bool("internal") {
-			return errors.New("Non-internal exports are not implemented")
+			return errors.New("non-internal exports are not implemented")
 		}
 
 		err = api.ChainExportRangeInternal(ctx, head.Key(), tail.Key(), lapi.ChainExportConfig{

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -92,7 +92,7 @@ var f3SubCmdPowerTable = &cli.Command{
 			Flags:     []cli.Flag{f3FlagPowerTableFromEC},
 			Before: func(cctx *cli.Context) error {
 				if cctx.Args().Len() > 1 {
-					return fmt.Errorf("too many arguments")
+					return errors.New("too many arguments")
 				}
 				return nil
 			},
@@ -186,7 +186,7 @@ var f3SubCmdPowerTable = &cli.Command{
 			},
 			Before: func(cctx *cli.Context) error {
 				if cctx.Args().Len() < 1 {
-					return fmt.Errorf("at least one actor ID must be specified")
+					return errors.New("at least one actor ID must be specified")
 				}
 				return nil
 			},

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -72,7 +72,7 @@ var filplusVerifyClientCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		froms := cctx.String("from")
 		if froms == "" {
-			return fmt.Errorf("must specify from address with --from")
+			return errors.New("must specify from address with --from")
 		}
 
 		fromk, err := address.NewFromString(froms)
@@ -726,7 +726,7 @@ var filplusCheckClientCmd = &cli.Command{
 	ArgsUsage: "clientAddress",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must specify client address to check")
+			return errors.New("must specify client address to check")
 		}
 
 		caddr, err := address.NewFromString(cctx.Args().First())
@@ -761,7 +761,7 @@ var filplusCheckNotaryCmd = &cli.Command{
 	ArgsUsage: "notaryAddress",
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() != 1 {
-			return fmt.Errorf("must specify notary address to check")
+			return errors.New("must specify notary address to check")
 		}
 
 		vaddr, err := address.NewFromString(cctx.Args().First())
@@ -781,7 +781,7 @@ var filplusCheckNotaryCmd = &cli.Command{
 			return err
 		}
 		if !found {
-			return fmt.Errorf("not found")
+			return errors.New("not found")
 		}
 
 		fmt.Println(dcap)

--- a/cli/log.go
+++ b/cli/log.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -82,7 +83,7 @@ var LogSetLevel = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if !cctx.Args().Present() {
-			return fmt.Errorf("level is required")
+			return errors.New("level is required")
 		}
 
 		systems := cctx.StringSlice("system")

--- a/cli/mpool.go
+++ b/cli/mpool.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	stdbig "math/big"
 	"sort"
@@ -161,7 +162,7 @@ var MpoolClear = &cli.Command{
 		really := cctx.Bool("really-do-it")
 		if !really {
 			//nolint:golint
-			return fmt.Errorf("--really-do-it must be specified for this action to have an effect; you have been warned")
+			return errors.New("--really-do-it must be specified for this action to have an effect; you have been warned")
 		}
 
 		local := cctx.Bool("local")

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -202,7 +203,7 @@ var msigInspectCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Args().Present() {
-			return ShowHelp(cctx, fmt.Errorf("must specify address of multisig to inspect"))
+			return ShowHelp(cctx, errors.New("must specify address of multisig to inspect"))
 		}
 
 		api, closer, err := GetFullNodeAPI(cctx)
@@ -400,11 +401,11 @@ var msigProposeCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 3 {
-			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address, destination, and value"))
+			return ShowHelp(cctx, errors.New("must pass at least multisig address, destination, and value"))
 		}
 
 		if cctx.NArg() > 3 && cctx.NArg() != 5 {
-			return ShowHelp(cctx, fmt.Errorf("must either pass three or five arguments"))
+			return ShowHelp(cctx, errors.New("must either pass three or five arguments"))
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -522,15 +523,15 @@ var msigApproveCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address and message ID"))
+			return ShowHelp(cctx, errors.New("must pass at least multisig address and message ID"))
 		}
 
 		if cctx.NArg() > 2 && cctx.NArg() < 5 {
-			return ShowHelp(cctx, fmt.Errorf("usage: msig approve <msig addr> <message ID> <proposer address> <desination> <value>"))
+			return ShowHelp(cctx, errors.New("usage: msig approve <msig addr> <message ID> <proposer address> <destination> <value>"))
 		}
 
 		if cctx.NArg() > 5 && cctx.NArg() != 7 {
-			return ShowHelp(cctx, fmt.Errorf("usage: msig approve <msig addr> <message ID> <proposer address> <desination> <value> [ <method> <params> ]"))
+			return ShowHelp(cctx, errors.New("usage: msig approve <msig addr> <message ID> <proposer address> <destination> <value> [ <method> <params> ]"))
 		}
 
 		srv, err := GetFullNodeServices(cctx)
@@ -659,15 +660,15 @@ var msigCancelCmd = &cli.Command{
 	},
 	Action: func(cctx *cli.Context) error {
 		if cctx.NArg() < 2 {
-			return ShowHelp(cctx, fmt.Errorf("must pass at least multisig address and message ID"))
+			return ShowHelp(cctx, errors.New("must pass at least multisig address and message ID"))
 		}
 
 		if cctx.NArg() > 2 && cctx.NArg() < 4 {
-			return ShowHelp(cctx, fmt.Errorf("usage: msig cancel <msig addr> <message ID> <desination> <value>"))
+			return ShowHelp(cctx, errors.New("usage: msig cancel <msig addr> <message ID> <destination> <value>"))
 		}
 
 		if cctx.NArg() > 4 && cctx.NArg() != 6 {
-			return ShowHelp(cctx, fmt.Errorf("usage: msig cancel <msig addr> <message ID> <desination> <value> [ <method> <params> ]"))
+			return ShowHelp(cctx, errors.New("usage: msig cancel <msig addr> <message ID> <destination> <value> [ <method> <params> ]"))
 		}
 
 		srv, err := GetFullNodeServices(cctx)

--- a/cli/send.go
+++ b/cli/send.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -104,7 +105,7 @@ var SendCmd = &cli.Command{
 			}
 			// ideally, this should never happen
 			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
-				return ShowHelp(cctx, fmt.Errorf("ETH addresses can only map to a FIL addresses starting with f410f or f0"))
+				return ShowHelp(cctx, errors.New("ETH addresses can only map to a FIL addresses starting with f410f or f0"))
 			}
 		}
 
@@ -213,7 +214,7 @@ var SendCmd = &cli.Command{
 
 		if cctx.IsSet("params-json") {
 			if params.Params != nil {
-				return fmt.Errorf("can only specify one of 'params-json' and 'params-hex'")
+				return errors.New("can only specify one of 'params-json' and 'params-hex'")
 			}
 			decparams, err := srv.DecodeTypedParamsFromJSON(ctx, params.To, params.Method, cctx.String("params-json"))
 			if err != nil {

--- a/cli/sending_ui.go
+++ b/cli/sending_ui.go
@@ -170,7 +170,7 @@ func runFeeCapAdjustmentUI(proto *api.MessagePrototype, baseFee abi.TokenAmount)
 		return nil, err
 	}
 	if !send {
-		return nil, fmt.Errorf("aborted by user")
+		return nil, errors.New("aborted by user")
 	}
 
 	proto.Message.GasFeeCap = big.Div(maxFee, big.NewInt(proto.Message.GasLimit))

--- a/cli/services.go
+++ b/cli/services.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -113,7 +114,7 @@ type CheckInfo struct {
 	Check api.MessageCheckStatus
 }
 
-var ErrCheckFailed = fmt.Errorf("check has failed")
+var ErrCheckFailed = errors.New("check has failed")
 
 func (s *ServicesImpl) RunChecksForPrototype(ctx context.Context, prototype *api.MessagePrototype) ([][]api.MessageCheckStatus, error) {
 	var outChecks [][]api.MessageCheckStatus

--- a/cli/state.go
+++ b/cli/state.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -374,7 +375,7 @@ var StateExecTraceCmd = &cli.Command{
 			}
 		}
 		if trace == nil {
-			return fmt.Errorf("failed to find message in tipset trace output")
+			return errors.New("failed to find message in tipset trace output")
 		}
 
 		out, err := json.MarshalIndent(trace, "", "  ")
@@ -537,7 +538,7 @@ var StateListMinersCmd = &cli.Command{
 			}
 			return nil
 		default:
-			return fmt.Errorf("unrecognized sorting order")
+			return errors.New("unrecognized sorting order")
 		case "", "none":
 		}
 

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -119,7 +120,7 @@ var SyncMarkBadCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 
 		if !cctx.Args().Present() {
-			return fmt.Errorf("must specify block cid to mark")
+			return errors.New("must specify block cid to mark")
 		}
 
 		bcid, err := cid.Decode(cctx.Args().First())
@@ -154,7 +155,7 @@ var SyncUnmarkBadCmd = &cli.Command{
 		}
 
 		if !cctx.Args().Present() {
-			return fmt.Errorf("must specify block cid to unmark")
+			return errors.New("must specify block cid to unmark")
 		}
 
 		bcid, err := cid.Decode(cctx.Args().First())

--- a/cli/wait.go
+++ b/cli/wait.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -44,7 +45,7 @@ var WaitApiCmd = &cli.Command{
 		}
 
 		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("timed out waiting for api to come online")
+			return errors.New("timed out waiting for api to come online")
 		}
 
 		return ctx.Err()


### PR DESCRIPTION
1. use errors.New to replace fmt.Errorf with no parameters
2. Fix spelling errors in words