### PR TITLE
chore: disable F3 participation via gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - feat(f3): remove dynnamic manifest functionality and use static manifest ([filecoin-project/lotus#13074](https://github.com/filecoin-project/lotus/pull/13074))
 - chore(deps): bump filecoin-ffi for fvm@v4.7 which adds Logs and IpldOps to debug FVM execution traces ([filecoin-project/lotus#13029](https://github.com/filecoin-project/lotus/pull/13029))
 - chore: return `method not supported` via Gateway when /v2 isn't supported by the backend ([filecoin-project/lotus#13121](https://github.com/filecoin-project/lotus/pull/13121)
+- chore: disable F3 participation via gateway ([filecoin-project/lotus#13123](https://github.com/filecoin-project/lotus/pull/13123)
 
 See https://github.com/filecoin-project/lotus/blob/release/v1.33.0/CHANGELOG.md
 

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -27,7 +27,6 @@ import (
 	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-paramfetch"
 
@@ -40,7 +39,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/index"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	proofsffi "github.com/filecoin-project/lotus/chain/proofs/ffi"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -395,13 +393,7 @@ var DaemonCmd = &cli.Command{
 			}
 			liteModeDeps = node.Options(
 				node.Override(new(lapi.Gateway), gapiv1),
-				node.Override(new(v2api.Gateway), gapiv2),
-
-				// Disable attempts of F3 participation via gateway.
-				node.Unset(new(*lf3.Config)),
-				node.Unset(new(manifest.ManifestProvider)),
-				node.Unset(new(lf3.F3Backend)),
-			)
+				node.Override(new(v2api.Gateway), gapiv2))
 		}
 
 		// some libraries like ipfs/go-ds-measure and ipfs/go-ipfs-blockstore

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/filecoin-project/go-f3/manifest"
+	"github.com/filecoin-project/lotus/chain/lf3"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
 	"github.com/klauspost/compress/zstd"
 	"github.com/mitchellh/go-homedir"
@@ -393,7 +395,13 @@ var DaemonCmd = &cli.Command{
 			}
 			liteModeDeps = node.Options(
 				node.Override(new(lapi.Gateway), gapiv1),
-				node.Override(new(v2api.Gateway), gapiv2))
+				node.Override(new(v2api.Gateway), gapiv2),
+
+				// Disable attempts of F3 participation via gateway.
+				node.Unset(new(*lf3.Config)),
+				node.Unset(new(manifest.ManifestProvider)),
+				node.Unset(new(lf3.F3Backend)),
+			)
 		}
 
 		// some libraries like ipfs/go-ds-measure and ipfs/go-ipfs-blockstore

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
-	"github.com/filecoin-project/go-f3/manifest"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
 	"github.com/klauspost/compress/zstd"
 	"github.com/mitchellh/go-homedir"
@@ -29,6 +27,7 @@ import (
 	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-paramfetch"
 
@@ -41,6 +40,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/index"
+	"github.com/filecoin-project/lotus/chain/lf3"
 	proofsffi "github.com/filecoin-project/lotus/chain/proofs/ffi"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"

--- a/itests/kit/node_opts.go
+++ b/itests/kit/node_opts.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet/key"
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/config"
+	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/repo"
@@ -267,6 +268,7 @@ func F3Disabled() NodeOpt {
 		node.Unset(new(*lf3.Config)),
 		node.Unset(new(manifest.ManifestProvider)),
 		node.Unset(new(lf3.F3Backend)),
+		node.Unset(new(full.F3CertificateProvider)),
 	)
 }
 

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -185,8 +185,9 @@ var ChainNode = Options(
 		Override(HandleIncomingMessagesKey, modules.HandleIncomingMessages),
 		Override(HandleIncomingBlocksKey, modules.HandleIncomingBlocks),
 	),
-
-	If(build.IsF3Enabled(),
+	ApplyIf(func(s *Settings) bool {
+		return build.IsF3Enabled() && !isLiteNode(s)
+	},
 		Override(new(*lf3.Config), lf3.NewConfig),
 		Override(new(manifest.ManifestProvider), lf3.NewManifestProvider),
 		Override(new(lf3.F3Backend), lf3.New),

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -154,6 +154,7 @@ var ChainNode = Options(
 		Override(new(full.EthTraceAPIV2), From(new(v2api.Gateway))),
 		Override(new(full.EthGasAPIV1), From(new(api.Gateway))),
 		Override(new(full.EthGasAPIV2), From(new(v2api.Gateway))),
+		If(build.IsF3Enabled(), Override(new(full.F3CertificateProvider), From(new(api.Gateway)))),
 		// EthSendAPI is a special case, we block the Untrusted method via GatewayEthSend even though it
 		// shouldn't be exposed on the Gateway API.
 		Override(new(eth.EthSendAPI), new(modules.GatewayEthSend)),

--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/filter"
 	"github.com/filecoin-project/lotus/chain/index"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -29,7 +28,7 @@ import (
 type TipSetResolverParams struct {
 	fx.In
 	ChainStore eth.ChainStore
-	F3         lf3.F3Backend `optional:"true"`
+	F3         full.F3CertificateProvider `optional:"true"`
 }
 
 func MakeV1TipSetResolver(params TipSetResolverParams) full.EthTipSetResolverV2 {


### PR DESCRIPTION
Disable F3 module when lotus is run with `--lite` commend since in that mode the daemon is simply a reverse proxy of a full node.

Fixes #13122 