### PR TITLE
ci: show the endpoint used to publish a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,11 +321,11 @@ jobs:
       - name: Publish release
         if: github.event.inputs.publish == 'true' || github.event_name == 'push'
         env:
-          release_id: ${{ fromJSON(steps.after.outputs.release).id }}
+          endpoint: ${{ format('/repos/{0}/releases/{1}', github.repository, fromJSON(steps.after.outputs.release).id) }}
           make_latest: ${{ matrix.project == 'node' && fromJSON(steps.project.outputs.config).latest || false }}
           GITHUB_TOKEN: ${{ secrets.TAG_CREATE_GITHUB_TOKEN || github.token }}
         run: |
-          gh api -X PATCH /repos/$GITHUB_REPOSITORY/releases/$release_id \
+          gh api -X PATCH "$endpoint" \
             --field draft=false \
             --raw-field make_latest="$make_latest" |
             jq -r '.'


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
This ensures we can inspect what endpoint was used to publish a release.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
This doesn't fix any issues. It will only be helpful in debugging.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
