### PR TITLE
chore: fix comment formatting and typos across codebase

### DIFF
--- a/blockstore/splitstore/splitstore.go
+++ b/blockstore/splitstore/splitstore.go
@@ -740,7 +740,7 @@ func (s *SplitStore) Start(chain ChainAccessor, us stmgr.UpgradeSchedule) error 
 		s.pruneEpoch = bytesToEpoch(bs)
 	case dstore.ErrNotFound:
 		if curTs == nil {
-			//this can happen in some tests
+			// this can happen in some tests
 			break
 		}
 		if err := s.setPruneEpoch(curTs.Height()); err != nil {

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -88,7 +88,7 @@ func (s *SplitStore) HeadChange(_, apply []*types.TipSet) error {
 	//       progress.
 	//       this is guaranteed by the chainstore, and it is pervasive in all lotus
 	//       -- if that ever changes then all hell will break loose in general and
-	//       we will have a rance to protectTipSets here.
+	//       we will have a chance to protectTipSets here.
 	//      Regardless, we put a mutex in HeadChange just to be safe
 
 	if !atomic.CompareAndSwapInt32(&s.compacting, 0, 1) {

--- a/cmd/lotus-sim/simulation/stages/funding_stage.go
+++ b/cmd/lotus-sim/simulation/stages/funding_stage.go
@@ -58,7 +58,7 @@ func (fs *FundingStage) Fund(bb *blockbuilder.BlockBuilder, target address.Addre
 //  1. Tries to send the given message.
 //  2. If that fails, it checks to see if the exit code was ErrInsufficientFunds.
 //  3. If so, it sends 1K FIL from the "burnt funds actor" (because we need to send it from
-//     somewhere) and re-tries the message.0
+//     somewhere) and re-tries the message.
 func (fs *FundingStage) SendAndFund(bb *blockbuilder.BlockBuilder, msg *types.Message) (res *types.MessageReceipt, err error) {
 	for i := 0; i < 10; i++ {
 		res, err = bb.PushMessage(msg)

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -1212,7 +1212,7 @@ exceeds HotstoreMaxSpaceTarget - HotstoreMaxSpaceThreshold`,
 			Type: "uint64",
 
 			Comment: `Safety buffer to prevent moving GC from overflowing disk when HotStoreMaxSpaceTarget
-is set.  Moving GC will not occur when total moving size exceeds
+is set. Moving GC will not occur when total moving size exceeds
 HotstoreMaxSpaceTarget - HotstoreMaxSpaceSafetyBuffer`,
 		},
 	},

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -510,7 +510,7 @@ type Splitstore struct {
 	HotStoreMaxSpaceThreshold uint64
 
 	// Safety buffer to prevent moving GC from overflowing disk when HotStoreMaxSpaceTarget
-	// is set.  Moving GC will not occur when total moving size exceeds
+	// is set. Moving GC will not occur when total moving size exceeds
 	// HotstoreMaxSpaceTarget - HotstoreMaxSpaceSafetyBuffer
 	HotstoreMaxSpaceSafetyBuffer uint64
 }

--- a/storage/pipeline/checks.go
+++ b/storage/pipeline/checks.go
@@ -176,11 +176,11 @@ func checkPrecommit(ctx context.Context, maddr address.Address, si SectorInfo, t
 		return xerrors.Errorf("checking if sector is allocated: %w", err)
 	}
 	if alloc {
-		//committed P2 message  but commit C2 message too late, pci should be null in this case
+		// committed P2 message but commit C2 message too late, pci should be null in this case
 		return &ErrSectorNumberAllocated{xerrors.Errorf("sector %d is allocated, but PreCommit info wasn't found on chain", si.SectorNumber)}
 	}
 
-	//never commit P2 message before, check ticket expiration
+	// never commit P2 message before, check ticket expiration
 	ticketEarliest := height - policy.MaxPreCommitRandomnessLookback
 
 	if si.TicketEpoch < ticketEarliest {

--- a/storage/sealer/manager.go
+++ b/storage/sealer/manager.go
@@ -363,8 +363,8 @@ func (m *Manager) SectorsUnsealPiece(ctx context.Context, sector storiface.Secto
 		// TODO: make restartable
 
 		// NOTE: we're unsealing the whole sector here as with SDR we can't really
-		//  unseal the sector partially. Requesting the whole sector here can
-		//  save us some work in case another piece is requested from here
+	// unseal the sector partially. Requesting the whole sector here can
+	// save us some work in case another piece is requested from here
 		log.Debugf("calling unseal sector on worker, sectoID=%d", sector.ID)
 
 		// Note: This unseal piece call will essentially become a no-op if the worker already has an Unsealed sector file for the given sector.

--- a/storage/sealer/manager.go
+++ b/storage/sealer/manager.go
@@ -363,8 +363,8 @@ func (m *Manager) SectorsUnsealPiece(ctx context.Context, sector storiface.Secto
 		// TODO: make restartable
 
 		// NOTE: we're unsealing the whole sector here as with SDR we can't really
-	// unseal the sector partially. Requesting the whole sector here can
-	// save us some work in case another piece is requested from here
+		// unseal the sector partially. Requesting the whole sector here can
+		// save us some work in case another piece is requested from here
 		log.Debugf("calling unseal sector on worker, sectoID=%d", sector.ID)
 
 		// Note: This unseal piece call will essentially become a no-op if the worker already has an Unsealed sector file for the given sector.

--- a/storage/sealer/piece_provider.go
+++ b/storage/sealer/piece_provider.go
@@ -26,7 +26,7 @@ type Unsealer interface {
 type PieceProvider interface {
 	// ReadPiece is used to read an Unsealed piece at the given offset and of the given size from a Sector
 	// pieceOffset + pieceSize specify piece bounds for unsealing (note: with SDR the entire sector will be unsealed by
-	//  default in most cases, but this might matter with future PoRep)
+	// default in most cases, but this might matter with future PoRep)
 	// startOffset is added to the pieceOffset to get the starting reader offset.
 	// The number of bytes that can be read is pieceSize-startOffset
 	ReadPiece(ctx context.Context, sector storiface.SectorRef, pieceOffset storiface.UnpaddedByteIndex, pieceSize abi.UnpaddedPieceSize, ticket abi.SealRandomness, unsealed cid.Cid) (storiface.Reader, bool, error)
@@ -169,7 +169,7 @@ var _ io.Closer = funcCloser(nil)
 // ReadPiece is used to read an Unsealed piece at the given offset and of the given size from a Sector
 // If an Unsealed sector file exists with the Piece Unsealed in it, we'll use that for the read.
 // Otherwise, we will Unseal a Sealed sector file for the given sector and read the Unsealed piece from it.
-// If we do NOT have an existing unsealed file  containing the given piece thus causing us to schedule an Unseal,
+// If we do NOT have an existing unsealed file containing the given piece thus causing us to schedule an Unseal,
 // the returned boolean parameter will be set to true.
 // If we have an existing unsealed file containing the given piece, the returned boolean will be set to false.
 func (p *pieceProvider) ReadPiece(ctx context.Context, sector storiface.SectorRef, pieceOffset storiface.UnpaddedByteIndex, size abi.UnpaddedPieceSize, ticket abi.SealRandomness, unsealed cid.Cid) (storiface.Reader, bool, error) {

--- a/storage/sealer/piece_reader.go
+++ b/storage/sealer/piece_reader.go
@@ -153,7 +153,7 @@ func (p *pieceReader) readSeqReader(b []byte) (n int, err error) {
 	// 1. Get the backing reader into the correct position
 
 	// if the backing reader is ahead of the offset we want, or more than
-	//  MaxPieceReaderBurnBytes behind, reset the reader
+	// MaxPieceReaderBurnBytes behind, reset the reader
 	if p.r == nil || p.rAt > off || p.rAt+MaxPieceReaderBurnBytes < off {
 		if p.r != nil {
 			if err := p.r.Close(); err != nil {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->

This commit standardizes comment formatting by ensuring consistent spacing 
after comment markers (//) and fixes minor typos in comments throughout the 
codebase. Changes include:

- Fixed spacing in inline comments to follow Go style conventions
- Corrected typo "rance" to "chance" in splitstore_compact.go
- Removed trailing "0" in funding_stage.go comment
- Removed extra spaces in multi-line comment formatting
- Improved readability of comments in storage sealer components

No functional changes were made; this is purely a documentation and 
formatting improvement.



## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
