### PR TITLE
chore: fix typos

### DIFF
--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -819,11 +819,11 @@ var importAnalyzeCmd = &cli.Command{
 		fmt.Println("Average time per epoch: ", totalTime/time.Duration(totalTipsets))
 		if actorExec, ok := charges["OnActorExec"]; ok {
 			timeInActors := actorExec.timeTaken.Mean() * actorExec.timeTaken.n
-			fmt.Printf("Avarage time per epoch in actors: %s (%.1f%%)\n", time.Duration(timeInActors)/time.Duration(totalTipsets), timeInActors/float64(totalTime)*100)
+			fmt.Printf("Average time per epoch in actors: %s (%.1f%%)\n", time.Duration(timeInActors)/time.Duration(totalTipsets), timeInActors/float64(totalTime)*100)
 		}
 		if actorExecDone, ok := charges["OnMethodInvocationDone"]; ok {
 			timeInActors := actorExecDone.timeTaken.Mean() * actorExecDone.timeTaken.n
-			fmt.Printf("Avarage time per epoch in OnActorExecDone %s (%.1f%%)\n", time.Duration(timeInActors)/time.Duration(totalTipsets), timeInActors/float64(totalTime)*100)
+			fmt.Printf("Average time per epoch in OnActorExecDone %s (%.1f%%)\n", time.Duration(timeInActors)/time.Duration(totalTipsets), timeInActors/float64(totalTime)*100)
 		}
 
 		n := 30

--- a/cmd/lotus-shed/cron-count.go
+++ b/cmd/lotus-shed/cron-count.go
@@ -119,7 +119,7 @@ var minerDeadlinePartitionMeasurementCmd = &cli.Command{
 			}
 			addr, err := address.NewFromString(ref.To)
 			if err != nil {
-				return xerrors.Errorf("faield to get address from input string: %w", err)
+				return xerrors.Errorf("failed to get address from input string: %w", err)
 			}
 			dline, err := n.StateMinerProvingDeadline(ctx, addr, tsBefore.Key())
 			if err != nil {
@@ -137,7 +137,7 @@ var minerDeadlinePartitionMeasurementCmd = &cli.Command{
 				return xerrors.Errorf("failed to get partitions: %w", err)
 			}
 			if len(psBefore) != len(psAfter) {
-				return xerrors.Errorf("faield")
+				return xerrors.Errorf("failed")
 			}
 
 			type partitionCount struct {

--- a/cmd/lotus-shed/miner-fees.go
+++ b/cmd/lotus-shed/miner-fees.go
@@ -211,7 +211,7 @@ var minerFeesCmd = &cli.Command{
 					if err != nil {
 						return xerrors.Errorf("getting tipset at deadline end epoch: %w", err)
 					}
-					// StateCompute at the height we arived at, which may not be dlEndEpoch if nulls were involved
+					// StateCompute at the height we arrived at, which may not be dlEndEpoch if nulls were involved
 					compute, err := api.StateCompute(ctx, dlEndTs.Height(), nil, dlEndTs.Key())
 					if err != nil {
 						return xerrors.Errorf("computing tipset at deadline end epoch: %w", err)

--- a/lib/ulimit/ulimit.go
+++ b/lib/ulimit/ulimit.go
@@ -84,7 +84,7 @@ func ManageFdLimit() (changed bool, newLimit uint64, err error) {
 	// corresponding resource
 	// the hard limit acts as a ceiling for the soft limit
 	// an unprivileged process may only set it's soft limit to a
-	// alue in the range from 0 up to the hard limit
+	// value in the range from 0 up to the hard limit
 	err = setLimit(targetLimit, targetLimit)
 	switch err {
 	case nil:

--- a/node/health.go
+++ b/node/health.go
@@ -92,7 +92,7 @@ func NewLiveHandler(api lapi.FullNode) *HealthHandler {
 
 // NewReadyHandler checks if we are ready to handle traffic.
 // 1. sync workers are reasonably up to date.
-// 2. libp2p is servicable
+// 2. libp2p is serviceable
 func NewReadyHandler(api lapi.FullNode) *HealthHandler {
 	ctx := context.Background()
 	h := HealthHandler{}


### PR DESCRIPTION
Spell check fixes: Correct typos across multiple files:

Formatting outputs: Corrected misspelled "Avarage" → "Average"
Error messages (e.g., cron-count.go): Fixed "faild" → "failed" in error reporting logic
Miner fees comment: Updated "arived" → "arrived" in the state computation height documentation
Ulimit documentation: Corrected "alue" → "value" in the resource limit range description
Libp2p health check: Fixed "servicable" → "serviceable" in the readiness check comment