### PR TITLE
chore: update Mainnet Golden Week height

### DIFF
--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -138,8 +138,8 @@ var UpgradeTockHeight = UpgradeTeepHeight + builtin.EpochsInDay*90
 // Only applied to calibnet which was already upgraded to Teep&Tock
 var UpgradeTockFixHeight = abi.ChainEpoch(-1)
 
-// ??????
-var UpgradeGoldenWeekHeight = abi.ChainEpoch(9999999999)
+// 2025-09-24T23:00:00Z
+var UpgradeGoldenWeekHeight = abi.ChainEpoch(5348280)
 
 var UpgradeTeepInitialFilReserved = InitialFilReserved // FIP-0100: no change for mainnet
 


### PR DESCRIPTION
## Proposed Changes
Update Mainnet Golden Week upgrade height to epoch `5348280` corresponding to `2025-09-24T23:00:00Z`

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green

