### PR TITLE
fix(f3): properly wire up eth v2 APIs for f3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - feat: ExpectedRewardForPower builtin utility function and `lotus-shed miner expected-reward` CLI command ([filecoin-project/lotus#13138](https://github.com/filecoin-project/lotus/pull/13138))
 - feat(gateway): add CORS headers if --cors is provided ([filecoin-project/lotus#13145](https://github.com/filecoin-project/lotus/pull/13145))
 - feat(spcli): make settle-deal optionally take deal id ranges ([filecoin-project/lotus#13146](https://github.com/filecoin-project/lotus/pull/13146))
+- fix(f3): properly wire up eth v2 APIs for f3 ([filecoin-project/lotus#13149](https://github.com/filecoin-project/lotus/pull/13149))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -192,6 +192,7 @@ var ChainNode = Options(
 		Override(new(*lf3.Config), lf3.NewConfig),
 		Override(new(manifest.ManifestProvider), lf3.NewManifestProvider),
 		Override(new(lf3.F3Backend), lf3.New),
+		Override(new(full.F3ModuleAPI), From(new(full.F3API))),
 	),
 )
 

--- a/node/impl/full/f3.go
+++ b/node/impl/full/f3.go
@@ -21,12 +21,27 @@ type F3CertificateProvider interface {
 	F3GetLatestCertificate(ctx context.Context) (*certs.FinalityCertificate, error)
 }
 
+type F3ModuleAPI interface {
+	F3CertificateProvider
+
+	F3GetOrRenewParticipationTicket(ctx context.Context, minerID address.Address, previous api.F3ParticipationTicket, instances uint64) (api.F3ParticipationTicket, error)
+	F3Participate(ctx context.Context, ticket api.F3ParticipationTicket) (api.F3ParticipationLease, error)
+	F3GetManifest(ctx context.Context) (*manifest.Manifest, error)
+	F3GetECPowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error)
+	F3GetF3PowerTable(ctx context.Context, tsk types.TipSetKey) (gpbft.PowerEntries, error)
+	F3IsRunning(ctx context.Context) (bool, error)
+	F3GetProgress(ctx context.Context) (gpbft.InstanceProgress, error)
+	F3ListParticipants(ctx context.Context) ([]api.F3Participant, error)
+}
+
 type F3API struct {
 	fx.In
 
 	F3      lf3.F3Backend         `optional:"true"`
 	F3Certs F3CertificateProvider `optional:"true"`
 }
+
+var _ F3ModuleAPI = (*F3API)(nil)
 
 func (f3api *F3API) F3GetOrRenewParticipationTicket(ctx context.Context, miner address.Address, previous api.F3ParticipationTicket, instances uint64) (api.F3ParticipationTicket, error) {
 	if f3api.F3 == nil {

--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -28,7 +28,7 @@ import (
 type TipSetResolverParams struct {
 	fx.In
 	ChainStore eth.ChainStore
-	F3         full.F3CertificateProvider `optional:"true"`
+	F3         full.F3ModuleAPI `optional:"true"`
 }
 
 func MakeV1TipSetResolver(params TipSetResolverParams) full.EthTipSetResolverV2 {


### PR DESCRIPTION
Fixes a problem introduced, but overlooked in
https://github.com/filecoin-project/lotus/pull/13123 which meant that F3 was never wired into the v2 TipSetProvider. Integration tests failed but we ignored it because we had a common flaky that was related so didn't take notice of it.
