### PR TITLE
feat: automatically detect if genesis CAR is compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - chore: switch to pure-go zstd decoder for snapshot imports.  ([filecoin-project/lotus#12857](https://github.com/filecoin-project/lotus/pull/12857))
 
+- feat: automatically detect if the genesis is zstd compressed. ([filecoin-project/lotus#12885](https://github.com/filecoin-project/lotus/pull/12885)
+
 # UNRELEASED v.1.32.0
 
 See https://github.com/filecoin-project/lotus/blob/release/v1.32.0/CHANGELOG.md

--- a/build/genesis_test.go
+++ b/build/genesis_test.go
@@ -1,0 +1,109 @@
+package build_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/build"
+)
+
+func TestGenesis(t *testing.T) {
+	for _, test := range []struct {
+		path string
+	}{
+		{path: "genesis/butterflynet.car.zst"},
+		{path: "genesis/calibnet.car.zst"},
+		{path: "genesis/interopnet.car.zst"},
+		{path: "genesis/mainnet.car.zst"},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			subject, err := os.Open(test.path)
+			require.NoError(t, err)
+
+			gotIsCompressed, err := build.IsZstdCompressed(subject)
+			require.NoError(t, err)
+			require.True(t, gotIsCompressed)
+
+			gotDecompressed, err := build.DecompressAsZstd(subject)
+			require.NoError(t, err)
+			require.NotEmpty(t, gotDecompressed)
+
+			gotIsCompressed, err = build.IsZstdCompressed(bytes.NewReader(gotDecompressed))
+			require.NoError(t, err)
+			require.False(t, gotIsCompressed)
+		})
+	}
+}
+
+func TestGenesis_ZstdCheck(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		given          func(t *testing.T) io.ReadSeeker
+		wantCompressed bool
+		wantErr        bool
+	}{
+		{
+			name: "arbitraryLongEnough",
+			given: func(t *testing.T) io.ReadSeeker {
+				return bytes.NewReader([]byte("fish"))
+			},
+		},
+		{
+			name: "arbitraryShort",
+			given: func(t *testing.T) io.ReadSeeker {
+				return bytes.NewReader([]byte("🐠"))
+			},
+		},
+		{
+			name: "arbitraryZstdCompressed",
+			given: func(t *testing.T) io.ReadSeeker {
+				var buf bytes.Buffer
+				writer, err := zstd.NewWriter(&buf)
+				require.NoError(t, err)
+				written, err := writer.Write([]byte("fish"))
+				require.NoError(t, err)
+				require.NotZero(t, written)
+				require.NoError(t, writer.Close())
+				return bytes.NewReader(buf.Bytes())
+			},
+			wantCompressed: true,
+		},
+		{
+			name:    "failingPositionReset",
+			given:   func(t *testing.T) io.ReadSeeker { return failOnSeekStart{} },
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := test.given(t)
+			gotCompressed, gotErr := build.IsZstdCompressed(target)
+			require.Equal(t, test.wantCompressed, gotCompressed)
+			require.Equal(t, test.wantErr, gotErr != nil)
+
+			if !test.wantErr {
+				gotPosition, err := target.Seek(0, io.SeekCurrent)
+				require.NoError(t, err)
+				require.Zero(t, gotPosition)
+			}
+		})
+	}
+}
+
+var _ io.ReadSeeker = (*failOnSeekStart)(nil)
+
+type failOnSeekStart struct{}
+
+func (failOnSeekStart) Read([]byte) (int, error) { return 0, nil }
+
+func (failOnSeekStart) Seek(_ int64, whence int) (int64, error) {
+	if whence == io.SeekStart {
+		return 0, errors.New("pursue the horizon; forsake the dawn; the start is long gone")
+	}
+	return 0, nil
+}

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -64,7 +64,7 @@ COMMANDS:
 
 OPTIONS:
    --api value               (default: "1234")
-   --genesis value           genesis file to use for first node run
+   --genesis value           genesis file to use for first node run, which may be a zstd compressed CAR or an uncompressed CAR file.
    --bootstrap               (default: true)
    --import-chain value      on first run, load chain from given file or url and validate
    --import-snapshot value   import chain state from a given chain export file or url


### PR DESCRIPTION


## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
When `--genesis` path is set, automatically detect if the genesis file is ZSTD compressed and decompress it.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
