### PR TITLE
feat(miner): remove batch balancer-related functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   - `DealIDs` has now been removed from the public API's `SectorOnChainInfo` (was deprecated in FIP-0079)
   - Removed `--only-cc` from `spcli sectors extend` command
   - Change circulating supply calculation for calibnet, butterflynet and 2k for nv25 upgrade; see ([filecoin-project/lotus#12938](https://github.com/filecoin-project/lotus/pull/12938)) for more information
+- feat(miner): remove batch balancer-related functionality ([filecoin-project/lotus#12919](https://github.com/filecoin-project/lotus/pull/12919))
 
 # UNRELEASED v.1.32.0
 

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -79,6 +79,7 @@ const (
 	SealRandomnessLookback         = ChainFinality
 	PaychSettleDelay               = paych16.SettleDelay
 	MaxPreCommitRandomnessLookback = builtin16.EpochsInDay + SealRandomnessLookback
+	DeclarationsMax                = 3000
 )
 
 var (
@@ -842,6 +843,9 @@ func GetAddressedSectorsMax(nwVer network.Version) (int, error) {
 	}
 }
 
+// GetDeclarationsMax is deprecated
+//
+// DEPRECATED: remove after nv25 (FIP 0100)
 func GetDeclarationsMax(nwVer network.Version) (int, error) {
 	v, err := actorstypes.VersionForNetwork(nwVer)
 	if err != nil {
@@ -912,7 +916,7 @@ func GetDeclarationsMax(nwVer network.Version) (int, error) {
 
 	case actorstypes.Version16:
 
-		return miner16.DeclarationsMax, nil
+		return DeclarationsMax, nil
 
 	default:
 		return 0, xerrors.Errorf("unsupported network version")

--- a/chain/actors/policy/policy.go.template
+++ b/chain/actors/policy/policy.go.template
@@ -37,6 +37,7 @@ const (
 	SealRandomnessLookback         = ChainFinality
 	PaychSettleDelay               = paych{{.latestVersion}}.SettleDelay
 	MaxPreCommitRandomnessLookback = builtin{{.latestVersion}}.EpochsInDay + SealRandomnessLookback
+	DeclarationsMax                = 3000
 )
 
 var (
@@ -283,6 +284,9 @@ func GetAddressedSectorsMax(nwVer network.Version) (int, error) {
 	}
 }
 
+// GetDeclarationsMax is deprecated
+// 
+// DEPRECATED: remove after nv25 (FIP 0100)
 func GetDeclarationsMax(nwVer network.Version) (int, error) {
 	v, err := actorstypes.VersionForNetwork(nwVer)
 	if err != nil {
@@ -294,6 +298,8 @@ func GetDeclarationsMax(nwVer network.Version) (int, error) {
 			{{if (eq . 0)}}
 				// TODO: Should we instead error here since the concept doesn't exist yet?
 				return miner{{.}}.AddressedPartitionsMax, nil
+			{{else if (ge . 16)}}
+				return DeclarationsMax, nil	
 			{{else}}
 				return miner{{.}}.DeclarationsMax, nil
 			{{end}}

--- a/cli/spcli/sectors.go
+++ b/cli/spcli/sectors.go
@@ -864,6 +864,7 @@ func SectorsExtendCmd(getActorAddress ActorAddressGetter) *cli.Command {
 				return err
 			}
 
+			// TODO: remove after nv25 (FIP 0100)
 			declMax, err := policy.GetDeclarationsMax(nv)
 			if err != nil {
 				return err

--- a/cmd/lotus-sim/simulation/stages/precommit_stage.go
+++ b/cmd/lotus-sim/simulation/stages/precommit_stage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/network"
-	miner5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
@@ -27,7 +26,7 @@ import (
 
 const (
 	minPreCommitBatchSize = 1
-	maxPreCommitBatchSize = miner5.PreCommitSectorBatchMaxSize
+	maxPreCommitBatchSize = 256
 )
 
 type PreCommitStage struct {

--- a/documentation/en/default-lotus-miner-config.toml
+++ b/documentation/en/default-lotus-miner-config.toml
@@ -381,6 +381,7 @@
   # env var: LOTUS_SEALING_COMMITBATCHSLACK
   #CommitBatchSlack = "1h0m0s"
 
+  # DEPRECATED: remove after nv25 (FIP 0100)
   # network BaseFee below which to stop doing precommit batching, instead
   # sending precommit messages to the chain individually. When the basefee is
   # below this threshold, precommit messages will get sent out immediately.
@@ -389,6 +390,7 @@
   # env var: LOTUS_SEALING_BATCHPRECOMMITABOVEBASEFEE
   #BatchPreCommitAboveBaseFee = "0.00000000032 FIL"
 
+  # DEPRECATED: remove after nv25 (FIP 0100)
   # network BaseFee below which to stop doing commit aggregation, instead
   # submitting proofs to the chain individually
   #

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -122,8 +122,8 @@ func DefaultStorageMiner() *StorageMiner {
 			AvailableBalanceBuffer:     types.FIL(big.Zero()),
 			DisableCollateralFallback:  false,
 
-			MaxPreCommitBatch:  miner5.PreCommitSectorBatchMaxSize, // up to 256 sectors
-			PreCommitBatchWait: Duration(24 * time.Hour),           // this should be less than 31.5 hours, which is the expiration of a precommit ticket
+			MaxPreCommitBatch:  256,
+			PreCommitBatchWait: Duration(24 * time.Hour), // this should be less than 31.5 hours, which is the expiration of a precommit ticket
 			// XXX snap deals wait deals slack if first
 			PreCommitBatchSlack: Duration(3 * time.Hour), // time buffer for forceful batch submission before sectors/deals in batch would start expiring, higher value will lower the chances for message fail due to expiration
 

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1083,7 +1083,8 @@ This is useful for forcing all deals to be assigned as snap deals to sectors mar
 			Name: "BatchPreCommitAboveBaseFee",
 			Type: "types.FIL",
 
-			Comment: `network BaseFee below which to stop doing precommit batching, instead
+			Comment: `DEPRECATED: remove after nv25 (FIP 0100)
+network BaseFee below which to stop doing precommit batching, instead
 sending precommit messages to the chain individually. When the basefee is
 below this threshold, precommit messages will get sent out immediately.`,
 		},
@@ -1091,7 +1092,8 @@ below this threshold, precommit messages will get sent out immediately.`,
 			Name: "AggregateAboveBaseFee",
 			Type: "types.FIL",
 
-			Comment: `network BaseFee below which to stop doing commit aggregation, instead
+			Comment: `DEPRECATED: remove after nv25 (FIP 0100)
+network BaseFee below which to stop doing commit aggregation, instead
 submitting proofs to the chain individually`,
 		},
 		{

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -294,11 +294,13 @@ type SealingConfig struct {
 	// time buffer for forceful batch submission before sectors/deals in batch would start expiring
 	CommitBatchSlack Duration
 
+	// DEPRECATED: remove after nv25 (FIP 0100)
 	// network BaseFee below which to stop doing precommit batching, instead
 	// sending precommit messages to the chain individually. When the basefee is
 	// below this threshold, precommit messages will get sent out immediately.
 	BatchPreCommitAboveBaseFee types.FIL
 
+	// DEPRECATED: remove after nv25 (FIP 0100)
 	// network BaseFee below which to stop doing commit aggregation, instead
 	// submitting proofs to the chain individually
 	AggregateAboveBaseFee types.FIL

--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -233,7 +233,8 @@ func (b *CommitBatcher) maybeStartBatch(notif bool) ([]sealiface.CommitBatchRes,
 
 	individual := (total < cfg.MinCommitBatch) || (total < miner.MinAggregatedSectors) || blackedOut() || !cfg.AggregateCommits
 
-	if !individual && !cfg.AggregateAboveBaseFee.Equals(big.Zero()) {
+	// TODO: remove after nv25 (FIP 0100)
+	if !individual && !cfg.AggregateAboveBaseFee.Equals(big.Zero()) && nv < network.Version25 {
 		if ts.MinTicketBlock().ParentBaseFee.LessThan(cfg.AggregateAboveBaseFee) {
 			individual = true
 		}

--- a/storage/pipeline/sealiface/config.go
+++ b/storage/pipeline/sealiface/config.go
@@ -52,7 +52,9 @@ type Config struct {
 	CommitBatchWait  time.Duration
 	CommitBatchSlack time.Duration
 
-	AggregateAboveBaseFee      abi.TokenAmount
+	// DEPRECATED: remove after nv25 (FIP 0100)
+	AggregateAboveBaseFee abi.TokenAmount
+	// DEPRECATED: remove after nv25 (FIP 0100)
 	BatchPreCommitAboveBaseFee abi.TokenAmount
 
 	MaxSectorProveCommitsSubmittedPerEpoch uint64

--- a/storage/pipeline/terminate_batch.go
+++ b/storage/pipeline/terminate_batch.go
@@ -197,6 +197,7 @@ func (b *TerminateBatcher) processBatch(notif, after bool) (*cid.Cid, error) {
 			break
 		}
 
+		// TODO: remove after nv25 (FIP 0100)
 		if len(params.Terminations) >= miner.DeclarationsMax {
 			break
 		}

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -544,6 +544,7 @@ func (s *WindowPoStScheduler) BatchPartitions(partitions []api.Partition, nv net
 		return nil, xerrors.Errorf("getting sectors per partition: %w", err)
 	}
 
+	// TODO: remove after nv25 (FIP 0100)
 	// Also respect the AddressedPartitionsMax (which is the same as DeclarationsMax (which is all really just MaxPartitionsPerDeadline))
 	declMax, err := policy.GetDeclarationsMax(nv)
 	if err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

close #12902

## Proposed Changes
<!-- A clear list of the changes being made -->

Removed BatchPreCommitAboveBaseFee, AggregateAboveBaseFee, and the related checks.

The MinCommitBatch is actually constrained by the SNARK circuits, so it will remain at 4 without change:

  - You need 4 or more sectors to ensure that the verification time for aggregated proofs is smaller than for batched proofs.

  - You need 13 sectors or more to ensure that the aggregated proof size is smaller than the batched proof size.

The MaxCommitBatch limit comes from the original ([FIP-0013](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0013.md#scale-and-limits-1)), and it seems there's not much incentive to modify it, so these two parameters will remain unchanged.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
