### PR TITLE
chore(blockstore): add an LRU cache to the API blockstore wrapper

### DIFF
--- a/blockstore/api.go
+++ b/blockstore/api.go
@@ -3,6 +3,7 @@ package blockstore
 import (
 	"context"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
@@ -15,14 +16,22 @@ type ChainIO interface {
 }
 
 type apiBlockstore struct {
-	api ChainIO
+	api   ChainIO
+	cache *lru.Cache[cid.Cid, []byte]
 }
 
 // This blockstore is adapted in the constructor.
 var _ BasicBlockstore = (*apiBlockstore)(nil)
 
 func NewAPIBlockstore(cio ChainIO) Blockstore {
-	bs := &apiBlockstore{api: cio}
+	lc, err := lru.New[cid.Cid, []byte](1024)
+	if err != nil {
+		panic(err)
+	}
+	bs := &apiBlockstore{
+		api:   cio,
+		cache: lc,
+	}
 	return Adapt(bs) // return an adapted blockstore.
 }
 
@@ -31,31 +40,44 @@ func (a *apiBlockstore) DeleteBlock(context.Context, cid.Cid) error {
 }
 
 func (a *apiBlockstore) Has(ctx context.Context, c cid.Cid) (bool, error) {
+	if a.cache.Contains(c) {
+		return true, nil
+	}
 	return a.api.ChainHasObj(ctx, c)
 }
 
 func (a *apiBlockstore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	if bb, ok := a.cache.Get(c); ok {
+		return blocks.NewBlockWithCid(bb, c)
+	}
 	bb, err := a.api.ChainReadObj(ctx, c)
 	if err != nil {
 		return nil, err
 	}
+	a.cache.Add(c, bb)
 	return blocks.NewBlockWithCid(bb, c)
 }
 
 func (a *apiBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
+	if bb, ok := a.cache.Get(c); ok {
+		return len(bb), nil
+	}
 	bb, err := a.api.ChainReadObj(ctx, c)
 	if err != nil {
 		return 0, err
 	}
+	a.cache.Add(c, bb)
 	return len(bb), nil
 }
 
 func (a *apiBlockstore) Put(ctx context.Context, block blocks.Block) error {
+	a.cache.Add(block.Cid(), block.RawData())
 	return a.api.ChainPutObj(ctx, block)
 }
 
 func (a *apiBlockstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 	for _, block := range blocks {
+		a.cache.Add(block.Cid(), block.RawData())
 		err := a.api.ChainPutObj(ctx, block)
 		if err != nil {
 			return err
@@ -68,6 +90,4 @@ func (a *apiBlockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error)
 	return nil, xerrors.New("not supported")
 }
 
-func (a *apiBlockstore) HashOnRead(enabled bool) {
-	return
-}
+func (a *apiBlockstore) HashOnRead(enabled bool) {}


### PR DESCRIPTION
I've been relying on `NewAPIBlockstore` a lot lately for lotus-shed commands, miscellaneous things to inspect state mainly, where I don't want to stop my node to mount it as the blockstore. But realised that a lot of the fetches are for the same small blocks because we have a lot of things like THE empty partition, THE empty deadline, THE empty HAMT. It turns out that putting a simple LRU in there makes it so much faster to do simple iteration and checking when you're hitting these things.

This is mainly used in lotus-shed, but it has a few uses in the `lotus` command, specifically for some things under `lotus filplus`, `lotus miner info` and `lotus multisig`. The `spcli` commands also use this a little.