### PR TITLE
feat(ci): only markdown action to skip some CI workflows

### DIFF
--- a/.github/actions/only-markdown/action.yml
+++ b/.github/actions/only-markdown/action.yml
@@ -1,0 +1,39 @@
+name: Only Markdown Changed
+description: Check whether every changed file in this PR has the .md extension.
+
+inputs:
+  github_token:
+    description: GitHub token (to fetch the diff)
+    required: true
+
+outputs:
+  only_markdown_changes:
+    description: 'True if every changed file has the .md extension'
+    value: ${{ steps.check.outputs.only_markdown_changes }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+        fetch-depth: 0
+
+    - name: List changed files
+      id: diff
+      shell: bash
+      run: |
+        BASE=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
+        git diff --name-only $BASE HEAD > changed.txt
+        echo "files=$(paste -sd ',' changed.txt)" >> $GITHUB_OUTPUT
+
+    - name: Determine if only .md files changed
+      id: check
+      shell: bash
+      run: |
+        nonmd=$(grep -vE '\.md$' changed.txt || true)
+        if [ -z "$nonmd" ]; then
+          echo "only_markdown_changes=true" >> $GITHUB_OUTPUT
+        else
+          echo "only_markdown_changes=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,24 @@ permissions:
   contents: read
 
 jobs:
+  planner:
+    name: Detect docs-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.check.outputs.only_markdown_changes }}
+    steps:
+      - name: Check for markdown-only changes
+        id: check
+        uses: ./.github/actions/only-markdown
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,8 +20,22 @@ permissions:
   contents: read
 
 jobs:
+  planner:
+    name: Detect docs-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.check.outputs.only_markdown_changes }}
+    steps:
+      - name: Check for markdown-only changes
+        id: check
+        uses: ./.github/actions/only-markdown
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   check-gen:
     name: Check (gen-check)
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +51,8 @@ jobs:
       - run: git diff --exit-code
   check-lint:
     name: Check (lint-all)
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +65,8 @@ jobs:
       - run: make lint
   check-fmt:
     name: Check (gofmt)
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +78,8 @@ jobs:
       - run: git diff --exit-code
   check-mod-tidy:
     name: Check (mod-tidy-check)
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,8 +28,22 @@ permissions:
   contents: read
 
 jobs:
+  planner:
+    name: Detect docs-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.check.outputs.only_markdown_changes }}
+    steps:
+      - name: Check for markdown-only changes
+        id: check
+        uses: ./.github/actions/only-markdown
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   docker:
     name: Docker (${{ matrix.image }} / ${{ matrix.network }}) [publish=${{ github.event.inputs.publish == 'true' || github.event_name != 'pull_request' }}]
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,10 +8,24 @@ permissions:
   contents: read
 
 jobs:
+  planner:
+    name: Detect docs-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.check.outputs.only_markdown_changes }}
+    steps:
+      - name: Check for markdown-only changes
+        id: check
+        uses: ./.github/actions/only-markdown
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   stale:
     permissions:
       issues: write
       pull-requests: write
+    needs: planner
+    if: ${{ needs.planner.outputs.only_docs != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v9


### PR DESCRIPTION
## Related Issues

Closes #13069 

## Proposed Changes

- Add a new composite action Only Markdown Changed to detect when a PR modifies only .md files.
- Introduce a planner job in each workflow that runs this action and outputs only_docs.
- Update build, test, check, and docer jobs to run only if only_docs != 'true'.
- Skip all heavy CI steps automatically on docs-only PRs, cutting CI runtime and costs.

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
