### PR TITLE
feat: changing the order of inspectMiner could improve efficiency

### DIFF
--- a/cmd/lotus-shed/miner-fees.go
+++ b/cmd/lotus-shed/miner-fees.go
@@ -580,7 +580,7 @@ var minerFeesInspect = &cli.Command{
 						return nil
 					}
 
-					fee, penalty, err := inspectMiner(trace.Msg.To)
+					fee, penalty, err := inspectMiner(trace.Msg.From)
 					if err != nil {
 						return xerrors.Errorf("inspecting miner: %w", err)
 					}


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Since inspectMiner needs to load the Miner, MinerState, Deadline, and DeadlineInfo, it’s quite time-consuming. So we should only call inspectMiner if we’re certain there will be a fee or penalty.

## Proposed Changes
<!-- A clear list of the changes being made -->
Ｃhanging the order of inspectMiner could improve efficiency.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
[skip changelog]
## Checklist

Before you mark the PR ready for review, please make sure that:

- [v] Commits have a clear commit message.
- [v] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
