### PR TITLE
feat: integrate & test FIP-0098 additions

### DIFF
--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -2,32 +2,40 @@ package miner
 
 import (
 	"github.com/ipfs/go-cid"
-	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/network"
-	"github.com/filecoin-project/lotus/chain/actors"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/big"
+	gstbuiltin "github.com/filecoin-project/go-state-types/builtin"
+	minertypes13 "github.com/filecoin-project/go-state-types/builtin/v13/miner"
+{{- range .versions}}
+	{{- if (ge . 16)}}
+		minertypes{{.}} "github.com/filecoin-project/go-state-types/builtin/v{{.}}/miner"
+		smoothing{{.}} "github.com/filecoin-project/go-state-types/builtin/v{{.}}/util/smoothing"
+	{{- end -}}
+{{end}}
+	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/dline"
-	"github.com/filecoin-project/go-state-types/proof"
-
-	"github.com/filecoin-project/lotus/chain/actors/adt"
-	"github.com/filecoin-project/lotus/chain/types"
-	minertypes16 "github.com/filecoin-project/go-state-types/builtin/v16/miner"
-	minertypes13 "github.com/filecoin-project/go-state-types/builtin/v13/miner"
-	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/manifest"
-
-{{range .versions}}
-    {{if (le . 7)}}
-	    builtin{{.}} "github.com/filecoin-project/specs-actors{{import .}}actors/builtin"
-    {{end}}
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/go-state-types/proof"
+{{- range .versions}}
+  {{- if (le . 7)}}
+    builtin{{.}} "github.com/filecoin-project/specs-actors{{import .}}actors/builtin"
+  {{- end -}}
 {{end}}
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/types"
 )
