### PR TITLE
fix: bad error message capitalisation

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -875,7 +875,7 @@ func (ht *apiIpldStore) Get(ctx context.Context, c cid.Cid, out interface{}) err
 		return nil
 	}
 
-	return fmt.Errorf("Object does not implement CBORUnmarshaler")
+	return fmt.Errorf("object does not implement CBORUnmarshaler")
 }
 
 func (ht *apiIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {

--- a/cli/spcli/actor.go
+++ b/cli/spcli/actor.go
@@ -820,7 +820,7 @@ func ActorProposeChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 				return err
 			}
 			if mi.NewWorker != newAddr {
-				return fmt.Errorf("Proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
+				return fmt.Errorf("proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
 			}
 
 			_, _ = fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully sent, change happens at height %d.\n", na, mi.WorkerChangeEpoch)
@@ -1058,7 +1058,7 @@ func ActorConfirmChangeWorkerCmd(getActor ActorAddressGetter) *cli.Command {
 				return err
 			}
 			if mi.Worker != newAddr {
-				return fmt.Errorf("Confirmed worker address change not reflected on chain: expected '%s', found '%s'", newAddr, mi.Worker)
+				return fmt.Errorf("confirmed worker address change not reflected on chain: expected '%s', found '%s'", newAddr, mi.Worker)
 			}
 
 			return nil

--- a/cmd/lotus-shed/actor.go
+++ b/cmd/lotus-shed/actor.go
@@ -859,7 +859,7 @@ var actorProposeChangeWorker = &cli.Command{
 			return err
 		}
 		if mi.NewWorker != newAddr {
-			return fmt.Errorf("Proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
+			return fmt.Errorf("proposed worker address change not reflected on chain: expected '%s', found '%s'", na, mi.NewWorker)
 		}
 
 		_, _ = fmt.Fprintf(cctx.App.Writer, "Worker key change to %s successfully proposed.\n", na)
@@ -980,7 +980,7 @@ var actorConfirmChangeWorker = &cli.Command{
 			return err
 		}
 		if mi.Worker != newAddr {
-			return fmt.Errorf("Confirmed worker address change not reflected on chain: expected '%s', found '%s'", newAddr, mi.Worker)
+			return fmt.Errorf("confirmed worker address change not reflected on chain: expected '%s', found '%s'", newAddr, mi.Worker)
 		}
 
 		return nil

--- a/cmd/lotus-shed/keyinfo.go
+++ b/cmd/lotus-shed/keyinfo.go
@@ -113,7 +113,7 @@ var keyinfoVerifyCmd = &cli.Command{
 			}
 
 			if len(list) != 1 {
-				return fmt.Errorf("Unexpected number of keys, expected 1, found %d", len(list))
+				return fmt.Errorf("unexpected number of keys, expected 1, found %d", len(list))
 			}
 
 			name, err := base32.RawStdEncoding.DecodeString(fileName)
@@ -127,7 +127,7 @@ var keyinfoVerifyCmd = &cli.Command{
 
 			break
 		default:
-			return fmt.Errorf("Unknown keytype %s", keyInfo.Type)
+			return fmt.Errorf("unknown keytype %s", keyInfo.Type)
 		}
 
 		return nil

--- a/cmd/lotus-shed/math.go
+++ b/cmd/lotus-shed/math.go
@@ -100,7 +100,7 @@ var mathSumCmd = &cli.Command{
 		case "raw":
 			fmt.Printf("%s\n", val)
 		default:
-			return fmt.Errorf("Unknown format")
+			return fmt.Errorf("unknown format")
 		}
 
 		return nil

--- a/tools/stats/influx/influx.go
+++ b/tools/stats/influx/influx.go
@@ -115,11 +115,11 @@ func GetLastRecordedHeight(influx client.Client, database string) (int64, error)
 	}
 
 	if len(res.Results) == 0 {
-		return 0, fmt.Errorf("No results found for last recorded height")
+		return 0, fmt.Errorf("no results found for last recorded height")
 	}
 
 	if len(res.Results[0].Series) == 0 {
-		return 0, fmt.Errorf("No results found for last recorded height")
+		return 0, fmt.Errorf("no results found for last recorded height")
 	}
 
 	height, err := (res.Results[0].Series[0].Values[0][1].(json.Number)).Int64()

--- a/tools/stats/ipldstore/ipldstore.go
+++ b/tools/stats/ipldstore/ipldstore.go
@@ -84,7 +84,7 @@ func (ht *ApiIpldStore) Get(ctx context.Context, c cid.Cid, out interface{}) err
 		return nil
 	}
 
-	return fmt.Errorf("Object does not implement CBORUnmarshaler")
+	return fmt.Errorf("object does not implement CBORUnmarshaler")
 }
 
 func (ht *ApiIpldStore) Put(ctx context.Context, v interface{}) (cid.Cid, error) {


### PR DESCRIPTION
Discussion in #12781 made me check how many instances of bad capitalisation we have left in the repo, and it's not very many so I decided to fix these. I'm just limiting myself to those fixes, not the misuse of `fmt.Errorf` or the xerrors/errors inconsistencies.

golangci-lint is supposed to catch these for us, but I think it's deprecated its checking of xerrors messages, simply reporting those as deprecated instead and we explicitly ignore that deprecation error, so we're left without checking.

I think it might be worthwhile also putting actual staticcheck in the mix, not just the golangci-lint staticcheck module which is different, but there's a lot more errors to fix that it throws up before we do that. Something to chip away at.