### PR TITLE
fix(cli): add `deposit-margin-factor` to the new miner commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - The minimum supported Golang version is now `1.24.7`
 - feat(gateway): expose StateGetRandomnessDigestFromBeacon ([filecoin-project/lotus#13339](https://github.com/filecoin-project/lotus/pull/13339))
 - chore(deps): update of quic-go to v0.54.1 and go-libp2p to v0.43.0 ([filecoin-project/lotus#13361](https://github.com/filecoin-project/lotus/pull/13361))
+- feat(spcli): add a `deposit-margin-factor` option to `lotus-miner actor new` and `lotus-shed miner create` so the sent deposit still covers the on-chain requirement if it rises between lookup and execution
 
 # Node and Miner v1.34.0 / 2025-09-11
 

--- a/cli/spcli/actor.go
+++ b/cli/spcli/actor.go
@@ -1491,6 +1491,11 @@ var ActorNewMinerCmd = &cli.Command{
 			Usage: "number of block confirmations to wait for",
 			Value: int(buildconstants.MessageConfidence),
 		},
+		&cli.Float64Flag{
+			Name:  "deposit-margin-factor",
+			Usage: "Multiplier (>=1.0) to scale the suggested deposit for on-chain variance (e.g. 1.01 adds 1%)",
+			Value: 1.01,
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := cctx.Context
@@ -1538,7 +1543,7 @@ var ActorNewMinerCmd = &cli.Command{
 		}
 		ssize := abi.SectorSize(sectorSizeInt)
 
-		_, err = createminer.CreateStorageMiner(ctx, full, owner, worker, sender, ssize, cctx.Uint64("confidence"))
+		_, err = createminer.CreateStorageMiner(ctx, full, owner, worker, sender, ssize, cctx.Uint64("confidence"), cctx.Float64("deposit-margin-factor"))
 		if err != nil {
 			return err
 		}

--- a/cli/spcli/createminer/create_miner.go
+++ b/cli/spcli/createminer/create_miner.go
@@ -19,7 +19,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-func CreateStorageMiner(ctx context.Context, fullNode v1api.FullNode, owner, worker, sender address.Address, ssize abi.SectorSize, confidence uint64) (address.Address, error) {
+func CreateStorageMiner(ctx context.Context, fullNode v1api.FullNode, owner, worker, sender address.Address, ssize abi.SectorSize, confidence uint64, depositMarginFactor float64) (address.Address, error) {
 	// make sure the sender account exists on chain
 	_, err := fullNode.StateLookupID(ctx, owner, types.EmptyTSK)
 	if err != nil {
@@ -93,15 +93,21 @@ func CreateStorageMiner(ctx context.Context, fullNode v1api.FullNode, owner, wor
 		return address.Undef, err
 	}
 
+	if depositMarginFactor < 1 {
+		return address.Undef, xerrors.Errorf("deposit margin factor must be greater than 1")
+	}
+
 	deposit, err := fullNode.StateMinerCreationDeposit(ctx, types.EmptyTSK)
 	if err != nil {
 		return address.Undef, xerrors.Errorf("getting miner creation deposit: %w", err)
 	}
 
+	scaledDeposit := types.BigDiv(types.BigMul(deposit, types.NewInt(uint64(depositMarginFactor*100))), types.NewInt(100))
+
 	createStorageMinerMsg := &types.Message{
 		To:    power.Address,
 		From:  sender,
-		Value: deposit,
+		Value: scaledDeposit,
 
 		Method: power.Methods.CreateMiner,
 		Params: params,


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
fix #13364

## Proposed Changes
<!-- A clear list of the changes being made -->
Add a `deposit-margin-factor` option to `lotus-miner actor new` and `lotus-shed miner create` to ensure the sent deposit still covers the on-chain requirement (even if it rises between lookup and execution), preventing miner creation from failing due to insufficient deposit.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
