### PR TITLE
feat(ci): automate 'kind/stale' labelling to old draft PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,9 @@
-name: Close and mark stale issue
+name: Mark and close stale items
 
 on:
   schedule:
   - cron: '0 12 * * *'
+  workflow_dispatch: 
 
 permissions:
   contents: read
@@ -28,5 +29,8 @@ jobs:
         days-before-issue-close: 3
         days-before-pr-stale: 5
         days-before-pr-close: 3
+        draft-days-before-stale: 365     # Mark draft PRs as stale after 1 year
+        draft-days-before-close: 30      # Close stale draft PRs after 30 days
         remove-stale-when-updated: true
         enable-statistics: true
+      

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,8 +29,24 @@ jobs:
         days-before-issue-close: 3
         days-before-pr-stale: 5
         days-before-pr-close: 3
-        draft-days-before-stale: 365     # Mark draft PRs as stale after 1 year
-        draft-days-before-close: 30      # Close stale draft PRs after 30 days
         remove-stale-when-updated: true
         enable-statistics: true
-      
+  label-stale-draft-prs:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Mark stale draft PRs
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Calculate cutoff date for last update (365 days ago)
+        cutoff_date=$(date -d "365 days ago" +%Y-%m-%d)
+        prs=$(gh pr list --repo $GITHUB_REPOSITORY --state open \
+          --json number,updatedAt,isDraft \
+          --jq ".[] | select(.isDraft) | select(.updatedAt < \"$cutoff_date\") | .number")
+          
+        for pr in $prs; do
+          echo "Marking PR #$pr as stale"
+          gh pr edit $pr --add-label "kind/stale"
+        done


### PR DESCRIPTION
## Proposed Changes
Add a workflow for adding the 'kind/stale' label to old draft PRs.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
