### PR TITLE
fix(grammar): fix article usage in comments

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -817,7 +817,7 @@ loop:
 		// FIXME: The reassembly logic should be part of the `client`
 		//  service, the consumer should not be concerned with the
 		//  `MaxRequestLength` limitation, it should just be able to request
-		//  an segment of arbitrary length. The same burden is put on
+		//  a segment of arbitrary length. The same burden is put on
 		//  `syncFork()` which needs to be aware this as well.
 		if blockSet[len(blockSet)-1].IsChildOf(blks[0]) == false {
 			return nil, xerrors.Errorf("retrieved segments of the chain are not connected at heights %d/%d",

--- a/cmd/lotus-shed/miner-multisig.go
+++ b/cmd/lotus-shed/miner-multisig.go
@@ -375,7 +375,7 @@ var mmApproveChangeOwner = &cli.Command{
 
 var mmProposeChangeWorker = &cli.Command{
 	Name:      "propose-change-worker",
-	Usage:     "Propose an worker address change",
+	Usage:     "Propose a worker address change",
 	ArgsUsage: "[newWorker]",
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Args().Present() {
@@ -580,7 +580,7 @@ var mmProposeChangeBeneficiary = &cli.Command{
 
 var mmConfirmChangeWorker = &cli.Command{
 	Name:      "confirm-change-worker",
-	Usage:     "Confirm an worker address change",
+	Usage:     "Confirm a worker address change",
 	ArgsUsage: "[newWorker]",
 	Action: func(cctx *cli.Context) error {
 		if !cctx.Args().Present() {

--- a/storage/sealer/worker_local.go
+++ b/storage/sealer/worker_local.go
@@ -714,7 +714,7 @@ func (l *LocalWorker) GenerateWindowPoStAdv(ctx context.Context, ppt abi.Registe
 		// When it does happen, window post runner logic will just re-check sectors, and retry with newly-discovered-bad sectors skipped
 		log.Errorf("couldn't read some challenges (skipped %d)", len(skipped))
 
-		// note: can't return an error as this in an jsonrpc call
+		// note: can't return an error as this in a jsonrpc call
 		return storiface.WindowPoStResult{Skipped: skipped}, nil
 	}
 


### PR DESCRIPTION
Fixes incorrect article usage in code comments and CLI usage strings. Following up on #13435, this corrects remaining instances where "an" was incorrectly used before consonant sounds:

  - "an segment" → "a segment" (chain/sync.go)
  - "an worker" → "a worker" (cmd/lotus-shed/miner-multisig.go, 2 occurrences)
  - "in an jsonrpc" → "in a jsonrpc" (storage/sealer/worker_local.go)