### PR TITLE
fix(docker): upgrade base image from ubuntu:20.04 to ubuntu:22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ARG GOFLAGS=""
 RUN make buildall
 
 #####################################
-FROM ubuntu:20.04 AS lotus-base
+FROM ubuntu:22.04 AS lotus-base
 MAINTAINER Lotus Development Team
 
 # Base resources


### PR DESCRIPTION
## Proposed Changes
Fixes [issue reported here](https://filecoinproject.slack.com/archives/CP50PPW2X/p1764594300634329)

The build stage uses golang:1.24.7-bookworm (glibc 2.36), but the runtime base was ubuntu:20.04 (glibc 2.31). This caused GLIBC_2.32/2.33/2.34 errors when running lotus binaries.

Ubuntu 22.04 provides glibc 2.35 which satisfies all required versions.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [ ] Commits have a clear commit message.
- [ ] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
