### PR TITLE
chore: switch to pure-go zstd decoder for snapshot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - refactor(eth): attach ToFilecoinMessage converter to EthCall method for improved package/module import structure. This change also exports the converter as a public method, enhancing usability for developers utilizing Lotus as a library. ([filecoin-project/lotus#12844](https://github.com/filecoin-project/lotus/pull/12844))
 
+- chore: switch to pure-go zstd decoder for snapshot imports.  ([filecoin-project/lotus#12857](https://github.com/filecoin-project/lotus/pull/12857))
+
 # UNRELEASED v.1.32.0
 
 See https://github.com/filecoin-project/lotus/blob/release/v1.32.0/CHANGELOG.md

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -15,9 +15,9 @@ import (
 	"runtime/pprof"
 	"strings"
 
-	"github.com/DataDog/zstd"
 	"github.com/cheggaaa/pb/v3"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
+	"github.com/klauspost/compress/zstd"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
@@ -579,12 +579,11 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 	var ir io.Reader = br
 
 	if string(header[1:]) == "\xB5\x2F\xFD" { // zstd
-		zr := zstd.NewReader(br)
-		defer func() {
-			if err := zr.Close(); err != nil {
-				log.Errorw("closing zstd reader", "error", err)
-			}
-		}()
+		zr, err := zstd.NewReader(br)
+		if err != nil {
+			return xerrors.Errorf("instantiating zstd reader: %w", err)
+		}
+		defer zr.Close()
 		ir = zr
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi // pro
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/BurntSushi/toml v1.3.2
-	github.com/DataDog/zstd v1.4.5
 	github.com/GeertJohan/go.rice v1.0.3
 	github.com/Gurpartap/async v0.0.0-20180927173644-4f7f499dd9ee
 	github.com/Kubuxu/imtui v0.0.0-20210401140320-41663d68d0fa

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
-github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/jt0CW30vsg=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.3 h1:k5viR+xGtIhF61125vCE1cmJ5957RQGXG6dmbaWZSmI=


### PR DESCRIPTION


## Related Issues
* #12852

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
The benchmarking performed as part of #12852 shows that the pure-go implementation of zstd decoder is fast-enough for snapshot import.

Switch to it motivated by the desire to reduce CGO dependencies across Lotus.

Fixes #12852

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
