### PR TITLE
chore: publish containers for `arm/64` platform and enable build cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,8 @@ jobs:
           sha="$(git rev-parse --short HEAD)"
           echo "ref=$ref" | tee -a "$GITHUB_OUTPUT"
           echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -108,5 +110,8 @@ jobs:
           push: ${{ env.PUBLISH == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           build-args: |
             ${{ matrix.network != 'mainnet' && format('GOFLAGS=-tags={0}', matrix.network) || ''}}


### PR DESCRIPTION
Publish containers for `arm64` architecture. Because, ARM-based cloud instances are much cheaper to run than other architectures.

While at it, enable caching for docker push step using github actions.
