### PR TITLE
fix(cli): handle disabled payment channel manager gracefully in info …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 > * [CHANGELOG_1.2x.md](./documentation/changelog/CHANGELOG_1.2x.md) - v1.20.0 to v1.29.2
 
 # UNRELEASED
+- fix(cli): handle disabled payment channel manager gracefully in lotus info command ([filecoin-project/lotus#13198](https://github.com/filecoin-project/lotus/pull/13198))
 - chore(deps): update go-libp2p to v0.42.0 ([filecoin-project/lotus#13190](https://github.com/filecoin-project/lotus/pull/13190))
 - chore: update Go version to 1.23.10 ([filecoin-project/lotus#13190](https://github.com/filecoin-project/lotus/pull/13190))
 - fix(cli): fix `lotus state sector` command to display DealIDs correctly post-FIP-0076 by querying market actor's ProviderSectors HAMT while maintaining backward compatibility with DeprecatedDealIDs field ([filecoin-project/lotus#13140](https://github.com/filecoin-project/lotus/pull/13140))

--- a/cli/info.go
+++ b/cli/info.go
@@ -150,9 +150,9 @@ func infoCmdAct(cctx *cli.Context) error {
 		}
 	} else {
 		switch {
-		case len(chs) <= 1:
+		case len(chs) == 1:
 			fmt.Printf("Payment Channels: %v channel\n", len(chs))
-		case len(chs) > 1:
+		default:
 			fmt.Printf("Payment Channels: %v channels\n", len(chs))
 		}
 	}

--- a/cli/info.go
+++ b/cli/info.go
@@ -142,14 +142,19 @@ func infoCmdAct(cctx *cli.Context) error {
 
 	chs, err := fullapi.PaychList(ctx)
 	if err != nil {
-		return err
-	}
-
-	switch {
-	case len(chs) <= 1:
-		fmt.Printf("Payment Channels: %v channel\n", len(chs))
-	case len(chs) > 1:
-		fmt.Printf("Payment Channels: %v channels\n", len(chs))
+		// Check if the error is because payment channel manager is disabled
+		if strings.Contains(err.Error(), "payment channel manager is disabled") {
+			fmt.Printf("Payment Channels: disabled (EnablePaymentChannelManager is set to false)\n")
+		} else {
+			return err
+		}
+	} else {
+		switch {
+		case len(chs) <= 1:
+			fmt.Printf("Payment Channels: %v channel\n", len(chs))
+		case len(chs) > 1:
+			fmt.Printf("Payment Channels: %v channels\n", len(chs))
+		}
 	}
 	fmt.Println()
 	tw := tabwriter.NewWriter(os.Stdout, 6, 6, 2, ' ', 0)

--- a/cli/info.go
+++ b/cli/info.go
@@ -143,7 +143,7 @@ func infoCmdAct(cctx *cli.Context) error {
 	chs, err := fullapi.PaychList(ctx)
 	if err != nil {
 		// Check if the error is because payment channel manager is disabled
-		if strings.Contains(err.Error(), "payment channel manager is disabled") {
+		if errors.Is(err, paych.ErrPaymentChannelDisabled) {
 			fmt.Printf("Payment Channels: disabled (EnablePaymentChannelManager is set to false)\n")
 		} else {
 			return err

--- a/cli/info.go
+++ b/cli/info.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/journal/alerting"
+	"github.com/filecoin-project/lotus/node/impl/paych"
 )
 
 var InfoCmd = &cli.Command{


### PR DESCRIPTION
## Proposed Changes
https://github.com/filecoin-project/lotus/pull/13139 introduced that the `EnablePaymentChannelManager` is set to false by default. With that as the default, the `lotus info` command was failing with an error instead of continuing to display useful information. Example:

```
lotus info
Network: mainnet
StartTime: 8m46s (started at 2025-07-07 12:13:51 +0000 UTC)
Chain: [sync ok] [basefee 84.464 fFIL] [epoch 5119485]
Peers to: [publish messages 177] [publish blocks 180]
⚠ 1 Active alerts (check lotus log alerts)
Chain health: 100% [healthy]

Default address: address not set

Wallet: 0 address
      Total balance: 0
      Market locked: 0
      Market available: 0

ERROR: payment channel manager is disabled (EnablePaymentChannelManager is set to false)
```

This change detects the specific "payment channel manager is disabled" error and allows the command to continue showing the bandwidth stats:

```
lotus info
Network: mainnet
StartTime: 13m30s (started at 2025-07-07 12:13:51 +0000 UTC)
Chain: [sync ok] [basefee 74.132 fFIL] [epoch 5119494]
Peers to: [publish messages 187] [publish blocks 190]
⚠ 1 Active alerts (check lotus log alerts)
Chain health: 100% [healthy]

Default address: address not set

Wallet: 0 address
      Total balance: 0
      Market locked: 0
      Market available: 0

Payment Channels: disabled (EnablePaymentChannelManager is set to false)

Bandwidth:
      TotalIn  TotalOut  RateIn   RateOut
      714 MB   64 MB     77 kB/s  26 kB/s
```

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
