### PR TITLE
chore(fees): add initial fees & migration testing (FIP-0100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - chore: upgrade drand client. ([filecoin-project/lotus#12830](https://github.com/filecoin-project/lotus/pull/12830))
 - chore: upgrade go-state-types with big.Int{} change that means an empty big.Int is now treated as zero for all operations ([filecoin-project/lotus#12936](https://github.com/filecoin-project/lotus/pull/12936))
 - fix!: change circulating supply calculation for calibnet, butterflynet and 2k for nv25 upgrade. ([filecoin-project/lotus#12938](https://github.com/filecoin-project/lotus/pull/12938))
+- feat: add DailyFee integration tests ([filecoin-project/lotus#12942](https://github.com/filecoin-project/lotus/pull/12942))
 
 # UNRELEASED v.1.32.0
 

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -1398,6 +1398,7 @@ const (
 type Deadline struct {
 	PostSubmissions      bitfield.BitField
 	DisputableProofCount uint64
+	DailyFee             abi.TokenAmount
 }
 
 type Partition struct {

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -21786,7 +21786,8 @@
                                     5,
                                     1
                                 ],
-                                "DisputableProofCount": 42
+                                "DisputableProofCount": 42,
+                                "DailyFee": "0"
                             }
                         ]
                     ],
@@ -21794,6 +21795,10 @@
                         {
                             "additionalProperties": false,
                             "properties": {
+                                "DailyFee": {
+                                    "additionalProperties": false,
+                                    "type": "object"
+                                },
                                 "DisputableProofCount": {
                                     "title": "number",
                                     "type": "number"

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -10185,7 +10185,8 @@
                                     5,
                                     1
                                 ],
-                                "DisputableProofCount": 42
+                                "DisputableProofCount": 42,
+                                "DailyFee": "0"
                             }
                         ]
                     ],
@@ -10193,6 +10194,10 @@
                         {
                             "additionalProperties": false,
                             "properties": {
+                                "DailyFee": {
+                                    "additionalProperties": false,
+                                    "type": "object"
+                                },
                                 "DisputableProofCount": {
                                     "title": "number",
                                     "type": "number"

--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -127,7 +127,7 @@ type Deadline interface {
 
 	PartitionsChanged(Deadline) (bool, error)
 	DisputableProofCount() (uint64, error)
-	DailyFee() abi.TokenAmount
+	DailyFee() (abi.TokenAmount, error)
 }
 
 type Partition interface {

--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -127,6 +127,7 @@ type Deadline interface {
 
 	PartitionsChanged(Deadline) (bool, error)
 	DisputableProofCount() (uint64, error)
+	DailyFee() abi.TokenAmount
 }
 
 type Partition interface {

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -211,7 +211,7 @@ type Deadline interface {
 
 	PartitionsChanged(Deadline) (bool, error)
 	DisputableProofCount() (uint64, error)
-	DailyFee() abi.TokenAmount
+	DailyFee() (abi.TokenAmount, error)
 }
 
 type Partition interface {

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -211,6 +211,7 @@ type Deadline interface {
 
 	PartitionsChanged(Deadline) (bool, error)
 	DisputableProofCount() (uint64, error)
+	DailyFee() abi.TokenAmount
 }
 
 type Partition interface {

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -552,6 +552,15 @@ func (d *deadline{{.v}}) DisputableProofCount() (uint64, error) {
 {{end}}
 }
 
+func (d *deadline{{.v}}) DailyFee() abi.TokenAmount {
+{{- if (ge .v 16)}}
+	if d.Deadline.DailyFee.Int != nil {
+		return d.Deadline.DailyFee
+	}
+{{- end}}
+	return big.Zero()
+}
+
 func (p *partition{{.v}}) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }
@@ -569,6 +578,12 @@ func (p *partition{{.v}}) UnprovenSectors() (bitfield.BitField, error) {
 }
 
 func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorOnChainInfo {
+{{- if (ge .v 16)}}
+	dailyFee := v{{.v}}.DailyFee
+	if dailyFee.Int == nil {
+		dailyFee = big.Zero()
+	}
+{{- end}}
 	info := SectorOnChainInfo{
 		SectorNumber:          v{{.v}}.SectorNumber,
 		SealProof:             v{{.v}}.SealProof,
@@ -590,7 +605,7 @@ func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorO
 		Flags:                 SectorOnChainInfoFlags(v{{.v}}.Flags),
 		{{- end}}
 		{{- if (ge .v 16)}}
-		DailyFee:              v{{.v}}.DailyFee,
+		DailyFee:              dailyFee,
 		{{- else}}
 		DailyFee:              big.Zero(),
 		{{- end}}

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -552,13 +552,13 @@ func (d *deadline{{.v}}) DisputableProofCount() (uint64, error) {
 {{end}}
 }
 
-func (d *deadline{{.v}}) DailyFee() abi.TokenAmount {
+func (d *deadline{{.v}}) DailyFee() (abi.TokenAmount, error) {
 {{- if (ge .v 16)}}
 	if d.Deadline.DailyFee.Int != nil {
-		return d.Deadline.DailyFee
+		return d.Deadline.DailyFee, nil
 	}
 {{- end}}
-	return big.Zero()
+	return big.Zero(), nil
 }
 
 func (p *partition{{.v}}) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -480,8 +480,8 @@ func (d *deadline0) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline0) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline0) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition0) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -480,6 +480,10 @@ func (d *deadline0) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline0) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition0) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v10.go
+++ b/chain/actors/builtin/miner/v10.go
@@ -515,6 +515,10 @@ func (d *deadline10) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline10) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition10) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v10.go
+++ b/chain/actors/builtin/miner/v10.go
@@ -515,8 +515,8 @@ func (d *deadline10) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline10) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline10) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition10) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v11.go
+++ b/chain/actors/builtin/miner/v11.go
@@ -515,8 +515,8 @@ func (d *deadline11) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline11) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline11) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition11) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v11.go
+++ b/chain/actors/builtin/miner/v11.go
@@ -515,6 +515,10 @@ func (d *deadline11) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline11) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition11) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v12.go
+++ b/chain/actors/builtin/miner/v12.go
@@ -515,8 +515,8 @@ func (d *deadline12) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline12) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline12) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition12) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v12.go
+++ b/chain/actors/builtin/miner/v12.go
@@ -515,6 +515,10 @@ func (d *deadline12) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline12) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition12) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v13.go
+++ b/chain/actors/builtin/miner/v13.go
@@ -515,6 +515,10 @@ func (d *deadline13) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline13) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition13) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v13.go
+++ b/chain/actors/builtin/miner/v13.go
@@ -515,8 +515,8 @@ func (d *deadline13) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline13) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline13) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition13) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v14.go
+++ b/chain/actors/builtin/miner/v14.go
@@ -515,8 +515,8 @@ func (d *deadline14) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline14) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline14) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition14) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v14.go
+++ b/chain/actors/builtin/miner/v14.go
@@ -515,6 +515,10 @@ func (d *deadline14) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline14) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition14) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v15.go
+++ b/chain/actors/builtin/miner/v15.go
@@ -515,8 +515,8 @@ func (d *deadline15) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline15) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline15) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition15) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v15.go
+++ b/chain/actors/builtin/miner/v15.go
@@ -515,6 +515,10 @@ func (d *deadline15) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline15) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition15) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v16.go
+++ b/chain/actors/builtin/miner/v16.go
@@ -13,6 +13,7 @@ import (
 	rle "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/big"
 	builtin16 "github.com/filecoin-project/go-state-types/builtin"
 	miner16 "github.com/filecoin-project/go-state-types/builtin/v16/miner"
 	adt16 "github.com/filecoin-project/go-state-types/builtin/v16/util/adt"
@@ -514,6 +515,13 @@ func (d *deadline16) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline16) DailyFee() abi.TokenAmount {
+	if d.Deadline.DailyFee.Int != nil {
+		return d.Deadline.DailyFee
+	}
+	return big.Zero()
+}
+
 func (p *partition16) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }
