### PR TITLE
fix(rpc): add read, write and idle configurable timeouts to gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This is the Lotus v1.33.1 release, which introduces performance improvements and
 - chore(deps): update of critical underlying dependencies with go-libp2p to v0.42.0 (filecoin-project/lotus#13190) and boxo to v0.32.0 ([filecoin-project/lotus#13202](https://github.com/filecoin-project/lotus/pull/13202)) and boxo v0.33.0([filecoin-project/lotus#13226](https://github.com/filecoin-project/lotus/pull/13226))
 - feat(spcli): correctly handle the batch logic of `lotus-miner actor settle-deal`; replace the dealid data source ([filecoin-project/lotus#13189](https://github.com/filecoin-project/lotus/pull/13189))
 - feat(spcli): add `--all-deals` to `lotus-miner actor settle-deal`. By default, only expired deals are processed ([filecoin-project/lotus#13243](https://github.com/filecoin-project/lotus/pull/13243))
+- fix(rpc): add read, write and idle configurable timeouts to gateway. ([filecoin-project/lotus#13327](https://github.com/filecoin-project/lotus/pull/13327))
 
 ## 📝 Changelog
 

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -172,6 +172,26 @@ var runCmd = &cli.Command{
 			Usage: "Enable logging of incoming API requests. Note: This will log POST request bodies which may impact performance due to body buffering and may expose sensitive data in logs",
 			Value: false,
 		},
+		&cli.DurationFlag{
+			Name:  "read-timeout",
+			Usage: "Maximum duration for reading the entire request, including the body. Use 0 to disable",
+			Value: gateway.ReadTimeout,
+		},
+		&cli.DurationFlag{
+			Name:  "write-timeout",
+			Usage: "Maximum duration before timing out writes of the response. Use 0 to disable (sensitive setting - be careful)",
+			Value: gateway.WriteTimeout,
+		},
+		&cli.DurationFlag{
+			Name:  "idle-timeout",
+			Usage: "Maximum amount of time to wait for the next request when keep-alives are enabled. Use 0 to disable",
+			Value: gateway.IdleTimeout,
+		},
+		&cli.IntFlag{
+			Name:  "max-header-bytes",
+			Usage: "Maximum number of bytes the server will read parsing the request header's keys and values",
+			Value: gateway.MaxHeaderBytes,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		log.Info("Starting lotus gateway")
@@ -208,6 +228,10 @@ var runCmd = &cli.Command{
 			maxFiltersPerConn           = cctx.Int("eth-max-filters-per-conn")
 			enableCORS                  = cctx.Bool("cors")
 			enableRequestLogging        = cctx.Bool("request-logging")
+			readTimeout                 = cctx.Duration("read-timeout")
+			writeTimeout                = cctx.Duration("write-timeout")
+			idleTimeout                 = cctx.Duration("idle-timeout")
+			maxHeaderBytes              = cctx.Int("max-header-bytes")
 		)
 
 		serverOptions := make([]jsonrpc.ServerOption, 0)
@@ -236,6 +260,10 @@ var runCmd = &cli.Command{
 			gateway.WithRateLimit(globalRateLimit),
 			gateway.WithRateLimitTimeout(rateLimitTimeout),
 			gateway.WithEthMaxFiltersPerConn(maxFiltersPerConn),
+			gateway.WithReadTimeout(readTimeout),
+			gateway.WithWriteTimeout(writeTimeout),
+			gateway.WithIdleTimeout(idleTimeout),
+			gateway.WithMaxHeaderBytes(maxHeaderBytes),
 		)
 		handler, err := gateway.Handler(
 			gwapi,


### PR DESCRIPTION
## Related Issues
Old PR https://github.com/filecoin-project/lotus/pull/13283/files. 
Adding configurable read, write and idle timeouts in gateway handler. Fixes [this](https://bugs.immunefi.com/dashboard/submission/51442) bug.

## Proposed Changes
Adding additional timeouts for gateway rpc handler.
Mainly these are the constants (Subject to change):
	readHeaderTimeout = 10 * time.Second
	readTimeout       = 60 * time.Second
	writeTimeout      = 0
	idleTimeout       = 60 * time.Second
	maxHeaderBytes    = 1 << 20

## Additional Info
Related slack discussion: https://filecoinproject.slack.com/archives/C05P37R9KQD/p1756354215245379

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
