### PR TITLE
fix(mpool): block filled on message equality

### DIFF
--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -485,7 +485,7 @@ func (mp *MessagePool) selectMessagesGreedy(ctx context.Context, curTs, ts *type
 	result := mp.selectPriorityMessages(ctx, pending, baseFee, ts)
 
 	// have we filled the block?
-	if result.gasLimit < minGas || len(result.msgs) > buildconstants.BlockMessageLimit {
+	if result.gasLimit < minGas || len(result.msgs) >= buildconstants.BlockMessageLimit {
 		return result, nil
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

I believe the current logic unnecessarily continues execution if selected messages already reach the block limit. In other places the logic seems correct, e.g., here:
https://github.com/filecoin-project/lotus/blob/896d3c33330a75a232b8332ee9632454c1765d6d/chain/messagepool/selection.go#L239-L242

[skip changelog]
Probably a changelog entry is not needed, given it's not a user-facing change, just a minimal optimisation in an infrequent situation.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