+
+var Methods = gstbuiltin.MethodsMiner
 
 func Load(store adt.Store, act *types.Actor) (State, error) {
 	if name, av, ok := actors.GetActorMetaByCode(act.Code); ok {
@@ -81,6 +89,7 @@ type State interface {
 	// Funds locked for various reasons.
 	LockedFunds() (LockedFunds, error)
 	FeeDebt() (abi.TokenAmount, error)
+	InitialPledge() (abi.TokenAmount, error)
 
     // Returns nil, nil if sector is not found
 	GetSector(abi.SectorNumber) (*SectorOnChainInfo, error)
@@ -155,7 +164,7 @@ type Partition interface {
 	UnprovenSectors() (bitfield.BitField, error)
 }
 
-type SectorOnChainInfo = minertypes16.SectorOnChainInfo
+type SectorOnChainInfo = minertypes{{.latestVersion}}.SectorOnChainInfo
 
 func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof, configWantSynthetic bool) (abi.RegisteredSealProof, error) {
 	// We added support for the new proofs in network version 7, and removed support for the old
@@ -252,13 +261,16 @@ type SectorClaim = minertypes.SectorClaim
 type ExpirationExtension2 = minertypes.ExpirationExtension2
 type CompactPartitionsParams = minertypes.CompactPartitionsParams
 type WithdrawBalanceParams = minertypes.WithdrawBalanceParams
+type MaxTerminationFeeParams = minertypes{{.latestVersion}}.MaxTerminationFeeParams
+type MaxTerminationFeeReturn = minertypes{{.latestVersion}}.MaxTerminationFeeReturn
+type InitialPledgeReturn = minertypes{{.latestVersion}}.InitialPledgeReturn
 
 type PieceActivationManifest = minertypes13.PieceActivationManifest
 type ProveCommitSectors3Params = minertypes13.ProveCommitSectors3Params
 type SectorActivationManifest = minertypes13.SectorActivationManifest
 type ProveReplicaUpdates3Params = minertypes13.ProveReplicaUpdates3Params
 type SectorUpdateManifest = minertypes13.SectorUpdateManifest
-type SectorOnChainInfoFlags = minertypes16.SectorOnChainInfoFlags
+type SectorOnChainInfoFlags = minertypes{{.latestVersion}}.SectorOnChainInfoFlags
 type VerifiedAllocationKey = minertypes13.VerifiedAllocationKey
 
 var QAPowerMax = minertypes.QAPowerMax
@@ -273,6 +285,9 @@ const WPoStChallengeLookback = minertypes.WPoStChallengeLookback
 const FaultDeclarationCutoff = minertypes.FaultDeclarationCutoff
 const MinAggregatedSectors = minertypes.MinAggregatedSectors
 const MinSectorExpiration = minertypes.MinSectorExpiration
+
+var TermFeePledgeMultiple = minertypes{{.latestVersion}}.TermFeePledgeMultiple
+var TermFeeMaxFaultFeeMultiple = minertypes{{.latestVersion}}.TermFeeMaxFaultFeeMultiple
 
 type SectorExpiration struct {
 	OnTime abi.ChainEpoch
@@ -317,5 +332,75 @@ func AllCodes() []cid.Cid {
 	return []cid.Cid{ {{range .versions}}
         (&state{{.}}{}).Code(),
     {{- end}}
+    }
+}
+
+func PledgePenaltyForContinuedFault(
+        nwVer network.Version,
+        rewardEstimate builtin.FilterEstimate,
+        networkQaPowerEstimate builtin.FilterEstimate,
+        qaSectorPower abi.StoragePower,
+) (abi.TokenAmount, error) {
+    v, err := actorstypes.VersionForNetwork(nwVer)
+    if err != nil {
+        return big.Zero(), err
+    }
+
+    if v <= actorstypes.Version16 {
+        return minertypes16.PledgePenaltyForContinuedFault(
+            smoothing16.FilterEstimate{
+                PositionEstimate: rewardEstimate.PositionEstimate,
+                VelocityEstimate: rewardEstimate.VelocityEstimate,
+            },
+            smoothing16.FilterEstimate{
+                PositionEstimate: networkQaPowerEstimate.PositionEstimate,
+                VelocityEstimate: networkQaPowerEstimate.VelocityEstimate,
+            },
+            qaSectorPower,
+        ), nil
+    }
+
+    switch v {
+    {{- range .versions}}
+        {{- if (gt . 16)}}
+    case actorstypes.Version{{.}}:
+            return minertypes{{.}}.PledgePenaltyForContinuedFault(
+                smoothing{{.}}.FilterEstimate{
+                    PositionEstimate: rewardEstimate.PositionEstimate,
+                    VelocityEstimate: rewardEstimate.VelocityEstimate,
+                },
+                smoothing{{.}}.FilterEstimate{
+                    PositionEstimate: networkQaPowerEstimate.PositionEstimate,
+                    VelocityEstimate: networkQaPowerEstimate.VelocityEstimate,
+                },
+                qaSectorPower,
+            ), nil
+        {{- end}}
+    {{- end}}
+    default:
+        return big.Zero(), xerrors.Errorf("unsupported network version: %d", v)
+    }
+}
+
+func PledgePenaltyForTermination(
+        nwVer network.Version,
+        initialPledge abi.TokenAmount,
+        sectorAge abi.ChainEpoch,
+        faultFee abi.TokenAmount,
+) (abi.TokenAmount, error) {
+    v, err := actorstypes.VersionForNetwork(nwVer)
+    if err != nil {
+        return big.Zero(), err
+    }
+
+    switch v {
+    {{- range .versions}}
+        {{- if (ge . 16)}}
+    case actorstypes.Version{{.}}:
+            return minertypes{{.}}.PledgePenaltyForTermination(initialPledge, sectorAge, faultFee), nil
+        {{- end}}
+    {{- end}}
+    default:
+        return big.Zero(), xerrors.Errorf("unsupported network version: %d", v)
     }
 }

--- a/chain/actors/builtin/power/actor.go.template
+++ b/chain/actors/builtin/power/actor.go.template
@@ -22,7 +22,8 @@ import (
 	    builtin{{.}} "github.com/filecoin-project/specs-actors{{import .}}actors/builtin"
     {{end}}
 {{end}}
-    builtin{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin"
+	builtin{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin"
+	powertypes{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin/v{{.latestVersion}}/power"
 )
 
 var (
@@ -137,3 +138,8 @@ func AllCodes() []cid.Cid {
     {{- end}}
     }
 }
+
+type (
+	MinerPowerParams = powertypes{{.latestVersion}}.MinerPowerParams
+	MinerPowerReturn = powertypes{{.latestVersion}}.MinerPowerReturn
+)

--- a/chain/actors/builtin/power/power.go
+++ b/chain/actors/builtin/power/power.go
@@ -10,6 +10,7 @@ import (
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/big"
 	builtin16 "github.com/filecoin-project/go-state-types/builtin"
+	powertypes16 "github.com/filecoin-project/go-state-types/builtin/v16/power"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/manifest"
 	builtin0 "github.com/filecoin-project/specs-actors/actors/builtin"
@@ -235,3 +236,8 @@ func AllCodes() []cid.Cid {
 		(&state16{}).Code(),
 	}
 }
+
+type (
+	MinerPowerParams = powertypes16.MinerPowerParams
+	MinerPowerReturn = powertypes16.MinerPowerReturn
+)

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -929,71 +929,38 @@ func AggregateProveCommitNetworkFee(nwVer network.Version, aggregateSize int, ba
 		return big.Zero(), err
 	}
 	switch v {
-
 	case actorstypes.Version0:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version2:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version3:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version4:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version5:
-
 		return miner5.AggregateNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version6:
-
 		return miner6.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version7:
-
 		return miner7.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version8:
-
 		return miner8.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version9:
-
 		return miner9.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version10:
-
 		return miner10.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version11:
-
 		return miner11.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version12:
-
 		return miner12.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version13:
-
 		return miner13.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version14:
-
 		return miner14.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version15:
-
 		return miner15.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version16:
-
-		return miner16.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-
+		return big.Zero(), nil
 	default:
 		return big.Zero(), xerrors.Errorf("unsupported network version")
 	}
@@ -1005,71 +972,38 @@ func AggregatePreCommitNetworkFee(nwVer network.Version, aggregateSize int, base
 		return big.Zero(), err
 	}
 	switch v {
-
 	case actorstypes.Version0:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version2:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version3:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version4:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version5:
-
 		return big.Zero(), nil
-
 	case actorstypes.Version6:
-
 		return miner6.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version7:
-
 		return miner7.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version8:
-
 		return miner8.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version9:
-
 		return miner9.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version10:
-
 		return miner10.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version11:
-
 		return miner11.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version12:
-
 		return miner12.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version13:
-
 		return miner13.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version14:
-
 		return miner14.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version15:
-
 		return miner15.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
 	case actorstypes.Version16:
-
-		return miner16.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-
+		return big.Zero(), nil
 	default:
 		return big.Zero(), xerrors.Errorf("unsupported network version")
 	}

--- a/chain/actors/policy/policy.go.template
+++ b/chain/actors/policy/policy.go.template
@@ -315,16 +315,18 @@ func AggregateProveCommitNetworkFee(nwVer network.Version, aggregateSize int, ba
 		return big.Zero(), err
 	}
 	switch v {
-	    {{range .versions}}
+	    {{- range .versions}}
 	    case actorstypes.Version{{.}}:
-            {{if (ge . 6)}}
-                return miner{{.}}.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
-            {{else if (eq . 5)}}
-                return miner{{.}}.AggregateNetworkFee(aggregateSize, baseFee), nil
-            {{else}}
+            {{- if (ge . 16)}}
                 return big.Zero(), nil
-            {{end}}
-        {{end}}
+            {{- else if (ge . 6)}}
+                return miner{{.}}.AggregateProveCommitNetworkFee(aggregateSize, baseFee), nil
+            {{- else if (eq . 5)}}
+                return miner{{.}}.AggregateNetworkFee(aggregateSize, baseFee), nil
+            {{- else}}
+                return big.Zero(), nil
+            {{- end -}}
+      {{- end}}
 	default:
 		return big.Zero(), xerrors.Errorf("unsupported network version")
 	}
@@ -336,14 +338,16 @@ func AggregatePreCommitNetworkFee(nwVer network.Version, aggregateSize int, base
 		return big.Zero(), err
 	}
 	switch v {
-	    {{range .versions}}
+	    {{- range .versions}}
 	    case actorstypes.Version{{.}}:
-            {{if (ge . 6)}}
-                return miner{{.}}.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
-            {{else}}
+            {{- if (ge . 16)}}
                 return big.Zero(), nil
-            {{end}}
-        {{end}}
+            {{- else if (ge . 6)}}
+                return miner{{.}}.AggregatePreCommitNetworkFee(aggregateSize, baseFee), nil
+            {{- else}}
+                return big.Zero(), nil
+            {{- end -}}
+      {{end}}
 	default:
 		return big.Zero(), xerrors.Errorf("unsupported network version")
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.7.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.16.0-rc7 // dependency-check-ignore: unknown
+	github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63 // dependency-check-ignore: unknown
 	github.com/filecoin-project/go-statemachine v1.0.3
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.16.0-rc7 h1:ODs527FEqmq/kKj4jXqRVGUx8t8+XLPjR9aP1f+YVus=
-github.com/filecoin-project/go-state-types v0.16.0-rc7/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
+github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63 h1:mcsUJkoQ1+Kal1wPbIBhjZOqlON8c1sw0K4TiefVwcs=
+github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
 github.com/filecoin-project/go-statemachine v1.0.3 h1:N07o6alys+V1tNoSTi4WuuoeNC4erS/6jE74+NsgQuk=
 github.com/filecoin-project/go-statemachine v1.0.3/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/go-state-types/pull/376
Ref: https://github.com/filecoin-project/builtin-actors/pull/1639

I've added some extras in our state types abstractions here, I'd like to add more and reduce (ideally remove) the direct uses of go-state-types versioned actor types we have through the codebase. (See https://github.com/filecoin-project/lotus/pull/12960 for some of how annoying this is). My goal in the itest was to not refer to go-state-types at all while testing all of those additions. We should be able to approach almost all other uses of those types throughout the code in the same way, but we're pretty sloppy.

Also removed some batch balancer stuff.