### PR TITLE
chore: increase the F3 GMessage buffer size to 1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - fix(f3): limit the concurrency of F3 power table calculation ([filecoin-project/lotus#13085](https://github.com/filecoin-project/lotus/pull/13085))
 - feat(f3): remove dynnamic manifest functionality and use static manifest ([filecoin-project/lotus#13074](https://github.com/filecoin-project/lotus/pull/13074))
 - chore(deps): bump filecoin-ffi for fvm@v4.7 which adds Logs and IpldOps to debug FVM execution traces ([filecoin-project/lotus#13029](https://github.com/filecoin-project/lotus/pull/13029))
-- chore: return `method not supported` via Gateway when /v2 isn't supported by the backend ([filecoin-project/lotus#13121](https://github.com/filecoin-project/lotus/pull/13121)
+- chore: return `method not supported` via Gateway when /v2 isn't supported by the backend ([filecoin-project/lotus#13121](https://github.com/filecoin-project/lotus/pull/13121))
+- chore: increase the F3 GMessage buffer size to 1024 ([filecoin-project/lotus#13126](https://github.com/filecoin-project/lotus/pull/13126))
 
 See https://github.com/filecoin-project/lotus/blob/release/v1.33.0/CHANGELOG.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ For the set of changes since the last stable release:
 
 # Node and Miner v1.32.2 / 2025-04-04
 
-This Lotus v1.32.2 release is a **MANDATORY patch release**. After the Calibration network upgraded to nv25, a bug was discovered in the ref-fvm KAMT library affecting ERC-20 token minting operations. You can read the full techincal breakdown of the issue [here](https://github.com/filecoin-project/builtin-actors/pull/1667).
+This Lotus v1.32.2 release is a **MANDATORY patch release**. After the Calibration network upgraded to nv25, a bug was discovered in the ref-fvm KAMT library affecting ERC-20 token minting operations. You can read the full technical breakdown of the issue [here](https://github.com/filecoin-project/builtin-actors/pull/1667).
 
 This patch release includes the following updates:
 - Schedules a mandatory Calibration upgrade, happening on `2025-04-07T23:00:00Z`, to fix the ERC-20 token minting bug on the Calibration network.

--- a/build/buildconstants/f3manifest_mainnet.json
+++ b/build/buildconstants/f3manifest_mainnet.json
@@ -39,7 +39,7 @@
   "PubSub": {
     "CompressionEnabled": true,
     "ChainCompressionEnabled": true,
-    "GMessageSubscriptionBufferSize": 768,
+    "GMessageSubscriptionBufferSize": 1024,
     "ValidatedMessageBufferSize": 1024
   },
   "ChainExchange": {


### PR DESCRIPTION
The GMessage buffer size is a non-consensus breaking parameter. It's a headroom beyond which pubsub will start dropping messages before they are seen by the F3 message processing logic.

During passive testing of F3 on mainnet we increased this buffer from its default value of 128 twice. We still observe reports by SPs that indicate the increased value may still not be enough for all cases. Increasing the buffer size is a low-risk parameter to adjust since the increase in memory consumption is negligible.

The root cause of the need for larger buffer size is slow state read in Lotus which consequently slows the serialised flow of message processing in F3. Work is under way to improve the efficiency of Lotus state fetch call that should reduce the reliance on larger buffers. But considering the small cost of having slightly larger buffers, it's worthwhile to do both.

Fixes #13103
