### PR TITLE
docs(release): v1.34.0. v1.34.1, v1.34.2 release template improvements

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -193,7 +193,7 @@ func main() {
 					},
 					&cli.StringFlag{
 						Name:     "level",
-						Usage:    "What's the level of the release? (Options: major, minor, patch)",
+						Usage:    "What's the level of the release? (Options: minor, patch)",
 						Value:    "patch",
 						Required: true,
 					},
@@ -256,8 +256,8 @@ func main() {
 					}
 
 					releaseLevel := c.String("level")
-					if releaseLevel != "major" && releaseLevel != "minor" && releaseLevel != "patch" {
-						return fmt.Errorf("invalid value for the 'level' flag. Allowed values are 'major', 'minor', and 'patch'")
+					if releaseLevel != "minor" && releaseLevel != "patch" {
+						return fmt.Errorf("invalid value for the 'level' flag. Allowed values are 'minor' and 'patch'")
 					}
 
 					networkUpgrade := c.String("network-upgrade")
@@ -343,6 +343,9 @@ func main() {
 
 					// Prepare issue creation options
 					issueTitle := fmt.Sprintf("Lotus %s v%s Release", releaseType, releaseTag)
+					if networkUpgrade != "" {
+						issueTitle += fmt.Sprintf(" (nv%s)", networkUpgrade)
+					}
 					issueBody := issueBodyBuffer.String()
 
 					// Remove duplicate newlines before headers and list items since the templating leaves a lot extra newlines around.

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -185,3 +185,4 @@ See the final release notes!
 # ⁉️ Do you have questions?
 
 Leave a comment in this ticket!
+


### PR DESCRIPTION
## Summary
- Remove "major" release level option from release CLI since we don't have special logic for major releases and have never done a major version release
- Add "(nv$networkVersion)" suffix to GitHub issue titles when a network upgrade version is specified
- Minor whitespace cleanup to release template

This PR will be used to collect incremental improvements during the v1.34.0 release process as recommended in the release template.

## Changes that need to be made
- [x] Document more of the changelog prep commands like https://github.com/filecoin-project/lotus/pull/13314#issuecomment-3255305086
- [ ] Document about copy/pasting changelog back into the release itself
- [ ] Document about how to handle changelog entries for new RCs
- [ ] Is there any guide about the kind of content to have for things like the migration section of the changelog?
- [ ] Document when the draft RC release gets triggered
- [ ] When dealing with the node and miner release, we don't list commands about cherrypicking commits across to the miner branch.
- [ ] Manual release GitHub workflow should default to `["node", "miner"]` so it's more obvious what to put in there when running the workflow manually
- [ ] We should update the template so that it's clear that the "before RC1" tasks need to be done even if not doing an RC
- [ ] Final release should make sure using final releases of go-state-types, filecoin-ffi and that actors CIDs don't change.
- [x] For network upgrades, also need to update the network name like https://github.com/filecoin-project/lotus/pull/13318

### Outdated or not a priority
- [ ] It would generally be great to see our CI be able to run faster
- [x] Why did releases get assigned to galargh in https://filecoinproject.slack.com/archives/C027TQMUVJN/p1757019721331769 ? 
   - @BigLep : I believe this got fixed in 2026

## Changes Made
1. **Release Script (`cmd/release/main.go`)**:
   - Removed "major" from allowed release levels (now only "minor" and "patch")
   - Updated validation logic to exclude "major" releases
   - Added network version suffix to GitHub issue titles when network upgrade is specified

2. **Release Template (`documentation/misc/RELEASE_ISSUE_TEMPLATE.md`)**:
   - Added trailing newline for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)