### PR TITLE
fix: make DealStatesEqual work properly

### DIFF
--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -156,7 +156,19 @@ type DealState interface {
 }
 
 func DealStatesEqual(a, b DealState) bool {
-	return DealStatesEqual(a, b)
+	if a.SectorNumber() != b.SectorNumber() {
+		return false
+	}
+	if a.SectorStartEpoch() != b.SectorStartEpoch() {
+		return false
+	}
+	if a.LastUpdatedEpoch() != b.LastUpdatedEpoch() {
+		return false
+	}
+	if a.SlashEpoch() != b.SlashEpoch() {
+		return false
+	}
+	return true
 }
 
 type DealStateChanges struct {
@@ -207,16 +219,7 @@ func (e *emptyDealState) SlashEpoch() abi.ChainEpoch {
 }
 
 func (e *emptyDealState) Equals(other DealState) bool {
-	if e.SectorStartEpoch() != other.SectorStartEpoch() {
-		return false
-	}
-	if e.LastUpdatedEpoch() != other.LastUpdatedEpoch() {
-		return false
-	}
-	if e.SlashEpoch() != other.SlashEpoch() {
-		return false
-	}
-	return true
+	return DealStatesEqual(e, other)
 }
 
 func EmptyDealState() DealState {

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -284,7 +284,19 @@ type DealState interface {
 }
 
 func DealStatesEqual(a, b DealState) bool {
-	return DealStatesEqual(a, b)
+	if a.SectorNumber() != b.SectorNumber() {
+		return false
+	}
+	if a.SectorStartEpoch() != b.SectorStartEpoch() {
+		return false
+	}
+	if a.LastUpdatedEpoch() != b.LastUpdatedEpoch() {
+		return false
+	}
+	if a.SlashEpoch() != b.SlashEpoch() {
+		return false
+	}
+	return true
 }
 
 type DealStateChanges struct {
@@ -334,16 +346,7 @@ func (e *emptyDealState) SlashEpoch() abi.ChainEpoch {
 }
 
 func (e *emptyDealState) Equals(other DealState) bool {
-	if e.SectorStartEpoch() != other.SectorStartEpoch() {
-		return false
-	}
-	if e.LastUpdatedEpoch() != other.LastUpdatedEpoch() {
-		return false
-	}
-	if e.SlashEpoch() != other.SlashEpoch() {
-		return false
-	}
-	return true
+	return DealStatesEqual(e, other)
 }
 
 func EmptyDealState() DealState {


### PR DESCRIPTION
I'm not sure this is even needed. I also don't know if `SectorNumber` should be considered here, it wasn't on the original form and I only added it because that would seem to be appropriate for completeness.

My short git detective walk suggests the `emptyDealState#Equals` method contents was deduped with `DealStatesEqual` as part of the DDO work in https://github.com/filecoin-project/lotus/pull/11226, but the wrong way around, ooops. So I'm flipping it back, but also adding `SectorNumber` because that would seem more correct 🤷‍♂️ ; depends on how this is used.

There's one use in [`StatePredicates#DealStateChangedForIDs`](https://github.com/filecoin-project/lotus/blob/4317d1aca71df1b87c8f6dc6813aa43ab24e6954/chain/events/state/predicates.go#L245-L246) but I can't see that being used anywhere.

There's one use in [`marketStatesDiffer#Modify`](https://github.com/filecoin-project/lotus/blob/4317d1aca71df1b87c8f6dc6813aa43ab24e6954/chain/actors/builtin/market/diff.go#L80-L81) as part of the `DiffAdtArray`. Downstream from this it's used by [`StatePredicates#OnDealStateAmtChanged`](https://github.com/filecoin-project/lotus/blob/4317d1aca71df1b87c8f6dc6813aa43ab24e6954/chain/events/state/predicates.go#L211-L212), but I can't see that being used anywhere either.