### PR TITLE
docs: fix markdown link syntax and typo

### DIFF
--- a/blockstore/badger/blockstore.go
+++ b/blockstore/badger/blockstore.go
@@ -240,7 +240,7 @@ func (b *Blockstore) unlockMove(state bsMoveState) {
 // a symlink from the current path to the new path; the old blockstore is deleted.
 //
 // The blockstore MUST accept new writes during the move and ensure that these
-// are persisted to the new blockstore; if a failure occurs aboring the move,
+// are persisted to the new blockstore; if a failure occurs aborting the move,
 // then they must be persisted to the old blockstore.
 // In short, the blockstore must not lose data from new writes during the move.
 func (b *Blockstore) movingGC(ctx context.Context) error {

--- a/documentation/misc/Builtin-actors_Development.md
+++ b/documentation/misc/Builtin-actors_Development.md
@@ -48,7 +48,7 @@ cd build/actors/
 ./pack.sh v15 v15.0.0-rc1
 ```
 
-This will fetch the CAR files from the [GitHub release page for `v15.0.0-rc1`](https://github.com/filecoin-project/builtin-actors/releases/tag/v15.0.0-rc1) and create a replacement for `build/actors/v15.tar.zst` and generate an update to [`builtin_actors_gen.go`](../../build/builtin_actors_gen.go). If v15 is the correct actors version for the current network version (as per [`upgrades.go`]((../../chain/consensus/filcns/upgrades.go)), then running itests, by default, will use your new bundle.
+This will fetch the CAR files from the [GitHub release page for `v15.0.0-rc1`](https://github.com/filecoin-project/builtin-actors/releases/tag/v15.0.0-rc1) and create a replacement for `build/actors/v15.tar.zst` and generate an update to [`builtin_actors_gen.go`](../../build/builtin_actors_gen.go). If v15 is the correct actors version for the current network version (as per [`upgrades.go`](../../chain/consensus/filcns/upgrades.go)), then running itests, by default, will use your new bundle.
 
 **If you want to bundle a custom build of builtin-actors from your local filesystem**:
 


### PR DESCRIPTION
Fixes:
  - Markdown links with double parentheses breaking navigation (documentation/misc/Builtin-actors_Development.md - link to upgrades.go)
  - Typo in blockstore comment: "aboring" → "aborting"