### PR TITLE
feat(paych): add EnablePaymentChannelManager config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   - default to PreCommit batching
   - default to ProveCommit aggregation
   - remove config options: AggregateCommits, AggregateAboveBaseFee, BatchPreCommitAboveBaseFee
+- feat(paych): add EnablePaymentChannelManager config option to disable payment channel manager by default ([filecoin-project/lotus#13139](https://github.com/filecoin-project/lotus/pull/13139))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   - default to PreCommit batching
   - default to ProveCommit aggregation
   - remove config options: AggregateCommits, AggregateAboveBaseFee, BatchPreCommitAboveBaseFee
-- feat(paych): add EnablePaymentChannelManager config option to disable payment channel manager by default ([filecoin-project/lotus#13139](https://github.com/filecoin-project/lotus/pull/13139))
+- feat(paych): add EnablePaymentChannelManager config option and disable payment channel manager by default ([filecoin-project/lotus#13139](https://github.com/filecoin-project/lotus/pull/13139))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -1,3 +1,12 @@
+# EnablePaymentChannelManager controls whether the payment channel manager is started.
+# Default: false (disabled) - payment channels get minimal use on mainnet.
+# Set to true to enable payment channel functionality if needed.
+#
+# type: bool
+# env var: LOTUS__ENABLEPAYMENTCHANNELMANAGER
+#EnablePaymentChannelManager = false
+
+
 [API]
   # Binding address for the Lotus API
   #

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -1,12 +1,3 @@
-# EnablePaymentChannelManager controls whether the payment channel manager is started.
-# Default: false (disabled) - payment channels get minimal use on mainnet.
-# Set to true to enable payment channel functionality if needed.
-#
-# type: bool
-# env var: LOTUS__ENABLEPAYMENTCHANNELMANAGER
-#EnablePaymentChannelManager = false
-
-
 [API]
   # Binding address for the Lotus API
   #
@@ -403,4 +394,15 @@
   # type: string
   # env var: LOTUS_FAULTREPORTER_CONSENSUSFAULTREPORTERADDRESS
   #ConsensusFaultReporterAddress = ""
+
+
+[PaymentChannels]
+  # EnablePaymentChannelManager controls whether the payment channel manager is started.
+  # Default: false (disabled) - payment channels are currently have minimal use on mainnet,
+  # although they remain a Filecoin protocol feature.
+  # Set to true to enable payment channel functionality if needed.
+  #
+  # type: bool
+  # env var: LOTUS_PAYMENTCHANNELS_ENABLEPAYMENTCHANNELMANAGER
+  #EnablePaymentChannelManager = false
 

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -398,8 +398,8 @@
 
 [PaymentChannels]
   # EnablePaymentChannelManager controls whether the payment channel manager is started.
-  # Default: false (disabled) - payment channels are currently have minimal use on mainnet,
-  # although they remain a Filecoin protocol feature.
+  # Default: false (disabled) - payment channels currently have minimal use on mainnet, although
+  # they remain a Filecoin protocol feature.
   # Set to true to enable payment channel functionality if needed.
   #
   # type: bool

--- a/itests/paych_cli_test.go
+++ b/itests/paych_cli_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/cli/clicommands"
 	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/node/config"
 )
 
 // TestPaymentChannelsBasic does a basic test to exercise the payment channel CLI
@@ -430,10 +431,15 @@ func getPaychState(ctx context.Context, t *testing.T, node kit.TestFullNode, chA
 
 func startPaychCreatorReceiverMiner(ctx context.Context, t *testing.T, paymentCreator *kit.TestFullNode, paymentReceiver *kit.TestFullNode, blocktime time.Duration) (address.Address, address.Address) {
 	var miner kit.TestMiner
-	opts := kit.ThroughRPC()
+	enablePaychOpt := kit.WithCfgOpt(func(cfg *config.FullNode) error {
+		cfg.PaymentChannels = config.PaymentChannelsConfig{
+			EnablePaymentChannelManager: true,
+		}
+		return nil
+	})
 	kit.NewEnsemble(t, kit.MockProofs()).
-		FullNode(paymentCreator, opts).
-		FullNode(paymentReceiver, opts).
+		FullNode(paymentCreator, kit.ThroughRPC(), enablePaychOpt).
+		FullNode(paymentReceiver, kit.ThroughRPC(), enablePaychOpt).
 		Miner(&miner, paymentCreator, kit.WithAllSubsystems()).
 		Start().
 		InterconnectAll().

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -118,13 +118,6 @@ var ChainNode = Options(
 	Override(new(wallet.Default), From(new(*wallet.LocalWallet))),
 	Override(new(api.Wallet), From(new(wallet.MultiWallet))),
 
-	// Service: Payment channels
-	Override(new(paychmgr.PaychAPI), From(new(modules.PaychAPI))),
-	Override(new(*paychmgr.Store), modules.NewPaychStore),
-	Override(new(*paychmgr.Manager), modules.NewManager),
-	Override(HandlePaymentChannelManagerKey, modules.HandlePaychManager),
-	Override(SettlePaymentChannelsKey, settler.SettlePaymentChannels),
-
 	// Markets (storage)
 	Override(new(*market.FundManager), market.NewFundManager),
 
@@ -360,6 +353,14 @@ func ConfigFullNode(c interface{}) Option {
 			If(cfg.ChainIndexer.EnableIndexer,
 				Override(InitChainIndexerKey, modules.InitChainIndexer(cfg.ChainIndexer)),
 			),
+		),
+
+		If(cfg.EnablePaymentChannelManager,
+			Override(new(paychmgr.PaychAPI), From(new(modules.PaychAPI))),
+			Override(new(*paychmgr.Store), modules.NewPaychStore),
+			Override(new(*paychmgr.Manager), modules.NewManager),
+			Override(HandlePaymentChannelManagerKey, modules.HandlePaychManager),
+			Override(SettlePaymentChannelsKey, settler.SettlePaymentChannels),
 		),
 	)
 }

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -43,6 +43,7 @@ import (
 	"github.com/filecoin-project/lotus/node/impl/full"
 	"github.com/filecoin-project/lotus/node/impl/gasutils"
 	"github.com/filecoin-project/lotus/node/impl/net"
+	"github.com/filecoin-project/lotus/node/impl/paych"
 	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/modules/lp2p"
@@ -355,12 +356,16 @@ func ConfigFullNode(c interface{}) Option {
 			),
 		),
 
-		If(cfg.EnablePaymentChannelManager,
+		If(cfg.PaymentChannels.EnablePaymentChannelManager,
 			Override(new(paychmgr.PaychAPI), From(new(modules.PaychAPI))),
 			Override(new(*paychmgr.Store), modules.NewPaychStore),
 			Override(new(*paychmgr.Manager), modules.NewManager),
 			Override(HandlePaymentChannelManagerKey, modules.HandlePaychManager),
 			Override(SettlePaymentChannelsKey, settler.SettlePaymentChannels),
+			Override(new(paych.PaychAPI), From(new(paych.PaychImpl))),
+		),
+		If(!cfg.PaymentChannels.EnablePaymentChannelManager,
+			Override(new(paych.PaychAPI), new(paych.DisabledPaych)),
 		),
 	)
 }

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -357,7 +357,7 @@ func ConfigFullNode(c interface{}) Option {
 		),
 
 		If(cfg.PaymentChannels.EnablePaymentChannelManager,
-			Override(new(paychmgr.PaychAPI), From(new(modules.PaychAPI))),
+			Override(new(paychmgr.ManagerNodeAPI), From(new(modules.PaychManagerNodeAPI))),
 			Override(new(*paychmgr.Store), modules.NewPaychStore),
 			Override(new(*paychmgr.Manager), modules.NewManager),
 			Override(HandlePaymentChannelManagerKey, modules.HandlePaychManager),

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -100,7 +100,9 @@ func DefaultFullNode() *FullNode {
 			ReconcileEmptyIndex: false,
 			MaxReconcileTipsets: 3 * builtin.EpochsInDay,
 		},
-		EnablePaymentChannelManager: false,
+		PaymentChannels: PaymentChannelsConfig{
+			EnablePaymentChannelManager: false,
+		},
 	}
 }
 

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -100,6 +100,7 @@ func DefaultFullNode() *FullNode {
 			ReconcileEmptyIndex: false,
 			MaxReconcileTipsets: 3 * builtin.EpochsInDay,
 		},
+		EnablePaymentChannelManager: false,
 	}
 }
 

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -329,14 +329,6 @@ Note: Setting this value to 0 disables the cache.`,
 			Comment: ``,
 		},
 		{
-			Name: "EnablePaymentChannelManager",
-			Type: "bool",
-
-			Comment: `EnablePaymentChannelManager controls whether the payment channel manager is started.
-Default: false (disabled) - payment channels get minimal use on mainnet.
-Set to true to enable payment channel functionality if needed.`,
-		},
-		{
 			Name: "Fevm",
 			Type: "FevmConfig",
 
@@ -357,6 +349,12 @@ Set to true to enable payment channel functionality if needed.`,
 		{
 			Name: "FaultReporter",
 			Type: "FaultReporterConfig",
+
+			Comment: ``,
+		},
+		{
+			Name: "PaymentChannels",
+			Type: "PaychConfig",
 
 			Comment: ``,
 		},
@@ -638,6 +636,17 @@ blocks. This should only be set when there's an external process mining
 blocks on behalf of the miner.
 When disabled and no external block producers are configured, all potential
 block rewards will be missed!`,
+		},
+	},
+	"PaychConfig": {
+		{
+			Name: "EnablePaymentChannelManager",
+			Type: "bool",
+
+			Comment: `EnablePaymentChannelManager controls whether the payment channel manager is started.
+Default: false (disabled) - payment channels are currently have minimal use on mainnet,
+although they remain a Filecoin protocol feature.
+Set to true to enable payment channel functionality if needed.`,
 		},
 	},
 	"ProvingConfig": {

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -354,7 +354,7 @@ Note: Setting this value to 0 disables the cache.`,
 		},
 		{
 			Name: "PaymentChannels",
-			Type: "PaychConfig",
+			Type: "PaymentChannelsConfig",
 
 			Comment: ``,
 		},
@@ -638,14 +638,14 @@ When disabled and no external block producers are configured, all potential
 block rewards will be missed!`,
 		},
 	},
-	"PaychConfig": {
+	"PaymentChannelsConfig": {
 		{
 			Name: "EnablePaymentChannelManager",
 			Type: "bool",
 
 			Comment: `EnablePaymentChannelManager controls whether the payment channel manager is started.
-Default: false (disabled) - payment channels are currently have minimal use on mainnet,
-although they remain a Filecoin protocol feature.
+Default: false (disabled) - payment channels currently have minimal use on mainnet, although
+they remain a Filecoin protocol feature.
 Set to true to enable payment channel functionality if needed.`,
 		},
 	},

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -329,6 +329,14 @@ Note: Setting this value to 0 disables the cache.`,
 			Comment: ``,
 		},
 		{
+			Name: "EnablePaymentChannelManager",
+			Type: "bool",
+
+			Comment: `EnablePaymentChannelManager controls whether the payment channel manager is started.
+Default: false (disabled) - payment channels get minimal use on mainnet.
+Set to true to enable payment channel functionality if needed.`,
+		},
+		{
 			Name: "Fevm",
 			Type: "FevmConfig",
 

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -18,15 +18,19 @@ type Common struct {
 // FullNode is a full node config
 type FullNode struct {
 	Common
-	Libp2p        Libp2p
-	Pubsub        Pubsub
-	Wallet        Wallet
-	Fees          FeeConfig
-	Chainstore    Chainstore
-	Fevm          FevmConfig
-	Events        EventsConfig
-	ChainIndexer  ChainIndexerConfig
-	FaultReporter FaultReporterConfig
+	Libp2p     Libp2p
+	Pubsub     Pubsub
+	Wallet     Wallet
+	Fees       FeeConfig
+	Chainstore Chainstore
+	// EnablePaymentChannelManager controls whether the payment channel manager is started.
+	// Default: false (disabled) - payment channels get minimal use on mainnet.
+	// Set to true to enable payment channel functionality if needed.
+	EnablePaymentChannelManager bool
+	Fevm                        FevmConfig
+	Events                      EventsConfig
+	ChainIndexer                ChainIndexerConfig
+	FaultReporter               FaultReporterConfig
 }
 
 // // Common

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -18,19 +18,16 @@ type Common struct {
 // FullNode is a full node config
 type FullNode struct {
 	Common
-	Libp2p     Libp2p
-	Pubsub     Pubsub
-	Wallet     Wallet
-	Fees       FeeConfig
-	Chainstore Chainstore
-	// EnablePaymentChannelManager controls whether the payment channel manager is started.
-	// Default: false (disabled) - payment channels get minimal use on mainnet.
-	// Set to true to enable payment channel functionality if needed.
-	EnablePaymentChannelManager bool
-	Fevm                        FevmConfig
-	Events                      EventsConfig
-	ChainIndexer                ChainIndexerConfig
-	FaultReporter               FaultReporterConfig
+	Libp2p          Libp2p
+	Pubsub          Pubsub
+	Wallet          Wallet
+	Fees            FeeConfig
+	Chainstore      Chainstore
+	Fevm            FevmConfig
+	Events          EventsConfig
+	ChainIndexer    ChainIndexerConfig
+	FaultReporter   FaultReporterConfig
+	PaymentChannels PaymentChannelsConfig
 }
 
 // // Common
@@ -674,4 +671,12 @@ type FaultReporterConfig struct {
 	// ReportConsensusFault messages. It will pay for gas fees, and receive any
 	// rewards. This address should have adequate funds to cover gas fees.
 	ConsensusFaultReporterAddress string
+}
+
+type PaymentChannelsConfig struct {
+	// EnablePaymentChannelManager controls whether the payment channel manager is started.
+	// Default: false (disabled) - payment channels are currently have minimal use on mainnet,
+	// although they remain a Filecoin protocol feature.
+	// Set to true to enable payment channel functionality if needed.
+	EnablePaymentChannelManager bool
 }

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -675,8 +675,8 @@ type FaultReporterConfig struct {
 
 type PaymentChannelsConfig struct {
 	// EnablePaymentChannelManager controls whether the payment channel manager is started.
-	// Default: false (disabled) - payment channels are currently have minimal use on mainnet,
-	// although they remain a Filecoin protocol feature.
+	// Default: false (disabled) - payment channels currently have minimal use on mainnet, although
+	// they remain a Filecoin protocol feature.
 	// Set to true to enable payment channel functionality if needed.
 	EnablePaymentChannelManager bool
 }

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -15,13 +15,40 @@ import (
 	"github.com/filecoin-project/lotus/paychmgr"
 )
 
-type PaychAPI struct {
+// PaychAPI is the external interface that Lotus provides for interacting with payment channels.
+type PaychAPI interface {
+	PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt, opts api.PaychGetOpts) (*api.ChannelInfo, error)
+	PaychFund(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error)
+	PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error)
+	PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error)
+	PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error)
+	PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error)
+	PaychNewPayment(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error)
+	PaychList(ctx context.Context) ([]address.Address, error)
+	PaychStatus(ctx context.Context, pch address.Address) (*api.PaychStatus, error)
+	PaychSettle(ctx context.Context, addr address.Address) (cid.Cid, error)
+	PaychCollect(ctx context.Context, addr address.Address) (cid.Cid, error)
+	PaychVoucherCheckValid(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher) error
+	PaychVoucherCheckSpendable(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (bool, error)
+	PaychVoucherAdd(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error)
+	PaychVoucherCreate(ctx context.Context, pch address.Address, amt types.BigInt, lane uint64) (*api.VoucherCreateResult, error)
+	PaychVoucherList(ctx context.Context, pch address.Address) ([]*paychtypes.SignedVoucher, error)
+	PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (cid.Cid, error)
+}
+
+// PaychImpl is the implementation of the PaychAPI interface that uses the paychmgr.Manager
+// to manage payment channels. It is designed to be used with dependency injection via fx.
+// It provides methods for creating, funding, and managing payment channels, as well as handling
+// vouchers and their associated operations.
+type PaychImpl struct {
 	fx.In
 
 	PaychMgr *paychmgr.Manager
 }
 
-func (a *PaychAPI) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt, opts api.PaychGetOpts) (*api.ChannelInfo, error) {
+var _ PaychAPI = &PaychImpl{}
+
+func (a *PaychImpl) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt, opts api.PaychGetOpts) (*api.ChannelInfo, error) {
 	ch, mcid, err := a.PaychMgr.GetPaych(ctx, from, to, amt, paychmgr.GetOpts{
 		Reserve:  true,
 		OffChain: opts.OffChain,
@@ -36,7 +63,7 @@ func (a *PaychAPI) PaychGet(ctx context.Context, from, to address.Address, amt t
 	}, nil
 }
 
-func (a *PaychAPI) PaychFund(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {
+func (a *PaychImpl) PaychFund(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {
 	ch, mcid, err := a.PaychMgr.GetPaych(ctx, from, to, amt, paychmgr.GetOpts{
 		Reserve:  false,
 		OffChain: false,
@@ -51,23 +78,23 @@ func (a *PaychAPI) PaychFund(ctx context.Context, from, to address.Address, amt 
 	}, nil
 }
 
-func (a *PaychAPI) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
+func (a *PaychImpl) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
 	return a.PaychMgr.AvailableFunds(ctx, ch)
 }
 
-func (a *PaychAPI) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
+func (a *PaychImpl) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
 	return a.PaychMgr.AvailableFundsByFromTo(ctx, from, to)
 }
 
-func (a *PaychAPI) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error) {
+func (a *PaychImpl) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error) {
 	return a.PaychMgr.GetPaychWaitReady(ctx, sentinel)
 }
 
-func (a *PaychAPI) PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error) {
+func (a *PaychImpl) PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error) {
 	return a.PaychMgr.AllocateLane(ctx, ch)
 }
 
-func (a *PaychAPI) PaychNewPayment(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) {
+func (a *PaychImpl) PaychNewPayment(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) {
 	amount := vouchers[len(vouchers)-1].Amount
 
 	// TODO: Fix free fund tracking in PaychGet
@@ -111,11 +138,11 @@ func (a *PaychAPI) PaychNewPayment(ctx context.Context, from, to address.Address
 	}, nil
 }
 
-func (a *PaychAPI) PaychList(ctx context.Context) ([]address.Address, error) {
+func (a *PaychImpl) PaychList(ctx context.Context) ([]address.Address, error) {
 	return a.PaychMgr.ListChannels(ctx)
 }
 
-func (a *PaychAPI) PaychStatus(ctx context.Context, pch address.Address) (*api.PaychStatus, error) {
+func (a *PaychImpl) PaychStatus(ctx context.Context, pch address.Address) (*api.PaychStatus, error) {
 	ci, err := a.PaychMgr.GetChannelInfo(ctx, pch)
 	if err != nil {
 		return nil, err
@@ -126,23 +153,23 @@ func (a *PaychAPI) PaychStatus(ctx context.Context, pch address.Address) (*api.P
 	}, nil
 }
 
-func (a *PaychAPI) PaychSettle(ctx context.Context, addr address.Address) (cid.Cid, error) {
+func (a *PaychImpl) PaychSettle(ctx context.Context, addr address.Address) (cid.Cid, error) {
 	return a.PaychMgr.Settle(ctx, addr)
 }
 
-func (a *PaychAPI) PaychCollect(ctx context.Context, addr address.Address) (cid.Cid, error) {
+func (a *PaychImpl) PaychCollect(ctx context.Context, addr address.Address) (cid.Cid, error) {
 	return a.PaychMgr.Collect(ctx, addr)
 }
 
-func (a *PaychAPI) PaychVoucherCheckValid(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher) error {
+func (a *PaychImpl) PaychVoucherCheckValid(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher) error {
 	return a.PaychMgr.CheckVoucherValid(ctx, ch, sv)
 }
 
-func (a *PaychAPI) PaychVoucherCheckSpendable(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (bool, error) {
+func (a *PaychImpl) PaychVoucherCheckSpendable(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (bool, error) {
 	return a.PaychMgr.CheckVoucherSpendable(ctx, ch, sv, secret, proof)
 }
 
-func (a *PaychAPI) PaychVoucherAdd(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error) {
+func (a *PaychImpl) PaychVoucherAdd(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error) {
 	return a.PaychMgr.AddVoucherInbound(ctx, ch, sv, proof, minDelta)
 }
 
@@ -153,11 +180,11 @@ func (a *PaychAPI) PaychVoucherAdd(ctx context.Context, ch address.Address, sv *
 // the two.
 // If there are insufficient funds in the channel to create the voucher,
 // returns a nil voucher and the shortfall.
-func (a *PaychAPI) PaychVoucherCreate(ctx context.Context, pch address.Address, amt types.BigInt, lane uint64) (*api.VoucherCreateResult, error) {
+func (a *PaychImpl) PaychVoucherCreate(ctx context.Context, pch address.Address, amt types.BigInt, lane uint64) (*api.VoucherCreateResult, error) {
 	return a.PaychMgr.CreateVoucher(ctx, pch, paychtypes.SignedVoucher{Amount: amt, Lane: lane})
 }
 
-func (a *PaychAPI) PaychVoucherList(ctx context.Context, pch address.Address) ([]*paychtypes.SignedVoucher, error) {
+func (a *PaychImpl) PaychVoucherList(ctx context.Context, pch address.Address) ([]*paychtypes.SignedVoucher, error) {
 	vi, err := a.PaychMgr.ListVouchers(ctx, pch)
 	if err != nil {
 		return nil, err
@@ -171,6 +198,81 @@ func (a *PaychAPI) PaychVoucherList(ctx context.Context, pch address.Address) ([
 	return out, nil
 }
 
-func (a *PaychAPI) PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (cid.Cid, error) {
+func (a *PaychImpl) PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (cid.Cid, error) {
 	return a.PaychMgr.SubmitVoucher(ctx, ch, sv, secret, proof)
+}
+
+// DisabledPaych is a stub implementation of the PaychAPI interface that returns errors for all
+// methods. It is used when the payment channel manager is disabled (e.g., when
+// EnablePaymentChannelManager is set to false in the configuration).
+type DisabledPaych struct{}
+
+var _ PaychAPI = &DisabledPaych{}
+
+func (a *DisabledPaych) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt, opts api.PaychGetOpts) (*api.ChannelInfo, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychFund(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error) {
+	return address.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error) {
+	return 0, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychNewPayment(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychList(ctx context.Context) ([]address.Address, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychStatus(ctx context.Context, pch address.Address) (*api.PaychStatus, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychSettle(ctx context.Context, addr address.Address) (cid.Cid, error) {
+	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychCollect(ctx context.Context, addr address.Address) (cid.Cid, error) {
+	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherCheckValid(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher) error {
+	return xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherCheckSpendable(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (bool, error) {
+	return false, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherAdd(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error) {
+	return types.BigInt{}, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherCreate(ctx context.Context, pch address.Address, amt types.BigInt, lane uint64) (*api.VoucherCreateResult, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherList(ctx context.Context, pch address.Address) ([]*paychtypes.SignedVoucher, error) {
+	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+}
+
+func (a *DisabledPaych) PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (cid.Cid, error) {
+	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
 }

--- a/node/impl/paych/paych.go
+++ b/node/impl/paych/paych.go
@@ -202,6 +202,10 @@ func (a *PaychImpl) PaychVoucherSubmit(ctx context.Context, ch address.Address, 
 	return a.PaychMgr.SubmitVoucher(ctx, ch, sv, secret, proof)
 }
 
+// ErrPaymentChannelDisabled is returned when payment channel operations are attempted
+// but the payment channel manager is disabled in the configuration.
+var ErrPaymentChannelDisabled = xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+
 // DisabledPaych is a stub implementation of the PaychAPI interface that returns errors for all
 // methods. It is used when the payment channel manager is disabled (e.g., when
 // EnablePaymentChannelManager is set to false in the configuration).
@@ -210,69 +214,69 @@ type DisabledPaych struct{}
 var _ PaychAPI = &DisabledPaych{}
 
 func (a *DisabledPaych) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt, opts api.PaychGetOpts) (*api.ChannelInfo, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychFund(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychAvailableFunds(ctx context.Context, ch address.Address) (*api.ChannelAvailableFunds, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychAvailableFundsByFromTo(ctx context.Context, from, to address.Address) (*api.ChannelAvailableFunds, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychGetWaitReady(ctx context.Context, sentinel cid.Cid) (address.Address, error) {
-	return address.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return address.Undef, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychAllocateLane(ctx context.Context, ch address.Address) (uint64, error) {
-	return 0, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return 0, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychNewPayment(ctx context.Context, from, to address.Address, vouchers []api.VoucherSpec) (*api.PaymentInfo, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychList(ctx context.Context) ([]address.Address, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychStatus(ctx context.Context, pch address.Address) (*api.PaychStatus, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychSettle(ctx context.Context, addr address.Address) (cid.Cid, error) {
-	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return cid.Undef, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychCollect(ctx context.Context, addr address.Address) (cid.Cid, error) {
-	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return cid.Undef, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherCheckValid(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher) error {
-	return xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherCheckSpendable(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (bool, error) {
-	return false, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return false, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherAdd(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, proof []byte, minDelta types.BigInt) (types.BigInt, error) {
-	return types.BigInt{}, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return types.BigInt{}, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherCreate(ctx context.Context, pch address.Address, amt types.BigInt, lane uint64) (*api.VoucherCreateResult, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherList(ctx context.Context, pch address.Address) ([]*paychtypes.SignedVoucher, error) {
-	return nil, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return nil, ErrPaymentChannelDisabled
 }
 
 func (a *DisabledPaych) PaychVoucherSubmit(ctx context.Context, ch address.Address, sv *paychtypes.SignedVoucher, secret []byte, proof []byte) (cid.Cid, error) {
-	return cid.Undef, xerrors.New("payment channel manager is disabled (EnablePaymentChannelManager is set to false)")
+	return cid.Undef, ErrPaymentChannelDisabled
 }

--- a/node/modules/paych.go
+++ b/node/modules/paych.go
@@ -15,7 +15,7 @@ import (
 	"github.com/filecoin-project/lotus/paychmgr"
 )
 
-func NewManager(mctx helpers.MetricsCtx, lc fx.Lifecycle, sm stmgr.StateManagerAPI, pchstore *paychmgr.Store, api paychmgr.PaychAPI) *paychmgr.Manager {
+func NewManager(mctx helpers.MetricsCtx, lc fx.Lifecycle, sm stmgr.StateManagerAPI, pchstore *paychmgr.Store, api paychmgr.ManagerNodeAPI) *paychmgr.Manager {
 	ctx := helpers.LifecycleCtx(mctx, lc)
 	ctx, shutdown := context.WithCancel(ctx)
 	ctx = metrics.AddNetworkTag(ctx)
@@ -27,14 +27,14 @@ func NewPaychStore(ds dtypes.MetadataDS) *paychmgr.Store {
 	return paychmgr.NewStore(ds)
 }
 
-type PaychAPI struct {
+type PaychManagerNodeAPI struct {
 	fx.In
 
 	full.MpoolAPI
 	full.StateAPI
 }
 
-var _ paychmgr.PaychAPI = &PaychAPI{}
+var _ paychmgr.ManagerNodeAPI = &PaychManagerNodeAPI{}
 
 // HandlePaychManager is called by dependency injection to set up hooks
 func HandlePaychManager(lc fx.Lifecycle, pm *paychmgr.Manager) {

--- a/paychmgr/manager.go
+++ b/paychmgr/manager.go
@@ -34,26 +34,26 @@ type stateManagerAPI interface {
 	Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error)
 }
 
-// PaychAPI defines the API methods needed by the payment channel manager
-type PaychAPI interface {
+// ManagerNodeAPI defines the API methods needed by the payment channel manager
+type ManagerNodeAPI interface {
 	StateAccountKey(context.Context, address.Address, types.TipSetKey) (address.Address, error)
 	StateWaitMsg(ctx context.Context, cid cid.Cid, confidence uint64, limit abi.ChainEpoch, allowReplaced bool) (*api.MsgLookup, error)
+	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 	MpoolPushMessage(ctx context.Context, msg *types.Message, maxFee *api.MessageSendSpec) (*types.SignedMessage, error)
 	WalletHas(ctx context.Context, addr address.Address) (bool, error)
 	WalletSign(ctx context.Context, k address.Address, msg []byte) (*crypto.Signature, error)
-	StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error)
 }
 
 // managerAPI defines all methods needed by the manager
 type managerAPI interface {
 	stateManagerAPI
-	PaychAPI
+	ManagerNodeAPI
 }
 
 // managerAPIImpl is used to create a composite that implements managerAPI
 type managerAPIImpl struct {
 	stmgr.StateManagerAPI
-	PaychAPI
+	ManagerNodeAPI
 }
 
 type Manager struct {
@@ -69,8 +69,8 @@ type Manager struct {
 	channels map[string]*channelAccessor
 }
 
-func NewManager(ctx context.Context, shutdown func(), sm stmgr.StateManagerAPI, pchstore *Store, api PaychAPI) *Manager {
-	impl := &managerAPIImpl{StateManagerAPI: sm, PaychAPI: api}
+func NewManager(ctx context.Context, shutdown func(), sm stmgr.StateManagerAPI, pchstore *Store, api ManagerNodeAPI) *Manager {
+	impl := &managerAPIImpl{StateManagerAPI: sm, ManagerNodeAPI: api}
 	return &Manager{
 		ctx:      ctx,
 		shutdown: shutdown,


### PR DESCRIPTION
## add EnablePaymentChannelManager config option to disable payment channel manager by default

This change introduces a new configuration option EnablePaymentChannelManager to control whether the payment channel manager is started on node startup.

- Added EnablePaymentChannelManager boolean field to FullNode config struct
- Set default value to false (disabled by default) since payment channels get minimal use on mainnet
- Added conditional wiring in node/builder_chain.go to only start payment channel manager when config option is enabled
- Updated config documentation with clear description of the option

This saves resources for light nodes and most full nodes that don't use payment channel functionality, while still allowing users to enable it when needed by setting EnablePaymentChannelManager: true in their config.

## Related Issues
https://github.com/filecoin-project/lotus/issues/12718

## Proposed Changes
- **Config Addition**: New `EnablePaymentChannelManager` boolean field in `FullNode` config struct
- **Default Behavior**: Payment channel manager disabled by default (`false`)
- **Conditional Service Wiring**: Modified dependency injection in `node/builder_chain.go` to only wire payment channel services when enabled
- **Documentation**: Updated config auto-generated documentation
- **Changelog**: Added entry to UNRELEASED section following contribution conventions

## Additional Info
- **Backward Compatibility**: Full backward compatibility maintained - users can enable payment channels by setting `EnablePaymentChannelManager: true`
- **Resource Savings**: Eliminates unnecessary resource usage for nodes that don't use payment channels
- **Testing**: All existing payment channel tests pass, config tests updated with new default

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green