### PR TITLE
fix(api): eth_getTransactionCount operate on current tipset state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 # UNRELEASED
 - feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 - chore(docs): mark v0 API as "deprecated" and v1 as "stable" ([filecoin-project/lotus#13264](https://github.com/filecoin-project/lotus/pull/13264))
-- fix(api): `eth_getCode` and `eth_getStorageAt` now return state after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
+- fix(api): `eth_getCode`, `eth_getStorageAt`, and `eth_getTransactionCount` now return state after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
 
 
 # Node v1.33.1 / 2025-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 # UNRELEASED
 - feat(net): add LOTUS_ENABLE_MESSAGE_FETCH_INSTRUMENTATION=1 to turn on metrics and debugging for local vs bitswap message fetching during block validation ([filecoin-project/lotus#13221](https://github.com/filecoin-project/lotus/pull/13221))
 - chore(docs): mark v0 API as "deprecated" and v1 as "stable" ([filecoin-project/lotus#13264](https://github.com/filecoin-project/lotus/pull/13264))
-- fix(api): `eth_getCode`, `eth_getStorageAt`, and `eth_getTransactionCount` now return state after the specified block rather than before it ([filecoin-project/lotus#13247](https://github.com/filecoin-project/lotus/issues/13247))
+- fix(api): `eth_getCode` and `eth_getStorageAt` now return state after the specified block rather than before it ([filecoin-project/lotus#13274](https://github.com/filecoin-project/lotus/pull/13274))
+- fix(api): `eth_getTransactionCount` now returns state after the specified block rather than before it ([filecoin-project/lotus#13275](https://github.com/filecoin-project/lotus/pull/13275))
 
 
 # Node v1.33.1 / 2025-07-31

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -261,8 +261,13 @@ func (e *ethTransaction) EthGetTransactionCount(ctx context.Context, sender etht
 		return ethtypes.EthUint64(0), err // don't wrap, to preserve ErrNullRound
 	}
 
+	stateCid, _, err := e.stateManager.TipSetState(ctx, ts)
+	if err != nil {
+		return 0, err
+	}
+
 	// Get the actor state at the specified tipset
-	actor, err := e.stateManager.LoadActor(ctx, addr, ts)
+	actor, err := e.stateManager.LoadActorRaw(ctx, addr, stateCid)
 	if err != nil {
 		if errors.Is(err, types.ErrActorNotFound) {
 			return 0, nil


### PR DESCRIPTION

Reviewer @rvagg
Similar to #13274
#### Test Plan
Run local devnet miner and daemon.
Send transaction and await receipt, then kill miner.
Query eth_getTransactionCount of sender.
Before this change it returns zero.
After this change it returns nonzero
#### Changes
* use LoadActorRaw to specify TipSetState cid