### PR TITLE
fix(fr32): correctly calculate the todo size under low core counts

### DIFF
--- a/storage/sealer/fr32/readers.go
+++ b/storage/sealer/fr32/readers.go
@@ -92,7 +92,7 @@ func (r *unpadReader) readInner(out []byte) (int, error) {
 		return 0, xerrors.Errorf("output must be of valid padded piece size: %w", err)
 	}
 
-	todo := abi.PaddedPieceSize(outTwoPow)
+	todo := min(abi.PaddedPieceSize(outTwoPow), abi.PaddedPieceSize(len(r.work)))
 	if r.left < uint64(todo) {
 		todo = abi.PaddedPieceSize(1 << (63 - bits.LeadingZeros64(r.left)))
 	}

--- a/storage/sealer/fr32/readers_test.go
+++ b/storage/sealer/fr32/readers_test.go
@@ -69,7 +69,9 @@ func TestPadWriterUnpadReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Generate random unpadded data
 			unpadded := make([]byte, tc.unpadSize)
-			rand.Read(unpadded)
+			n, err := rand.Read(unpadded)
+			require.NoError(t, err)
+			require.Equal(t, int(tc.unpadSize), n)
 
 			// Create a buffer to store padded data
 			paddedBuf := new(bytes.Buffer)
@@ -111,11 +113,13 @@ func TestPadWriterUnpadReader(t *testing.T) {
 func TestUnpadReaderSmallReads(t *testing.T) {
 	unpadSize := abi.UnpaddedPieceSize(127 * 1024) // 128KB unpadded
 	unpadded := make([]byte, unpadSize)
-	rand.Read(unpadded)
+	n, err := rand.Read(unpadded)
+	require.NoError(t, err)
+	require.Equal(t, int(unpadSize), n)
 
 	paddedBuf := new(bytes.Buffer)
 	padWriter := fr32.NewPadWriter(paddedBuf)
-	_, err := padWriter.Write(unpadded)
+	_, err = padWriter.Write(unpadded)
 	require.NoError(t, err)
 	require.NoError(t, padWriter.Close())
 
@@ -141,11 +145,13 @@ func TestUnpadReaderSmallReads(t *testing.T) {
 func TestUnpadReaderLargeReads(t *testing.T) {
 	unpadSize := abi.UnpaddedPieceSize(127 * 1024 * 1024) // 128MB unpadded
 	unpadded := make([]byte, unpadSize)
-	rand.Read(unpadded)
+	n, err := rand.Read(unpadded)
+	require.NoError(t, err)
+	require.Equal(t, int(unpadSize), n)
 
 	paddedBuf := new(bytes.Buffer)
 	padWriter := fr32.NewPadWriter(paddedBuf)
-	_, err := padWriter.Write(unpadded)
+	_, err = padWriter.Write(unpadded)
 	require.NoError(t, err)
 	require.NoError(t, padWriter.Close())
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

Fixes https://github.com/filecoin-project/lotus/issues/9324

## Proposed Changes
<!-- A clear list of the changes being made -->

Currently, the **unpadReader**'s work size is calculated using **MTTresh * mtChunkCount(sz)**. When the core count is low, this may cause the todo length to exceed `len(work)`. 

In the current implementation, the length of `out` is actually expanded automatically by Go's underlying mechanisms, making adjustments quite troublesome.

```go
// io.go
func ReadAll(r Reader) ([]byte, error) {
  b := make([]byte, 0, 512)
  for {
    n, err := r.Read(b[len(b):cap(b)])
    b = b[:len(b)+n]
    if err != nil { /* ... */ }

    if len(b) == cap(b) {
      // Add more capacity (let append pick how much).
      b = append(b, 0)[:len(b)] // <-- here
    }
  }
}
```

There are two feasible solutions:

1. Increase the minimum **mtChunkCount** to 16.
2. Ensure that **todo** does not exceed the size of **work**.

I'm not entirely sure if other conditions could also lead to similar issues, so for now, I've chosen the second approach. I added a check when calculating **todo** to prevent overflow:

```go
todo := min(abi.PaddedPieceSize(outTwoPow), abi.PaddedPieceSize(len(r.work)))
```

Additionally I’ve also fixed the CI.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
