### PR TITLE
fix: allow users to optionally configure node startup even if index reconciliation fails

### DIFF
--- a/node/config/types.go
+++ b/node/config/types.go
@@ -640,6 +640,8 @@ type ChainIndexerConfig struct {
 	// - This ensures that the index is always in a consistent state with the chain before the node starts.
 	//
 	// Default: false
+	// // WARNING: Only set to true if you are okay with an index that may be out of sync with the chain.
+	// This can lead to inaccurate or missing data in RPC responses that depend on the indexer.
 	AllowIndexReconciliationFailure bool
 }
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -628,6 +628,19 @@ type ChainIndexerConfig struct {
 	// Note: Setting this value too low may result in incomplete indexing, while setting it too high
 	// may increase startup time.
 	MaxReconcileTipsets uint64
+
+	// AllowIndexReconciliationFailure determines whether node startup should continue
+	// if the index reconciliation with the chain state fails.
+	//
+	// When set to true:
+	// - If index reconciliation fails during startup, the node will log a warning but continue to start.
+	//
+	// When set to false (default):
+	// - If index reconciliation fails during startup, the node will fail to start.
+	// - This ensures that the index is always in a consistent state with the chain before the node starts.
+	//
+	// Default: false
+	AllowIndexReconciliationFailure bool
 }
 
 type HarmonyDB struct {


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/issues/12897.

There chain state has some missing messages and this PR enables them to start the node even if index reconciliation fails.