### PR TITLE
build: release Lotus Node and Miner v1.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,7 @@
 
 # Node and Miner v1.34.1 / 2025-09-15
 
-This is a **critical patch release** that fixes an issue with the v1.34.0 release where the incorrect version of filecoin-ffi was included.
-
-## 🔧 Bug Fixes
-
-- **Critical Fix**: Updated filecoin-ffi from v1.34.0-dev to the stable v1.34.0 release
-  - This ensures the inclusion of ref-fvm v4.7.3 update that was missing in v1.34.0
-  - All users of v1.34.0 should upgrade to v1.34.1 immediately
+This is a non-critical patch release that fixes an issue with the Lotus `v1.34.0` release where the incorrect version of filecoin-ffi was included.  Lotus `v1.34.0` used filecoin-ffi `v1.34.0-dev` when it should have used `v1.34.0`.  This isn’t critical since it’s the same filecoin-ffi version used during the nv27 Calibration network upgrade, but for consistency with other Node implementations like Forest, we are creating this release.  This ensures the inclusion of ref-fvm `v4.7.3` update that was missing in v1.34.0.  All users of v1.34.0 are encouraged to upgrade to v1.34.1.
 
 # Node and Miner v1.34.0 / 2025-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 # UNRELEASED
 
+# Node and Miner v1.34.1 / 2025-09-15
+
+This is a **critical patch release** that fixes an issue with the v1.34.0 release where the incorrect version of filecoin-ffi was included.
+
+## 🔧 Bug Fixes
+
+- **Critical Fix**: Updated filecoin-ffi from v1.34.0-dev to the stable v1.34.0 release
+  - This ensures the inclusion of ref-fvm v4.7.3 update that was missing in v1.34.0
+  - All users of v1.34.0 should upgrade to v1.34.1 immediately
+
 # Node and Miner v1.34.0 / 2025-09-11
 
 This is a **MANDATORY Lotus v1.34.0 release**, which will deliver the Filecoin network version 27, codenamed “Golden Week” 🏮. This release candidate sets the upgrade epoch for the Mainnet network to **Epoch 5348280:  2025-09-24T23:00:00Z**.  (See the [local time for other timezones](https://www.worldtimebuddy.com/?qm=1&lid=100,5128581,5368361,1816670&h=100&date=2025-9-24&sln=23-24&hf=1&c=1196).)  

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/v0/gateway.json
+++ b/build/openrpc/v0/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/v2/full.json
+++ b/build/openrpc/v2/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/v2/gateway.json
+++ b/build/openrpc/v2/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.34.0"
+        "version": "1.34.1"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.34.0"
+const NodeBuildVersion string = "1.34.1"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -18,7 +18,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.34.0"
+const MinerBuildVersion = "1.34.1"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -8,7 +8,7 @@ USAGE:
    lotus-miner [global options] command [command options]
 
 VERSION:
-   1.34.0
+   1.34.1
 
 COMMANDS:
    init     Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -8,7 +8,7 @@ USAGE:
    lotus-worker [global options] command [command options]
 
 VERSION:
-   1.34.0
+   1.34.1
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -8,7 +8,7 @@ USAGE:
    lotus [global options] command [command options]
 
 VERSION:
-   1.34.0
+   1.34.1
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
## Related Issues

The v1.34.0 release incorrectly shipped with `filecoin-ffi v1.34.0-dev` instead of the stable `filecoin-ffi v1.34.0` release. This patch release corrects this packaging error to include the proper stable version with ref-fvm v4.7.3.

https://github.com/filecoin-project/lotus/issues/13340

## Proposed Changes

  - Update filecoin-ffi submodule from `v1.34.0-dev` to stable `v1.34.0`
  - Bump version to v1.34.1 in `build/version.go`
  - Update CHANGELOG.md with v1.34.1 patch release notes
  - Regenerate documentation via `make gen` and `make docsgen-cli`

  ## Additional Info

  All users running v1.34.0 should upgrade to v1.34.1 to ensure they have the correct stable version of filecoin-ffi.


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
