### PR TITLE
chore: stop using F3Backend directly in Eth modules

### DIFF
--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/filter"
 	"github.com/filecoin-project/lotus/chain/index"
-	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -29,7 +28,7 @@ import (
 type TipSetResolverParams struct {
 	fx.In
 	ChainStore eth.ChainStore
-	F3         lf3.F3Backend `optional:"true"`
+	F3         full.F3CertificateProvider `optional:"true"`
 }
 
 func MakeV1TipSetResolver(params TipSetResolverParams) full.EthTipSetResolverV2 {


### PR DESCRIPTION
This is on top of https://github.com/filecoin-project/lotus/pull/13123 to explore how we can further decouple F3.