### PR TITLE
fix(rpc): add read, write and idle timeout to rpc handler

### DIFF
--- a/node/rpc.go
+++ b/node/rpc.go
@@ -47,7 +47,11 @@ func ServeRPC(h http.Handler, id string, addr multiaddr.Multiaddr) (StopFunc, er
 	// Instantiate the server and start listening.
 	srv := &http.Server{
 		Handler:           h,
-		ReadHeaderTimeout: 30 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20,
 		BaseContext: func(listener net.Listener) context.Context {
 			ctx := context.Background()
 			ctx = metrics.AddNetworkTag(ctx)

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -31,6 +31,15 @@ import (
 
 var rpclog = logging.Logger("rpc")
 
+const (
+	// HTTP server timeout constants
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 60 * time.Second
+	writeTimeout      = 60 * time.Second
+	idleTimeout       = 60 * time.Second
+	maxHeaderBytes    = 1 << 20
+)
+
 // ServeRPC serves an HTTP handler over the supplied listen multiaddr.
 //
 // This function spawns a goroutine to run the server, and returns immediately.
@@ -47,11 +56,11 @@ func ServeRPC(h http.Handler, id string, addr multiaddr.Multiaddr) (StopFunc, er
 	// Instantiate the server and start listening.
 	srv := &http.Server{
 		Handler:           h,
-		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      60 * time.Second,
-		IdleTimeout:       60 * time.Second,
-		MaxHeaderBytes:    1 << 20,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
 		BaseContext: func(listener net.Listener) context.Context {
 			ctx := context.Background()
 			ctx = metrics.AddNetworkTag(ctx)


### PR DESCRIPTION
## Related Issues
Adding read, write and idle timeouts in rpc handler. Fixes [this](https://bugs.immunefi.com/dashboard/submission/51442) bug. 


## Proposed Changes
Adding additional timeouts for rpc handler.

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [X ] Commits have a clear commit message.
- [X ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
