### PR TITLE
fix(api): eth_getCode and eth_getStorageAt operate on current tipset state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 # UNRELEASED
 - feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 - chore(docs): mark v0 API as "deprecated" and v1 as "stable" ([filecoin-project/lotus#13264](https://github.com/filecoin-project/lotus/pull/13264))
-- fix(api): `eth_getCode` now returns the code after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
+- fix(api): `eth_getCode` and `eth_getStorageAt` now return state after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
 
 
 # Node v1.33.1 / 2025-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 # UNRELEASED
 - feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 - chore(docs): mark v0 API as "deprecated" and v1 as "stable" ([filecoin-project/lotus#13264](https://github.com/filecoin-project/lotus/pull/13264))
-- fix(api): `eth\_getCode` now returns the code after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
+- fix(api): `eth_getCode` now returns the code after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
 
 
 # Node v1.33.1 / 2025-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 # UNRELEASED
 - feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 - chore(docs): mark v0 API as "deprecated" and v1 as "stable" ([filecoin-project/lotus#13264](https://github.com/filecoin-project/lotus/pull/13264))
+- fix(api): `eth\_getCode` now returns the code after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
 
 
 # Node v1.33.1 / 2025-07-31

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -39,6 +39,10 @@ var ErrExpensiveFork = errors.New("refusing explicit call due to state fork at e
 // tipset's parent. In the presence of null blocks, the height at which the message is invoked may
 // be less than the specified tipset.
 func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error) {
+	return sm.CallOnState(ctx, cid.Undef, msg, ts)
+}
+
+func (sm *StateManager) CallOnState(ctx context.Context, stateCid cid.Cid, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error) {
 	// Copy the message as we modify it below.
 	msgCopy := *msg
 	msg = &msgCopy
@@ -56,7 +60,7 @@ func (sm *StateManager) Call(ctx context.Context, msg *types.Message, ts *types.
 		msg.Value = types.NewInt(0)
 	}
 
-	return sm.callInternal(ctx, msg, nil, ts, cid.Undef, sm.GetNetworkVersion, false, execSameSenderMessages)
+	return sm.callInternal(ctx, msg, nil, ts, stateCid, sm.GetNetworkVersion, false, execSameSenderMessages)
 }
 
 // ApplyOnStateWithGas applies the given message on top of the given state root with gas tracing enabled

--- a/node/impl/eth/api.go
+++ b/node/impl/eth/api.go
@@ -210,6 +210,7 @@ type StateManager interface {
 
 	ExecutionTrace(ctx context.Context, ts *types.TipSet) (cid.Cid, []*api.InvocResult, error)
 	Call(ctx context.Context, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error)
+	CallOnState(ctx context.Context, stateCid cid.Cid, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error)
 	CallWithGas(ctx context.Context, msg *types.Message, priorMsgs []types.ChainMsg, ts *types.TipSet, applyTsMessages bool) (*api.InvocResult, error)
 	ApplyOnStateWithGas(ctx context.Context, stateCid cid.Cid, msg *types.Message, ts *types.TipSet) (*api.InvocResult, error)
 

--- a/node/impl/eth/lookup.go
+++ b/node/impl/eth/lookup.go
@@ -88,9 +88,8 @@ func (e *ethLookup) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 		return nil, nil
 	}
 
-	from, _ := (ethtypes.EthAddress{}).ToFilecoinAddress()
 	msg := &types.Message{
-		From:       from,
+		From:       builtinactors.SystemActorAddr,
 		To:         to,
 		Value:      big.Zero(),
 		Method:     builtintypes.MethodsEVM.GetBytecode,
@@ -103,7 +102,7 @@ func (e *ethLookup) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 	// Try calling until we find a height with no migration.
 	var res *api.InvocResult
 	for {
-		res, err = e.stateManager.ApplyOnStateWithGas(ctx, stateCid, msg, ts)
+		res, err = e.stateManager.CallOnState(ctx, stateCid, msg, ts)
 		if err != stmgr.ErrExpensiveFork {
 			break
 		}

--- a/node/impl/eth/lookup.go
+++ b/node/impl/eth/lookup.go
@@ -7,7 +7,6 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	builtintypes "github.com/filecoin-project/go-state-types/builtin"
@@ -163,13 +162,12 @@ func (e *ethLookup) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 		return nil, xerrors.Errorf("cannot get Filecoin address: %w", err)
 	}
 
-	// use the system actor as the caller
-	from, err := address.NewIDAddress(0)
+	stateCid, _, err := e.stateManager.TipSetState(ctx, ts)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to construct system sender address: %w", err)
+		return nil, err
 	}
 
-	actor, err := e.stateManager.LoadActor(ctx, to, ts)
+	actor, err := e.stateManager.LoadActorRaw(ctx, to, stateCid)
 	if err != nil {
 		if errors.Is(err, types.ErrActorNotFound) {
 			return ethtypes.EthBytes(make([]byte, 32)), nil
@@ -189,7 +187,7 @@ func (e *ethLookup) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 	}
 
 	msg := &types.Message{
-		From:       from,
+		From:       builtinactors.SystemActorAddr,
 		To:         to,
 		Value:      big.Zero(),
 		Method:     builtintypes.MethodsEVM.GetStorageAt,
@@ -202,7 +200,7 @@ func (e *ethLookup) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAdd
 	// Try calling until we find a height with no migration.
 	var res *api.InvocResult
 	for {
-		res, err = e.stateManager.Call(ctx, msg, ts)
+		res, err = e.stateManager.CallOnState(ctx, stateCid, msg, ts)
 		if err != stmgr.ErrExpensiveFork {
 			break
 		}


### PR DESCRIPTION
Reviewer @rvagg
Fixes #13247

I use `TipSetState` and `LoadActorRaw` instead of `ParentState` within `LoadActor`, which roughly matches the behavior of `EthCall`.

When looking for other methods that might have this problem in lookup.go, I noticed that `EthGetBalance` seems to already do `TipSetState` and `LoadActorRaw`.

#### Test Plan
Deploy a contract and await the receipt
Once receipt returns non-null, immediately kill lotus-miner
Query daemon with eth_getCode on latest
Before this change, eth_getCode outputs 0x (because ErrActorNotFound)
After this change, eth_getCode outputs the deployed bytecode

Apply a tx on the contract that sets nonzero storage from zero.
Once receipt  returns non-null, immediately kill lotus-miner
Query daemon with eth_getStorageAt on latest
Before this change, eth_getStorageAt outputs zero
After this change, eth_getStorageAt outputs nonzero

#### Changes
* add func `CallOnState` to pass a stateCid parameter to `Call`
* eth_getCode and eth_getStorageAt use state from `TipSetState` instead of `ParentState`, and `LoadActorRaw` instead of `LoadActor`.