### PR TITLE
fix: prevent panic in `FullNodeProxy` with empty node list

### DIFF
--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -239,6 +239,11 @@ func OnSingleNode(ctx context.Context) context.Context {
 }
 
 func FullNodeProxy[T api.FullNode](ins []T, outstr *api.FullNodeStruct) {
+	if len(ins) == 0 {
+		log.Errorf("FullNodeProxy called with empty node list")
+		return
+	}
+
 	outs := api.GetInternalStructs(outstr)
 
 	var rins []reflect.Value


### PR DESCRIPTION
fix: prevent panic in FullNodeProxy with empty node list

## Related Issues
Fixes #12931

## Proposed Changes
- Add check in FullNodeProxy to prevent panic when called with an empty node list

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
