### PR TITLE
fix(eth): use 0-indexed transactionPosition in trace_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ## 🐛 Bug Fixes
 
+- Fix off-by-one in `transactionPosition` returned by `trace_block`, `trace_filter` and `trace_transaction`. Positions were 1-indexed; per the Ethereum trace API spec they are 0-indexed and must match the corresponding `transactionIndex` from `eth_getBlockByNumber`. ([filecoin-project/lotus#13610](https://github.com/filecoin-project/lotus/pull/13610))
+
 ## 👌 Improvements
 
 # UNRELEASED v1.36.0

--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -820,13 +820,13 @@ func TestTraceFilter(t *testing.T) {
 
 	// Assert that initial transactions returned by the trace are valid
 	require.Len(t, traces, 3)
-	require.Equal(t, 1, traces[0].TransactionPosition)
+	require.Equal(t, 0, traces[0].TransactionPosition)
 	require.Equal(t, "call", traces[0].EthTrace.Type)
-	require.Equal(t, 1, traces[1].TransactionPosition)
+	require.Equal(t, 0, traces[1].TransactionPosition)
 	require.Equal(t, "call", traces[1].EthTrace.Type)
 
 	// our transaction will be in the third element of traces with the expected hash
-	require.Equal(t, 1, traces[2].TransactionPosition)
+	require.Equal(t, 0, traces[2].TransactionPosition)
 	require.Equal(t, hash, traces[2].TransactionHash)
 	require.Equal(t, "create", traces[2].EthTrace.Type)
 
@@ -846,7 +846,7 @@ func TestTraceFilter(t *testing.T) {
 
 	// we should only get our contract deploy transaction
 	require.Len(t, tracesAddressFilter, 1)
-	require.Equal(t, 1, tracesAddressFilter[0].TransactionPosition)
+	require.Equal(t, 0, tracesAddressFilter[0].TransactionPosition)
 	require.Equal(t, hash, tracesAddressFilter[0].TransactionHash)
 	require.Equal(t, "create", tracesAddressFilter[0].EthTrace.Type)
 

--- a/node/impl/eth/trace.go
+++ b/node/impl/eth/trace.go
@@ -92,8 +92,6 @@ func (e *ethTrace) EthTraceBlock(ctx context.Context, blkNum string) ([]*ethtype
 			continue
 		}
 
-		msgIdx++
-
 		txHash, err := getTransactionHashByCid(ctx, e.chainStore, ir.MsgCid)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get transaction hash by cid: %w", err)
@@ -121,6 +119,8 @@ func (e *ethTrace) EthTraceBlock(ctx context.Context, blkNum string) ([]*ethtype
 				TransactionPosition: msgIdx,
 			})
 		}
+
+		msgIdx++
 	}
 
 	return allTraces, nil


### PR DESCRIPTION
Thanks to Yan from Blockscout for picking this one up. It's been present since the beginning for these APIs. Confirmed incorrect by querying public Ethereum APIs to make sure they are all zero-based.

```sh
curl "https://filecoin.chain.love/rpc/v1" -s -X POST -H "Content-Type: application/json" \
  --data '{"id":1,"jsonrpc":"2.0","method":"trace_block","params":["latest"]}' \
  | jq '.result | map(.transactionPosition) | unique' | head -5
[
  1,
  2,
  3,
  4,
```

```sh
$ curl "https://docs-demo.quiknode.pro/" -s -X POST -H "Content-Type: application/json" \
  --data '{"id":1,"jsonrpc":"2.0","method":"trace_block","params":["latest"]}' \
  | jq '.result | map(.transactionPosition) | unique' | head -5
[
  0,
  1,
  2,
  3,
```

cc @LesnyRumcajs 