### PR TITLE
feat(eth): use F3 for "finalized" and "safe" resolution in v1 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   - snapshot export now defaults to v2 format with embedded F3 finality certificates, dramatically reducing F3 catchup time from ~8 hours
   - transparently imports both v1 and v2 snapshot formats
   - to export v1 snapshots, use `lotus chain export --skip-old-msgs --recent-stateroots=2001 --snapshot-version=1 <filename>`
-
+- feat(eth): use F3 for "finalized" and "safe" resolution in v1 APIs. This switches the /v1 Ethereum APIs to have the same resolution rules as /v2, enabling F3 awareness for all Ethereum calls where `"finalized"` or `"safe"` is supplied. See [F3-aware Ethereum APIs via `/v2` endpoint and improvements to existing `/v1` APIs](#f3-aware-ethereum-apis-via-v2-endpoint-and-improvements-to-existing-v1-apis) below for details of how the /v2 APIs work as introduced in the 1.33.0 release. Set the environment variable `LOTUS_ETH_V1_DISABLE_F3_FINALITY_RESOLUTION` to `1` to revert this behaviour but note that the option to revert will likely be removed in a future release. ([filecoin-project/lotus#13298](https://github.com/filecoin-project/lotus/pull/13298))
 
 # Node v1.33.1 / 2025-07-31
 This is the Lotus v1.33.1 release, which introduces performance improvements and operational enhancements. This release focuses on improving F3 subsystem performance, and enhancing CLI tools for better storage provider operations. Notable improvements include up to 6-10x performance gains in F3 power table calculations, ensuring that PreCommit and ProveCommit operations are aggregating to get optimal gas usage after FIP-100, and a enhanced sector management tool with CSV output support. These improvements collectively enhance the stability and efficiency of Lotus operations for both node operators and storage providers.

--- a/itests/eth_api_f3_test.go
+++ b/itests/eth_api_f3_test.go
@@ -142,7 +142,7 @@ func TestEthAPIWithF3(t *testing.T) {
 			}
 		}
 		ecFinalized    = ecFixedLookback(policy.ChainFinality)
-		ecSafeV1       = ecFixedLookback(30)
+		ecSafeV1       = ecFixedLookback(200)
 		ecSafeV2       = ecFixedLookback(200)
 		tipSetAtHeight = func(height abi.ChainEpoch) func(t *testing.T) *types.TipSet {
 			return func(t *testing.T) *types.TipSet {
@@ -218,7 +218,7 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCertErr = nil
 				mockF3.LatestCert = plausibleCertAt(t, f3FinalizedEpoch)
 			},
-			wantTipSetV1: ecFinalized,
+			wantTipSetV1: f3Finalized,
 			wantTipSetV2: f3Finalized,
 		},
 		{
@@ -230,7 +230,7 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCertErr = nil
 				mockF3.LatestCert = plausibleCertAt(t, targetHeight)
 			},
-			wantTipSetV1: ecSafeV1,
+			wantTipSetV1: tipSetAtHeight(targetHeight),
 			wantTipSetV2: tipSetAtHeight(targetHeight),
 		},
 		{
@@ -303,8 +303,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = nil
 				mockF3.LatestCertErr = internalF3Error
 			},
-			wantTipSetV1: ecFinalized,
-			wantErrV2:    internalF3Error.Error(),
+			wantErrV1: internalF3Error.Error(),
+			wantErrV2: internalF3Error.Error(),
 		},
 		{
 			name:     "safe tag when f3 fails, but f3 is not activated",
@@ -315,8 +315,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = nil
 				mockF3.LatestCertErr = internalF3Error
 			},
-			wantTipSetV1: ecSafeV1,
-			wantErrV2:    internalF3Error.Error(),
+			wantErrV1: internalF3Error.Error(),
+			wantErrV2: internalF3Error.Error(),
 		},
 		{
 			name:     "safe tag when f3 fails",
@@ -327,8 +327,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = nil
 				mockF3.LatestCertErr = internalF3Error
 			},
-			wantTipSetV1: ecSafeV1,
-			wantErrV2:    internalF3Error.Error(),
+			wantErrV1: internalF3Error.Error(),
+			wantErrV2: internalF3Error.Error(),
 		},
 		{
 			name:     "finalize tag when f3 is too far behind falls back to ec",
@@ -363,8 +363,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = implausibleCert
 				mockF3.LatestCertErr = nil
 			},
-			wantTipSetV1: ecFinalized,
-			wantErrV2:    "decoding latest f3 cert tipset key",
+			wantErrV1: "decoding latest f3 cert tipset key",
+			wantErrV2: "decoding latest f3 cert tipset key",
 		},
 		{
 			name:     "safe tag when f3 is broken, but f3 is not activated",
@@ -375,8 +375,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = implausibleCert
 				mockF3.LatestCertErr = nil
 			},
-			wantTipSetV1: ecSafeV1,
-			wantErrV2:    "decoding latest f3 cert tipset key",
+			wantErrV1: "decoding latest f3 cert tipset key",
+			wantErrV2: "decoding latest f3 cert tipset key",
 		},
 		{
 			name:     "safe tag when f3 is broken",
@@ -387,8 +387,8 @@ func TestEthAPIWithF3(t *testing.T) {
 				mockF3.LatestCert = implausibleCert
 				mockF3.LatestCertErr = nil
 			},
-			wantTipSetV1: ecSafeV1,
-			wantErrV2:    "decoding latest f3 cert tipset key",
+			wantErrV1: "decoding latest f3 cert tipset key",
+			wantErrV2: "decoding latest f3 cert tipset key",
 		},
 		{
 			name:     "height before ec finalized epoch is ok",

--- a/itests/eth_api_test.go
+++ b/itests/eth_api_test.go
@@ -410,7 +410,7 @@ func TestEthBlockNumberAliases(t *testing.T) {
 		expectedLag abi.ChainEpoch
 	}{
 		{"latest", 1},                       // head - 1
-		{"safe", 30},                        // "latest" - 30
+		{"safe", 200},                       // "latest" - 200 when F3 isn't running
 		{"finalized", policy.ChainFinality}, // "latest" - 900
 	} {
 		t.Run(tc.param, func(t *testing.T) {


### PR DESCRIPTION
As per chat with @BigLep, this is how we backport F3 finalisation rules to v1 Eth APIs if we want to go with that path. It also comes with a future clean-up task that we should open an issue for if we merge this.

---

Same rules as v2:

* "finalized" and "safe" resolve to whatever F3 has finalized
* Fall-back for "safe" is to 200 epochs behind head when F3 isn't operating
* Fall-back for "finalized" is 900 epochs behind head when F3 isn't operating

Run with LOTUS_ETH_V1_DISABLE_F3_FINALITY_RESOLUTION=1 to revert to the old resolution rules.

Future clean-up required:

* Remove LOTUS_ETH_V1_DISABLE_F3_FINALITY_RESOLUTION option
* Remove builder_chain.go split paths for v1 and v2 Eth module building - reuse same modules across v1 and v2.
* Simplify eth_api_f3_test.go to remove special rules for v1 vs v2 - test same rules
