### PR TITLE
feat(cliutil): accept non-JWT API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## 👌 Improvements
 
+- feat(cliutil): accept non-JWT API tokens in `TOKEN:ADDRESS`, enabling use of third-party RPC providers (e.g. Glif) that issue opaque API keys ([filecoin-project/lotus#13578](https://github.com/filecoin-project/lotus/pull/13578))
+
 # Node v1.35.1 / 2026-03-31
 
 This is the stable release of Lotus node v1.35.1, a patch release that extends EC finality tooling into the v2 API, Eth RPC, and `lotus-shed`, improves Ethereum RPC and gas estimation behavior, lowers several CLI batch defaults to reduce out-of-gas failures, and raises the minimum supported Golang version to `1.25.0`. The final release also includes late backports for Ethereum RLP hardening, proof-parameter fetch robustness, indexed `StateSearchMsg` lookback handling, tightened Ethereum filter block-range enforcement, and null-round-aware EC finality chain walks.

--- a/cli/util/apiinfo.go
+++ b/cli/util/apiinfo.go
@@ -55,7 +55,16 @@ func (a APIInfo) DialArgs(version string) (string, error) {
 			return "", err
 		}
 
-		return "ws://" + addr + "/rpc/" + version, nil
+		scheme := "ws"
+		multiaddr.ForEach(ma, func(c multiaddr.Component) bool {
+			switch c.Protocol().Code {
+			case multiaddr.P_WSS, multiaddr.P_TLS:
+				scheme = "wss"
+			}
+			return true
+		})
+
+		return scheme + "://" + addr + "/rpc/" + version, nil
 	}
 
 	_, err = url.Parse(a.Addr)

--- a/cli/util/apiinfo.go
+++ b/cli/util/apiinfo.go
@@ -3,7 +3,6 @@ package cliutil
 import (
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -13,10 +12,6 @@ import (
 
 var log = logging.Logger("cliutil")
 
-var (
-	infoWithToken = regexp.MustCompile("^[a-zA-Z0-9\\-_]+?\\.[a-zA-Z0-9\\-_]+?\\.([a-zA-Z0-9\\-_]+)?:.+$")
-)
-
 type APIInfo struct {
 	Addr  string
 	Token []byte
@@ -25,10 +20,13 @@ type APIInfo struct {
 func ParseApiInfo(s string) APIInfo {
 	var tok []byte
 
-	if infoWithToken.Match([]byte(s)) {
-		sp := strings.SplitN(s, ":", 2)
-		tok = []byte(sp[0])
-		s = sp[1]
+	// Format is "TOKEN:ADDRESS". Skip the split when the address is a
+	// bare multiaddr (leading "/") or a URL scheme (":" followed by "//").
+	if !strings.HasPrefix(s, "/") {
+		if idx := strings.Index(s, ":"); idx > 0 && !strings.HasPrefix(s[idx+1:], "//") {
+			tok = []byte(s[:idx])
+			s = s[idx+1:]
+		}
 	}
 
 	return APIInfo{

--- a/cli/util/apiinfo_test.go
+++ b/cli/util/apiinfo_test.go
@@ -1,0 +1,159 @@
+package cliutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseApiInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantToken string
+		wantAddr  string
+	}{
+		{
+			name:      "jwt token + multiaddr",
+			input:     "eyJhbG.eyJBbGxvdy.qpZpDnaPmjz:/ip4/127.0.0.1/tcp/1234",
+			wantToken: "eyJhbG.eyJBbGxvdy.qpZpDnaPmjz",
+			wantAddr:  "/ip4/127.0.0.1/tcp/1234",
+		},
+		{
+			name:      "jwt token + multiaddr with /http",
+			input:     "eyJhbG.eyJBbGxvdy.qpZpDnaPmjz:/ip4/127.0.0.1/tcp/1234/http",
+			wantToken: "eyJhbG.eyJBbGxvdy.qpZpDnaPmjz",
+			wantAddr:  "/ip4/127.0.0.1/tcp/1234/http",
+		},
+		{
+			name:      "opaque token + dns multiaddr with /wss",
+			input:     "opaque-api-key:/dns/host/tcp/443/wss",
+			wantToken: "opaque-api-key",
+			wantAddr:  "/dns/host/tcp/443/wss",
+		},
+		{
+			name:      "opaque token + wss URL",
+			input:     "opaque-api-key:wss://host",
+			wantToken: "opaque-api-key",
+			wantAddr:  "wss://host",
+		},
+		{
+			name:      "opaque token + https URL (Glif-style)",
+			input:     "GLIFAPIKEY:https://api.node.glif.io/rpc/v1",
+			wantToken: "GLIFAPIKEY",
+			wantAddr:  "https://api.node.glif.io/rpc/v1",
+		},
+		{
+			name:      "token + ipv6 multiaddr",
+			input:     "tok:/ip6/::1/tcp/1234",
+			wantToken: "tok",
+			wantAddr:  "/ip6/::1/tcp/1234",
+		},
+		{
+			name:     "bare multiaddr",
+			input:    "/ip4/127.0.0.1/tcp/1234",
+			wantAddr: "/ip4/127.0.0.1/tcp/1234",
+		},
+		{
+			name:     "bare ipv6 multiaddr with shorthand",
+			input:    "/ip6/::1/tcp/1234",
+			wantAddr: "/ip6/::1/tcp/1234",
+		},
+		{
+			name:     "bare ipv6 multiaddr with full form",
+			input:    "/ip6/2001:db8::1/tcp/1234",
+			wantAddr: "/ip6/2001:db8::1/tcp/1234",
+		},
+		{
+			name:     "bare wss URL",
+			input:    "wss://host",
+			wantAddr: "wss://host",
+		},
+		{
+			name:     "bare ws URL with port and path",
+			input:    "ws://host:1234/rpc/v1",
+			wantAddr: "ws://host:1234/rpc/v1",
+		},
+		{
+			name:     "bare https URL",
+			input:    "https://api.node.glif.io/rpc/v1",
+			wantAddr: "https://api.node.glif.io/rpc/v1",
+		},
+		{
+			name:     "URL with userinfo treated as bare URL",
+			input:    "http://user:pass@host:1234/path",
+			wantAddr: "http://user:pass@host:1234/path",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			wantAddr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseApiInfo(tt.input)
+			assert.Equal(t, tt.wantToken, string(got.Token))
+			assert.Equal(t, tt.wantAddr, got.Addr)
+		})
+	}
+}
+
+func TestAPIInfoDialArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "multiaddr with /http stays ws",
+			addr: "/ip4/127.0.0.1/tcp/1234/http",
+			want: "ws://127.0.0.1:1234/rpc/v1",
+		},
+		{
+			name: "multiaddr with /ws stays ws",
+			addr: "/ip4/127.0.0.1/tcp/1234/ws",
+			want: "ws://127.0.0.1:1234/rpc/v1",
+		},
+		{
+			name: "multiaddr with /wss upgrades to wss",
+			addr: "/dns4/host.example/tcp/443/wss",
+			want: "wss://host.example:443/rpc/v1",
+		},
+		{
+			name: "multiaddr with /tls/ws upgrades to wss",
+			addr: "/dns4/host.example/tcp/443/tls/ws",
+			want: "wss://host.example:443/rpc/v1",
+		},
+		{
+			name: "http URL passes through",
+			addr: "http://host:1234",
+			want: "http://host:1234/rpc/v1",
+		},
+		{
+			name: "https URL passes through",
+			addr: "https://api.node.glif.io",
+			want: "https://api.node.glif.io/rpc/v1",
+		},
+		{
+			name: "wss URL passes through",
+			addr: "wss://host.example",
+			want: "wss://host.example/rpc/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := APIInfo{Addr: tt.addr}.DialArgs("v1")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Allows non-JWT tokens from third-party RPC providers (e.g. Glif) to be parsed correctly in TOKEN:ADDRESS .

## Related Issues
https://filecoinproject.slack.com/archives/CP50PPW2X/p1775732893778079
https://github.com/filecoin-project/lotus/issues/8385
