### PR TITLE
feat(shed): lotus-shed miner fees-inspect to inspect cron burn per epoch

### DIFF
--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -58,6 +58,7 @@ var minerCmd = &cli.Command{
 		minerLockedVestedCmd,
 		minerListVestingCmd,
 		minerFeesCmd,
+		minerFeesInspect,
 		minerListBalancesCmd,
 	},
 }


### PR DESCRIPTION
```
USAGE:
   lotus-shed miner fees-inspect [--tipset <tipset>] [--count <count>]

DESCRIPTION:
   Inspect miner fees in the given tipset and its parents. The output is a CSV with the following columns:
   Epoch, Burn, Fees, Penalties, Expected, Miners ...
   Where:
     - Epoch: the epoch of the tipset
     - Burn: the total amount of attoFIL burned by miners in this tipset
     - Fees: the total amount of expected proof fees paid by miners in this tipset
     - Penalties: the total amount of penalties expected to be paid by miners in this tipset
     - Expected: whether the sum of fees and penalties equals the burn amount (✓ or ✗), a discrepancy here likely results from burnt precommit deposits or miners who can't pay fees, neither of which are not calculated here
     - Miners: the list of miners that burned or were expected to burn in this tipset

OPTIONS:
   --tipset value  tipset or height (@X or @head for latest) (default: "@head")
   --count value   number of tipsets to inspect, working backwards from the --tipset (default: 1)
```

```
$ lotus-shed miner fees-inspect --tipset @4947700 --count 100
Epoch, Burn, Fees, Penalties, Expected, Miners ...
4947700, 0, 0, 0, ✓
4947699, 18466635330772230, 18466635330772230, 0, ✓, f03134685
4947698, 94038070157651401, 94038070157651401, 0, ✓, f03373333
4947697, 0, 0, 0, ✓
4947696, 124067515275316719, 124067515275316719, 0, ✓, f01081394, f03402379
4947695, 160523685227130192, 93372347165851527, 0, ✗, f03519199
4947694, 91947413454146569, 91947413454146569, 0, ✓, f03055018, f03493414
4947693, 0, 0, 0, ✓
4947692, 0, 0, 0, ✓
4947691, 90778337934411868, 90379800356973714, 398537577438154, ✓, f01350631, f03529375
4947690, 0, 0, 0, ✓
4947689, 0, 0, 0, ✓
4947688, 93398292407966807, 93398292407966807, 0, ✓, f03298672
4947687, 0, 0, 0, ✓
4947686, 98342578857692959, 94357129274003585, 3985449583689374, ✓, f03499888
...
```