### PR TITLE
fix(itests): prevent wdPostLoop deadline skip race condition

### DIFF
--- a/itests/kit/node_unmanaged.go
+++ b/itests/kit/node_unmanaged.go
@@ -966,7 +966,15 @@ func (tm *TestUnmanagedMiner) wdPostLoop() {
 		}
 
 		for tm.ctx.Err() == nil {
-			postSectors, err := tm.sectorsToPost()
+			// Get deadline info at the start of this iteration to avoid race conditions
+			// where the chain advances between checking sectors and waiting for next deadline.
+			di, err := tm.FullNode.StateMinerProvingDeadline(tm.ctx, tm.ActorAddr, types.EmptyTSK)
+			if err != nil {
+				recordPostOrError(windowPost{Error: fmt.Errorf("failed to get proving deadline: %w", err)})
+				return
+			}
+
+			postSectors, err := tm.sectorsToPostWithDeadline(di)
 			if err != nil {
 				recordPostOrError(windowPost{Error: err})
 				return
@@ -981,8 +989,8 @@ func (tm *TestUnmanagedMiner) wdPostLoop() {
 				recordPostOrError(windowPost{Posted: postSectors})
 			}
 
-			// skip to next challenge window
-			if err := tm.waitForNextPostDeadline(); err != nil {
+			// skip to next challenge window, using the deadline info from the start of this iteration
+			if err := tm.waitForNextPostDeadlineFrom(di); err != nil {
 				recordPostOrError(windowPost{Error: err})
 				return
 			}
@@ -990,19 +998,16 @@ func (tm *TestUnmanagedMiner) wdPostLoop() {
 	}()
 }
 
-// waitForNextPostDeadline waits until we are within the next challenge window for this miner
-func (tm *TestUnmanagedMiner) waitForNextPostDeadline() error {
+// waitForNextPostDeadlineFrom waits until the deadline described in di closes and the next one opens.
+func (tm *TestUnmanagedMiner) waitForNextPostDeadlineFrom(di *dline.Info) error {
 	ctx, cancel := context.WithCancel(tm.ctx)
 	defer cancel()
 
-	di, err := tm.FullNode.StateMinerProvingDeadline(ctx, tm.ActorAddr, types.EmptyTSK)
-	if err != nil {
-		return fmt.Errorf("waitForNextPostDeadline: failed to get proving deadline: %w", err)
-	}
-	currentDeadlineIdx := CurrentDeadlineIndex(di)
-	nextDeadlineEpoch := di.PeriodStart + di.WPoStChallengeWindow*abi.ChainEpoch(currentDeadlineIdx+1)
+	// Wait for the current deadline to close. di.Close is the epoch when
+	// the current deadline ends, which is also when the next deadline opens.
+	nextDeadlineEpoch := di.Close
 
-	tm.log("Window PoST waiting until next challenge window, currentDeadlineIdx: %d, nextDeadlineEpoch: %d", currentDeadlineIdx, nextDeadlineEpoch)
+	tm.log("Window PoST waiting until next challenge window, currentDeadlineIdx: %d, nextDeadlineEpoch: %d", di.Index, nextDeadlineEpoch)
 
 	heads, err := tm.FullNode.ChainNotify(ctx)
 	if err != nil {
@@ -1020,16 +1025,12 @@ func (tm *TestUnmanagedMiner) waitForNextPostDeadline() error {
 		}
 	}
 
-	return fmt.Errorf("waitForNextPostDeadline: failed to wait for nextDeadlineEpoch %d", nextDeadlineEpoch)
+	return fmt.Errorf("waitForNextPostDeadlineFrom: failed to wait for nextDeadlineEpoch %d", nextDeadlineEpoch)
 }
 
-// sectorsToPost returns the sectors that are due to be posted in the current challenge window
-func (tm *TestUnmanagedMiner) sectorsToPost() ([]abi.SectorNumber, error) {
-	di, err := tm.FullNode.StateMinerProvingDeadline(tm.ctx, tm.ActorAddr, types.EmptyTSK)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get proving deadline: %w", err)
-	}
-
+// sectorsToPostWithDeadline returns the sectors that are due to be posted for the deadline
+// described in di.
+func (tm *TestUnmanagedMiner) sectorsToPostWithDeadline(di *dline.Info) ([]abi.SectorNumber, error) {
 	currentDeadlineIdx := CurrentDeadlineIndex(di)
 
 	var allSectors []abi.SectorNumber


### PR DESCRIPTION
Another attempt at fixing https://github.com/filecoin-project/lotus/issues/13005

There's a gap between when we figure out what sectors to post, and when we wait for the _next_ deadline to do more posting where the deadline might have advanced and we'd miss the deadline within which there were sectors to post, and we're waiting on a new deadline beyond that one.

Compounding this is the `WatchMinerForPost` functionality we use on the preminer which will hold up mining until expected post has been received, so the miner that should have a sector to post has moved on to waiting for the next deadline which will never come because the preminer will be holding up block production waiting for a post to appear in the mpool.

Not a certain fix, but this seems right to me, we'll find out probably.