### PR TITLE
docs: update Filecoin Plus documentation link to the current URL

### DIFF
--- a/cmd/lotus-fountain/site/index.html
+++ b/cmd/lotus-fountain/site/index.html
@@ -46,7 +46,7 @@
             <div class="card-content">
                 <h2>FILECOIN CALIBRATION FAUCET GRANT DATACAP</h2>
                 <p>Test Filecoin Plus (Fil+) workflows with DataCap allocations. Understand verified deals, practice client onboarding, and simulate storage provider interactions in a safe environment.</p>
-                <p>Explore more about <a href="https://docs.filecoin.io/basics/filecoin-plus" target="_blank">Filecoin Plus</a> and <a href="https://docs.filecoin.io/storage-provider/filecoin-deals" target="_blank">storage deals</a>.</p>
+                <p>Explore more about <a href="https://docs.filecoin.io/basics/how-storage-works/filecoin-plus" target="_blank">Filecoin Plus</a> and <a href="https://docs.filecoin.io/storage-provider/filecoin-deals" target="_blank">storage deals</a>.</p>
             </div>
             <div class="button-container">
                 <a href="datacap.html" class="button">Grant DataCap</a>


### PR DESCRIPTION
Replaced the outdated Filecoin Plus documentation link (https://docs.filecoin.io/basics/filecoin-plus) with the current and correct URL (https://docs.filecoin.io/basics/how-storage-works/filecoin-plus) in cmd/lotus-fountain/site/index.html to ensure users are directed to the latest information.