@@ -531,6 +539,10 @@ func (p *partition16) UnprovenSectors() (bitfield.BitField, error) {
 }
 
 func fromV16SectorOnChainInfo(v16 miner16.SectorOnChainInfo) SectorOnChainInfo {
+	dailyFee := v16.DailyFee
+	if dailyFee.Int == nil {
+		dailyFee = big.Zero()
+	}
 	info := SectorOnChainInfo{
 		SectorNumber:          v16.SectorNumber,
 		SealProof:             v16.SealProof,
@@ -547,7 +559,7 @@ func fromV16SectorOnChainInfo(v16 miner16.SectorOnChainInfo) SectorOnChainInfo {
 		PowerBaseEpoch:        v16.PowerBaseEpoch,
 		ReplacedDayReward:     v16.ReplacedDayReward,
 		Flags:                 SectorOnChainInfoFlags(v16.Flags),
-		DailyFee:              v16.DailyFee,
+		DailyFee:              dailyFee,
 	}
 	return info
 }

--- a/chain/actors/builtin/miner/v16.go
+++ b/chain/actors/builtin/miner/v16.go
@@ -515,11 +515,11 @@ func (d *deadline16) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline16) DailyFee() abi.TokenAmount {
+func (d *deadline16) DailyFee() (abi.TokenAmount, error) {
 	if d.Deadline.DailyFee.Int != nil {
-		return d.Deadline.DailyFee
+		return d.Deadline.DailyFee, nil
 	}
-	return big.Zero()
+	return big.Zero(), nil
 }
 
 func (p *partition16) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -512,6 +512,10 @@ func (d *deadline2) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline2) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition2) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -512,8 +512,8 @@ func (d *deadline2) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline2) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline2) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition2) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v3.go
+++ b/chain/actors/builtin/miner/v3.go
@@ -512,6 +512,10 @@ func (d *deadline3) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline3) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition3) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v3.go
+++ b/chain/actors/builtin/miner/v3.go
@@ -512,8 +512,8 @@ func (d *deadline3) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline3) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline3) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition3) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v4.go
+++ b/chain/actors/builtin/miner/v4.go
@@ -512,8 +512,8 @@ func (d *deadline4) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline4) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline4) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition4) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v4.go
+++ b/chain/actors/builtin/miner/v4.go
@@ -512,6 +512,10 @@ func (d *deadline4) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline4) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition4) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v5.go
+++ b/chain/actors/builtin/miner/v5.go
@@ -512,6 +512,10 @@ func (d *deadline5) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline5) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition5) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v5.go
+++ b/chain/actors/builtin/miner/v5.go
@@ -512,8 +512,8 @@ func (d *deadline5) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline5) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline5) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition5) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v6.go
+++ b/chain/actors/builtin/miner/v6.go
@@ -512,6 +512,10 @@ func (d *deadline6) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline6) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition6) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v6.go
+++ b/chain/actors/builtin/miner/v6.go
@@ -512,8 +512,8 @@ func (d *deadline6) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline6) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline6) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition6) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v7.go
+++ b/chain/actors/builtin/miner/v7.go
@@ -511,6 +511,10 @@ func (d *deadline7) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline7) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition7) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v7.go
+++ b/chain/actors/builtin/miner/v7.go
@@ -511,8 +511,8 @@ func (d *deadline7) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline7) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline7) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition7) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v8.go
+++ b/chain/actors/builtin/miner/v8.go
@@ -511,8 +511,8 @@ func (d *deadline8) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline8) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline8) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition8) AllSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v8.go
+++ b/chain/actors/builtin/miner/v8.go
@@ -511,6 +511,10 @@ func (d *deadline8) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline8) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition8) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v9.go
+++ b/chain/actors/builtin/miner/v9.go
@@ -515,6 +515,10 @@ func (d *deadline9) DisputableProofCount() (uint64, error) {
 
 }
 
+func (d *deadline9) DailyFee() abi.TokenAmount {
+	return big.Zero()
+}
+
 func (p *partition9) AllSectors() (bitfield.BitField, error) {
 	return p.Partition.Sectors, nil
 }

--- a/chain/actors/builtin/miner/v9.go
+++ b/chain/actors/builtin/miner/v9.go
@@ -515,8 +515,8 @@ func (d *deadline9) DisputableProofCount() (uint64, error) {
 
 }
 
-func (d *deadline9) DailyFee() abi.TokenAmount {
-	return big.Zero()
+func (d *deadline9) DailyFee() (abi.TokenAmount, error) {
+	return big.Zero(), nil
 }
 
 func (p *partition9) AllSectors() (bitfield.BitField, error) {

--- a/documentation/en/api-v0-methods.md
+++ b/documentation/en/api-v0-methods.md
@@ -4952,7 +4952,8 @@ Response:
       5,
       1
     ],
-    "DisputableProofCount": 42
+    "DisputableProofCount": 42,
+    "DailyFee": "0"
   }
 ]
 ```

--- a/documentation/en/api-v1-unstable-methods.md
+++ b/documentation/en/api-v1-unstable-methods.md
@@ -7383,7 +7383,8 @@ Response:
       5,
       1
     ],
-    "DisputableProofCount": 42
+    "DisputableProofCount": 42,
+    "DailyFee": "0"
   }
 ]
 ```

