### PR TITLE
ci: migrate workflows to checkout v4

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -17,7 +17,7 @@ jobs:
       IGNORE_PATTERN: 'dependency-check-ignore:\s'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out the repository
         with:
           submodules: 'recursive'


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.