### PR TITLE
feat: handle non-existing actors gracefully in F3 power proportion CLI

### DIFF
--- a/cli/f3.go
+++ b/cli/f3.go
@@ -228,6 +228,7 @@ var f3SubCmdPowerTable = &cli.Command{
 					}
 					ScaledSum  int64
 					Proportion float64
+					NotFound   []gpbft.ActorID
 				}{
 					Instance: instance,
 					FromEC:   cctx.Bool(f3FlagPowerTableFromEC.Name),
@@ -287,7 +288,8 @@ var f3SubCmdPowerTable = &cli.Command{
 					seenIDs[actorID] = struct{}{}
 					scaled, key := pt.Get(actorID)
 					if key == nil {
-						return fmt.Errorf("actor ID %d not found in power table", actorID)
+						result.NotFound = append(result.NotFound, actorID)
+						continue
 					}
 					result.ScaledSum += scaled
 				}


### PR DESCRIPTION


## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
When calculating proportional F3 participation power for a given actor IDs instead of failing when an actor isn't found, collect the non-existing ones and report them. This makes up a better UX when debugging F3 in cases where actors don't exist in the F3 power table.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
