### PR TITLE
feat(shed): optional --pprofport

### DIFF
--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/pprof"
+	"time"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
@@ -150,7 +151,11 @@ func main() {
 			if port := cctx.Int("pprof-port"); port != 0 {
 				go func() {
 					log.Infow("Starting pprof server", "port", port)
-					if err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil); !errors.Is(err, http.ErrServerClosed) {
+					server := &http.Server{
+						Addr:              fmt.Sprintf("localhost:%d", port),
+						ReadHeaderTimeout: 5 * time.Second,
+					}
+					if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 						log.Errorw("pprof server stopped unexpectedly", "err", err)
 					}
 				}()


### PR DESCRIPTION
Open to suggestions on more idiomatic ways to expose this if you have any. We have some long-running commands in lotus-shed (like `migrate-state`) that are handy to be able to profile while running.