### PR TITLE
feat(shed): cron queue inspection util

### DIFF
--- a/cmd/lotus-shed/cron-count.go
+++ b/cmd/lotus-shed/cron-count.go
@@ -311,7 +311,7 @@ var cronQueueCountCmd = &cli.Command{
 			}
 			var event power.CronEvent
 			if err := events.ForEach(&event, func(epoch int64) error {
-				fmt.Printf("Epoch: %s, Miner: %s, Method: %s\n", epoch, event.MinerAddr)
+				fmt.Printf("Epoch: %s, Miner: %s\n", epochStr, event.MinerAddr)
 				return nil
 			}); err != nil {
 				return xerrors.Errorf("failed to iterate cron events: %w", err)

--- a/cmd/lotus-shed/cron-count.go
+++ b/cmd/lotus-shed/cron-count.go
@@ -8,13 +8,16 @@ import (
 	"github.com/ipfs/go-cid"
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/urfave/cli/v2"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
 	miner11 "github.com/filecoin-project/go-state-types/builtin/v11/miner"
 	"github.com/filecoin-project/go-state-types/builtin/v11/util/adt"
+	power "github.com/filecoin-project/go-state-types/builtin/v15/power"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build/buildconstants"
@@ -28,6 +31,7 @@ var cronWcCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		minerDeadlineCronCountCmd,
 		minerDeadlinePartitionMeasurementCmd,
+		cronQueueCountCmd,
 	},
 }
 
@@ -266,6 +270,60 @@ var minerDeadlinePartitionMeasurementCmd = &cli.Command{
 			return err
 		}
 		return nil
+	},
+}
+
+var cronQueueCountCmd = &cli.Command{
+	Name:        "queue",
+	Description: "list all entries in the cron queue",
+	Action: func(c *cli.Context) error {
+		n, acloser, err := lcli.GetFullNodeAPI(c)
+		if err != nil {
+			return err
+		}
+		defer acloser()
+		ctx := lcli.ReqContext(c)
+
+		bs := ReadOnlyAPIBlockstore{n}
+		adtStore := adt.WrapStore(ctx, ipldcbor.NewCborStore(&bs))
+
+		// Get power actor state
+		powerActor, err := n.StateGetActor(ctx, builtin.StoragePowerActorAddr, types.EmptyTSK)
+		if err != nil {
+			return xerrors.Errorf("failed to get power actor: %w", err)
+		}
+
+		var powerState power.State
+		if err := adtStore.Get(ctx, powerActor.Head, &powerState); err != nil {
+			return xerrors.Errorf("failed to load power state: %w", err)
+		}
+
+		// Load cron queue
+		q, err := adt.AsMap(adtStore, powerState.CronEventQueue, power.CronQueueHamtBitwidth)
+		if err != nil {
+			return xerrors.Errorf("failed to load cron queue hamt: %w", err)
+		}
+		amtRoot := cbg.CborCid{}
+		if err := q.ForEach(&amtRoot, func(epochStr string) error {
+			events, err := adt.AsArray(adtStore, cid.Cid(amtRoot), power.CronQueueAmtBitwidth)
+			if err != nil {
+				return xerrors.Errorf("failed to load cron queue amt: %w", err)
+			}
+			var event power.CronEvent
+			if err := events.ForEach(&event, func(epoch int64) error {
+				fmt.Printf("Epoch: %s, Miner: %s, Method: %s\n", epoch, event.MinerAddr)
+				return nil
+			}); err != nil {
+				return xerrors.Errorf("failed to iterate cron events: %w", err)
+			}
+
+			return nil
+
+		}); err != nil {
+			return xerrors.Errorf("failed to iterate cron events: %w", err)
+		}
+		return nil
+
 	},
 }
 

--- a/cmd/lotus-shed/cron-count.go
+++ b/cmd/lotus-shed/cron-count.go
@@ -307,7 +307,7 @@ var cronQueueCountCmd = &cli.Command{
 		}
 		amtRoot := cbg.CborCid{}
 		if err := q.ForEach(&amtRoot, func(epoch string) error {
-			epochInt, err := binary.ReadUvarint(bytes.NewReader([]byte(epoch)))
+			epochInt, err := binary.ReadVarint(bytes.NewReader([]byte(epoch)))
 			if err != nil {
 				return xerrors.Errorf("failed to parse epoch: %w", err)
 			}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
None

## Proposed Changes
<!-- A clear list of the changes being made -->
lotus-shed cron queue utility to see which miners have an entry in the power actor cron queue.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
This is important information because it allows us to debug the potential for disastorous frozen cron code paths. 
 I did this to debug this thread: https://filecoinproject.slack.com/archives/CPFTWMY7N/p1736752473709029 

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
