### PR TITLE
fix: remove F3 data with existing chain cleanup

### DIFF
--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -15,6 +15,9 @@ import (
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
 	metricsprom "github.com/ipfs/go-metrics-prometheus"
 	"github.com/klauspost/compress/zstd"
 	"github.com/mitchellh/go-homedir"
@@ -696,8 +699,12 @@ func removeExistingChain(cctx *cli.Context, lr repo.Repo) error {
 	if err != nil {
 		return xerrors.Errorf("error locking repo: %w", err)
 	}
+	lockedRepoClosed := false
 	// Ensure that lockedRepo is closed when this function exits
 	defer func() {
+		if lockedRepoClosed {
+			return
+		}
 		if closeErr := lockedRepo.Close(); closeErr != nil {
 			log.Errorf("Error closing the lockedRepo: %v", closeErr)
 		}
@@ -722,8 +729,68 @@ func removeExistingChain(cctx *cli.Context, lr repo.Repo) error {
 		return xerrors.Errorf("error removing chain directory: %w", err)
 	}
 
-	log.Info("chain and splitstore data have been removed")
+	if err := deleteLegacyF3Datastore(cctx, lockedRepo); err != nil {
+		return xerrors.Errorf("error removing legacy F3 datastore entries: %w", err)
+	}
+
+	if err := lockedRepo.Close(); err != nil {
+		return xerrors.Errorf("error closing repo before removing F3 files: %w", err)
+	}
+	lockedRepoClosed = true
+
+	f3DatastorePath := filepath.Join(repoPath, "datastore", "f3")
+	log.Info("removing F3 datastore directory:", f3DatastorePath)
+
+	err = os.RemoveAll(f3DatastorePath)
+	if err != nil {
+		return xerrors.Errorf("error removing F3 datastore directory: %w", err)
+	}
+
+	f3Path := filepath.Join(repoPath, "f3")
+	log.Info("removing F3 directory:", f3Path)
+
+	err = os.RemoveAll(f3Path)
+	if err != nil {
+		return xerrors.Errorf("error removing F3 directory: %w", err)
+	}
+
+	log.Info("chain, splitstore, and F3 data have been removed")
 	return nil
+}
+
+func deleteLegacyF3Datastore(cctx *cli.Context, lockedRepo repo.LockedRepo) error {
+	ctx := context.Background()
+	if cctx != nil {
+		ctx = lcli.ReqContext(cctx)
+	}
+
+	mds, err := lockedRepo.Datastore(ctx, "/metadata")
+	if err != nil {
+		return err
+	}
+
+	f3LegacyDs := namespace.Wrap(mds, datastore.NewKey("/f3"))
+	qr, err := f3LegacyDs.Query(ctx, query.Query{KeysOnly: true})
+	if err != nil {
+		return err
+	}
+	defer qr.Close() //nolint:errcheck
+
+	batch, err := f3LegacyDs.Batch(ctx)
+	if err != nil {
+		return err
+	}
+
+	for res, ok := qr.NextSync(); ok; res, ok = qr.NextSync() {
+		if res.Error != nil {
+			return res.Error
+		}
+		if err := batch.Delete(ctx, datastore.NewKey(res.Key)); err != nil {
+			return err
+		}
+	}
+
+	return batch.Commit(ctx)
 }
 
 func deleteSplitstoreDir(lr repo.LockedRepo) error {

--- a/cli/lotus/daemon_test.go
+++ b/cli/lotus/daemon_test.go
@@ -1,0 +1,92 @@
+//go:build !nodaemon
+
+package lotus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+
+	"github.com/filecoin-project/lotus/node/repo"
+)
+
+func TestRemoveExistingChainRemovesF3Data(t *testing.T) {
+	repoPath := t.TempDir()
+
+	r, err := repo.NewFS(repoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Init(repo.FullNode); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	lr, err := r.Lock(repo.FullNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mds, err := lr.Datastore(ctx, "/metadata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyF3Ds := namespace.Wrap(mds, datastore.NewKey("/f3"))
+	if err := legacyF3Ds.Put(ctx, datastore.NewKey("/legacy"), []byte("stale")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mds.Put(ctx, datastore.NewKey("/keep"), []byte("keep")); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	removedDirs := []string{
+		filepath.Join(repoPath, "datastore", "chain"),
+		filepath.Join(repoPath, "datastore", "splitstore"),
+		filepath.Join(repoPath, "datastore", "f3"),
+		filepath.Join(repoPath, "f3"),
+	}
+	for _, dir := range removedDirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "stale"), []byte("stale"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := removeExistingChain(nil, r); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range removedDirs {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, got err: %v", dir, err)
+		}
+	}
+
+	lr, err = r.Lock(repo.FullNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lr.Close() //nolint:errcheck
+
+	mds, err = lr.Datastore(ctx, "/metadata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyF3Ds = namespace.Wrap(mds, datastore.NewKey("/f3"))
+
+	if _, err := legacyF3Ds.Get(ctx, datastore.NewKey("/legacy")); !errors.Is(err, datastore.ErrNotFound) {
+		t.Fatalf("expected legacy F3 metadata to be removed, got err: %v", err)
+	}
+	if _, err := mds.Get(ctx, datastore.NewKey("/keep")); err != nil {
+		t.Fatalf("expected unrelated metadata to remain: %v", err)
+	}
+}


### PR DESCRIPTION
## Related Issues
[Slack thread in the Zondax-channel.](https://filecoinproject.slack.com/archives/C06EK9G28TC/p1777911721915769)

## Proposed Changes
`lotus daemon --import-snapshot --remove-existing-chain` now removes F3 chain-derived data along with the existing chain and splitstore data.

This clears:
- `datastore/f3`, where snapshot-imported F3 certstore data lives
- repo-level `f3` runtime WAL data
- legacy `/f3` entries in the metadata datastore, so the old F3 migration path cannot repopulate stale F3 certstore data after cleanup

## Motivation

`--remove-existing-chain` previously deleted only `datastore/chain` and splitstore data. F3 data could survive the cleanup and interfere with later snapshot imports or startup, especially when the stored initial F3 instance or power table no longer matches the current network manifest.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
