### PR TITLE
chore: reduce log level for failure to `fetch tipset during hello`

### DIFF
--- a/chain/exchange/client.go
+++ b/chain/exchange/client.go
@@ -130,7 +130,7 @@ func (c *client) doRequest(
 		// Process and validate response.
 		validRes, err := c.processResponse(req, res, tipsets)
 		if err != nil {
-			log.Warnf("processing peer %s response failed: %s",
+			log.Debugf("processing peer %s response failed: %s",
 				peer.String(), err)
 			continue
 		}

--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -128,7 +128,7 @@ func (hs *Service) HandleStream(s inet.Stream) {
 	ctx := network.WithNoDial(context.Background(), "fetching filecoin hello tipset")
 	ts, err := hs.syncer.FetchTipSet(ctx, s.Conn().RemotePeer(), types.NewTipSetKey(hmsg.HeaviestTipSet...))
 	if err != nil {
-		log.Errorf("failed to fetch tipset from peer during hello: %+v", err)
+		log.Debugf("failed to fetch tipset from peer during hello: %+v", err)
 		return
 	}
 


### PR DESCRIPTION
Failure to fetch tipset during hello is not really an error and is repeatedly logged. Reduce noise by changing log level to `DEBUG`.

Additionally, it also reduces the log level for client request service, to avoid repeated `WARN` logs since logging is done in a loop.

 See: https://github.com/filecoin-project/lotus/pull/11543#issuecomment-2094110694
