### PR TITLE
feat: expose market ProviderSectors access on state-types abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - Removed `--only-cc` from `spcli sectors extend` command
   - Change circulating supply calculation for calibnet, butterflynet and 2k for nv25 upgrade; see ([filecoin-project/lotus#12938](https://github.com/filecoin-project/lotus/pull/12938)) for more information
 - feat(miner): remove batch balancer-related functionality ([filecoin-project/lotus#12919](https://github.com/filecoin-project/lotus/pull/12919))
+- feat(market): expose access to ProviderSectors on the market actor abstraction ([filecoin-project/lotus#12978](https://github.com/filecoin-project/lotus/pull/12978))
 
 # UNRELEASED v.1.32.0
 

--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -76,9 +76,9 @@ func MakeState(store adt.Store, av actorstypes.Version) (State, error) {
 type State interface {
 	cbor.Marshaler
 
-    Code() cid.Cid
-    ActorKey() string
-    ActorVersion() actorstypes.Version
+	Code() cid.Cid
+	ActorKey() string
+	ActorVersion() actorstypes.Version
 
 	BalancesChanged(State) (bool, error)
 	EscrowTable() (BalanceTable, error)
@@ -95,6 +95,7 @@ type State interface {
 	NextID() (abi.DealID, error)
 	GetState() interface{}
 	GetAllocationIdForPendingDeal(dealId abi.DealID) (verifregtypes.AllocationId, error)
+	ProviderSectors() (ProviderSectors, error)
 }
 
 type BalanceTable interface {
@@ -153,6 +154,15 @@ type DealState interface {
 	SlashEpoch() abi.ChainEpoch       // -1 if deal never slashed
 
 	Equals(other DealState) bool
+}
+
+type ProviderSectors interface {
+	Get(actorId abi.ActorID) (SectorDealIDs, bool, error)
+}
+
+type SectorDealIDs interface {
+	ForEach(cb func(abi.SectorNumber, []abi.DealID) error) error
+	Get(sectorNumber abi.SectorNumber) ([]abi.DealID, bool, error)
 }
 
 func DealStatesEqual(a, b DealState) bool {

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -178,6 +178,7 @@ type State interface {
 	NextID() (abi.DealID, error)
 	GetState() interface{}
 	GetAllocationIdForPendingDeal(dealId abi.DealID) (verifregtypes.AllocationId, error)
+	ProviderSectors() (ProviderSectors, error)
 }
 
 type BalanceTable interface {
@@ -281,6 +282,15 @@ type DealState interface {
 	SlashEpoch() abi.ChainEpoch       // -1 if deal never slashed
 
 	Equals(other DealState) bool
+}
+
+type ProviderSectors interface {
+	Get(actorId abi.ActorID) (SectorDealIDs, bool, error)
+}
+
+type SectorDealIDs interface {
+	ForEach(cb func(abi.SectorNumber, []abi.DealID) error) error
+	Get(sectorNumber abi.SectorNumber) ([]abi.DealID, bool, error)
 }
 
 func DealStatesEqual(a, b DealState) bool {

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -460,3 +460,63 @@ func (s *state{{.v}}) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state{{.v}}) ProviderSectors() (ProviderSectors, error) {
+{{if lt .v 13}}
+	return nil, xerrors.Errorf("unsupported before actors v13")
+{{else}}
+	proverSectors, err := adt{{.v}}.AsMap(s.store, s.State.ProviderSectors, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &providerSectors{{.v}}{proverSectors, s.store}, nil
+{{end}}
+}
+
+{{if ge .v 13}}
+	type providerSectors{{.v}} struct {
+		*adt{{.v}}.Map
+		adt{{.v}}.Store
+	}
+
+	type sectorDealIDs{{.v}} struct {
+		*adt{{.v}}.Map
+	}
+
+	func (s *providerSectors{{.v}}) Get(actorId abi.ActorID) (SectorDealIDs, bool, error) {
+		var sectorDealIdsCID cbg.CborCid
+		if ok, err := s.Map.Get(abi.UIntKey(uint64(actorId)), &sectorDealIdsCID); err != nil {
+			return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+		} else if !ok {
+			return nil, false, nil
+		}
+		sectorDealIds, err := adt{{.v}}.AsMap(s.Store, cid.Cid(sectorDealIdsCID), builtin.DefaultHamtBitwidth)
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+		}
+		return &sectorDealIDs{{.v}}{sectorDealIds}, true, nil
+	}
+
+	func (s *sectorDealIDs{{.v}}) ForEach(cb func(abi.SectorNumber, []abi.DealID) error) error {
+		var dealIds abi.DealIDList
+		return s.Map.ForEach(&dealIds, func(key string) error {
+			uk, err := abi.ParseUIntKey(key)
+			if err != nil {
+				return xerrors.Errorf("failed to parse sector number from key %s: %w", key, err)
+			}
+			return cb(abi.SectorNumber(uk), dealIds)
+		})
+	}
+
+	func (s *sectorDealIDs{{.v}}) Get(sectorNumber abi.SectorNumber) ([]abi.DealID, bool, error) {
+		var dealIds abi.DealIDList
+		found, err := s.Map.Get(abi.UIntKey(uint64(sectorNumber)), &dealIds)
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to load sector deal ids for sector %d: %w", sectorNumber, err)
+		}
+		if !found {
+			return nil, false, nil
+		}
+		return dealIds, true, nil
+	}
+{{end}}

--- a/chain/actors/builtin/market/v0.go
+++ b/chain/actors/builtin/market/v0.go
@@ -379,3 +379,9 @@ func (s *state0) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state0) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v10.go
+++ b/chain/actors/builtin/market/v10.go
@@ -424,3 +424,9 @@ func (s *state10) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state10) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v11.go
+++ b/chain/actors/builtin/market/v11.go
@@ -424,3 +424,9 @@ func (s *state11) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state11) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v12.go
+++ b/chain/actors/builtin/market/v12.go
@@ -424,3 +424,9 @@ func (s *state12) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state12) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v13.go
+++ b/chain/actors/builtin/market/v13.go
@@ -424,3 +424,59 @@ func (s *state13) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state13) ProviderSectors() (ProviderSectors, error) {
+
+	proverSectors, err := adt13.AsMap(s.store, s.State.ProviderSectors, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &providerSectors13{proverSectors, s.store}, nil
+
+}
+
+type providerSectors13 struct {
+	*adt13.Map
+	adt13.Store
+}
+
+type sectorDealIDs13 struct {
+	*adt13.Map
+}
+
+func (s *providerSectors13) Get(actorId abi.ActorID) (SectorDealIDs, bool, error) {
+	var sectorDealIdsCID cbg.CborCid
+	if ok, err := s.Map.Get(abi.UIntKey(uint64(actorId)), &sectorDealIdsCID); err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+	} else if !ok {
+		return nil, false, nil
+	}
+	sectorDealIds, err := adt13.AsMap(s.Store, cid.Cid(sectorDealIdsCID), builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+	}
+	return &sectorDealIDs13{sectorDealIds}, true, nil
+}
+
+func (s *sectorDealIDs13) ForEach(cb func(abi.SectorNumber, []abi.DealID) error) error {
+	var dealIds abi.DealIDList
+	return s.Map.ForEach(&dealIds, func(key string) error {
+		uk, err := abi.ParseUIntKey(key)
+		if err != nil {
+			return xerrors.Errorf("failed to parse sector number from key %s: %w", key, err)
+		}
+		return cb(abi.SectorNumber(uk), dealIds)
+	})
+}
+
+func (s *sectorDealIDs13) Get(sectorNumber abi.SectorNumber) ([]abi.DealID, bool, error) {
+	var dealIds abi.DealIDList
+	found, err := s.Map.Get(abi.UIntKey(uint64(sectorNumber)), &dealIds)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for sector %d: %w", sectorNumber, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+	return dealIds, true, nil
+}

--- a/chain/actors/builtin/market/v14.go
+++ b/chain/actors/builtin/market/v14.go
@@ -424,3 +424,59 @@ func (s *state14) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state14) ProviderSectors() (ProviderSectors, error) {
+
+	proverSectors, err := adt14.AsMap(s.store, s.State.ProviderSectors, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &providerSectors14{proverSectors, s.store}, nil
+
+}
+
+type providerSectors14 struct {
+	*adt14.Map
+	adt14.Store
+}
+
+type sectorDealIDs14 struct {
+	*adt14.Map
+}
+
+func (s *providerSectors14) Get(actorId abi.ActorID) (SectorDealIDs, bool, error) {
+	var sectorDealIdsCID cbg.CborCid
+	if ok, err := s.Map.Get(abi.UIntKey(uint64(actorId)), &sectorDealIdsCID); err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+	} else if !ok {
+		return nil, false, nil
+	}
+	sectorDealIds, err := adt14.AsMap(s.Store, cid.Cid(sectorDealIdsCID), builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for actor %d: %w", actorId, err)
+	}
+	return &sectorDealIDs14{sectorDealIds}, true, nil
+}
+
+func (s *sectorDealIDs14) ForEach(cb func(abi.SectorNumber, []abi.DealID) error) error {
+	var dealIds abi.DealIDList
+	return s.Map.ForEach(&dealIds, func(key string) error {
+		uk, err := abi.ParseUIntKey(key)
+		if err != nil {
+			return xerrors.Errorf("failed to parse sector number from key %s: %w", key, err)
+		}
+		return cb(abi.SectorNumber(uk), dealIds)
+	})
+}
+
+func (s *sectorDealIDs14) Get(sectorNumber abi.SectorNumber) ([]abi.DealID, bool, error) {
+	var dealIds abi.DealIDList
+	found, err := s.Map.Get(abi.UIntKey(uint64(sectorNumber)), &dealIds)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load sector deal ids for sector %d: %w", sectorNumber, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+	return dealIds, true, nil
+}

--- a/chain/actors/builtin/market/v2.go
+++ b/chain/actors/builtin/market/v2.go
@@ -379,3 +379,9 @@ func (s *state2) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state2) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v3.go
+++ b/chain/actors/builtin/market/v3.go
@@ -375,3 +375,9 @@ func (s *state3) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state3) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v4.go
+++ b/chain/actors/builtin/market/v4.go
@@ -375,3 +375,9 @@ func (s *state4) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state4) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v5.go
+++ b/chain/actors/builtin/market/v5.go
@@ -375,3 +375,9 @@ func (s *state5) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state5) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v6.go
+++ b/chain/actors/builtin/market/v6.go
@@ -393,3 +393,9 @@ func (s *state6) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state6) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v7.go
+++ b/chain/actors/builtin/market/v7.go
@@ -393,3 +393,9 @@ func (s *state7) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state7) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v8.go
+++ b/chain/actors/builtin/market/v8.go
@@ -410,3 +410,9 @@ func (s *state8) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state8) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/chain/actors/builtin/market/v9.go
+++ b/chain/actors/builtin/market/v9.go
@@ -424,3 +424,9 @@ func (s *state9) Code() cid.Cid {
 
 	return code
 }
