### PR TITLE
feat(ci): add stale branch workflow

### DIFF
--- a/.github/workflows/stale-branches
+++ b/.github/workflows/stale-branches
@@ -20,5 +20,5 @@ jobs:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
         days-before-stale: 180
         days-before-delete: 360
-        branches-filter-regex: ''^(?!release/miner)'
+        branches-filter-regex: ''^(?!release)'
         dry-run: false

--- a/.github/workflows/stale-branches
+++ b/.github/workflows/stale-branches
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Stale Branches
-      uses: crs-k/stale-branches@v5.0.0
+      uses: crs-k/stale-branches@c6e09a3de1046d68b21eccdca23321d0ec277964 # v7.0.0
       with:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
         days-before-stale: 180 #Number of days a branch has been inactive before it is considered stale and a 'stale branch 🗑️' issue is opened.

--- a/.github/workflows/stale-branches
+++ b/.github/workflows/stale-branches
@@ -18,7 +18,16 @@ jobs:
       uses: crs-k/stale-branches@v5.0.0
       with:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
-        days-before-stale: 90
-        days-before-delete: 360
-        branches-filter-regex: ''^(?!release)'
-        dry-run: false
+        days-before-stale: 180 #Number of days a branch has been inactive before it is considered stale and a 'stale branch 🗑️' issue is opened.
+        days-before-delete: 360 #Number of days a branch has been inactive before it is deleted.
+        comment-updates: false #comment with updated information will be added to existing issues each workflow run.
+        max-issues: 20 #the number of 'stale branch 🗑️' issues that can exist. Also, max number of branches that can be deleted per run.
+        tag-committer: true #when an issue is opened, the last committer will be tagged in the comments.
+        stale-branch-label: 'stale branch 🗑️' #Label applied to issues created for stale branches. Must be unique to this workflow.
+        compare-branches: 'info' #compares each branch to the repo's default branch. When set to info, additional output describes if the current branch is ahead, behind, diverged, or identical to the default branch.
+        branches-filter-regex: ''^(?!release)' #Optional Regex that will be used to filter branches from this action
+        include-protected-branches: false #If this is enabled, the action will include protected branches in the process.
+        rate-limit: true #If this is enabled, the action will stop if it exceeds 95% of the GitHub API rate limit.
+        pr-check: false #If this is enabled, the action will first check for incoming/outgoing PRs associated with the branch.
+        dry-run: true #when enabled, the action will not delete or tag any branches. If a branch has an active pr, it will be ignored.
+        ignore-issue-interaction: false #If this is enabled, the action will not interact with Github issues.

--- a/.github/workflows/stale-branches
+++ b/.github/workflows/stale-branches
@@ -18,7 +18,7 @@ jobs:
       uses: crs-k/stale-branches@v5.0.0
       with:
         repo-token: '${{ secrets.GITHUB_TOKEN }}'
-        days-before-stale: 180
+        days-before-stale: 90
         days-before-delete: 360
         branches-filter-regex: ''^(?!release)'
         dry-run: false

--- a/.github/workflows/stale-branches
+++ b/.github/workflows/stale-branches
@@ -1,0 +1,24 @@
+# .github/workflows/stale-branches.yml
+
+name: Stale Branches
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+    
+permissions:
+  issues: write
+  contents: write
+
+jobs:
+  stale_branches:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Stale Branches
+      uses: crs-k/stale-branches@v5.0.0
+      with:
+        repo-token: '${{ secrets.GITHUB_TOKEN }}'
+        days-before-stale: 180
+        days-before-delete: 360
+        branches-filter-regex: ''^(?!release/miner)'
+        dry-run: false


### PR DESCRIPTION
## Proposed Changes
Add a workflow that marks stale branches and deletes stale branches:
- Branches are marked as stale after 180 days without no commits.
- Branch that have been inactive for 360 days is deleted.
- Has no protection rules.
- Exclude any branch that starts with 'release/miner' as these have no branch protection rules ([ref](https://github.com/filecoin-project/lotus/branches/all?query=release%2Fminer))
- Is not the default branch

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
