### PR TITLE
fix(api): trace transaction api to return correct error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## ⭐ New Features
 
 ## 🐛 Bug Fixes
+- fix(api): trace transaction api returns the correct error ([filecoin-project/lotus#13614](https://github.com/filecoin-project/lotus/pull/13614))
 
 ## 👌 Improvements
 

--- a/node/impl/eth/trace.go
+++ b/node/impl/eth/trace.go
@@ -438,7 +438,7 @@ func traceIsEVMOrEAM(et *types.ExecutionTrace) bool {
 		return false
 	}
 	return builtinactors.IsEvmActor(et.InvokedActor.State.Code) ||
-		et.InvokedActor.Id != abi.ActorID(builtin.EthereumAddressManagerActorID)
+		et.InvokedActor.Id == abi.ActorID(builtin.EthereumAddressManagerActorID)
 }
 
 func traceErrMsg(et *types.ExecutionTrace) string {


### PR DESCRIPTION
## Related Issues
https://github.com/filecoin-project/lotus/issues/13613

## Proposed Changes
The PR changes now returns true only if the actor is Either EVM or EAM:
 - With this now the trace call returns correct error code in the trace.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green

Trace transaction on hash `0x7285d2336d2c8b351afa17711d910050dc19ff2c0839d07ea85ae17b44721b4c`, now correctly returns error `Reverted`.

Contract:
```solidity
contract AlwaysRevert {                                                                                                                                                                                                                             
      constructor() {                                                                                                                                                                                                                                 
          revert("nope");                                                                                                                                                                                                                             
      }           
  }
```
```text

     {
         "id": 1,
         "jsonrpc": "2.0",
         "result": [
             {
                 "type": "create",
                 "error": "Reverted",
                 "subtraces": 0,
                 "traceAddress": [],
                 "action": {
                     "from": "0xb7aa1e9c847cda5f60f1ae6f65c3eae44848d41f",
                     "gas": "0x5e97ed5",
                     "value": "0x0",
                     "init": "0x6080604052348015600e575f5ffd5b5060405162461bcd60e51b8152600401603f906020808252600490820152636e6f706560e01b604082015260600190565b60405180910390fdfe"
                 },
                 "result": {
                     "gasUsed": "0x1b5acd",
                     "code": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046e6f706500000000000000000000000000000000000000000000000000000000"
                 },
                 "blockHash": "0x46f03eaba68948d6198720c6d0d9fe72830f5f8a53716472fee6a55e564f3b3a",
                 "blockNumber": 3693736,
                 "transactionHash": "0x7285d2336d2c8b351afa17711d910050dc19ff2c0839d07ea85ae17b44721b4c",
                 "transactionPosition": 1
             }
         ]
     }
```