### PR TITLE
feat(ci): run unit test jobs on arm64 machines additionally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
+        # We need to cache for each architecture we support: x86_64 and arm64
         runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,16 @@ jobs:
     name: Discover Test Groups
     runs-on: ubuntu-latest
     outputs:
-      groups: ${{ steps.test.outputs.groups }}
+      test_group_execution_contexts: ${{ steps.list_test_group_execution_contexts.outputs.test_group_execution_contexts }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           fetch-depth: 0
-      - id: test
+      - id: list_test_group_execution_contexts
         run: |
-          echo "groups<<EOF" >> $GITHUB_OUTPUT
-          go run ./cmd/ci/main.go --json list-test-groups | jq -r '.msg' | tee -a $GITHUB_OUTPUT
+          echo "test_group_execution_contexts<<EOF" >> $GITHUB_OUTPUT
+          go run ./cmd/ci/main.go --json list-test-group-execution-contexts | jq -r '.msg' | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
   cache:
     name: Cache Dependencies
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.discover.outputs.groups) }}
+        include: ${{ fromJson(needs.discover.outputs.test_group_execution_contexts) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
   cache:
     name: Cache Dependencies
-    runs-on: ubuntu-latest
-    outputs:
-      fetch_params_key: ${{ steps.fetch_params.outputs.key }}
-      fetch_params_path: ${{ steps.fetch_params.outputs.path }}
-      make_deps_key: ${{ steps.make_deps.outputs.key }}
-      make_deps_path: ${{ steps.make_deps.outputs.path }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,6 +98,23 @@ jobs:
         with:
           key: ${{ steps.make_deps.outputs.key }}
           path: ${{ steps.make_deps.outputs.path }}
+      - env:
+          fetch_params_key: ${{ steps.fetch_params.outputs.key }}
+          fetch_params_path: ${{ steps.fetch_params.outputs.path }}
+          make_deps_key: ${{ steps.make_deps.outputs.key }}
+          make_deps_path: ${{ steps.make_deps.outputs.path }}
+          file: jobs.cache.${{ runner.os }}.${{ runner.arch }}.outputs.json
+        run: |
+          jq -n '{
+            "fetch_params_key": env.fetch_params_key,
+            "fetch_params_path": env.fetch_params_path,
+            "make_deps_key": env.make_deps_key,
+            "make_deps_path": env.make_deps_path
+          }' | tee -a "$file"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jobs.cache.${{ runner.os }}.${{ runner.arch }}.outputs
+          path: jobs.cache.${{ runner.os }}.${{ runner.arch }}.outputs.json
   test:
     needs: [discover, cache]
     name: Test (${{ matrix.name }}) ${{ toJson(matrix.runner) }}
@@ -122,18 +137,37 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
+      - id: artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jobs.cache.${{ runner.os }}.${{ runner.arch }}.outputs
+      - id: cache
+        env:
+          file: jobs.cache.${{ runner.os }}.${{ runner.arch }}.outputs.json
+        run: |
+          echo "make_deps_key=$(jq -r .make_deps_key "$file")" | tee -a $GITHUB_OUTPUT
+          echo "make_deps_path<<EOF" | tee -a $GITHUB_OUTPUT
+          jq -r .make_deps_path "$file" | tee -a $GITHUB_OUTPUT
+          echo "EOF" | tee -a $GITHUB_OUTPUT
+
+          echo "fetch_params_key=$(jq -r .fetch_params_key "$file")" | tee -a $GITHUB_OUTPUT
+          echo "fetch_params_path<<EOF" | tee -a $GITHUB_OUTPUT
+          jq -r .fetch_params_path "$file" | tee -a $GITHUB_OUTPUT
+          echo "EOF" | tee -a $GITHUB_OUTPUT
+
+          rm "$file"
       - name: Restore cached make deps outputs
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.cache.outputs.make_deps_key }}
-          path: ${{ needs.cache.outputs.make_deps_path }}
+          key: ${{ steps.cache.outputs.make_deps_key }}
+          path: ${{ steps.cache.outputs.make_deps_path }}
           fail-on-cache-miss: true
       - if: ${{ fromJson(steps.group.outputs.metadata).needs_parameters }}
         name: Restore cached fetch params outputs
         uses: actions/cache/restore@v4
         with:
-          key: ${{ needs.cache.outputs.fetch_params_key }}
-          path: ${{ needs.cache.outputs.fetch_params_path }}
+          key: ${{ steps.cache.outputs.fetch_params_key }}
+          path: ${{ steps.cache.outputs.fetch_params_path }}
           fail-on-cache-miss: true
       # TODO: Install statediff (used to be used for conformance)
       - name: Create temporary directory for reports
@@ -145,8 +179,8 @@ jobs:
           NAME: ${{ matrix.name }}
           LOTUS_SRC_DIR: ${{ github.workspace }}
           REPORTS_PATH: ${{ steps.reports.outputs.path }}
