### PR TITLE
docs: fix typos in comments and documentation

### DIFF
--- a/chain/actors/aerrors/wrap.go
+++ b/chain/actors/aerrors/wrap.go
@@ -87,7 +87,7 @@ func Fatalf(format string, args ...interface{}) ActorError {
 	}
 }
 
-// Wrap extens chain of errors with a message
+// Wrap extended chain of errors with a message
 func Wrap(err ActorError, message string) ActorError {
 	if err == nil {
 		return nil

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -348,7 +348,7 @@ func (mp *MessagePool) selectMessagesOptimal(ctx context.Context, curTs, ts *typ
 		log.Infow("merge message chains done", "took", dt)
 	}
 
-	// 7. We have reached the edge of what can fit wholesale; if we still hae available
+	// 7. We have reached the edge of what can fit wholesale; if we still have available
 	//    gasLimit to pack some more chains, then trim the last chain and push it down.
 	//    Trimming invalidates subsequent dependent chains so that they can't be selected
 	//    as their dependency cannot be (fully) included.

--- a/chain/store/coalescer.go
+++ b/chain/store/coalescer.go
@@ -134,7 +134,7 @@ func (c *HeadChangeCoalescer) background(minDelay, maxDelay, mergeInterval time.
 }
 
 func (c *HeadChangeCoalescer) coalesce(revert, apply []*types.TipSet) {
-	// newly reverted tipsets cancel out with pending applys.
+	// newly reverted tipsets cancel out with pending applies.
 	// similarly, newly applied tipsets cancel out with pending reverts.
 
 	// pending tipsets
@@ -160,13 +160,13 @@ func (c *HeadChangeCoalescer) coalesce(revert, apply []*types.TipSet) {
 	}
 
 	// coalesced revert set
-	// - pending reverts are cancelled by incoming applys
-	// - incoming reverts are cancelled by pending applys
+	// - pending reverts are cancelled by incoming applies
+	// - incoming reverts are cancelled by pending applies
 	newRevert := c.merge(c.revert, revert, pendApply, applying)
 
 	// coalesced apply set
-	// - pending applys are cancelled by incoming reverts
-	// - incoming applys are cancelled by pending reverts
+	// - pending applies are cancelled by incoming reverts
+	// - incoming applies are cancelled by pending reverts
 	newApply := c.merge(c.apply, apply, pendRevert, reverting)
 
 	// commit the coalesced sets

--- a/chain/types/actor_event.go
+++ b/chain/types/actor_event.go
@@ -39,7 +39,7 @@ type ActorEventFilter struct {
 	ToHeight *abi.ChainEpoch `json:"toHeight,omitempty"`
 
 	// Restricts events returned to those emitted from messages contained in this tipset.
-	// If `TipSetKey` is legt empty in the filter criteria, then neither `FromHeight` nor `ToHeight` are allowed.
+	// If `TipSetKey` is left empty in the filter criteria, then neither `FromHeight` nor `ToHeight` are allowed.
 	TipSetKey *TipSetKey `json:"tipsetKey,omitempty"`
 }
 

--- a/lib/harmony/harmonydb/doc.go
+++ b/lib/harmony/harmonydb/doc.go
@@ -18,7 +18,7 @@ Name the file "today's date" in the format: YYYYMMDD.sql (ex: 20231231.sql for t
 	a. CREATE TABLE should NOT have a schema:
 		GOOD: CREATE TABLE foo ();
 		BAD:  CREATE TABLE me.foo ();
-	b. Schema is managed for you. It provides isolation for integraton tests & multi-use.
+	b. Schema is managed for you. It provides isolation for integration tests & multi-use.
 	c. Git Merges: All run once, so old-after-new is OK when there are no deps.
 	d. NEVER change shipped sql files. Have later files make corrections.
 	e. Anything not ran will be ran, so an older date making it to master is OK.


### PR DESCRIPTION
Corrects 5 spelling errors across the codebase:
  - `extens` → `extended` in aerrors/wrap.go
  - `hae` → `have` in messagepool/selection.go
  - `applys` → `applies` (4 occurrences) in store/coalescer.go
  - `legt` → `left` in types/actor_event.go
  - `integraton` → `integration` in harmonydb/doc.go
  
 [skip changelog]