### PR TITLE
feat(cli): lotus state active-sectors --show-partitions + CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - feat(gateway): add CORS headers if --cors is provided ([filecoin-project/lotus#13145](https://github.com/filecoin-project/lotus/pull/13145))
 - feat(spcli): make settle-deal optionally take deal id ranges ([filecoin-project/lotus#13146](https://github.com/filecoin-project/lotus/pull/13146))
 - fix(f3): properly wire up eth v2 APIs for f3 ([filecoin-project/lotus#13149](https://github.com/filecoin-project/lotus/pull/13149))
+- `lotus state active-sectors` now outputs CSV format and supports an optional `--show-partitions` to list active sector deadlines and partitions. ([filecoin-project/lotus#13152](https://github.com/filecoin-project/lotus/pull/13152))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/cli/state.go
+++ b/cli/state.go
@@ -301,6 +301,12 @@ var StateActiveSectorsCmd = &cli.Command{
 	Name:      "active-sectors",
 	Usage:     "Query the active sector set of a miner",
 	ArgsUsage: "[minerAddress]",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "show-partitions",
+			Usage: "show sector deadlines and partitions",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
@@ -329,8 +335,23 @@ var StateActiveSectorsCmd = &cli.Command{
 			return err
 		}
 
+		showPartitions := cctx.Bool("show-partitions")
+		header := "Sector Number, Sealed CID"
+		if showPartitions {
+			header = "Sector Number, Deadline, Partition, Sealed CID"
+		}
+		fmt.Println(header)
+
 		for _, s := range sectors {
-			fmt.Printf("%d: %s\n", s.SectorNumber, s.SealedCID)
+			if showPartitions {
+				sp, err := api.StateSectorPartition(ctx, maddr, s.SectorNumber, ts.Key())
+				if err != nil {
+					return err
+				}
+				fmt.Printf("%d, %d, %d, %s\n", s.SectorNumber, sp.Deadline, sp.Partition, s.SealedCID)
+			} else {
+				fmt.Printf("%d, %s\n", s.SectorNumber, s.SealedCID)
+			}
 		}
 
 		return nil

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1368,7 +1368,8 @@ USAGE:
    lotus state active-sectors [command options] [minerAddress]
 
 OPTIONS:
-   --help, -h  show help
+   --show-partitions  show sector deadlines and partitions (default: false)
+   --help, -h         show help
 ```
 
 ### lotus state list-actors


### PR DESCRIPTION
- Add option to show partitions and deadlines.
- Print output in CSV

In the future, I suggest merging the `lotus state sectors` and `lotus state active-sectors`. By default, they will be set to active. Use the flag `--show-all` to view all sectors.