### PR TITLE
fix(eth): scope receipt logs by message, cap event filter across tipsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): `eth_getTransactionReceipt` no longer fails when another transaction in the same block emits a large number of events. `MaxFilterResults` now caps only multi-tipset event queries; single-block calls (`eth_getLogs` with `BlockHash`, `eth_getBlockReceipts`, `eth_getTransactionReceipt`) bypass it. Public RPC operators should apply rate and response-size limits at the proxy layer for these calls; a single response can be large when a block contains log-heavy transactions ([filecoin-project/lotus#13617](https://github.com/filecoin-project/lotus/pull/13617))
+
 ## 👌 Improvements
 
 # UNRELEASED v1.36.0

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -414,7 +414,14 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 
 		var ces []*CollectedEvent
 		var currentID int64 = -1
+		var lastHeight abi.ChainEpoch = -1
+		var tipsetsSeen int
 		var ce *CollectedEvent
+
+		// Queries narrowed to a single message or tipset bypass MaxResults. For range queries,
+		// the cap is enforced as a hard limit once events come from more than one tipset; a
+		// range whose events all live in one tipset may exceed MaxResults.
+		enforceMaxResults := f.MaxResults > 0 && f.TipsetCid == cid.Undef && f.MsgCid == cid.Undef
 
 		for q.Next() {
 			select {
@@ -457,24 +464,27 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 				return nil, xerrors.Errorf("read prefill row: %w", err)
 			}
 
-			// The query will return all entries for all matching events, so we need to keep track
-			// of which event we are dealing with and create a new one each time we see a new id
+			// The query returns all entries for all matching events; create a new CollectedEvent each time we see a new id.
 			if row.id != currentID {
-				// Unfortunately we can't easily incorporate the max results limit into the query due to the
-				// unpredictable number of rows caused by joins
-				// Error here to inform the caller that we've hit the max results limit
-				if f.MaxResults > 0 && len(ces) >= f.MaxResults {
-					return nil, ErrMaxResultsReached
+				rowHeight := abi.ChainEpoch(row.height)
+				if rowHeight != lastHeight {
+					tipsetsSeen++
+					lastHeight = rowHeight
 				}
 
 				currentID = row.id
 				ce = &CollectedEvent{
 					EventIdx: row.eventIndex,
 					Reverted: row.reverted,
-					Height:   abi.ChainEpoch(row.height),
+					Height:   rowHeight,
 					MsgIdx:   row.messageIndex,
 				}
 				ces = append(ces, ce)
+
+				// Hard cap once events span multiple tipsets; a single contributing tipset may bust.
+				if enforceMaxResults && tipsetsSeen > 1 && len(ces) > f.MaxResults {
+					return nil, ErrMaxResultsReached
+				}
 
 				if row.emitterAddr == nil {
 					ce.EmitterAddr, err = address.NewIDAddress(row.emitterID)
@@ -612,6 +622,11 @@ func makePrefillFilterQuery(f *EventFilter) ([]any, string, error) {
 		// unless asking for a specific tipset, we never want to see reverted historical events
 		clauses = append(clauses, "e.reverted=?")
 		values = append(values, false)
+	}
+
+	if f.MsgCid != cid.Undef {
+		clauses = append(clauses, "tm.message_cid=?")
+		values = append(values, f.MsgCid.Bytes())
 	}
 
 	if len(f.Addresses) > 0 {

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -433,11 +433,6 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 			lastEmitterAddrBytes string          // valid when !lastEmitterIsID && set
 		)
 
-		// Queries narrowed to a single message or tipset bypass MaxResults. For range queries,
-		// the cap is enforced as a hard limit once events come from more than one tipset; a
-		// range whose events all live in one tipset may exceed MaxResults.
-		enforceMaxResults := f.MaxResults > 0 && f.TipsetCid == cid.Undef && f.MsgCid == cid.Undef
-
 		// Reused across rows; declaring inside the loop allocates fresh slots each iteration.
 		var row struct {
 			id           int64
@@ -497,8 +492,10 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 				}
 				ces = append(ces, ce)
 
-				// Hard cap once events span multiple tipsets; a single contributing tipset may bust.
-				if enforceMaxResults && tipsetsSeen > 1 && len(ces) > f.MaxResults {
+				// MaxResults applies as a hard cap only once events span more than one tipset;
+				// a single contributing tipset may exceed the cap. Single-tipset and
+				// single-message queries naturally bypass this because tipsetsSeen stays at 1.
+				if f.MaxResults > 0 && tipsetsSeen > 1 && len(ces) > f.MaxResults {
 					return nil, ErrMaxResultsReached
 				}
 

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -418,6 +418,12 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 		var tipsetsSeen int
 		var ce *CollectedEvent
 
+		// Rows are sorted by (height, message_index, event_index), so consecutive events
+		// usually share tipset_key_cid and message_cid; cache the last seen to skip work.
+		var lastTsKeyCid cid.Cid
+		var lastTsKey types.TipSetKey
+		var lastMsgCid cid.Cid
+
 		// Queries narrowed to a single message or tipset bypass MaxResults. For range queries,
 		// the cap is enforced as a hard limit once events come from more than one tipset; a
 		// range whose events all live in one tipset may exceed MaxResults.
@@ -498,25 +504,29 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 					}
 				}
 
-				tsKeyCid, err := cid.Cast(row.tipsetKeyCid)
-				if err != nil {
-					return nil, xerrors.Errorf("parse tipsetkey cid: %w", err)
+				if string(row.tipsetKeyCid) != lastTsKeyCid.KeyString() {
+					lastTsKeyCid, err = cid.Cast(row.tipsetKeyCid)
+					if err != nil {
+						return nil, xerrors.Errorf("parse tipsetkey cid: %w", err)
+					}
+					ts, err := si.cs.GetTipSetByCid(ctx, lastTsKeyCid)
+					if err != nil {
+						return nil, xerrors.Errorf("get tipset by cid: %w", err)
+					}
+					if ts == nil {
+						return nil, xerrors.Errorf("failed to get tipset from cid: tipset is nil for cid: %s", lastTsKeyCid)
+					}
+					lastTsKey = ts.Key()
 				}
+				ce.TipSetKey = lastTsKey
 
-				ts, err := si.cs.GetTipSetByCid(ctx, tsKeyCid)
-				if err != nil {
-					return nil, xerrors.Errorf("get tipset by cid: %w", err)
+				if string(row.messageCid) != lastMsgCid.KeyString() {
+					lastMsgCid, err = cid.Cast(row.messageCid)
+					if err != nil {
+						return nil, xerrors.Errorf("parse message cid: %w", err)
+					}
 				}
-				if ts == nil {
-					return nil, xerrors.Errorf("failed to get tipset from cid: tipset is nil for cid: %s", tsKeyCid)
-				}
-
-				ce.TipSetKey = ts.Key()
-
-				ce.MsgCid, err = cid.Cast(row.messageCid)
-				if err != nil {
-					return nil, xerrors.Errorf("parse message cid: %w", err)
-				}
+				ce.MsgCid = lastMsgCid
 			}
 
 			ce.Entries = append(ce.Entries, types.EventEntry{

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -424,32 +424,42 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 		var lastTsKey types.TipSetKey
 		var lastMsgCid cid.Cid
 
+		// Memoize emitter address; the flag handles invalidation when the source path
+		// switches between ID actor and delegated bytes.
+		var (
+			lastEmitterAddr      address.Address // address.Undef until first set
+			lastEmitterIsID      bool            // true if last was derived from emitterID
+			lastEmitterID        uint64          // valid when lastEmitterIsID
+			lastEmitterAddrBytes string          // valid when !lastEmitterIsID && set
+		)
+
 		// Queries narrowed to a single message or tipset bypass MaxResults. For range queries,
 		// the cap is enforced as a hard limit once events come from more than one tipset; a
 		// range whose events all live in one tipset may exceed MaxResults.
 		enforceMaxResults := f.MaxResults > 0 && f.TipsetCid == cid.Undef && f.MsgCid == cid.Undef
+
+		// Reused across rows; declaring inside the loop allocates fresh slots each iteration.
+		var row struct {
+			id           int64
+			height       uint64
+			tipsetKeyCid []byte
+			emitterID    uint64
+			emitterAddr  []byte
+			eventIndex   int
+			messageCid   []byte
+			messageIndex int
+			reverted     bool
+			flags        []byte
+			key          string
+			codec        uint64
+			value        []byte
+		}
 
 		for q.Next() {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			default:
-			}
-
-			var row struct {
-				id           int64
-				height       uint64
-				tipsetKeyCid []byte
-				emitterID    uint64
-				emitterAddr  []byte
-				eventIndex   int
-				messageCid   []byte
-				messageIndex int
-				reverted     bool
-				flags        []byte
-				key          string
-				codec        uint64
-				value        []byte
 			}
 
 			if err := q.Scan(
@@ -493,16 +503,25 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 				}
 
 				if row.emitterAddr == nil {
-					ce.EmitterAddr, err = address.NewIDAddress(row.emitterID)
-					if err != nil {
-						return nil, xerrors.Errorf("failed to parse emitter id: %w", err)
+					if !lastEmitterIsID || row.emitterID != lastEmitterID || lastEmitterAddr == address.Undef {
+						lastEmitterAddr, err = address.NewIDAddress(row.emitterID)
+						if err != nil {
+							return nil, xerrors.Errorf("failed to parse emitter id: %w", err)
+						}
+						lastEmitterIsID = true
+						lastEmitterID = row.emitterID
 					}
 				} else {
-					ce.EmitterAddr, err = address.NewFromBytes(row.emitterAddr)
-					if err != nil {
-						return nil, xerrors.Errorf("parse emitter addr: %w", err)
+					if lastEmitterIsID || string(row.emitterAddr) != lastEmitterAddrBytes || lastEmitterAddr == address.Undef {
+						lastEmitterAddr, err = address.NewFromBytes(row.emitterAddr)
+						if err != nil {
+							return nil, xerrors.Errorf("parse emitter addr: %w", err)
+						}
+						lastEmitterIsID = false
+						lastEmitterAddrBytes = string(row.emitterAddr)
 					}
 				}
+				ce.EmitterAddr = lastEmitterAddr
 
 				if string(row.tipsetKeyCid) != lastTsKeyCid.KeyString() {
 					lastTsKeyCid, err = cid.Cast(row.tipsetKeyCid)

--- a/chain/index/events_test.go
+++ b/chain/index/events_test.go
@@ -628,8 +628,7 @@ func TestMaxFilterResults(t *testing.T) {
 	// Apply the indexer to process the tipsets
 	require.NoError(t, si.Apply(ctx, fakeTipSet1, fakeTipSet2))
 
-	// if we hit max results, we should get an error
-	// we have total 4 events
+	// All 4 events are in one tipset; MaxResults applies at tipset boundaries so no bisection occurs.
 	testCases := []struct {
 		name          string
 		maxResults    int
@@ -637,8 +636,8 @@ func TestMaxFilterResults(t *testing.T) {
 		expectedErr   string
 	}{
 		{name: "no max results", maxResults: 0, expectedCount: 4},
-		{name: "max result more that total events", maxResults: 10, expectedCount: 4},
-		{name: "max results less than total events", maxResults: 1, expectedErr: ErrMaxResultsReached.Error()},
+		{name: "max above total events", maxResults: 10, expectedCount: 4},
+		{name: "max below tipset event count returns full tipset", maxResults: 1, expectedCount: 4},
 	}
 
 	for _, tc := range testCases {
@@ -659,6 +658,294 @@ func TestMaxFilterResults(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TipsetCid-scoped queries return every event for the tipset regardless of MaxResults;
+// eth_getTransactionReceipt and eth_getLogs-by-block-hash depend on this.
+func TestMaxFilterResultsTipsetCidBypass(t *testing.T) {
+	ctx := context.Background()
+	seed := time.Now().UnixNano()
+	t.Logf("seed: %d", seed)
+	rng := pseudo.New(pseudo.NewSource(seed))
+	headHeight := abi.ChainEpoch(60)
+
+	si, _, cs := setupWithHeadIndexed(t, headHeight, rng)
+	t.Cleanup(func() { _ = si.Close() })
+
+	events := []types.Event{
+		*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "type", v: []byte("a")}}, multicodec.Raw),
+		*fakeEventWithCodec(abi.ActorID(2), []kv{{k: "type", v: []byte("b")}}, multicodec.Raw),
+		*fakeEventWithCodec(abi.ActorID(3), []kv{{k: "type", v: []byte("c")}}, multicodec.Raw),
+		*fakeEventWithCodec(abi.ActorID(4), []kv{{k: "type", v: []byte("d")}}, multicodec.Raw),
+	}
+
+	fm := fakeMessage(address.TestAddress, address.TestAddress)
+	em1 := executedMessage{msg: fm, evs: events}
+
+	si.SetActorToDelegatedAddresFunc(func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool) {
+		idAddr, err := address.NewIDAddress(uint64(emitter))
+		if err != nil {
+			return address.Undef, false
+		}
+		return idAddr, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(ctx context.Context, cs ChainStore, msgTs, rctTs *types.TipSet) ([]executedMessage, error) {
+		return []executedMessage{em1}, nil
+	})
+
+	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
+	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1)
+	cs.SetTipsetByHeightAndKey(2, fakeTipSet2.Key(), fakeTipSet2)
+	cs.SetTipSetByCid(t, fakeTipSet1)
+	cs.SetTipSetByCid(t, fakeTipSet2)
+	cs.SetMessagesForTipset(fakeTipSet1, []types.ChainMsg{fm})
+	require.NoError(t, si.Apply(ctx, fakeTipSet1, fakeTipSet2))
+
+	tsCid, err := fakeTipSet1.Key().Cid()
+	require.NoError(t, err)
+
+	f := &EventFilter{
+		TipsetCid:  tsCid,
+		MaxResults: 1,
+	}
+	ces, err := si.GetEventsForFilter(ctx, f)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(ces))
+}
+
+// MaxResults is a hard cap once a range query's events span more than one tipset; a
+// single contributing tipset may exceed MaxResults but two or more tipsets together
+// must not.
+func TestMaxFilterResultsTipsetBoundary(t *testing.T) {
+	ctx := context.Background()
+	seed := time.Now().UnixNano()
+	t.Logf("seed: %d", seed)
+	rng := pseudo.New(pseudo.NewSource(seed))
+	headHeight := abi.ChainEpoch(60)
+
+	si, _, cs := setupWithHeadIndexed(t, headHeight, rng)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool) {
+		idAddr, err := address.NewIDAddress(uint64(emitter))
+		if err != nil {
+			return address.Undef, false
+		}
+		return idAddr, true
+	})
+
+	// Two events at height 1, two events at height 2.
+	fm1 := fakeMessage(address.TestAddress, address.TestAddress)
+	fm2 := fakeMessage(address.TestAddress, address.TestAddress)
+	fm2.Nonce = 198
+	em1 := executedMessage{
+		msg: fm1,
+		evs: []types.Event{
+			*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "type", v: []byte("a")}}, multicodec.Raw),
+			*fakeEventWithCodec(abi.ActorID(2), []kv{{k: "type", v: []byte("b")}}, multicodec.Raw),
+		},
+	}
+	em2 := executedMessage{
+		msg: fm2,
+		evs: []types.Event{
+			*fakeEventWithCodec(abi.ActorID(3), []kv{{k: "type", v: []byte("c")}}, multicodec.Raw),
+			*fakeEventWithCodec(abi.ActorID(4), []kv{{k: "type", v: []byte("d")}}, multicodec.Raw),
+		},
+	}
+
+	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
+	fakeTipSet3 := fakeTipSet(t, rng, 3, nil)
+	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1)
+	cs.SetTipsetByHeightAndKey(2, fakeTipSet2.Key(), fakeTipSet2)
+	cs.SetTipsetByHeightAndKey(3, fakeTipSet3.Key(), fakeTipSet3)
+	cs.SetTipSetByCid(t, fakeTipSet1)
+	cs.SetTipSetByCid(t, fakeTipSet2)
+	cs.SetTipSetByCid(t, fakeTipSet3)
+	cs.SetMessagesForTipset(fakeTipSet1, []types.ChainMsg{fm1})
+	cs.SetMessagesForTipset(fakeTipSet2, []types.ChainMsg{fm2})
+
+	si.setExecutedMessagesLoaderFunc(func(ctx context.Context, cs ChainStore, msgTs, rctTs *types.TipSet) ([]executedMessage, error) {
+		return []executedMessage{em1}, nil
+	})
+	require.NoError(t, si.Apply(ctx, fakeTipSet1, fakeTipSet2))
+
+	si.setExecutedMessagesLoaderFunc(func(ctx context.Context, cs ChainStore, msgTs, rctTs *types.TipSet) ([]executedMessage, error) {
+		return []executedMessage{em2}, nil
+	})
+	require.NoError(t, si.Apply(ctx, fakeTipSet2, fakeTipSet3))
+
+	testCases := []struct {
+		name          string
+		maxResults    int
+		expectedCount int
+		expectedErr   string
+	}{
+		{name: "no max results returns all", maxResults: 0, expectedCount: 4},
+		{name: "max above total returns all", maxResults: 10, expectedCount: 4},
+		{name: "max equal to total returns all", maxResults: 4, expectedCount: 4},
+		{name: "max below total fires", maxResults: 3, expectedErr: ErrMaxResultsReached.Error()},
+		{name: "max equal to first tipset count fires", maxResults: 2, expectedErr: ErrMaxResultsReached.Error()},
+		{name: "max below first tipset count fires", maxResults: 1, expectedErr: ErrMaxResultsReached.Error()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &EventFilter{
+				MinHeight:  1,
+				MaxHeight:  2,
+				MaxResults: tc.maxResults,
+			}
+
+			ces, err := si.GetEventsForFilter(ctx, f)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedCount, len(ces))
+			}
+		})
+	}
+}
+
+// MsgCid restricts filter queries to events emitted by a single message; this exercises
+// per-tx scoping for eth_getTransactionReceipt against a tipset that contains other
+// messages. The MsgCid path also bypasses MaxResults because the natural unit is the
+// message's events.
+func TestEventFilterMsgCid(t *testing.T) {
+	ctx := context.Background()
+	seed := time.Now().UnixNano()
+	t.Logf("seed: %d", seed)
+	rng := pseudo.New(pseudo.NewSource(seed))
+	headHeight := abi.ChainEpoch(60)
+
+	si, _, cs := setupWithHeadIndexed(t, headHeight, rng)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(ctx context.Context, emitter abi.ActorID, ts *types.TipSet) (address.Address, bool) {
+		idAddr, err := address.NewIDAddress(uint64(emitter))
+		if err != nil {
+			return address.Undef, false
+		}
+		return idAddr, true
+	})
+
+	// Two messages in the same tipset; each emits two events.
+	fm1 := fakeMessage(address.TestAddress, address.TestAddress)
+	fm2 := fakeMessage(address.TestAddress, address.TestAddress)
+	fm2.Nonce = 198
+	em1 := executedMessage{
+		msg: fm1,
+		evs: []types.Event{
+			*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "type", v: []byte("m1a")}}, multicodec.Raw),
+			*fakeEventWithCodec(abi.ActorID(2), []kv{{k: "type", v: []byte("m1b")}}, multicodec.Raw),
+		},
+	}
+	em2 := executedMessage{
+		msg: fm2,
+		evs: []types.Event{
+			*fakeEventWithCodec(abi.ActorID(3), []kv{{k: "type", v: []byte("m2a")}}, multicodec.Raw),
+			*fakeEventWithCodec(abi.ActorID(4), []kv{{k: "type", v: []byte("m2b")}}, multicodec.Raw),
+		},
+	}
+
+	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
+	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1)
+	cs.SetTipsetByHeightAndKey(2, fakeTipSet2.Key(), fakeTipSet2)
+	cs.SetTipSetByCid(t, fakeTipSet1)
+	cs.SetTipSetByCid(t, fakeTipSet2)
+	cs.SetMessagesForTipset(fakeTipSet1, []types.ChainMsg{fm1, fm2})
+
+	si.setExecutedMessagesLoaderFunc(func(ctx context.Context, cs ChainStore, msgTs, rctTs *types.TipSet) ([]executedMessage, error) {
+		return []executedMessage{em1, em2}, nil
+	})
+	require.NoError(t, si.Apply(ctx, fakeTipSet1, fakeTipSet2))
+
+	tsCid, err := fakeTipSet1.Key().Cid()
+	require.NoError(t, err)
+	otherTsCid, err := fakeTipSet2.Key().Cid()
+	require.NoError(t, err)
+
+	requireEventEmitter := func(t *testing.T, ces []*CollectedEvent, expectedEmitters ...abi.ActorID) {
+		t.Helper()
+		require.Equal(t, len(expectedEmitters), len(ces))
+		for i, ce := range ces {
+			expected, err := address.NewIDAddress(uint64(expectedEmitters[i]))
+			require.NoError(t, err)
+			require.Equal(t, expected, ce.EmitterAddr)
+		}
+	}
+
+	t.Run("MsgCid scopes to single message", func(t *testing.T) {
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			MinHeight: 1,
+			MaxHeight: 1,
+			MsgCid:    fm1.Cid(),
+		})
+		require.NoError(t, err)
+		requireEventEmitter(t, ces, 1, 2)
+
+		ces, err = si.GetEventsForFilter(ctx, &EventFilter{
+			MinHeight: 1,
+			MaxHeight: 1,
+			MsgCid:    fm2.Cid(),
+		})
+		require.NoError(t, err)
+		requireEventEmitter(t, ces, 3, 4)
+	})
+
+	t.Run("without MsgCid returns all messages' events", func(t *testing.T) {
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			MinHeight: 1,
+			MaxHeight: 1,
+		})
+		require.NoError(t, err)
+		requireEventEmitter(t, ces, 1, 2, 3, 4)
+	})
+
+	t.Run("MsgCid combined with matching TipsetCid", func(t *testing.T) {
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			TipsetCid: tsCid,
+			MsgCid:    fm1.Cid(),
+		})
+		require.NoError(t, err)
+		requireEventEmitter(t, ces, 1, 2)
+	})
+
+	t.Run("MsgCid combined with mismatched TipsetCid returns nothing", func(t *testing.T) {
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			TipsetCid: otherTsCid,
+			MsgCid:    fm1.Cid(),
+		})
+		require.NoError(t, err)
+		require.Empty(t, ces)
+	})
+
+	t.Run("MsgCid not present in tipset returns nothing", func(t *testing.T) {
+		// A valid CID the indexer has not seen as a message; the tipset is indexed so the
+		// filter just returns no rows.
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			MinHeight: 1,
+			MaxHeight: 1,
+			MsgCid:    tsCid,
+		})
+		require.NoError(t, err)
+		require.Empty(t, ces)
+	})
+
+	t.Run("MsgCid bypasses MaxResults", func(t *testing.T) {
+		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
+			MinHeight:  1,
+			MaxHeight:  1,
+			MsgCid:     fm1.Cid(),
+			MaxResults: 1,
+		})
+		require.NoError(t, err)
+		requireEventEmitter(t, ces, 1, 2)
+	})
 }
 
 func sortAddresses(addrs []address.Address) {

--- a/chain/index/interface.go
+++ b/chain/index/interface.go
@@ -45,6 +45,7 @@ type EventFilter struct {
 	MinHeight abi.ChainEpoch // minimum epoch to apply filter or -1 if no minimum
 	MaxHeight abi.ChainEpoch // maximum epoch to apply filter or -1 if no maximum
 	TipsetCid cid.Cid
+	MsgCid    cid.Cid           // optional: restrict to events emitted by a single message; pairs with TipsetCid or a height range
 	Addresses []address.Address // list of actor addresses that are extpected to emit the event
 
 	KeysWithCodec map[string][]types.ActorEventBlock // map of key names to a list of alternate values that may match

--- a/documentation/en/default-lotus-config.toml
+++ b/documentation/en/default-lotus-config.toml
@@ -273,7 +273,20 @@
   # env var: LOTUS_EVENTS_MAXFILTERS
   #MaxFilters = 100
 
-  # MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.
+  # MaxFilterResults caps the events returned by event filter queries used by the actor
+  # events API (GetActorEventsRaw, SubscribeActorEventsRaw) and the Ethereum event and
+  # receipt APIs (eth_getLogs, eth_getFilterLogs, eth_getFilterChanges,
+  # eth_getBlockReceipts). Set to 0 for no limit.
+  # 
+  # The cap is a hard limit only when a query's events come from more than one tipset.
+  # A range whose events all live in a single tipset may exceed MaxFilterResults; queries
+  # scoped to a single tipset (TipsetCid set, eth_getLogs with a BlockHash,
+  # eth_getBlockReceipts) bypass it entirely. eth_getTransactionReceipt narrows to a
+  # single message at the index level and is also unaffected. The cap exists to bound
+  # the cost of multi-tipset range queries.
+  # 
+  # Self-hosted nodes serving trusted callers can use 0 or a high value. Public RPC
+  # operators should keep it bounded.
   #
   # type: int
   # env var: LOTUS_EVENTS_MAXFILTERRESULTS

--- a/node/config/doc_gen.go
+++ b/node/config/doc_gen.go
@@ -224,7 +224,20 @@ of filters per connection.`,
 			Name: "MaxFilterResults",
 			Type: "int",
 
-			Comment: `MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.`,
+			Comment: `MaxFilterResults caps the events returned by event filter queries used by the actor
+events API (GetActorEventsRaw, SubscribeActorEventsRaw) and the Ethereum event and
+receipt APIs (eth_getLogs, eth_getFilterLogs, eth_getFilterChanges,
+eth_getBlockReceipts). Set to 0 for no limit.
+
+The cap is a hard limit only when a query's events come from more than one tipset.
+A range whose events all live in a single tipset may exceed MaxFilterResults; queries
+scoped to a single tipset (TipsetCid set, eth_getLogs with a BlockHash,
+eth_getBlockReceipts) bypass it entirely. eth_getTransactionReceipt narrows to a
+single message at the index level and is also unaffected. The cap exists to bound
+the cost of multi-tipset range queries.
+
+Self-hosted nodes serving trusted callers can use 0 or a high value. Public RPC
+operators should keep it bounded.`,
 		},
 		{
 			Name: "MaxFilterHeightRange",

--- a/node/config/types.go
+++ b/node/config/types.go
@@ -562,7 +562,20 @@ type EventsConfig struct {
 	// of filters per connection.
 	MaxFilters int
 
-	// MaxFilterResults specifies the maximum number of results that can be accumulated by an actor event filter.
+	// MaxFilterResults caps the events returned by event filter queries used by the actor
+	// events API (GetActorEventsRaw, SubscribeActorEventsRaw) and the Ethereum event and
+	// receipt APIs (eth_getLogs, eth_getFilterLogs, eth_getFilterChanges,
+	// eth_getBlockReceipts). Set to 0 for no limit.
+	//
+	// The cap is a hard limit only when a query's events come from more than one tipset.
+	// A range whose events all live in a single tipset may exceed MaxFilterResults; queries
+	// scoped to a single tipset (TipsetCid set, eth_getLogs with a BlockHash,
+	// eth_getBlockReceipts) bypass it entirely. eth_getTransactionReceipt narrows to a
+	// single message at the index level and is also unaffected. The cap exists to bound
+	// the cost of multi-tipset range queries.
+	//
+	// Self-hosted nodes serving trusted callers can use 0 or a high value. Public RPC
+	// operators should keep it bounded.
 	MaxFilterResults int
 
 	// MaxFilterHeightRange specifies the maximum range of heights that can be used in a filter (to avoid querying

--- a/node/impl/eth/api.go
+++ b/node/impl/eth/api.go
@@ -2,11 +2,11 @@ package eth
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-jsonrpc"
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	ErrChainIndexerDisabled = xerrors.New("chain indexer is disabled; please enable the ChainIndexer to use the ETH RPC API")
-	ErrModuleDisabled       = xerrors.New("module disabled, enable with Fevm.EnableEthRPC / LOTUS_FEVM_ENABLEETHRPC")
+	ErrChainIndexerDisabled  = errors.New("chain indexer is disabled; please enable the ChainIndexer to use the ETH RPC API")
+	ErrModuleDisabled        = errors.New("module disabled, enable with Fevm.EnableEthRPC / LOTUS_FEVM_ENABLEETHRPC")
+	ErrEventsNotYetAvailable = errors.New("events for the requested block are not yet available")
 )
 
 var log = logging.Logger("node/eth")

--- a/node/impl/eth/api.go
+++ b/node/impl/eth/api.go
@@ -132,9 +132,10 @@ type EthEventsAPI interface {
 type EthEventsInternal interface {
 	EthEventsAPI
 
-	// GetEthLogsForBlockAndTransaction returns the logs for a block and transaction, it is intended
-	// for internal use rather than being exposed via the JSON-RPC API.
-	GetEthLogsForBlockAndTransaction(ctx context.Context, blockHash *ethtypes.EthHash, txHash ethtypes.EthHash) ([]ethtypes.EthLog, error)
+	// GetEthLogsForBlockAndTransaction returns the logs for a single message in a tipset; the
+	// caller supplies the message CID directly so the indexer query is narrowed at the SQL
+	// level. Intended for internal use rather than being exposed via the JSON-RPC API.
+	GetEthLogsForBlockAndTransaction(ctx context.Context, blockHash *ethtypes.EthHash, msgCid cid.Cid) ([]ethtypes.EthLog, error)
 	// GC runs a garbage collection loop, deleting filters that have not been used within the ttl
 	// window, it is intended for internal use rather than being exposed via the JSON-RPC API.
 	GC(ctx context.Context, ttl time.Duration)

--- a/node/impl/eth/events.go
+++ b/node/impl/eth/events.go
@@ -316,21 +316,45 @@ func (e *ethEvents) EthUnsubscribe(ctx context.Context, id ethtypes.EthSubscript
 }
 
 func (e *ethEvents) GetEthLogsForBlockAndTransaction(ctx context.Context, blockHash *ethtypes.EthHash, txHash ethtypes.EthHash) ([]ethtypes.EthLog, error) {
-	ces, err := e.ethGetEventsForFilter(ctx, &ethtypes.EthFilterSpec{BlockHash: blockHash})
+	if e.eventFilterManager == nil {
+		return nil, api.ErrNotSupported
+	}
+	if e.chainIndexer == nil {
+		return nil, ErrChainIndexerDisabled
+	}
+	if blockHash == nil {
+		return nil, errors.New("block hash is required")
+	}
+
+	msgCid, err := e.chainIndexer.GetCidFromHash(ctx, txHash)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to resolve transaction hash: %w", err)
 	}
-	logs, err := ethFilterLogsFromEvents(ctx, ces, e.chainStore, e.stateManager)
+	if msgCid == cid.Undef {
+		return nil, nil
+	}
+
+	tipsetCid := blockHash.ToCid()
+	ts, err := e.chainStore.GetTipSetByCid(ctx, tipsetCid)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to get tipset by cid: %w", err)
 	}
-	var out []ethtypes.EthLog
-	for _, log := range logs {
-		if log.TransactionHash == txHash {
-			out = append(out, log)
-		}
+	if ts.Height() >= e.chainStore.GetHeaviestTipSet().Height() {
+		return nil, ErrEventsNotYetAvailable
 	}
-	return out, nil
+
+	ces, err := e.chainIndexer.GetEventsForFilter(ctx, &index.EventFilter{
+		MinHeight: -1,
+		MaxHeight: -1,
+		TipsetCid: tipsetCid,
+		MsgCid:    msgCid,
+		Codec:     multicodec.Raw,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get events for filter from chain indexer: %w", err)
+	}
+
+	return ethFilterLogsFromEvents(ctx, ces, e.chainStore, e.stateManager)
 }
 
 // GC runs a garbage collection loop, deleting filters that have not been used within the ttl window
@@ -379,12 +403,12 @@ func (e *ethEvents) ethGetEventsForFilter(ctx context.Context, filterSpec *ethty
 			return nil, xerrors.Errorf("failed to get tipset by cid: %w", err)
 		}
 		if ts.Height() >= head.Height() {
-			return nil, xerrors.New("cannot ask for events for a tipset at or greater than head")
+			return nil, ErrEventsNotYetAvailable
 		}
 	}
 
 	if pf.minHeight >= head.Height() || pf.maxHeight >= head.Height() {
-		return nil, xerrors.New("cannot ask for events for a tipset at or greater than head")
+		return nil, ErrEventsNotYetAvailable
 	}
 
 	ef := &index.EventFilter{

--- a/node/impl/eth/events.go
+++ b/node/impl/eth/events.go
@@ -473,6 +473,38 @@ func ethFilterResultFromMessages(cs []*types.SignedMessage) (*ethtypes.EthFilter
 }
 
 func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, cs ChainStore, sa StateManager) ([]ethtypes.EthLog, error) {
+	// Skip re-resolving msg->txHash and tipset->blockHash on every emitted log. Per-result
+	// (msg, tipset) sets are small (bounded by messages-per-block * tipsets-per-range).
+	txHashByMsg := make(map[cid.Cid]ethtypes.EthHash)
+	txHashFor := func(c cid.Cid) (ethtypes.EthHash, error) {
+		if h, ok := txHashByMsg[c]; ok {
+			return h, nil
+		}
+		h, err := ethTxHashFromMessageCid(ctx, c, cs)
+		if err != nil {
+			return ethtypes.EmptyEthHash, err
+		}
+		txHashByMsg[c] = h
+		return h, nil
+	}
+
+	blockHashByTipset := make(map[types.TipSetKey]ethtypes.EthHash)
+	blockHashFor := func(tsk types.TipSetKey) (ethtypes.EthHash, error) {
+		if h, ok := blockHashByTipset[tsk]; ok {
+			return h, nil
+		}
+		c, err := tsk.Cid()
+		if err != nil {
+			return ethtypes.EmptyEthHash, err
+		}
+		h, err := ethtypes.EthHashFromCid(c)
+		if err != nil {
+			return ethtypes.EmptyEthHash, err
+		}
+		blockHashByTipset[tsk] = h
+		return h, nil
+	}
+
 	var logs []ethtypes.EthLog
 	for _, ev := range evs {
 		log := ethtypes.EthLog{
@@ -496,7 +528,7 @@ func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, c
 			return nil, err
 		}
 
-		log.TransactionHash, err = ethTxHashFromMessageCid(ctx, ev.MsgCid, cs)
+		log.TransactionHash, err = txHashFor(ev.MsgCid)
 		if err != nil {
 			return nil, err
 		}
@@ -504,11 +536,8 @@ func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, c
 			// We've garbage collected the message, ignore the events and continue.
 			continue
 		}
-		c, err := ev.TipSetKey.Cid()
-		if err != nil {
-			return nil, err
-		}
-		log.BlockHash, err = ethtypes.EthHashFromCid(c)
+
+		log.BlockHash, err = blockHashFor(ev.TipSetKey)
 		if err != nil {
 			return nil, err
 		}

--- a/node/impl/eth/events.go
+++ b/node/impl/eth/events.go
@@ -315,7 +315,7 @@ func (e *ethEvents) EthUnsubscribe(ctx context.Context, id ethtypes.EthSubscript
 	return true, nil
 }
 
-func (e *ethEvents) GetEthLogsForBlockAndTransaction(ctx context.Context, blockHash *ethtypes.EthHash, txHash ethtypes.EthHash) ([]ethtypes.EthLog, error) {
+func (e *ethEvents) GetEthLogsForBlockAndTransaction(ctx context.Context, blockHash *ethtypes.EthHash, msgCid cid.Cid) ([]ethtypes.EthLog, error) {
 	if e.eventFilterManager == nil {
 		return nil, api.ErrNotSupported
 	}
@@ -325,13 +325,8 @@ func (e *ethEvents) GetEthLogsForBlockAndTransaction(ctx context.Context, blockH
 	if blockHash == nil {
 		return nil, errors.New("block hash is required")
 	}
-
-	msgCid, err := e.chainIndexer.GetCidFromHash(ctx, txHash)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to resolve transaction hash: %w", err)
-	}
 	if msgCid == cid.Undef {
-		return nil, nil
+		return nil, errors.New("message cid is required")
 	}
 
 	tipsetCid := blockHash.ToCid()

--- a/node/impl/eth/events.go
+++ b/node/impl/eth/events.go
@@ -473,8 +473,9 @@ func ethFilterResultFromMessages(cs []*types.SignedMessage) (*ethtypes.EthFilter
 }
 
 func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, cs ChainStore, sa StateManager) ([]ethtypes.EthLog, error) {
-	// Skip re-resolving msg->txHash and tipset->blockHash on every emitted log. Per-result
-	// (msg, tipset) sets are small (bounded by messages-per-block * tipsets-per-range).
+	// Skip re-resolving msg->txHash, tipset->blockHash, and emitter->EthAddress on every
+	// emitted log. The set of distinct (msg, tipset, emitter) tuples in any filter result
+	// is small relative to the log count, so plain maps suffice.
 	txHashByMsg := make(map[cid.Cid]ethtypes.EthHash)
 	txHashFor := func(c cid.Cid) (ethtypes.EthHash, error) {
 		if h, ok := txHashByMsg[c]; ok {
@@ -505,7 +506,20 @@ func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, c
 		return h, nil
 	}
 
-	var logs []ethtypes.EthLog
+	ethAddrByEmitter := make(map[address.Address]ethtypes.EthAddress)
+	ethAddrFor := func(a address.Address) (ethtypes.EthAddress, error) {
+		if e, ok := ethAddrByEmitter[a]; ok {
+			return e, nil
+		}
+		e, err := ethtypes.EthAddressFromFilecoinAddress(a)
+		if err != nil {
+			return ethtypes.EthAddress{}, err
+		}
+		ethAddrByEmitter[a] = e
+		return e, nil
+	}
+
+	logs := make([]ethtypes.EthLog, 0, len(evs))
 	for _, ev := range evs {
 		log := ethtypes.EthLog{
 			Removed:          ev.Reverted,
@@ -523,7 +537,7 @@ func ethFilterLogsFromEvents(ctx context.Context, evs []*index.CollectedEvent, c
 			continue
 		}
 
-		log.Address, err = ethtypes.EthAddressFromFilecoinAddress(ev.EmitterAddr)
+		log.Address, err = ethAddrFor(ev.EmitterAddr)
 		if err != nil {
 			return nil, err
 		}

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -337,7 +337,7 @@ func (e *ethTransaction) EthGetTransactionReceiptLimited(ctx context.Context, tx
 
 	baseFee := parentTs.Blocks()[0].ParentBaseFee
 
-	receipt, err := newEthTxReceipt(ctx, tx, baseFee, msgLookup.Receipt, e.ethEvents)
+	receipt, err := newEthTxReceipt(ctx, tx, c, baseFee, msgLookup.Receipt, e.ethEvents)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create Eth receipt: %w", err)
 	}
@@ -390,7 +390,7 @@ func (e *ethTransaction) EthGetBlockReceiptsLimited(ctx context.Context, blockPa
 			return nil, xerrors.Errorf("failed to create EthTx: %w", err)
 		}
 
-		receipt, err := newEthTxReceipt(ctx, tx, baseFee, receipts[i], e.ethEvents)
+		receipt, err := newEthTxReceipt(ctx, tx, msg.Cid(), baseFee, receipts[i], e.ethEvents)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to create Eth receipt: %w", err)
 		}

--- a/node/impl/eth/utils.go
+++ b/node/impl/eth/utils.go
@@ -445,7 +445,7 @@ func newEthTx(
 	return tx, nil
 }
 
-func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, baseFee big.Int, msgReceipt types.MessageReceipt, ev EthEventsInternal) (ethtypes.EthTxReceipt, error) {
+func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, msgCid cid.Cid, baseFee big.Int, msgReceipt types.MessageReceipt, ev EthEventsInternal) (ethtypes.EthTxReceipt, error) {
 	var (
 		transactionIndex ethtypes.EthUint64
 		blockHash        ethtypes.EthHash
@@ -515,7 +515,7 @@ func newEthTxReceipt(ctx context.Context, tx ethtypes.EthTx, baseFee big.Int, ms
 	}
 
 	if rct := msgReceipt; rct.EventsRoot != nil {
-		logs, err := ev.GetEthLogsForBlockAndTransaction(ctx, &blockHash, tx.Hash)
+		logs, err := ev.GetEthLogsForBlockAndTransaction(ctx, &blockHash, msgCid)
 		if err != nil {
 			return ethtypes.EthTxReceipt{}, xerrors.Errorf("failed to get eth logs for block and transaction: %w", err)
 		}


### PR DESCRIPTION
eth_getTransactionReceipt narrows event lookup to the requested message at the index level, so a transaction emitting many events no longer blocks receipt retrieval for other transactions in the same block. MaxFilterResults is now a hard cap only when a query's events span more than one tipset; single-tipset queries (TipsetCid, BlockHash) bypass it.

Fixes: https://github.com/filecoin-project/lotus/issues/13616

---

I want to get some RPC API operators involved in this because it does have implications for response forms. The current implementation will just error when you try to eth_getTransactionReceipt or eth_getBlockReceipts where there are more than `MaxFilterResults` logs in the collection (tx for the former, all tx's in the block for the latter, and MaxFilterResults default is 10,000). This removes the cap entirely for queries scoped to a single tipset, and narrows the receipt path further to events for the requested transaction, so it'll faithfully return what's there. `MaxFilterResults` applies where a query spans tipsets, so we always give you a way to get transactions, but if it's expensive we'll force you to get more granular. But, this means the maximum number of logs is going to be bigger than now so the JSON serialised form will be much larger, meaning much larger response bodies.

We have an example on calibnet now that's a useful reference thanks to @wjmelements:

```sh
$ curl -s -X POST -H "Content-Type: application/json" --data \
  '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x547fd9f825662cf2d587a122e04bc0e3a7dd124813bcd9383ee76cde0fe45157"],"id":1}' \
  http://localhost:1235/rpc/v1 > receipt.json
$ du -h receipt.json
84M     receipt.json
```

This msg used 8B gas, and has 216,000 logs in a single transaction. A lot of the noise in the json is not raw log content, so there's not quite so much variation in what you log but a single tx could probably fairly easily push toward the 300,000 log mark within the 10B gas limit, maybe more. Potentially multiple transactions in a tipset like this, which means very large JSON response bodies. Maybe 120M JSON body worst case for a single transaction. Manage to pack multiple into a tipset and it'd get interesting.

Current Lotus lets you not even serve that response. This PR lets you serve it but doesn't give you a direct opt-out. `MaxFilterResults` only applies when someone wants to do multi-tipset eth_getLogs.

ISTM that leaning on proxy-level response body size limiting might be the appropriate mitigation for this. But we could also put back in some kind of protection here at the Lotus level if you just want to not serve such large responses and tell the caller to go figure something else out. Maybe for unpaid RPC endpoints that's the right call. Is Lotus the right place to do that?

Some options:

1. Status quo as per this PR, proxy-level response body limiting is the knob to tune here
2. Add some kind of tunable response-body cap, probably in lotus-gateway (might be tricky since we defer to go-jsonrpc but maybe we can implicate it too to help)
3. Add a new per-event call cap, similar to how `MaxFilterResults` works today but a new variable that'll refuse to serve responses that involve large numbers of events
4. A variation of number 3 where we introduce a boolean that makes `MaxFilterResults` as it is now apply in the current Lotus form, effectively overriding the changes in this PR.