### PR TITLE
feat(f3): migrate f3 datastore to separate datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `lotus state active-sectors` now outputs CSV format and supports an optional `--show-partitions` to list active sector deadlines and partitions. ([filecoin-project/lotus#13152](https://github.com/filecoin-project/lotus/pull/13152))
 - chore: generate v0 JSON RPC specification ([filecoin-project/lotus#13155](https://github.com/filecoin-project/lotus/pull/13155))
 - deps(f3): bump go-f3 version to 0.8.6, move power table cache to go-f3 from lotus ([filecoin-project/lotus#13144](https://github.com/filecoin-project/lotus/pull/13144))
+- feat(f3): move go-f3 datastore to separate leveldb instance ([filecoin-project/lotus#13174](https://github.com/filecoin-project/lotus/pull/13174))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -187,6 +187,7 @@ var ChainNode = Options(
 	ApplyIf(func(s *Settings) bool {
 		return build.IsF3Enabled() && !isLiteNode(s)
 	},
+		Override(new(dtypes.F3DS), modules.F3Datastore),
 		Override(new(*lf3.Config), lf3.NewConfig),
 		Override(new(lf3.F3Backend), lf3.New),
 		Override(new(full.F3ModuleAPI), From(new(full.F3API))),

--- a/node/modules/dtypes/storage.go
+++ b/node/modules/dtypes/storage.go
@@ -12,6 +12,9 @@ import (
 // main repo datastore.
 type MetadataDS datastore.Batching
 
+// F3DS stores F3 data. By default it's namespaced under /f3 in main repo datastore.
+type F3DS datastore.Batching
+
 type (
 	// UniversalBlockstore is the universal blockstore backend.
 	UniversalBlockstore blockstore.Blockstore

--- a/node/modules/storage.go
+++ b/node/modules/storage.go
@@ -57,3 +57,19 @@ func Datastore(disableLog bool) func(lc fx.Lifecycle, mctx helpers.MetricsCtx, r
 		return bds, nil
 	}
 }
+
+func F3Datastore(lc fx.Lifecycle, mctx helpers.MetricsCtx, r repo.LockedRepo) (dtypes.F3DS, error) {
+	ctx := helpers.LifecycleCtx(mctx, lc)
+	mds, err := r.Datastore(ctx, "/f3")
+	if err != nil {
+		return nil, err
+	}
+
+	lc.Append(fx.Hook{
+		OnStop: func(_ context.Context) error {
+			return mds.Close()
+		},
+	})
+
+	return mds, nil
+}

--- a/node/repo/fsrepo_ds.go
+++ b/node/repo/fsrepo_ds.go
@@ -16,6 +16,7 @@ type dsCtor func(path string, readonly bool) (datastore.Batching, error)
 
 var fsDatastores = map[string]dsCtor{
 	"metadata": levelDs,
+	"f3":       levelDs,
 }
 
 // Helper badgerDs() and its imports are unused


### PR DESCRIPTION
Migrate the f3 datastore from being namespaced in the metadata metadata
datastore to having its own dedicated datastore.

Depends on https://github.com/filecoin-project/lotus/pull/13144