### PR TITLE
ci: update curl in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,13 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
+      - name: Update curl
+        if: runner.os == 'MacOS'
+        run: |
+          brew update
+          brew unlink curl
+          brew install curl
+          brew link curl --force
       - name: Build binaries
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This addresses the issues we've seen with the release workflow - https://github.com/filecoin-project/lotus/actions/runs/16368564857

`macos-13` started using `curl@8.14.1`, which seems to have issues with setting the correct exit codes. What happens now on `macos-13` is:
1. We try to download a filecoin-ffi release asset
2. The download fails
3. Curl responds with exit code 0
4. We continue with the script execution
5. The script fails fatally when trying to manipulate the downloaded asset

What happens on `macos-14`, which uses an earlier version of curl:
1. We try to download a filecoin-ffi release asset
2. The download fails
3. Curl responds with exit code 92
4. We fall back to building filecoin-ffi from source

The root cause of these issues is the faulty way in which we try to download the release assets. To fix that, we'll have to update https://github.com/filecoin-project/filecoin-ffi/blob/master/install-filcrypto#L79. However, I do need a little more time to figure out how to update it correctly.

In the meantime, as a quick fix, this PR proposes to upgrade curl to a version (8.15.0) that correctly exits when the download fails, which means, for now, we'll always fall back to building filecoin-ffi from source during the release.