--- a/itests/daily_fees_test.go
+++ b/itests/daily_fees_test.go
@@ -1,0 +1,525 @@
+package itests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
+	miner14 "github.com/filecoin-project/go-state-types/builtin/v14/miner"
+	verifreg14 "github.com/filecoin-project/go-state-types/builtin/v14/verifreg"
+	miner15 "github.com/filecoin-project/go-state-types/builtin/v15/miner"
+	miner16 "github.com/filecoin-project/go-state-types/builtin/v16/miner"
+	"github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	"github.com/filecoin-project/go-state-types/network"
+	gstStore "github.com/filecoin-project/go-state-types/store"
+
+	"github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/state"
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/wallet/key"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/lib/must"
+)
+
+func TestDailyFees(t *testing.T) {
+	req := require.New(t)
+
+	kit.QuietMiningLogs()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const defaultSectorSize = abi.SectorSize(2 << 10) // 2KiB
+	var (
+		blocktime = 2 * time.Millisecond
+		client    kit.TestFullNode
+		genminer  kit.TestMiner
+		// don't upgrade until our original sectors are fully proven and power updated, to keep the test simple
+		nv25epoch abi.ChainEpoch = builtin.EpochsInDay + 200
+		feePostWg sync.WaitGroup
+	)
+
+	initialBigBalance := types.MustParseFIL("100fil").Int64()
+	sealProofType := must.One(miner.SealProofTypeFromSectorSize(defaultSectorSize, network.Version23, miner.SealProofVariant_Standard))
+	rootKey := must.One(key.GenerateKey(types.KTSecp256k1))
+	verifierKey := must.One(key.GenerateKey(types.KTSecp256k1))
+	verifiedClientKey := must.One(key.GenerateKey(types.KTBLS))
+	unverifiedClient := must.One(key.GenerateKey(types.KTBLS))
+
+	t.Log("*** Setting up network with genesis miner and clients")
+
+	// Setup and begin mining with a single miner (A)
+	// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
+	ens := kit.NewEnsemble(t,
+		kit.MockProofs(true),
+		kit.RootVerifier(rootKey, abi.NewTokenAmount(initialBigBalance)),
+		kit.Account(verifierKey, abi.NewTokenAmount(initialBigBalance)),
+		kit.Account(verifiedClientKey, abi.NewTokenAmount(initialBigBalance)),
+		kit.Account(unverifiedClient, abi.NewTokenAmount(initialBigBalance)),
+		kit.UpgradeSchedule(stmgr.Upgrade{
+			Network: network.Version24,
+			Height:  -1,
+		}, stmgr.Upgrade{
+			Network:   network.Version25,
+			Height:    nv25epoch,
+			Migration: filcns.UpgradeActorsV16,
+		},
+		)).
+		FullNode(&client, kit.SectorSize(defaultSectorSize)).
+		Miner(&genminer, &client, kit.PresealSectors(5), kit.SectorSize(defaultSectorSize), kit.WithAllSubsystems()).
+		Start().
+		InterconnectAll()
+
+	store := gstStore.WrapBlockStore(ctx, blockstore.NewAPIBlockstore(client))
+
+	blockMiners := ens.BeginMiningMustPost(blocktime)
+	req.Len(blockMiners, 1)
+	blockMiner := blockMiners[0]
+
+	nodeOpts := []kit.NodeOpt{kit.SectorSize(defaultSectorSize), kit.OwnerAddr(client.DefaultKey)}
+	mminer, ens := ens.UnmanagedMiner(ctx, &client, nodeOpts...)
+	defer mminer.Stop()
+
+	// circulatingSupplyBefore gets the circulating supply just before the given tipset key;
+	// for calculating the fee we need to know the circulating supply that was given to builtin
+	// actors at the time it was originally calculated, so we need the CS from the tipset before
+	// the one where the message was executed.
+	circulatingSupplyBefore := func(tsk types.TipSetKey) abi.TokenAmount {
+		ts, err := client.ChainGetTipSet(ctx, tsk)
+		req.NoError(err)
+		cs, err := client.StateVMCirculatingSupplyInternal(ctx, ts.Parents())
+		req.NoError(err)
+		return cs.FilCirculating
+	}
+
+	// checkDailyFee checks the daily fee for a sector, returning true if the sector is in the v16
+	// format and false if it is in the v15 format. It also returns the daily fee.
+	checkDailyFee := func(sn abi.SectorNumber) (bool, abi.TokenAmount) {
+		head, err := client.ChainHead(ctx)
+		req.NoError(err)
+
+		st, err := state.LoadStateTree(store, head.ParentState())
+		req.NoError(err)
+
+		act, err := st.GetActor(mminer.ActorAddr)
+		req.NoError(err)
+
+		var sectorsArr *adt.Array
+		{
+			nv, err := client.StateNetworkVersion(ctx, head.Key())
+			req.NoError(err)
+			switch nv {
+			case network.Version24:
+				var miner miner15.State
+				err = store.Get(ctx, act.Head, &miner)
+				req.NoError(err)
+				sectorsArr, err = adt.AsArray(store, miner.Sectors, miner15.SectorsAmtBitwidth)
+				req.NoError(err)
+				t.Logf("Got miner15.State: %+v", miner)
+			case network.Version25:
+				var miner miner16.State
+				err = store.Get(ctx, act.Head, &miner)
+				req.NoError(err)
+				sectorsArr, err = adt.AsArray(store, miner.Sectors, miner16.SectorsAmtBitwidth)
+				req.NoError(err)
+				t.Logf("Got miner16.State: %+v", miner)
+			default:
+				t.Fatalf("unexpected network version: %d", nv)
+			}
+		}
+
+		// SectorOnChainInfo has a lazy migration for v16, it could take either a 15 field format or a
+		// 16 field format with a DailyFee field on the end. We want to determine whether its a 15 or a
+		// 16 field version by first trying to decode it as a 15 field version.
+
+		dailyFee := abi.NewTokenAmount(0)
+		var v16 bool
+
+		var soci15 miner15.SectorOnChainInfo
+		ok, err := sectorsArr.Get(uint64(sn), &soci15)
+		if err == nil {
+			req.True(ok)
+		} else {
+			// try for v16 sector format, the unmarshaller can also handle the 15 field variety so we do
+			// this second
+			var soci16 miner16.SectorOnChainInfo
+			ok, err = sectorsArr.Get(uint64(sn), &soci16)
+			req.NoError(err)
+			req.True(ok)
+			req.NotNil(soci16.DailyFee)
+			req.NotNil(soci16.DailyFee.Int)
+			dailyFee = soci16.DailyFee
+			v16 = true
+		}
+
+		// call the public API and check that it shows what we know
+		s, err := client.StateSectorGetInfo(ctx, mminer.ActorAddr, sn, head.Key())
+		req.NoError(err)
+		req.NotNil(s.DailyFee)
+		req.NotNil(s.DailyFee.Int)
+		req.Equal(0, big.Cmp(dailyFee, s.DailyFee),
+			"daily fees not equal: expected %s, got %s", dailyFee, s.DailyFee)
+
+		return v16, dailyFee
+	}
+
+	// expectMinerBurn asserts that the miner actor has spent the given amount of funds.
+	// UnmanagedMiner generously gives a large Value in its message submissions to the miner actor, so
+	// we need to check the miner's balance to see what it currently is, then find all messages sent
+	// to the miner actor and sum their values to see how much should be in there. Then the remainder
+	// is the amount that has been burned.
+	//
+	// This is not quite how we expect the daily fee mechanism to work in practice: UnmanagedMiner
+	// doesn't (currently) win any block rewards, so it has no vesting funds to pull from. So instead,
+	// our daily fee is extracted from the balance. If we had vesting funds, we would need to check
+	// that as well.
+	expectMinerBurn := func(expectBurn abi.TokenAmount) {
+		ts, err := client.ChainHead(ctx)
+		req.NoError(err)
+
+		// current balance of the actor
+		act, err := client.StateGetActor(ctx, mminer.ActorAddr, types.EmptyTSK)
+		req.NoError(err)
+		minerBalance := act.Balance
+
+		// hunt through the chain and look for messages sent to our miner and extract their value
+		totalSend := abi.NewTokenAmount(0)
+		parentTs := ts.Parents()
+		req.NoError(err)
+		for ts.Height() > 1 {
+			msgs, err := client.ChainGetMessagesInTipset(ctx, parentTs)
+			req.NoError(err)
+			for _, msg := range msgs {
+				if msg.Message.To == mminer.ActorAddr {
+					totalSend = big.Add(totalSend, msg.Message.Value)
+				}
+			}
+			ts, err = client.ChainGetTipSet(ctx, parentTs)
+			req.NoError(err)
+			parentTs = ts.Parents()
+		}
+
+		require.Equal(
+			t,
+			expectBurn.Int64(),
+			big.Sub(totalSend, minerBalance).Int64(),
+			"expected miner to have burned %s, but it's burned %s", expectBurn, big.Sub(minerBalance, totalSend),
+		)
+	}
+
+	// checkFeeRecords checks that the DailyFee values in the miner's Deadlines and the FeeDeduction
+	// totals in the ExpirationQueues for each partition are consistent with what the public API
+	// reports for sector locations and their daily fees.
+	checkFeeRecords := func(expectTotalFees abi.TokenAmount) {
+		t.Log("*** Check consistency of deadline fee records and expiration queue fee deduction records")
+
+		// deadline DailyFee values should sum up the live sectors in that deadline
+		sectors, err := client.StateMinerSectors(ctx, mminer.ActorAddr, nil, types.EmptyTSK)
+		req.NoError(err)
+		deadlines, err := client.StateMinerDeadlines(ctx, mminer.ActorAddr, types.EmptyTSK)
+		req.NoError(err)
+		expectedDeadlineFees := make([]abi.TokenAmount, len(deadlines))
+		expectedExpirationQueueFees := make(map[miner.SectorLocation]abi.TokenAmount, len(deadlines))
+		var actualTotalFees abi.TokenAmount
+		for _, sector := range sectors {
+			loc, err := client.StateSectorPartition(ctx, mminer.ActorAddr, sector.SectorNumber, types.EmptyTSK)
+			req.NoError(err)
+			expectedDeadlineFees[loc.Deadline] = big.Add(expectedDeadlineFees[loc.Deadline], sector.DailyFee)
+			expectedExpirationQueueFees[*loc] = big.Add(expectedExpirationQueueFees[*loc], sector.DailyFee)
+			actualTotalFees = big.Add(actualTotalFees, sector.DailyFee)
+		}
+
+		req.Equal(0, big.Cmp(expectTotalFees, actualTotalFees), "expected total fees %s, got %s", expectTotalFees, actualTotalFees)
+
+		// public API has DailyFee on each Deadline
+		for i, deadline := range deadlines {
+			fee := expectedDeadlineFees[i]
+			req.Equal(0, big.Cmp(fee, deadline.DailyFee), "expected %s, got %s for deadline %d", fee, deadline.DailyFee, i)
+		}
+
+		nv, err := client.StateNetworkVersion(ctx, types.EmptyTSK)
+		req.NoError(err)
+		if nv < network.Version25 {
+			// nothing to see here, we're done
+			return
+		}
+
+		// we need to go deeper for the queues
+		act, err := client.StateGetActor(ctx, mminer.ActorAddr, types.EmptyTSK)
+		req.NoError(err)
+		var minerState miner16.State
+		err = store.Get(ctx, act.Head, &minerState)
+		req.NoError(err)
+		dls, err := minerState.LoadDeadlines(store)
+		req.NoError(err)
+		var checkedExpirationQueueFees int
+
+		err = dls.ForEach(store, func(dlIdx uint64, dl *miner16.Deadline) error {
+			// check the daily fee again (sanity check)
+			fee := expectedDeadlineFees[dlIdx]
+			req.Equal(0, big.Cmp(fee, dl.DailyFee), "expected %s, got %s for deadline %d", fee, dl.DailyFee, dlIdx)
+			if !fee.IsZero() {
+				t.Logf("checked deadline %d daily fee: expected %s, got %s", dlIdx, fee, dl.DailyFee)
+			}
+
+			// dive into the partitions
+			partitions, err := dl.PartitionsArray(store)
+			req.NoError(err)
+			quant := minerState.QuantSpecForDeadline(dlIdx)
+			var partition miner16.Partition
+			err = partitions.ForEach(&partition, func(i int64) error {
+				expectedFee, ok := expectedExpirationQueueFees[miner.SectorLocation{Deadline: dlIdx, Partition: uint64(i)}]
+				if ok {
+					checkedExpirationQueueFees++
+				} else {
+					// we don't have record of a sector in here, there shouldn't be a reason to go deeper but just in case ...
+					expectedFee = abi.NewTokenAmount(0)
+				}
+				var actualFee abi.TokenAmount
+
+				// hunt through the expiration queue and find all the fees that are set to be deducted for this deadline+partition
+				queue, err := miner16.LoadExpirationQueue(store, partition.ExpirationsEpochs, quant, miner16.PartitionExpirationAmtBitwidth)
+				req.NoError(err)
+				var expSet miner16.ExpirationSet
+				err = queue.ForEach(&expSet, func(i int64) error {
+					actualFee = big.Add(actualFee, expSet.FeeDeduction)
+					return nil
+				})
+				req.NoError(err)
+
+				req.Equal(0, big.Cmp(expectedFee, actualFee), "expected %s, got %s for deadline %d partition %d expiration fee deduction", expectedFee, actualFee, dlIdx, i)
+				t.Logf("checked deadline %d partition %d expiration fee deduction: expected %s, got %s", dlIdx, i, expectedFee, actualFee)
+				return nil
+			})
+			req.NoError(err)
+
+			return nil
+		})
+		req.NoError(err)
+
+		req.Equal(len(expectedExpirationQueueFees), checkedExpirationQueueFees, "checked %d expiration queue fees, expected %d", checkedExpirationQueueFees, len(expectedExpirationQueueFees))
+	}
+
+	ens.Start()
+
+	t.Log("*** Onboarding sectors before the network upgrade")
+	expectMinerBurn(abi.NewTokenAmount(0))
+	checkFeeRecords(abi.NewTokenAmount(0))
+
+	_, verifiedClientAddresses := kit.SetupVerifiedClients(ctx, t, &client, rootKey, verifierKey, []*key.Key{verifiedClientKey})
+	verifiedClientAddr := verifiedClientAddresses[0]
+	minerId := must.One(address.IDFromAddress(mminer.ActorAddr))
+
+	piece := abi.PieceInfo{
+		Size:     abi.PaddedPieceSize(defaultSectorSize),
+		PieceCID: cid.MustParse("baga6ea4seaqlhznlutptgfwhffupyer6txswamerq5fc2jlwf2lys2mm5jtiaeq"),
+	}
+	clientId, allocationId := kit.SetupAllocation(ctx, t, &client, minerId, piece, verifiedClientAddr, 0, 0)
+
+	var allSectors []abi.SectorNumber
+	ccSectors24, _ := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{{}, {}}) // 2 CC sectors
+	allSectors = append(allSectors, ccSectors24...)
+	dealSector24, _ := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{kit.SectorWithRandPiece()})
+	allSectors = append(allSectors, dealSector24...)
+	verifiedSector24, _ := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{
+		{Piece: piece.PieceCID, Verified: &miner14.VerifiedAllocationKey{Client: clientId, ID: verifreg14.AllocationId(allocationId)}}})
+	allSectors = append(allSectors, verifiedSector24...)
+
+	blockMiner.WatchMinerForPost(mminer.ActorAddr)
+
+	t.Log("*** Checking daily fees on sectors onboarded before the network upgrade, before their first PoST")
+
+	// No fees, no fee information at all in these sectors (sanity check)
+	for _, sn := range allSectors {
+		has, fee := checkDailyFee(sn)
+		req.False(has) // v15
+		req.Equal(abi.NewTokenAmount(0), fee)
+	}
+	expectMinerBurn(abi.NewTokenAmount(0))
+	checkFeeRecords(abi.NewTokenAmount(0))
+
+	t.Log("*** Waiting for PoST for sectors onboarded before the network upgrade")
+
+	expectedRaw := uint64(defaultSectorSize * 4)  // 4 sectors onboarded
+	expectedQap := uint64(defaultSectorSize * 13) // 3 sectors + 1 verified sector
+	mminer.WaitTillActivatedAndAssertPower(allSectors, expectedRaw, expectedQap)
+
+	t.Log("*** Checking daily fees on sectors onboarded before the network upgrade, after their first PoST")
+
+	// PoST shouldn't have changed anything
+	for _, sn := range allSectors {
+		has, fee := checkDailyFee(sn)
+		req.False(has) // v15
+		req.Equal(abi.NewTokenAmount(0), fee)
+	}
+	expectMinerBurn(abi.NewTokenAmount(0))
+	checkFeeRecords(abi.NewTokenAmount(0))
+
+	// Move past the upgrade
+	client.WaitTillChain(ctx, kit.HeightAtLeast(nv25epoch+5))
+
+	t.Log("*** Re-checking daily fees on sectors onboarded before the network upgrade")
+
+	// Still no fees, sectors shouldn't have been touched
+	for _, sn := range allSectors {
+		has, fee := checkDailyFee(sn)
+		req.False(has) // v15
+		req.Equal(abi.NewTokenAmount(0), fee)
+	}
+	expectMinerBurn(abi.NewTokenAmount(0))
+	checkFeeRecords(abi.NewTokenAmount(0))
+
+	t.Log("*** Snapping deals into sectors after the network upgrade")
+
+	// Snap both CC sectors, one with an unverified piece, one with a verified piece, capture the
+	// CS value at each snap so we can accurately predict the expected daily fee
+	_, snap0Tsk := mminer.SnapDeal(ccSectors24[0], kit.SectorManifest{Piece: piece.PieceCID})
+	ccSectors240ExpectedFee := miner16.DailyProofFee(circulatingSupplyBefore(snap0Tsk), abi.NewStoragePower(int64(defaultSectorSize)))
+	clientId, allocationId = kit.SetupAllocation(ctx, t, &client, minerId, piece, verifiedClientAddr, 0, 0)
+	_, snap1Tsk := mminer.SnapDeal(ccSectors24[1], kit.SectorManifest{Piece: piece.PieceCID, Verified: &miner14.VerifiedAllocationKey{Client: clientId, ID: verifreg14.AllocationId(allocationId)}})
+	ccSectors241ExpectedFee := miner16.DailyProofFee(circulatingSupplyBefore(snap1Tsk), abi.NewStoragePower(int64(defaultSectorSize*10)))
+
+	feePostWg.Add(1)
+	go func() {
+		mminer.WaitTillPost(ccSectors24[0]) // both onboarded together, so they should post together
+		feePostWg.Done()
+	}()
+
+	t.Log("*** Checking daily fees on old and snapped sectors")
+
+	// No fees on untouched sectors, but because we expect all our sectors to be stored in the root
+	// of the HAMT together and we've modified at least one of them, they would have all been
+	// rewritten in the new v16 format, so we shouldn't see v15's here anymore.
+	noFeeSectors := append(append([]abi.SectorNumber{}, dealSector24...), verifiedSector24...)
+	for _, sn := range noFeeSectors {
+		has, fee := checkDailyFee(sn)
+		req.True(has) // v16
+		req.Equal(abi.NewTokenAmount(0), fee)
+	}
+
+	// fees on snapped sectors, first our non-verified sector, then our verified sector, with 10x qap
+	has, fee := checkDailyFee(ccSectors24[0])
+	req.True(has)
+	req.Equal(ccSectors240ExpectedFee, fee)
+	has, fee = checkDailyFee(ccSectors24[1])
+	req.True(has)
+	req.Equal(ccSectors241ExpectedFee, fee)
+
+	expectMinerBurn(abi.NewTokenAmount(0)) // fees are registered, but not yet paid
+	checkFeeRecords(big.Add(ccSectors240ExpectedFee, ccSectors241ExpectedFee))
+
+	t.Log("*** Onboarding sectors after the network upgrade")
+
+	clientId, allocationId = kit.SetupAllocation(ctx, t, &client, minerId, piece, verifiedClientAddr, 0, 0)
+
+	ccSectors25, ccTsk := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{{}, {}}) // 2 CC sectors
+	allSectors = append(allSectors, ccSectors25...)
+	ccSectors25ExpectedFee := miner16.DailyProofFee(circulatingSupplyBefore(ccTsk), abi.NewStoragePower(int64(defaultSectorSize)))
+	feePostWg.Add(1)
+	go func() {
+		mminer.WaitTillPost(ccSectors25[0]) // both onboarded together, so they should post together
+		feePostWg.Done()
+	}()
+
+	dealSector25, dealTsk := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{kit.SectorWithRandPiece()})
+	allSectors = append(allSectors, dealSector25...)
+	dealSector25ExpectedFee := miner16.DailyProofFee(circulatingSupplyBefore(dealTsk), abi.NewStoragePower(int64(defaultSectorSize)))
+	feePostWg.Add(1)
+	go func() {
+		mminer.WaitTillPost(dealSector25[0])
+		feePostWg.Done()
+	}()
+
+	verifiedSector25, verifiedTsk := mminer.OnboardSectors(sealProofType, []kit.SectorManifest{
+		{Piece: piece.PieceCID, Verified: &miner14.VerifiedAllocationKey{Client: clientId, ID: verifreg14.AllocationId(allocationId)}}})
+	allSectors = append(allSectors, verifiedSector25...)
+	verified25ExpectedFee := miner16.DailyProofFee(circulatingSupplyBefore(verifiedTsk), abi.NewStoragePower(int64(defaultSectorSize*10)))
+	feePostWg.Add(1)
+	go func() {
+		mminer.WaitTillPost(verifiedSector25[0])
+		feePostWg.Done()
+	}()
+
+	checkAllFees := func() {
+		t.Log("*** Checking daily fees on old sectors")
+
+		for _, sn := range noFeeSectors {
+			has, fee := checkDailyFee(sn)
+			req.True(has) // v16
+			req.Equal(abi.NewTokenAmount(0), fee)
+		}
+
+		t.Log("*** Re-checking daily fees on snapped sectors")
+
+		has, fee = checkDailyFee(ccSectors24[0])
+		req.True(has)
+		req.Equal(ccSectors240ExpectedFee, fee)
+		has, fee = checkDailyFee(ccSectors24[1])
+		req.True(has)
+		req.Equal(ccSectors241ExpectedFee, fee)
+
+		t.Log("*** Checking daily fees on new sectors")
+
+		has, fee = checkDailyFee(ccSectors25[0])
+		req.True(has)
+		req.Equal(ccSectors25ExpectedFee, fee)
+		has, fee = checkDailyFee(ccSectors25[1])
+		req.True(has)
+		req.Equal(ccSectors25ExpectedFee, fee)
+		has, fee = checkDailyFee(dealSector25[0])
+		req.True(has)
+		req.Equal(dealSector25ExpectedFee, fee)
+		has, fee = checkDailyFee(verifiedSector25[0])
+		req.True(has)
+		req.Equal(verified25ExpectedFee, fee)
+	}
+
+	checkAllFees() // before PoST
+
+	t.Log("*** Waiting for PoST for sectors onboarded after the network upgrade")
+
+	expectedRaw = uint64(defaultSectorSize * 8)  // 8 sectors onboarded
+	expectedQap = uint64(defaultSectorSize * 35) // 5 sectors + 3 (incl 1 snap) verified sectors
+	mminer.WaitTillActivatedAndAssertPower(allSectors, expectedRaw, expectedQap)
+
+	checkAllFees() // after PoST
+
+	// wait for all fees to be paid—we need each one to have reached its first deadline and they are
+	// likely spread out over multiple deadlines
+	feePostWg.Wait()
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
+	// wait one deadline to make sure we get to the end of the current deadline where we've done a
+	// PoST.
+	// NOTE: we are crossing our fingers a little here, it is possible that our snapped sectors end
+	// up hitting two proving deadlines if we didn't compress our nv25 onboarding enough and get
+	// allocated to nicely aligned deadlines.
+	client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+miner.WPoStChallengeWindow()))
+
+	var expectTotalBurn abi.TokenAmount
+	for _, fee := range []abi.TokenAmount{
+		ccSectors240ExpectedFee,
+		ccSectors241ExpectedFee,
+		ccSectors25ExpectedFee, // x2
+		ccSectors25ExpectedFee,
+		dealSector25ExpectedFee,
+		verified25ExpectedFee,
+	} {
+		expectTotalBurn = big.Add(expectTotalBurn, fee)
+	}
+	// we've passed our first deadline where fees were payable, both for the snapped nv24 sectors
+	// and the nv25 sectors
+	expectMinerBurn(expectTotalBurn)
+	// with only one fee payment so far for all sectors, the total in the records should be the same as the burn
+	checkFeeRecords(expectTotalBurn)
+}

