### PR TITLE
fix(miner): fix error handling when reading HTTP response body in `GeneratePoRepVanillaProof`

### DIFF
--- a/storage/paths/remote.go
+++ b/storage/paths/remote.go
@@ -991,12 +991,12 @@ func (r *Remote) GeneratePoRepVanillaProof(ctx context.Context, sr storiface.Sec
 
 			// Read the response body
 			body, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
 			if err != nil {
 				merr = multierror.Append(merr, xerrors.Errorf("resp.Body ReadAll: %w", err))
 				log.Warnw("GeneratePoRepVanillaProof read response body failed", "url", url, "error", err)
 				continue
 			}
-			_ = resp.Body.Close()
 
 			// Return the proof if successful
 			return body, nil


### PR DESCRIPTION
[skip changelog]
## Related Issues
https://github.com/filecoin-project/lotus/issues/13333

This PR fix the issue.
```golang=992
			// Read the response body
			body, err := io.ReadAll(resp.Body)
			if err != nil {
				merr = multierror.Append(merr, xerrors.Errorf("resp.Body ReadAll: %w", err))
				log.Warnw("GeneratePoRepVanillaProof read response body failed", "url", url, "error", err)
                                 continue //@note change update here
			}
			_ = resp.Body.Close()
```

## Proposed Changes
1. Update the function GeneratePoRepVanillaProof to handle error when reading HTTP response

## Additional Info

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
