### PR TITLE
fix(faucet): add removed styles that are still in use

### DIFF
--- a/cmd/lotus-fountain/site/datacap.html
+++ b/cmd/lotus-fountain/site/datacap.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Grant DataCap - Lotus Fountain</title>
-    <link rel="stylesheet" type="text/css" href="main.css">
+    <link rel="stylesheet" type="text/css" href="faucet-components.css">
 	<script src="https://www.google.com/recaptcha/api.js"></script>
 	<script>
    		function onSubmit(token) {

--- a/cmd/lotus-fountain/site/faucet-components.css
+++ b/cmd/lotus-fountain/site/faucet-components.css
@@ -1,0 +1,76 @@
+
+.Index {
+    width: 100vw;
+    height: 100vh;
+    background-color: #f0f0f0;
+    color: #333;
+    font-family: 'Helvetica Neue', sans-serif;
+
+    display: grid;
+    grid-template-columns: auto 40vw auto;
+    grid-template-rows: auto auto auto 3em;
+    grid-template-areas:
+    ". . . ."
+    ". main main ."
+    ". . . ."
+    "footer footer footer footer";
+}
+
+.Index-footer {
+    background-color: #333;
+    grid-area: footer;
+}
+
+.Index-footer > div {
+    padding-left: 0.7em;
+    padding-top: 0.7em;
+}
+
+.Index-nodes {
+    grid-area: main;
+}
+
+.Index-node {
+    margin: 5px;
+    padding: 15px;
+    background-color: #fff;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+span {
+    display: block;
+    margin-bottom: 5px;
+}
+
+input[type="text"] {
+    width: 100%;
+    padding: 10px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+}
+
+button {
+    background-color: #4c9aff;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    padding: 10px 20px;
+    font-size: 1.2em;
+}
+
+button:hover {
+    background-color: #4c7eff;
+}
+
+a:link {
+    color: #333;
+}
+
+a:visited {
+    color: #333;
+}
+
+a:hover {
+    color: #555;
+}

--- a/cmd/lotus-fountain/site/funds.html
+++ b/cmd/lotus-fountain/site/funds.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Sending Funds - Lotus Fountain</title>
-    <link rel="stylesheet" type="text/css" href="main.css">
+    <link rel="stylesheet" type="text/css" href="faucet-components.css">
 	<script src="https://www.google.com/recaptcha/api.js"></script>
 	<script>
    		function onSubmit(token) {


### PR DESCRIPTION
## Related Issues
There's a bug in [#13056](https://github.com/filecoin-project/lotus/pull/13056/files) that affected styling on the `/funds` and `/datacap` routes by removing styles that were still in use. 🫠

## Proposed Changes

I've restored the original styling by:
- Creating a dedicated file for these styles
- Importing this file specifically in the affected `/funds` and `/datacap` components
- Planning a proper styling standardization in upcoming PRs to prevent similar issues

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
