### PR TITLE
Return `method not supported` via Gateway when /v2 is absent

### DIFF
--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -386,10 +386,11 @@ var DaemonCmd = &cli.Command{
 
 			gapiv2, closerV2, err := lcli.GetGatewayAPIV2(cctx)
 			if err != nil {
-				return err
+				log.Warnf("Unable to connect to v2 API. Using method not supported for /rpc/v2 in gateway", "err", err)
+				gapiv2 = &v2api.GatewayStruct{ /* Returns "method not supported" for everything */ }
+			} else {
+				defer closerV2()
 			}
-			defer closerV2()
-
 			liteModeDeps = node.Options(
 				node.Override(new(lapi.Gateway), gapiv1),
 				node.Override(new(v2api.Gateway), gapiv2))


### PR DESCRIPTION
When there is no /v2 api offered by the full-node gracefully fallback to returning `method not supported` via Gateway.

Fixes #13119 