### PR TITLE
feat: fall back to EC if F3 finalized tipeset is older than 900 epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - fix(deps): fix Ledger hardware wallet support ([filecoin-project/lotus#13048](https://github.com/filecoin-project/lotus/pull/13048))
 - fix(eth): always return nil for eth transactions not found ([filecoin-project/lotus#12999](https://github.com/filecoin-project/lotus/pull/12999))
 - feat: add gas to application metric reporting `vm/applyblocks_early_gas`, `vm/applyblocks_messages_gas`, `vm/applyblocks_cron_gas` ([filecoin-project/lotus#13030](https://github.com/filecoin-project/lotus/pull/13030))
+- feat: fall back to EC if F3 finalized tipeset is older than 900 epochs ([filecoin-project/lotus#13066](https://github.com/filecoin-project/lotus/pull/13066))
+
 
 ### Experimental v2 APIs with F3 awareness
 

--- a/itests/api_v2_test.go
+++ b/itests/api_v2_test.go
@@ -134,6 +134,18 @@ func TestAPIV2_ThroughRPC(t *testing.T) {
 				wantResponseStatus: http.StatusOK,
 			},
 			{
+				name: "old f3 finalized falls back to ec",
+				when: func(t *testing.T) {
+					mockF3.Running = true
+					mockF3.Finalizing = true
+					mockF3.LatestCertErr = nil
+					mockF3.LatestCert = plausibleCertAt(t, targetHeight-policy.ChainFinality-5)
+				},
+				request:            `{"jsonrpc":"2.0","method":"Filecoin.ChainGetTipSet","params":[{"tag":"finalized"}],"id":1}`,
+				wantTipSet:         tipSetAtHeight(targetHeight - policy.ChainFinality),
+				wantResponseStatus: http.StatusOK,
+			},
+			{
 				name: "safe tag is ec safe distance when more recent than f3 finalized",
 				when: func(t *testing.T) {
 					mockF3.Running = true


### PR DESCRIPTION
In Lotus v2 APIs, in an event where F3 finalized tipset is too far behind EC, > 900 epochs return EC finalized tipset.

Part of: https://github.com/filecoin-project/lotus/issues/13062