-          SKIP_CONFORMANCE: ${{ fromJson(steps.group.outputs.metadata).skip_conformance || '1' }}
-          TEST_RUSTPROOFS_LOGS: ${{ fromJson(steps.group.outputs.metadata).test_rustproofs_logs || '0' }}
+          SKIP_CONFORMANCE: ${{ fromJson(steps.group.outputs.metadata).skip_conformance && '1' || '0' }}
+          TEST_RUSTPROOFS_LOGS: ${{ fromJson(steps.group.outputs.metadata).test_rustproofs_logs && '1' || '0' }}
           FORMAT: ${{ fromJson(steps.group.outputs.metadata).format || 'standard-verbose' }}
           PACKAGES: ${{ join(fromJson(steps.group.outputs.metadata).packages, ' ') }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,13 +113,13 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+      - uses: ./.github/actions/install-system-dependencies
+      - uses: ./.github/actions/install-go
       - id: group
         run: |
           echo "metadata<<EOF" >> $GITHUB_OUTPUT
           go run ./cmd/ci/main.go --json get-test-group-metadata --name "${{ matrix.name }}" | jq -r '.msg' | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - uses: ./.github/actions/install-system-dependencies
-      - uses: ./.github/actions/install-go
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Restore cached make deps outputs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,140 +31,10 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
       - id: test
-        env:
-          # Unit test groups other than unit-rest
-          utests: |
-            [
-              {"name": "unit-cli", "packages": ["./cli/...", "./cmd/...", "./api/..."]},
-              {"name": "unit-storage", "packages": ["./storage/...", "./extern/..."]},
-              {"name": "unit-node", "packages": ["./node/..."]}
-            ]
-          # Other tests that require special configuration
-          otests: |
-            [
-              {
-                "name": "multicore-sdr",
-                "packages": ["./storage/sealer/ffiwrapper"],
-                "go_test_flags": "-run=TestMulticoreSDR",
-                "test_rustproofs_logs": "1"
-              }, {
-                "name": "conformance",
-                "packages": ["./conformance"],
-                "go_test_flags": "-run=TestConformance",
-                "skip_conformance": "0"
-              }
-            ]
-          # Mapping from test group names to custom runner labels
-          # The jobs default to running on the default hosted runners (4 CPU, 16 RAM).
-          # We use self-hosted xlarge (4 CPU, 8 RAM; and large - 2 CPU, 4 RAM) runners
-          #   to extend the available runner capacity (60 default hosted runners).
-          # We use self-hosted 4xlarge (16 CPU, 32 RAM; and 2xlarge - 8 CPU, 16 RAM) self-hosted
-          #   to support resource intensive jobs.
-          runners: |
-            {
-              "itest-niporep_manual": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-sector_pledge": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-worker": ["self-hosted", "linux", "x64", "4xlarge"],
-              "itest-manual_onboarding": ["self-hosted", "linux", "x64", "4xlarge"],
-
-              "itest-gateway": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-sector_import_full": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-sector_import_simple": ["self-hosted", "linux", "x64", "2xlarge"],
-              "itest-wdpost": ["self-hosted", "linux", "x64", "2xlarge"],
-              "unit-storage": ["self-hosted", "linux", "x64", "2xlarge"],
-
-              "itest-cli": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-deals_invalid_utf8_label": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-decode_params": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-dup_mpool_messages": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_account_abstraction": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_api": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_balance": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_bytecode": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_config": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_conformance": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_deploy": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_fee_history": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-eth_transactions": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-fevm_address": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-fevm_events": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-gas_estimation": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-get_messages_in_ts": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-lite_migration": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-lookup_robust_address": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mempool": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mpool_msg_uuid": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-mpool_push_with_uuid": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-msgindex": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-multisig": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-net": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-nonce": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-path_detach_redeclare": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-pending_deal_allocation": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-remove_verifreg_datacap": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_miner_collateral": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-sector_numassign": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-self_sent_txn": ["self-hosted", "linux", "x64", "xlarge"],
-              "itest-verifreg": ["self-hosted", "linux", "x64", "xlarge"],
-              "multicore-sdr": ["self-hosted", "linux", "x64", "xlarge"],
-              "unit-node": ["self-hosted", "linux", "x64", "xlarge"]
-            }
-          # A list of test groups that require Proof Parameters to be fetched
-          parameters: |
-            [
-              "conformance",
-              "itest-api",
-              "itest-direct_data_onboard_verified",
-              "itest-direct_data_onboard",
-              "itest-manual_onboarding",
-              "itest-niporep_manual",
-              "itest-net",
-              "itest-path_detach_redeclare",
-              "itest-sealing_resources",
-              "itest-sector_import_full",
-              "itest-sector_import_simple",
-              "itest-sector_pledge",
-              "itest-sector_unseal",
-              "itest-wdpost_no_miner_storage",
-              "itest-wdpost_worker_config",
-              "itest-wdpost",
-              "itest-worker",
-              "multicore-sdr",
-              "unit-cli",
-              "unit-storage"
-            ]
         run: |
-          # Create a list of integration test groups
-          itests="$(
-            find ./itests -name "*_test.go" | \
-              jq -R '{
-                "name": "itest-\(. | split("/") | .[2] | sub("_test.go$";""))",
-                "packages": [.]
-              }' | jq -s
-            )"
-
-          # Create a list of packages that are covered by the integration and unit tests
-          packages="$(jq -n --argjson utests "$utests" '$utests | map(.packages) | flatten | . + ["./itests/..."]')"
-
-          # Create a new group for the unit tests that are not yet covered
-          rest="$(
-            find . -name "*_test.go" | cut -d/ -f2 | sort | uniq | \
-              jq -R '"./\(.)/..."' | \
-              jq -s --argjson p "$packages" '{"name": "unit-rest", "packages": (. - $p)}'
-          )"
-
-          # Combine the groups for integration tests, unit tests, the new unit-rest group, and the other tests
-          groups="$(jq -n --argjson i "$itests" --argjson u "$utests" --argjson r "$rest" --argjson o "$otests" '$i + $u + [$r] + $o')"
-
-          # Apply custom runner labels to the groups
-          groups="$(jq -n --argjson g "$groups" --argjson r "$runners" '$g | map(. + {"runner": (.name as $n | $r | .[$n]) })')"
-
-          # Apply the needs_parameters flag to the groups
-          groups="$(jq -n --argjson g "$groups" --argjson p "$parameters" '$g | map(. + {"needs_parameters": ([.name] | inside($p)) })')"
-
-          # Output the groups
-          echo "groups=$groups"
-          echo "groups=$(jq -nc --argjson g "$groups" '$g')" >> $GITHUB_OUTPUT
+          echo "groups<<EOF" >> $GITHUB_OUTPUT
+          go run ./cmd/ci/main.go --json list-test-groups | jq -r '.msg' | tee -a $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
   cache:
     name: Cache Dependencies
     runs-on: ubuntu-latest
@@ -232,8 +102,8 @@ jobs:
           path: ${{ steps.make_deps.outputs.path }}
   test:
     needs: [discover, cache]
