### PR TITLE
feat(cli): support hex-eth format for wallet export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 ## 👌 Improvements
 
 - feat(cliutil): accept non-JWT API tokens in `TOKEN:ADDRESS`, enabling use of third-party RPC providers (e.g. Glif) that issue opaque API keys ([filecoin-project/lotus#13578](https://github.com/filecoin-project/lotus/pull/13578))
-- feat(cli): `lotus wallet export` gains a `--format` flag with a new `hex-eth` value that emits the raw 32-byte private key as hex, directly importable into Ethereum tools (Metamask, ethers.js, foundry). `hex-eth` is also accepted by `lotus wallet import` together with a `--type` flag (`secp256k1` or `delegated`).
+- feat(cli): `lotus wallet export` gains a `--format` flag with a new `hex-eth` value that emits the raw 32-byte private key as hex, directly importable into Ethereum tools (Metamask, ethers.js, foundry). `hex-eth` is also accepted by `lotus wallet import` together with a `--type` flag (`secp256k1` or `delegated`, defaulting to `delegated`). ([filecoin-project/lotus#13586](https://github.com/filecoin-project/lotus/pull/13586))
 
 # Node v1.35.1 / 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ## 👌 Improvements
 
 - feat(cliutil): accept non-JWT API tokens in `TOKEN:ADDRESS`, enabling use of third-party RPC providers (e.g. Glif) that issue opaque API keys ([filecoin-project/lotus#13578](https://github.com/filecoin-project/lotus/pull/13578))
+- feat(cli): `lotus wallet export` gains a `--format` flag with a new `hex-eth` value that emits the raw 32-byte private key as hex, directly importable into Ethereum tools (Metamask, ethers.js, foundry). `hex-eth` is also accepted by `lotus wallet import` together with a `--type` flag (`secp256k1` or `delegated`).
 
 # Node v1.35.1 / 2026-03-31
 

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -277,6 +277,13 @@ var walletExport = &cli.Command{
 	Name:      "export",
 	Usage:     "export keys",
 	ArgsUsage: "[address]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "format",
+			Usage: "output format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; secp256k1 and delegated keys only)",
+			Value: "hex-lotus",
+		},
+	},
 	Action: func(cctx *cli.Context) error {
 		api, closer, err := GetFullNodeAPI(cctx)
 		if err != nil {
@@ -301,12 +308,28 @@ var walletExport = &cli.Command{
 			return err
 		}
 
-		b, err := json.Marshal(ki)
-		if err != nil {
-			return err
+		switch cctx.String("format") {
+		case "hex-lotus":
+			b, err := json.Marshal(ki)
+			if err != nil {
+				return err
+			}
+			afmt.Println(hex.EncodeToString(b))
+		case "json-lotus":
+			b, err := json.Marshal(ki)
+			if err != nil {
+				return err
+			}
+			afmt.Println(string(b))
+		case "hex-eth":
+			if ki.Type != types.KTSecp256k1 && ki.Type != types.KTDelegated {
+				return fmt.Errorf("hex-eth format requires a secp256k1 or delegated key, got: %s", ki.Type)
+			}
+			afmt.Println("0x" + hex.EncodeToString(ki.PrivateKey))
+		default:
+			return fmt.Errorf("unrecognized format: %s", cctx.String("format"))
 		}
 
-		afmt.Println(hex.EncodeToString(b))
 		return nil
 	},
 }
@@ -318,8 +341,13 @@ var walletImport = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "format",
-			Usage: "specify input format for key",
+			Usage: "input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; requires --type)",
 			Value: "hex-lotus",
+		},
+		&cli.StringFlag{
+			Name:  "type",
+			Usage: "key type for raw private-key formats ('hex-eth'): 'secp256k1' or 'delegated'",
+			Value: "delegated",
 		},
 		&cli.BoolFlag{
 			Name:  "as-default",
@@ -409,6 +437,29 @@ var walletImport = &cli.Command{
 			default:
 				return fmt.Errorf("unrecognized key type: %d", gk.SigType)
 			}
+		case "hex-eth":
+			var keyType types.KeyType
+			switch cctx.String("type") {
+			case "secp256k1":
+				keyType = types.KTSecp256k1
+			case "delegated":
+				keyType = types.KTDelegated
+			default:
+				return fmt.Errorf("--type for hex-eth format must be 'secp256k1' or 'delegated', got: %q", cctx.String("type"))
+			}
+
+			hexStr := strings.TrimSpace(string(inpdata))
+			hexStr = strings.TrimPrefix(hexStr, "0x")
+			hexStr = strings.TrimPrefix(hexStr, "0X")
+			pk, err := hex.DecodeString(hexStr)
+			if err != nil {
+				return xerrors.Errorf("decoding hex private key: %w", err)
+			}
+			if len(pk) != 32 {
+				return fmt.Errorf("expected 32-byte private key, got %d bytes", len(pk))
+			}
+			ki.Type = keyType
+			ki.PrivateKey = pk
 		default:
 			return fmt.Errorf("unrecognized format: %s", cctx.String("format"))
 		}

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -325,6 +325,9 @@ var walletExport = &cli.Command{
 			if ki.Type != types.KTSecp256k1 && ki.Type != types.KTDelegated {
 				return fmt.Errorf("hex-eth format requires a secp256k1 or delegated key, got: %s", ki.Type)
 			}
+			if len(ki.PrivateKey) != 32 {
+				return fmt.Errorf("expected 32-byte private key, got %d bytes", len(ki.PrivateKey))
+			}
 			afmt.Println("0x" + hex.EncodeToString(ki.PrivateKey))
 		default:
 			return fmt.Errorf("unrecognized format: %s", cctx.String("format"))
@@ -341,12 +344,12 @@ var walletImport = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "format",
-			Usage: "input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; requires --type)",
+			Usage: "input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; key type set via --type)",
 			Value: "hex-lotus",
 		},
 		&cli.StringFlag{
 			Name:  "type",
-			Usage: "key type for raw private-key formats ('hex-eth'): 'secp256k1' or 'delegated'",
+			Usage: "key type for raw private-key formats such as 'hex-eth': 'secp256k1' or 'delegated'",
 			Value: "delegated",
 		},
 		&cli.BoolFlag{

--- a/cli/wallet_test.go
+++ b/cli/wallet_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -175,28 +176,177 @@ func TestWalletSetDefault(t *testing.T) {
 }
 
 func TestWalletExport(t *testing.T) {
-	app, mockApi, buffer, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
-	defer done()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	addr, err := address.NewIDAddress(1234)
 	assert.NoError(t, err)
 
-	keyInfo := types.KeyInfo{
-		Type:       types.KTSecp256k1,
-		PrivateKey: []byte("0x000000000000000000001"),
+	pkBytes := make([]byte, 32)
+	for i := range pkBytes {
+		pkBytes[i] = byte(i + 1)
+	}
+	pkHex := hex.EncodeToString(pkBytes)
+
+	t.Run("default-format-is-hex-lotus", func(t *testing.T) {
+		app, mockApi, buffer, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
+		defer done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ki := types.KeyInfo{Type: types.KTSecp256k1, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletExport(ctx, addr).Return(&ki, nil)
+
+		expected, err := json.Marshal(ki)
+		assert.NoError(t, err)
+
+		err = app.Run([]string{"wallet", "export", "f01234"})
+		assert.NoError(t, err)
+		assert.Contains(t, buffer.String(), hex.EncodeToString(expected))
+	})
+
+	t.Run("json-lotus", func(t *testing.T) {
+		app, mockApi, buffer, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
+		defer done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ki := types.KeyInfo{Type: types.KTSecp256k1, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletExport(ctx, addr).Return(&ki, nil)
+
+		expected, err := json.Marshal(ki)
+		assert.NoError(t, err)
+
+		err = app.Run([]string{"wallet", "export", "--format", "json-lotus", "f01234"})
+		assert.NoError(t, err)
+		assert.Contains(t, buffer.String(), string(expected))
+	})
+
+	t.Run("hex-eth", func(t *testing.T) {
+		app, mockApi, buffer, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
+		defer done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ki := types.KeyInfo{Type: types.KTDelegated, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletExport(ctx, addr).Return(&ki, nil)
+
+		err = app.Run([]string{"wallet", "export", "--format", "hex-eth", "f01234"})
+		assert.NoError(t, err)
+		assert.Contains(t, buffer.String(), "0x"+pkHex)
+	})
+
+	t.Run("hex-eth-rejects-bls", func(t *testing.T) {
+		app, mockApi, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
+		defer done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ki := types.KeyInfo{Type: types.KTBLS, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletExport(ctx, addr).Return(&ki, nil)
+
+		err = app.Run([]string{"wallet", "export", "--format", "hex-eth", "f01234"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "hex-eth")
+	})
+
+	t.Run("unknown-format", func(t *testing.T) {
+		app, mockApi, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletExport))
+		defer done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ki := types.KeyInfo{Type: types.KTSecp256k1, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletExport(ctx, addr).Return(&ki, nil)
+
+		err = app.Run([]string{"wallet", "export", "--format", "bogus", "f01234"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unrecognized format")
+	})
+}
+
+func TestWalletImportHexEth(t *testing.T) {
+	addr, err := address.NewIDAddress(1234)
+	assert.NoError(t, err)
+
+	pkBytes := make([]byte, 32)
+	for i := range pkBytes {
+		pkBytes[i] = byte(i + 1)
+	}
+	pkHex := hex.EncodeToString(pkBytes)
+
+	writeTmp := func(t *testing.T, content string) string {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), "key-*.hex")
+		assert.NoError(t, err)
+		_, err = f.WriteString(content)
+		assert.NoError(t, err)
+		assert.NoError(t, f.Close())
+		return f.Name()
 	}
 
-	mockApi.EXPECT().WalletExport(ctx, addr).Return(&keyInfo, nil)
+	t.Run("delegated-default", func(t *testing.T) {
+		app, mockApi, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletImport))
+		defer done()
 
-	ki, err := json.Marshal(keyInfo)
-	assert.NoError(t, err)
+		path := writeTmp(t, pkHex)
 
-	err = app.Run([]string{"wallet", "export", "f01234"})
-	assert.NoError(t, err)
-	assert.Contains(t, buffer.String(), hex.EncodeToString(ki))
+		expected := &types.KeyInfo{Type: types.KTDelegated, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletImport(gomock.Any(), expected).Return(addr, nil)
+
+		err = app.Run([]string{"wallet", "import", "--format", "hex-eth", path})
+		assert.NoError(t, err)
+	})
+
+	t.Run("secp256k1-explicit", func(t *testing.T) {
+		app, mockApi, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletImport))
+		defer done()
+
+		path := writeTmp(t, pkHex)
+
+		expected := &types.KeyInfo{Type: types.KTSecp256k1, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletImport(gomock.Any(), expected).Return(addr, nil)
+
+		err = app.Run([]string{"wallet", "import", "--format", "hex-eth", "--type", "secp256k1", path})
+		assert.NoError(t, err)
+	})
+
+	t.Run("strips-0x-prefix-and-whitespace", func(t *testing.T) {
+		app, mockApi, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletImport))
+		defer done()
+
+		path := writeTmp(t, "  0x"+pkHex+"\n")
+
+		expected := &types.KeyInfo{Type: types.KTDelegated, PrivateKey: pkBytes}
+		mockApi.EXPECT().WalletImport(gomock.Any(), expected).Return(addr, nil)
+
+		err = app.Run([]string{"wallet", "import", "--format", "hex-eth", path})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects-wrong-length", func(t *testing.T) {
+		app, _, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletImport))
+		defer done()
+
+		path := writeTmp(t, "deadbeef")
+
+		err = app.Run([]string{"wallet", "import", "--format", "hex-eth", path})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "32-byte")
+	})
+
+	t.Run("rejects-invalid-type", func(t *testing.T) {
+		app, _, _, done := NewMockAppWithFullAPI(t, WithCategory("wallet", walletImport))
+		defer done()
+
+		path := writeTmp(t, pkHex)
+
+		err = app.Run([]string{"wallet", "import", "--format", "hex-eth", "--type", "bls", path})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be 'secp256k1' or 'delegated'")
+	})
 }
 
 func TestWrapMessageFRC0102(t *testing.T) {

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -284,7 +284,8 @@ USAGE:
    lotus wallet export [command options] [address]
 
 OPTIONS:
-   --help, -h  show help
+   --format value  output format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; secp256k1 and delegated keys only) (default: "hex-lotus")
+   --help, -h      show help
 ```
 
 ### lotus wallet import
@@ -297,7 +298,8 @@ USAGE:
    lotus wallet import [command options] [<path> (optional, will read from stdin if omitted)]
 
 OPTIONS:
-   --format value  specify input format for key (default: "hex-lotus")
+   --format value  input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; requires --type) (default: "hex-lotus")
+   --type value    key type for raw private-key formats ('hex-eth'): 'secp256k1' or 'delegated' (default: "delegated")
    --as-default    import the given key as your new default key (default: false)
    --help, -h      show help
 ```

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -298,8 +298,8 @@ USAGE:
    lotus wallet import [command options] [<path> (optional, will read from stdin if omitted)]
 
 OPTIONS:
-   --format value  input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; requires --type) (default: "hex-lotus")
-   --type value    key type for raw private-key formats ('hex-eth'): 'secp256k1' or 'delegated' (default: "delegated")
+   --format value  input format: 'hex-lotus' (hex-encoded JSON KeyInfo), 'json-lotus' (JSON KeyInfo), 'gfc-json' (go-filecoin JSON), 'hex-eth' (raw 32-byte private key as hex, Ethereum-compatible; key type set via --type) (default: "hex-lotus")
+   --type value    key type for raw private-key formats such as 'hex-eth': 'secp256k1' or 'delegated' (default: "delegated")
    --as-default    import the given key as your new default key (default: false)
    --help, -h      show help
 ```


### PR DESCRIPTION
Adds `--format hex-eth` to `lotus wallet export` (raw 32-byte private key as `0x`-prefixed hex) and `lotus wallet import` (with new `--type` flag, defaulting to `delegated`).