### PR TITLE
fix(grammar): correct article usage in comments and error messages

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -318,7 +318,7 @@ type FullNode interface {
 	// MpoolBatchPushUntrusted batch pushes a signed message to mempool from untrusted sources.
 	MpoolBatchPushUntrusted(context.Context, []*types.SignedMessage) ([]cid.Cid, error) //perm:write
 
-	// MpoolBatchPushMessage batch pushes a unsigned message to mempool.
+	// MpoolBatchPushMessage batch pushes an unsigned message to mempool.
 	MpoolBatchPushMessage(context.Context, []*types.Message, *MessageSendSpec) ([]*types.SignedMessage, error) //perm:sign
 
 	// MpoolCheckMessages performs logical checks on a batch of messages

--- a/api/v0api/full.go
+++ b/api/v0api/full.go
@@ -245,7 +245,7 @@ type FullNode interface {
 	// MpoolBatchPushUntrusted batch pushes a signed message to mempool from untrusted sources.
 	MpoolBatchPushUntrusted(context.Context, []*types.SignedMessage) ([]cid.Cid, error) //perm:write
 
-	// MpoolBatchPushMessage batch pushes a unsigned message to mempool.
+	// MpoolBatchPushMessage batch pushes an unsigned message to mempool.
 	MpoolBatchPushMessage(context.Context, []*types.Message, *api.MessageSendSpec) ([]*types.SignedMessage, error) //perm:sign
 
 	// MpoolGetNonce gets next nonce for the specified sender.

--- a/chain/exchange/protocol_encoding.go
+++ b/chain/exchange/protocol_encoding.go
@@ -11,7 +11,7 @@ import (
 	types "github.com/filecoin-project/lotus/chain/types"
 )
 
-// CompactedMessagesCBOR is used for encoding/decoding compacted messages. This is a ustom type as we need custom limits.
+// CompactedMessagesCBOR is used for encoding/decoding compacted messages. This is a custom type as we need custom limits.
 // - Max messages is 150,000 as that's 15 times the max block size (in messages). It needs to be
 // large enough to cover a full tipset full of full blocks.
 type CompactedMessagesCBOR struct {

--- a/cli/spcli/actor.go
+++ b/cli/spcli/actor.go
@@ -1508,7 +1508,7 @@ var ActorNewMinerCmd = &cli.Command{
 
 		var owner address.Address
 		if cctx.String("owner") == "" {
-			return xerrors.Errorf("must provide a owner address")
+			return xerrors.Errorf("must provide an owner address")
 		}
 		owner, err = address.NewFromString(cctx.String("owner"))
 


### PR DESCRIPTION
Corrects article usage errors  in comments and error messages:
- "a unsigned" → "an unsigned" in api/api_full.go, api/v0api/full.go
- "a owner address" → "an owner address" in cli/spcli/actor.go
- "ustom" → "custom" in chain/exchange/protocol_encoding.go

[skip changelog]