-    name: Test (${{ matrix.name }})
-    runs-on: ${{ github.repository_owner == 'filecoin-project' && matrix.runner || 'ubuntu-latest' }}
+    name: Test (${{ matrix.name }}) ${{ toJson(matrix.runner) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,6 +113,11 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+      - id: group
+        run: |
+          echo "metadata<<EOF" >> $GITHUB_OUTPUT
+          go run ./cmd/ci/main.go --json get-test-group-metadata --name "${{ matrix.name }}" | jq -r '.msg' | tee -a $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/install-system-dependencies
       - uses: ./.github/actions/install-go
       - name: Install gotestsum
@@ -253,7 +128,7 @@ jobs:
           key: ${{ needs.cache.outputs.make_deps_key }}
           path: ${{ needs.cache.outputs.make_deps_path }}
           fail-on-cache-miss: true
-      - if: ${{ matrix.needs_parameters }}
+      - if: ${{ fromJson(steps.group.outputs.metadata).needs_parameters }}
         name: Restore cached fetch params outputs
         uses: actions/cache/restore@v4
         with:
@@ -270,22 +145,22 @@ jobs:
           NAME: ${{ matrix.name }}
           LOTUS_SRC_DIR: ${{ github.workspace }}
           REPORTS_PATH: ${{ steps.reports.outputs.path }}
-          SKIP_CONFORMANCE: ${{ matrix.skip_conformance || '1' }}
-          TEST_RUSTPROOFS_LOGS: ${{ matrix.test_rustproofs_logs || '0' }}
-          FORMAT: ${{ matrix.format || 'standard-verbose' }}
-          PACKAGES: ${{ join(matrix.packages, ' ') }}
+          SKIP_CONFORMANCE: ${{ fromJson(steps.group.outputs.metadata).skip_conformance || '1' }}
+          TEST_RUSTPROOFS_LOGS: ${{ fromJson(steps.group.outputs.metadata).test_rustproofs_logs || '0' }}
+          FORMAT: ${{ fromJson(steps.group.outputs.metadata).format || 'standard-verbose' }}
+          PACKAGES: ${{ join(fromJson(steps.group.outputs.metadata).packages, ' ') }}
         run: |
           gotestsum \
             --format "$FORMAT" \
             --junitfile "$REPORTS_PATH/$NAME.xml" \
             --jsonfile "$REPORTS_PATH/$NAME.json" \
             --packages="$PACKAGES" \
-            -- ${{ matrix.go_test_flags || '' }}
+            -- ${{ fromJson(steps.group.outputs.metadata).go_test_flags || '' }}
       - name: Modify junit.xml for BuildPulse
         env:
           NAME: ${{ matrix.name }}
           REPORTS_PATH: ${{ steps.reports.outputs.path }}
-          PACKAGES: ${{ join(matrix.packages, ' ') }}
+          PACKAGES: ${{ join(fromJson(steps.group.outputs.metadata).packages, ' ') }}
         if: always()
         run: |
           # Modify test suite name and classname attributes in JUnit XML for better grouping
@@ -303,7 +178,7 @@ jobs:
       - if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}
+          name: ${{ matrix.name }}-${{ runner.os }}-${{ runner.arch }}
           path: |
             ${{ steps.reports.outputs.path }}/${{ matrix.name }}.xml
             ${{ steps.reports.outputs.path }}/${{ matrix.name }}.json

--- a/cmd/ci/README.md
+++ b/cmd/ci/README.md
@@ -4,7 +4,7 @@ The Lotus CI Tool is a CLI (Command Line Interface) utility designed to facilita
 
 ## Features
 
-- List all test groups.
+- List all test group execution contexts.
 - Get the metadata for a test group.
 
 ## Installation
@@ -22,9 +22,9 @@ The `ci` tool provides several commands and options to interact with.
 
 ### Commands
 
-- **List Test Groups**: List all test groups.
+- **List Test Group Execution Contexts**: List all test group execution contexts.
     ```sh
-    ./ci list-test-groups
+    ./ci list-test-group-execution-contexts
     ```
 - **Get Test Group Metadata**: Get the metadata for a test group.
     ```sh
@@ -40,9 +40,9 @@ The `ci` tool provides several commands and options to interact with.
 
 ## Examples
 
-List all test groups with JSON formatted output:
+List all test group execution contexts with JSON formatted output:
 ```sh
-./ci --json list-test-groups
+./ci --json list-test-group-execution-contexts
 ```
 
 Get the metadata for a test group with JSON formatted output:

--- a/cmd/ci/README.md
+++ b/cmd/ci/README.md
@@ -1,0 +1,51 @@
+# Lotus CI Tool
+
+The Lotus CI Tool is a CLI (Command Line Interface) utility designed to facilitate interactions with the Lotus metadata. This tool allows users to retrieve version information in either JSON or text format which is required in the Lotus CI environment.
+
+## Features
+
+- List all test groups.
+- Get the metadata for a test group.
+
+## Installation
+
+To install the Lotus CI Tool, you need to have Go installed on your system.
+
+1. Build the tool:
+    ```sh
+    go build -o ci ./cmd/ci
+    ```
+
+## Usage
+
+The `ci` tool provides several commands and options to interact with.
+
+### Commands
+
+- **List Test Groups**: List all test groups.
+    ```sh
+    ./ci list-test-groups
+    ```
+- **Get Test Group Metadata**: Get the metadata for a test group.
+    ```sh
+    ./ci get-test-group-metadata --name "unit-cli"
+    ```
+
+### Global Options
+
+- **--json**: Format output as JSON.
+    ```sh
+    ./ci --json
+    ```
+
+## Examples
+
+List all test groups with JSON formatted output:
+```sh
+./ci --json list-test-groups
+```
+
+Get the metadata for a test group with JSON formatted output:
+```sh
+./ci --json get-test-group-metadata --name "unit-cli"
+```

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -234,7 +234,7 @@ func getTestGroupMetadata(testGroupName string) TestGroupMetadata {
 	}
 }
 
-func findIntegrationTestGroups() ([]TestGroup, error) {
+func getIntegrationTestGroups() ([]TestGroup, error) {
 	groups := []TestGroup{}
 
 	err := filepath.Walk("itests", func(path string, info os.FileInfo, err error) error {
@@ -310,7 +310,7 @@ func main() {
 				Name:  "list-test-groups",
 				Usage: "List all test groups",
 				Action: func(c *cli.Context) error {
-					integrationTestGroups, err := findIntegrationTestGroups()
+					integrationTestGroups, err := getIntegrationTestGroups()
 					if err != nil {
 						return err
 					}

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -12,8 +12,20 @@ import (
 
 type TestGroup struct {
 	Name   string   `json:"name"`
-	Runner []string `json:"runner"`
+	Runner Runner `json:"runner"`
 }
+
+type Runner []string
+
+var (
+	linux_x64_4xlarge = []string{"self-hosted", "linux", "x64", "4xlarge"}
+	linux_x64_2xlarge = []string{"self-hosted", "linux", "x64", "2xlarge"}
+	linux_x64_xlarge = []string{"self-hosted", "linux", "x64", "xlarge"}
+	linux_arm64_2xlarge = []string{"self-hosted", "linux", "arm64", "2xlarge"}
+	linux_arm64_xlarge = []string{"self-hosted", "linux", "arm64", "xlarge"}
+	linux_x64 = []string{"self-hosted", "linux", "x64"}
+	linux_arm64 = []string{"self-hosted", "linux", "arm64"}
+)
 
 type TestGroupMetadata struct {
 	Packages          []string `json:"packages"`
@@ -128,72 +140,72 @@ func getGoTestFlags(testGroupName string) string {
 	return ""
 }
 
-func getRunners(testGroupName string) [][]string {
+func getRunners(testGroupName string) []Runner {
 	if os.Getenv("GITHUB_REPOSITORY_OWNER") != "filecoin-project" {
-		return [][]string{{"ubuntu-latest"}}
+		return []Runner{linux_x64}
 	}
 
-	testGroupNamesToRunners := map[string][][]string{
-		"itest-niporep_manual":    {{"self-hosted", "linux", "x64", "4xlarge"}},
-		"itest-sector_pledge":     {{"self-hosted", "linux", "x64", "4xlarge"}},
-		"itest-worker":            {{"self-hosted", "linux", "x64", "4xlarge"}},
-		"itest-manual_onboarding": {{"self-hosted", "linux", "x64", "4xlarge"}},
+	testGroupNamesToRunners := map[string][]Runner{
+		"itest-niporep_manual":    {linux_x64_4xlarge},
+		"itest-sector_pledge":     {linux_x64_4xlarge},
+		"itest-worker":            {linux_x64_4xlarge},
+		"itest-manual_onboarding": {linux_x64_4xlarge},
 
-		"itest-gateway":              {{"self-hosted", "linux", "x64", "2xlarge"}},
-		"itest-sector_import_full":   {{"self-hosted", "linux", "x64", "2xlarge"}},
-		"itest-sector_import_simple": {{"self-hosted", "linux", "x64", "2xlarge"}},
-		"itest-wdpost":               {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"itest-gateway":              {linux_x64_2xlarge},
+		"itest-sector_import_full":   {linux_x64_2xlarge},
+		"itest-sector_import_simple": {linux_x64_2xlarge},
+		"itest-wdpost":               {linux_x64_2xlarge},
 		"unit-storage": {
-			{"self-hosted", "linux", "x64", "2xlarge"},
-			{"self-hosted", "linux", "arm64", "2xlarge"},
+			linux_x64_2xlarge,
+			linux_arm64_2xlarge,
 		},
 
-		"itest-cli":                      {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-deals_invalid_utf8_label": {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-decode_params":            {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-dup_mpool_messages":       {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_account_abstraction":  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_api":                  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_balance":              {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_bytecode":             {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_config":               {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_conformance":          {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_deploy":               {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_fee_history":          {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-eth_transactions":         {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-fevm_address":             {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-fevm_events":              {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-gas_estimation":           {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-get_messages_in_ts":       {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-lite_migration":           {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-lookup_robust_address":    {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-mempool":                  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-mpool_msg_uuid":           {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-mpool_push_with_uuid":     {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-msgindex":                 {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-multisig":                 {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-net":                      {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-nonce":                    {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-path_detach_redeclare":    {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-pending_deal_allocation":  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-remove_verifreg_datacap":  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-sector_miner_collateral":  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-sector_numassign":         {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-self_sent_txn":            {{"self-hosted", "linux", "x64", "xlarge"}},
-		"itest-verifreg":                 {{"self-hosted", "linux", "x64", "xlarge"}},
-		"multicore-sdr":                  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-cli":                      {linux_x64_xlarge},
+		"itest-deals_invalid_utf8_label": {linux_x64_xlarge},
+		"itest-decode_params":            {linux_x64_xlarge},
+		"itest-dup_mpool_messages":       {linux_x64_xlarge},
+		"itest-eth_account_abstraction":  {linux_x64_xlarge},
+		"itest-eth_api":                  {linux_x64_xlarge},
+		"itest-eth_balance":              {linux_x64_xlarge},
+		"itest-eth_bytecode":             {linux_x64_xlarge},
+		"itest-eth_config":               {linux_x64_xlarge},
+		"itest-eth_conformance":          {linux_x64_xlarge},
+		"itest-eth_deploy":               {linux_x64_xlarge},
+		"itest-eth_fee_history":          {linux_x64_xlarge},
+		"itest-eth_transactions":         {linux_x64_xlarge},
+		"itest-fevm_address":             {linux_x64_xlarge},
+		"itest-fevm_events":              {linux_x64_xlarge},
+		"itest-gas_estimation":           {linux_x64_xlarge},
+		"itest-get_messages_in_ts":       {linux_x64_xlarge},
+		"itest-lite_migration":           {linux_x64_xlarge},
+		"itest-lookup_robust_address":    {linux_x64_xlarge},
+		"itest-mempool":                  {linux_x64_xlarge},
+		"itest-mpool_msg_uuid":           {linux_x64_xlarge},
+		"itest-mpool_push_with_uuid":     {linux_x64_xlarge},
+		"itest-msgindex":                 {linux_x64_xlarge},
+		"itest-multisig":                 {linux_x64_xlarge},
+		"itest-net":                      {linux_x64_xlarge},
+		"itest-nonce":                    {linux_x64_xlarge},
+		"itest-path_detach_redeclare":    {linux_x64_xlarge},
+		"itest-pending_deal_allocation":  {linux_x64_xlarge},
+		"itest-remove_verifreg_datacap":  {linux_x64_xlarge},
+		"itest-sector_miner_collateral":  {linux_x64_xlarge},
+		"itest-sector_numassign":         {linux_x64_xlarge},
+		"itest-self_sent_txn":            {linux_x64_xlarge},
+		"itest-verifreg":                 {linux_x64_xlarge},
+		"multicore-sdr":                  {linux_x64_xlarge},
 		"unit-node": {
-			{"self-hosted", "linux", "x64", "xlarge"},
-			{"self-hosted", "linux", "arm64", "xlarge"},
+			linux_x64_xlarge,
+			linux_arm64_xlarge,
 		},
 
 		"unit-cli": {
-			{"ubuntu-latest"},
-			{"ubuntu-24.04-arm"},
+			linux_x64,
+			linux_arm64,
 		},
 		"unit-rest": {
-			{"ubuntu-latest"},
-			{"ubuntu-24.04-arm"},
+			linux_x64,
+			linux_arm64,
 		},
 	}
 
@@ -201,7 +213,7 @@ func getRunners(testGroupName string) [][]string {
 		return runners
 	}
 
-	return [][]string{{"ubuntu-latest"}}
+	return []Runner{linux_x64}
 }
 
 func getTestGroups(testGroupName string) []TestGroup {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+type TestGroup struct {
+	Name   string   `json:"name"`
+	Runner []string `json:"runner"`
+}
+
+type TestGroupMetadata struct {
+	Packages          []string `json:"packages"`
+	NeedsParameters   bool     `json:"needs_parameters"`
+	SkipConformance   bool     `json:"skip_conformance"`
+	TestRustProofLogs bool     `json:"test_rust_proof_logs"`
+	Format            string   `json:"format"`
+	GoTestFlags       string   `json:"go_test_flags"`
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func getPackages(name string) []string {
+	namesToPackages := map[string][]string{
+		"multicore-sdr": {strings.Join([]string{"storage", "sealer", "ffiwrapper"}, string(os.PathSeparator))},
+		"conformance":   {strings.Join([]string{"conformance"}, string(os.PathSeparator))},
+		"unit-cli": {
+			strings.Join([]string{"cli", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"cmd", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"api", "..."}, string(os.PathSeparator)),
+		},
+		"unit-storage": {
+			strings.Join([]string{"storage", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"extern", "..."}, string(os.PathSeparator)),
+		},
+		"unit-node": {
+			strings.Join([]string{"node", "..."}, string(os.PathSeparator)),
+		},
+		"unit-rest": {
+			strings.Join([]string{"blockstore", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"build", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"chain", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"conformance", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"gateway", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"journal", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"lib", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"paychmgr", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{"tools", "..."}, string(os.PathSeparator)),
+		},
+	}
+
+	if strings.HasPrefix(name, "itest-") {
+		return []string{strings.Join([]string{"itests", strings.Join([]string{strings.TrimPrefix(name, "itest-"), "test.go"}, "_")}, string(os.PathSeparator))}
+	}
+
+	return namesToPackages[name]
+}
+
+func getNeedsParameters(name string) bool {
+	names := []string{
+		"conformance",
+		"itest-api",
+		"itest-direct_data_onboard_verified",
+		"itest-direct_data_onboard",
+		"itest-manual_onboarding",
+		"itest-niporep_manual",
+		"itest-net",
+		"itest-path_detach_redeclare",
+		"itest-sealing_resources",
+		"itest-sector_import_full",
+		"itest-sector_import_simple",
+		"itest-sector_pledge",
+		"itest-sector_unseal",
+		"itest-wdpost_no_miner_storage",
+		"itest-wdpost_worker_config",
+		"itest-wdpost",
+		"itest-worker",
+		"multicore-sdr",
+		"unit-cli",
+		"unit-storage",
+	}
+	return contains(names, name)
+}
+
+func getSkipConformance(name string) bool {
+	names := []string{
+		"conformance",
+	}
+	return !contains(names, name)
+}
+
+func getTestRustProofLogs(name string) bool {
+	names := []string{
+		"multicore-sdr",
+	}
+	return contains(names, name)
+}
+
+func getFormat() string {
+	return "standard-verbose"
+}
+
+func getGoTestFlags(name string) string {
+	namesToFlags := map[string]string{
+		"multicore-sdr": "-run=TestMulticoreSDR",
+		"conformance":   "-run=TestConformance",
+	}
+	if flag, ok := namesToFlags[name]; ok {
+		return flag
+	}
+	return ""
+}
+
+func getRunners(name string) [][]string {
+	if os.Getenv("GITHUB_REPOSITORY_OWNER") != "filecoin-project" {
+		return [][]string{{"ubuntu-latest"}}
+	}
+
+	namesToRunners := map[string][][]string{
+		"itest-niporep_manual":    {{"self-hosted", "linux", "x64", "4xlarge"}},
+		"itest-sector_pledge":     {{"self-hosted", "linux", "x64", "4xlarge"}},
+		"itest-worker":            {{"self-hosted", "linux", "x64", "4xlarge"}},
+		"itest-manual_onboarding": {{"self-hosted", "linux", "x64", "4xlarge"}},
+
+		"itest-gateway":              {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"itest-sector_import_full":   {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"itest-sector_import_simple": {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"itest-wdpost":               {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"unit-storage":               {{"self-hosted", "linux", "x64", "2xlarge"}},
+
+		"itest-cli":                      {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-deals_invalid_utf8_label": {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-decode_params":            {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-dup_mpool_messages":       {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_account_abstraction":  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_api":                  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_balance":              {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_bytecode":             {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_config":               {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_conformance":          {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_deploy":               {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_fee_history":          {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-eth_transactions":         {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-fevm_address":             {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-fevm_events":              {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-gas_estimation":           {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-get_messages_in_ts":       {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-lite_migration":           {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-lookup_robust_address":    {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-mempool":                  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-mpool_msg_uuid":           {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-mpool_push_with_uuid":     {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-msgindex":                 {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-multisig":                 {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-net":                      {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-nonce":                    {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-path_detach_redeclare":    {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-pending_deal_allocation":  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-remove_verifreg_datacap":  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-sector_miner_collateral":  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-sector_numassign":         {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-self_sent_txn":            {{"self-hosted", "linux", "x64", "xlarge"}},
+		"itest-verifreg":                 {{"self-hosted", "linux", "x64", "xlarge"}},
+		"multicore-sdr":                  {{"self-hosted", "linux", "x64", "xlarge"}},
+		"unit-node":                      {{"self-hosted", "linux", "x64", "xlarge"}},
+	}
+
+	if runners, ok := namesToRunners[name]; ok {
+		return runners
+	}
+
+	return [][]string{{"ubuntu-latest"}}
+}
+
+func getTestGroups(name string) []TestGroup {
+	runners := getRunners(name)
+
+	groups := []TestGroup{}
+
+	for _, runner := range runners {
+		groups = append(groups, TestGroup{
+			Name:   name,
+			Runner: runner,
+		})
+	}
+
+	return groups
+}
+
+func getTestGroupMetadata(name string) TestGroupMetadata {
+	packages := getPackages(name)
+	needsParameters := getNeedsParameters(name)
+	skipConformance := getSkipConformance(name)
+	testRustProofLogs := getTestRustProofLogs(name)
+	format := getFormat()
+	goTestFlags := getGoTestFlags(name)
+
+	return TestGroupMetadata{
+		Packages:          packages,
+		NeedsParameters:   needsParameters,
+		SkipConformance:   skipConformance,
+		TestRustProofLogs: testRustProofLogs,
+		Format:            format,
+		GoTestFlags:       goTestFlags,
+	}
+}
+
+func findIntegrationTestGroups() ([]TestGroup, error) {
+	groups := []TestGroup{}
+
+	err := filepath.Walk("itests", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && strings.HasSuffix(info.Name(), "_test.go") {
+			parts := strings.Split(path, string(os.PathSeparator))
+			name := strings.Join([]string{"itest", strings.TrimSuffix(parts[1], "_test.go")}, "-")
+			groups = append(groups, getTestGroups(name)...)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return groups, nil
+}
+
+func getUnitTestGroups() []TestGroup {
+	groups := []TestGroup{}
+
+	groups = append(groups, getTestGroups("unit-cli")...)
+	groups = append(groups, getTestGroups("unit-storage")...)
+	groups = append(groups, getTestGroups("unit-node")...)
+	groups = append(groups, getTestGroups("unit-rest")...)
+
+	return groups
+}
+
+func getOtherTestGroups() []TestGroup {
+	groups := []TestGroup{}
+
+	groups = append(
+		groups,
+		getTestGroups("multicore-sdr")...,
+	)
+	groups = append(
+		groups,
+		getTestGroups("conformance")...,
+	)
+
+	return groups
+}
+
+func main() {
+	app := &cli.App{
+		Name:  "ci",
+		Usage: "Lotus CI tool",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "json",
+				Usage: "Format output as JSON",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			if c.Bool("json") {
+				log.SetFormatter(&log.JSONFormatter{})
+			} else {
+				log.SetFormatter(&log.TextFormatter{
+					TimestampFormat: "2006-01-02 15:04:05",
+					FullTimestamp:   true,
+				})
+			}
+			log.SetOutput(os.Stdout)
+			return nil
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "list-test-groups",
+				Usage: "List all test groups",
+				Action: func(c *cli.Context) error {
+					integrationTestGroups, err := findIntegrationTestGroups()
+					if err != nil {
+						return err
+					}
+					unitTestGroups := getUnitTestGroups()
+					otherTestGroups := getOtherTestGroups()
+					groups := append(append(integrationTestGroups, unitTestGroups...), otherTestGroups...)
+					b, err := json.MarshalIndent(groups, "", "  ")
+					if err != nil {
+						log.Fatal(err)
+					}
+					log.Info(string(b))
+					return nil
+				},
+			},
+			{
+				Name:  "get-test-group-metadata",
+				Usage: "Get the metadata for a test group",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "name",
+						Usage:    "Name of the test group",
+						Required: true,
+					},
+				},
+				Action: func(c *cli.Context) error {
+					name := c.String("name")
+					metadata := getTestGroupMetadata(name)
+					b, err := json.MarshalIndent(metadata, "", "  ")
+					if err != nil {
+						log.Fatal(err)
+					}
+					log.Info(string(b))
+					return nil
+				},
+			},
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -33,37 +33,41 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
+func createPackagePath(pathParts ...string) string {
+	return strings.Join(append([]string{"."}, pathParts...), string(os.PathSeparator))
+}
+
 func getPackages(testGroupName string) []string {
 	testGroupNamesToPackages := map[string][]string{
-		"multicore-sdr": {strings.Join([]string{".", "storage", "sealer", "ffiwrapper"}, string(os.PathSeparator))},
-		"conformance":   {strings.Join([]string{".", "conformance"}, string(os.PathSeparator))},
+		"multicore-sdr": {createPackagePath("storage", "sealer", "ffiwrapper")},
+		"conformance":   {createPackagePath("conformance")},
 		"unit-cli": {
-			strings.Join([]string{".", "cli", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "cmd", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "api", "..."}, string(os.PathSeparator)),
+			createPackagePath("cli", "..."),
+			createPackagePath("cmd", "..."),
+			createPackagePath("api", "..."),
 		},
 		"unit-storage": {
-			strings.Join([]string{".", "storage", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "extern", "..."}, string(os.PathSeparator)),
+			createPackagePath("storage", "..."),
+			createPackagePath("extern", "..."),
 		},
 		"unit-node": {
-			strings.Join([]string{".", "node", "..."}, string(os.PathSeparator)),
+			createPackagePath("node", "..."),
 		},
 		"unit-rest": {
-			strings.Join([]string{".", "blockstore", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "build", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "chain", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "conformance", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "gateway", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "journal", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "lib", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "paychmgr", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{".", "tools", "..."}, string(os.PathSeparator)),
+			createPackagePath("blockstore", "..."),
+			createPackagePath("build", "..."),
+			createPackagePath("chain", "..."),
+			createPackagePath("conformance", "..."),
+			createPackagePath("gateway", "..."),
+			createPackagePath("journal", "..."),
+			createPackagePath("lib", "..."),
+			createPackagePath("paychmgr", "..."),
+			createPackagePath("tools", "..."),
 		},
 	}
 
 	if strings.HasPrefix(testGroupName, "itest-") {
-		return []string{strings.Join([]string{".", "itests", strings.Join([]string{strings.TrimPrefix(testGroupName, "itest-"), "test.go"}, "_")}, string(os.PathSeparator))}
+		return []string{createPackagePath("itests", strings.Join([]string{strings.TrimPrefix(testGroupName, "itest-"), "test.go"}, "_"))}
 	}
 
 	return testGroupNamesToPackages[testGroupName]

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -146,20 +146,6 @@ func getRunners(testGroupName string) []Runner {
 	}
 
 	testGroupNamesToRunners := map[string][]Runner{
-		"itest-niporep_manual":    {linux_x64_4xlarge},
-		"itest-sector_pledge":     {linux_x64_4xlarge},
-		"itest-worker":            {linux_x64_4xlarge},
-		"itest-manual_onboarding": {linux_x64_4xlarge},
-
-		"itest-gateway":              {linux_x64_2xlarge},
-		"itest-sector_import_full":   {linux_x64_2xlarge},
-		"itest-sector_import_simple": {linux_x64_2xlarge},
-		"itest-wdpost":               {linux_x64_2xlarge},
-		"unit-storage": {
-			linux_x64_2xlarge,
-			linux_arm64_2xlarge,
-		},
-
 		"itest-cli":                      {linux_x64_xlarge},
 		"itest-deals_invalid_utf8_label": {linux_x64_xlarge},
 		"itest-decode_params":            {linux_x64_xlarge},
@@ -176,37 +162,36 @@ func getRunners(testGroupName string) []Runner {
 		"itest-fevm_address":             {linux_x64_xlarge},
 		"itest-fevm_events":              {linux_x64_xlarge},
 		"itest-gas_estimation":           {linux_x64_xlarge},
+		"itest-gateway":              		{linux_x64_2xlarge},
 		"itest-get_messages_in_ts":       {linux_x64_xlarge},
 		"itest-lite_migration":           {linux_x64_xlarge},
 		"itest-lookup_robust_address":    {linux_x64_xlarge},
+		"itest-manual_onboarding": 				{linux_x64_4xlarge},
 		"itest-mempool":                  {linux_x64_xlarge},
 		"itest-mpool_msg_uuid":           {linux_x64_xlarge},
 		"itest-mpool_push_with_uuid":     {linux_x64_xlarge},
 		"itest-msgindex":                 {linux_x64_xlarge},
 		"itest-multisig":                 {linux_x64_xlarge},
 		"itest-net":                      {linux_x64_xlarge},
+		"itest-niporep_manual":    				{linux_x64_4xlarge},
 		"itest-nonce":                    {linux_x64_xlarge},
 		"itest-path_detach_redeclare":    {linux_x64_xlarge},
 		"itest-pending_deal_allocation":  {linux_x64_xlarge},
 		"itest-remove_verifreg_datacap":  {linux_x64_xlarge},
+		"itest-sector_import_full":   		{linux_x64_2xlarge},
+		"itest-sector_import_simple": 		{linux_x64_2xlarge},
 		"itest-sector_miner_collateral":  {linux_x64_xlarge},
 		"itest-sector_numassign":         {linux_x64_xlarge},
+		"itest-sector_pledge":     				{linux_x64_4xlarge},
 		"itest-self_sent_txn":            {linux_x64_xlarge},
 		"itest-verifreg":                 {linux_x64_xlarge},
+		"itest-wdpost":               		{linux_x64_2xlarge},
+		"itest-worker":            				{linux_x64_4xlarge},
 		"multicore-sdr":                  {linux_x64_xlarge},
-		"unit-node": {
-			linux_x64_xlarge,
-			linux_arm64_xlarge,
-		},
-
-		"unit-cli": {
-			linux_x64,
-			linux_arm64,
-		},
-		"unit-rest": {
-			linux_x64,
-			linux_arm64,
-		},
+		"unit-cli": 											{linux_x64,linux_arm64},
+		"unit-node": 											{linux_x64,linux_arm64},
+		"unit-rest": 											{linux_x64,linux_arm64},
+		"unit-storage": 									{linux_x64,linux_arm64},
 	}
 
 	if runners, ok := testGroupNamesToRunners[testGroupName]; ok {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -214,9 +214,9 @@ func getRunners(testGroupName string) []Runner {
 		"itest-worker":                   {linux_x64_4xlarge},
 		"multicore-sdr":                  {linux_x64_xlarge},
 		"unit-cli":                       {linux_x64, linux_arm64},
-		"unit-node":                      {linux_x64, linux_arm64},
+		"unit-node":                      {linux_x64_xlarge, linux_arm64_xlarge},
 		"unit-rest":                      {linux_x64, linux_arm64},
-		"unit-storage":                   {linux_x64, linux_arm64},
+		"unit-storage":                   {linux_x64_2xlarge, linux_arm64_2xlarge},
 	}
 
 	if runners, ok := testGroupNamesToRunners[testGroupName]; ok {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -10,21 +10,21 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type TestGroup struct {
-	Name   string   `json:"name"`
+type TestGroupExecutionContext struct {
+	Name   string `json:"name"`
 	Runner Runner `json:"runner"`
 }
 
 type Runner []string
 
 var (
-	linux_x64_4xlarge = []string{"self-hosted", "linux", "x64", "4xlarge"}
-	linux_x64_2xlarge = []string{"self-hosted", "linux", "x64", "2xlarge"}
-	linux_x64_xlarge = []string{"self-hosted", "linux", "x64", "xlarge"}
+	linux_x64_4xlarge   = []string{"self-hosted", "linux", "x64", "4xlarge"}
+	linux_x64_2xlarge   = []string{"self-hosted", "linux", "x64", "2xlarge"}
+	linux_x64_xlarge    = []string{"self-hosted", "linux", "x64", "xlarge"}
 	linux_arm64_2xlarge = []string{"self-hosted", "linux", "arm64", "2xlarge"}
-	linux_arm64_xlarge = []string{"self-hosted", "linux", "arm64", "xlarge"}
-	linux_x64 = []string{"self-hosted", "linux", "x64"}
-	linux_arm64 = []string{"self-hosted", "linux", "arm64"}
+	linux_arm64_xlarge  = []string{"self-hosted", "linux", "arm64", "xlarge"}
+	linux_x64           = []string{"self-hosted", "linux", "x64"}
+	linux_arm64         = []string{"self-hosted", "linux", "arm64"}
 )
 
 type TestGroupMetadata struct {
@@ -60,8 +60,8 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			{
-				Name:  "list-test-groups",
-				Usage: "List all test groups",
+				Name:  "list-test-group-execution-contexts",
+				Usage: "List all test group execution contexts",
 				Action: func(c *cli.Context) error {
 					integrationTestGroups, err := getIntegrationTestGroups()
 					if err != nil {
@@ -107,8 +107,8 @@ func main() {
 	}
 }
 
-func getIntegrationTestGroups() ([]TestGroup, error) {
-	groups := []TestGroup{}
+func getIntegrationTestGroups() ([]TestGroupExecutionContext, error) {
+	groups := []TestGroupExecutionContext{}
 
 	err := filepath.Walk("itests", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -130,33 +130,33 @@ func getIntegrationTestGroups() ([]TestGroup, error) {
 	return groups, nil
 }
 
-func getUnitTestGroups() []TestGroup {
-	groups := []TestGroup{}
+func getUnitTestGroups() []TestGroupExecutionContext {
+	groups := []TestGroupExecutionContext{}
 
 	for _, value := range []string{"cli", "node", "rest", "storage"} {
-		groups = append(groups, getTestGroups("unit-" + value)...)
+		groups = append(groups, getTestGroups("unit-"+value)...)
 	}
 
 	return groups
 }
 
-func getOtherTestGroups() []TestGroup {
-	groups := []TestGroup{}
+func getOtherTestGroups() []TestGroupExecutionContext {
+	groups := []TestGroupExecutionContext{}
 
 	for _, value := range []string{"conformance", "multicore-sdr"} {
 		groups = append(groups, getTestGroups(value)...)
-}
+	}
 
 	return groups
 }
 
-func getTestGroups(testGroupName string) []TestGroup {
+func getTestGroups(testGroupName string) []TestGroupExecutionContext {
 	runners := getRunners(testGroupName)
 
-	groups := []TestGroup{}
+	groups := []TestGroupExecutionContext{}
 
 	for _, runner := range runners {
-		groups = append(groups, TestGroup{
+		groups = append(groups, TestGroupExecutionContext{
 			Name:   testGroupName,
 			Runner: runner,
 		})
@@ -187,36 +187,36 @@ func getRunners(testGroupName string) []Runner {
 		"itest-fevm_address":             {linux_x64_xlarge},
 		"itest-fevm_events":              {linux_x64_xlarge},
 		"itest-gas_estimation":           {linux_x64_xlarge},
-		"itest-gateway":              		{linux_x64_2xlarge},
+		"itest-gateway":                  {linux_x64_2xlarge},
 		"itest-get_messages_in_ts":       {linux_x64_xlarge},
 		"itest-lite_migration":           {linux_x64_xlarge},
 		"itest-lookup_robust_address":    {linux_x64_xlarge},
-		"itest-manual_onboarding": 				{linux_x64_4xlarge},
+		"itest-manual_onboarding":        {linux_x64_4xlarge},
 		"itest-mempool":                  {linux_x64_xlarge},
 		"itest-mpool_msg_uuid":           {linux_x64_xlarge},
 		"itest-mpool_push_with_uuid":     {linux_x64_xlarge},
 		"itest-msgindex":                 {linux_x64_xlarge},
 		"itest-multisig":                 {linux_x64_xlarge},
 		"itest-net":                      {linux_x64_xlarge},
-		"itest-niporep_manual":    				{linux_x64_4xlarge},
+		"itest-niporep_manual":           {linux_x64_4xlarge},
 		"itest-nonce":                    {linux_x64_xlarge},
 		"itest-path_detach_redeclare":    {linux_x64_xlarge},
 		"itest-pending_deal_allocation":  {linux_x64_xlarge},
 		"itest-remove_verifreg_datacap":  {linux_x64_xlarge},
-		"itest-sector_import_full":   		{linux_x64_2xlarge},
-		"itest-sector_import_simple": 		{linux_x64_2xlarge},
+		"itest-sector_import_full":       {linux_x64_2xlarge},
+		"itest-sector_import_simple":     {linux_x64_2xlarge},
 		"itest-sector_miner_collateral":  {linux_x64_xlarge},
 		"itest-sector_numassign":         {linux_x64_xlarge},
-		"itest-sector_pledge":     				{linux_x64_4xlarge},
+		"itest-sector_pledge":            {linux_x64_4xlarge},
 		"itest-self_sent_txn":            {linux_x64_xlarge},
 		"itest-verifreg":                 {linux_x64_xlarge},
-		"itest-wdpost":               		{linux_x64_2xlarge},
-		"itest-worker":            				{linux_x64_4xlarge},
+		"itest-wdpost":                   {linux_x64_2xlarge},
+		"itest-worker":                   {linux_x64_4xlarge},
 		"multicore-sdr":                  {linux_x64_xlarge},
-		"unit-cli": 											{linux_x64,linux_arm64},
-		"unit-node": 											{linux_x64,linux_arm64},
-		"unit-rest": 											{linux_x64,linux_arm64},
-		"unit-storage": 									{linux_x64,linux_arm64},
+		"unit-cli":                       {linux_x64, linux_arm64},
+		"unit-node":                      {linux_x64, linux_arm64},
+		"unit-rest":                      {linux_x64, linux_arm64},
+		"unit-storage":                   {linux_x64, linux_arm64},
 	}
 
 	if runners, ok := testGroupNamesToRunners[testGroupName]; ok {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -260,10 +260,9 @@ func getIntegrationTestGroups() ([]TestGroup, error) {
 func getUnitTestGroups() []TestGroup {
 	groups := []TestGroup{}
 
-	groups = append(groups, getTestGroups("unit-cli")...)
-	groups = append(groups, getTestGroups("unit-storage")...)
-	groups = append(groups, getTestGroups("unit-node")...)
-	groups = append(groups, getTestGroups("unit-rest")...)
+	for _, value := range []string{"cli", "node", "rest", "storage"} {
+		groups = append(groups, getTestGroups("unit-" + value)...)
+	}
 
 	return groups
 }
@@ -271,14 +270,9 @@ func getUnitTestGroups() []TestGroup {
 func getOtherTestGroups() []TestGroup {
 	groups := []TestGroup{}
 
-	groups = append(
-		groups,
-		getTestGroups("multicore-sdr")...,
-	)
-	groups = append(
-		groups,
-		getTestGroups("conformance")...,
-	)
+	for _, value := range []string{"conformance", "multicore-sdr"} {
+		groups = append(groups, getTestGroups(value)...)
+}
 
 	return groups
 }

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -15,6 +15,7 @@ type TestGroupExecutionContext struct {
 	Runner Runner `json:"runner"`
 }
 
+// Runner is a list because it is a list of labels associated with a single runner.
 type Runner []string
 
 var (
@@ -170,7 +171,7 @@ func getRunners(testGroupName string) []Runner {
 		return []Runner{linux_x64}
 	}
 
-	testGroupNamesToRunners := map[string][]Runner{
+	testGroupNameToRunners := map[string][]Runner{
 		"itest-cli":                      {linux_x64_xlarge},
 		"itest-deals_invalid_utf8_label": {linux_x64_xlarge},
 		"itest-decode_params":            {linux_x64_xlarge},
@@ -219,7 +220,7 @@ func getRunners(testGroupName string) []Runner {
 		"unit-storage":                   {linux_x64_2xlarge, linux_arm64_2xlarge},
 	}
 
-	if runners, ok := testGroupNamesToRunners[testGroupName]; ok {
+	if runners, ok := testGroupNameToRunners[testGroupName]; ok {
 		return runners
 	}
 
@@ -245,7 +246,11 @@ func getTestGroupMetadata(testGroupName string) TestGroupMetadata {
 }
 
 func getPackages(testGroupName string) []string {
-	testGroupNamesToPackages := map[string][]string{
+	if strings.HasPrefix(testGroupName, "itest-") {
+		return []string{createPackagePath("itests", strings.Join([]string{strings.TrimPrefix(testGroupName, "itest-"), "test.go"}, "_"))}
+	}
+
+	testGroupNameToPackages := map[string][]string{
 		"multicore-sdr": {createPackagePath("storage", "sealer", "ffiwrapper")},
 		"conformance":   {createPackagePath("conformance")},
 		"unit-cli": {
@@ -273,11 +278,7 @@ func getPackages(testGroupName string) []string {
 		},
 	}
 
-	if strings.HasPrefix(testGroupName, "itest-") {
-		return []string{createPackagePath("itests", strings.Join([]string{strings.TrimPrefix(testGroupName, "itest-"), "test.go"}, "_"))}
-	}
-
-	return testGroupNamesToPackages[testGroupName]
+	return testGroupNameToPackages[testGroupName]
 }
 
 func getNeedsParameters(testGroupName string) bool {
@@ -325,11 +326,11 @@ func getFormat() string {
 }
 
 func getGoTestFlags(testGroupName string) string {
-	testGroupNamesToFlags := map[string]string{
+	testGroupNameToFlags := map[string]string{
 		"multicore-sdr": "-run=TestMulticoreSDR",
 		"conformance":   "-run=TestConformance",
 	}
-	if flag, ok := testGroupNamesToFlags[testGroupName]; ok {
+	if flag, ok := testGroupNameToFlags[testGroupName]; ok {
 		return flag
 	}
 	return ""

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -139,7 +139,10 @@ func getRunners(name string) [][]string {
 		"itest-sector_import_full":   {{"self-hosted", "linux", "x64", "2xlarge"}},
 		"itest-sector_import_simple": {{"self-hosted", "linux", "x64", "2xlarge"}},
 		"itest-wdpost":               {{"self-hosted", "linux", "x64", "2xlarge"}},
-		"unit-storage":               {{"self-hosted", "linux", "x64", "2xlarge"}},
+		"unit-storage":               {
+			{"self-hosted", "linux", "x64", "2xlarge"},
+			{"self-hosted", "linux", "arm64", "2xlarge"},
+		},
 
 		"itest-cli":                      {{"self-hosted", "linux", "x64", "xlarge"}},
 		"itest-deals_invalid_utf8_label": {{"self-hosted", "linux", "x64", "xlarge"}},
@@ -175,7 +178,19 @@ func getRunners(name string) [][]string {
 		"itest-self_sent_txn":            {{"self-hosted", "linux", "x64", "xlarge"}},
 		"itest-verifreg":                 {{"self-hosted", "linux", "x64", "xlarge"}},
 		"multicore-sdr":                  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"unit-node":                      {{"self-hosted", "linux", "x64", "xlarge"}},
+		"unit-node":                      {
+			{"self-hosted", "linux", "x64", "xlarge"},
+			{"self-hosted", "linux", "arm64", "xlarge"},
+		},
+
+		"unit-cli": {
+			{"ubuntu-latest"},
+			{"ubuntu-24.04-arm"},
+		},
+		"unit-rest": {
+			{"ubuntu-latest"},
+			{"ubuntu-24.04-arm"},
+		},
 	}
 
 	if runners, ok := namesToRunners[name]; ok {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -35,35 +35,35 @@ func contains(slice []string, item string) bool {
 
 func getPackages(name string) []string {
 	namesToPackages := map[string][]string{
-		"multicore-sdr": {strings.Join([]string{"storage", "sealer", "ffiwrapper"}, string(os.PathSeparator))},
-		"conformance":   {strings.Join([]string{"conformance"}, string(os.PathSeparator))},
+		"multicore-sdr": {strings.Join([]string{".", "storage", "sealer", "ffiwrapper"}, string(os.PathSeparator))},
+		"conformance":   {strings.Join([]string{".", "conformance"}, string(os.PathSeparator))},
 		"unit-cli": {
-			strings.Join([]string{"cli", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"cmd", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"api", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "cli", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "cmd", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "api", "..."}, string(os.PathSeparator)),
 		},
 		"unit-storage": {
-			strings.Join([]string{"storage", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"extern", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "storage", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "extern", "..."}, string(os.PathSeparator)),
 		},
 		"unit-node": {
-			strings.Join([]string{"node", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "node", "..."}, string(os.PathSeparator)),
 		},
 		"unit-rest": {
-			strings.Join([]string{"blockstore", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"build", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"chain", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"conformance", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"gateway", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"journal", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"lib", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"paychmgr", "..."}, string(os.PathSeparator)),
-			strings.Join([]string{"tools", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "blockstore", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "build", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "chain", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "conformance", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "gateway", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "journal", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "lib", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "paychmgr", "..."}, string(os.PathSeparator)),
+			strings.Join([]string{".", "tools", "..."}, string(os.PathSeparator)),
 		},
 	}
 
 	if strings.HasPrefix(name, "itest-") {
-		return []string{strings.Join([]string{"itests", strings.Join([]string{strings.TrimPrefix(name, "itest-"), "test.go"}, "_")}, string(os.PathSeparator))}
+		return []string{strings.Join([]string{".", "itests", strings.Join([]string{strings.TrimPrefix(name, "itest-"), "test.go"}, "_")}, string(os.PathSeparator))}
 	}
 
 	return namesToPackages[name]
@@ -139,7 +139,7 @@ func getRunners(name string) [][]string {
 		"itest-sector_import_full":   {{"self-hosted", "linux", "x64", "2xlarge"}},
 		"itest-sector_import_simple": {{"self-hosted", "linux", "x64", "2xlarge"}},
 		"itest-wdpost":               {{"self-hosted", "linux", "x64", "2xlarge"}},
-		"unit-storage":               {
+		"unit-storage": {
 			{"self-hosted", "linux", "x64", "2xlarge"},
 			{"self-hosted", "linux", "arm64", "2xlarge"},
 		},
@@ -178,7 +178,7 @@ func getRunners(name string) [][]string {
 		"itest-self_sent_txn":            {{"self-hosted", "linux", "x64", "xlarge"}},
 		"itest-verifreg":                 {{"self-hosted", "linux", "x64", "xlarge"}},
 		"multicore-sdr":                  {{"self-hosted", "linux", "x64", "xlarge"}},
-		"unit-node":                      {
+		"unit-node": {
 			{"self-hosted", "linux", "x64", "xlarge"},
 			{"self-hosted", "linux", "arm64", "xlarge"},
 		},


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Resolves #12860

## Proposed Changes
<!-- A clear list of the changes being made -->
Start running `unit-*` jobs on arm64 machines in addition to x86_64 ones. 

## Additional Info
<!-- Callouts, links to documentation, and etc -->
In order to accommodate this change, I moved the test discovery code to a dedicated Go CLI. The important change in the structure of metadata is that now each test group can be associated with many target runners.

What's more, I split the test group discovery into part 1 which lists all the test groups, and part 2 which returns the metadata (e.g. runner information, etc.) for a given test group name. Thanks to this the outputs of the discovery job can be smaller and we minimise the risk of hitting the maximum output size limit.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
