### PR TITLE
feat(exec): dump intermediate cache blocks from FVM exec in StateReplay

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -1262,6 +1262,12 @@ type InvocResult struct {
 	ExecutionTrace types.ExecutionTrace
 	Error          string
 	Duration       time.Duration
+	CachedBlocks   []Block `json:",omitempty"`
+}
+
+type Block struct {
+	Cid  cid.Cid
+	Data []byte
 }
 
 type IpldObject struct {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -17487,16 +17487,49 @@
                                                 "tt": 60000000000
                                             }
                                         ],
-                                        "Subcalls": null
+                                        "Subcalls": null,
+                                        "Logs": [
+                                            "string value"
+                                        ]
                                     }
+                                ],
+                                "Logs": [
+                                    "string value"
                                 ]
                             },
                             "Error": "string value",
-                            "Duration": 60000000000
+                            "Duration": 60000000000,
+                            "CachedBlocks": [
+                                {
+                                    "Cid": {
+                                        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+                                    },
+                                    "Data": "Ynl0ZSBhcnJheQ=="
+                                }
+                            ]
                         }
                     ],
                     "additionalProperties": false,
                     "properties": {
+                        "CachedBlocks": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "Cid": {
+                                        "title": "Content Identifier",
+                                        "type": "string"
+                                    },
+                                    "Data": {
+                                        "media": {
+                                            "binaryEncoding": "base64"
+                                        },
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
                         "Duration": {
                             "title": "number",
                             "type": "number"
@@ -17570,6 +17603,12 @@
                                         }
                                     },
                                     "type": "object"
+                                },
+                                "Logs": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "Msg": {
                                     "additionalProperties": false,
@@ -18182,12 +18221,26 @@
                                                         "tt": 60000000000
                                                     }
                                                 ],
-                                                "Subcalls": null
+                                                "Subcalls": null,
+                                                "Logs": [
+                                                    "string value"
+                                                ]
                                             }
+                                        ],
+                                        "Logs": [
+                                            "string value"
                                         ]
                                     },
                                     "Error": "string value",
-                                    "Duration": 60000000000
+                                    "Duration": 60000000000,
+                                    "CachedBlocks": [
+                                        {
+                                            "Cid": {
+                                                "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+                                            },
+                                            "Data": "Ynl0ZSBhcnJheQ=="
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -18202,6 +18255,25 @@
                             "items": {
                                 "additionalProperties": false,
                                 "properties": {
+                                    "CachedBlocks": {
+                                        "items": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "Cid": {
+                                                    "title": "Content Identifier",
+                                                    "type": "string"
+                                                },
+                                                "Data": {
+                                                    "media": {
+                                                        "binaryEncoding": "base64"
+                                                    },
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
                                     "Duration": {
                                         "title": "number",
                                         "type": "number"
@@ -18275,6 +18347,12 @@
                                                     }
                                                 },
                                                 "type": "object"
+                                            },
+                                            "Logs": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
                                             },
                                             "Msg": {
                                                 "additionalProperties": false,
@@ -23541,16 +23619,49 @@
                                                 "tt": 60000000000
                                             }
                                         ],
-                                        "Subcalls": null
+                                        "Subcalls": null,
+                                        "Logs": [
+                                            "string value"
+                                        ]
                                     }
+                                ],
+                                "Logs": [
+                                    "string value"
                                 ]
                             },
                             "Error": "string value",
-                            "Duration": 60000000000
+                            "Duration": 60000000000,
+                            "CachedBlocks": [
+                                {
+                                    "Cid": {
+                                        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+                                    },
+                                    "Data": "Ynl0ZSBhcnJheQ=="
+                                }
+                            ]
                         }
                     ],
                     "additionalProperties": false,
                     "properties": {
+                        "CachedBlocks": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "Cid": {
+                                        "title": "Content Identifier",
+                                        "type": "string"
+                                    },
+                                    "Data": {
+                                        "media": {
+                                            "binaryEncoding": "base64"
+                                        },
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
                         "Duration": {
                             "title": "number",
                             "type": "number"
@@ -23624,6 +23735,12 @@
                                         }
                                     },
                                     "type": "object"
+                                },
+                                "Logs": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "Msg": {
                                     "additionalProperties": false,

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -8386,16 +8386,49 @@
                                                 "tt": 60000000000
                                             }
                                         ],
