### PR TITLE
ci: update PR title validation to accept revert titles and move skip changelog to description

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,22 @@
+# PR Validation Workflows
+
+## Important Considerations
+
+### Synchronization Requirements
+- **CRITICAL**: Changes to validation logic MUST be reflected in CONTRIBUTING.md](../../CONTRIBUTING.md).  CONTRIBUTING.md and enforcement workflows should be kept in sync.
+- Update both enforcement (workflows) AND documentation (CONTRIBUTING.md) together
+- Consider impact on existing open PRs when changing validation rules
+
+### GitHub API Limitations  
+- `pull_request_target` required for write permissions to post reviews
+- 5-second delay before dismissing reviews to avoid race conditions
+- Bot review detection relies on `user.type === 'Bot'`
+
+### Regex Pattern Gotchas
+- Case sensitivity matters: `Revert` vs `revert`
+- Escaping required for special characters in descriptions
+- JavaScript regex syntax differs from other tools
+
+### Workflow Permissions
+- `pr-title-check.yml` needs `pull-requests: write` for reviews
+- `changelog.yml` uses default permissions (read-only)

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   changelog:
-    if: contains(github.event.pull_request.title, '[skip changelog]') == false &&
+    if: contains(github.event.pull_request.body, '[skip changelog]') == false &&
         contains(github.event.pull_request.labels.*.name, 'skip/changelog') == false &&
         github.event.pull_request.draft == false
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -25,7 +25,10 @@ jobs:
             const title = context.payload.pull_request.title;
             // This should match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions
             // 202408: Beyond Conventional Commit conventions, we also optionally suport the "scope" outside of paranenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
-            const pattern = /^(\[skip changelog\]\s)?(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w.]+\))?!?:?\s(\w+:)?\s?["'`a-z].+$/;
+            // Also accept "Revert ..." titles from GitHub's revert functionality
+            const conventionalPattern = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w.]+\))?!?:?\s(\w+:)?\s?["'`a-z].+$/;
+            const revertPattern = /^Revert\s".+"$/;
+            const pattern = new RegExp(`(${conventionalPattern.source})|(${revertPattern.source})`);
             
             if (!pattern.test(title)) {
               await github.rest.pulls.createReview({

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,10 +23,10 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const title = context.payload.pull_request.title;
-            // This should match https://github.com/filecoin-project/lotus/blob/master/README.md#pr-title-conventions
-            // 202408: Beyond Conventional Commit conventions, we also optionally suport the "scope" outside of paranenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
-            // Also accept "Revert ..." titles from GitHub's revert functionality
+            // This should match https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions
+            // 202408: Beyond Conventional Commit conventions, we also optionally support the "scope" outside of parenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
             const conventionalPattern = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w.]+\))?!?:?\s(\w+:)?\s?["'`a-z].+$/;
+            // Also accept "Revert ..." titles from GitHub's revert functionality
             const revertPattern = /^Revert\s".+"$/;
             const pattern = new RegExp(`(${conventionalPattern.source})|(${revertPattern.source})`);
             

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,13 @@ For doing FIP development that involves a change in [builtin-actors](https://git
 
 ## PR Title Conventions
 
-PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-This means the PR title should be in the form of `<type>(<scope>): <description>`
+PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard or be a GitHub revert title.
+This means the PR title should be in the form of `<type>(<scope>): <description>` or `Revert "<original title>"`
   - example: `fix(mempool): introduce a cache for valid signatures`
+  - example: `Revert "feat: add new feature"`
   - `type`: MUST be one of _build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test_
   - `scope`: OPTIONAL arbitrary string that is usually one of _api, chain, deps, mempool, multisig, networking, paych, proving, sealing, state, wallet_
   - Breaking changes must add a `!`
-  - Optionally the PR title can be prefixed with `[skip changelog]` if no changelog edits should be made for this change.
 
 Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/pr-title-check.yml
 
@@ -55,7 +55,7 @@ To expedite the release process, the CHANGELOG is built-up incrementally.
 We enforce that each PR updates CHANGELOG.md or signals that the change doesn't need it.
 If the PR affects users (e.g., new feature, bug fix, system requirements change), update the CHANGELOG.md and add details to the UNRELEASED section.
 If the change does not require a CHANGELOG.md entry, do one of the following:
-- Add `[skip changelog]` to the PR title
+- Add `[skip changelog]` to the PR description
 - Add the label `skip/changelog` to the PR
 
 Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/changelog.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Lotus is a universally open project and welcomes contributions of all kinds: cod
 - [Working with builtin-actors](#working-with-builtin-actors)
 - [PR Title Conventions](#pr-title-conventions)
 - [CHANGELOG Management](#changelog-management)
+- [Dependency Management](#dependency-management)
 - [Markdown Conventions](#markdown-conventions)
   - [Table Of Contents](#table-of-contents)
 - [Getting Help](#getting-help)
@@ -37,13 +38,15 @@ For doing FIP development that involves a change in [builtin-actors](https://git
 
 ## PR Title Conventions
 
-PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard or be a GitHub revert title.
-This means the PR title should be in the form of `<type>(<scope>): <description>` or `Revert "<original title>"`
+PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
+This means the PR title should be in the form of `<type>(<scope>): <description>`
   - example: `fix(mempool): introduce a cache for valid signatures`
   - example: `Revert "feat: add new feature"`
   - `type`: MUST be one of _build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test_
   - `scope`: OPTIONAL arbitrary string that is usually one of _api, chain, deps, mempool, multisig, networking, paych, proving, sealing, state, wallet_
   - Breaking changes must add a `!`
+
+Alternatively, titles can match a GitHub revert title: `Revert "<original title>"`
 
 Note that this is enforced with https://github.com/filecoin-project/lotus/blob/master/.github/workflows/pr-title-check.yml
 


### PR DESCRIPTION
## Summary
- Accept "Revert ..." titles from GitHub's revert functionality in pr-title-check.yml
- Remove [skip changelog] prefix support from PR titles 
- Update changelog.yml to check for [skip changelog] in PR description instead of title
- Update CONTRIBUTING.md to document both changes

## Test plan
- [ ] Test PR with "Revert ..." title (should pass validation)
- [ ] Test PR with "[skip changelog]" in title (should fail validation)
- [ ] Test PR with "[skip changelog]" in description (should skip changelog requirement)
- [ ] Verify CONTRIBUTING.md documentation matches enforcement logic

🤖 Generated with [Claude Code](https://claude.ai/code)