### PR TITLE
fix(eth): restore lite node Eth transaction API on gateway mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): restore lite node Eth transaction API (`EthGetTransactionByHash`, `EthGetTransactionReceipt`, etc.) that returned nil results when the gateway was used as the backing full node ([filecoin-project/lotus#13577](https://github.com/filecoin-project/lotus/pull/13577))
+
 ## 👌 Improvements
 
 # Node v1.35.1 / 2026-03-31

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -151,11 +151,12 @@ var ChainNode = Options(
 		If(build.IsF3Enabled(), Override(new(full.F3CertificateProvider), From(new(api.Gateway)))),
 		// EthSendAPI is a special case, we block the Untrusted method via GatewayEthSend even though it
 		// shouldn't be exposed on the Gateway API.
-		Override(new(eth.EthSendAPI), new(modules.GatewayEthSend)),
-		// EthTransactionAPIV1 is a special case, we block the Limited methods via
-		// GatewayEthTransaction even though it shouldn't be exposed on the Gateway API.
-		Override(new(full.EthTransactionAPIV1), new(modules.GatewayEthTransaction)),
-		Override(new(full.EthTransactionAPIV2), new(modules.GatewayEthTransaction)),
+		Override(new(eth.EthSendAPI), modules.NewGatewayEthSend),
+		// EthTransactionAPIV1/V2 are special cases: the V1 Gateway API is missing the Limited methods
+		// altogether, and even on V2 we want to block them as a precautionary measure. These wrappers
+		// delegate to the underlying Gateway implementations for the rest.
+		Override(new(full.EthTransactionAPIV1), modules.NewGatewayEthTransactionV1),
+		Override(new(full.EthTransactionAPIV2), modules.NewGatewayEthTransactionV2),
 
 		Override(new(index.Indexer), modules.ChainIndexer(config.ChainIndexerConfig{
 			EnableIndexer: false,

--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -11,6 +11,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/v2api"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/events/filter"
 	"github.com/filecoin-project/lotus/chain/index"
@@ -291,31 +293,63 @@ func MakeEthEventsExtended(cfg config.EventsConfig, enableEthRPC bool) func(EthE
 // EthSendRawTransactionUntrusted. The Gateway API doesn't expose this method, so this is a
 // precautionary measure.
 type GatewayEthSend struct {
-	fx.In
-	eth.EthSendAPI
+	api.Gateway
+}
+
+var _ eth.EthSendAPI = (*GatewayEthSend)(nil)
+
+func NewGatewayEthSend(gw api.Gateway) eth.EthSendAPI {
+	return &GatewayEthSend{Gateway: gw}
 }
 
 func (*GatewayEthSend) EthSendRawTransactionUntrusted(ctx context.Context, rawTx ethtypes.EthBytes) (ethtypes.EthHash, error) {
 	return ethtypes.EthHash{}, xerrors.New("EthSendRawTransactionUntrusted is not supported in gateway mode")
 }
 
-// GatewayEthTransaction is a helper to provide the Gateway with the EthTransactionAPI but block the
-// use of EthGetTransactionByHashLimited, EthGetTransactionReceiptLimited and
-// EthGetBlockReceiptsLimited. The Gateway API doesn't expose these methods, so this is a
-// precautionary measure.
-type GatewayEthTransaction struct {
-	fx.In
-	eth.EthTransactionAPI
+// GatewayEthTransactionV1 is a helper to provide the Gateway with the EthTransactionAPI but block
+// the use of EthGetTransactionByHashLimited, EthGetTransactionReceiptLimited and
+// EthGetBlockReceiptsLimited. The V1 Gateway API doesn't expose these methods, so this is both a
+// precautionary measure and required to satisfy the eth.EthTransactionAPI interface.
+type GatewayEthTransactionV1 struct {
+	api.Gateway
 }
 
-func (*GatewayEthTransaction) EthGetTransactionByHashLimited(ctx context.Context, txHash *ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTx, error) {
+var _ full.EthTransactionAPIV1 = (*GatewayEthTransactionV1)(nil)
+
+func NewGatewayEthTransactionV1(gw api.Gateway) full.EthTransactionAPIV1 {
+	return &GatewayEthTransactionV1{Gateway: gw}
+}
+
+func (*GatewayEthTransactionV1) EthGetTransactionByHashLimited(ctx context.Context, txHash *ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTx, error) {
 	return nil, xerrors.New("EthGetTransactionByHashLimited is not supported in gateway mode")
 }
-func (*GatewayEthTransaction) EthGetTransactionReceiptLimited(ctx context.Context, txHash ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTxReceipt, error) {
+func (*GatewayEthTransactionV1) EthGetTransactionReceiptLimited(ctx context.Context, txHash ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTxReceipt, error) {
+	return nil, xerrors.New("EthGetTransactionReceiptLimited is not supported in gateway mode")
+}
+func (*GatewayEthTransactionV1) EthGetBlockReceiptsLimited(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*ethtypes.EthTxReceipt, error) {
+	return nil, xerrors.New("EthGetBlockReceiptsLimited is not supported in gateway mode")
+}
+
+// GatewayEthTransactionV2 is the V2 equivalent of GatewayEthTransactionV1, wrapping the v2api
+// Gateway and blocking the Limited methods as a precautionary measure.
+type GatewayEthTransactionV2 struct {
+	v2api.Gateway
+}
+
+var _ full.EthTransactionAPIV2 = (*GatewayEthTransactionV2)(nil)
+
+func NewGatewayEthTransactionV2(gw v2api.Gateway) full.EthTransactionAPIV2 {
+	return &GatewayEthTransactionV2{Gateway: gw}
+}
+
+func (*GatewayEthTransactionV2) EthGetTransactionByHashLimited(ctx context.Context, txHash *ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTx, error) {
 	return nil, xerrors.New("EthGetTransactionByHashLimited is not supported in gateway mode")
 }
-func (*GatewayEthTransaction) EthGetBlockReceiptsLimited(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*ethtypes.EthTxReceipt, error) {
-	return nil, xerrors.New("EthGetTransactionByHashLimited is not supported in gateway mode")
+func (*GatewayEthTransactionV2) EthGetTransactionReceiptLimited(ctx context.Context, txHash ethtypes.EthHash, limit abi.ChainEpoch) (*ethtypes.EthTxReceipt, error) {
+	return nil, xerrors.New("EthGetTransactionReceiptLimited is not supported in gateway mode")
+}
+func (*GatewayEthTransactionV2) EthGetBlockReceiptsLimited(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*ethtypes.EthTxReceipt, error) {
+	return nil, xerrors.New("EthGetBlockReceiptsLimited is not supported in gateway mode")
 }
 
 type EventFilterManagerParams struct {


### PR DESCRIPTION
```
❯ 2026-04-09T19:50:55.870+0800    ERROR   rpc     go-jsonrpc@v0.9.0/websocket.go:150      handle me:write tcp4 127.0.0.1:1234->127.0.0.1:55936: use of closed network connection
  2026-04-09T19:51:25.453+0800    ERROR   rpc     go-jsonrpc@v0.9.0/handler.go:241        panic in rpc method 'eth_blockNumber': runtime error: invalid memory address or nil pointer dereference
  github.com/filecoin-project/go-jsonrpc.doCall.func1
          /root/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.9.0/handler.go:241
  runtime.gopanic
          /usr/local/go/src/runtime/panic.go:783
  runtime.panicmem
          /usr/local/go/src/runtime/panic.go:262
  runtime.sigpanic
          /usr/local/go/src/runtime/signal_unix.go:925
  github.com/filecoin-project/lotus/node/modules.(*GatewayEthTransaction).EthBlockNumber
          <autogenerated>:1
  reflect.Value.call
          /usr/local/go/src/reflect/value.go:581
  reflect.Value.Call
          /usr/local/go/src/reflect/value.go:365
  github.com/filecoin-project/lotus/metrics/proxy.proxy.func1
          /root/workspace/lotus/metrics/proxy/proxy.go:82
  github.com/filecoin-project/lotus/api.(*FullNodeStruct).EthBlockNumber
          /root/workspace/lotus/api/proxy_gen.go:1735
  reflect.Value.call
          /usr/local/go/src/reflect/value.go:581
  reflect.Value.Call
          /usr/local/go/src/reflect/value.go:365
  github.com/filecoin-project/go-jsonrpc/auth.PermissionedProxy.func1
          /root/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.9.0/auth/auth.go:62
  github.com/filecoin-project/lotus/api.(*FullNodeStruct).EthBlockNumber
          /root/workspace/lotus/api/proxy_gen.go:1735
  reflect.Value.call
          /usr/local/go/src/reflect/value.go:581
  reflect.Value.Call
          /usr/local/go/src/reflect/value.go:365
  github.com/filecoin-project/go-jsonrpc.doCall
          /root/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.9.0/handler.go:245
  github.com/filecoin-project/go-jsonrpc.(*handler).handle
          /root/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.9.0/handler.go:399
  2026-04-09T19:51:25.453+0800    ERROR   rpc     go-jsonrpc@v0.9.0/server.go:142 RPC Error: fatal error calling 'eth_blockNumber': panic in rpc method 'eth_blockNumber': runtime error: invalid memory address
  or nil pointer dereference
  2026-04-09T19:51:25.453+0800    WARN    rpc     go-jsonrpc@v0.9.0/server.go:152 rpc error: fatal error calling 'eth_blockNumber': panic in rpc method 'eth_blockNumber': runtime error: invalid memory address
```

**code from claude, I'm not sure if this implementation meets the spec requirements. I hope the reviewer can take over directly to make changes, thank you.**

The lite (gateway) node wired GatewayEthTransaction and GatewayEthSend with an embedded fx.In struct returned as a zero value. fx.In only triggers field injection when the struct is used as a constructor parameter, not as a return value, so the embedded eth.EthTransactionAPI / eth.EthSendAPI interface in each wrapper was never populated. Any promoted method call — most visibly eth_blockNumber — panicked with a nil pointer dereference:

  panic in rpc method 'eth_blockNumber': runtime error: invalid memory
  address or nil pointer dereference

Convert the wrappers into proper fx constructors that take api.Gateway (V1) / v2api.Gateway (V2) as a parameter and delegate to them via struct embedding. Split GatewayEthTransaction into V1 and V2 variants since the underlying Gateway types differ between API versions. The Limited methods continue to return "not supported in gateway mode" errors as a precautionary measure; their error strings (which all previously read "EthGetTransactionByHashLimited ...") are corrected to match each method name. Add compile-time interface assertions in line with the existing convention in node/modules/eth.go and neighbouring files.

