### PR TITLE
chore(test): skip unfixed flaky gateway limits test

### DIFF
--- a/itests/gateway_test.go
+++ b/itests/gateway_test.go
@@ -352,6 +352,12 @@ func sendFunds(ctx context.Context, fromNode *kit.TestFullNode, fromAddr address
 }
 
 func TestGatewayRateLimits(t *testing.T) {
+	t.Skip("this test is flaky and needs to be fixed")
+	// Fails on the RequireDuration check, e.g. error like:
+	// 	Max difference between 2025-02-10 12:05:34.63725116 +0000 UTC m=+30.240446844 and 2025-02-10 12:05:33.519935593 +0000 UTC m=+29.123131278 allowed is 800ms, but difference was 1.117315566s
+	// There may be additional calls going through the API that only show up at random and these
+	// aren't accounted for. See note below about paymentChannelSettler, which is one such call.
+
 	req := require.New(t)
 
 	kit.QuietMiningLogs()

--- a/itests/gateway_test.go
+++ b/itests/gateway_test.go
@@ -357,6 +357,7 @@ func TestGatewayRateLimits(t *testing.T) {
 	// 	Max difference between 2025-02-10 12:05:34.63725116 +0000 UTC m=+30.240446844 and 2025-02-10 12:05:33.519935593 +0000 UTC m=+29.123131278 allowed is 800ms, but difference was 1.117315566s
 	// There may be additional calls going through the API that only show up at random and these
 	// aren't accounted for. See note below about paymentChannelSettler, which is one such call.
+	// Tracking issue: https://github.com/filecoin-project/lotus/issues/12566
 
 	req := require.New(t)
 


### PR DESCRIPTION
I'll drop some notes in https://github.com/filecoin-project/lotus/issues/12566 further to the comment I'm leaving in here. It's been flaky too long and hasn't been prioritised to be fixed.