-                                        "Subcalls": null
+                                        "Subcalls": null,
+                                        "Logs": [
+                                            "string value"
+                                        ]
                                     }
+                                ],
+                                "Logs": [
+                                    "string value"
                                 ]
                             },
                             "Error": "string value",
-                            "Duration": 60000000000
+                            "Duration": 60000000000,
+                            "CachedBlocks": [
+                                {
+                                    "Cid": {
+                                        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+                                    },
+                                    "Data": "Ynl0ZSBhcnJheQ=="
+                                }
+                            ]
                         }
                     ],
                     "additionalProperties": false,
                     "properties": {
+                        "CachedBlocks": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "Cid": {
+                                        "title": "Content Identifier",
+                                        "type": "string"
+                                    },
+                                    "Data": {
+                                        "media": {
+                                            "binaryEncoding": "base64"
+                                        },
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
                         "Duration": {
                             "title": "number",
                             "type": "number"
@@ -8469,6 +8502,12 @@
                                         }
                                     },
                                     "type": "object"
+                                },
+                                "Logs": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "Msg": {
                                     "additionalProperties": false,
@@ -10872,16 +10911,49 @@
                                                 "tt": 60000000000
                                             }
                                         ],
-                                        "Subcalls": null
+                                        "Subcalls": null,
+                                        "Logs": [
+                                            "string value"
+                                        ]
                                     }
+                                ],
+                                "Logs": [
+                                    "string value"
                                 ]
                             },
                             "Error": "string value",
-                            "Duration": 60000000000
+                            "Duration": 60000000000,
+                            "CachedBlocks": [
+                                {
+                                    "Cid": {
+                                        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+                                    },
+                                    "Data": "Ynl0ZSBhcnJheQ=="
+                                }
+                            ]
                         }
                     ],
                     "additionalProperties": false,
                     "properties": {
+                        "CachedBlocks": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "Cid": {
+                                        "title": "Content Identifier",
+                                        "type": "string"
+                                    },
+                                    "Data": {
+                                        "media": {
+                                            "binaryEncoding": "base64"
+                                        },
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
                         "Duration": {
                             "title": "number",
                             "type": "number"
@@ -10955,6 +11027,12 @@
                                         }
                                     },
                                     "type": "object"
+                                },
+                                "Logs": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
                                 },
                                 "Msg": {
                                     "additionalProperties": false,

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -292,12 +292,12 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 
 var errHaltExecution = fmt.Errorf("halt")
 
-func (sm *StateManager) Replay(ctx context.Context, ts *types.TipSet, mcid cid.Cid) (*types.Message, *vm.ApplyRet, error) {
+func (sm *StateManager) Replay(ctx context.Context, ts *types.TipSet, mcid cid.Cid, cacheStore blockstore.Blockstore) (*types.Message, *vm.ApplyRet, error) {
 	var finder messageFinder
 	// message to find
 	finder.mcid = mcid
 
-	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &finder, true)
+	_, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, &finder, true, cacheStore)
 	if err != nil && !errors.Is(err, errHaltExecution) {
 		return nil, nil, xerrors.Errorf("unexpected error during execution: %w", err)
 	}

--- a/chain/stmgr/execute.go
+++ b/chain/stmgr/execute.go
@@ -82,7 +82,7 @@ func (sm *StateManager) tipSetState(ctx context.Context, ts *types.TipSet, recom
 		}
 	}
 
-	st, rec, err = sm.tsExec.ExecuteTipSet(ctx, sm, ts, sm.tsExecMonitor, false)
+	st, rec, err = sm.tsExec.ExecuteTipSet(ctx, sm, ts, sm.tsExecMonitor, false, nil)
 	if err != nil {
 		return cid.Undef, cid.Undef, err
 	}
@@ -136,7 +136,7 @@ func tryLookupTipsetState(ctx context.Context, cs *store.ChainStore, ts *types.T
 }
 
 func (sm *StateManager) ExecutionTraceWithMonitor(ctx context.Context, ts *types.TipSet, em ExecMonitor) (cid.Cid, error) {
-	st, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, em, true)
+	st, _, err := sm.tsExec.ExecuteTipSet(ctx, sm, ts, em, true, nil)
 	return st, err
 }
 

