### PR TITLE
feat(gateway): add CORS headers if --cors is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - feat(f3): integrate cached MapReduce from go-hamt-ipld, which improves performance of F3 power table calculation by 6-10x ([filecoin-project/lotus#13134](https://github.com/filecoin-project/lotus/pull/13134))
 - fix(spcli): send SettleDealPayments msg to f05 for `lotus-miner actor settle-deal` ([filecoin-project/lotus#13142](https://github.com/filecoin-project/lotus/pull/13142))
 - feat: ExpectedRewardForPower builtin utility function and `lotus-shed miner expected-reward` CLI command ([filecoin-project/lotus#13138](https://github.com/filecoin-project/lotus/pull/13138))
+- feat(gateway): add CORS headers if --cors is provided ([filecoin-project/lotus#13145](https://github.com/filecoin-project/lotus/pull/13145))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -162,6 +162,11 @@ var runCmd = &cli.Command{
 			Usage: "The maximum number of filters plus subscriptions that a single websocket connection can maintain",
 			Value: gateway.DefaultEthMaxFiltersPerConn,
 		},
+		&cli.BoolFlag{
+			Name:  "cors",
+			Usage: "Enable CORS headers to allow cross-origin requests from web browsers",
+			Value: false,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		log.Info("Starting lotus gateway")
@@ -196,6 +201,7 @@ var runCmd = &cli.Command{
 			rateLimitTimeout            = cctx.Duration("rate-limit-timeout")
 			perHostConnectionsPerMinute = cctx.Int("conn-per-minute")
 			maxFiltersPerConn           = cctx.Int("eth-max-filters-per-conn")
+			enableCORS                  = cctx.Bool("cors")
 		)
 
 		serverOptions := make([]jsonrpc.ServerOption, 0)
@@ -230,6 +236,7 @@ var runCmd = &cli.Command{
 			gateway.WithPerConnectionAPIRateLimit(perConnectionRateLimit),
 			gateway.WithPerHostConnectionsPerMinute(perHostConnectionsPerMinute),
 			gateway.WithJsonrpcServerOptions(serverOptions...),
+			gateway.WithCORS(enableCORS),
 		)
 		if err != nil {
 			return xerrors.Errorf("failed to set up gateway HTTP handler")

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -41,12 +41,14 @@ type ShutdownHandler interface {
 
 var _ ShutdownHandler = (*statefulCallHandler)(nil)
 var _ ShutdownHandler = (*RateLimitHandler)(nil)
+var _ ShutdownHandler = (*CORSHandler)(nil)
 
 // handlerOptions holds the options for the Handler function.
 type handlerOptions struct {
 	perConnectionAPIRateLimit   int
 	perHostConnectionsPerMinute int
 	jsonrpcServerOptions        []jsonrpc.ServerOption
+	enableCORS                  bool
 }
 
 // HandlerOption is a functional option for configuring the Handler.
@@ -78,6 +80,13 @@ func WithPerHostConnectionsPerMinute(limit int) HandlerOption {
 func WithJsonrpcServerOptions(options ...jsonrpc.ServerOption) HandlerOption {
 	return func(opts *handlerOptions) {
 		opts.jsonrpcServerOptions = options
+	}
+}
+
+// WithCORS sets whether to enable CORS headers to allow cross-origin requests from web browsers.
+func WithCORS(enable bool) HandlerOption {
+	return func(opts *handlerOptions) {
+		opts.enableCORS = enable
 	}
 }
 
@@ -123,16 +132,24 @@ func Handler(gateway *Node, options ...HandlerOption) (ShutdownHandler, error) {
 	m.Handle("/health/readyz", node.NewReadyHandler(gateway.v1Proxy.server))
 	m.PathPrefix("/").Handler(http.DefaultServeMux)
 
-	handler := &statefulCallHandler{m}
+	var handler http.Handler = &statefulCallHandler{m}
+
+	// Apply CORS wrapper if enabled
+	if opts.enableCORS {
+		handler = NewCORSHandler(handler)
+	}
+
+	// Apply rate limiting wrapper if enabled
 	if opts.perConnectionAPIRateLimit > 0 || opts.perHostConnectionsPerMinute > 0 {
-		return NewRateLimitHandler(
+		handler = NewRateLimitHandler(
 			handler,
 			opts.perConnectionAPIRateLimit,
 			opts.perHostConnectionsPerMinute,
 			connectionLimiterCleanupInterval,
-		), nil
+		)
 	}
-	return handler, nil
+
+	return handler.(ShutdownHandler), nil
 }
 
 type statefulCallHandler struct {
@@ -284,6 +301,37 @@ func (h *RateLimitHandler) cleanupExpiredLimiters(ctx context.Context) {
 
 func (h *RateLimitHandler) Shutdown(ctx context.Context) error {
 	h.cancelFunc()
+	return shutdown(ctx, h.next)
+}
+
+// CORSHandler handles CORS headers for cross-origin requests.
+type CORSHandler struct {
+	next http.Handler
+}
+
+// NewCORSHandler creates a new CORSHandler that wraps the provided handler
+// and adds appropriate CORS headers to allow cross-origin requests from web browsers.
+func NewCORSHandler(next http.Handler) *CORSHandler {
+	return &CORSHandler{next: next}
+}
+
+func (h *CORSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set CORS headers
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With")
+	w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
+
+	// Handle preflight OPTIONS requests
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	h.next.ServeHTTP(w, r)
+}
+
+func (h *CORSHandler) Shutdown(ctx context.Context) error {
 	return shutdown(ctx, h.next)
 }
 

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -323,7 +323,7 @@ func (h *CORSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
 
 	// Handle preflight OPTIONS requests
-	if r.Method == "OPTIONS" {
+	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)
 		return
 	}


### PR DESCRIPTION
Allows remote access from a browser sandbox if exposed.

I needed this for some browser dev work to talk to my local node, and I have it running now and it's 👌.

Closes: #6402
