### PR TITLE
feat(shed): lotus-shed find-msg --count X actor:Method

### DIFF
--- a/cmd/lotus-shed/find-msg.go
+++ b/cmd/lotus-shed/find-msg.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/builtin"
+	miner16 "github.com/filecoin-project/go-state-types/builtin/v16/miner"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	"github.com/filecoin-project/lotus/chain/actors"
+	lcli "github.com/filecoin-project/lotus/cli"
+)
+
+var findMsgCmd = &cli.Command{
+	Name: "find-msg",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "tipset",
+			Usage: "tipset or height (@X or @head for latest)",
+			Value: "@head",
+		},
+		&cli.IntFlag{
+			Name:  "count",
+			Usage: "number of tipsets to inspect, working backwards from the --tipset",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return xerrors.Errorf("failed to get full node API: %w", err)
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		ts, err := lcli.LoadTipSet(ctx, cctx, api)
+		if err != nil {
+			return xerrors.Errorf("failed to load tipset: %w", err)
+		}
+
+		if !cctx.IsSet("count") {
+			return fmt.Errorf("count is required")
+		}
+		count := cctx.Int("count")
+
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("method (<actor>:<method name>) is required")
+		}
+		method := cctx.Args().Get(0)
+		if len(strings.Split(method, ":")) != 2 {
+			return fmt.Errorf("method (<actor>:<method name>) is required")
+		}
+		actor, methodName := strings.Split(method, ":")[0], strings.Split(method, ":")[1]
+
+		nv, err := api.StateNetworkVersion(ctx, ts.Key())
+		if err != nil {
+			return xerrors.Errorf("failed to get network version: %w", err)
+		}
+		av, err := actorstypes.VersionForNetwork(nv)
+		if err != nil {
+			return xerrors.Errorf("failed to get actor version: %w", err)
+		}
+		actorKeys := manifest.GetBuiltinActorsKeys(av)
+		if !slices.Contains(actorKeys, actor) {
+			return fmt.Errorf("actor %s not valid, one one of: %s", actor, strings.Join(actorKeys, ", "))
+		}
+
+		methods, err := (func() (any, error) {
+			switch actor {
+			case "account":
+				return builtin.MethodsAccount, nil
+			case "cron":
+				return builtin.MethodsCron, nil
+			case "init":
+				return builtin.MethodsInit, nil
+			case "storagemarket":
+				return builtin.MethodsMarket, nil
+			case "storageminer":
+				return builtin.MethodsMiner, nil
+			case "multisig":
+				return builtin.MethodsMultisig, nil
+			case "paymentchannel":
+				return builtin.MethodsPaych, nil
+			case "storagepower":
+				return builtin.MethodsPower, nil
+			case "reward":
+				return builtin.MethodsReward, nil
+			case "system":
+				return struct{}{}, nil // nothing here
+			case "verifiedregistry":
+				return builtin.MethodsVerifiedRegistry, nil
+			case "datacap":
+				return builtin.MethodsDatacap, nil
+			case "evm":
+				return builtin.MethodsEVM, nil
+			case "eam":
+				return builtin.MethodsEAM, nil
+			case "placeholder":
+				return builtin.MethodsPlaceholder, nil
+			case "ethaccount":
+				return builtin.MethodsEthAccount, nil
+			default:
+				return nil, fmt.Errorf("actor %s not valid, one one of: %s", actor, strings.Join(actorKeys, ", "))
+			}
+		}())
+		if err != nil {
+			return xerrors.Errorf("failed to get methods for actor %s: %w", actor, err)
+		}
+
+		// use reflection to find the field name on the methods object, and then the uint64 value of that field
+
+		var methodNum abi.MethodNum
+		var found bool
+		methodNames := make([]string, 0)
+		value := reflect.ValueOf(methods)
+		typeOfMethods := value.Type()
+		for i := 0; i < typeOfMethods.NumField(); i++ {
+			field := typeOfMethods.Field(i)
+			if field.Name == methodName {
+				methodNum = abi.MethodNum(value.Field(i).Uint())
+				found = true
+				break
+			}
+			methodNames = append(methodNames, field.Name)
+		}
+		if !found && methodName != "Send" {
+			return fmt.Errorf("method %s not valid on actor %s, want one of: %s", methodName, actor, strings.Join(methodNames, ", "))
+		} // else Send as method 0 is a special case we can handle
+
+		var msgCnt int
+		actorIsType := make(map[address.Address]bool)
+		metaCache := make(map[cid.Cid]string)
+
+		additional := ""
+		switch actor {
+		case "storageminer":
+			switch methodName {
+			case "ProveCommitSectors3":
+				additional = ", Sectors, Type"
+			}
+		}
+		_, _ = fmt.Fprintf(cctx.App.Writer, "Epoch, MsgCid, From, To, Method%s\n", additional)
+
+		for i := 0; i < count; i++ {
+			if ts.Height()%2880 == 0 {
+				_, _ = fmt.Fprintf(cctx.App.ErrWriter, "Epoch: %d, messages: %d\n", ts.Height(), msgCnt)
+			}
+			msgs, err := api.ChainGetMessagesInTipset(ctx, ts.Key())
+			if err != nil {
+				return xerrors.Errorf("failed to get messages in tipset: %w", err)
+			}
+			msgCnt += len(msgs)
+
+			for _, msg := range msgs {
+				if msg.Message.Method != methodNum {
+					continue
+				}
+				if is, ok := actorIsType[msg.Message.To]; ok && !is {
+					continue
+				}
+
+				var name string
+				act, err := api.StateGetActor(ctx, msg.Message.To, ts.Key())
+				if err != nil && !strings.Contains(err.Error(), "actor not found") {
+					return xerrors.Errorf("failed to get actor: %w", err)
+				} else if err != nil {
+					// not found, assume it's an account actor (may not be, but that's a TODO)
+					name = "account"
+				} else {
+					var has bool
+					if name, has = metaCache[act.Code]; !has {
+						var ok bool
+						if name, _, ok = actors.GetActorMetaByCode(act.Code); ok {
+							metaCache[act.Code] = name
+						} else {
+							_, _ = fmt.Fprintf(cctx.App.ErrWriter, "Unknown actor code: %s\n", act.Code)
+						}
+					}
+				}
+				if name != actor {
+					actorIsType[msg.Message.To] = false
+					continue
+				}
+				actorIsType[msg.Message.To] = true
+
+				additional := ""
+
+				switch actor {
+				case "storageminer":
+					switch methodName {
+					case "ProveCommitSectors3":
+						var params miner16.ProveCommitSectors3Params
+						if err := params.UnmarshalCBOR(bytes.NewReader(msg.Message.Params)); err != nil {
+							return err
+						}
+						typ := "batch"
+						if params.AggregateProof != nil {
+							typ = "aggregate"
+						}
+						additional = fmt.Sprintf(", %d, %s", len(params.SectorActivations), typ)
+					}
+				}
+
+				_, _ = fmt.Fprintf(cctx.App.Writer, "%d, %s, %s, %s, %d%s\n", ts.Height(), msg.Cid, msg.Message.From, msg.Message.To, msg.Message.Method, additional)
+			}
+
+			if ts, err = api.ChainGetTipSet(ctx, ts.Parents()); err != nil {
+				return xerrors.Errorf("failed to get tipset: %w", err)
+			}
+		}
+		return nil
+	},
+}

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -93,6 +93,7 @@ func main() {
 		blockCmd,
 		adlCmd,
 		f3Cmd,
+		findMsgCmd,
 	}
 
 	app := &cli.App{


### PR DESCRIPTION
Search back through the chain to find messages of a particular type and print them out. Also includes the ability to add special cases for more information, currently just PCS3 which will also print out the number of sectors and the proof type.

This has been sitting in my local repo and I've been hardwiring values but I keep on having to use it so I made it more generic and will check it in.

@rjan90 this is one of the recent uses I've had for this tool so we can look at batch vs aggregate onboarding:

```
$ lotus-shed find-msg --tipset @4950273 --count 2 storageminer:ProveCommitSectors3
Epoch, MsgCid, From, To, Method, Sectors, Type
4950273, bafy2bzacebofnwjazb2nksoxmj7yn5whfhxtub7thlf3pfllnfetejkgqmpwi, f3xedke4ro7xhaovd3vk5gov7ezmrdc3k6pp2qa2svcwmd5qmhio2tlp7e6omv36hhi4ihjs22ryowdklqc6lq, f02920450, 34, 1, batch
4950273, bafy2bzaced5zn6vwh55e5bqk5yiqw3xy3ii43av6cmwdoyi7iuesiiaev4yk4, f3wzxynjiptyogm442qg4cv74czijfzj7fzymqx6gmr6yw6oojhmlg7qavplholgoeyiyxh2zostfrnc2w2mxq, f01240, 34, 1, batch
4950273, bafy2bzacedy2dayukexlpkp5akaun4wgx6pddtahtbxpkhnzfhql52mhaeoyy, f3q5cnepquk3naivrukfcp24mnpo43tucnu6te6ms2c2zyqnyqxpxig2qdhvhxlwid5q7dwxqfixmwyqtyd2gq, f02063867, 34, 1, batch
4950273, bafy2bzacedcz45nfqrhanzildzjuqvnfgzkqwi7b6gzy26v7lvwjrd3oeynks, f3qvbwnmocyveigvfuhpttk6vbcafosecsj5kifh5wqkhrkoi5e4k465facveidwqctleilvodznozllujxkua, f02924003, 34, 1, batch
4950273, bafy2bzacebawqdmarkekupxfqpn2vqeysls2cuuxuvjueksvs5mme7622aqec, f3r4ntpk2kyvrwrl5omoywknjinlvtin3pteo4ayh2gyfjxfj6yotbokp6oq5qvqtqiwvrgftz473jbzbwhdaa, f03499693, 34, 8, aggregate
4950273, bafy2bzacebu5jvanfkgpr3mtmvgdx6cv2nenuq3nubykb7szd44beqph4zkbw, f3whlqhwwjbskfercjnbydhfahrxyk6f6kzbpnewbktkohohvmq6svk7c2a2n7rylyevn643zupejisz44tr3a, f03336022, 34, 1, batch
4950273, bafy2bzacedwg2u2hh4lf5wnu3ztngcuxeehtfzsu2kdtlx7pwxd3gcrnv5fse, f3w5q2le2ddphyjcgqlbrmqy3om2oaholoeyjh7az2lbt7srys3iw6d7bmme24ewbomxhuk6olgwxvtcbffvpq, f02874347, 34, 1, batch
4950273, bafy2bzaceb4dec3bjdbkkxz3xio6jitakqvbq6i75gjjnloyyemn5x4zvdnpu, f3wrkctnvewvgsdilkkrxhop7pq3jbbsuyebynjeipx233xj7sz73n2rpcpf4uujnge7gg35teecebp4jjooaa, f03228500, 34, 15, aggregate
4950273, bafy2bzacedmmlg222mb4awwyilpaybof3d5lsdawqeinwpv7ydwuid3mrcj2s, f3qgmv6ytd7kjv3ud47iww4zucfvb6f64nulor4vmkx6xqbqunucprktv5uhbpal2wtmla2fenl665p2anbgta, f03336023, 34, 3, batch
4950273, bafy2bzacec4attzgcyrevxar4my6uwhzxgg5saos3sw5esutjlkq3abmmaxqg, f3wzxynjiptyogm442qg4cv74czijfzj7fzymqx6gmr6yw6oojhmlg7qavplholgoeyiyxh2zostfrnc2w2mxq, f01240, 34, 1, batch
```