### PR TITLE
style: add rate limit details

### DIFF
--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -249,7 +249,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Limit based on wallet address
 	limiter := h.limiter.GetWalletLimiter(filecoinAddress.String())
 	if !limiter.Allow() {
-		http.Error(w, http.StatusText(http.StatusTooManyRequests)+": wallet limit", http.StatusTooManyRequests)
+		http.Error(w, http.StatusText(http.StatusTooManyRequests)+": wallet limit\nYou can request tFIL and DataCap every 2 hours.", http.StatusTooManyRequests)
 		return
 	}
 


### PR DESCRIPTION
## Related Issues
Issue #13063 
This PR adds rate limit details to "Too many requests: Wallet limit" error message because it lacks clarity. [See UXIT dogfooding report.](https://filecoin.notion.site/Lotus-Fountain-Faucet-Report-19d7631f28258082a636f96df8b5d7fc)

## Proposed Changes
Added rate limit details - "You can request tFIL every 2 hours". 

## Additional Info
<img width="761" alt="Screenshot 2025-05-07 at 12 49 13" src="https://github.com/user-attachments/assets/8df15e43-a0a6-4abc-9c2a-3405c65371aa" />

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
