### PR TITLE
fix(doc): minor spelling fixes

### DIFF
--- a/node/repo/fsrepo.go
+++ b/node/repo/fsrepo.go
@@ -648,7 +648,7 @@ func (fsr *fsLockedRepo) List() ([]string, error) {
 	return keys, nil
 }
 
-// Get gets a key out of keystore and returns types.KeyInfo coresponding to named key
+// Get gets a key out of keystore and returns types.KeyInfo corresponding to named key
 func (fsr *fsLockedRepo) Get(name string) (types.KeyInfo, error) {
 	if err := fsr.stillValid(); err != nil {
 		return types.KeyInfo{}, err

--- a/node/repo/memrepo.go
+++ b/node/repo/memrepo.go
@@ -361,7 +361,7 @@ func (lmem *lockedMemRepo) List() ([]string, error) {
 	return res, nil
 }
 
-// Get gets a key out of keystore and returns types.KeyInfo coresponding to named key
+// Get gets a key out of keystore and returns types.KeyInfo corresponding to named key
 func (lmem *lockedMemRepo) Get(name string) (types.KeyInfo, error) {
 	if err := lmem.checkToken(); err != nil {
 		return types.KeyInfo{}, err


### PR DESCRIPTION
Spotted and fixed a few wording hiccups:

node/repo/fsrepo.go // node/repo/memrepo.go
`coresponding` - `corresponding`