+
+func (s *state9) ProviderSectors() (ProviderSectors, error) {
+
+	return nil, xerrors.Errorf("unsupported before actors v13")
+
+}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.7.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-paramfetch v0.0.4
-	github.com/filecoin-project/go-state-types v0.16.0-rc8 // dependency-check-ignore: unknown
+	github.com/filecoin-project/go-state-types v0.16.0-rc9 // dependency-check-ignore: unknown
 	github.com/filecoin-project/go-statemachine v1.0.3
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
-github.com/filecoin-project/go-state-types v0.16.0-rc8 h1:tVgcoLhUPauhEhHDZtnHc99KSZwjF3loVAAEi1yR/AE=
-github.com/filecoin-project/go-state-types v0.16.0-rc8/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
+github.com/filecoin-project/go-state-types v0.16.0-rc9 h1:L7v1ZafjCa+v/9BCYc0WotSwy8CjDeyJUpTKpgnv8jg=
+github.com/filecoin-project/go-state-types v0.16.0-rc9/go.mod h1:YCESyrqnyu17y0MazbV6Uwma5+BrMvEKEQp5QWeIf9g=
 github.com/filecoin-project/go-statemachine v1.0.3 h1:N07o6alys+V1tNoSTi4WuuoeNC4erS/6jE74+NsgQuk=
 github.com/filecoin-project/go-statemachine v1.0.3/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/lotus/issues/11997

See the itest for how this is used.

~_Depends on https://github.com/filecoin-project/go-state-types/pull/378_~