### PR TITLE
feat(gateway): add per-request logging to gateway with --request-logging

### DIFF
--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -167,6 +167,11 @@ var runCmd = &cli.Command{
 			Usage: "Enable CORS headers to allow cross-origin requests from web browsers",
 			Value: false,
 		},
+		&cli.BoolFlag{
+			Name:  "request-logging",
+			Usage: "Enable logging of incoming API requests. Note: This will log POST request bodies which may impact performance due to body buffering and may expose sensitive data in logs",
+			Value: false,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		log.Info("Starting lotus gateway")
@@ -202,6 +207,7 @@ var runCmd = &cli.Command{
 			perHostConnectionsPerMinute = cctx.Int("conn-per-minute")
 			maxFiltersPerConn           = cctx.Int("eth-max-filters-per-conn")
 			enableCORS                  = cctx.Bool("cors")
+			enableRequestLogging        = cctx.Bool("request-logging")
 		)
 
 		serverOptions := make([]jsonrpc.ServerOption, 0)
@@ -237,6 +243,7 @@ var runCmd = &cli.Command{
 			gateway.WithPerHostConnectionsPerMinute(perHostConnectionsPerMinute),
 			gateway.WithJsonrpcServerOptions(serverOptions...),
 			gateway.WithCORS(enableCORS),
+			gateway.WithRequestLogging(enableRequestLogging),
 		)
 		if err != nil {
 			return xerrors.Errorf("failed to set up gateway HTTP handler")


### PR DESCRIPTION
Logs POST bodies too, so probably not ideal for environments where performance is critical, or where you think there might be data leakage (although the gateway is intended for non-sensitive traffic).

This was just a private branch feature but I found it super useful for debugging and decided there's a good chance I'm going to want this again. I also tried logging to stdout, but having it interleaved with error logs ended up being more useful. Unfortunately the JSON bodies get escaped to be reproduced as JSON output, but it's not terrible.

Another alternative I considered was providing a filename, so it ends up a bit like a classic HTTP server log, `--request-logging=access.log`, but it goes a bit further than HTTP server logging with the request body capture so it may be best to not give the impression that this is the right thing to do.

```json
{"level":"info","ts":"2025-05-28T22:58:32.768+1000","logger":"gateway","caller":"gateway/handler.go:380","msg":"request","remote_ip":"192.168.1.12","method":"POST","url":"/rpc/v1","body":"{\"id\":\"0f6d72ba-f240-4ef9-83c8-9ecc42f5a635\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getBalance\",\"params\":[\"0x0542c82a785fab8b53c7c59aaad7093d87265f3a\",\"0x29414a\"]}"}
{"level":"info","ts":"2025-05-28T22:58:32.769+1000","logger":"gateway","caller":"gateway/handler.go:380","msg":"request","remote_ip":"192.168.1.12","method":"POST","url":"/rpc/v1","body":"{\"id\":\"e764c4b6-234c-44c0-b59c-5b75407488fe\",\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"0x0e690d3e60b0576d01352ab03b258115eb84a047\",\"data\":\"0x01ffc9a780
ac58cd00000000000000000000000000000000000000000000000000000000\"},\"0x29414a\"]}"}                                                                                                          {"level":"warn","ts":"2025-05-28T22:58:32.773+1000","logger":"rpc","caller":"go-jsonrpc@v0.7.0/handler.go:421","msg":"error in RPC call to 'eth_call': message execution failed (exit=[33],
revert reason=[message failed with backtrace:\n00: f0162143 (method 3844450837) -- contract reverted at 86 (33)\n01: f0162143 (method 6) -- contract reverted at 349 (33)\n (RetCode=33)], vm error=[none])"}
```