### PR TITLE
fix: resolve quote nesting in network-specific build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,15 +79,15 @@ INTEROPNET_FLAGS=-tags=interopnet
 
 # Network-specific pattern rules
 debug-%:
-	$(MAKE) $* GOFLAGS="$(GOFLAGS) $(DEBUG_FLAGS)"
+	$(MAKE) $* GOFLAGS='$(GOFLAGS) $(DEBUG_FLAGS)'
 2k-%:
-	$(MAKE) $* GOFLAGS="$(GOFLAGS) $(TWOK_FLAGS)"
+	$(MAKE) $* GOFLAGS='$(GOFLAGS) $(TWOK_FLAGS)'
 calibnet-%:
-	$(MAKE) $* GOFLAGS="$(GOFLAGS) $(CALIBNET_FLAGS)"
+	$(MAKE) $* GOFLAGS='$(GOFLAGS) $(CALIBNET_FLAGS)'
 butterflynet-%:
-	$(MAKE) $* GOFLAGS="$(GOFLAGS) $(BUTTERFLYNET_FLAGS)"
+	$(MAKE) $* GOFLAGS='$(GOFLAGS) $(BUTTERFLYNET_FLAGS)'
 interopnet-%:
-	$(MAKE) $* GOFLAGS="$(GOFLAGS) $(INTEROPNET_FLAGS)"
+	$(MAKE) $* GOFLAGS='$(GOFLAGS) $(INTEROPNET_FLAGS)'
 
 build-devnets: build lotus-seed lotus-shed
 .PHONY: build-devnets


### PR DESCRIPTION
Fixes quote nesting bug in network-specific build targets when LDFLAGS is set.

  Commands like `LDFLAGS=-L/usr/local/cuda/lib64 make calibnet-lotus` failed due to nested double quotes in GOFLAGS construction:
  - `GOFLAGS+=-ldflags="$(ldflags)"` + `GOFLAGS="$(GOFLAGS) $(FLAGS)"`
  - Result: `GOFLAGS="-ldflags="..." -tags=calibnet"` (parsing error)

  Changed to single quotes to avoid nesting.