### PR TITLE
chore(docs): minor spelling fixes

### DIFF
--- a/cli/services.go
+++ b/cli/services.go
@@ -96,7 +96,7 @@ func (s *ServicesImpl) DecodeTypedParamsFromJSON(ctx context.Context, to address
 	p := reflect.New(methodMeta.Params.Elem()).Interface().(cbg.CBORMarshaler)
 
 	if err := json.Unmarshal([]byte(paramstr), p); err != nil {
-		return nil, fmt.Errorf("unmarshaling input into params type: %w", err)
+		return nil, fmt.Errorf("unmarshalling input into params type: %w", err)
 	}
 
 	buf := new(bytes.Buffer)

--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -727,7 +727,7 @@ var importAnalyzeCmd = &cli.Command{
 					var tse TipSetExec
 					err := json.Unmarshal(b, &tse)
 					if err != nil {
-						log.Warnf("error unmarshaling tipset: %+v", err)
+						log.Warnf("error unmarshalling tipset: %+v", err)
 						continue
 					}
 

--- a/cmd/lotus-shed/state-stats.go
+++ b/cmd/lotus-shed/state-stats.go
@@ -533,7 +533,7 @@ var statSnapshotCmd = &cli.Command{
 
 				var b types.BlockHeader
 				if err := b.UnmarshalCBOR(bytes.NewBuffer(nd.RawData())); err != nil {
-					return xerrors.Errorf("unmarshaling block header (cid=%s): %w", blkCid, err)
+					return xerrors.Errorf("unmarshalling block header (cid=%s): %w", blkCid, err)
 				}
 
 				// header directly to result channel

--- a/cmd/lotus-sim/simulation/blockbuilder/blockbuilder.go
+++ b/cmd/lotus-sim/simulation/blockbuilder/blockbuilder.go
@@ -127,7 +127,7 @@ func (bb *BlockBuilder) PushMessage(msg *types.Message) (*types.MessageReceipt, 
 	}
 	if !builtin.IsAccountActor(actor.Code) {
 		return nil, xerrors.Errorf(
-			"messags may only be sent from account actors, got message from %s (%s)",
+			"messages may only be sent from account actors, got message from %s (%s)",
 			msg.From, builtin.ActorNameByCode(actor.Code),
 		)
 	}

--- a/cmd/lotus-sim/simulation/simulation.go
+++ b/cmd/lotus-sim/simulation/simulation.go
@@ -251,7 +251,7 @@ func (sim *Simulation) Walk(
 		minEpoch = sim.head.Height() - abi.ChainEpoch(lookback)
 	}
 
-	// Given tha loading messages and receipts can be a little bit slow, we do this in parallel.
+	// Given that loading messages and receipts can be a little bit slow, we do this in parallel.
 	//
 	// 1. We spin up some number of workers.
 	// 2. We hand tipsets to workers in round-robin order.

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -575,7 +575,7 @@ func resolveOnce(bs blockstore.Blockstore, tse stmgr.Executor) func(ctx context.
 		if names[0] == "@state" {
 			var act types.Actor
 			if err := act.UnmarshalCBOR(bytes.NewReader(nd.RawData())); err != nil {
-				return nil, nil, xerrors.Errorf("unmarshaling actor struct for @state: %w", err)
+				return nil, nil, xerrors.Errorf("unmarshalling actor struct for @state: %w", err)
 			}
 
 			head, err := ds.Get(ctx, act.Head)


### PR DESCRIPTION
 ## Summary

  This PR fixes various spelling errors found in error messages and comments:
  - `unmarshaling` → `unmarshalling` (British English spelling for consistency)
  - `messags` → `messages`
  - `tha` → `that`

  ## Changes

  - **cli/services.go**: Fixed "unmarshaling" → "unmarshalling" in error message
  - **cmd/lotus-bench/import.go**: Fixed "unmarshaling" → "unmarshalling" in log message
  - **cmd/lotus-shed/state-stats.go**: Fixed "unmarshaling" → "unmarshalling" in error message
  - **cmd/lotus-sim/simulation/blockbuilder/blockbuilder.go**: Fixed "messags" → "messages" typo
  - **cmd/lotus-sim/simulation/simulation.go**: Fixed "tha" → "that" typo in comment
  - **node/impl/full/chain.go**: Fixed "unmarshaling" → "unmarshalling" in error message

  [skip changelog]