### PR TITLE
fix(grammar): add missing apostrophes in error messages

### DIFF
--- a/chain/consensus/common.go
+++ b/chain/consensus/common.go
@@ -338,7 +338,7 @@ func checkBlockMessages(ctx context.Context, sm *stmgr.StateManager, cs *store.C
 	}
 
 	if b.Header.Messages != mrcid {
-		return fmt.Errorf("messages didnt match message root in header")
+		return fmt.Errorf("messages didn't match message root in header")
 	}
 
 	// Finally, flush.

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -384,7 +384,7 @@ func copyBlockstore(ctx context.Context, from, to bstore.Blockstore) error {
 // maybe this code should actually live in blocksync??
 func zipTipSetAndMessages(bs cbor.IpldStore, ts *types.TipSet, allbmsgs []*types.Message, allsmsgs []*types.SignedMessage, bmi, smi [][]uint64) (*store.FullTipSet, error) {
 	if len(ts.Blocks()) != len(smi) || len(ts.Blocks()) != len(bmi) {
-		return nil, fmt.Errorf("msgincl length didnt match tipset size")
+		return nil, fmt.Errorf("msgincl length didn't match tipset size")
 	}
 
 	if err := checkMsgMeta(ts, allbmsgs, allsmsgs, bmi, smi); err != nil {
@@ -1108,7 +1108,7 @@ func checkMsgMeta(ts *types.TipSet, allbmsgs []*types.Message, allsmsgs []*types
 		}
 
 		if b.Messages != mrcid {
-			return fmt.Errorf("messages didnt match message root in header for ts %s", ts.Key())
+			return fmt.Errorf("messages didn't match message root in header for ts %s", ts.Key())
 		}
 	}
 

--- a/paychmgr/paych.go
+++ b/paychmgr/paych.go
@@ -285,7 +285,7 @@ func (ca *channelAccessor) checkVoucherValidUnlocked(ctx context.Context, ch add
 	}
 
 	if len(sv.Merges) != 0 {
-		return nil, fmt.Errorf("dont currently support paych lane merges")
+		return nil, fmt.Errorf("don't currently support paych lane merges")
 	}
 
 	return laneStates, nil
@@ -540,7 +540,7 @@ func (ca *channelAccessor) laneState(ctx context.Context, state lpaych.State, ch
 func (ca *channelAccessor) totalRedeemedWithVoucher(laneStates map[uint64]lpaych.LaneState, sv *paych.SignedVoucher) (big.Int, error) {
 	// TODO: merges
 	if len(sv.Merges) != 0 {
-		return big.Int{}, xerrors.Errorf("dont currently support paych lane merges")
+		return big.Int{}, xerrors.Errorf("don't currently support paych lane merges")
 	}
 
 	total := big.NewInt(0)


### PR DESCRIPTION
Add missing apostrophes in contractions within error messages to improve grammar and professionalism.
  - `chain/consensus/common.go`: "didnt" → "didn't"
  - `chain/sync.go`: "didnt" → "didn't" (2 instances)
  - `paychmgr/paych.go`: "dont" → "don't" (2 instances)
  
[skip changelog]