### PR TITLE
chore: fix typo in subscription naming

### DIFF
--- a/cli/util/api.go
+++ b/cli/util/api.go
@@ -409,7 +409,7 @@ type GetFullNodeOptions struct {
 
 type GetFullNodeOption func(*GetFullNodeOptions)
 
-func FullNodeWithEthSubscribtionHandler(sh api.EthSubscriber) GetFullNodeOption {
+func FullNodeWithEthSubscriptionHandler(sh api.EthSubscriber) GetFullNodeOption {
 	return func(opts *GetFullNodeOptions) {
 		opts.EthSubHandler = sh
 	}

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -176,12 +176,12 @@ var runCmd = &cli.Command{
 		v1SubHnd := gateway.NewEthSubHandler()
 		v2SubHnd := gateway.NewEthSubHandler()
 
-		v1, closerV1, err := lcli.GetFullNodeAPIV1(cctx, cliutil.FullNodeWithEthSubscribtionHandler(v1SubHnd))
+		v1, closerV1, err := lcli.GetFullNodeAPIV1(cctx, cliutil.FullNodeWithEthSubscriptionHandler(v1SubHnd))
 		if err != nil {
 			return err
 		}
 		defer closerV1()
-		v2, closerV2, err := lcli.GetFullNodeAPIV2(cctx, cliutil.FullNodeWithEthSubscribtionHandler(v2SubHnd))
+		v2, closerV2, err := lcli.GetFullNodeAPIV2(cctx, cliutil.FullNodeWithEthSubscriptionHandler(v2SubHnd))
 		if err != nil {
 			return err
 		}

--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -202,7 +202,7 @@ func MakeEthEventsExtended(cfg config.EventsConfig, enableEthRPC bool) func(EthE
 		lctx := helpers.LifecycleCtx(params.MetricsCtx, params.Lifecycle)
 
 		var (
-			subscribtionCtx      context.Context  = lctx
+			subscriptionCtx                       = lctx
 			chainStore           eth.ChainStore   = params.ChainStore
 			stateManager         eth.StateManager = params.StateManager
 			chainIndexer         index.Indexer    = params.Indexer
@@ -211,14 +211,14 @@ func MakeEthEventsExtended(cfg config.EventsConfig, enableEthRPC bool) func(EthE
 			memPoolFilterManager *filter.MemPoolFilterManager
 			filterStore          filter.FilterStore
 			subscriptionManager  *eth.EthSubscriptionManager
-			maxFilterHeightRange abi.ChainEpoch = abi.ChainEpoch(cfg.MaxFilterHeightRange)
+			maxFilterHeightRange = abi.ChainEpoch(cfg.MaxFilterHeightRange)
 		)
 
 		if !enableEthRPC {
 			// all event functionality is disabled
 			// the historic filter API relies on the real time one
 			return eth.NewEthEventsAPI(
-				subscribtionCtx,
+				subscriptionCtx,
 				chainStore,
 				stateManager,
 				chainIndexer,
@@ -238,7 +238,7 @@ func MakeEthEventsExtended(cfg config.EventsConfig, enableEthRPC bool) func(EthE
 		eventFilterManager = params.EventFilterManager
 
 		ee := eth.NewEthEventsAPI(
-			subscribtionCtx,
+			subscriptionCtx,
 			chainStore,
 			stateManager,
 			chainIndexer,


### PR DESCRIPTION
Fix a few typos in code and remove redundant type declarations.

