### PR TITLE
fix(eth): trace_filter returns [] for null round ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - feat(cli): add --order-by-nonce flag to list messages sequentially when filtering by sender ([filecoin-project/lotus#13394](https://github.com/filecoin-project/lotus/pull/13394))
 - fix(eth): use error code 3 for EExecutionReverted for Ethereum RPC tooling compatibility ([filecoin-project/lotus#13467](https://github.com/filecoin-project/lotus/pull/13467))
   - BREAKING: RPC error codes changed - EActorNotFound (3→11), EExecutionReverted (11→3). Mismatched client/server versions will deserialize these errors as the wrong Go type, breaking errors.Is/As checks.
+- fix(eth): trace_filter returns [] for null round ranges ([filecoin-project/lotus#13483](https://github.com/filecoin-project/lotus/pull/13483))
 
 # Node v1.34.3 / 2025-12-03
 

--- a/node/impl/eth/trace.go
+++ b/node/impl/eth/trace.go
@@ -278,7 +278,7 @@ func (e *ethTrace) EthTraceFilter(ctx context.Context, filter ethtypes.EthTraceF
 		return nil, xerrors.Errorf("cannot parse toBlock: %w", err)
 	}
 
-	var results []*ethtypes.EthTraceFilterResult
+	results := []*ethtypes.EthTraceFilterResult{}
 
 	if filter.Count != nil {
 		// If filter.Count is specified and it is 0, return an empty result set immediately.


### PR DESCRIPTION
When all blocks in a trace_filter range are null rounds, the API was returning JSON `null` instead of `[]` because the results slice was never initialised.

It turns out this API is the odd one out, `trace_block`, `eth_getLogs`, `eth_getBlockReceipts`, handle these cases more elegantly, returning `[]`. But because in Go, the difference between JSON marshalling a `null` vs a `[]` is subtle, this one got left out.