### PR TITLE
docs: update broken link

### DIFF
--- a/documentation/en/architecture/architecture.md
+++ b/documentation/en/architecture/architecture.md
@@ -256,7 +256,7 @@ wraps all of this into an `ApplyRet`, which is returned.
 # Building a Lotus node
 
 When we launch a Lotus node with the command `./lotus daemon`
-(see [here](https://github.com/filecoin-project/lotus/blob/master/cmd/lotus/daemon.go) for more),
+(see [here](https://github.com/filecoin-project/lotus/blob/master/cli/lotus/daemon.go) for more),
 the node is created through [dependency injection](https://godoc.org/go.uber.org/fx).
 This relies on reflection, which makes some of the references hard to follow.
 The node sets up all of the subsystems it needs to run, such as the repository, the network connections, the chain sync


### PR DESCRIPTION
## Related Issues
No related issues. This PR fixes the source code link for the `./lotus daemon` command in the documentation, making it easier for developers to find the correct file.

## Proposed Changes
- Fixed the source code link in `documentation/en/architecture/architecture.md` for the `./lotus daemon` command, updating the path from `cmd/lotus/daemon.go` to `cli/lotus/daemon.go`.

## Additional Info
- Reference: [Lotus GitHub Repository](https://github.com/filecoin-project/lotus)
- The updated link now points to the actual `daemon.go` file, improving documentation accuracy and usability.

#### before
![before](https://github.com/user-attachments/assets/d8d80c75-5ccf-4de2-9202-a970e331d973)
#### after
![after](https://github.com/user-attachments/assets/1ccd0392-138a-496f-8671-12e8ac65c3dd)


## Checklist

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management) (Doc fix, no changelog needed)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior (Doc fix, no tests needed)
- [x] CI is green