### PR TITLE
feat(ci): go list check versions available for untagged dependencies

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -11,11 +11,18 @@ jobs:
   dependency-check:
     runs-on: ubuntu-latest
     name: Dependency Check
+    env:
+      V0_PATTERN: 'v0\.0\.0-[0-9]{14}-[0-9a-f]{7,}(\s*(\/\/.*)?)?$'
+      RELEASE_PATTERN: 'v[0-9]+\.[0-9]+\.[0-9]+(\+incompatible)?(\s*(\/\/.*)?)?$'
+      IGNORE_PATTERN: 'dependency-check-ignore:\s'
+
     steps:
       - uses: actions/checkout@v3
         name: Check out the repository
         with:
           submodules: 'recursive'
+      - uses: ./.github/actions/install-go
+
       - id: all
         name: Extract all dependencies from go.mod (include indirect dependencies and comments)
         run: |
@@ -38,30 +45,48 @@ jobs:
           # Append the result to the file specified by the GITHUB_OUTPUT environment variable.
           tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
       - id: unreleased
         name: Find all dependencies that use prerelease versions (i.e., exclude vX.Y.Z and v0.0.0 versions)
         env:
           DEPENDENCIES: ${{ steps.all.outputs.dependencies }}
         run: |
           echo "dependencies<<EOF" >> $GITHUB_OUTPUT
-          grep -Pv '(v0\.0\.0-[0-9]{14}-[0-9a-f]{7,}|v[0-9]+\.[0-9]+\.[0-9]+(\+incompatible)?)( |$)' <<< "$DEPENDENCIES" | tee -a $GITHUB_OUTPUT
+          grep -Pv "$V0_PATTERN|$RELEASE_PATTERN" <<< "$DEPENDENCIES" | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
       - id: unexplained
         name: Find all unreleased dependencies without a dependency-check-ignore comment
         env:
           DEPENDENCIES: ${{ steps.unreleased.outputs.dependencies }}
         run: |
           echo "dependencies<<EOF" >> $GITHUB_OUTPUT
-          grep -Pv 'dependency-check-ignore:\s' <<< "$DEPENDENCIES" | tee -a $GITHUB_OUTPUT
+          grep -Pv "$IGNORE_PATTERN" <<< "$DEPENDENCIES" | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - if: steps.unexplained.outputs.dependencies != ''
-        name: Throw if any unreleased unexplained dependencies exist
+
+      - id: v0check
+        name: Check v0.0.0 dependencies for available tags
+        run: |
+          echo "tagged<<EOF" >> $GITHUB_OUTPUT
+          grep -P "$V0_PATTERN" go.mod | grep -Pv "$IGNORE_PATTERN" | while read -r line; do
+            dep=$(echo "$line" | cut -d' ' -f1)
+            if [ ! -z "$(go list -m -versions $dep 2>/dev/null | awk 'NF>1')" ]; then
+              echo "$dep"
+            fi
+          done | tee -a $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - if: steps.unexplained.outputs.dependencies != '' || steps.v0check.outputs.tagged != ''
+        name: Throw if any unexplained dependencies exist
         env:
           MESSAGE: |
-            A new unreleased and unexplained dependency was discovered in this PR. Please do one of the options in [dependency management conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#dependency-management).
+            Dependencies requiring attention found in this PR. Please follow the [dependency management conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#dependency-management).
 
-            Unexplained unreleased dependencies:
-            ${{steps.unexplained.outputs.dependencies}}
+            ${{ steps.unexplained.outputs.dependencies != '' && 'Unexplained unreleased dependencies:' || '' }}
+            ${{ steps.unexplained.outputs.dependencies }}
+
+            ${{ steps.v0check.outputs.tagged != '' && 'Unexplained v0.0.0 dependencies with available tags:' || '' }}
+            ${{ steps.v0check.outputs.tagged }}
         run: |
           echo "::error::${MESSAGE//$'\n'/%0A}"
           exit 1

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/gregdhill/go-openrpc v0.0.0-20220114144539-ae6f44720487
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
-	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
+	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e // dependency-check-ignore: TODO: needs upgrading to tagged version
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -352,7 +352,7 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
+	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect; dependency-check-ignore: required by github.com/elastic/go-sysinfo
 	lukechampine.com/blake3 v1.3.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )


### PR DESCRIPTION
This is on top of https://github.com/filecoin-project/lotus/pull/12740, I'm experimenting with using `go list -versions` to inspect `v0.0.0` dependencies (as per discussion with @BigLep). We should be able to say "you're using an untagged version, but it has a version, that's naughty.