### PR TITLE
docs: point to regex and tools for conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,8 @@ This means the PR title should be in the form of `<type>(<scope>): <description>
 
 Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/pr-title-check.yml
 
+If it is unclear why one's title is getting flagged, it the regex defined in [pr-title-check.yml](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/pr-title-check.yml#L28) can be plugged into a debugger like [regex101.com](https://regex101.com/r/kUrU3F/2).
+
 ## CHANGELOG Management
 
 To expedite the release process, the CHANGELOG is built-up incrementally.


### PR DESCRIPTION
This was done in response to discussion on #fil-lotus-dev: https://filecoinproject.slack.com/archives/CP50PPW2X/p1738873972951379