### PR TITLE
chore(fountain): add sitemap and robots files

### DIFF
--- a/cmd/lotus-fountain/site/robots.txt
+++ b/cmd/lotus-fountain/site/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://faucet.calibnet.chainsafe-fil.io/sitemap.xml

--- a/cmd/lotus-fountain/site/sitemap.xml
+++ b/cmd/lotus-fountain/site/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://faucet.calibnet.chainsafe-fil.io/</loc>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://faucet.calibnet.chainsafe-fil.io/funds</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://faucet.calibnet.chainsafe-fil.io/datacap</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+</urlset>


### PR DESCRIPTION
## Related Issues
#13057 

## Proposed Changes
1. Added robots.txt:
•  Allows all web crawlers to access the site (User-agent: *)
•  Permits access to all pages (Allow: /)
•  Points to the sitemap location at https://faucet.calibnet.chainsafe-fil.io/sitemap.xml
2. Added sitemap.xml:
•  Contains three URLs for the Calibnet faucet site:
◦  Main page (/) with priority 1.0
◦  Funds page (/funds) with priority 0.8
◦  Datacap page (/datacap) with priority 0.8
•  All pages are set to update monthly (changefreq)
•  The sitemap follows the standard sitemap.org schema

## Additional Info
<img width="1034" alt="Screenshot 2025-04-23 at 16 37 59" src="https://github.com/user-attachments/assets/3867b8f8-eebf-4cc3-8dd4-cf0590e70dbf" />

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
