### PR TITLE
fix: f3: topic filter with no static manifest

### DIFF
--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -368,9 +368,9 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 	allowTopics = append(allowTopics, drandTopics...)
 
 	if in.F3Config != nil {
-		if in.F3Config.StaticManifest != nil {
-			gpbftTopic := manifest.PubSubTopicFromNetworkName(in.F3Config.StaticManifest.NetworkName)
-			chainexTopic := manifest.ChainExchangeTopicFromNetworkName(in.F3Config.StaticManifest.NetworkName)
+		if in.F3Config.StaticManifest != nil || in.F3Config.ContractAddress != "" {
+			gpbftTopic := manifest.PubSubTopicFromNetworkName(in.F3Config.BaseNetworkName)
+			chainexTopic := manifest.ChainExchangeTopicFromNetworkName(in.F3Config.BaseNetworkName)
 			allowTopics = append(allowTopics, gpbftTopic, chainexTopic)
 		}
 		if in.F3Config.DynamicManifestProvider != "" {


### PR DESCRIPTION
The code would only allow the main network pubsub topic if the static manifest were specified.
Not sure how that slipped through my manual tests. I think I was testing it with the code that was overriding static manifest with contract one, and only later I made the two options exclusive.