### PR TITLE
fix(api): use params `tipset-key` to load the tipset for gas premium calculation

### DIFF
--- a/node/impl/full/gas.go
+++ b/node/impl/full/gas.go
@@ -57,7 +57,7 @@ func (a *GasAPI) GasEstimateFeeCap(
 	maxqueueblks int64,
 	tsk types.TipSetKey,
 ) (types.BigInt, error) {
-	return gasutils.GasEstimateFeeCap(a.Chain, msg, maxqueueblks)
+	return gasutils.GasEstimateFeeCap(ctx, a.Chain, msg, maxqueueblks, tsk)
 }
 
 func (m *GasModule) GasEstimateFeeCap(
@@ -66,7 +66,7 @@ func (m *GasModule) GasEstimateFeeCap(
 	maxqueueblks int64,
 	tsk types.TipSetKey,
 ) (types.BigInt, error) {
-	return gasutils.GasEstimateFeeCap(m.Chain, msg, maxqueueblks)
+	return gasutils.GasEstimateFeeCap(ctx, m.Chain, msg, maxqueueblks, tsk)
 }
 
 func (a *GasAPI) GasEstimateGasPremium(
@@ -74,9 +74,9 @@ func (a *GasAPI) GasEstimateGasPremium(
 	nblocksincl uint64,
 	sender address.Address,
 	gaslimit int64,
-	_ types.TipSetKey,
+	tsk types.TipSetKey,
 ) (types.BigInt, error) {
-	return gasutils.GasEstimateGasPremium(ctx, a.Chain, a.PriceCache, nblocksincl)
+	return gasutils.GasEstimateGasPremium(ctx, a.Chain, a.PriceCache, nblocksincl, tsk)
 }
 
 func (m *GasModule) GasEstimateGasPremium(
@@ -84,9 +84,9 @@ func (m *GasModule) GasEstimateGasPremium(
 	nblocksincl uint64,
 	sender address.Address,
 	gaslimit int64,
-	_ types.TipSetKey,
+	tsk types.TipSetKey,
 ) (types.BigInt, error) {
-	return gasutils.GasEstimateGasPremium(ctx, m.Chain, m.PriceCache, nblocksincl)
+	return gasutils.GasEstimateGasPremium(ctx, m.Chain, m.PriceCache, nblocksincl, tsk)
 }
 
 func (a *GasAPI) GasEstimateGasLimit(ctx context.Context, msgIn *types.Message, tsk types.TipSetKey) (int64, error) {
@@ -105,9 +105,9 @@ func (m *GasModule) GasEstimateGasLimit(ctx context.Context, msgIn *types.Messag
 	return gasutils.GasEstimateGasLimit(ctx, m.Chain, m.Stmgr, m.Mpool, msgIn, ts)
 }
 
-func (m *GasModule) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, _ types.TipSetKey) (*types.Message, error) {
+func (m *GasModule) GasEstimateMessageGas(ctx context.Context, msg *types.Message, spec *api.MessageSendSpec, ts types.TipSetKey) (*types.Message, error) {
 	if msg.GasLimit == 0 {
-		gasLimit, err := m.GasEstimateGasLimit(ctx, msg, types.EmptyTSK)
+		gasLimit, err := m.GasEstimateGasLimit(ctx, msg, ts)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func (m *GasModule) GasEstimateMessageGas(ctx context.Context, msg *types.Messag
 	}
 
 	if msg.GasPremium == types.EmptyInt || types.BigCmp(msg.GasPremium, types.NewInt(0)) == 0 {
-		gasPremium, err := m.GasEstimateGasPremium(ctx, 10, msg.From, msg.GasLimit, types.EmptyTSK)
+		gasPremium, err := m.GasEstimateGasPremium(ctx, 10, msg.From, msg.GasLimit, ts)
 		if err != nil {
 			return nil, xerrors.Errorf("estimating gas price: %w", err)
 		}
@@ -128,7 +128,7 @@ func (m *GasModule) GasEstimateMessageGas(ctx context.Context, msg *types.Messag
 	}
 
 	if msg.GasFeeCap == types.EmptyInt || types.BigCmp(msg.GasFeeCap, types.NewInt(0)) == 0 {
-		feeCap, err := m.GasEstimateFeeCap(ctx, msg, 20, types.EmptyTSK)
+		feeCap, err := m.GasEstimateFeeCap(ctx, msg, 20, ts)
 		if err != nil {
 			return nil, xerrors.Errorf("estimating fee cap: %w", err)
 		}

--- a/node/impl/gasutils/gasutils.go
+++ b/node/impl/gasutils/gasutils.go
@@ -224,8 +224,11 @@ func GasEstimateGasLimit(
 	return ret, nil
 }
 
-func GasEstimateFeeCap(cstore ChainStoreAPI, msg *types.Message, maxqueueblks int64) (types.BigInt, error) {
-	ts := cstore.GetHeaviestTipSet()
+func GasEstimateFeeCap(ctx context.Context, cstore ChainStoreAPI, msg *types.Message, maxqueueblks int64, tsk types.TipSetKey) (types.BigInt, error) {
+	ts, err := cstore.GetTipSetFromKey(ctx, tsk)
+	if err != nil {
+		return types.BigInt{}, xerrors.Errorf("getting tipset from key: %w", err)
+	}
 
 	parentBaseFee := ts.Blocks()[0].ParentBaseFee
 	increaseFactor := math.Pow(1.+1./float64(buildconstants.BaseFeeMaxChangeDenom), float64(maxqueueblks))
@@ -240,7 +243,7 @@ func GasEstimateFeeCap(cstore ChainStoreAPI, msg *types.Message, maxqueueblks in
 	return out, nil
 }
 
-func GasEstimateGasPremium(ctx context.Context, cstore ChainStoreAPI, cache *GasPriceCache, nblocksincl uint64) (types.BigInt, error) {
+func GasEstimateGasPremium(ctx context.Context, cstore ChainStoreAPI, cache *GasPriceCache, nblocksincl uint64, tsKey types.TipSetKey) (types.BigInt, error) {
 	if nblocksincl == 0 {
 		nblocksincl = 1
 	}
@@ -248,7 +251,11 @@ func GasEstimateGasPremium(ctx context.Context, cstore ChainStoreAPI, cache *Gas
 	var prices []GasMeta
 	var blocks int
 
-	ts := cstore.GetHeaviestTipSet()
+	ts, err := cstore.GetTipSetFromKey(ctx, tsKey)
+	if err != nil {
+		return types.BigInt{}, err
+	}
+
 	for i := uint64(0); i < nblocksincl*2; i++ {
 		if ts.Height() == 0 {
 			break // genesis

--- a/node/impl/gasutils/gasutils.go
+++ b/node/impl/gasutils/gasutils.go
@@ -253,7 +253,7 @@ func GasEstimateGasPremium(ctx context.Context, cstore ChainStoreAPI, cache *Gas
 
 	ts, err := cstore.GetTipSetFromKey(ctx, tsKey)
 	if err != nil {
-		return types.BigInt{}, err
+		return types.BigInt{}, xerrors.Errorf("getting tipset from key: %w", err)
 	}
 
 	for i := uint64(0); i < nblocksincl*2; i++ {


### PR DESCRIPTION
## Proposed Changes
- Use the `TipSetKey` if it is provided in the API params instead of getting heaviest tipset (only use heaviest if API params doesn't have a TipSetKey)

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
