### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/build-pulse.yml
+++ b/.github/workflows/build-pulse.yml
@@ -37,12 +37,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Check out lotus
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: lotus
           ref: ${{ github.event.inputs.head_commit_id || github.event.workflow_run.head_commit.id }}
       - name: Check out buildpulse-action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: buildpulse/buildpulse-action
           path: buildpulse-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/builtin-actor-tests.yml
+++ b/.github/workflows/builtin-actor-tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Release Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       skip_checks: ${{ steps.changes.outputs.nonMarkdownFiles == 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
@@ -40,7 +40,7 @@ jobs:
     if: ${{ needs.pre-check.outputs.skip_checks != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
     if: ${{ needs.pre-check.outputs.skip_checks != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -71,7 +71,7 @@ jobs:
     if: ${{ needs.pre-check.outputs.skip_checks != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
     if: ${{ needs.pre-check.outputs.skip_checks != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/create-release-issue.yml
+++ b/.github/workflows/create-release-issue.yml
@@ -54,7 +54,7 @@ jobs:
     name: Create Release Issue
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/install-go
       - env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -17,7 +17,7 @@ jobs:
       IGNORE_PATTERN: 'dependency-check-ignore:\s'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Check out the repository
         with:
           submodules: 'recursive'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
             fi
           fi
           echo "channel=$channel" | tee -a $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       projects: ${{ steps.projects.outputs.projects }}
     steps:
       - name: Check out lotus
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
@@ -88,7 +88,7 @@ jobs:
             xargs -I {} -0 echo "config={}" |
             tee -a $GITHUB_OUTPUT
       - name: Check out lotus
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -97,7 +97,7 @@ jobs:
       - name: Install Go
         uses: ./.github/actions/install-go
       - if: github.event.inputs.ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
             xargs -I {} -0 echo "config={}" |
             tee -a $GITHUB_OUTPUT
       - name: Check out lotus
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       test_group_execution_contexts: ${{ steps.list_test_group_execution_contexts.outputs.test_group_execution_contexts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
         # We need to cache for each architecture we support: x86_64 and arm64
         runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -122,7 +122,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.discover.outputs.test_group_execution_contexts) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       test_group_execution_contexts: ${{ steps.list_test_group_execution_contexts.outputs.test_group_execution_contexts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
         # We need to cache for each architecture we support: x86_64 and arm64
         runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -127,7 +127,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.discover.outputs.test_group_execution_contexts) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 0


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0