### PR TITLE
chore: disable F3 manifest autofusing on butterflynet for testing purposes

### DIFF
--- a/build/buildconstants/params_butterfly.go
+++ b/build/buildconstants/params_butterfly.go
@@ -108,4 +108,4 @@ var F3ManifestServerID = MustParseID("12D3KooWJr9jy4ngtJNR7JC1xgLFra3DjEtyxskRYW
 // The initial F3 power table CID.
 var F3InitialPowerTableCID cid.Cid = cid.Undef
 
-const F3BootstrapEpoch abi.ChainEpoch = 1000
+const F3BootstrapEpoch abi.ChainEpoch = -1


### PR DESCRIPTION
To be able to test F3 on butterflynet without having to build a bespoke image of lotus or reset the butterflynet change the F3 bootstrap epoch to -1. This disables the autofusing of static manifest.
