### PR TITLE
feat(cli): add FRC-102 compatible EIP-191 signing via --fevm flag (#13256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## 👌 Improvements
 - docs: fix outdated link in documentation ([#13436](https://github.com/filecoin-project/lotus/pull/13436))
 - docs: fix dead link in documentation ([#13437](https://github.com/filecoin-project/lotus/pull/13437))
+- feat(cli): implement FRC-0102 signing envelope for wallet sign/verify ([filecoin-project/lotus#13471](https://github.com/filecoin-project/lotus/pull/13471))
 
 # Node v1.34.3 / 2025-12-03
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -338,7 +338,7 @@ USAGE:
    lotus wallet sign [command options] <signing address> <hexMessage>
 
 OPTIONS:
-   --fevm      Use EIP-191 (Ethereum-style) prefix for signing FEVM messages per FRC-102 (default: false)
+   --raw       sign raw bytes without FRC-0102 envelope (not recommended) (default: false)
    --help, -h  show help
 ```
 
@@ -352,6 +352,7 @@ USAGE:
    lotus wallet verify [command options] <signing address> <hexMessage> <signature>
 
 OPTIONS:
+   --raw       verify raw bytes without FRC-0102 envelope (not recommended) (default: false)
    --help, -h  show help
 ```
 


### PR DESCRIPTION
## Related Issues
This PR aims to fix Issue #13256 
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
This PR updates the `lotus wallet sign` command to implement FRC-102, allowing users to sign messages with an EIP-191 (Ethereum-style) prefix for FEVM compatibility.  
<!-- A clear list of the changes being made -->

## Additional Info
- Added `--fevm` flag to `wallet sign` command.
- Prepends the appropriate prefix to messages before signing (EIP-191 for FEVM, Filecoin prefix for native messages).
- Supports interoperability with other Filecoin wallets using FRC-102.
- Returns signatures in the same format as the existing command.

<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
