### PR TITLE
allow verifreg commands in lotus-shed to be run against a gateway

### DIFF
--- a/cmd/lotus-shed/verifreg.go
+++ b/cmd/lotus-shed/verifreg.go
@@ -80,7 +80,20 @@ var verifRegAddVerifierFromMsigCmd = &cli.Command{
 		api := srv.FullNodeAPI()
 		ctx := lcli.ReqContext(cctx)
 
-		vrk, err := api.StateVerifiedRegistryRootKey(ctx, types.EmptyTSK)
+		vact, err := api.StateGetActor(ctx, verifreg.Address, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		apibs := blockstore.NewAPIBlockstore(api)
+		store := adt.WrapStore(ctx, cbor.NewCborStore(apibs))
+
+		vst, err := verifreg.Load(store, vact)
+		if err != nil {
+			return err
+		}
+
+		vrk, err := vst.RootKey()
 		if err != nil {
 			return err
 		}
@@ -460,7 +473,20 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 			return err
 		}
 
-		vrk, err := api.StateVerifiedRegistryRootKey(ctx, types.EmptyTSK)
+		vact, err := api.StateGetActor(ctx, verifreg.Address, types.EmptyTSK)
+		if err != nil {
+			return err
+		}
+
+		apibs := blockstore.NewAPIBlockstore(api)
+		store := adt.WrapStore(ctx, cbor.NewCborStore(apibs))
+
+		vst, err := verifreg.Load(store, vact)
+		if err != nil {
+			return err
+		}
+
+		vrk, err := vst.RootKey()
 		if err != nil {
 			return err
 		}
@@ -469,9 +495,6 @@ var verifRegRemoveVerifiedClientDataCapCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-
-		apibs := blockstore.NewAPIBlockstore(api)
-		store := adt.WrapStore(ctx, cbor.NewCborStore(apibs))
 
 		st, err := multisig.Load(store, vrkState)
 		if err != nil {


### PR DESCRIPTION
They still expect a 'full node api', but are in practice used with a gateway. Changes to the primary gateway to restrict available methods mean that it's preferable to have only the methods available on the gateay in use for these commands

