### PR TITLE
chore(deps): bump go-state-types to v0.16.0-rc8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.7.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63 // dependency-check-ignore: unknown
+	github.com/filecoin-project/go-state-types v0.16.0-rc8 // dependency-check-ignore: unknown
 	github.com/filecoin-project/go-statemachine v1.0.3
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63 h1:mcsUJkoQ1+Kal1wPbIBhjZOqlON8c1sw0K4TiefVwcs=
-github.com/filecoin-project/go-state-types v0.16.0-rc7.0.20250320064648-8f3281fc0d63/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
+github.com/filecoin-project/go-state-types v0.16.0-rc8 h1:tVgcoLhUPauhEhHDZtnHc99KSZwjF3loVAAEi1yR/AE=
+github.com/filecoin-project/go-state-types v0.16.0-rc8/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
 github.com/filecoin-project/go-statemachine v1.0.3 h1:N07o6alys+V1tNoSTi4WuuoeNC4erS/6jE74+NsgQuk=
 github.com/filecoin-project/go-statemachine v1.0.3/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=

--- a/itests/daily_fees_test.go
+++ b/itests/daily_fees_test.go
@@ -613,15 +613,15 @@ func TestDailyFees(t *testing.T) {
 	// Wait for all fees to be paid—we need each one to have reached its first deadline and they are
 	// likely spread out over multiple deadlines
 	feePostWg.Wait()
-	head, err := client.ChainHead(ctx)
-	req.NoError(err)
 	// Wait one exta deadline to make sure we get to the end of the current deadline where we've done
 	// a PoST
+	head, err := client.ChainHead(ctx)
+	req.NoError(err)
 	client.WaitTillChain(ctx, kit.HeightAtLeast(head.Height()+miner.WPoStChallengeWindow()+10))
 
 	var expectTotalBurn abi.TokenAmount
 	for _, sector := range allSectors {
-		paymentsPast := provingWindowsSince(sector.sn, nv25epoch)
+		paymentsPast := provingWindowsSince(sector.sn, sector.feeEpoch)
 		expectTotalBurn = big.Add(expectTotalBurn, big.Mul(big.NewInt(int64(paymentsPast)), sector.expectedFee))
 	}
 


### PR DESCRIPTION
Was supposed to be done in https://github.com/filecoin-project/lotus/pull/12968