--- a/itests/kit/funds.go
+++ b/itests/kit/funds.go
@@ -9,9 +9,17 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
+	verifregtypes13 "github.com/filecoin-project/go-state-types/builtin/v13/verifreg"
+	datacap2 "github.com/filecoin-project/go-state-types/builtin/v9/datacap"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/datacap"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/verifreg"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/wallet/key"
 )
 
 // SendFunds sends funds from the default wallet of the specified sender node
@@ -37,4 +45,147 @@ func (f *TestFullNode) WaitMsg(ctx context.Context, msg cid.Cid) {
 	require.NoError(f.t, err)
 
 	require.EqualValues(f.t, 0, res.Receipt.ExitCode, "message did not successfully execute")
+}
+
+// SetupVerifiedClients assumes that rootKey has been set in the ensemble's genesis and that
+// verifierKey and verifiedClientKeys exist as accounts. It first sets up the verifier with datacap
+// to allocate, and then allocates datacap to each of the verified clients.
+// It returns the address of the verifier and the addresses of the verified clients.
+func SetupVerifiedClients(ctx context.Context, t *testing.T, client *TestFullNode, rootKey *key.Key, verifierKey *key.Key, verifiedClientKeys []*key.Key) (verifierAddr address.Address, ret []address.Address) {
+	// import the root key.
+	rootAddr, err := client.WalletImport(ctx, &rootKey.KeyInfo)
+	require.NoError(t, err)
+
+	// import the verifiers' keys.
+	verifierAddr, err = client.WalletImport(ctx, &verifierKey.KeyInfo)
+	require.NoError(t, err)
+
+	// import the verified client's key.
+	for _, k := range verifiedClientKeys {
+		verifiedClientAddr, err := client.WalletImport(ctx, &k.KeyInfo)
+		require.NoError(t, err)
+		ret = append(ret, verifiedClientAddr)
+	}
+
+	allowance := big.NewInt(100000000000)
+	params, aerr := actors.SerializeParams(&verifreg.AddVerifierParams{Address: verifierAddr, Allowance: allowance})
+	require.NoError(t, aerr)
+
+	msg := &types.Message{
+		From:   rootAddr,
+		To:     verifreg.Address,
+		Method: verifreg.Methods.AddVerifier,
+		Params: params,
+		Value:  big.Zero(),
+	}
+
+	sm, err := client.MpoolPushMessage(ctx, msg, nil)
+	require.NoError(t, err, "AddVerifier failed")
+
+	res, err := client.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, res.Receipt.ExitCode)
+
+	verifierAllowance, err := client.StateVerifierStatus(ctx, verifierAddr, types.EmptyTSK)
+	require.NoError(t, err)
+	require.Equal(t, allowance, *verifierAllowance)
+
+	// assign datacap to clients
+	for _, ad := range ret {
+		initialDatacap := big.NewInt(10000)
+
+		params, aerr = actors.SerializeParams(&verifreg.AddVerifiedClientParams{Address: ad, Allowance: initialDatacap})
+		require.NoError(t, aerr)
+
+		msg = &types.Message{
+			From:   verifierAddr,
+			To:     verifreg.Address,
+			Method: verifreg.Methods.AddVerifiedClient,
+			Params: params,
+			Value:  big.Zero(),
+		}
+
+		sm, err = client.MpoolPushMessage(ctx, msg, nil)
+		require.NoError(t, err)
+
+		res, err = client.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, res.Receipt.ExitCode)
+	}
+
+	return
+}
+
+func SetupAllocation(
+	ctx context.Context,
+	t *testing.T,
+	node api.FullNode,
+	minerId uint64,
+	dc abi.PieceInfo,
+	verifiedClientAddr address.Address,
+	expiration abi.ChainEpoch, // set to zero if we want to use maximum
+	termMax abi.ChainEpoch, // set to zero if we want to use maximum
+) (clientID abi.ActorID, allocationID verifregtypes13.AllocationId) {
+	if termMax == 0 {
+		termMax = verifreg.MaximumVerifiedAllocationTerm
+	}
+	if expiration == 0 {
+		expiration = verifreg.MaximumVerifiedAllocationExpiration
+	}
+
+	var requests []verifreg.AllocationRequest
+
+	allocationRequest := verifreg.AllocationRequest{
+		Provider:   abi.ActorID(minerId),
+		Data:       dc.PieceCID,
+		Size:       dc.Size,
+		TermMin:    verifreg.MinimumVerifiedAllocationTerm,
+		TermMax:    termMax,
+		Expiration: expiration,
+	}
+	requests = append(requests, allocationRequest)
+
+	allocationRequests := verifreg.AllocationRequests{
+		Allocations: requests,
+	}
+
+	receiverParams, aerr := actors.SerializeParams(&allocationRequests)
+	require.NoError(t, aerr)
+
+	transferParams, aerr := actors.SerializeParams(&datacap2.TransferParams{
+		To:           builtin.VerifiedRegistryActorAddr,
+		Amount:       big.Mul(big.NewInt(int64(dc.Size)), builtin.TokenPrecision),
+		OperatorData: receiverParams,
+	})
+	require.NoError(t, aerr)
+
+	msg := &types.Message{
+		To:     builtin.DatacapActorAddr,
+		From:   verifiedClientAddr,
+		Method: datacap.Methods.TransferExported,
+		Params: transferParams,
+		Value:  big.Zero(),
+	}
+
+	sm, err := node.MpoolPushMessage(ctx, msg, nil)
+	require.NoError(t, err)
+
+	res, err := node.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, res.Receipt.ExitCode)
+
+	// check that we have an allocation
+	allocations, err := node.StateGetAllocations(ctx, verifiedClientAddr, types.EmptyTSK)
+	require.NoError(t, err)
+
+	for key, value := range allocations {
+		vkey := verifregtypes13.AllocationId(key)
+		if dc.PieceCID.Equals(value.Data) && vkey >= allocationID {
+			allocationID = verifregtypes13.AllocationId(key)
+			clientID = value.Client
+		}
+	}
+
+	require.NotEqual(t, verifreg.AllocationId(0), allocationID) // found it in there
+	return clientID, allocationID
 }

