### PR TITLE
chore: set mainnet nv28 upgrade epoch

### DIFF
--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -140,8 +140,8 @@ var UpgradeTockFixHeight = abi.ChainEpoch(-1)
 // 2025-09-24T23:00:00Z
 const UpgradeGoldenWeekHeight = abi.ChainEpoch(5348280)
 
-// ????
-var UpgradeFireHorseHeight = abi.ChainEpoch(9999999999)
+// 2026-05-27T:14:00:00Z
+var UpgradeFireHorseHeight = abi.ChainEpoch(6052800)
 
 var UpgradeTeepInitialFilReserved = InitialFilReserved // FIP-0100: no change for mainnet
 


### PR DESCRIPTION
## Related Issues
#13532 

## Proposed Changes
Set mainnet nv28 upgrade epoch - ref: https://filecoinproject.slack.com/archives/C05P37R9KQD/p1778508150666689.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
