### PR TITLE
fix: assert that EC finalized tipset height is never negative in v2 APIs

### DIFF
--- a/node/impl/full/chain_v2.go
+++ b/node/impl/full/chain_v2.go
@@ -153,6 +153,6 @@ func (cm *ChainModuleV2) getTipSetByAnchor(ctx context.Context, anchor *types.Ti
 
 func (cm *ChainModuleV2) getECFinalized(ctx context.Context) (*types.TipSet, error) {
 	head := cm.Chain.GetHeaviestTipSet()
-	finalizedHeight := head.Height() - policy.ChainFinality
+	finalizedHeight := max(0, head.Height()-policy.ChainFinality)
 	return cm.Chain.GetTipsetByHeight(ctx, finalizedHeight, head, true)
 }


### PR DESCRIPTION
Fix an edge case where if the head epoch is below the chain finality policy (defaulting to 900) EC finalized head height would become negative.

Fixes: #13167

