### PR TITLE
chore(lint): upgrade golangci-lint & fix new lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - gosec
     - unconvert
     - staticcheck
-    - exportloopref
+    - copyloopvar
     - unused
 
 # We don't want to skip builtin/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(warning Your Golang version is go$(shell expr $(GOVERSION) / 1000000).$(shell 
 $(error Update Golang to version to at least $(shell cat GO_VERSION_MIN))
 endif
 
-GOLANGCI_LINT_VERSION=v1.59.0
+GOLANGCI_LINT_VERSION=v1.63.4
 
 # git modules that need to be loaded
 MODULES:=

--- a/api/api_errors.go
+++ b/api/api_errors.go
@@ -161,9 +161,9 @@ func (e *ErrExecutionReverted) ToJSONRPCError() (jsonrpc.JSONRPCError, error) {
 }
 
 // NewErrExecutionReverted creates a new ErrExecutionReverted with the given reason.
-func NewErrExecutionReverted(exitCode exitcode.ExitCode, error, reason string, data []byte) *ErrExecutionReverted {
+func NewErrExecutionReverted(exitCode exitcode.ExitCode, errMsg, reason string, data []byte) *ErrExecutionReverted {
 	return &ErrExecutionReverted{
-		Message: fmt.Sprintf("message execution failed (exit=[%s], revert reason=[%s], vm error=[%s])", exitCode, reason, error),
+		Message: fmt.Sprintf("message execution failed (exit=[%s], revert reason=[%s], vm error=[%s])", exitCode, reason, errMsg),
 		Data:    fmt.Sprintf("0x%x", data),
 	}
 }

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -666,7 +666,6 @@ func Generate(out io.Writer, iface, pkg string, ainfo ApiASTInfo) error {
 	}
 
 	for _, g := range groupslice {
-		g := g
 		if _, err := fmt.Fprintf(out, "## %s\n", g.GroupName); err != nil {
 			return err
 		}

--- a/blockstore/splitstore/markset_badger.go
+++ b/blockstore/splitstore/markset_badger.go
@@ -377,9 +377,9 @@ func (s *BadgerMarkSet) Close() error {
 	return closeBadgerDB(db, s.path, s.persist)
 }
 
-func openBadgerDB(path string, recover bool) (*badger.DB, error) {
+func openBadgerDB(path string, doRecover bool) (*badger.DB, error) {
 	// if it is not a recovery, clean up first
-	if !recover {
+	if !doRecover {
 		err := os.RemoveAll(path)
 		if err != nil {
 			return nil, xerrors.Errorf("error clearing markset directory: %w", err)

--- a/chain/actors/aerrors/wrap.go
+++ b/chain/actors/aerrors/wrap.go
@@ -50,9 +50,7 @@ func Newf(retCode exitcode.ExitCode, format string, args ...interface{}) ActorEr
 	}
 }
 
-// todo: bit hacky
-
-func NewfSkip(skip int, retCode exitcode.ExitCode, format string, args ...interface{}) ActorError {
+func NewSkipf(skip int, retCode exitcode.ExitCode, format string, args ...interface{}) ActorError {
 	if retCode == 0 {
 		return &actorError{
 			fatal:   true,
@@ -67,6 +65,25 @@ func NewfSkip(skip int, retCode exitcode.ExitCode, format string, args ...interf
 		retCode: retCode,
 
 		msg:   fmt.Sprintf(format, args...),
+		frame: xerrors.Caller(skip),
+	}
+}
+
+func NewSkip(skip int, retCode exitcode.ExitCode, reason string) ActorError {
+	if retCode == 0 {
+		return &actorError{
+			fatal:   true,
+			retCode: 0,
+
+			msg:   "tried creating an error and setting RetCode to 0",
+			frame: xerrors.Caller(skip),
+			err:   errors.New(reason),
+		}
+	}
+	return &actorError{
+		retCode: retCode,
+
+		msg:   reason,
 		frame: xerrors.Caller(skip),
 	}
 }

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -477,7 +477,7 @@ func DealProviderCollateralBounds(
 	size abi.PaddedPieceSize, verified bool,
 	rawBytePower, qaPower, baselinePower abi.StoragePower,
 	circulatingFil abi.TokenAmount, nwVer network.Version,
-) (min, max abi.TokenAmount, err error) {
+) (abi.TokenAmount, abi.TokenAmount, error) {
 	v, err := actorstypes.VersionForNetwork(nwVer)
 	if err != nil {
 		return big.Zero(), big.Zero(), err

--- a/chain/actors/policy/policy.go.template
+++ b/chain/actors/policy/policy.go.template
@@ -175,7 +175,7 @@ func DealProviderCollateralBounds(
 	size abi.PaddedPieceSize, verified bool,
 	rawBytePower, qaPower, baselinePower abi.StoragePower,
 	circulatingFil abi.TokenAmount, nwVer network.Version,
-) (min, max abi.TokenAmount, err error) {
+) (abi.TokenAmount, abi.TokenAmount, error) {
 	v, err := actorstypes.VersionForNetwork(nwVer)
 	if err != nil {
 		return big.Zero(), big.Zero(), err

--- a/chain/badtscache.go
+++ b/chain/badtscache.go
@@ -19,10 +19,10 @@ type BadBlockReason struct {
 	OriginalReason *BadBlockReason
 }
 
-func NewBadBlockReason(cid []cid.Cid, format string, i ...interface{}) BadBlockReason {
+func NewBadBlockReason(cid []cid.Cid, reason string) BadBlockReason {
 	return BadBlockReason{
 		TipSet: cid,
-		Reason: fmt.Sprintf(format, i...),
+		Reason: reason,
 	}
 }
 

--- a/chain/events/events_test.go
+++ b/chain/events/events_test.go
@@ -1292,7 +1292,6 @@ func TestStateChangedTimeout(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fcs := newFakeCS(t)
 

--- a/chain/events/filter/event_test.go
+++ b/chain/events/filter/event_test.go
@@ -275,7 +275,6 @@ func TestEventFilterCollectEvents(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // appease lint
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.filter.CollectEvents(context.Background(), tc.te, false, addrMap.ResolveAddress); err != nil {
 				require.NoError(t, err, "collect events")

--- a/chain/events/tscache.go
+++ b/chain/events/tscache.go
@@ -31,10 +31,10 @@ type tipSetCache struct {
 	storage tsCacheAPI
 }
 
-func newTSCache(storage tsCacheAPI, cap abi.ChainEpoch) *tipSetCache {
+func newTSCache(storage tsCacheAPI, capacity abi.ChainEpoch) *tipSetCache {
 	return &tipSetCache{
-		byKey:    make(map[types.TipSetKey]*types.TipSet, cap),
-		byHeight: make([]*types.TipSet, cap),
+		byKey:    make(map[types.TipSetKey]*types.TipSet, capacity),
+		byHeight: make([]*types.TipSet, capacity),
 		start:    0,
 		len:      0,
 

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -137,9 +137,6 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 	rawPow, qaPow := big.NewInt(0), big.NewInt(0)
 	for i, m := range miners {
 		// Create miner through power actor
-		i := i
-		m := m
-
 		variant := miner.SealProofVariant_Standard
 		if synthetic {
 			variant = miner.SealProofVariant_Synthetic

--- a/chain/index/indexer.go
+++ b/chain/index/indexer.go
@@ -295,21 +295,18 @@ func (si *SqliteIndexer) indexTipset(ctx context.Context, tx *sql.Tx, ts *types.
 
 	for i, msg := range msgs {
 		insertTipsetMsgStmt := tx.Stmt(si.stmts.insertTipsetMessageStmt)
-		msg := msg
 		if _, err := insertTipsetMsgStmt.ExecContext(ctx, tsKeyCidBytes, height, 0, msg.Cid().Bytes(), i); err != nil {
 			return xerrors.Errorf("failed to insert tipset message: %w", err)
 		}
 	}
 
 	for _, blk := range ts.Blocks() {
-		blk := blk
 		_, smsgs, err := si.cs.MessagesForBlock(ctx, blk)
 		if err != nil {
 			return xerrors.Errorf("failed to get messages for block: %w", err)
 		}
 
 		for _, smsg := range smsgs {
-			smsg := smsg
 			if smsg.Signature.Type != crypto.SigTypeDelegated {
 				continue
 			}

--- a/chain/index/pub_sub.go
+++ b/chain/index/pub_sub.go
@@ -41,13 +41,11 @@ func (si *SqliteIndexer) notifyUpdateSubs() {
 	si.mu.Lock()
 	tSubs := make([]*updateSub, 0, len(si.updateSubs))
 	for _, tSub := range si.updateSubs {
-		tSub := tSub
 		tSubs = append(tSubs, tSub)
 	}
 	si.mu.Unlock()
 
 	for _, tSub := range tSubs {
-		tSub := tSub
 		select {
 		case tSub.ch <- chainIndexUpdated{}:
 		case <-tSub.ctx.Done():

--- a/chain/messagepool/selection_test.go
+++ b/chain/messagepool/selection_test.go
@@ -1481,7 +1481,6 @@ func TestGasReward(t *testing.T) {
 
 	mp := new(MessagePool)
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
 			msg := &types.SignedMessage{
 				Message: types.Message{

--- a/chain/messagesigner/messagesigner_test.go
+++ b/chain/messagesigner/messagesigner_test.go
@@ -175,7 +175,6 @@ func TestMessageSignerSignMessage(t *testing.T) {
 		}},
 	}}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			mpool := newMockMpool()
 			ds := ds_sync.MutexWrap(datastore.NewMapDatastore())

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -252,9 +252,6 @@ func TestForkRefuseCall(t *testing.T) {
 
 	for after := 0; after < 3; after++ {
 		for before := 0; before < 3; before++ {
-			// Makes the lints happy...
-			after := after
-			before := before
 			t.Run(fmt.Sprintf("after:%d,before:%d", after, before), func(t *testing.T) {
 				testForkRefuseCall(t, before, after)
 			})

--- a/chain/store/basefee_test.go
+++ b/chain/store/basefee_test.go
@@ -26,7 +26,6 @@ func TestBaseFee(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
 			preSmoke := ComputeNextBaseFee(types.NewInt(test.basefee), test.limitUsed, test.noOfBlocks, buildconstants.UpgradeSmokeHeight-1)
 			assert.Equal(t, fmt.Sprintf("%d", test.preSmoke), preSmoke.String())

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -910,7 +910,6 @@ func (cs *ChainStore) LoadTipSet(ctx context.Context, tsk types.TipSetKey) (*typ
 	cids := tsk.Cids()
 	blks := make([]*types.BlockHeader, len(cids))
 	for i, c := range cids {
-		i, c := i, c
 		eg.Go(func() error {
 			b, err := cs.GetBlock(ctx, c)
 			if err != nil {

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -595,8 +595,6 @@ func (syncer *Syncer) ValidateTipSet(ctx context.Context, fts *store.FullTipSet,
 
 	var futures []async.ErrorFuture
 	for _, b := range fts.Blocks {
-		b := b // rebind to a scoped variable
-
 		futures = append(futures, async.Err(func() error {
 			if err := syncer.ValidateBlock(ctx, b, useCache); err != nil {
 				if isPermanent(err) {

--- a/chain/types/electionproof_test.go
+++ b/chain/types/electionproof_test.go
@@ -25,7 +25,6 @@ func TestPoissonFunction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("lam-%d-%d", test.lambdaBase, test.lambdaShift), func(t *testing.T) {
 			b := &bytes.Buffer{}
 			b.WriteString("icdf\n")
@@ -58,7 +57,6 @@ func TestLambdaFunction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%s-%s", test.power, test.totalPower), func(t *testing.T) {
 			pow, ok := new(big.Int).SetString(test.power, 10)
 			assert.True(t, ok)

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -318,7 +318,6 @@ func TestEthFilterResultMarshalJSON(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			data, err := json.Marshal(tc.res)
 			require.NoError(t, err)
@@ -442,7 +441,6 @@ func TestEthAddressListUnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			var got EthAddressList
 			err := json.Unmarshal([]byte(tc.input), &got)

--- a/chain/types/fil_test.go
+++ b/chain/types/fil_test.go
@@ -104,7 +104,6 @@ func TestFilShort(t *testing.T) {
 		{fil: "-0.0002212344", expect: "-221.234 μFIL"},
 		{fil: "-0.00022123444", expect: "-221.234 μFIL"},
 	} {
-		s := s
 		t.Run(s.fil, func(t *testing.T) {
 			f, err := ParseFIL(s.fil)
 			require.NoError(t, err)

--- a/chain/types/percent_test.go
+++ b/chain/types/percent_test.go
@@ -20,7 +20,6 @@ func TestPercent(t *testing.T) {
 		{-1012, "-10.12"},
 		{0, "0.0"},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("%d <> %s", tc.p, tc.s), func(t *testing.T) {
 			m, err := tc.p.MarshalJSON()
 			require.NoError(t, err)

--- a/chain/types/tipset.go
+++ b/chain/types/tipset.go
@@ -223,15 +223,15 @@ func (ts *TipSet) MinTimestamp() uint64 {
 func (ts *TipSet) MinTicketBlock() *BlockHeader {
 	blks := ts.Blocks()
 
-	min := blks[0]
+	minBlk := blks[0]
 
 	for _, b := range blks[1:] {
-		if b.LastTicket().Less(min.LastTicket()) {
-			min = b
+		if b.LastTicket().Less(minBlk.LastTicket()) {
+			minBlk = b
 		}
 	}
 
-	return min
+	return minBlk
 }
 
 func (ts *TipSet) ParentMessageReceipts() cid.Cid {

--- a/chain/vm/burn_test.go
+++ b/chain/vm/burn_test.go
@@ -31,7 +31,6 @@ func TestGasBurn(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
 			refund, toBurn := ComputeGasOverestimationBurn(test.used, test.limit)
 			assert.Equal(t, test.refund, refund, "refund")
@@ -62,7 +61,6 @@ func TestGasOutputs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
 			output := ComputeGasOutputs(test.used, test.limit, baseFee, types.NewInt(test.feeCap), types.NewInt(test.premium), true)
 			i2s := func(i uint64) string {

--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -193,7 +193,6 @@ func (*ActorRegistry) transform(instance invokee) (nativeCode, error) {
 	exports := instance.Exports()
 	runtimeType := reflect.TypeOf((*vmr.Runtime)(nil)).Elem()
 	for i, e := range exports {
-		i := i
 		m := e.Method
 		newErr := func(format string, args ...interface{}) error {
 			str := fmt.Sprintf(format, args...)

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -289,7 +289,7 @@ func (rt *Runtime) CreateActor(codeID cid.Cid, addr address.Address) {
 	}
 	act, aerr := rt.vm.areg.Create(codeID, rt)
 	if aerr != nil {
-		rt.Abortf(aerr.RetCode(), aerr.Error())
+		rt.Abort(aerr.RetCode(), aerr.Error())
 	}
 
 	_, err := rt.state.GetActor(addr)
@@ -368,18 +368,23 @@ func (rt *Runtime) Context() context.Context {
 
 func (rt *Runtime) Abortf(code exitcode.ExitCode, msg string, args ...interface{}) {
 	log.Warnf("Abortf: " + fmt.Sprintf(msg, args...))
-	panic(aerrors.NewfSkip(2, code, msg, args...))
+	panic(aerrors.NewSkipf(2, code, msg, args...))
+}
+
+func (rt *Runtime) Abort(code exitcode.ExitCode, msg string) {
+	log.Warnf("Abortf: " + msg)
+	panic(aerrors.NewSkip(2, code, msg))
 }
 
 func (rt *Runtime) AbortStateMsg(msg string) {
-	panic(aerrors.NewfSkip(3, 101, msg))
+	panic(aerrors.NewSkip(3, 101, msg))
 }
 
 func (rt *Runtime) ValidateImmediateCallerType(ts ...cid.Cid) {
 	rt.abortIfAlreadyValidated()
 	callerCid, ok := rt.GetActorCodeCID(rt.Caller())
 	if !ok {
-		panic(aerrors.Fatalf("failed to lookup code cid for caller"))
+		panic(aerrors.Fatal("failed to lookup code cid for caller"))
 	}
 	for _, t := range ts {
 		if t == callerCid {

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -1104,7 +1104,6 @@ If the client id different then claim can be extended up to maximum 5 years from
 		eg := errgroup.Group{}
 		eg.SetLimit(10)
 		for _, msg := range smsgs {
-			msg := msg
 			eg.Go(func() error {
 				wait, err := api.StateWaitMsg(ctx, msg.Cid(), uint64(cctx.Int("confidence")), 2000, true)
 				if err != nil {
@@ -1174,8 +1173,6 @@ func CreateExtendClaimMsg(ctx context.Context, api api.FullNode, pcm map[verifre
 				return nil, xerrors.Errorf("getting claims for miner %s: %s", maddr, err)
 			}
 			for claimID, claim := range claims {
-				claimID := claimID
-				claim := claim
 				// If the client is not the original client - burn datacap
 				if claim.Client != wid {
 					// The new duration should be greater than the original deal duration and claim should not already be expired
@@ -1219,7 +1216,6 @@ func CreateExtendClaimMsg(ctx context.Context, api api.FullNode, pcm map[verifre
 		}
 
 		for claimID := range pcm {
-			claimID := claimID
 			claim, ok := claims[verifregtypes9.ClaimId(claimID)]
 			if !ok {
 				return nil, xerrors.Errorf("claim %d not found for provider %s", claimID, miners[0])
@@ -1252,8 +1248,6 @@ func CreateExtendClaimMsg(ctx context.Context, api api.FullNode, pcm map[verifre
 
 	if len(miners) == 0 && len(pcm) > 0 {
 		for claimID, prov := range pcm {
-			prov := prov
-			claimID := claimID
 			claim, err := api.StateGetClaim(ctx, prov.Addr, verifregtypes9.ClaimId(claimID), types.EmptyTSK)
 			if err != nil {
 				return nil, xerrors.Errorf("could not load the claim %d: %s", claimID, err)

--- a/cli/lotus/lotus.go
+++ b/cli/lotus/lotus.go
@@ -45,7 +45,6 @@ func App() *cli.App {
 	}()
 
 	for _, cmd := range local {
-		cmd := cmd
 		originBefore := cmd.Before
 		cmd.Before = func(cctx *cli.Context) error {
 			if jaeger != nil {

--- a/cli/miner/miner.go
+++ b/cli/miner/miner.go
@@ -56,7 +56,6 @@ func App() *cli.App {
 	}()
 
 	for _, cmd := range local {
-		cmd := cmd
 		originBefore := cmd.Before
 		cmd.Before = func(cctx *cli.Context) error {
 			if jaeger != nil {

--- a/cli/miner/sealing.go
+++ b/cli/miner/sealing.go
@@ -115,14 +115,14 @@ func workersCmd(sealing bool) *cli.Command {
 					}
 
 					str := fmt.Sprint(c)
-					if max := stat.Info.Resources.ResourceSpec(stt.RegisteredSealProof, stt.TaskType).MaxConcurrent; max > 0 {
+					if maxConcurrent := stat.Info.Resources.ResourceSpec(stt.RegisteredSealProof, stt.TaskType).MaxConcurrent; maxConcurrent > 0 {
 						switch {
-						case c < max:
+						case c < maxConcurrent:
 							str = color.GreenString(str)
-						case c >= max:
+						case c >= maxConcurrent:
 							str = color.YellowString(str)
 						}
-						str = fmt.Sprintf("%s/%d", str, max)
+						str = fmt.Sprintf("%s/%d", str, maxConcurrent)
 					} else {
 						str = color.CyanString(str)
 					}

--- a/cmd/lotus-shed/market.go
+++ b/cmd/lotus-shed/market.go
@@ -100,7 +100,6 @@ var marketCronStateCmd = &cli.Command{
 			return err
 		}
 		for e := range dealOpsRecord {
-			e := e
 			err := dealOpsMultiMap.ForEach(abi.ChainEpoch(e), func(id abi.DealID) error {
 				dealOpsRecord[e] = append(dealOpsRecord[e], id)
 				return nil

--- a/cmd/tvx/exec.go
+++ b/cmd/tvx/exec.go
@@ -183,7 +183,7 @@ func execVectorsStdin() error {
 	}
 }
 
-func execVectorFile(r conformance.Reporter, path string) (diffs []string, error error) {
+func execVectorFile(r conformance.Reporter, path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open test vector: %w", err)

--- a/conformance/corpus_test.go
+++ b/conformance/corpus_test.go
@@ -132,7 +132,6 @@ func TestConformance(t *testing.T) {
 			}
 
 			for _, variant := range vector.Pre.Variants {
-				variant := variant
 				t.Run(variant.ID, func(t *testing.T) {
 					_, _ = invokee(t, &vector, &variant) //nolint:errcheck
 				})

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -185,7 +185,6 @@ func ExecuteTipsetVector(r Reporter, vector *schema.TestVector, variant *schema.
 	var receiptsIdx int
 	var prevEpoch = baseEpoch
 	for i, ts := range vector.ApplyTipsets {
-		ts := ts // capture
 		execEpoch := baseEpoch + abi.ChainEpoch(ts.EpochOffset)
 		params := ExecuteTipsetParams{
 			Preroot:     root,

--- a/gateway/eth_sub.go
+++ b/gateway/eth_sub.go
@@ -29,7 +29,6 @@ func (e *EthSubHandler) AddSub(ctx context.Context, id ethtypes.EthSubscriptionI
 	defer e.lk.Unlock()
 
 	for _, p := range e.queued[id] {
-		p := p // copy
 		if err := sink(ctx, &p); err != nil {
 			return err
 		}

--- a/gateway/node_test.go
+++ b/gateway/node_test.go
@@ -85,7 +85,6 @@ func TestGatewayAPIChainGetTipSetByHeight(t *testing.T) {
 		},
 	}}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockGatewayDepsAPI{}
 			a := NewNode(mock)

--- a/itests/eth_conformance_test.go
+++ b/itests/eth_conformance_test.go
@@ -401,14 +401,13 @@ func TestEthOpenRPCConformance(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		name := tc.method
 		if tc.variant != "" {
 			name += "_" + tc.variant
 		}
 		t.Run(name, func(t *testing.T) {
 			if tc.skipReason != "" {
-				t.Skipf(tc.skipReason)
+				t.Skip(tc.skipReason)
 			}
 
 			schema, ok := schemas[tc.method]

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -109,7 +109,7 @@ func TestEthNewPendingTransactionFilter(t *testing.T) {
 	select {
 	case <-waitAllCh:
 	case <-ctx.Done():
-		t.Errorf("timeout waiting to pack messages")
+		t.Error("timeout waiting to pack messages")
 	}
 
 	expected := make(map[string]bool)
@@ -257,7 +257,7 @@ func TestEthNewPendingTransactionSub(t *testing.T) {
 	select {
 	case <-waitAllCh:
 	case <-ctx.Done():
-		t.Errorf("timeout waiting to pack messages")
+		t.Error("timeout waiting to pack messages")
 	}
 
 	expected := make(map[string]bool)
@@ -353,7 +353,7 @@ func TestEthNewBlockFilter(t *testing.T) {
 	select {
 	case <-waitAllCh:
 	case <-ctx.Done():
-		t.Errorf("timeout waiting to pack messages")
+		t.Error("timeout waiting to pack messages")
 	}
 
 	expected := make(map[string]bool)
@@ -831,7 +831,6 @@ func TestEthGetLogs(t *testing.T) {
 	messages := invokeAndWaitUntilAllOnChain(t, client, invocations)
 
 	for _, tc := range testCases {
-		tc := tc // appease the lint despot
 		t.Run(tc.name, func(t *testing.T) {
 			res, err := client.EthGetLogs(ctx, tc.spec)
 			require.NoError(err)
@@ -887,7 +886,6 @@ func TestEthGetFilterChanges(t *testing.T) {
 	messages := invokeAndWaitUntilAllOnChain(t, client, invocations)
 
 	for _, tc := range testCases {
-		tc := tc // appease the lint despot
 		t.Run(tc.name, func(t *testing.T) {
 			filterID, ok := testFilters[tc.name]
 			require.True(ok)
@@ -955,7 +953,6 @@ func TestEthSubscribeLogs(t *testing.T) {
 	time.Sleep(blockTime * 6)
 
 	for _, tc := range testCases {
-		tc := tc // appease the lint despot
 		t.Run(tc.name, func(t *testing.T) {
 			responseCh, ok := testResponses[tc.name]
 			require.True(ok)
@@ -1008,7 +1005,6 @@ func TestEthGetFilterLogs(t *testing.T) {
 	messages := invokeAndWaitUntilAllOnChain(t, client, invocations)
 
 	for _, tc := range testCases {
-		tc := tc // appease the lint despot
 		t.Run(tc.name, func(t *testing.T) {
 			filterID, ok := testFilters[tc.name]
 			require.True(ok)
@@ -1226,7 +1222,6 @@ func TestEthGetLogsWithBlockRanges(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // appease the lint despot
 		t.Run(tc.name, func(t *testing.T) {
 			res, err := client.EthGetLogs(ctx, tc.spec)
 			require.NoError(err)
@@ -2344,7 +2339,7 @@ func AssertEthLogs(t *testing.T, actual []*ethtypes.EthLog, expected []ExpectedE
 				}
 			}
 
-			t.Errorf(buf.String())
+			t.Error(buf.String())
 		}
 	}
 
@@ -2355,7 +2350,7 @@ func AssertEthLogs(t *testing.T, actual []*ethtypes.EthLog, expected []ExpectedE
 			buf.WriteString(fmt.Sprintf("  address: %s\n", expected[i].Address))
 			buf.WriteString(fmt.Sprintf("  topics: %s\n", formatTopics(expected[i].Topics)))
 			buf.WriteString(fmt.Sprintf("  data: %x\n", expected[i].Data))
-			t.Errorf(buf.String())
+			t.Error(buf.String())
 		}
 	}
 }

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -76,7 +76,6 @@ func TestFEVMRecursive(t *testing.T) {
 
 	// Successful calls
 	for _, callCount := range callCounts {
-		callCount := callCount // linter unhappy unless callCount is local to loop
 		t.Run(fmt.Sprintf("TestFEVMRecursive%d", callCount), func(t *testing.T) {
 			_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", buildInputFromUint64(callCount))
 			require.NoError(t, err)
@@ -94,7 +93,6 @@ func TestFEVMRecursiveFail(t *testing.T) {
 	// Unsuccessful calls
 	failCallCounts := []uint64{340, 400, 600, 850, 1000}
 	for _, failCallCount := range failCallCounts {
-		failCallCount := failCallCount // linter unhappy unless callCount is local to loop
 		t.Run(fmt.Sprintf("TestFEVMRecursiveFail%d", failCallCount), func(t *testing.T) {
 			_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", buildInputFromUint64(failCallCount))
 			require.Error(t, err)
@@ -1037,8 +1035,6 @@ func TestFEVMErrorParsing(t *testing.T) {
 		"failDivZero()":      "0x4e487b710000000000000000000000000000000000000000000000000000000000000012", // DivideByZero()
 		"failCustom()":       customError,
 	} {
-		sig := sig
-		expected := expected
 		t.Run(sig, func(t *testing.T) {
 			entryPoint := kit.CalcFuncSignature(sig)
 			t.Run("EthCall", func(t *testing.T) {

--- a/itests/supply_test.go
+++ b/itests/supply_test.go
@@ -117,23 +117,23 @@ func TestCirciulationSupplyUpgrade(t *testing.T) {
 	// This allows us to normalize against fluctuations in circulating supply based on the underlying
 	// dynamics irrelevant to this change
 
-	max := height0
+	maxHeight := height0
 	if height0 < height1 {
-		max = height1
+		maxHeight = height1
 	}
-	max = max + 1 // Measure supply at height after the deal locking funds was published
+	maxHeight = maxHeight + 1 // Measure supply at height after the deal locking funds was published
 
 	// Let both chains catch up
 	fullNode0.WaitTillChain(ctx, func(ts *types.TipSet) bool {
-		return ts.Height() >= max
+		return ts.Height() >= maxHeight
 	})
 	fullNode1.WaitTillChain(ctx, func(ts *types.TipSet) bool {
-		return ts.Height() >= max
+		return ts.Height() >= maxHeight
 	})
 
-	ts0, err := fullNode0.ChainGetTipSetByHeight(ctx, max, types.EmptyTSK)
+	ts0, err := fullNode0.ChainGetTipSetByHeight(ctx, maxHeight, types.EmptyTSK)
 	require.NoError(t, err)
-	ts1, err := fullNode1.ChainGetTipSetByHeight(ctx, max, types.EmptyTSK)
+	ts1, err := fullNode1.ChainGetTipSetByHeight(ctx, maxHeight, types.EmptyTSK)
 	require.NoError(t, err)
 
 	nv22Supply, err := fullNode0.StateVMCirculatingSupplyInternal(ctx, ts0.Key())

--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -42,7 +42,6 @@ func TestWindowedPost(t *testing.T) {
 		162,  // while sealing
 		5000, // while proving
 	} {
-		height := height // copy to satisfy lints
 		t.Run(fmt.Sprintf("upgrade-%d", height), func(t *testing.T) {
 			testWindowPostUpgrade(t, blocktime, nSectors, height)
 		})

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -477,8 +477,6 @@ func (e *ethTransaction) EthGetBlockReceiptsLimited(ctx context.Context, blockPa
 
 	ethReceipts := make([]*api.EthTxReceipt, 0, len(msgs))
 	for i, msg := range msgs {
-		msg := msg
-
 		tx, err := newEthTx(ctx, e.chainStore, stateTree, ts.Height(), tsCid, msg.Cid(), i)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to create EthTx: %w", err)

--- a/node/impl/eth/utils.go
+++ b/node/impl/eth/utils.go
@@ -319,7 +319,6 @@ func parseEthTopics(topics ethtypes.EthTopicSpec) (map[string][][]byte, error) {
 		// Ethereum topics are emitted using `LOG{0..4}` opcodes resulting in topics1..4
 		key := fmt.Sprintf("t%d", idx+1)
 		for _, v := range vals {
-			v := v // copy the ethhash to avoid repeatedly referencing the same one.
 			keys[key] = append(keys[key], v[:])
 		}
 	}

--- a/node/impl/full/multisig.go
+++ b/node/impl/full/multisig.go
@@ -237,9 +237,9 @@ func (a *MsigAPI) msigApproveOrCancelTxnHash(ctx context.Context, operation api.
 	}, nil
 }
 
-func serializeAddParams(new address.Address, inc bool) ([]byte, error) {
+func serializeAddParams(newa address.Address, inc bool) ([]byte, error) {
 	enc, actErr := actors.SerializeParams(&multisig2.AddSignerParams{
-		Signer:   new,
+		Signer:   newa,
 		Increase: inc,
 	})
 	if actErr != nil {
@@ -249,10 +249,10 @@ func serializeAddParams(new address.Address, inc bool) ([]byte, error) {
 	return enc, nil
 }
 
-func serializeSwapParams(old address.Address, new address.Address) ([]byte, error) {
+func serializeSwapParams(olda address.Address, newa address.Address) ([]byte, error) {
 	enc, actErr := actors.SerializeParams(&multisig2.SwapSignerParams{
-		From: old,
-		To:   new,
+		From: olda,
+		To:   newa,
 	})
 	if actErr != nil {
 		return nil, actErr

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -1111,15 +1111,15 @@ func (a *StateAPI) stateComputeDataCIDv3(ctx context.Context, maddr address.Addr
 	return *ucid, nil
 }
 
-func (a *StateAPI) StateChangedActors(ctx context.Context, old cid.Cid, new cid.Cid) (map[string]types.Actor, error) {
+func (a *StateAPI) StateChangedActors(ctx context.Context, oldc cid.Cid, newc cid.Cid) (map[string]types.Actor, error) {
 	store := a.Chain.ActorStore(ctx)
 
-	oldTree, err := state.LoadStateTree(store, old)
+	oldTree, err := state.LoadStateTree(store, oldc)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load old state tree: %w", err)
 	}
 
-	newTree, err := state.LoadStateTree(store, new)
+	newTree, err := state.LoadStateTree(store, newc)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load new state tree: %w", err)
 	}

--- a/paychmgr/paych_test.go
+++ b/paychmgr/paych_test.go
@@ -195,7 +195,6 @@ func TestCheckVoucherValid(t *testing.T) {
 	}}
 
 	for _, tcase := range tcases {
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			// Create an actor for the channel with the test case balance
 			act := &types.Actor{

--- a/paychmgr/store.go
+++ b/paychmgr/store.go
@@ -210,7 +210,7 @@ func (ps *Store) findChan(ctx context.Context, filter func(ci *ChannelInfo) bool
 
 // findChans loops over all channels, only including those that pass the filter.
 // max is the maximum number of channels to return. Set to zero to return unlimited channels.
-func (ps *Store) findChans(ctx context.Context, filter func(*ChannelInfo) bool, max int) ([]ChannelInfo, error) {
+func (ps *Store) findChans(ctx context.Context, filter func(*ChannelInfo) bool, maxMatches int) ([]ChannelInfo, error) {
 	res, err := ps.ds.Query(ctx, dsq.Query{Prefix: dsKeyChannelInfo})
 	if err != nil {
 		return nil, err
@@ -244,7 +244,7 @@ func (ps *Store) findChans(ctx context.Context, filter func(*ChannelInfo) bool, 
 		// If we've reached the maximum number of matches, return.
 		// Note that if max is zero we return an unlimited number of matches
 		// because len(matches) will always be at least 1.
-		if len(matches) == max {
+		if len(matches) == maxMatches {
 			return matches, nil
 		}
 	}

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -484,7 +484,6 @@ func (st *Local) Reserve(ctx context.Context, sid storiface.SectorRef, ft storif
 	}()
 
 	for _, fileType := range ft.AllSet() {
-		fileType := fileType
 		id := storiface.ID(storiface.PathByType(storageIDs, fileType))
 
 		p, ok := st.paths[id]

--- a/storage/pipeline/checks.go
+++ b/storage/pipeline/checks.go
@@ -53,8 +53,6 @@ func checkPieces(ctx context.Context, maddr address.Address, sn abi.SectorNumber
 	var offset abi.PaddedPieceSize
 
 	for i, p := range pieces {
-		p, i := p, i
-
 		// check that the piece is correctly aligned
 		if offset%p.Piece().Size != 0 {
 			return &ErrInvalidPiece{xerrors.Errorf("sector %d piece %d is not aligned: size=%xh offset=%xh off-by=%xh", sn, i, p.Piece().Size, offset, offset%p.Piece().Size)}

--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -641,7 +641,6 @@ func (b *CommitBatcher) aggregateProofType(nv network.Version) (abi.RegisteredAg
 
 func (b *CommitBatcher) allocationCheck(Pieces []miner.PieceActivationManifest, precomitInfo *miner.SectorPreCommitOnChainInfo, miner abi.ActorID, ts *types.TipSet) error {
 	for _, p := range Pieces {
-		p := p
 		// skip pieces not claiming an allocation
 		if p.VerifiedAllocationKey == nil {
 			continue

--- a/storage/pipeline/states_failed.go
+++ b/storage/pipeline/states_failed.go
@@ -555,8 +555,6 @@ func recoveryPiecesToFix(ctx context.Context, api SealingAPI, sector SectorInfo,
 	nonBuiltinMarketPieces := 0
 
 	for i, p := range sector.Pieces {
-		i, p := i, p
-
 		err := p.handleDealInfo(handleDealInfoParams{
 			FillerHandler: func(info UniversalPieceInfo) error {
 				// if no deal is associated with the piece, ensure that we added it as

--- a/storage/pipeline/states_sealing.go
+++ b/storage/pipeline/states_sealing.go
@@ -717,7 +717,6 @@ func (m *Sealing) processPieces(ctx context.Context, sector SectorInfo) ([]miner
 	pams := make([]miner.PieceActivationManifest, 0, len(sector.Pieces))
 
 	for _, piece := range sector.Pieces {
-		piece := piece
 		if piece.HasDealInfo() {
 			info := piece.DealInfo()
 			// If we have a dealID then covert to PAM

--- a/storage/sealer/sched_assigner_common.go
+++ b/storage/sealer/sched_assigner_common.go
@@ -192,7 +192,6 @@ func (a *AssignerCommon) TrySched(sh *Scheduler) {
 
 		scheduledWindows[wnd] = struct{}{}
 
-		window := window // copy
 		select {
 		case sh.OpenWindows[wnd].Done <- &window:
 		default:

--- a/storage/sealer/sched_resources.go
+++ b/storage/sealer/sched_resources.go
@@ -203,18 +203,18 @@ func (a *ActiveResources) CanHandleRequest(schedID uuid.UUID, tt sealtasks.SealT
 
 // utilization returns a number in 0..1 range indicating fraction of used resources
 func (a *ActiveResources) utilization(wr storiface.WorkerResources) float64 { // todo task type
-	var max float64
+	var maxutil float64
 
 	cpu := float64(a.cpuUse) / float64(wr.CPUs)
-	max = cpu
+	maxutil = cpu
 
 	memUsed := a.memUsedMin
 	if memUsed < wr.MemUsed {
 		memUsed = wr.MemUsed
 	}
 	memMin := float64(memUsed) / float64(wr.MemPhysical)
-	if memMin > max {
-		max = memMin
+	if memMin > maxutil {
+		maxutil = memMin
 	}
 
 	vmemUsed := a.memUsedMax
@@ -223,18 +223,18 @@ func (a *ActiveResources) utilization(wr storiface.WorkerResources) float64 { //
 	}
 	memMax := float64(vmemUsed) / float64(wr.MemPhysical+wr.MemSwap)
 
-	if memMax > max {
-		max = memMax
+	if memMax > maxutil {
+		maxutil = memMax
 	}
 
 	if len(wr.GPUs) > 0 {
 		gpuMax := a.gpuUsed / float64(len(wr.GPUs))
-		if gpuMax > max {
-			max = gpuMax
+		if gpuMax > maxutil {
+			maxutil = gpuMax
 		}
 	}
 
-	return max
+	return maxutil
 }
 
 func (a *ActiveResources) taskCount(tt *sealtasks.SealTaskType) int {

--- a/storage/wdpost/wdpost_run_faults.go
+++ b/storage/wdpost/wdpost_run_faults.go
@@ -231,13 +231,11 @@ func (s *WindowPoStScheduler) asyncFaultRecover(di dline.Info, ts *types.TipSet)
 		if len(recoveries) == len(sigmsgs) {
 			for i, recovery := range recoveries {
 				// clone for function literal
-				recovery := recovery
-				msgCID := optionalCid(sigmsgs[i])
 				s.journal.RecordEvent(s.evtTypes[evtTypeWdPoStRecoveries], func() interface{} {
 					j := WdPoStRecoveriesProcessedEvt{
 						evtCommon:    s.getEvtCommon(err),
 						Declarations: recovery,
-						MessageCID:   msgCID,
+						MessageCID:   optionalCid(sigmsgs[i]),
 					}
 					j.Error = err
 					return j


### PR DESCRIPTION
Draft because it's not finished. I'm bailing for now because there's so much to fix. If someone else wants to pick this up in the meantime then you'd be welcome to take it.

The new `G115` gosec errors (integer overflow on conversion) are the most annoying and I'm tempted to disable it entirely because they're not going to be easy to work through, but it's not a bad error to check for so we should probably at least try to deal with them.