### PR TITLE
feat: improve `lotus-gateway` build for network selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 > * [CHANGELOG_1.2x.md](./documentation/changelog/CHANGELOG_1.2x.md) - v1.20.0 to v1.29.2
 
 # UNRELEASED
+- feat: improve `lotus-gateway` build for network selection ([filecoin-project/lotus#12969](https://github.com/filecoin-project/lotus/pull/12969))
 - Allow users to start node even if Index Reconciliation fails (https://github.com/filecoin-project/lotus/pull/12930)
 - Exposed `StateGetNetworkParams` in the Lotus Gateway API ([filecoin-project/lotus#12881](https://github.com/filecoin-project/lotus/pull/12881))
 - **BREAKING**: Removed `SupportedProofTypes` from `StateGetNetworkParams` response as it was unreliable and didn't match FVM's actual supported proofs ([filecoin-project/lotus#12881](https://github.com/filecoin-project/lotus/pull/12881))

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ debug: build-devnets  ## Build with debug tags
 
 calibnet: GOFLAGS+=-tags=calibnet
 calibnet: build-devnets  ## Build for calibnet network
+	@touch .calibnet-mode
 
 butterflynet: GOFLAGS+=-tags=butterflynet
 butterflynet: build-devnets  ## Build for butterflynet network
@@ -115,7 +116,13 @@ BINS+=lotus-shed
 
 lotus-gateway: $(BUILD_DEPS)  ## Build the Lotus gateway
 	rm -f lotus-gateway
-	$(GOCC) build $(GOFLAGS) -o lotus-gateway ./cmd/lotus-gateway
+	@if [ -f .calibnet-mode ]; then \
+		echo "Building lotus-gateway with calibnet tags"; \
+		$(GOCC) build -tags=calibnet $(GOFLAGS) -o lotus-gateway ./cmd/lotus-gateway; \
+	else \
+		echo "Building lotus-gateway for mainnet"; \
+		$(GOCC) build $(GOFLAGS) -o lotus-gateway ./cmd/lotus-gateway; \
+	fi
 .PHONY: lotus-gateway
 BINS+=lotus-gateway
 
@@ -292,7 +299,7 @@ lint:
 .PHONY: lint
 
 clean:  ## Clean build artifacts
-	rm -rf $(CLEAN) $(BINS)
+	rm -rf $(CLEAN) $(BINS) .calibnet-mode
 	-$(MAKE) -C $(FFI_PATH) clean
 .PHONY: clean
 


### PR DESCRIPTION
## Related Issues
Closes #12967 #12767 

## Proposed Changes

- Add a marker file .calibnet-mode that gets created when running `make calibnet`
- Make `lotus-gateway` check for that markerfile
   - If the file exists, it builds with calibnet tags
   - If the file doesn’t exist, it builds for mainnet
- Make sure the marker file gets removed when running `make clean`

## Additional Info
We discussed other approaches as well, but we wanted to keep current state intact and not add `lotus-gateway` to `make calibnet` since it is already overloaded, as having to build extra binaries is not ideal. And additionally we wanted to keep consistency, and prefer to build `lotus-gateway` instead of introducing a special `lotus-gateway-calib`.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
