### PR TITLE
chore: publish 2k docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,7 @@ jobs:
           - butterflynet
           - calibnet
           - debug
+          - 2k
         include:
           - image: lotus
             network: mainnet


### PR DESCRIPTION
In addition to existing networks, also publish docker images for 2k network.

