### PR TITLE
feat(metrics): instrument bitswap usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
 - fix(cli): make lotus-miner sectors extend command resilient to higher gas ([filecoin-project/lotus#11927](https://github.com/filecoin-project/lotus/pull/11928))
 - feat(api): update go-f3 to 0.8.8, add F3GetPowerTableByInstance to the API ([filecoin-project/lotus#13201](https://github.com/filecoin-project/lotus/pull/13201))
 - fix(cli): use F3GetPowerTableByInstance to resolve F3 power tables by default, `--by-tipset` flag can be used to restore old behavior ([filecoin-project/lotus#13201](https://github.com/filecoin-project/lotus/pull/13201))
-- fix(cli): correctly construct the TerminateSectors params
+- fix(cli): correctly construct the TerminateSectors params ([filecoin-project/lotus#13207](https://github.com/filecoin-project/lotus/pull/13207))
+- feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 
 # Node v1.33.0 / 2025-05-08
 The Lotus v1.33.0 release introduces experimental v2 APIs with F3 awareness, featuring a new TipSet selection mechanism that significantly enhances how applications interact with the Filecoin blockchain. This release candidate also adds F3-aware Ethereum APIs via the /v2 endpoint.  All of the /v2 APIs implement intelligent fallback mechanisms between F3 and Expected Consensus and are exposed through the Lotus Gateway.

--- a/blockstore/instrumented.go
+++ b/blockstore/instrumented.go
@@ -1,0 +1,217 @@
+package blockstore
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/exchange"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+// InstrumentedBlockService wraps a blockservice.BlockService to provide
+// metrics tracking for local vs network block fetches
+type InstrumentedBlockService struct {
+	blockservice.BlockService
+	local Blockstore // Local blockstore to check for local hits
+}
+
+// NewInstrumentedBlockService creates a new instrumented block service
+func NewInstrumentedBlockService(bs Blockstore, exch exchange.Interface) *InstrumentedBlockService {
+	return &InstrumentedBlockService{
+		BlockService: blockservice.New(bs, exch),
+		local:        bs,
+	}
+}
+
+// instrumentedMetrics tracks metrics for block fetch operations
+type instrumentedMetrics struct {
+	isSession bool
+}
+
+// recordFetchMetrics tracks metrics for a batch of CID fetches
+func (m *instrumentedMetrics) recordFetchMetrics(ctx context.Context, cids []cid.Cid, local Blockstore) (localCount int, networkCids []cid.Cid) {
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		stats.Record(ctx, MessageFetchMeasures.Duration.M(float64(duration.Milliseconds())))
+	}()
+
+	// Record total requested
+	stats.Record(ctx, MessageFetchMeasures.Requested.M(int64(len(cids))))
+
+	// Check which blocks are available locally
+	networkCids = make([]cid.Cid, 0, len(cids))
+
+	for _, c := range cids {
+		if has, err := local.Has(ctx, c); err == nil && has {
+			localCount++
+		} else {
+			networkCids = append(networkCids, c)
+		}
+	}
+
+	// Record local vs network counts
+	if localCount > 0 {
+		stats.Record(ctx, MessageFetchMeasures.Local.M(int64(localCount)))
+	}
+	if len(networkCids) > 0 {
+		stats.Record(ctx, MessageFetchMeasures.Network.M(int64(len(networkCids))))
+	}
+
+	// Log details for debugging
+	if len(networkCids) > 0 {
+		logLevel := "Debugw"
+		logMsg := "message fetch requiring network"
+		if m.isSession {
+			logLevel = "Infow"
+			logMsg = "bitswap session fetch required"
+		}
+
+		if logLevel == "Infow" {
+			log.Infow(logMsg,
+				"total_requested", len(cids),
+				"local_hits", localCount,
+				"network_fetches", len(networkCids),
+				"network_cids", networkCids)
+		} else {
+			log.Debugw(logMsg,
+				"total_requested", len(cids),
+				"local_hits", localCount,
+				"network_fetches", len(networkCids),
+				"network_cids", networkCids)
+		}
+	} else {
+		logMsg := "message fetch all local"
+		if m.isSession {
+			logMsg = "session fetch all local"
+		}
+		log.Debugw(logMsg,
+			"total_requested", len(cids),
+			"local_hits", localCount)
+	}
+
+	return localCount, networkCids
+}
+
+// recordSingleFetchMetrics tracks metrics for a single CID fetch
+func (m *instrumentedMetrics) recordSingleFetchMetrics(ctx context.Context, c cid.Cid, local Blockstore) string {
+	start := time.Now()
+
+	// Check if available locally first
+	fetchSource := "local"
+	if has, err := local.Has(ctx, c); err != nil || !has {
+		fetchSource = "network"
+		logMsg := "single message fetch requiring network"
+		if m.isSession {
+			logMsg = "bitswap session single fetch required"
+			log.Infow(logMsg, "cid", c)
+		} else {
+			log.Debugw(logMsg, "cid", c)
+		}
+	}
+
+	// Record metrics with source tag
+	ctx, _ = tag.New(ctx, tag.Upsert(FetchSource, fetchSource))
+	defer func() {
+		duration := time.Since(start)
+		stats.Record(ctx, MessageFetchMeasures.Duration.M(float64(duration.Milliseconds())))
+		stats.Record(ctx, MessageFetchMeasures.Requested.M(1))
+
+		if fetchSource == "local" {
+			stats.Record(ctx, MessageFetchMeasures.Local.M(1))
+		} else {
+			stats.Record(ctx, MessageFetchMeasures.Network.M(1))
+		}
+	}()
+
+	return fetchSource
+}
+
+// GetBlocks wraps the underlying GetBlocks to track local vs network fetches
+func (ibs *InstrumentedBlockService) GetBlocks(ctx context.Context, cids []cid.Cid) <-chan blocks.Block {
+	m := &instrumentedMetrics{isSession: false}
+	m.recordFetchMetrics(ctx, cids, ibs.local)
+	return ibs.BlockService.GetBlocks(ctx, cids)
+}
+
+// GetBlock wraps the underlying GetBlock to track individual fetches
+func (ibs *InstrumentedBlockService) GetBlock(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	m := &instrumentedMetrics{isSession: false}
+	m.recordSingleFetchMetrics(ctx, c, ibs.local)
+	return ibs.BlockService.GetBlock(ctx, c)
+}
+
+// NewSession creates a new instrumented session
+func (ibs *InstrumentedBlockService) NewSession(ctx context.Context) *InstrumentedSession {
+	session := blockservice.NewSession(ctx, ibs.BlockService)
+	return &InstrumentedSession{
+		BlockGetter: session,
+		local:       ibs.local,
+	}
+}
+
+// Implement the remaining BlockService interface methods by delegating to the wrapped service
+
+// AddBlock adds a single block to the blockservice
+func (ibs *InstrumentedBlockService) AddBlock(ctx context.Context, block blocks.Block) error {
+	return ibs.BlockService.AddBlock(ctx, block)
+}
+
+// AddBlocks adds multiple blocks to the blockservice
+func (ibs *InstrumentedBlockService) AddBlocks(ctx context.Context, blocks []blocks.Block) error {
+	return ibs.BlockService.AddBlocks(ctx, blocks)
+}
+
+// DeleteBlock deletes a block from the blockservice
+func (ibs *InstrumentedBlockService) DeleteBlock(ctx context.Context, c cid.Cid) error {
+	return ibs.BlockService.DeleteBlock(ctx, c)
+}
+
+// Blockstore returns the underlying blockstore
+func (ibs *InstrumentedBlockService) Blockstore() BasicBlockstore {
+	return ibs.BlockService.Blockstore()
+}
+
+// Exchange returns the underlying exchange
+func (ibs *InstrumentedBlockService) Exchange() exchange.Interface {
+	return ibs.BlockService.Exchange()
+}
+
+// Close closes the blockservice
+func (ibs *InstrumentedBlockService) Close() error {
+	if closer, ok := ibs.BlockService.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// InstrumentedSession wraps a blockservice session to provide metrics
+type InstrumentedSession struct {
+	blockservice.BlockGetter
+	local Blockstore
+}
+
+// GetBlocks wraps the session's GetBlocks to track metrics
+func (is *InstrumentedSession) GetBlocks(ctx context.Context, cids []cid.Cid) <-chan blocks.Block {
+	m := &instrumentedMetrics{isSession: true}
+	m.recordFetchMetrics(ctx, cids, is.local)
+	return is.BlockGetter.GetBlocks(ctx, cids)
+}
+
+// GetBlock wraps the session's GetBlock to track individual fetches
+func (is *InstrumentedSession) GetBlock(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	m := &instrumentedMetrics{isSession: true}
+	m.recordSingleFetchMetrics(ctx, c, is.local)
+	return is.BlockGetter.GetBlock(ctx, c)
+}
+
+// Ensure InstrumentedSession implements the BlockGetter interface
+var _ blockservice.BlockGetter = (*InstrumentedSession)(nil)
+
+// Ensure InstrumentedBlockService implements the BlockService interface
+var _ blockservice.BlockService = (*InstrumentedBlockService)(nil)

--- a/documentation/en/architecture/architecture.md
+++ b/documentation/en/architecture/architecture.md
@@ -366,6 +366,19 @@ that wraps the stores
 `ChainExchange()` and `ChainBlockservice()` establish a BitSwap connection (FIXME libp2p link)
 to exchange chain information in the form of `blocks.Block`s stored in the repo. (See sync section for more details, the Filecoin blocks and messages are backed by these raw IPFS blocks that together form the different structures that define the state of the current/heaviest chain.)
 
+##### Monitoring Bitswap Usage
+
+To monitor how often Lotus needs to use bitswap for fetching messages (as opposed to having them available locally from pubsub), you can enable message fetch instrumentation:
+
+```bash
+export LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1
+```
+
+This enables metrics that track:
+- `lotus_message_fetch_requested`: Total messages requested
+- `lotus_message_fetch_local`: Messages found in local blockstore (from pubsub)
+- `lotus_message_fetch_network`: Messages that required bitswap network fetch
+
 #### Incoming handlers
 `HandleIncomingBlocks()` and `HandleIncomingMessages()` start the services in charge of processing new Filecoin blocks
 and messages from the network (see `<undefined>` for more information about the topics the node is subscribed to, FIXME: should that be part of the libp2p section or should we expand on gossipsub separately?).

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -76,6 +76,9 @@ var (
 	// piecereader
 	PRReadType, _ = tag.NewKey("pr_type") // seq / rand
 	PRReadSize, _ = tag.NewKey("pr_size") // small / big
+
+	// message fetching
+	FetchSource, _ = tag.NewKey("fetch_source") // "local" or "network"
 )
 
 // Measures
@@ -131,6 +134,12 @@ var (
 	VMApplied                           = stats.Int64("vm/applied", "Counter for messages (including internal messages) processed by the VM", stats.UnitDimensionless)
 	VMExecutionWaiting                  = stats.Int64("vm/execution_waiting", "Counter for VM executions waiting to be assigned to a lane", stats.UnitDimensionless)
 	VMExecutionRunning                  = stats.Int64("vm/execution_running", "Counter for running VM executions", stats.UnitDimensionless)
+
+	// message fetching
+	MessageFetchRequested = stats.Int64("message/fetch_requested", "Number of messages requested for fetch", stats.UnitDimensionless)
+	MessageFetchLocal     = stats.Int64("message/fetch_local", "Number of messages found locally", stats.UnitDimensionless)
+	MessageFetchNetwork   = stats.Int64("message/fetch_network", "Number of messages fetched from network", stats.UnitDimensionless)
+	MessageFetchDuration  = stats.Float64("message/fetch_duration_ms", "Duration of message fetch operations", stats.UnitMilliseconds)
 
 	// miner
 	WorkerCallsStarted           = stats.Int64("sealing/worker_calls_started", "Counter of started worker tasks", stats.UnitDimensionless)
@@ -451,6 +460,28 @@ var (
 		Measure:     VMExecutionRunning,
 		Aggregation: view.Sum(),
 		TagKeys:     []tag.Key{ExecutionLane, Network},
+	}
+
+	// message fetching
+	MessageFetchRequestedView = &view.View{
+		Measure:     MessageFetchRequested,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{Network},
+	}
+	MessageFetchLocalView = &view.View{
+		Measure:     MessageFetchLocal,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{Network},
+	}
+	MessageFetchNetworkView = &view.View{
+		Measure:     MessageFetchNetwork,
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{Network},
+	}
+	MessageFetchDurationView = &view.View{
+		Measure:     MessageFetchDuration,
+		Aggregation: defaultMillisecondsDistribution,
+		TagKeys:     []tag.Key{FetchSource, Network},
 	}
 
 	// miner
@@ -829,6 +860,10 @@ var ChainNodeViews = append([]*view.View{
 	VMAppliedView,
 	VMExecutionWaitingView,
 	VMExecutionRunningView,
+	MessageFetchRequestedView,
+	MessageFetchLocalView,
+	MessageFetchNetworkView,
+	MessageFetchDurationView,
 }, DefaultViews...)
 
 var MinerNodeViews = append([]*view.View{


### PR DESCRIPTION
Only enabled with LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 due to minor additional blockstore index usage.

Looks a little like this during normal operation:

<img width="2790" height="614" alt="Screenshot 2025-07-18 at 1 09 14 pm" src="https://github.com/user-attachments/assets/f9d99441-a35f-4e64-a3e4-e409043cfa83" />

It's difficult to show this from Prometheus well but bitswap usage seems to be fairly rare, we're able to get most messages from pubsub. The occasional fetches make it look like it hovers a bit above 95% but it's very patchy.

The timings aren't quite as interesting as hoped due to the infrequency but they do show some interesting things about the local blockstore, just isolated to messages.