### PR TITLE
fix: use single quotes in GOFLAGS ldflags to match network targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifneq ($(strip $(LDFLAGS)),)
 	ldflags+=-extldflags=$(LDFLAGS)
 endif
 
-GOFLAGS+=-ldflags="$(ldflags)"
+GOFLAGS+=-ldflags='$(ldflags)'
 
 FIX_IMPORTS = $(GOCC) run ./scripts/fiximports
 


### PR DESCRIPTION
## Related Issues
Fixes quote nesting issue introduced by PR #13328.

## Proposed Changes
PR #13328 changed network-specific targets to use single quotes around GOFLAGS assignments, but the base GOFLAGS definition still used double quotes around $(ldflags), causing quote nesting when LDFLAGS is set, and failure to run the make <network> commands.