### PR TITLE
build: update Lotus Node and Miner version to v1.36.1-dev in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,15 @@
 
 ## ☢️ Upgrade Warnings ☢️
 
-- Minimum go-version supported is go 1.25.7 ([filecoin-project/lotus#13594](https://github.com/filecoin-project/lotus/pull/13594))
-
 ## ⭐ New Features
 
 ## 🐛 Bug Fixes
 
 ## 👌 Improvements
 
-- feat(cliutil): accept non-JWT API tokens in `TOKEN:ADDRESS`, enabling use of third-party RPC providers (e.g. Glif) that issue opaque API keys ([filecoin-project/lotus#13578](https://github.com/filecoin-project/lotus/pull/13578))
-- feat(cli): `lotus wallet export` gains a `--format` flag with a new `hex-eth` value that emits the raw 32-byte private key as hex, directly importable into Ethereum tools (Metamask, ethers.js, foundry). `hex-eth` is also accepted by `lotus wallet import` together with a `--type` flag (`secp256k1` or `delegated`, defaulting to `delegated`). ([filecoin-project/lotus#13586](https://github.com/filecoin-project/lotus/pull/13586))
+# UNRELEASED v1.36.0
+
+See https://github.com/filecoin-project/lotus/blob/release/v1.36.0/CHANGELOG.md
 
 # Node v1.35.1 / 2026-03-31
 

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/v0/gateway.json
+++ b/build/openrpc/v0/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/v2/full.json
+++ b/build/openrpc/v2/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/v2/gateway.json
+++ b/build/openrpc/v2/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "1.35.2-dev"
+        "version": "v1.36.1-dev"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "1.35.2-dev"
+const NodeBuildVersion string = "v1.36.1-dev"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {
@@ -18,7 +18,7 @@ func NodeUserVersion() BuildVersion {
 }
 
 // MinerBuildVersion is the local build version of the Lotus miner
-const MinerBuildVersion = "1.35.2-dev"
+const MinerBuildVersion = "v1.36.1-dev"
 
 func MinerUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -8,7 +8,7 @@ USAGE:
    lotus-miner [global options] command [command options]
 
 VERSION:
-   1.35.2-dev
+   v1.36.1-dev
 
 COMMANDS:
    init     Initialize a lotus miner repo

--- a/documentation/en/cli-lotus-worker.md
+++ b/documentation/en/cli-lotus-worker.md
@@ -8,7 +8,7 @@ USAGE:
    lotus-worker [global options] command [command options]
 
 VERSION:
-   1.35.2-dev
+   v1.36.1-dev
 
 COMMANDS:
    run        Start lotus worker

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -8,7 +8,7 @@ USAGE:
    lotus [global options] command [command options]
 
 VERSION:
-   1.35.2-dev
+   v1.36.1-dev
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/13532

## Proposed Changes
Update Lotus Node and Miner version to v1.36.1-dev in master. Prepare for shipping the Lotus v1.36.0-rc1

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
