### PR TITLE
chore: fix typos in docs

### DIFF
--- a/blockstore/splitstore/README.md
+++ b/blockstore/splitstore/README.md
@@ -60,7 +60,7 @@ These are options in the `[Chainstore.Splitstore]` section of the configuration:
   nodes beyond 4 finalities, while running with the discard coldstore option.
   It is also useful for miners who accept deals and need to lookback messages beyond
   the 4 finalities, which would otherwise hit the coldstore.
-- `HotStoreFullGCFrequency` -- specifies how frequenty to garbage collect the hotstore
+- `HotStoreFullGCFrequency` -- specifies how frequently to garbage collect the hotstore
   using full (moving) GC.
   The default value is 20, which uses full GC every 20 compactions (about once a week);
   set to 0 to disable full GC altogether.

--- a/chain/actors/aerrors/wrap.go
+++ b/chain/actors/aerrors/wrap.go
@@ -102,7 +102,7 @@ func Wrap(err ActorError, message string) ActorError {
 	}
 }
 
-// Wrapf extens chain of errors with a message
+// Wrapf extends chain of errors with a message
 func Wrapf(err ActorError, format string, args ...interface{}) ActorError {
 	if err == nil {
 		return nil


### PR DESCRIPTION
# Proposed Changes

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

## Corrected misspellings:
- `frequenty` → `frequently`
- `extens` → `extends`

## Additional Info
No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [x] PR title conforms with contribution conventions
- [ ] Update CHANGELOG.md or signal that this change does not need it per contribution conventions
- [ ] New features have usage guidelines and / or documentation updates in
- [ ] Lotus Documentation
- [ ] Discussion Tutorials
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green