--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -38,8 +38,8 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet/key"
 )
 
-// TODO: this shouldn't be fixed, we should make a new one for each sector/piece
-var fixedPieceCid = cid.MustParse("baga6ea4seaqjtovkwk4myyzj56eztkh5pzsk5upksan6f5outesy62bsvl4dsha")
+// TODO: make a randomiser for this
+var rndPieceCid = cid.MustParse("baga6ea4seaqjtovkwk4myyzj56eztkh5pzsk5upksan6f5outesy62bsvl4dsha")
 
 // 32 bytes of 1's: this value essentially ignored in NI-PoRep proofs, but all zeros is not recommended.
 // Regardless of what we submit to the chain, actors will replace it with 32 1's anyway but we are
@@ -88,9 +88,20 @@ type sectorInfo struct {
 	sealedCid           cid.Cid
 	unsealedCid         cid.Cid
 	sectorProof         []byte
-	pieces              []abi.PieceInfo
+	pieces              []miner14.PieceActivationManifest
 	sealTickets         abi.SealRandomness
 	sealRandomnessEpoch abi.ChainEpoch
+}
+
+func (si sectorInfo) piecesToPieceInfos() []abi.PieceInfo {
+	pcPieces := make([]abi.PieceInfo, len(si.pieces))
+	for i, piece := range si.pieces {
+		pcPieces[i] = abi.PieceInfo{
+			Size:     piece.Size,
+			PieceCID: piece.CID,
+		}
+	}
+	return pcPieces
 }
 
 type windowPost struct {
@@ -188,6 +199,20 @@ func WithExpectedExitCodes(exitCodes []exitcode.ExitCode) OnboardOpt {
 	}
 }
 
