### PR TITLE
chore: upgrade to go-f3 `v0.8.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/filecoin-project/go-cbor-util v0.0.1
 	github.com/filecoin-project/go-commp-utils/v2 v2.1.0
 	github.com/filecoin-project/go-crypto v0.1.0
-	github.com/filecoin-project/go-f3 v0.8.1
+	github.com/filecoin-project/go-f3 v0.8.2
 	github.com/filecoin-project/go-fil-commcid v0.2.0
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.4.0
 	github.com/filecoin-project/go-jsonrpc v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/filecoin-project/go-commp-utils/v2 v2.1.0/go.mod h1:NbxJYlhxtWaNhlVCj
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-crypto v0.1.0 h1:Pob2MphoipMbe/ksxZOMcQvmBHAd3sI/WEqcbpIsGI0=
 github.com/filecoin-project/go-crypto v0.1.0/go.mod h1:K9UFXvvoyAVvB+0Le7oGlKiT9mgA5FHOJdYQXEE8IhI=
-github.com/filecoin-project/go-f3 v0.8.1 h1:stlc3ZW5rHXVdvTbCreKh1475GB7noTtvfPGraOkdRA=
-github.com/filecoin-project/go-f3 v0.8.1/go.mod h1:dAqNQ59L/zxjt32KI5kM8gzPtN8odwYHTjNcEq5wp1s=
+github.com/filecoin-project/go-f3 v0.8.2 h1:oH1KOMvr4jGTvqUNfM7+4VcznJYjXa1z86Notp744nc=
+github.com/filecoin-project/go-f3 v0.8.2/go.mod h1:dAqNQ59L/zxjt32KI5kM8gzPtN8odwYHTjNcEq5wp1s=
 github.com/filecoin-project/go-fil-commcid v0.2.0 h1:B+5UX8XGgdg/XsdUpST4pEBviKkFOw+Fvl2bLhSKGpI=
 github.com/filecoin-project/go-fil-commcid v0.2.0/go.mod h1:8yigf3JDIil+/WpqR5zoKyP0jBPCOGtEqq/K1CcMy9Q=
 github.com/filecoin-project/go-fil-commp-hashhash v0.2.0 h1:HYIUugzjq78YvV3vC6rL95+SfC/aSTVSnZSZiDV5pCk=


### PR DESCRIPTION
Upgrade to the latest `go-f3` to pull in the bug fixes and GPBFT topic name change.

