### PR TITLE
chore: remove obsolete // +build tag

### DIFF
--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -1,5 +1,4 @@
 //go:build debug || 2k
-// +build debug 2k
 
 package buildconstants
 

--- a/build/buildconstants/params_2k_test.go
+++ b/build/buildconstants/params_2k_test.go
@@ -1,5 +1,4 @@
 //go:build debug || 2k
-// +build debug 2k
 
 package buildconstants
 

--- a/build/buildconstants/params_butterfly.go
+++ b/build/buildconstants/params_butterfly.go
@@ -1,5 +1,4 @@
 //go:build butterflynet
-// +build butterflynet
 
 package buildconstants
 

--- a/build/buildconstants/params_butterfly_test.go
+++ b/build/buildconstants/params_butterfly_test.go
@@ -1,5 +1,4 @@
 //go:build butterflynet
-// +build butterflynet
 
 package buildconstants
 

--- a/build/buildconstants/params_calibnet.go
+++ b/build/buildconstants/params_calibnet.go
@@ -1,5 +1,4 @@
 //go:build calibnet
-// +build calibnet
 
 package buildconstants
 

--- a/build/buildconstants/params_calibnet_test.go
+++ b/build/buildconstants/params_calibnet_test.go
@@ -1,5 +1,4 @@
 //go:build calibnet
-// +build calibnet
 
 package buildconstants
 

--- a/build/buildconstants/params_debug.go
+++ b/build/buildconstants/params_debug.go
@@ -1,5 +1,4 @@
 //go:build debug
-// +build debug
 
 package buildconstants
 

--- a/build/buildconstants/params_interop.go
+++ b/build/buildconstants/params_interop.go
@@ -1,5 +1,4 @@
 //go:build interopnet
-// +build interopnet
 
 package buildconstants
 

--- a/build/buildconstants/params_interop_test.go
+++ b/build/buildconstants/params_interop_test.go
@@ -1,5 +1,4 @@
 //go:build interopnet
-// +build interopnet
 
 package buildconstants
 

--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -1,5 +1,4 @@
 //go:build !debug && !2k && !testground && !calibnet && !butterflynet && !interopnet
-// +build !debug,!2k,!testground,!calibnet,!butterflynet,!interopnet
 
 package buildconstants
 

--- a/build/buildconstants/params_mainnet_test.go
+++ b/build/buildconstants/params_mainnet_test.go
@@ -1,5 +1,4 @@
 //go:build !debug && !2k && !testground && !calibnet && !butterflynet && !interopnet
-// +build !debug,!2k,!testground,!calibnet,!butterflynet,!interopnet
 
 package buildconstants
 

--- a/build/buildconstants/params_shared_vals.go
+++ b/build/buildconstants/params_shared_vals.go
@@ -1,5 +1,4 @@
 //go:build !testground
-// +build !testground
 
 package buildconstants
 

--- a/build/buildconstants/params_testground.go
+++ b/build/buildconstants/params_testground.go
@@ -1,5 +1,4 @@
 //go:build testground
-// +build testground
 
 // This file makes hardcoded parameters (const) configurable as vars.
 //

--- a/build/buildconstants/params_testground_test.go
+++ b/build/buildconstants/params_testground_test.go
@@ -1,5 +1,4 @@
 //go:build testground
-// +build testground
 
 package buildconstants
 

--- a/build/builtin_actors_gen_test.go
+++ b/build/builtin_actors_gen_test.go
@@ -1,5 +1,4 @@
 //go:build release
-// +build release
 
 package build_test
 

--- a/build/tools.go
+++ b/build/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package build
 

--- a/chain/proofs/ffi/verifier_cgo.go
+++ b/chain/proofs/ffi/verifier_cgo.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 package proofsffi
 

--- a/chain/types/message_fuzz.go
+++ b/chain/types/message_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package types
 

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -1,5 +1,4 @@
 //go:build !nodaemon
-// +build !nodaemon
 
 package lotus
 

--- a/cli/lotus/daemon_nodaemon.go
+++ b/cli/lotus/daemon_nodaemon.go
@@ -1,5 +1,4 @@
 //go:build nodaemon
-// +build nodaemon
 
 package lotus
 

--- a/cli/lotus/debug_advance.go
+++ b/cli/lotus/debug_advance.go
@@ -1,5 +1,4 @@
 //go:build debug
-// +build debug
 
 package lotus
 

--- a/lib/ulimit/ulimit_freebsd.go
+++ b/lib/ulimit/ulimit_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package ulimit
 

--- a/lib/ulimit/ulimit_test.go
+++ b/lib/ulimit/ulimit_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // This file tests file descriptor limits; since this is an OS feature, it should not be annotated
 

--- a/lib/ulimit/ulimit_unix.go
+++ b/lib/ulimit/ulimit_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || linux || netbsd || openbsd
-// +build darwin linux netbsd openbsd
 
 package ulimit
 

--- a/storage/sealer/cgroups.go
+++ b/storage/sealer/cgroups.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package sealer
 

--- a/storage/sealer/cgroups_linux.go
+++ b/storage/sealer/cgroups_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sealer
 

--- a/storage/sealer/ffiwrapper/prover_cgo.go
+++ b/storage/sealer/ffiwrapper/prover_cgo.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 package ffiwrapper
 

--- a/storage/sealer/ffiwrapper/sealer_cgo.go
+++ b/storage/sealer/ffiwrapper/sealer_cgo.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 package ffiwrapper
 

--- a/storage/sealer/ffiwrapper/verifier_cgo.go
+++ b/storage/sealer/ffiwrapper/verifier_cgo.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 package ffiwrapper
 

--- a/storage/sealer/fsutil/dealloc_other.go
+++ b/storage/sealer/fsutil/dealloc_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package fsutil
 

--- a/storage/sealer/fsutil/filesize_unix.go
+++ b/storage/sealer/fsutil/filesize_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fsutil
 

--- a/storage/sealer/fsutil/statfs_unix.go
+++ b/storage/sealer/fsutil/statfs_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fsutil
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild




## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
