### PR TITLE
fix(deps): remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,13 @@
 linters:
   disable-all: true
   enable:
-    - gofmt
     - govet
-    - goimports
     - misspell
     - revive
     - errcheck
     - gosec
     - unconvert
     - staticcheck
-    - exportloopref
     - unused
 
 # We don't want to skip builtin/


### PR DESCRIPTION
Removed `gofmt`, `goimports`,  and `exportloopref` from `.golangci.yml` because they are now considered formatters, not linters. Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).
