### PR TITLE
refactor(eth): attach ToFilecoinMessage converter to EthCall.

### DIFF
--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -23,7 +23,10 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
 
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/build/buildconstants"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/must"
 )
 
@@ -245,6 +248,64 @@ type EthCall struct {
 	GasPrice EthBigInt   `json:"gasPrice"`
 	Value    EthBigInt   `json:"value"`
 	Data     EthBytes    `json:"data"`
+}
+
+func (c *EthCall) ToFilecoinMessage() (*types.Message, error) {
+	var from address.Address
+	if c.From == nil || *c.From == (EthAddress{}) {
+		// Send from the filecoin "system" address.
+		var err error
+		from, err = (EthAddress{}).ToFilecoinAddress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct the ethereum system address: %w", err)
+		}
+	} else {
+		// The from address must be translatable to an f4 address.
+		var err error
+		from, err = c.From.ToFilecoinAddress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to translate sender address (%s): %w", c.From.String(), err)
+		}
+		if p := from.Protocol(); p != address.Delegated {
+			return nil, fmt.Errorf("expected a class 4 address, got: %d: %w", p, err)
+		}
+	}
+
+	var params []byte
+	if len(c.Data) > 0 {
+		initcode := abi.CborBytes(c.Data)
+		params2, err := actors.SerializeParams(&initcode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize params: %w", err)
+		}
+		params = params2
+	}
+
+	var to address.Address
+	var method abi.MethodNum
+	if c.To == nil {
+		// this is a contract creation
+		to = builtintypes.EthereumAddressManagerActorAddr
+		method = builtintypes.MethodsEAM.CreateExternal
+	} else {
+		addr, err := c.To.ToFilecoinAddress()
+		if err != nil {
+			return nil, xerrors.Errorf("cannot get Filecoin address: %w", err)
+		}
+		to = addr
+		method = builtintypes.MethodsEVM.InvokeContract
+	}
+
+	return &types.Message{
+		From:       from,
+		To:         to,
+		Value:      big.Int(c.Value),
+		Method:     method,
+		Params:     params,
+		GasLimit:   build.BlockGasLimit,
+		GasFeeCap:  big.Zero(),
+		GasPremium: big.Zero(),
+	}, nil
 }
 
 func (c *EthCall) UnmarshalJSON(b []byte) error {

--- a/node/impl/eth/gas.go
+++ b/node/impl/eth/gas.go
@@ -186,7 +186,7 @@ func (e *ethGas) EthEstimateGas(ctx context.Context, p jsonrpc.RawParams) (ethty
 		return ethtypes.EthUint64(0), xerrors.Errorf("decoding params: %w", err)
 	}
 
-	msg, err := ethCallToFilecoinMessage(ctx, params.Tx)
+	msg, err := params.Tx.ToFilecoinMessage()
 	if err != nil {
 		return ethtypes.EthUint64(0), err
 	}
@@ -237,7 +237,7 @@ func (e *ethGas) EthEstimateGas(ctx context.Context, p jsonrpc.RawParams) (ethty
 }
 
 func (e *ethGas) EthCall(ctx context.Context, tx ethtypes.EthCall, blkParam ethtypes.EthBlockNumberOrHash) (ethtypes.EthBytes, error) {
-	msg, err := ethCallToFilecoinMessage(ctx, tx)
+	msg, err := tx.ToFilecoinMessage()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to convert ethcall to filecoin message: %w", err)
 	}


### PR DESCRIPTION
Reviving the work @raulk (all credits to him) did in https://github.com/filecoin-project/lotus/pull/12062, but did not land due to a failing test and the original function being refactored has moved a bit.

## Proposed Changes
Small refactor to clean things up.

- This converter is better placed as an EthCall method instead of a package-level function.
- The resulting package/module import graph is sane.
- Exporting this as a public method is very helpful for those who use Lotus as a library.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