--- a/chain/stmgr/stmgr.go
+++ b/chain/stmgr/stmgr.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v8/actors/migration/nv16"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	_init "github.com/filecoin-project/lotus/chain/actors/builtin/init"
@@ -119,7 +120,7 @@ func (m *migrationResultCache) Delete(ctx context.Context, root cid.Cid) {
 
 type Executor interface {
 	NewActorRegistry() *vm.ActorRegistry
-	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor, vmTracing bool) (stateroot cid.Cid, rectsroot cid.Cid, err error)
+	ExecuteTipSet(ctx context.Context, sm *StateManager, ts *types.TipSet, em ExecMonitor, vmTracing bool, cacheStore blockstore.Blockstore) (stateroot cid.Cid, rectsroot cid.Cid, err error)
 }
 
 type StateManager struct {

--- a/chain/types/execresult.go
+++ b/chain/types/execresult.go
@@ -45,6 +45,7 @@ type ExecutionTrace struct {
 	InvokedActor *ActorTrace      `json:",omitempty"`
 	GasCharges   []*GasTrace      `cborgen:"maxlen=1000000000"`
 	Subcalls     []ExecutionTrace `cborgen:"maxlen=1000000000"`
+	Logs         []string         `cborgen:"maxlen=1000000000" json:",omitempty"`
 }
 
 func (et ExecutionTrace) SumGas() GasTrace {

--- a/chain/vm/execution.go
+++ b/chain/vm/execution.go
@@ -10,6 +10,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 
+	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/metrics"
 )
@@ -56,6 +57,10 @@ func (e *vmExecutor) ApplyImplicitMessage(ctx context.Context, msg *types.Messag
 
 func (e *vmExecutor) Flush(ctx context.Context) (cid.Cid, error) {
 	return e.vmi.Flush(ctx)
+}
+
+func (e *vmExecutor) DumpCache(bs blockstore.Blockstore) error {
+	return e.vmi.DumpCache(bs)
 }
 
 type executionToken struct {

--- a/chain/vm/fvm.go
+++ b/chain/vm/fvm.go
@@ -538,6 +538,10 @@ func (vm *FVM) Flush(ctx context.Context) (cid.Cid, error) {
 	return vm.fvm.Flush()
 }
 
+func (vm *FVM) DumpCache(cacheStore blockstore.Blockstore) error {
+	return vm.fvm.DumpCache(cacheStore)
+}
+
 type dualExecutionFVM struct {
 	main  *FVM
 	debug *FVM
@@ -606,6 +610,10 @@ func (vm *dualExecutionFVM) ApplyImplicitMessage(ctx context.Context, msg *types
 
 func (vm *dualExecutionFVM) Flush(ctx context.Context) (cid.Cid, error) {
 	return vm.main.Flush(ctx)
+}
+
+func (vm *dualExecutionFVM) DumpCache(cacheStore blockstore.Blockstore) error {
+	return vm.main.DumpCache(cacheStore)
 }
 
 // Passing this as a pointer of structs has proven to be an enormous PiTA; hence this code.

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -686,6 +686,10 @@ func (vm *LegacyVM) Flush(ctx context.Context) (cid.Cid, error) {
 	return root, nil
 }
 
+func (vm *LegacyVM) DumpCache(_ blockstore.Blockstore) error {
+	return fmt.Errorf("not supported")
+}
+
 // ActorStore gets the buffered blockstore associated with the LegacyVM. This includes any temporary
 // blocks produced during this LegacyVM's execution.
 func (vm *LegacyVM) ActorStore(ctx context.Context) adt.Store {

--- a/chain/vm/vmi.go
+++ b/chain/vm/vmi.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/network"
 
+	bstore "github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -35,6 +36,9 @@ type Interface interface {
 	ApplyImplicitMessage(ctx context.Context, msg *types.Message) (*ApplyRet, error)
 	// Flush all buffered objects into the state store provided to the VM at construction.
 	Flush(ctx context.Context) (cid.Cid, error)
+	// Dump the contents of the caching blockstore to the provided blockstore. This will include the
+	// final state tree as well as any intermediate objects created during messagae execution.
+	DumpCache(bs bstore.Blockstore) error
 }
 
 // WARNING: You will not affect your node's execution by misusing this feature, but you will confuse yourself thoroughly!

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -175,6 +175,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 		params.Rand,
 		recordOutputs,
 		true,
+		nil,
 		params.BaseFee,
 		nil,
 	)

--- a/documentation/en/api-v0-methods.md
+++ b/documentation/en/api-v0-methods.md
@@ -3871,12 +3871,26 @@ Response:
             "tt": 60000000000
           }
         ],
-        "Subcalls": null
+        "Subcalls": null,
+        "Logs": [
+          "string value"
+        ]
       }
+    ],
+    "Logs": [
+      "string value"
     ]
   },
   "Error": "string value",
