### PR TITLE
ci: stop publishing x64 macos binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
         project: ${{ fromJSON(needs.check.outputs.projects).*.name }}
         runner:
           - ubuntu-latest # Linux X64
-          - macos-13 # MacOs X64
           - macos-14 # MacOS ARM64
     steps:
       - name: Print runner information
@@ -172,11 +171,6 @@ jobs:
         with:
           name: lotus-${{ matrix.project }}-Linux-X64
           path: linux_amd64_v1
-      - name: Download macOS X64 binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: lotus-${{ matrix.project }}-macOS-X64
-          path: darwin_amd64_v1
       - name: Download macOS ARM64 binaries
         uses: actions/download-artifact@v4
         with:
@@ -190,25 +184,14 @@ jobs:
         env:
           prefix: ${{ matrix.project == 'node' && 'lotus' || format('lotus-{0}', matrix.project) }}
           version: ${{ fromJSON(steps.project.outputs.config).version }}
-          binaries: ${{ toJSON(fromJSON(steps.project.outputs.config).binaries) }}
         run: |
-          mkdir darwin_all
-          while read -r binary; do
-            if [[ -z "$binary" ]]; then
-              continue
-            fi
-            makefat ./darwin_all/$binary ./darwin_amd64_v1/$binary ./darwin_arm64/$binary
-          done <<< "$(jq -r '.[]' <<< "$binaries")"
-          mkdir dist
-          pushd dist
-          for directory in darwin_all linux_amd64_v1; do
+          for directory in darwin_arm64 linux_amd64_v1; do
             archive_name="${prefix}_v${version}_${directory}"
             cp -r ../$directory $archive_name
             tar -czf $archive_name.tar.gz $archive_name
             rm -r $archive_name
           done
-          popd
-          ls -la dist
+          ls -la .
       - name: Install Kubo (checksums generation dependency)
         uses: ipfs/download-ipfs-distribution-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,10 @@ build/builtin-actors/v*
 build/builtin-actors/*.car
 
 dist/
+# deprecated
 darwin_amd64_v1/
 darwin_arm64/
+# deprecated
 darwin_all/
 linux_amd64_v1/
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
https://github.com/filecoin-project/lotus/issues/13262

## Proposed Changes
<!-- A clear list of the changes being made -->

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green