### PR TITLE
test(fevm): isolate bundle gas canaries, retune for v18

### DIFF
--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -203,6 +203,7 @@ func getRunners(testGroupName string) []Runner {
 		"itest-eth_fee_history":          {linux_x64_xlarge},
 		"itest-eth_transactions":         {linux_x64_xlarge},
 		"itest-fevm_address":             {linux_x64_xlarge},
+		"itest-fevm_bundle_canary":       {linux_x64_xlarge},
 		"itest-fevm_events":              {linux_x64_xlarge},
 		"itest-gas_estimation":           {linux_x64_xlarge},
 		"itest-gateway":                  {linux_x64_2xlarge},

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/fatih/color"
 	"github.com/ipfs/go-cid"
@@ -21,7 +20,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
-	"github.com/filecoin-project/lotus/lib/tablewriter"
+	"github.com/filecoin-project/lotus/lib/gasstats"
 )
 
 var msgCmd = &cli.Command{
@@ -103,7 +102,7 @@ var msgCmd = &cli.Command{
 						typ = "Subcall"
 					}
 					_, _ = fmt.Fprintln(cctx.App.Writer, color.New(color.Bold).Sprint(fmt.Sprintf("%s (%s%s) gas charges:", typ, descPfx, trace.Msg.To)))
-					if err := statsTable(cctx.App.Writer, trace, false); err != nil {
+					if err := writeGasStats(cctx.App.Writer, trace, false); err != nil {
 						return err
 					}
 					for _, subtrace := range trace.Subcalls {
@@ -120,13 +119,13 @@ var msgCmd = &cli.Command{
 				if len(res.ExecutionTrace.Subcalls) > 0 {
 					_, _ = fmt.Fprintln(cctx.App.Writer)
 					_, _ = fmt.Fprintln(cctx.App.Writer, color.New(color.Bold).Sprint("Total gas charges:"))
-					if err := statsTable(cctx.App.Writer, res.ExecutionTrace, true); err != nil {
+					if err := writeGasStats(cctx.App.Writer, res.ExecutionTrace, true); err != nil {
 						return err
 					}
-					perCallTrace := gasTracesPerCall(res.ExecutionTrace)
+					perCallTrace := gasstats.PerCallTrace(res.ExecutionTrace)
 					_, _ = fmt.Fprintln(cctx.App.Writer)
 					_, _ = fmt.Fprintln(cctx.App.Writer, color.New(color.Bold).Sprint("Gas charges per call:"))
-					if err := statsTable(cctx.App.Writer, perCallTrace, false); err != nil {
+					if err := writeGasStats(cctx.App.Writer, perCallTrace, false); err != nil {
 						return err
 					}
 				}
@@ -393,104 +392,7 @@ func messageFromCID(cctx *cli.Context, c cid.Cid) (types.ChainMsg, error) {
 	return messageFromBytes(cctx, msgb)
 }
 
-type gasTally struct {
-	storageGas int64
-	computeGas int64
-	count      int
-}
-
-func accumGasTallies(charges map[string]*gasTally, totals *gasTally, trace types.ExecutionTrace, recurse bool) {
-	for _, charge := range trace.GasCharges {
-		name := charge.Name
-		if _, ok := charges[name]; !ok {
-			charges[name] = &gasTally{}
-		}
-		charges[name].computeGas += charge.ComputeGas
-		charges[name].storageGas += charge.StorageGas
-		charges[name].count++
-		totals.computeGas += charge.ComputeGas
-		totals.storageGas += charge.StorageGas
-		totals.count++
-	}
-	if recurse {
-		for _, subtrace := range trace.Subcalls {
-			accumGasTallies(charges, totals, subtrace, recurse)
-		}
-	}
-}
-
-func statsTable(out io.Writer, trace types.ExecutionTrace, recurse bool) error {
-	tw := tablewriter.New(
-		tablewriter.Col("Type"),
-		tablewriter.Col("Count", tablewriter.RightAlign()),
-		tablewriter.Col("Storage Gas", tablewriter.RightAlign()),
-		tablewriter.Col("S%", tablewriter.RightAlign()),
-		tablewriter.Col("Compute Gas", tablewriter.RightAlign()),
-		tablewriter.Col("C%", tablewriter.RightAlign()),
-		tablewriter.Col("Total Gas", tablewriter.RightAlign()),
-		tablewriter.Col("T%", tablewriter.RightAlign()),
-	)
-
-	totals := &gasTally{}
-	charges := make(map[string]*gasTally)
-	accumGasTallies(charges, totals, trace, recurse)
-
-	// Sort by name
-	names := make([]string, 0, len(charges))
-	for name := range charges {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		charge := charges[name]
-		tw.Write(map[string]interface{}{
-			"Type":        name,
-			"Count":       charge.count,
-			"Storage Gas": charge.storageGas,
-			"S%":          fmt.Sprintf("%.2f", float64(charge.storageGas)/float64(totals.storageGas)*100),
-			"Compute Gas": charge.computeGas,
-			"C%":          fmt.Sprintf("%.2f", float64(charge.computeGas)/float64(totals.computeGas)*100),
-			"Total Gas":   charge.storageGas + charge.computeGas,
-			"T%":          fmt.Sprintf("%.2f", float64(charge.storageGas+charge.computeGas)/float64(totals.storageGas+totals.computeGas)*100),
-		})
-	}
-	tw.Write(map[string]interface{}{
-		"Type":        "Total",
-		"Count":       totals.count,
-		"Storage Gas": totals.storageGas,
-		"S%":          "100.00",
-		"Compute Gas": totals.computeGas,
-		"C%":          "100.00",
-		"Total Gas":   totals.storageGas + totals.computeGas,
-		"T%":          "100.00",
-	})
-	return tw.Flush(out, tablewriter.WithBorders())
-}
-
-// Takes an execution trace and returns a new trace that groups all the gas charges by the message
-// they were charged in, with the gas charges named per message; the output is partial and only
-// suitable for calling statsTable() with.
-func gasTracesPerCall(inTrace types.ExecutionTrace) types.ExecutionTrace {
-	outTrace := types.ExecutionTrace{
-		GasCharges: []*types.GasTrace{},
-	}
-	count := 1
-	var accum func(name string, trace types.ExecutionTrace)
-	accum = func(name string, trace types.ExecutionTrace) {
-		totals := &gasTally{}
-		charges := make(map[string]*gasTally)
-		accumGasTallies(charges, totals, trace, false)
-		outTrace.GasCharges = append(outTrace.GasCharges, &types.GasTrace{
-			Name:       fmt.Sprintf("#%d %s", count, name),
-			ComputeGas: totals.computeGas,
-			StorageGas: totals.storageGas,
-		})
-		count++
-		for _, subtrace := range trace.Subcalls {
-			accum(name+"➜"+subtrace.Msg.To.String(), subtrace)
-		}
-	}
-	accum(inTrace.Msg.To.String(), inTrace)
-	return outTrace
+func writeGasStats(w io.Writer, trace types.ExecutionTrace, recurse bool) error {
+	tallies, total := gasstats.Aggregate(trace, recurse)
+	return gasstats.FormatTable(w, tallies, total)
 }

--- a/itests/fevm_bundle_canary_test.go
+++ b/itests/fevm_bundle_canary_test.go
@@ -221,8 +221,26 @@ func TestFEVMRecursiveDelegatecallCanary(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("count=%d,success=%t", tc.recursionCount, tc.expectSuccess), func(t *testing.T) {
 			fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, "contracts/RecursiveDelegeatecall.hex")
-			trace, observedCount, err := runRecursiveDelegatecall(ctx, t, client, fromAddr, actorAddr, tc.recursionCount)
+			trace, exit, observedCount, err := runRecursiveDelegatecall(ctx, t, client, fromAddr, actorAddr, tc.recursionCount)
 			require.NoError(t, err)
+
+			// The outer recursiveCall always exits Ok: the contract catches
+			// failing sub-delegatecalls and returns the iteration count
+			// reached before the failure. A non-Ok outer exit signals a
+			// behavioural change beyond bundle drift, not a retune.
+			if exit != exitcode.Ok {
+				reportCanaryFailure(t, canaryFailure{
+					testName:       "TestFEVMRecursiveDelegatecallCanary",
+					caseLabel:      fmt.Sprintf("count=%d", tc.recursionCount),
+					recursionCount: int(tc.recursionCount),
+					expectedExit:   exitcode.Ok,
+					actualExit:     exit,
+					trace:          trace,
+					perIterApprox:  delegatecallPerIterGasApprox,
+					extraReason:    "outer recursiveCall returned non-Ok; the contract is expected to catch inner failures and return Ok",
+				})
+				return
+			}
 
 			var problem string
 			switch {
@@ -241,7 +259,7 @@ func TestFEVMRecursiveDelegatecallCanary(t *testing.T) {
 				caseLabel:      fmt.Sprintf("count=%d", tc.recursionCount),
 				recursionCount: int(tc.recursionCount),
 				expectedExit:   exitcode.Ok,
-				actualExit:     exitcode.Ok,
+				actualExit:     exit,
 				trace:          trace,
 				perIterApprox:  delegatecallPerIterGasApprox,
 				extraReason:    problem,
@@ -318,7 +336,6 @@ func TestFEVMCanaryBundleCompareHistorical(t *testing.T) {
 		t.Skip("set LOTUS_TEST_FEVM_CANARY_HISTORICAL=1 to run")
 	}
 	for _, tr := range bundleTransitionsFromSchedule() {
-		tr := tr
 		t.Run(tr.label, func(t *testing.T) {
 			measureBundleTransition(t, tr)
 		})
@@ -391,29 +408,29 @@ func runRecursiveActorCall(ctx context.Context, t *testing.T, client *kit.TestFu
 
 // runRecursiveDelegatecall invokes recursiveCall(uint256) on a
 // RecursiveDelegatecall contract and then queries totalCalls() to find out
-// how many iterations actually ran. Returns the recursiveCall trace plus
-// the observed iteration count.
-func runRecursiveDelegatecall(ctx context.Context, t *testing.T, client *kit.TestFullNode, from, contract address.Address, n uint64) (types.ExecutionTrace, uint64, error) {
+// how many iterations actually ran. Returns the recursiveCall trace, the
+// outer-call receipt exit code, and the observed iteration count.
+func runRecursiveDelegatecall(ctx context.Context, t *testing.T, client *kit.TestFullNode, from, contract address.Address, n uint64) (types.ExecutionTrace, exitcode.ExitCode, uint64, error) {
 	t.Helper()
 	input := kit.EvmWordUint64(n)
 	entry := kit.CalcFuncSignature("recursiveCall(uint256)")
 	wait, err := client.EVM().InvokeSolidity(ctx, from, contract, entry, input)
 	if err != nil {
-		return types.ExecutionTrace{}, 0, err
+		return types.ExecutionTrace{}, 0, 0, err
 	}
 	replay, err := client.StateReplay(ctx, types.EmptyTSK, wait.Message)
 	if err != nil {
-		return types.ExecutionTrace{}, 0, err
+		return types.ExecutionTrace{}, 0, 0, err
 	}
 	result, _, err := client.EVM().InvokeContractByFuncName(ctx, from, contract, "totalCalls()", []byte{})
 	if err != nil {
-		return replay.ExecutionTrace, 0, err
+		return replay.ExecutionTrace, wait.Receipt.ExitCode, 0, err
 	}
 	total, err := kit.EvmDecodeUint64(result)
 	if err != nil {
-		return replay.ExecutionTrace, 0, err
+		return replay.ExecutionTrace, wait.Receipt.ExitCode, 0, err
 	}
-	return replay.ExecutionTrace, total, nil
+	return replay.ExecutionTrace, wait.Receipt.ExitCode, total, nil
 }
 
 // canaryFailure bundles the context needed to produce a useful failure

--- a/itests/fevm_bundle_canary_test.go
+++ b/itests/fevm_bundle_canary_test.go
@@ -1,0 +1,521 @@
+// Bundle-dependent FEVM gas canaries.
+//
+// # What these tests are
+//
+// These tests pin the boundary recursion counts at which specific FEVM
+// contracts exhaust their gas budget. They are *canaries*: they are expected
+// to fail when the built-in actors bundle is rebuilt, because a new Rust
+// toolchain or any actor source change produces slightly different WASM,
+// which in turn produces slightly different per-instruction gas totals after
+// `fvm_wasm_instrument` injects the pre-block gas counter. Typical
+// per-iteration drift is on the order of ±15k gas in `wasm_exec` (a
+// fraction of a percent of the ~3M per-iteration total), and is often zero
+// for a given release. Boundary retunes are rare. See the historical drift
+// table further down.
+//
+// # When a canary fails
+//
+// First, decide if this is *normal bundle drift* or something to investigate.
+// Run TestFEVMCanaryBundleCompare (or .Historical for the full table); it
+// prints a per-bucket delta between the previous and current bundle. If:
+//
+//   - the delta is entirely in `wasm_exec`, all other buckets are bit-
+//     identical before and after,
+//   - the per-iteration delta is on the order of ±20k gas or smaller, and
+//   - the boundary has shifted by at most a couple of iterations,
+//
+// then this is normal bundle-rebuild drift (different compiled WASM =
+// different metered-block split = different wasm_exec total). Re-tune the
+// boundary constants in this file to the new passing values and update the
+// corresponding `PerIterGasApprox` constant to the new per-iteration total.
+//
+// If drift also shows up in non-wasm_exec buckets, the FVM pricelist or an
+// IPLD schema changed at this network-version boundary, this is not pure bundle
+// drift. That's only expected at NV boundaries that explicitly ship a new
+// pricelist (e.g. v11->v12 was the Watermelon pricelist; v15->v16 was the
+// Watermelon -> Teep transition). Investigate before assuming a simple
+// retune is safe.
+//
+// If the per-iteration delta is large (>~5% of per-iter total), or the
+// failing exit code has changed rather than just the boundary, escalate.
+//
+// # Seeing what changed across a bundle upgrade
+//
+// TestFEVMCanaryBundleCompare below uses `kit.UpgradeSchedule` to run the
+// canary message *twice* in one test: once under the previous actors bundle
+// (current NV - 1), then once under the current bundle after an in-test
+// network upgrade. It prints per-bucket gas for both and a delta. Run it
+// with:
+//
+//	go test -v -run TestFEVMCanaryBundleCompare ./itests/fevm_bundle_canary_test.go
+//
+// This is diagnostic, never asserts on gas values, and is the quickest way
+// to confirm "is this just bundle drift".
+//
+// # Tuning workflow
+//
+//  1. Canary fails in CI on a bundle bump.
+//  2. Run `TestFEVMCanaryBundleCompare` to see the before/after delta.
+//  3. If drift looks normal, update the boundary constants below. Also
+//     update the corresponding `PerIterGasApprox` constant to the new
+//     observed per-iteration cost — the failure reporter uses it to flag
+//     anomalous drift next time.
+//  4. If drift looks anomalous, escalate.
+//
+// Add a row to the "Historical drift" table below when retuning.
+//
+// # Historical drift
+//
+// Per-iteration gas delta for the RecCall actor-call canary
+// (stackDepth=0, 100 recursive calls), measured with
+// TestFEVMCanaryBundleCompareHistorical. Most transitions are 100%
+// wasm_exec drift (pure bundle rebuild, compiler-induced); NV-level FVM
+// or pricelist changes that touch other buckets are noted.
+//
+//	Transition          | per-iter delta |    total / 100 | notes
+//	--------------------+----------------+----------------+------------------------------------
+//	v11 -> v12 (nv21)   |         -3,490 |       -349,084 | Watermelon pricelist intro;
+//	                    |                |                |   wasm_exec -906,896;
+//	                    |                |                |   new IPLD buckets replace
+//	                    |                |                |   OnBlockOpenPerByte (+557,812
+//	                    |                |                |   across non-wasm_exec)
+//	v12 -> v13 (nv22)   |              0 |              0 | no change
+//	v13 -> v14 (nv23)   |        -91,769 |     -9,176,966 | wasm_exec only; v14 much cheaper.
+//	                    |                |                |   Triggered PR #12144 (2024-06):
+//	                    |                |                |   delegatecall 226 -> 228,
+//	                    |                |                |   actor-call pass 253 -> 255
+//	v14 -> v15 (nv24)   |              0 |              0 | no change
+//	v15 -> v16 (nv25)   |        +15,957 |     +1,595,701 | Watermelon -> Teep pricelist;
+//	                    |                |                |   wasm_exec +1,586,656;
+//	                    |                |                |   OnScanIpldLinks +7,035,
+//	                    |                |                |   OnBlockOpen +2,010
+//	v16 -> v17 (nv27)   |         -8,045 |       -804,557 | wasm_exec only
+//	v17 -> v18 (nv28)   |        +14,402 |     +1,440,205 | wasm_exec only.
+//	                    |                |                |   Triggered PR #13585 (2026-04):
+//	                    |                |                |   actor-call pass 255 -> 254
+//
+// When retuning, regenerate this table by running:
+//
+//	LOTUS_TEST_FEVM_CANARY_HISTORICAL=1 go test -v \
+//	  -run TestFEVMCanaryBundleCompareHistorical \
+//	  ./itests/fevm_bundle_canary_test.go
+package itests
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/go-state-types/network"
+
+	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/itests/kit"
+	"github.com/filecoin-project/lotus/lib/gasstats"
+)
+
+// Canary constants. Retune alongside any bundle-driven failure. Keep
+// `PerIterGasApprox` in the same ballpark as the latest observed per-
+// iteration cost so the failure reporter can flag anomalous drift.
+const (
+	// TestFEVMRecursiveActorCallCanary: recursive FEVM actor-call boundaries.
+	// Pairs are (stackDepth, recursionLimit). Highest passing recursionLimit
+	// for each stackDepth, plus the first failing value.
+	// Last tuned: 2026-04-21 against actors v18.0.0-rc1 (nv28 rollout).
+	actorCallBoundaryD0Pass   = 254
+	actorCallBoundaryD0Fail   = 261
+	actorCallBoundaryD251Pass = 164
+	actorCallBoundaryD251Fail = 173
+	// Approximate gas per recursive call observed when these constants were
+	// last tuned. Used to sanity-check the magnitude of drift on failure.
+	actorCallPerIterGasApprox int64 = 3_010_000
+
+	// TestFEVMRecursiveDelegatecallCanary: max delegatecall depth.
+	// `highestSuccess` is the largest N where the contract returns N
+	// successfully; `iterationsBeforeFailing` is the N reached inside the
+	// contract before running out of gas on a too-large request.
+	delegatecallHighestSuccess             = 228
+	delegatecallIterationsBeforeFail       = 222
+	delegatecallPerIterGasApprox     int64 = 100_000
+
+	// Sub-boundary count used by the bundle-compare diagnostic. Must pass
+	// comfortably under both the current and the previous actors bundle.
+	bundleCompareRecursionCount = 100
+)
+
+// TestFEVMRecursiveActorCallCanary exercises the recursive-actor-call
+// boundaries against the current actors bundle. See the file header for how
+// to interpret a failure.
+func TestFEVMRecursiveActorCallCanary(t *testing.T) {
+	ctx, cancel, client := kit.SetupFEVMTest(t)
+	defer cancel()
+
+	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, "contracts/RecCall.hex")
+
+	const exitTransactionReverted = exitcode.ExitCode(33)
+
+	cases := []struct {
+		stackDepth     int
+		recursionLimit int
+		expect         exitcode.ExitCode
+		label          string
+	}{
+		{0, actorCallBoundaryD0Pass, exitcode.Ok, "d0-pass"},
+		{251, actorCallBoundaryD251Pass, exitcode.Ok, "d251-pass"},
+		{0, actorCallBoundaryD0Fail, exitTransactionReverted, "d0-fail"},
+		{251, actorCallBoundaryD251Fail, exitTransactionReverted, "d251-fail"},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s(depth=%d,limit=%d)", tc.label, tc.stackDepth, tc.recursionLimit), func(t *testing.T) {
+			trace, actualExit := runRecursiveActorCall(ctx, t, client, fromAddr, actorAddr, tc.stackDepth, tc.recursionLimit)
+			if actualExit == tc.expect {
+				return
+			}
+			reportCanaryFailure(t, canaryFailure{
+				testName:       "TestFEVMRecursiveActorCallCanary",
+				caseLabel:      tc.label,
+				recursionCount: tc.recursionLimit,
+				expectedExit:   tc.expect,
+				actualExit:     actualExit,
+				trace:          trace,
+				perIterApprox:  actorCallPerIterGasApprox,
+			})
+		})
+	}
+}
+
+// TestFEVMRecursiveDelegatecallCanary exercises the maximum delegatecall
+// depth against the current actors bundle. See the file header for how to
+// interpret a failure.
+func TestFEVMRecursiveDelegatecallCanary(t *testing.T) {
+	ctx, cancel, client := kit.SetupFEVMTest(t)
+	defer cancel()
+
+	cases := []struct {
+		recursionCount uint64
+		expectSuccess  bool
+	}{
+		// successes up to the tuned boundary
+		{1, true},
+		{2, true},
+		{10, true},
+		{100, true},
+		{delegatecallHighestSuccess, true},
+		// failures past the boundary
+		{delegatecallHighestSuccess + 1, false},
+		{1000, false},
+		{10000000, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("count=%d,success=%t", tc.recursionCount, tc.expectSuccess), func(t *testing.T) {
+			fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, "contracts/RecursiveDelegeatecall.hex")
+			trace, observedCount, err := runRecursiveDelegatecall(ctx, t, client, fromAddr, actorAddr, tc.recursionCount)
+			require.NoError(t, err)
+
+			var problem string
+			switch {
+			case tc.expectSuccess && int(observedCount) != int(tc.recursionCount):
+				problem = fmt.Sprintf("expected to reach %d, reached %d", tc.recursionCount, observedCount)
+			case !tc.expectSuccess && int(observedCount) == int(tc.recursionCount):
+				problem = fmt.Sprintf("expected to run out of gas before %d, reached %d anyway", tc.recursionCount, tc.recursionCount)
+			case !tc.expectSuccess && int(observedCount) != int(delegatecallIterationsBeforeFail):
+				problem = fmt.Sprintf("expected to fail at iteration %d, failed at %d", delegatecallIterationsBeforeFail, observedCount)
+			}
+			if problem == "" {
+				return
+			}
+			reportCanaryFailure(t, canaryFailure{
+				testName:       "TestFEVMRecursiveDelegatecallCanary",
+				caseLabel:      fmt.Sprintf("count=%d", tc.recursionCount),
+				recursionCount: int(tc.recursionCount),
+				expectedExit:   exitcode.Ok,
+				actualExit:     exitcode.Ok,
+				trace:          trace,
+				perIterApprox:  delegatecallPerIterGasApprox,
+				extraReason:    problem,
+			})
+		})
+	}
+}
+
+// bundleTransition describes a network-version boundary at which the actors
+// bundle changed. Discovered dynamically from filcns.DefaultUpgradeSchedule
+// and actorstypes.VersionForNetwork — no manual list to maintain.
+type bundleTransition struct {
+	// label is a short identifier like "v17->v18 (nv28)".
+	label string
+	// genesisNV is the network version the test genesis starts at (the last
+	// NV where the pre-transition actors version was active).
+	genesisNV network.Version
+	// upgradeNV is the target version to migrate to.
+	upgradeNV network.Version
+	// migration is the state-migration function invoked at upgradeNV.
+	migration stmgr.MigrationFunc
+}
+
+// bundleTransitionsFromSchedule walks the default lotus upgrade schedule and
+// returns the subset of upgrades that advance the actors version. Filtered
+// to transitions where the pre-upgrade actors version is >= minActorsVersion,
+// since the canary message exercises FEVM (EAM/EVM/EthAccount actors) which
+// stabilised at v11. Ordered chronologically.
+func bundleTransitionsFromSchedule() []bundleTransition {
+	const minActorsVersion = actorstypes.Version11
+
+	schedule := filcns.DefaultUpgradeSchedule()
+	sort.Slice(schedule, func(i, j int) bool { return schedule[i].Height < schedule[j].Height })
+
+	var out []bundleTransition
+	for _, up := range schedule {
+		if up.Migration == nil {
+			continue
+		}
+		newAV, err := actorstypes.VersionForNetwork(up.Network)
+		if err != nil || up.Network == 0 {
+			continue
+		}
+		prevAV, err := actorstypes.VersionForNetwork(up.Network - 1)
+		if err != nil || newAV <= prevAV || prevAV < minActorsVersion {
+			continue
+		}
+		out = append(out, bundleTransition{
+			label:     fmt.Sprintf("v%d->v%d (nv%d)", prevAV, newAV, up.Network),
+			genesisNV: up.Network - 1,
+			upgradeNV: up.Network,
+			migration: up.Migration,
+		})
+	}
+	return out
+}
+
+// TestFEVMCanaryBundleCompare is a diagnostic, not an assertion test. It
+// runs the canary message under the previous actors bundle, triggers an
+// in-chain migration to the current bundle, and runs it again, printing a
+// per-bucket gas delta. Use this to judge whether a canary failure is
+// normal bundle drift or an anomaly.
+func TestFEVMCanaryBundleCompare(t *testing.T) {
+	transitions := bundleTransitionsFromSchedule()
+	require.NotEmpty(t, transitions, "no bundle transitions discovered from upgrade schedule")
+	measureBundleTransition(t, transitions[len(transitions)-1])
+}
+
+// TestFEVMCanaryBundleCompareHistorical iterates through every bundle
+// transition from v11 onward and prints the per-iteration gas delta for each.
+// Use when regenerating the "Historical drift" table in this file's header.
+func TestFEVMCanaryBundleCompareHistorical(t *testing.T) {
+	if os.Getenv("LOTUS_TEST_FEVM_CANARY_HISTORICAL") == "" {
+		t.Skip("set LOTUS_TEST_FEVM_CANARY_HISTORICAL=1 to run")
+	}
+	for _, tr := range bundleTransitionsFromSchedule() {
+		tr := tr
+		t.Run(tr.label, func(t *testing.T) {
+			measureBundleTransition(t, tr)
+		})
+	}
+}
+
+// measureBundleTransition runs the canary message under the pre-migration
+// bundle and again under the post-migration bundle, logging a per-bucket
+// delta table. Never asserts on gas values.
+func measureBundleTransition(t *testing.T, tr bundleTransition) {
+	kit.QuietMiningLogs()
+
+	const upgradeHeight = abi.ChainEpoch(40)
+
+	client, _, ens := kit.EnsembleMinimal(t,
+		kit.MockProofs(),
+		kit.ThroughRPC(),
+		kit.UpgradeSchedule(stmgr.Upgrade{
+			Height:  -1,
+			Network: tr.genesisNV,
+		}, stmgr.Upgrade{
+			Height:    upgradeHeight,
+			Network:   tr.upgradeNV,
+			Migration: tr.migration,
+		}),
+	)
+	ens.InterconnectAll().BeginMining(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, "contracts/RecCall.hex")
+
+	t.Logf("running canary under previous actors bundle (nv%d)", tr.genesisNV)
+	beforeTrace, exit := runRecursiveActorCall(ctx, t, client, fromAddr, actorAddr, 0, bundleCompareRecursionCount)
+	require.Equal(t, exitcode.Ok, exit, "sub-boundary canary run should pass under previous bundle")
+
+	t.Logf("waiting for network upgrade to nv%d at height %d", tr.upgradeNV, upgradeHeight)
+	client.WaitTillChain(ctx, kit.HeightAtLeast(upgradeHeight+5))
+
+	t.Logf("running canary under post-upgrade actors bundle (nv%d)", tr.upgradeNV)
+	afterTrace, exit := runRecursiveActorCall(ctx, t, client, fromAddr, actorAddr, 0, bundleCompareRecursionCount)
+	require.Equal(t, exitcode.Ok, exit, "sub-boundary canary run should pass under current bundle")
+
+	t.Logf("\n=== %s: stackDepth=0, recursionLimit=%d ===", tr.label, bundleCompareRecursionCount)
+	logBundleCompare(t, beforeTrace, afterTrace, bundleCompareRecursionCount)
+}
+
+// --- helpers ---
+
+// runRecursiveActorCall invokes exec1(uint256,uint256,uint256) on a RecCall
+// contract, waits for the message, and returns its execution trace plus the
+// receipt exit code. Unlike the kit's ExpectExit helper, this returns both
+// the exit code and the trace so the caller can decide what to do on a
+// boundary mismatch.
+func runRecursiveActorCall(ctx context.Context, t *testing.T, client *kit.TestFullNode, from, contract address.Address, stackDepth, recursionLimit int) (types.ExecutionTrace, exitcode.ExitCode) {
+	t.Helper()
+	input := make([]byte, 32*3)
+	binary.BigEndian.PutUint64(input[24:], uint64(stackDepth))
+	binary.BigEndian.PutUint64(input[32+24:], uint64(stackDepth))
+	binary.BigEndian.PutUint64(input[32+32+24:], uint64(recursionLimit))
+
+	entry := kit.CalcFuncSignature("exec1(uint256,uint256,uint256)")
+	wait, err := client.EVM().InvokeSolidity(ctx, from, contract, entry, input)
+	require.NoError(t, err)
+	replay, err := client.StateReplay(ctx, types.EmptyTSK, wait.Message)
+	require.NoError(t, err)
+	return replay.ExecutionTrace, wait.Receipt.ExitCode
+}
+
+// runRecursiveDelegatecall invokes recursiveCall(uint256) on a
+// RecursiveDelegatecall contract and then queries totalCalls() to find out
+// how many iterations actually ran. Returns the recursiveCall trace plus
+// the observed iteration count.
+func runRecursiveDelegatecall(ctx context.Context, t *testing.T, client *kit.TestFullNode, from, contract address.Address, n uint64) (types.ExecutionTrace, uint64, error) {
+	t.Helper()
+	input := kit.EvmWordUint64(n)
+	entry := kit.CalcFuncSignature("recursiveCall(uint256)")
+	wait, err := client.EVM().InvokeSolidity(ctx, from, contract, entry, input)
+	if err != nil {
+		return types.ExecutionTrace{}, 0, err
+	}
+	replay, err := client.StateReplay(ctx, types.EmptyTSK, wait.Message)
+	if err != nil {
+		return types.ExecutionTrace{}, 0, err
+	}
+	result, _, err := client.EVM().InvokeContractByFuncName(ctx, from, contract, "totalCalls()", []byte{})
+	if err != nil {
+		return replay.ExecutionTrace, 0, err
+	}
+	total, err := kit.EvmDecodeUint64(result)
+	if err != nil {
+		return replay.ExecutionTrace, 0, err
+	}
+	return replay.ExecutionTrace, total, nil
+}
+
+// canaryFailure bundles the context needed to produce a useful failure
+// report.
+type canaryFailure struct {
+	testName       string
+	caseLabel      string
+	recursionCount int
+	expectedExit   exitcode.ExitCode
+	actualExit     exitcode.ExitCode
+	trace          types.ExecutionTrace
+	perIterApprox  int64
+	extraReason    string
+}
+
+// reportCanaryFailure prints a per-bucket gas breakdown, computes the per-
+// iteration cost and compares against the stored approximation, and gives a
+// one-line hint on whether this looks like normal drift or an anomaly.
+// After reporting, it fails the test.
+func reportCanaryFailure(t *testing.T, f canaryFailure) {
+	t.Helper()
+
+	tallies, total := gasstats.Aggregate(f.trace, true)
+	top := gasstats.TopN(tallies, 8)
+
+	var perIter int64
+	if f.recursionCount > 0 {
+		perIter = total.Total() / int64(f.recursionCount)
+	}
+
+	t.Logf("\n=== CANARY FAILURE: %s / %s ===", f.testName, f.caseLabel)
+	if f.extraReason != "" {
+		t.Logf("reason: %s", f.extraReason)
+	} else {
+		t.Logf("expected exit %s, got %s", f.expectedExit, f.actualExit)
+	}
+	t.Logf("total gas: %d (compute %d, storage %d, charges %d)", total.Total(), total.ComputeGas, total.StorageGas, total.Count)
+	t.Logf("per-iteration gas (total / %d iterations): ~%d", f.recursionCount, perIter)
+	if f.perIterApprox > 0 && perIter > 0 {
+		deltaPct := float64(perIter-f.perIterApprox) / float64(f.perIterApprox) * 100
+		t.Logf("stored approx: ~%d; drift: %+.1f%%", f.perIterApprox, deltaPct)
+	}
+	t.Logf("top gas buckets:")
+	for _, tally := range top {
+		pct := float64(tally.Total()) / float64(total.Total()) * 100
+		t.Logf("  %-28s count=%-6d total=%-12d (%5.1f%%)", tally.Name, tally.Count, tally.Total(), pct)
+	}
+
+	t.Logf("\ninterpretation:")
+	t.Logf("  Run TestFEVMCanaryBundleCompare to see the per-bucket delta")
+	t.Logf("  vs the previous bundle. Normal bundle drift is 100%% in wasm_exec")
+	t.Logf("  Refer to this file's header for more information and investigate")
+	t.Logf("  before a possible mechanical retune of the boundary constants.")
+
+	t.Fatalf("canary boundary tripped: see diagnostic above")
+}
+
+// logBundleCompare prints side-by-side per-bucket gas for two traces of the
+// same message under different actors bundles, plus deltas. Sorted by
+// absolute delta descending so the drifting buckets rise to the top.
+func logBundleCompare(t *testing.T, before, after types.ExecutionTrace, iterCount int) {
+	t.Helper()
+
+	beforeTallies, totalBefore := gasstats.Aggregate(before, true)
+	afterTallies, totalAfter := gasstats.Aggregate(after, true)
+
+	byName := map[string]struct{ before, after int64 }{}
+	for _, t := range beforeTallies {
+		e := byName[t.Name]
+		e.before = t.Total()
+		byName[t.Name] = e
+	}
+	for _, t := range afterTallies {
+		e := byName[t.Name]
+		e.after = t.Total()
+		byName[t.Name] = e
+	}
+
+	type row struct {
+		name          string
+		before, after int64
+		delta         int64
+	}
+	rows := make([]row, 0, len(byName))
+	for name, v := range byName {
+		rows = append(rows, row{name, v.before, v.after, v.after - v.before})
+	}
+	sort.Slice(rows, func(i, j int) bool { return abs(rows[i].delta) > abs(rows[j].delta) })
+
+	t.Logf("%-28s %14s %14s %14s", "Bucket", "Before", "After", "Delta")
+	for _, r := range rows {
+		t.Logf("%-28s %14d %14d %+14d", r.name, r.before, r.after, r.delta)
+	}
+	t.Logf("%-28s %14d %14d %+14d", "TOTAL", totalBefore.Total(), totalAfter.Total(), totalAfter.Total()-totalBefore.Total())
+	if iterCount > 0 {
+		t.Logf("per-iteration delta (%d iterations): %+d", iterCount, (totalAfter.Total()-totalBefore.Total())/int64(iterCount))
+	}
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -39,37 +39,6 @@ import (
 	"github.com/filecoin-project/lotus/itests/kit"
 )
 
-// convert a simple byte array into input data which is a left padded 32 byte array
-func inputDataFromArray(input []byte) []byte {
-	inputData := make([]byte, 32)
-	copy(inputData[32-len(input):], input[:])
-	return inputData
-}
-
-// convert a "from" address into input data which is a left padded 32 byte array
-func inputDataFromFrom(ctx context.Context, t *testing.T, client *kit.TestFullNode, from address.Address) []byte {
-	fromId, err := client.StateLookupID(ctx, from, types.EmptyTSK)
-	require.NoError(t, err)
-	senderEthAddr, err := ethtypes.EthAddressFromFilecoinAddress(fromId)
-	require.NoError(t, err)
-	inputData := make([]byte, 32)
-	copy(inputData[32-len(senderEthAddr):], senderEthAddr[:])
-	return inputData
-}
-
-func decodeOutputToUint64(output []byte) (uint64, error) {
-	var result uint64
-	buf := bytes.NewReader(output[len(output)-8:])
-	err := binary.Read(buf, binary.BigEndian, &result)
-	return result, err
-}
-func buildInputFromUint64(number uint64) []byte {
-	// Convert the number to a binary uint64 array
-	binaryNumber := make([]byte, 8)
-	binary.BigEndian.PutUint64(binaryNumber, number)
-	return inputDataFromArray(binaryNumber)
-}
-
 // TestFEVMRecursive does a basic fevm contract installation and invocation
 func TestFEVMRecursive(t *testing.T) {
 	callCounts := []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 230, 330}
@@ -81,7 +50,7 @@ func TestFEVMRecursive(t *testing.T) {
 	// Successful calls
 	for _, callCount := range callCounts {
 		t.Run(fmt.Sprintf("TestFEVMRecursive%d", callCount), func(t *testing.T) {
-			_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", buildInputFromUint64(callCount))
+			_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", kit.EvmWordUint64(callCount))
 			require.NoError(t, err)
 		})
 	}
@@ -98,7 +67,7 @@ func TestFEVMRecursiveFail(t *testing.T) {
 	failCallCounts := []uint64{340, 400, 600, 850, 1000}
 	for _, failCallCount := range failCallCounts {
 		t.Run(fmt.Sprintf("TestFEVMRecursiveFail%d", failCallCount), func(t *testing.T) {
-			_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", buildInputFromUint64(failCallCount))
+			_, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", kit.EvmWordUint64(failCallCount))
 			require.Error(t, err)
 			require.Equal(t, exitcode.ExitCode(37), wait.Receipt.ExitCode)
 		})
@@ -127,54 +96,9 @@ func TestFEVMRecursive2(t *testing.T) {
 	require.Equal(t, 2, len(events))
 }
 
-// TestFEVMRecursiveDelegatecallCount tests the maximum delegatecall recursion depth.
-func TestFEVMRecursiveDelegatecallCount(t *testing.T) {
-	ctx, cancel, client := kit.SetupFEVMTest(t)
-	defer cancel()
-
-	// these depend on the actors bundle, may need to be adjusted with a network upgrade
-	const highestSuccessCount = 228
-	const expectedIterationsBeforeFailing = 222
-
-	filename := "contracts/RecursiveDelegeatecall.hex"
-
-	testCases := []struct {
-		recursionCount uint64
-		expectSuccess  bool
-	}{
-		// success
-		{1, true},
-		{2, true},
-		{10, true},
-		{100, true},
-		{highestSuccessCount, true},
-		// failure
-		{highestSuccessCount + 1, false},
-		{1000, false},
-		{10000000, false},
-	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("recursionCount=%d,expectSuccess=%t", tc.recursionCount, tc.expectSuccess), func(t *testing.T) {
-			fromAddr, idAddr := client.EVM().DeployContractFromFilename(ctx, filename)
-			inputData := buildInputFromUint64(tc.recursionCount)
-			_, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "recursiveCall(uint256)", inputData)
-			require.NoError(t, err)
-
-			result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "totalCalls()", []byte{})
-			require.NoError(t, err)
-
-			resultUint, err := decodeOutputToUint64(result)
-			require.NoError(t, err)
-
-			if tc.expectSuccess {
-				require.Equal(t, int(tc.recursionCount), int(resultUint))
-			} else {
-				require.NotEqual(t, int(resultUint), int(tc.recursionCount), "unexpected recursion count, if the actors bundle has changed, this test may need to be adjusted")
-				require.Equal(t, int(expectedIterationsBeforeFailing), int(resultUint))
-			}
-		})
-	}
-}
+// TestFEVMRecursiveDelegatecallCount moved to fevm_bundle_canary_test.go
+// as TestFEVMRecursiveDelegatecallCanary — its boundary values retune with
+// every actors bundle release.
 
 // TestFEVMBasic does a basic fevm contract installation and invocation
 func TestFEVMBasic(t *testing.T) {
@@ -188,7 +112,7 @@ func TestFEVMBasic(t *testing.T) {
 
 	// invoke the contract with owner
 	{
-		inputData := inputDataFromFrom(ctx, t, client, fromAddr)
+		inputData := kit.EvmWordFromAddr(ctx, t, client, fromAddr)
 		result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "getBalance(address)", inputData)
 		require.NoError(t, err)
 
@@ -199,7 +123,7 @@ func TestFEVMBasic(t *testing.T) {
 
 	// invoke the contract with non owner
 	{
-		inputData := inputDataFromFrom(ctx, t, client, fromAddr)
+		inputData := kit.EvmWordFromAddr(ctx, t, client, fromAddr)
 		inputData[31]++ // change the pub address to one that has 0 balance by modifying the last byte of the address
 		result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "getBalance(address)", inputData)
 		require.NoError(t, err)
@@ -244,8 +168,8 @@ func TestFEVMDelegateCall(t *testing.T) {
 
 	// call Contract Storage which makes a delegatecall to contract Actor
 	// this contract call sets the "counter" variable to 7, from default value 0
-	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
-	inputDataValue := inputDataFromArray([]byte{7})
+	inputDataContract := kit.EvmWordFromAddr(ctx, t, client, actorAddr)
+	inputDataValue := kit.EvmWordBytes([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
 	// verify that the returned value of the call to setvars is 7
@@ -299,8 +223,8 @@ func TestFEVMDelegateCallRevert(t *testing.T) {
 	// call Contract Storage which makes a delegatecall to contract Actor
 	// this contract call sets the "counter" variable to 7, from default value 0
 
-	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
-	inputDataValue := inputDataFromArray([]byte{7})
+	inputDataContract := kit.EvmWordFromAddr(ctx, t, client, actorAddr)
+	inputDataValue := kit.EvmWordBytes([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
 	// verify that the returned value of the call to setvars is 7
@@ -501,8 +425,8 @@ func TestFEVMDelegateCallRecursiveFail(t *testing.T) {
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
 	// any data will do for this test that fails
-	inputDataContract := inputDataFromFrom(ctx, t, client, actorAddr)
-	inputDataValue := inputDataFromArray([]byte{7})
+	inputDataContract := kit.EvmWordFromAddr(ctx, t, client, actorAddr)
+	inputDataValue := kit.EvmWordBytes([]byte{7})
 	inputData := append(inputDataContract, inputDataValue...)
 
 	// verify that we run out of gas then revert.
@@ -587,7 +511,6 @@ func TestFEVMRecursiveActorCall(t *testing.T) {
 	fromAddr, actorAddr := client.EVM().DeployContractFromFilename(ctx, filenameActor)
 
 	exitCodeStackOverflow := exitcode.ExitCode(37)
-	exitCodeTransactionReverted := exitcode.ExitCode(33)
 
 	testCases := []struct {
 		stackDepth     int
@@ -612,11 +535,10 @@ func TestFEVMRecursiveActorCall(t *testing.T) {
 		{200, 32, exitcode.Ok},
 		{251, 32, exitcode.Ok},
 		{252, 32, exitCodeStackOverflow},
-		// the following are actors bundle dependent and may need to be tweaked with a network upgrade
-		{0, 255, exitcode.Ok},
-		{251, 164, exitcode.Ok},
-		{0, 261, exitCodeTransactionReverted},
-		{251, 173, exitCodeTransactionReverted},
+		// Bundle-dependent gas-exhaustion boundary cases live in
+		// fevm_bundle_canary_test.go; those retune with every actors bundle.
+		// The cases above exercise the wasm-stack / recursion-protection
+		// boundary, which is not bundle-dependent.
 	}
 	for _, tc := range testCases {
 		var fail string
@@ -754,7 +676,7 @@ func TestFEVMDeployWithValue(t *testing.T) {
 	ret, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, idAddr, "getNewContractBalance()", []byte{})
 	require.NoError(t, err)
 
-	contractBalance, err := decodeOutputToUint64(ret)
+	contractBalance, err := kit.EvmDecodeUint64(ret)
 	require.NoError(t, err)
 
 	// require balance of NewContract is testValue
@@ -789,7 +711,7 @@ func TestFEVMDestroyCreate2(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert contract has correct data
-	ethFromAddr := inputDataFromFrom(ctx, t, client, fromAddr)
+	ethFromAddr := kit.EvmWordFromAddr(ctx, t, client, fromAddr)
 	require.Equal(t, ethFromAddr, ret)
 
 	// run test() which 1.calls sefldestruct 2. verifies sender() is the correct value 3. attempts and fails to deploy via create2
@@ -957,7 +879,7 @@ func TestFEVMGetChainPropertiesBlockTimestamp(t *testing.T) {
 	ret, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "getTimestamp()", []byte{})
 	require.NoError(t, err)
 
-	timestampFromSolidity, err := decodeOutputToUint64(ret)
+	timestampFromSolidity, err := kit.EvmDecodeUint64(ret)
 	require.NoError(t, err)
 
 	ethBlock := client.EVM().GetEthBlockFromWait(ctx, wait)
@@ -977,7 +899,7 @@ func TestFEVMGetChainPropertiesBlockNumber(t *testing.T) {
 	ret, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "getBlockNumber()", []byte{})
 	require.NoError(t, err)
 
-	blockHeightFromSolidity, err := decodeOutputToUint64(ret)
+	blockHeightFromSolidity, err := kit.EvmDecodeUint64(ret)
 	require.NoError(t, err)
 
 	ethBlock := client.EVM().GetEthBlockFromWait(ctx, wait)
@@ -1014,7 +936,7 @@ func TestFEVMGetChainPropertiesBaseFee(t *testing.T) {
 
 	ret, wait, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "getBasefee()", []byte{})
 	require.NoError(t, err)
-	baseFeeRet, err := decodeOutputToUint64(ret)
+	baseFeeRet, err := kit.EvmDecodeUint64(ret)
 	require.NoError(t, err)
 
 	ethBlock := client.EVM().GetEthBlockFromWait(ctx, wait)
@@ -1937,7 +1859,7 @@ func TestTstore(t *testing.T) {
 	require.NoError(t, err)
 
 	fromAddr, contractAddr2 := client.EVM().DeployContractFromFilename(ctx, filenameActor)
-	inputDataContract := inputDataFromFrom(ctx, t, client, contractAddr2)
+	inputDataContract := kit.EvmWordFromAddr(ctx, t, client, contractAddr2)
 
 	//Step 3 test reentry from multiple contracts in a transaction
 	_, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractAddr, "testReentry(address)", inputDataContract)
@@ -1988,10 +1910,10 @@ func TestFEVMMigrationBytecodeSwap(t *testing.T) {
 
 	// Deploy SimpleCoin contract and verify it works
 	_, contractIdAddr := client.EVM().DeployContractFromFilename(ctx, "contracts/SimpleCoin.hex")
-	inputData := inputDataFromFrom(ctx, t, client, fromAddr)
+	inputData := kit.EvmWordFromAddr(ctx, t, client, fromAddr)
 	result, _, err := client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractIdAddr, "getBalance(address)", inputData)
 	require.NoError(t, err)
-	balance, err := decodeOutputToUint64(result)
+	balance, err := kit.EvmDecodeUint64(result)
 	require.NoError(t, err)
 	require.Equal(t, uint64(10000), balance)
 
@@ -2031,7 +1953,7 @@ func TestFEVMMigrationBytecodeSwap(t *testing.T) {
 	// the contract that was originally SimpleCoin
 	result, _, err = client.EVM().InvokeContractByFuncName(ctx, fromAddr, contractIdAddr, "getDifficulty()", nil)
 	require.NoError(t, err)
-	_, err = decodeOutputToUint64(result)
+	_, err = kit.EvmDecodeUint64(result)
 	require.NoError(t, err)
 
 	// Verify the source contract is unaffected

--- a/itests/kit/solidity.go
+++ b/itests/kit/solidity.go
@@ -1,8 +1,18 @@
 package kit
 
 import (
-	"github.com/filecoin-project/go-keccak"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
 
+	"github.com/filecoin-project/go-keccak"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
 
@@ -18,6 +28,48 @@ func EthFunctionHash(sig string) []byte {
 	hasher := keccak.NewLegacyKeccak256()
 	hasher.Write([]byte(sig))
 	return hasher.Sum(nil)[:4]
+}
+
+// EvmWordBytes right-aligns input into a 32-byte big-endian EVM word.
+// Panics if input is longer than 32 bytes.
+func EvmWordBytes(input []byte) []byte {
+	if len(input) > 32 {
+		panic(fmt.Sprintf("EvmWordBytes: input of %d bytes exceeds word size", len(input)))
+	}
+	word := make([]byte, 32)
+	copy(word[32-len(input):], input)
+	return word
+}
+
+// EvmWordUint64 encodes n as a 32-byte big-endian EVM word.
+func EvmWordUint64(n uint64) []byte {
+	word := make([]byte, 32)
+	binary.BigEndian.PutUint64(word[24:], n)
+	return word
+}
+
+// EvmWordFromAddr resolves a Filecoin address to its corresponding Ethereum
+// address and returns it as a 32-byte big-endian EVM word.
+func EvmWordFromAddr(ctx context.Context, t *testing.T, client *TestFullNode, from address.Address) []byte {
+	t.Helper()
+	fromID, err := client.StateLookupID(ctx, from, types.EmptyTSK)
+	require.NoError(t, err)
+	ethAddr, err := ethtypes.EthAddressFromFilecoinAddress(fromID)
+	require.NoError(t, err)
+	return EvmWordBytes(ethAddr[:])
+}
+
+// EvmDecodeUint64 interprets the low 8 bytes of an EVM word as a big-endian
+// uint64. Returns an error if output is shorter than 8 bytes.
+func EvmDecodeUint64(output []byte) (uint64, error) {
+	if len(output) < 8 {
+		return 0, fmt.Errorf("EvmDecodeUint64: output too short: %d bytes, need 8", len(output))
+	}
+	var n uint64
+	if err := binary.Read(bytes.NewReader(output[len(output)-8:]), binary.BigEndian, &n); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // SolidityContractDef holds information about one of the test contracts

--- a/itests/kit/solidity.go
+++ b/itests/kit/solidity.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-keccak"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-keccak"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"

--- a/lib/gasstats/gasstats.go
+++ b/lib/gasstats/gasstats.go
@@ -99,11 +99,11 @@ func FormatTable(w io.Writer, tallies []Tally, total Tally) error {
 		"Type":        "Total",
 		"Count":       total.Count,
 		"Storage Gas": total.StorageGas,
-		"S%":          "100.00",
+		"S%":          pct(total.StorageGas, total.StorageGas),
 		"Compute Gas": total.ComputeGas,
-		"C%":          "100.00",
+		"C%":          pct(total.ComputeGas, total.ComputeGas),
 		"Total Gas":   total.Total(),
-		"T%":          "100.00",
+		"T%":          pct(total.Total(), total.Total()),
 	})
 	return tw.Flush(w, tablewriter.WithBorders())
 }

--- a/lib/gasstats/gasstats.go
+++ b/lib/gasstats/gasstats.go
@@ -1,0 +1,150 @@
+// Package gasstats aggregates per-charge-name gas totals from an
+// [types.ExecutionTrace] and formats them for human consumption.
+package gasstats
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/lib/tablewriter"
+)
+
+// Tally is the aggregated gas for all charges with a given name.
+type Tally struct {
+	Name       string
+	ComputeGas int64
+	StorageGas int64
+	Count      int
+}
+
+// Total returns the sum of compute and storage gas.
+func (t Tally) Total() int64 {
+	return t.ComputeGas + t.StorageGas
+}
+
+// Aggregate walks trace and returns one Tally per unique charge name plus a
+// combined total. If recurse is true, subcalls are included; otherwise only
+// the top-level trace's charges are counted.
+//
+// The returned tallies are sorted by name for stable output.
+func Aggregate(trace types.ExecutionTrace, recurse bool) (tallies []Tally, total Tally) {
+	byName := map[string]*Tally{}
+	accumulate(byName, &total, trace, recurse)
+
+	tallies = make([]Tally, 0, len(byName))
+	for _, t := range byName {
+		tallies = append(tallies, *t)
+	}
+	sort.Slice(tallies, func(i, j int) bool { return tallies[i].Name < tallies[j].Name })
+	return tallies, total
+}
+
+func accumulate(byName map[string]*Tally, total *Tally, trace types.ExecutionTrace, recurse bool) {
+	for _, charge := range trace.GasCharges {
+		t, ok := byName[charge.Name]
+		if !ok {
+			t = &Tally{Name: charge.Name}
+			byName[charge.Name] = t
+		}
+		t.ComputeGas += charge.ComputeGas
+		t.StorageGas += charge.StorageGas
+		t.Count++
+		total.ComputeGas += charge.ComputeGas
+		total.StorageGas += charge.StorageGas
+		total.Count++
+	}
+	if recurse {
+		for _, sub := range trace.Subcalls {
+			accumulate(byName, total, sub, recurse)
+		}
+	}
+}
+
+// FormatTable renders tallies as a bordered table with per-column percentages
+// of the supplied totals. A final "Total" row shows the grand total.
+func FormatTable(w io.Writer, tallies []Tally, total Tally) error {
+	tw := tablewriter.New(
+		tablewriter.Col("Type"),
+		tablewriter.Col("Count", tablewriter.RightAlign()),
+		tablewriter.Col("Storage Gas", tablewriter.RightAlign()),
+		tablewriter.Col("S%", tablewriter.RightAlign()),
+		tablewriter.Col("Compute Gas", tablewriter.RightAlign()),
+		tablewriter.Col("C%", tablewriter.RightAlign()),
+		tablewriter.Col("Total Gas", tablewriter.RightAlign()),
+		tablewriter.Col("T%", tablewriter.RightAlign()),
+	)
+
+	pct := func(num, den int64) string {
+		if den == 0 {
+			return "0.00"
+		}
+		return fmt.Sprintf("%.2f", float64(num)/float64(den)*100)
+	}
+
+	for _, t := range tallies {
+		tw.Write(map[string]any{
+			"Type":        t.Name,
+			"Count":       t.Count,
+			"Storage Gas": t.StorageGas,
+			"S%":          pct(t.StorageGas, total.StorageGas),
+			"Compute Gas": t.ComputeGas,
+			"C%":          pct(t.ComputeGas, total.ComputeGas),
+			"Total Gas":   t.Total(),
+			"T%":          pct(t.Total(), total.Total()),
+		})
+	}
+	tw.Write(map[string]any{
+		"Type":        "Total",
+		"Count":       total.Count,
+		"Storage Gas": total.StorageGas,
+		"S%":          "100.00",
+		"Compute Gas": total.ComputeGas,
+		"C%":          "100.00",
+		"Total Gas":   total.Total(),
+		"T%":          "100.00",
+	})
+	return tw.Flush(w, tablewriter.WithBorders())
+}
+
+// TopN returns the N tallies with the largest Total(), preserving descending
+// order. If fewer than N tallies exist, all are returned. N <= 0 returns nil.
+func TopN(tallies []Tally, n int) []Tally {
+	if n <= 0 {
+		return nil
+	}
+	sorted := make([]Tally, len(tallies))
+	copy(sorted, tallies)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Total() > sorted[j].Total()
+	})
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+// PerCallTrace transforms an ExecutionTrace into a synthetic flat trace where
+// each subcall's aggregated gas becomes a single named GasTrace. The returned
+// trace is only suitable for rendering via Aggregate/FormatTable; it is not a
+// valid execution trace.
+func PerCallTrace(in types.ExecutionTrace) types.ExecutionTrace {
+	out := types.ExecutionTrace{GasCharges: []*types.GasTrace{}}
+	count := 1
+	var visit func(name string, trace types.ExecutionTrace)
+	visit = func(name string, trace types.ExecutionTrace) {
+		_, total := Aggregate(trace, false)
+		out.GasCharges = append(out.GasCharges, &types.GasTrace{
+			Name:       fmt.Sprintf("#%d %s", count, name),
+			ComputeGas: total.ComputeGas,
+			StorageGas: total.StorageGas,
+		})
+		count++
+		for _, sub := range trace.Subcalls {
+			visit(name+"➜"+sub.Msg.To.String(), sub)
+		}
+	}
+	visit(in.Msg.To.String(), in)
+	return out
+}


### PR DESCRIPTION
Move bundle-dependent FEVM recursion canaries out of fevm_test.go into itests/fevm_bundle_canary_test.go with a documented retune workflow, per-bucket gas failure reporter, and a historical drift table covering v11 through v18. Retune actor-call boundary 255 -> 254 for v18.0.0-rc1.

Add TestFEVMCanaryBundleCompare: drives the canary across a bundle transition via kit.UpgradeSchedule and prints a per-bucket gas delta, so a failure can be classified as normal bundle drift versus a regression. A Historical variant iterates every transition discovered from filcns.DefaultUpgradeSchedule + VersionForNetwork.

---

This is mostly just moving things around and expanding the canary to be more verbose with a lot more commenting around it to make it easier for future maintainers. There's also more tooling in the test file for figuring things out thanks to the gas stats package. Plus, the tuning for v18 to fix CI of course; to be clear, v18 has fairly normal / expected drift, explained mostly by a change in Rust version.