-  "Duration": 60000000000
+  "Duration": 60000000000,
+  "CachedBlocks": [
+    {
+      "Cid": {
+        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+      },
+      "Data": "Ynl0ZSBhcnJheQ=="
+    }
+  ]
 }
 ```
 
@@ -4133,12 +4147,26 @@ Response:
                 "tt": 60000000000
               }
             ],
-            "Subcalls": null
+            "Subcalls": null,
+            "Logs": [
+              "string value"
+            ]
           }
+        ],
+        "Logs": [
+          "string value"
         ]
       },
       "Error": "string value",
-      "Duration": 60000000000
+      "Duration": 60000000000,
+      "CachedBlocks": [
+        {
+          "Cid": {
+            "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+          },
+          "Data": "Ynl0ZSBhcnJheQ=="
+        }
+      ]
     }
   ]
 }
@@ -5604,12 +5632,26 @@ Response:
             "tt": 60000000000
           }
         ],
-        "Subcalls": null
+        "Subcalls": null,
+        "Logs": [
+          "string value"
+        ]
       }
+    ],
+    "Logs": [
+      "string value"
     ]
   },
   "Error": "string value",
-  "Duration": 60000000000
+  "Duration": 60000000000,
+  "CachedBlocks": [
+    {
+      "Cid": {
+        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+      },
+      "Data": "Ynl0ZSBhcnJheQ=="
+    }
+  ]
 }
 ```
 

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -6108,12 +6108,26 @@ Response:
             "tt": 60000000000
           }
         ],
-        "Subcalls": null
+        "Subcalls": null,
+        "Logs": [
+          "string value"
+        ]
       }
+    ],
+    "Logs": [
+      "string value"
     ]
   },
   "Error": "string value",
-  "Duration": 60000000000
+  "Duration": 60000000000,
+  "CachedBlocks": [
+    {
+      "Cid": {
+        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+      },
+      "Data": "Ynl0ZSBhcnJheQ=="
+    }
+  ]
 }
 ```
 
@@ -6370,12 +6384,26 @@ Response:
                 "tt": 60000000000
               }
             ],
-            "Subcalls": null
+            "Subcalls": null,
+            "Logs": [
+              "string value"
+            ]
           }
+        ],
+        "Logs": [
+          "string value"
         ]
       },
       "Error": "string value",
-      "Duration": 60000000000
+      "Duration": 60000000000,
+      "CachedBlocks": [
+        {
+          "Cid": {
+            "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+          },
+          "Data": "Ynl0ZSBhcnJheQ=="
+        }
+      ]
     }
   ]
 }
@@ -8054,12 +8082,26 @@ Response:
             "tt": 60000000000
           }
         ],
-        "Subcalls": null
+        "Subcalls": null,
+        "Logs": [
+          "string value"
+        ]
       }
+    ],
+    "Logs": [
+      "string value"
     ]
   },
   "Error": "string value",
-  "Duration": 60000000000
+  "Duration": 60000000000,
+  "CachedBlocks": [
+    {
+      "Cid": {
+        "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+      },
+      "Data": "Ynl0ZSBhcnJheQ=="
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
* Plumb through dump_cache from fvm4 to access intermediate blocks:
  - https://github.com/filecoin-project/filecoin-ffi/pull/512
  - https://github.com/filecoin-project/ref-fvm/pull/2101
* Enable cache dumping in StateReplay with LOTUS_REPLAY_DUMP_CACHED_BLOCKS
* Add optional "Blocks" field InvocResult
* Handle ExecutionEvent::Log's and add "Logs" field to ExecutionTrace
* Dump intermediate cache blocks to CAR in /tmp when they appear while using `lotus-shed msg --exec-trace`.

As with https://github.com/filecoin-project/filecoin-ffi/pull/512, I may bail on some or all of this, it's a little bit janky (but it is for debugging!). But the `ExecutionEvent::Log` thing probably needs to stay, so that may become a new PR.