### PR TITLE
chore: fix typos in docs

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -453,7 +453,7 @@ func between(min, max, val int) int {
 }
 
 func (b *Blockstore) deleteDB(path string) {
-	// follow symbolic links, otherwise the data wil be left behind
+	// follow symbolic links, otherwise the data will be left behind
 	linkPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		log.Warnf("error resolving symlinks in %s", path)

--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -529,7 +529,7 @@ func (s *SplitStore) Put(ctx context.Context, blk blocks.Block) error {
 }
 
 func (s *SplitStore) PutMany(ctx context.Context, blks []blocks.Block) error {
-	// filter identites
+	// filter identities
 	idcids := 0
 	for _, blk := range blks {
 		if isIdentiyCid(blk.Cid()) {


### PR DESCRIPTION
# Proposed Changes

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

## Corrected misspellings:

- `wil` → `will`
- `identites` → `identities`

## Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [x] PR title conforms with contribution conventions
- [ ] Update CHANGELOG.md or signal that this change does not need it per contribution conventions
- [ ] New features have usage guidelines and / or documentation updates in
- [ ] Lotus Documentation
- [ ] Discussion Tutorials
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
