### PR TITLE
chore(eth): make EthGetBlockByNumber & EthGetBlockByHash share cache code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - Removed `--only-cc` from `spcli sectors extend` command
   - Change circulating supply calculation for calibnet, butterflynet and 2k for nv25 upgrade; see ([filecoin-project/lotus#12938](https://github.com/filecoin-project/lotus/pull/12938)) for more information
 - feat(miner): remove batch balancer-related functionality ([filecoin-project/lotus#12919](https://github.com/filecoin-project/lotus/pull/12919))
+- chore(eth): make EthGetBlockByNumber & EthGetBlockByHash share the same cache and be impacted by `EthBlkCacheSize` config settings ([filecoin-project/lotus#12979](https://github.com/filecoin-project/lotus/pull/12979))
 
 # UNRELEASED v.1.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   - Removed `--only-cc` from `spcli sectors extend` command
   - Change circulating supply calculation for calibnet, butterflynet and 2k for nv25 upgrade; see ([filecoin-project/lotus#12938](https://github.com/filecoin-project/lotus/pull/12938)) for more information
 - feat(miner): remove batch balancer-related functionality ([filecoin-project/lotus#12919](https://github.com/filecoin-project/lotus/pull/12919))
-- chore(eth): make EthGetBlockByNumber & EthGetBlockByHash share the same cache and be impacted by `EthBlkCacheSize` config settings ([filecoin-project/lotus#12979](https://github.com/filecoin-project/lotus/pull/12979))
+- chore(eth): make `EthGetBlockByNumber` & `EthGetBlockByHash` share the same cache and be impacted by `EthBlkCacheSize` config settings ([filecoin-project/lotus#12979](https://github.com/filecoin-project/lotus/pull/12979))
 
 # UNRELEASED v.1.32.0
 


### PR DESCRIPTION
Both will benefit from the same cache and be impacted by EthBlkCacheSize

Ref: https://github.com/filecoin-project/lotus/issues/12977

_(Also some minor fixups in here to rename some vars to what they should have been, when I refactored this originally most interfaces were "providers", hence the `p` in the names.)_