+// SectorManifest is (currently) a simplified SectorAllocationManifest, allowing zero or one pieces
+// to be built into a sector, where that one piece may be verified. Leave blank to onboard a CC
+// sector.
+type SectorManifest struct {
+	Piece    cid.Cid
+	Verified *miner14.VerifiedAllocationKey
+}
+
+func SectorWithRandPiece() SectorManifest {
+	return SectorManifest{
+		Piece: rndPieceCid,
+	}
+}
+
 // OnboardSectors onboards the specified number of sectors to the miner using the specified proof
 // type. If `withPieces` is true and the proof type supports it, the sectors will be onboarded with
 // pieces, otherwise they will be CC.
@@ -196,10 +221,9 @@ func WithExpectedExitCodes(exitCodes []exitcode.ExitCode) OnboardOpt {
 // process with real proofs.
 func (tm *TestUnmanagedMiner) OnboardSectors(
 	proofType abi.RegisteredSealProof,
-	withPieces bool,
-	count int,
+	manifest []SectorManifest,
 	opts ...OnboardOpt,
-) []abi.SectorNumber {
+) ([]abi.SectorNumber, types.TipSetKey) {
 
 	req := require.New(tm.t)
 
@@ -208,7 +232,7 @@ func (tm *TestUnmanagedMiner) OnboardSectors(
 		req.NoError(o(&options))
 	}
 
-	sectors := make([]sectorInfo, count)
+	sectors := make([]sectorInfo, len(manifest))
 
 	// Wait for the seal randomness to be available (we can only draw seal randomness from
 	// tipsets that have already achieved finality)
@@ -219,8 +243,7 @@ func (tm *TestUnmanagedMiner) OnboardSectors(
 
 	// For each sector, run PC1, PC2, C1 an C2, preparing for ProveCommit. If the proof needs it we
 	// will also submit a precommit for the sector.
-	for i := 0; i < count; i++ {
-		idx := i
+	for idx, sm := range manifest {
 
 		// We hold on to `sector`, adding new properties to it as we go along until we're finished with
 		// this phase, then add it to `sectors`
@@ -228,12 +251,13 @@ func (tm *TestUnmanagedMiner) OnboardSectors(
 		sector.sealRandomnessEpoch = sealRandEpoch
 
 		eg.Go(func() error {
-			if withPieces {
+			if sm.Piece.Defined() {
 				// Build a sector with non-zero pieces to onboard
 				if tm.mockProofs {
-					sector.pieces = []abi.PieceInfo{{
-						Size:     abi.PaddedPieceSize(tm.options.sectorSize),
-						PieceCID: fixedPieceCid,
+					sector.pieces = []miner14.PieceActivationManifest{{
+						Size:                  abi.PaddedPieceSize(tm.options.sectorSize),
+						CID:                   sm.Piece,
+						VerifiedAllocationKey: sm.Verified,
 					}}
 				} else {
 					var err error
@@ -282,7 +306,7 @@ func (tm *TestUnmanagedMiner) OnboardSectors(
 	}
 
 	// Submit ProveCommit for all sectors
-	exitCodes := tm.submitProveCommit(proofType, sectors, options.requireActivationSuccess, options.modifyNIActivationsBeforeSubmit)
+	exitCodes, tsk := tm.submitProveCommit(proofType, sectors, options.requireActivationSuccess, options.modifyNIActivationsBeforeSubmit)
 
 	// ProveCommit may have succeeded overall, but some sectors may have failed if RequireActivationSuccess
 	// was set to false. We need to return the exit codes for each sector so the caller can determine
@@ -305,12 +329,13 @@ func (tm *TestUnmanagedMiner) OnboardSectors(
 
 	tm.wdPostLoop()
 
-	return onboarded
+	return onboarded, tsk
 }
 
 // SnapDeal snaps a deal into a sector, generating a new sealed sector and updating the sector's state.
 // WindowPoSt should continue to operate after this operation if required.
-func (tm *TestUnmanagedMiner) SnapDeal(sectorNumber abi.SectorNumber) []abi.PieceInfo {
+// The SectorManifest argument (currently) only impacts mock proofs, and is ignored otherwise.
+func (tm *TestUnmanagedMiner) SnapDeal(sectorNumber abi.SectorNumber, sm SectorManifest) ([]abi.PieceInfo, types.TipSetKey) {
 	req := require.New(tm.t)
 
 	tm.log("Snapping a deal into sector %d ...", sectorNumber)
@@ -355,7 +380,7 @@ func (tm *TestUnmanagedMiner) SnapDeal(sectorNumber abi.SectorNumber) []abi.Piec
 	} else {
 		pieces = []abi.PieceInfo{{
 			Size:     abi.PaddedPieceSize(tm.options.sectorSize),
-			PieceCID: cid.MustParse("baga6ea4seaqlhznlutptgfwhffupyer6txswamerq5fc2jlwf2lys2mm5jtiaeq"),
+			PieceCID: sm.Piece,
 		}}
 		snapProof = []byte{0xde, 0xad, 0xbe, 0xef}
 		newSealedCid = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkieka")
@@ -365,10 +390,14 @@ func (tm *TestUnmanagedMiner) SnapDeal(sectorNumber abi.SectorNumber) []abi.Piec
 
 	var manifest []miner14.PieceActivationManifest
 	for _, piece := range pieces {
-		manifest = append(manifest, miner14.PieceActivationManifest{
+		pm := miner14.PieceActivationManifest{
 			CID:  piece.PieceCID,
 			Size: piece.Size,
-		})
+		}
+		if tm.mockProofs {
+			pm.VerifiedAllocationKey = sm.Verified
+		}
+		manifest = append(manifest, pm)
 	}
 
 	head, err := tm.FullNode.ChainHead(tm.ctx)
@@ -398,12 +427,12 @@ func (tm *TestUnmanagedMiner) SnapDeal(sectorNumber abi.SectorNumber) []abi.Piec
 	req.NoError(err)
 	req.True(r.Receipt.ExitCode.IsSuccess())
 
-	si.pieces = pieces
+	si.pieces = manifest
 	si.sealedCid = newSealedCid
 	si.unsealedCid = newUnsealedCid
 	tm.setCommittedSector(si)
 
-	return pieces
+	return pieces, r.TipSet
 }
 
 func (tm *TestUnmanagedMiner) log(msg string, args ...interface{}) {
@@ -487,9 +516,9 @@ func (tm *TestUnmanagedMiner) mkAndSavePiecesToOnboard(sector sectorInfo) (secto
 	}
 
 	// Create a struct for the piece info
-	sector.pieces = []abi.PieceInfo{{
-		Size:     paddedPieceSize,
-		PieceCID: pieceCIDA,
+	sector.pieces = []miner14.PieceActivationManifest{{
+		Size: paddedPieceSize,
+		CID:  pieceCIDA,
 	}}
 
 	// Create a temporary file for the sealed sector
@@ -679,7 +708,7 @@ func (tm *TestUnmanagedMiner) submitProveCommit(
 	sectors []sectorInfo,
 	requireActivationSuccess bool,
 	modifyNIActivationsBeforeSubmit func([]miner14.SectorNIActivationInfo) []miner14.SectorNIActivationInfo,
-) []exitcode.ExitCode {
+) ([]exitcode.ExitCode, types.TipSetKey) {
 
 	req := require.New(tm.t)
 
@@ -767,13 +796,7 @@ func (tm *TestUnmanagedMiner) submitProveCommit(
 		for i, sector := range sectors {
 			activations[i] = miner14.SectorActivationManifest{SectorNumber: sector.sectorNumber}
 			if len(sector.pieces) > 0 {
-				activations[i].Pieces = make([]miner14.PieceActivationManifest, len(sector.pieces))
-				for j, piece := range sector.pieces {
-					activations[i].Pieces[j] = miner14.PieceActivationManifest{
-						CID:  piece.PieceCID,
-						Size: piece.Size,
-					}
-				}
+				activations[i].Pieces = sector.pieces
 			}
 		}
 
@@ -819,7 +842,7 @@ func (tm *TestUnmanagedMiner) submitProveCommit(
 		}
 	}
 
-	return exitCodes
+	return exitCodes, msgReturn.TipSet
 }
 
 func (tm *TestUnmanagedMiner) wdPostLoop() {
@@ -1230,7 +1253,7 @@ func (tm *TestUnmanagedMiner) generatePreCommit(sector sectorInfo, sealRandEpoch
 	if tm.mockProofs {
 		sector.sealedCid = cid.MustParse("bagboea4b5abcatlxechwbp7kjpjguna6r6q7ejrhe6mdp3lf34pmswn27pkkiekz")
 		if len(sector.pieces) > 0 {
-			sector.unsealedCid = fixedPieceCid
+			sector.unsealedCid = sector.pieces[0].CID // TODO: handle multiple pieces?
 		}
 		return sector, nil
 	}
@@ -1269,7 +1292,7 @@ func (tm *TestUnmanagedMiner) generatePreCommit(sector sectorInfo, sealRandEpoch
 		sector.sectorNumber,
 		actorId,
 		sealTickets,
-		sector.pieces,
+		sector.piecesToPieceInfos(),
 	)
 	if err != nil {
 		return sectorInfo{}, fmt.Errorf("failed to run SealPreCommitPhase1 for sector %d: %w", sector.sectorNumber, err)
@@ -1362,7 +1385,7 @@ func (tm *TestUnmanagedMiner) generateSectorProof(sector sectorInfo) ([]byte, er
 		actorId,
 		sector.sealTickets,
 		interactiveRandomness,
-		sector.pieces,
+		sector.piecesToPieceInfos(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run SealCommitPhase1 for sector %d: %w", sector.sectorNumber, err)

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -87,7 +88,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			minerC.AssertNoPower()
 
 			// ---- Miner B onboards a CC sector
-			bSectors := minerB.OnboardSectors(sealProofType, false, 1)
+			bSectors, _ := minerB.OnboardSectors(sealProofType, []kit.SectorManifest{{}})
 			req.Len(bSectors, 1)
 			// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 			minerB.AssertNoPower()
@@ -95,7 +96,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			blockMiner.WatchMinerForPost(minerB.ActorAddr)
 
 			// --- Miner C onboards sector with data/pieces
-			cSectors := minerC.OnboardSectors(sealProofType, true, 1)
+			cSectors, _ := minerC.OnboardSectors(sealProofType, []kit.SectorManifest{kit.SectorWithRandPiece()})
 			// Miner C should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 			minerC.AssertNoPower()
 			// Ensure that the block miner checks for and waits for posts during the appropriate proving window from our new miner with a sector
@@ -106,7 +107,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			minerC.WaitTillActivatedAndAssertPower(cSectors, uint64(defaultSectorSize), uint64(defaultSectorSize))
 
 			// Miner B has activated the CC sector -> upgrade it with snapdeals
-			_ = minerB.SnapDeal(bSectors[0])
+			_, _ = minerB.SnapDeal(bSectors[0], kit.SectorManifest{Piece: cid.MustParse("baga6ea4seaqlhznlutptgfwhffupyer6txswamerq5fc2jlwf2lys2mm5jtiaeq")})
 		})
 	}
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -88,7 +87,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			minerC.AssertNoPower()
 
 			// ---- Miner B onboards a CC sector
-			bSectors, _ := minerB.OnboardSectors(sealProofType, []kit.SectorManifest{{}})
+			bSectors, _ := minerB.OnboardSectors(sealProofType, kit.NewSectorBatch().AddEmptySectors(1))
 			req.Len(bSectors, 1)
 			// Miner B should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 			minerB.AssertNoPower()
@@ -96,7 +95,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			blockMiner.WatchMinerForPost(minerB.ActorAddr)
 
 			// --- Miner C onboards sector with data/pieces
-			cSectors, _ := minerC.OnboardSectors(sealProofType, []kit.SectorManifest{kit.SectorWithRandPiece()})
+			cSectors, _ := minerC.OnboardSectors(sealProofType, kit.NewSectorBatch().AddSectorsWithRandomPieces(1))
 			// Miner C should still not have power as power can only be gained after sector is activated i.e. the first WindowPost is submitted for it
 			minerC.AssertNoPower()
 			// Ensure that the block miner checks for and waits for posts during the appropriate proving window from our new miner with a sector
@@ -107,7 +106,7 @@ func TestManualSectorOnboarding(t *testing.T) {
 			minerC.WaitTillActivatedAndAssertPower(cSectors, uint64(defaultSectorSize), uint64(defaultSectorSize))
 
 			// Miner B has activated the CC sector -> upgrade it with snapdeals
-			_, _ = minerB.SnapDeal(bSectors[0], kit.SectorManifest{Piece: cid.MustParse("baga6ea4seaqlhznlutptgfwhffupyer6txswamerq5fc2jlwf2lys2mm5jtiaeq")})
+			_, _ = minerB.SnapDeal(bSectors[0], kit.SectorManifest{Piece: kit.BogusPieceCid2})
 		})
 	}
 }

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -244,6 +244,7 @@ func (a *StateAPI) StateMinerDeadlines(ctx context.Context, m address.Address, t
 		out[i] = api.Deadline{
 			PostSubmissions:      ps,
 			DisputableProofCount: l,
+			DailyFee:             dl.DailyFee(),
 		}
 		return nil
 	}); err != nil {

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -240,11 +240,15 @@ func (a *StateAPI) StateMinerDeadlines(ctx context.Context, m address.Address, t
 		if err != nil {
 			return err
 		}
+		dailyFee, err := dl.DailyFee()
+		if err != nil {
+			return err
+		}
 
 		out[i] = api.Deadline{
 			PostSubmissions:      ps,
 			DisputableProofCount: l,
-			DailyFee:             dl.DailyFee(),
+			DailyFee:             dailyFee,
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
FIP-0100 fees migration test. Still some more to add here and I'm stacking up PRs a little. This one is on top of #12938 which sets up circulating supply.

This PR uses UnmanagedMiner and has some changes I'd like to get merged regardless of FIP-0100's status. Currently we're testing onboarding different kinds of sectors while in nv24, then hitting the upgrade and snapping into CC sectors and checking fees. Also need to add new sectors post-nv25 and probably an extension or two. I also still haven't figured out how to test actual fee deduction in a reliable way, and it would also be good to do that with the BR cap too if I can figure out how to manage that as well.