### PR TITLE
chore(lint): upgrade golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,66 +1,115 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
-    - govet
-    - goimports
-    - misspell
-    - revive
+    - copyloopvar
     - errcheck
     - gosec
-    - unconvert
+    - govet
+    - misspell
+    - revive
     - staticcheck
-    - copyloopvar
+    - unconvert
     - unused
+  exclusions:
+    generated: lax
+    # We don't want to skip builtin/
+    paths:
+      - vendor$
+      - testdata$
+      - examples$
+    rules:
+      # gosec: known-noisy rules across the whole codebase
+      - linters: [gosec]
+        text: '^G101: Potential hardcoded credentials'
+      - linters: [gosec]
+        text: '^G108: Profiling endpoint is automatically exposed on /debug/pprof'
+      - linters: [gosec]
+        text: '^G115: integer overflow conversion'
+      - linters: [gosec]
+        text: '^G117: Marshaled struct field'
+      - linters: [gosec]
+        text: '^G118: '
+      - linters: [gosec]
+        text: '^G204: Subprocess launched with (variable|a potential tainted input or cmd arguments)'
+      - linters: [gosec]
+        text: '^G301: Expect directory permissions to be 0750 or less'
+      - linters: [gosec]
+        text: '^G302: Expect file permissions to be 0600 or less'
+      - linters: [gosec]
+        text: '^G304: Potential file inclusion via variable'
+      - linters: [gosec]
+        text: '^G306: Expect WriteFile permissions to be 0600 or less'
+      - linters: [gosec]
+        text: '^G404: Use of weak random number generator'
+      - linters: [gosec]
+        text: '^G703: '
+      - linters: [gosec]
+        text: '^G704: '
+      # gosec: disable entirely in test files and known-unsafe paths
+      - linters: [gosec]
+        path: .*_test.go
+      - linters: [gosec]
+        path: chain/vectors/gen/.*
+      - linters: [gosec]
+        path: cmd/lotus-bench/.*
+      # staticcheck
+      - linters: [staticcheck]
+        text: '^SA1019: xerrors.* is deprecated: As of Go 1.13, use errors'
+      # revive: style rules we've chosen not to enforce
+      - linters: [revive]
+        text: '^blank-imports: a blank import should be only in a main or test package, or have a comment justifying it'
+      - linters: [revive]
+        text: '^dot-imports: should not use dot imports'
+      - linters: [revive]
+        text: '^exported: (func|type) name will be used as [^\s]+ by other packages, and that stutters; consider calling this \w+'
+      - linters: [revive]
+        text: '^exported: comment on exported (const|function|type|var) [^\s]+ should be of the form "\w+ \.\.\."'
+      - linters: [revive]
+        text: '^exported: exported (const|function|method|type|var) [^\s]+ should have comment (\(or a comment on this block\) )?or be unexported'
+      - linters: [revive]
+        text: '^indent-error-flow: if block ends with a return statement, so drop this else and outdent its block'
+      - linters: [revive]
+        text: '^package-comments: package comment should be of the form "Package \w+ \.\.\."'
+      - linters: [revive]
+        text: '^package-comments: should have a package comment'
+      - linters: [revive]
+        text: '^unexported-return: exported func \w+ returns unexported type [^\s]+, which can be annoying to use'
+      - linters: [revive]
+        text: '^unused-parameter: parameter ''\w+'' seems to be unused, consider removing or renaming it as _'
+      - linters: [revive]
+        text: '^var-naming: (const|func|type|var|struct field|(method|func|interface method) parameter) [A-Z]\w+ should be'
+      - linters: [revive]
+        text: '^var-naming: .*(Api|Html|Http|Id|Json|Rpc|Url|Uuid|Vm)\w* should be .*(API|HTML|HTTP|ID|JSON|RPC|URL|UUID|VM)'
+      - linters: [revive]
+        text: '^var-naming: don''t use underscores in Go names'
+      - linters: [revive]
+        text: '^var-naming: \w+ \w+_ should be \w+'
+      - linters: [revive]
+        text: '^var-naming: don''t use ALL_CAPS in Go names; use CamelCase'
+      - linters: [revive]
+        text: '^redefines-builtin-id: redefinition of the built-in (function|type) (max|min|cap|recover|new|error)'
+      # unused: generated actor versioning code has interface-conformant methods not called directly
+      - linters: [unused]
+        path: chain/actors/builtin/.*
+      # staticcheck QF1008: generated actor versioning code uses explicit embedded field selectors
+      # (e.g., s.State.X) deliberately to handle method/field name shadowing that varies across
+      # actor versions. Templates generate uniform code; explicit selectors avoid recursion bugs
+      # and ambiguity that would otherwise need per-version conditionals.
+      - linters: [staticcheck]
+        text: '^QF1008: '
+        path: chain/actors/builtin/.*
 
-# We don't want to skip builtin/
-skip-dirs-use-default: false
-skip-dirs:
-  - vendor$
-  - testdata$
-  - examples$
-
-issues:
-  exclude:
-    # gosec
-    - "^G101: Potential hardcoded credentials"
-    - "^G108: Profiling endpoint is automatically exposed on /debug/pprof"
-    - "^G115: integer overflow conversion u?int(8|32|64)? -> u?int(8|32|64)?"
-    - "^G204: Subprocess launched with (variable|a potential tainted input or cmd arguments)"
-    - "^G301: Expect directory permissions to be 0750 or less"
-    - "^G302: Expect file permissions to be 0600 or less"
-    - "^G304: Potential file inclusion via variable"
-    - "^G306: Expect WriteFile permissions to be 0600 or less"
-    - "^G404: Use of weak random number generator"
-    # staticcheck
-    - "^SA1019: xerrors.* is deprecated: As of Go 1.13, use errors"
-    # revive
-    - "^blank-imports: a blank import should be only in a main or test package, or have a comment justifying it"
-    - "^dot-imports: should not use dot imports"
-    - "^exported: (func|type) name will be used as [^\\s]+ by other packages, and that stutters; consider calling this \\w+"
-    - "^exported: comment on exported (const|var) [^\\s]+ should be of the form \"\\w+ ...\""
-    - "^exported: exported (const|function|method|type|var) [^\\s]+ should have comment (\\(or a comment on this block\\) )?or be unexported"
-    - "^indent-error-flow: if block ends with a return statement, so drop this else and outdent its block \\(move short variable declaration to its own line if necessary\\)"
-    - "^package-comments: package comment should be of the form \"Package \\w+ ...\""
-    - "^package-comments: should have a package comment"
-    - "^unexported-return: exported func \\w+ returns unexported type [^\\s]+, which can be annoying to use"
-    - "^unused-parameter: parameter '\\w+' seems to be unused, consider removing or renaming it as _"
-    - "^var-naming: (const|func|type|var|struct field|(method|func|interface method) parameter) [A-Z]\\w+ should be"
-    - "^var-naming: (method|range var) \\w*(Api|Http|Id|Rpc|Url)[^\\s]* should be \\w*(API|HTTP|ID|RPC|URL)"
-    - "^var-naming: don't use underscores in Go names"
-    - "^var-naming: don't use ALL_CAPS in Go names; use CamelCase"
-    - "^redefines-builtin-id: redefinition of the built-in (function|type) (max|min|cap|recover|new|error)"
-
-  exclude-use-default: false
-  exclude-rules:
-    - path: .*_test.go
-      linters:
-        - gosec
-
-    - path: chain/vectors/gen/.*
-      linters:
-        - gosec
-
-    - path: cmd/lotus-bench/.*
-      linters:
-        - gosec
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - vendor$
+      - testdata$
+      - examples$
+      # Generated actor versioned files use composite literal syntax ({{T{...}})
+      # that conflicts with Go template delimiters and can't be gofmt -s simplified
+      - chain/actors/builtin/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(warning Your Golang version is go$(shell expr $(GOVERSION) / 1000000).$(shell 
 $(error Update Golang to version to at least $(shell cat GO_VERSION_MIN))
 endif
 
-GOLANGCI_LINT_VERSION=v1.64.8
+GOLANGCI_LINT_VERSION=v2.12.2
 
 # git modules that need to be loaded
 MODULES:=
@@ -323,7 +323,7 @@ unittests:  ## Run unit tests
 lint:
 	go mod tidy
 	go vet ./...
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout 10m --concurrency 4
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout 10m --concurrency 4
 .PHONY: lint
 
 clean:  ## Clean build artifacts

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -92,7 +92,7 @@ func TestReturnTypes(t *testing.T) {
 						}
 
 						switch typ.Kind() {
-						case reflect.Ptr:
+						case reflect.Pointer:
 							fallthrough
 						case reflect.Array:
 							fallthrough

--- a/api/docgen-openrpc/openrpc.go
+++ b/api/docgen-openrpc/openrpc.go
@@ -108,7 +108,7 @@ func OpenRPCSchemaTypeMapper(ty reflect.Type) *jsonschema.Type {
 		return &js
 	}
 
-	if ty.Kind() == reflect.Ptr {
+	if ty.Kind() == reflect.Pointer {
 		ty = ty.Elem()
 	}
 
@@ -146,7 +146,7 @@ func OpenRPCSchemaTypeMapper(ty reflect.Type) *jsonschema.Type {
 	case reflect.Float32, reflect.Float64:
 	case reflect.Bool:
 	case reflect.String:
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 	default:
 	}
 

--- a/api/docgen/docgen.go
+++ b/api/docgen/docgen.go
@@ -45,6 +45,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/verifreg"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+	"github.com/filecoin-project/lotus/lib/parsehelper"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	sealing "github.com/filecoin-project/lotus/storage/pipeline"
 	"github.com/filecoin-project/lotus/storage/sealer/sealtasks"
@@ -574,7 +575,7 @@ func ExampleValue(method string, t, parent reflect.Type) interface{} {
 		}
 		return out.Interface()
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if t.Elem().Kind() == reflect.Struct {
 			es := exampleStruct(method, t.Elem(), t)
 			ExampleValues[t] = es
@@ -781,19 +782,19 @@ func ParseApiASTInfo(apiFile, iface, pkg, dir string) (ApiASTInfo, error) { //no
 	if err != nil {
 		return ApiASTInfo{}, fmt.Errorf("filepath absolute file: %s, err: %w", apiFile, err)
 	}
-	pkgs, err := parser.ParseDir(fset, apiDir, nil, parser.AllErrors|parser.ParseComments)
+	files, err := parsehelper.ParseDir(fset, apiDir, pkg, parser.AllErrors|parser.ParseComments)
 	if err != nil {
 		return ApiASTInfo{}, fmt.Errorf("parse error: %w", err)
 	}
 
-	ap := pkgs[pkg]
-
-	f := ap.Files[apiFile]
+	f := files[apiFile]
 
 	cmap := ast.NewCommentMap(fset, f, f.Comments)
 
 	v := &Visitor{iface, make(map[string]ast.Node)}
-	ast.Walk(v, ap)
+	for _, file := range files {
+		ast.Walk(v, file)
+	}
 
 	comments := make(map[string]string)
 	groupDocs := make(map[string]string)

--- a/api/v0api/v1_wrapper.go
+++ b/api/v0api/v1_wrapper.go
@@ -73,7 +73,7 @@ func (w *WrapperV1Full) Version(ctx context.Context) (api.APIVersion, error) {
 }
 
 func (w *WrapperV1Full) executePrototype(ctx context.Context, p *api.MessagePrototype) (cid.Cid, error) {
-	sm, err := w.FullNode.MpoolPushMessage(ctx, &p.Message, nil)
+	sm, err := w.MpoolPushMessage(ctx, &p.Message, nil)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("pushing message: %w", err)
 	}
@@ -119,7 +119,7 @@ func (w *WrapperV1Full) MsigApproveTxnHash(ctx context.Context, msig address.Add
 }
 
 func (w *WrapperV1Full) MsigCancel(ctx context.Context, msig address.Address, txID uint64, to address.Address, amt types.BigInt, src address.Address, method uint64, params []byte) (cid.Cid, error) {
-	p, err := w.FullNode.MsigCancelTxnHash(ctx, msig, txID, to, amt, src, method, params)
+	p, err := w.MsigCancelTxnHash(ctx, msig, txID, to, amt, src, method, params)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("creating prototype: %w", err)
 	}
@@ -206,7 +206,7 @@ func (w *WrapperV1Full) ChainGetRandomnessFromBeacon(ctx context.Context, tsk ty
 }
 
 func (w *WrapperV1Full) PaychGet(ctx context.Context, from, to address.Address, amt types.BigInt) (*api.ChannelInfo, error) {
-	return w.FullNode.PaychFund(ctx, from, to, amt)
+	return w.PaychFund(ctx, from, to, amt)
 }
 
 func (w *WrapperV1Full) BeaconGetEntry(ctx context.Context, epoch abi.ChainEpoch) (*types.BeaconEntry, error) {

--- a/blockstore/badger/blockstore_test_suite.go
+++ b/blockstore/badger/blockstore_test_suite.go
@@ -194,7 +194,7 @@ func (s *Suite) TestAllKeysRespectsContext(t *testing.T) {
 
 	cancel()
 	// pull one value out to avoid race
-	_, _ = <-ch
+	<-ch
 
 	v, ok = <-ch
 	require.Equal(t, cid.Undef, v)

--- a/blockstore/splitstore/splitstore_compact.go
+++ b/blockstore/splitstore/splitstore_compact.go
@@ -373,8 +373,6 @@ func (s *SplitStore) trackTxnRefMany(cids []cid.Cid) {
 
 		s.txnRefs[c] = struct{}{}
 	}
-
-	return
 }
 
 // protect all pending transactional references

--- a/build/panic_reporter.go
+++ b/build/panic_reporter.go
@@ -165,10 +165,7 @@ func writeJournalTail(tailLen int, repoPath, file string) {
 	}
 	jScan := backscanner.New(j, int(js.Size()))
 	linesWritten := 0
-	for {
-		if linesWritten > tailLen {
-			break
-		}
+	for linesWritten <= tailLen {
 		line, _, err := jScan.LineBytes()
 		if err != nil {
 			if err != io.EOF {

--- a/chain/actors/builtin/evm/state.go.template
+++ b/chain/actors/builtin/evm/state.go.template
@@ -3,9 +3,9 @@ package evm
 import (
 	"github.com/ipfs/go-cid"
 
-	"github.com/filecoin-project/lotus/chain/actors/adt"
-	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
 
 	evm{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}evm"
 )
@@ -43,7 +43,7 @@ func (s *state{{.v}}) Nonce() (uint64, error) {
 }
 
 func (s *state{{.v}}) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state{{.v}}) GetState() interface{} {
@@ -51,11 +51,11 @@ func (s *state{{.v}}) GetState() interface{} {
 }
 
 func (s *state{{.v}}) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state{{.v}}) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state{{.v}}) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v10.go
+++ b/chain/actors/builtin/evm/v10.go
@@ -42,7 +42,7 @@ func (s *state10) Nonce() (uint64, error) {
 }
 
 func (s *state10) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state10) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state10) GetState() interface{} {
 }
 
 func (s *state10) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state10) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state10) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v11.go
+++ b/chain/actors/builtin/evm/v11.go
@@ -42,7 +42,7 @@ func (s *state11) Nonce() (uint64, error) {
 }
 
 func (s *state11) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state11) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state11) GetState() interface{} {
 }
 
 func (s *state11) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state11) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state11) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v12.go
+++ b/chain/actors/builtin/evm/v12.go
@@ -42,7 +42,7 @@ func (s *state12) Nonce() (uint64, error) {
 }
 
 func (s *state12) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state12) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state12) GetState() interface{} {
 }
 
 func (s *state12) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state12) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state12) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v13.go
+++ b/chain/actors/builtin/evm/v13.go
@@ -42,7 +42,7 @@ func (s *state13) Nonce() (uint64, error) {
 }
 
 func (s *state13) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state13) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state13) GetState() interface{} {
 }
 
 func (s *state13) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state13) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state13) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v14.go
+++ b/chain/actors/builtin/evm/v14.go
@@ -42,7 +42,7 @@ func (s *state14) Nonce() (uint64, error) {
 }
 
 func (s *state14) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state14) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state14) GetState() interface{} {
 }
 
 func (s *state14) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state14) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state14) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v15.go
+++ b/chain/actors/builtin/evm/v15.go
@@ -42,7 +42,7 @@ func (s *state15) Nonce() (uint64, error) {
 }
 
 func (s *state15) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state15) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state15) GetState() interface{} {
 }
 
 func (s *state15) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state15) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state15) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v16.go
+++ b/chain/actors/builtin/evm/v16.go
@@ -42,7 +42,7 @@ func (s *state16) Nonce() (uint64, error) {
 }
 
 func (s *state16) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state16) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state16) GetState() interface{} {
 }
 
 func (s *state16) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state16) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state16) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v17.go
+++ b/chain/actors/builtin/evm/v17.go
@@ -42,7 +42,7 @@ func (s *state17) Nonce() (uint64, error) {
 }
 
 func (s *state17) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state17) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state17) GetState() interface{} {
 }
 
 func (s *state17) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state17) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state17) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/evm/v18.go
+++ b/chain/actors/builtin/evm/v18.go
@@ -42,7 +42,7 @@ func (s *state18) Nonce() (uint64, error) {
 }
 
 func (s *state18) IsAlive() (bool, error) {
-	return s.State.Tombstone == nil, nil
+	return s.Tombstone == nil, nil
 }
 
 func (s *state18) GetState() interface{} {
@@ -50,11 +50,11 @@ func (s *state18) GetState() interface{} {
 }
 
 func (s *state18) GetBytecodeCID() (cid.Cid, error) {
-	return s.State.Bytecode, nil
+	return s.Bytecode, nil
 }
 
 func (s *state18) GetBytecodeHash() ([32]byte, error) {
-	return s.State.BytecodeHash, nil
+	return s.BytecodeHash, nil
 }
 
 func (s *state18) GetBytecode() ([]byte, error) {

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -27,7 +27,7 @@ import (
 	adt{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/util/adt"
 {{else}}
 	market{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}market"
-	markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"
+	{{if (ne .v 9)}}markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"{{end}}
 	adt{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/adt"
 {{end}}
 {{if (ge .v 3)}}
@@ -357,16 +357,16 @@ func fromV{{.v}}DealProposal(v{{.v}} market{{.v}}.DealProposal) (DealProposal, e
         if v{{.v}}.IsString() {
             str, err := v{{.v}}.ToString()
             if err != nil {
-                return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert string label to string: %w", err)
+                return {{if (eq .v 9)}}market{{.v}}{{else}}markettypes{{end}}.EmptyDealLabel, xerrors.Errorf("failed to convert string label to string: %w", err)
             }
-            return markettypes.NewLabelFromString(str)
+            return {{if (eq .v 9)}}market{{.v}}{{else}}markettypes{{end}}.NewLabelFromString(str)
         }
 
         bs, err := v{{.v}}.ToBytes()
         if err != nil {
-            return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert bytes label to bytes: %w", err)
+            return {{if (eq .v 9)}}market{{.v}}{{else}}markettypes{{end}}.EmptyDealLabel, xerrors.Errorf("failed to convert bytes label to bytes: %w", err)
         }
-        return markettypes.NewLabelFromBytes(bs)
+        return {{if (eq .v 9)}}market{{.v}}{{else}}markettypes{{end}}.NewLabelFromBytes(bs)
     }
 {{end}}
 

--- a/chain/actors/builtin/market/v9.go
+++ b/chain/actors/builtin/market/v9.go
@@ -15,7 +15,6 @@ import (
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/builtin"
 	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
-	markettypes "github.com/filecoin-project/go-state-types/builtin/v9/market"
 	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
 
@@ -330,16 +329,16 @@ func fromV9Label(v9 market9.DealLabel) (DealLabel, error) {
 	if v9.IsString() {
 		str, err := v9.ToString()
 		if err != nil {
-			return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert string label to string: %w", err)
+			return market9.EmptyDealLabel, xerrors.Errorf("failed to convert string label to string: %w", err)
 		}
-		return markettypes.NewLabelFromString(str)
+		return market9.NewLabelFromString(str)
 	}
 
 	bs, err := v9.ToBytes()
 	if err != nil {
-		return markettypes.EmptyDealLabel, xerrors.Errorf("failed to convert bytes label to bytes: %w", err)
+		return market9.EmptyDealLabel, xerrors.Errorf("failed to convert bytes label to bytes: %w", err)
 	}
-	return markettypes.NewLabelFromBytes(bs)
+	return market9.NewLabelFromBytes(bs)
 }
 
 func (s *state9) GetState() interface{} {

--- a/chain/actors/builtin/miner/state.go.template
+++ b/chain/actors/builtin/miner/state.go.template
@@ -407,7 +407,7 @@ func (s *state{{.v}}) Info() (MinerInfo, error) {
 		Worker:           info.Worker,
 		ControlAddresses: info.ControlAddresses,
 
-		PendingWorkerKey:  (*WorkerKeyChange)(info.PendingWorkerKey),
+		PendingWorkerKey:  {{if (eq .v 9)}}info.PendingWorkerKey{{else}}(*WorkerKeyChange)(info.PendingWorkerKey){{end}},
 
 		PeerId:                     info.PeerId,
 		Multiaddrs:                 info.Multiaddrs,
@@ -417,8 +417,8 @@ func (s *state{{.v}}) Info() (MinerInfo, error) {
 		ConsensusFaultElapsed:      {{if (ge .v 2)}}info.ConsensusFaultElapsed{{else}}-1{{end}},
 		{{if (ge .v 9)}}
             Beneficiary:                info.Beneficiary,
-            BeneficiaryTerm:        BeneficiaryTerm(info.BeneficiaryTerm),
-            PendingBeneficiaryTerm: (*PendingBeneficiaryChange)(info.PendingBeneficiaryTerm),
+            BeneficiaryTerm:        {{if (eq .v 9)}}info.BeneficiaryTerm{{else}}BeneficiaryTerm(info.BeneficiaryTerm){{end}},
+            PendingBeneficiaryTerm: {{if (eq .v 9)}}info.PendingBeneficiaryTerm{{else}}(*PendingBeneficiaryChange)(info.PendingBeneficiaryTerm){{end}},
         {{end}}
 	}
 
@@ -512,7 +512,7 @@ func (d *deadline{{.v}}) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline{{.v}}) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -529,11 +529,11 @@ func (d *deadline{{.v}}) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other{{.v}}.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other{{.v}}.Partitions), nil
 }
 
 func (d *deadline{{.v}}) PartitionsPoSted() (bitfield.BitField, error) {
-	return d.Deadline.{{if (ge .v 3)}}PartitionsPoSted{{else}}PostSubmissions{{end}}, nil
+	return {{if (ge .v 3)}}d.Deadline.PartitionsPoSted{{else}}d.PostSubmissions{{end}}, nil
 }
 
 func (d *deadline{{.v}}) DisputableProofCount() (uint64, error) {
@@ -560,19 +560,19 @@ func (d *deadline{{.v}}) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition{{.v}}) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition{{.v}}) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition{{.v}}) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition{{.v}}) UnprovenSectors() (bitfield.BitField, error) {
-	return {{if (ge .v 2)}}p.Partition.Unproven{{else}}bitfield.New(){{end}}, nil
+	return {{if (ge .v 2)}}p.Unproven{{else}}bitfield.New(){{end}}, nil
 }
 
 func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorOnChainInfo {
@@ -600,7 +600,7 @@ func fromV{{.v}}SectorOnChainInfo(v{{.v}} miner{{.v}}.SectorOnChainInfo) SectorO
 		{{- if (ge .v 12)}}
 		PowerBaseEpoch:        v{{.v}}.PowerBaseEpoch,
 		ReplacedDayReward:     {{ if (lt .v 16)}}&{{end}}v{{.v}}.ReplacedDayReward,
-		Flags:                 SectorOnChainInfoFlags(v{{.v}}.Flags),
+		Flags:                 {{if (eq .v .latestVersion)}}v{{.v}}.Flags{{else}}SectorOnChainInfoFlags(v{{.v}}.Flags){{end}},
 		{{- end}}
 		{{- if (ge .v 16)}}
 		DailyFee:              dailyFee,

--- a/chain/actors/builtin/miner/v0.go
+++ b/chain/actors/builtin/miner/v0.go
@@ -449,7 +449,7 @@ func (d *deadline0) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline0) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -466,11 +466,11 @@ func (d *deadline0) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other0.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other0.Partitions), nil
 }
 
 func (d *deadline0) PartitionsPoSted() (bitfield.BitField, error) {
-	return d.Deadline.PostSubmissions, nil
+	return d.PostSubmissions, nil
 }
 
 func (d *deadline0) DisputableProofCount() (uint64, error) {
@@ -485,15 +485,15 @@ func (d *deadline0) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition0) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition0) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition0) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition0) UnprovenSectors() (bitfield.BitField, error) {

--- a/chain/actors/builtin/miner/v10.go
+++ b/chain/actors/builtin/miner/v10.go
@@ -480,7 +480,7 @@ func (d *deadline10) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline10) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline10) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other10.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other10.Partitions), nil
 }
 
 func (d *deadline10) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline10) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition10) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition10) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition10) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition10) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV10SectorOnChainInfo(v10 miner10.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v11.go
+++ b/chain/actors/builtin/miner/v11.go
@@ -480,7 +480,7 @@ func (d *deadline11) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline11) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline11) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other11.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other11.Partitions), nil
 }
 
 func (d *deadline11) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline11) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition11) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition11) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition11) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition11) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV11SectorOnChainInfo(v11 miner11.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v12.go
+++ b/chain/actors/builtin/miner/v12.go
@@ -480,7 +480,7 @@ func (d *deadline12) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline12) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline12) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other12.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other12.Partitions), nil
 }
 
 func (d *deadline12) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline12) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition12) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition12) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition12) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition12) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV12SectorOnChainInfo(v12 miner12.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v13.go
+++ b/chain/actors/builtin/miner/v13.go
@@ -480,7 +480,7 @@ func (d *deadline13) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline13) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline13) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other13.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other13.Partitions), nil
 }
 
 func (d *deadline13) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline13) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition13) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition13) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition13) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition13) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV13SectorOnChainInfo(v13 miner13.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v14.go
+++ b/chain/actors/builtin/miner/v14.go
@@ -480,7 +480,7 @@ func (d *deadline14) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline14) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline14) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other14.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other14.Partitions), nil
 }
 
 func (d *deadline14) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline14) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition14) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition14) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition14) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition14) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV14SectorOnChainInfo(v14 miner14.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v15.go
+++ b/chain/actors/builtin/miner/v15.go
@@ -480,7 +480,7 @@ func (d *deadline15) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline15) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline15) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other15.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other15.Partitions), nil
 }
 
 func (d *deadline15) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline15) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition15) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition15) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition15) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition15) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV15SectorOnChainInfo(v15 miner15.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v16.go
+++ b/chain/actors/builtin/miner/v16.go
@@ -480,7 +480,7 @@ func (d *deadline16) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline16) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline16) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other16.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other16.Partitions), nil
 }
 
 func (d *deadline16) PartitionsPoSted() (bitfield.BitField, error) {
@@ -523,19 +523,19 @@ func (d *deadline16) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition16) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition16) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition16) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition16) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV16SectorOnChainInfo(v16 miner16.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v17.go
+++ b/chain/actors/builtin/miner/v17.go
@@ -480,7 +480,7 @@ func (d *deadline17) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline17) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline17) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other17.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other17.Partitions), nil
 }
 
 func (d *deadline17) PartitionsPoSted() (bitfield.BitField, error) {
@@ -523,19 +523,19 @@ func (d *deadline17) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition17) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition17) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition17) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition17) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV17SectorOnChainInfo(v17 miner17.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v18.go
+++ b/chain/actors/builtin/miner/v18.go
@@ -480,7 +480,7 @@ func (d *deadline18) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline18) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline18) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other18.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other18.Partitions), nil
 }
 
 func (d *deadline18) PartitionsPoSted() (bitfield.BitField, error) {
@@ -523,19 +523,19 @@ func (d *deadline18) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition18) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition18) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition18) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition18) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV18SectorOnChainInfo(v18 miner18.SectorOnChainInfo) SectorOnChainInfo {
@@ -558,7 +558,7 @@ func fromV18SectorOnChainInfo(v18 miner18.SectorOnChainInfo) SectorOnChainInfo {
 		SectorKeyCID:          v18.SectorKeyCID,
 		PowerBaseEpoch:        v18.PowerBaseEpoch,
 		ReplacedDayReward:     v18.ReplacedDayReward,
-		Flags:                 SectorOnChainInfoFlags(v18.Flags),
+		Flags:                 v18.Flags,
 		DailyFee:              dailyFee,
 	}
 	return info

--- a/chain/actors/builtin/miner/v2.go
+++ b/chain/actors/builtin/miner/v2.go
@@ -481,7 +481,7 @@ func (d *deadline2) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline2) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -498,11 +498,11 @@ func (d *deadline2) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other2.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other2.Partitions), nil
 }
 
 func (d *deadline2) PartitionsPoSted() (bitfield.BitField, error) {
-	return d.Deadline.PostSubmissions, nil
+	return d.PostSubmissions, nil
 }
 
 func (d *deadline2) DisputableProofCount() (uint64, error) {
@@ -517,19 +517,19 @@ func (d *deadline2) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition2) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition2) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition2) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition2) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV2SectorOnChainInfo(v2 miner2.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v3.go
+++ b/chain/actors/builtin/miner/v3.go
@@ -477,7 +477,7 @@ func (d *deadline3) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline3) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -494,7 +494,7 @@ func (d *deadline3) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other3.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other3.Partitions), nil
 }
 
 func (d *deadline3) PartitionsPoSted() (bitfield.BitField, error) {
@@ -517,19 +517,19 @@ func (d *deadline3) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition3) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition3) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition3) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition3) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV3SectorOnChainInfo(v3 miner3.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v4.go
+++ b/chain/actors/builtin/miner/v4.go
@@ -477,7 +477,7 @@ func (d *deadline4) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline4) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -494,7 +494,7 @@ func (d *deadline4) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other4.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other4.Partitions), nil
 }
 
 func (d *deadline4) PartitionsPoSted() (bitfield.BitField, error) {
@@ -517,19 +517,19 @@ func (d *deadline4) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition4) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition4) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition4) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition4) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV4SectorOnChainInfo(v4 miner4.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v5.go
+++ b/chain/actors/builtin/miner/v5.go
@@ -477,7 +477,7 @@ func (d *deadline5) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline5) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -494,7 +494,7 @@ func (d *deadline5) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other5.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other5.Partitions), nil
 }
 
 func (d *deadline5) PartitionsPoSted() (bitfield.BitField, error) {
@@ -517,19 +517,19 @@ func (d *deadline5) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition5) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition5) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition5) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition5) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV5SectorOnChainInfo(v5 miner5.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v6.go
+++ b/chain/actors/builtin/miner/v6.go
@@ -477,7 +477,7 @@ func (d *deadline6) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline6) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -494,7 +494,7 @@ func (d *deadline6) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other6.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other6.Partitions), nil
 }
 
 func (d *deadline6) PartitionsPoSted() (bitfield.BitField, error) {
@@ -517,19 +517,19 @@ func (d *deadline6) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition6) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition6) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition6) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition6) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV6SectorOnChainInfo(v6 miner6.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v7.go
+++ b/chain/actors/builtin/miner/v7.go
@@ -476,7 +476,7 @@ func (d *deadline7) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline7) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (d *deadline7) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other7.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other7.Partitions), nil
 }
 
 func (d *deadline7) PartitionsPoSted() (bitfield.BitField, error) {
@@ -516,19 +516,19 @@ func (d *deadline7) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition7) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition7) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition7) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition7) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV7SectorOnChainInfo(v7 miner7.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v8.go
+++ b/chain/actors/builtin/miner/v8.go
@@ -476,7 +476,7 @@ func (d *deadline8) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline8) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (d *deadline8) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other8.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other8.Partitions), nil
 }
 
 func (d *deadline8) PartitionsPoSted() (bitfield.BitField, error) {
@@ -516,19 +516,19 @@ func (d *deadline8) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition8) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition8) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition8) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition8) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV8SectorOnChainInfo(v8 miner8.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/miner/v9.go
+++ b/chain/actors/builtin/miner/v9.go
@@ -379,7 +379,7 @@ func (s *state9) Info() (MinerInfo, error) {
 		Worker:           info.Worker,
 		ControlAddresses: info.ControlAddresses,
 
-		PendingWorkerKey: (*WorkerKeyChange)(info.PendingWorkerKey),
+		PendingWorkerKey: info.PendingWorkerKey,
 
 		PeerId:                     info.PeerId,
 		Multiaddrs:                 info.Multiaddrs,
@@ -389,8 +389,8 @@ func (s *state9) Info() (MinerInfo, error) {
 		ConsensusFaultElapsed:      info.ConsensusFaultElapsed,
 
 		Beneficiary:            info.Beneficiary,
-		BeneficiaryTerm:        BeneficiaryTerm(info.BeneficiaryTerm),
-		PendingBeneficiaryTerm: (*PendingBeneficiaryChange)(info.PendingBeneficiaryTerm),
+		BeneficiaryTerm:        info.BeneficiaryTerm,
+		PendingBeneficiaryTerm: info.PendingBeneficiaryTerm,
 	}
 
 	return mi, nil
@@ -480,7 +480,7 @@ func (d *deadline9) LoadPartition(idx uint64) (Partition, error) {
 }
 
 func (d *deadline9) ForEachPartition(cb func(uint64, Partition) error) error {
-	ps, err := d.Deadline.PartitionsArray(d.store)
+	ps, err := d.PartitionsArray(d.store)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (d *deadline9) PartitionsChanged(other Deadline) (bool, error) {
 		return true, nil
 	}
 
-	return !d.Deadline.Partitions.Equals(other9.Deadline.Partitions), nil
+	return !d.Partitions.Equals(other9.Partitions), nil
 }
 
 func (d *deadline9) PartitionsPoSted() (bitfield.BitField, error) {
@@ -520,19 +520,19 @@ func (d *deadline9) DailyFee() (abi.TokenAmount, error) {
 }
 
 func (p *partition9) AllSectors() (bitfield.BitField, error) {
-	return p.Partition.Sectors, nil
+	return p.Sectors, nil
 }
 
 func (p *partition9) FaultySectors() (bitfield.BitField, error) {
-	return p.Partition.Faults, nil
+	return p.Faults, nil
 }
 
 func (p *partition9) RecoveringSectors() (bitfield.BitField, error) {
-	return p.Partition.Recoveries, nil
+	return p.Recoveries, nil
 }
 
 func (p *partition9) UnprovenSectors() (bitfield.BitField, error) {
-	return p.Partition.Unproven, nil
+	return p.Unproven, nil
 }
 
 func fromV9SectorOnChainInfo(v9 miner9.SectorOnChainInfo) SectorOnChainInfo {

--- a/chain/actors/builtin/multisig/state.go.template
+++ b/chain/actors/builtin/multisig/state.go.template
@@ -45,7 +45,7 @@ func make{{.v}}(store adt.Store, signers []address.Address, threshold uint64, st
 	out := state{{.v}}{store: store}
 	out.State = msig{{.v}}.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -55,14 +55,14 @@ func make{{.v}}(store adt.Store, signers []address.Address, threshold uint64, st
 			return nil, err
 		}
 
-		out.State.PendingTxns = em
+		out.PendingTxns = em
 	{{else}}
 		em, err := adt{{.v}}.StoreEmptyMap(store, builtin{{.v}}.DefaultHamtBitwidth)
 		if err != nil {
 			return nil, err
 		}
 
-		out.State.PendingTxns = em
+		out.PendingTxns = em
 	{{end}}
 	return &out, nil
 }
@@ -73,7 +73,7 @@ type state{{.v}} struct {
 }
 
 func (s *state{{.v}}) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state{{.v}}) StartEpoch() (abi.ChainEpoch, error) {
@@ -97,7 +97,7 @@ func (s *state{{.v}}) Signers() ([]address.Address, error) {
 }
 
 func (s *state{{.v}}) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt{{.v}}.AsMap(s.store, s.State.PendingTxns{{if (ge .v 3)}}, builtin{{.v}}.DefaultHamtBitwidth{{end}})
+	arr, err := adt{{.v}}.AsMap(s.store, s.PendingTxns{{if (ge .v 3)}}, builtin{{.v}}.DefaultHamtBitwidth{{end}})
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (s *state{{.v}}) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other{{.v}}.PendingTxns), nil
+	return !s.PendingTxns.Equals(other{{.v}}.PendingTxns), nil
 }
 
 func (s *state{{.v}}) transactions() (adt.Map, error) {
@@ -129,7 +129,7 @@ func (s *state{{.v}}) decodeTransaction(val *cbg.Deferred) (Transaction, error) 
 	if err := tx.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
 		return Transaction{}, err
 	}
-	return Transaction(tx), nil
+	return {{if (eq .v .latestVersion)}}tx{{else}}Transaction(tx){{end}}, nil
 }
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/multisig/v0.go
+++ b/chain/actors/builtin/multisig/v0.go
@@ -35,7 +35,7 @@ func make0(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state0{store: store}
 	out.State = msig0.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -45,7 +45,7 @@ func make0(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -56,7 +56,7 @@ type state0 struct {
 }
 
 func (s *state0) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state0) StartEpoch() (abi.ChainEpoch, error) {
@@ -80,7 +80,7 @@ func (s *state0) Signers() ([]address.Address, error) {
 }
 
 func (s *state0) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt0.AsMap(s.store, s.State.PendingTxns)
+	arr, err := adt0.AsMap(s.store, s.PendingTxns)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (s *state0) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other0.PendingTxns), nil
+	return !s.PendingTxns.Equals(other0.PendingTxns), nil
 }
 
 func (s *state0) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v10.go
+++ b/chain/actors/builtin/multisig/v10.go
@@ -36,7 +36,7 @@ func make10(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state10{store: store}
 	out.State = msig10.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make10(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state10 struct {
 }
 
 func (s *state10) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state10) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state10) Signers() ([]address.Address, error) {
 }
 
 func (s *state10) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt10.AsMap(s.store, s.State.PendingTxns, builtin10.DefaultHamtBitwidth)
+	arr, err := adt10.AsMap(s.store, s.PendingTxns, builtin10.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state10) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other10.PendingTxns), nil
+	return !s.PendingTxns.Equals(other10.PendingTxns), nil
 }
 
 func (s *state10) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v11.go
+++ b/chain/actors/builtin/multisig/v11.go
@@ -36,7 +36,7 @@ func make11(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state11{store: store}
 	out.State = msig11.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make11(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state11 struct {
 }
 
 func (s *state11) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state11) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state11) Signers() ([]address.Address, error) {
 }
 
 func (s *state11) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt11.AsMap(s.store, s.State.PendingTxns, builtin11.DefaultHamtBitwidth)
+	arr, err := adt11.AsMap(s.store, s.PendingTxns, builtin11.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state11) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other11.PendingTxns), nil
+	return !s.PendingTxns.Equals(other11.PendingTxns), nil
 }
 
 func (s *state11) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v12.go
+++ b/chain/actors/builtin/multisig/v12.go
@@ -36,7 +36,7 @@ func make12(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state12{store: store}
 	out.State = msig12.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make12(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state12 struct {
 }
 
 func (s *state12) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state12) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state12) Signers() ([]address.Address, error) {
 }
 
 func (s *state12) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt12.AsMap(s.store, s.State.PendingTxns, builtin12.DefaultHamtBitwidth)
+	arr, err := adt12.AsMap(s.store, s.PendingTxns, builtin12.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state12) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other12.PendingTxns), nil
+	return !s.PendingTxns.Equals(other12.PendingTxns), nil
 }
 
 func (s *state12) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v13.go
+++ b/chain/actors/builtin/multisig/v13.go
@@ -36,7 +36,7 @@ func make13(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state13{store: store}
 	out.State = msig13.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make13(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state13 struct {
 }
 
 func (s *state13) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state13) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state13) Signers() ([]address.Address, error) {
 }
 
 func (s *state13) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt13.AsMap(s.store, s.State.PendingTxns, builtin13.DefaultHamtBitwidth)
+	arr, err := adt13.AsMap(s.store, s.PendingTxns, builtin13.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state13) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other13.PendingTxns), nil
+	return !s.PendingTxns.Equals(other13.PendingTxns), nil
 }
 
 func (s *state13) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v14.go
+++ b/chain/actors/builtin/multisig/v14.go
@@ -36,7 +36,7 @@ func make14(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state14{store: store}
 	out.State = msig14.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make14(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state14 struct {
 }
 
 func (s *state14) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state14) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state14) Signers() ([]address.Address, error) {
 }
 
 func (s *state14) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt14.AsMap(s.store, s.State.PendingTxns, builtin14.DefaultHamtBitwidth)
+	arr, err := adt14.AsMap(s.store, s.PendingTxns, builtin14.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state14) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other14.PendingTxns), nil
+	return !s.PendingTxns.Equals(other14.PendingTxns), nil
 }
 
 func (s *state14) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v15.go
+++ b/chain/actors/builtin/multisig/v15.go
@@ -36,7 +36,7 @@ func make15(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state15{store: store}
 	out.State = msig15.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make15(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state15 struct {
 }
 
 func (s *state15) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state15) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state15) Signers() ([]address.Address, error) {
 }
 
 func (s *state15) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt15.AsMap(s.store, s.State.PendingTxns, builtin15.DefaultHamtBitwidth)
+	arr, err := adt15.AsMap(s.store, s.PendingTxns, builtin15.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state15) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other15.PendingTxns), nil
+	return !s.PendingTxns.Equals(other15.PendingTxns), nil
 }
 
 func (s *state15) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v16.go
+++ b/chain/actors/builtin/multisig/v16.go
@@ -36,7 +36,7 @@ func make16(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state16{store: store}
 	out.State = msig16.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make16(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state16 struct {
 }
 
 func (s *state16) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state16) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state16) Signers() ([]address.Address, error) {
 }
 
 func (s *state16) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt16.AsMap(s.store, s.State.PendingTxns, builtin16.DefaultHamtBitwidth)
+	arr, err := adt16.AsMap(s.store, s.PendingTxns, builtin16.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state16) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other16.PendingTxns), nil
+	return !s.PendingTxns.Equals(other16.PendingTxns), nil
 }
 
 func (s *state16) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v17.go
+++ b/chain/actors/builtin/multisig/v17.go
@@ -36,7 +36,7 @@ func make17(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state17{store: store}
 	out.State = msig17.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make17(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state17 struct {
 }
 
 func (s *state17) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state17) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state17) Signers() ([]address.Address, error) {
 }
 
 func (s *state17) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt17.AsMap(s.store, s.State.PendingTxns, builtin17.DefaultHamtBitwidth)
+	arr, err := adt17.AsMap(s.store, s.PendingTxns, builtin17.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state17) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other17.PendingTxns), nil
+	return !s.PendingTxns.Equals(other17.PendingTxns), nil
 }
 
 func (s *state17) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v18.go
+++ b/chain/actors/builtin/multisig/v18.go
@@ -36,7 +36,7 @@ func make18(store adt.Store, signers []address.Address, threshold uint64, startE
 	out := state18{store: store}
 	out.State = msig18.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make18(store adt.Store, signers []address.Address, threshold uint64, startE
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state18 struct {
 }
 
 func (s *state18) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state18) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state18) Signers() ([]address.Address, error) {
 }
 
 func (s *state18) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt18.AsMap(s.store, s.State.PendingTxns, builtin18.DefaultHamtBitwidth)
+	arr, err := adt18.AsMap(s.store, s.PendingTxns, builtin18.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state18) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other18.PendingTxns), nil
+	return !s.PendingTxns.Equals(other18.PendingTxns), nil
 }
 
 func (s *state18) transactions() (adt.Map, error) {
@@ -113,7 +113,7 @@ func (s *state18) decodeTransaction(val *cbg.Deferred) (Transaction, error) {
 	if err := tx.UnmarshalCBOR(bytes.NewReader(val.Raw)); err != nil {
 		return Transaction{}, err
 	}
-	return Transaction(tx), nil
+	return tx, nil
 }
 
 func (s *state18) GetState() interface{} {

--- a/chain/actors/builtin/multisig/v2.go
+++ b/chain/actors/builtin/multisig/v2.go
@@ -35,7 +35,7 @@ func make2(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state2{store: store}
 	out.State = msig2.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -45,7 +45,7 @@ func make2(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -56,7 +56,7 @@ type state2 struct {
 }
 
 func (s *state2) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state2) StartEpoch() (abi.ChainEpoch, error) {
@@ -80,7 +80,7 @@ func (s *state2) Signers() ([]address.Address, error) {
 }
 
 func (s *state2) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt2.AsMap(s.store, s.State.PendingTxns)
+	arr, err := adt2.AsMap(s.store, s.PendingTxns)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (s *state2) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other2.PendingTxns), nil
+	return !s.PendingTxns.Equals(other2.PendingTxns), nil
 }
 
 func (s *state2) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v3.go
+++ b/chain/actors/builtin/multisig/v3.go
@@ -36,7 +36,7 @@ func make3(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state3{store: store}
 	out.State = msig3.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make3(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state3 struct {
 }
 
 func (s *state3) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state3) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state3) Signers() ([]address.Address, error) {
 }
 
 func (s *state3) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt3.AsMap(s.store, s.State.PendingTxns, builtin3.DefaultHamtBitwidth)
+	arr, err := adt3.AsMap(s.store, s.PendingTxns, builtin3.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state3) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other3.PendingTxns), nil
+	return !s.PendingTxns.Equals(other3.PendingTxns), nil
 }
 
 func (s *state3) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v4.go
+++ b/chain/actors/builtin/multisig/v4.go
@@ -36,7 +36,7 @@ func make4(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state4{store: store}
 	out.State = msig4.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make4(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state4 struct {
 }
 
 func (s *state4) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state4) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state4) Signers() ([]address.Address, error) {
 }
 
 func (s *state4) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt4.AsMap(s.store, s.State.PendingTxns, builtin4.DefaultHamtBitwidth)
+	arr, err := adt4.AsMap(s.store, s.PendingTxns, builtin4.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state4) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other4.PendingTxns), nil
+	return !s.PendingTxns.Equals(other4.PendingTxns), nil
 }
 
 func (s *state4) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v5.go
+++ b/chain/actors/builtin/multisig/v5.go
@@ -36,7 +36,7 @@ func make5(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state5{store: store}
 	out.State = msig5.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make5(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state5 struct {
 }
 
 func (s *state5) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state5) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state5) Signers() ([]address.Address, error) {
 }
 
 func (s *state5) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt5.AsMap(s.store, s.State.PendingTxns, builtin5.DefaultHamtBitwidth)
+	arr, err := adt5.AsMap(s.store, s.PendingTxns, builtin5.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state5) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other5.PendingTxns), nil
+	return !s.PendingTxns.Equals(other5.PendingTxns), nil
 }
 
 func (s *state5) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v6.go
+++ b/chain/actors/builtin/multisig/v6.go
@@ -36,7 +36,7 @@ func make6(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state6{store: store}
 	out.State = msig6.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make6(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state6 struct {
 }
 
 func (s *state6) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state6) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state6) Signers() ([]address.Address, error) {
 }
 
 func (s *state6) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt6.AsMap(s.store, s.State.PendingTxns, builtin6.DefaultHamtBitwidth)
+	arr, err := adt6.AsMap(s.store, s.PendingTxns, builtin6.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state6) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other6.PendingTxns), nil
+	return !s.PendingTxns.Equals(other6.PendingTxns), nil
 }
 
 func (s *state6) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v7.go
+++ b/chain/actors/builtin/multisig/v7.go
@@ -36,7 +36,7 @@ func make7(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state7{store: store}
 	out.State = msig7.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make7(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state7 struct {
 }
 
 func (s *state7) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state7) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state7) Signers() ([]address.Address, error) {
 }
 
 func (s *state7) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt7.AsMap(s.store, s.State.PendingTxns, builtin7.DefaultHamtBitwidth)
+	arr, err := adt7.AsMap(s.store, s.PendingTxns, builtin7.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state7) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other7.PendingTxns), nil
+	return !s.PendingTxns.Equals(other7.PendingTxns), nil
 }
 
 func (s *state7) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v8.go
+++ b/chain/actors/builtin/multisig/v8.go
@@ -36,7 +36,7 @@ func make8(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state8{store: store}
 	out.State = msig8.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make8(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state8 struct {
 }
 
 func (s *state8) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state8) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state8) Signers() ([]address.Address, error) {
 }
 
 func (s *state8) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt8.AsMap(s.store, s.State.PendingTxns, builtin8.DefaultHamtBitwidth)
+	arr, err := adt8.AsMap(s.store, s.PendingTxns, builtin8.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state8) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other8.PendingTxns), nil
+	return !s.PendingTxns.Equals(other8.PendingTxns), nil
 }
 
 func (s *state8) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/multisig/v9.go
+++ b/chain/actors/builtin/multisig/v9.go
@@ -36,7 +36,7 @@ func make9(store adt.Store, signers []address.Address, threshold uint64, startEp
 	out := state9{store: store}
 	out.State = msig9.State{}
 	out.State.Signers = signers
-	out.State.NumApprovalsThreshold = threshold
+	out.NumApprovalsThreshold = threshold
 	out.State.StartEpoch = startEpoch
 	out.State.UnlockDuration = unlockDuration
 	out.State.InitialBalance = initialBalance
@@ -46,7 +46,7 @@ func make9(store adt.Store, signers []address.Address, threshold uint64, startEp
 		return nil, err
 	}
 
-	out.State.PendingTxns = em
+	out.PendingTxns = em
 
 	return &out, nil
 }
@@ -57,7 +57,7 @@ type state9 struct {
 }
 
 func (s *state9) LockedBalance(currEpoch abi.ChainEpoch) (abi.TokenAmount, error) {
-	return s.State.AmountLocked(currEpoch - s.State.StartEpoch), nil
+	return s.AmountLocked(currEpoch - s.State.StartEpoch), nil
 }
 
 func (s *state9) StartEpoch() (abi.ChainEpoch, error) {
@@ -81,7 +81,7 @@ func (s *state9) Signers() ([]address.Address, error) {
 }
 
 func (s *state9) ForEachPendingTxn(cb func(id int64, txn Transaction) error) error {
-	arr, err := adt9.AsMap(s.store, s.State.PendingTxns, builtin9.DefaultHamtBitwidth)
+	arr, err := adt9.AsMap(s.store, s.PendingTxns, builtin9.DefaultHamtBitwidth)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (s *state9) PendingTxnChanged(other State) (bool, error) {
 		// treat an upgrade as a change, always
 		return true, nil
 	}
-	return !s.State.PendingTxns.Equals(other9.PendingTxns), nil
+	return !s.PendingTxns.Equals(other9.PendingTxns), nil
 }
 
 func (s *state9) transactions() (adt.Map, error) {

--- a/chain/actors/builtin/paych/message.go.template
+++ b/chain/actors/builtin/paych/message.go.template
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
-	paychtypes "github.com/filecoin-project/go-state-types/builtin/v8/paych"
+    {{if (ne .v 8)}}paychtypes "github.com/filecoin-project/go-state-types/builtin/v8/paych"{{end}}
     {{if (le .v 7)}}
 	    builtin{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/builtin"
 	    init{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/builtin/init"
@@ -59,7 +59,7 @@ func (m message{{.v}}) Create(to address.Address, initialAmount abi.TokenAmount)
 	}, nil
 }
 
-func (m message{{.v}}) Update(paych address.Address, sv *paychtypes.SignedVoucher, secret []byte) (*types.Message, error) {
+func (m message{{.v}}) Update(paych address.Address, sv *{{if (eq .v 8)}}paych{{.v}}{{else}}paychtypes{{end}}.SignedVoucher, secret []byte) (*types.Message, error) {
 	params, aerr := actors.SerializeParams(&paych{{.v}}.UpdateChannelStateParams{
 	{{if (le .v 6)}}
 	    Sv:     toV0SignedVoucher(*sv),

--- a/chain/actors/builtin/paych/message8.go
+++ b/chain/actors/builtin/paych/message8.go
@@ -9,7 +9,6 @@ import (
 	builtin8 "github.com/filecoin-project/go-state-types/builtin"
 	init8 "github.com/filecoin-project/go-state-types/builtin/v8/init"
 	paych8 "github.com/filecoin-project/go-state-types/builtin/v8/paych"
-	paychtypes "github.com/filecoin-project/go-state-types/builtin/v8/paych"
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	init_ "github.com/filecoin-project/lotus/chain/actors/builtin/init"
@@ -46,7 +45,7 @@ func (m message8) Create(to address.Address, initialAmount abi.TokenAmount) (*ty
 	}, nil
 }
 
-func (m message8) Update(paych address.Address, sv *paychtypes.SignedVoucher, secret []byte) (*types.Message, error) {
+func (m message8) Update(paych address.Address, sv *paych8.SignedVoucher, secret []byte) (*types.Message, error) {
 	params, aerr := actors.SerializeParams(&paych8.UpdateChannelStateParams{
 
 		Sv: *sv,

--- a/chain/actors/builtin/paych/state.go.template
+++ b/chain/actors/builtin/paych/state.go.template
@@ -71,7 +71,7 @@ func (s *state{{.v}}) getOrLoadLsAmt() (*adt{{.v}}.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt{{.v}}.AsArray(s.store, s.State.LaneStates{{if (ge .v 3)}}, paych{{.v}}.LaneStatesAmtBitwidth{{end}})
+	lsamt, err := adt{{.v}}.AsArray(s.store, s.LaneStates{{if (ge .v 3)}}, paych{{.v}}.LaneStatesAmtBitwidth{{end}})
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v0.go
+++ b/chain/actors/builtin/paych/v0.go
@@ -66,7 +66,7 @@ func (s *state0) getOrLoadLsAmt() (*adt0.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt0.AsArray(s.store, s.State.LaneStates)
+	lsamt, err := adt0.AsArray(s.store, s.LaneStates)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v10.go
+++ b/chain/actors/builtin/paych/v10.go
@@ -66,7 +66,7 @@ func (s *state10) getOrLoadLsAmt() (*adt10.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt10.AsArray(s.store, s.State.LaneStates, paych10.LaneStatesAmtBitwidth)
+	lsamt, err := adt10.AsArray(s.store, s.LaneStates, paych10.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v11.go
+++ b/chain/actors/builtin/paych/v11.go
@@ -66,7 +66,7 @@ func (s *state11) getOrLoadLsAmt() (*adt11.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt11.AsArray(s.store, s.State.LaneStates, paych11.LaneStatesAmtBitwidth)
+	lsamt, err := adt11.AsArray(s.store, s.LaneStates, paych11.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v12.go
+++ b/chain/actors/builtin/paych/v12.go
@@ -66,7 +66,7 @@ func (s *state12) getOrLoadLsAmt() (*adt12.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt12.AsArray(s.store, s.State.LaneStates, paych12.LaneStatesAmtBitwidth)
+	lsamt, err := adt12.AsArray(s.store, s.LaneStates, paych12.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v13.go
+++ b/chain/actors/builtin/paych/v13.go
@@ -66,7 +66,7 @@ func (s *state13) getOrLoadLsAmt() (*adt13.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt13.AsArray(s.store, s.State.LaneStates, paych13.LaneStatesAmtBitwidth)
+	lsamt, err := adt13.AsArray(s.store, s.LaneStates, paych13.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v14.go
+++ b/chain/actors/builtin/paych/v14.go
@@ -66,7 +66,7 @@ func (s *state14) getOrLoadLsAmt() (*adt14.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt14.AsArray(s.store, s.State.LaneStates, paych14.LaneStatesAmtBitwidth)
+	lsamt, err := adt14.AsArray(s.store, s.LaneStates, paych14.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v15.go
+++ b/chain/actors/builtin/paych/v15.go
@@ -66,7 +66,7 @@ func (s *state15) getOrLoadLsAmt() (*adt15.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt15.AsArray(s.store, s.State.LaneStates, paych15.LaneStatesAmtBitwidth)
+	lsamt, err := adt15.AsArray(s.store, s.LaneStates, paych15.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v16.go
+++ b/chain/actors/builtin/paych/v16.go
@@ -66,7 +66,7 @@ func (s *state16) getOrLoadLsAmt() (*adt16.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt16.AsArray(s.store, s.State.LaneStates, paych16.LaneStatesAmtBitwidth)
+	lsamt, err := adt16.AsArray(s.store, s.LaneStates, paych16.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v17.go
+++ b/chain/actors/builtin/paych/v17.go
@@ -66,7 +66,7 @@ func (s *state17) getOrLoadLsAmt() (*adt17.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt17.AsArray(s.store, s.State.LaneStates, paych17.LaneStatesAmtBitwidth)
+	lsamt, err := adt17.AsArray(s.store, s.LaneStates, paych17.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v18.go
+++ b/chain/actors/builtin/paych/v18.go
@@ -66,7 +66,7 @@ func (s *state18) getOrLoadLsAmt() (*adt18.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt18.AsArray(s.store, s.State.LaneStates, paych18.LaneStatesAmtBitwidth)
+	lsamt, err := adt18.AsArray(s.store, s.LaneStates, paych18.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v2.go
+++ b/chain/actors/builtin/paych/v2.go
@@ -66,7 +66,7 @@ func (s *state2) getOrLoadLsAmt() (*adt2.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt2.AsArray(s.store, s.State.LaneStates)
+	lsamt, err := adt2.AsArray(s.store, s.LaneStates)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v3.go
+++ b/chain/actors/builtin/paych/v3.go
@@ -66,7 +66,7 @@ func (s *state3) getOrLoadLsAmt() (*adt3.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt3.AsArray(s.store, s.State.LaneStates, paych3.LaneStatesAmtBitwidth)
+	lsamt, err := adt3.AsArray(s.store, s.LaneStates, paych3.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v4.go
+++ b/chain/actors/builtin/paych/v4.go
@@ -66,7 +66,7 @@ func (s *state4) getOrLoadLsAmt() (*adt4.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt4.AsArray(s.store, s.State.LaneStates, paych4.LaneStatesAmtBitwidth)
+	lsamt, err := adt4.AsArray(s.store, s.LaneStates, paych4.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v5.go
+++ b/chain/actors/builtin/paych/v5.go
@@ -66,7 +66,7 @@ func (s *state5) getOrLoadLsAmt() (*adt5.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt5.AsArray(s.store, s.State.LaneStates, paych5.LaneStatesAmtBitwidth)
+	lsamt, err := adt5.AsArray(s.store, s.LaneStates, paych5.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v6.go
+++ b/chain/actors/builtin/paych/v6.go
@@ -66,7 +66,7 @@ func (s *state6) getOrLoadLsAmt() (*adt6.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt6.AsArray(s.store, s.State.LaneStates, paych6.LaneStatesAmtBitwidth)
+	lsamt, err := adt6.AsArray(s.store, s.LaneStates, paych6.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v7.go
+++ b/chain/actors/builtin/paych/v7.go
@@ -66,7 +66,7 @@ func (s *state7) getOrLoadLsAmt() (*adt7.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt7.AsArray(s.store, s.State.LaneStates, paych7.LaneStatesAmtBitwidth)
+	lsamt, err := adt7.AsArray(s.store, s.LaneStates, paych7.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v8.go
+++ b/chain/actors/builtin/paych/v8.go
@@ -66,7 +66,7 @@ func (s *state8) getOrLoadLsAmt() (*adt8.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt8.AsArray(s.store, s.State.LaneStates, paych8.LaneStatesAmtBitwidth)
+	lsamt, err := adt8.AsArray(s.store, s.LaneStates, paych8.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/paych/v9.go
+++ b/chain/actors/builtin/paych/v9.go
@@ -66,7 +66,7 @@ func (s *state9) getOrLoadLsAmt() (*adt9.Array, error) {
 	}
 
 	// Get the lane state from the chain
-	lsamt, err := adt9.AsArray(s.store, s.State.LaneStates, paych9.LaneStatesAmtBitwidth)
+	lsamt, err := adt9.AsArray(s.store, s.LaneStates, paych9.LaneStatesAmtBitwidth)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/actors/builtin/power/state.go.template
+++ b/chain/actors/builtin/power/state.go.template
@@ -26,7 +26,9 @@ import (
 	power{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}power"
 	adt{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/adt"
 {{end}}
-    builtin{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin"
+{{if and (ne .v .latestVersion) (le .v 7)}}
+	builtin{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin"
+{{end}}
 )
 
 var _ State = (*state{{.v}})(nil)
@@ -111,7 +113,7 @@ func (s *state{{.v}}) MinerNominalPowerMeetsConsensusMinimum(a address.Address) 
 }
 
 func (s *state{{.v}}) TotalPowerSmoothed() (builtin.FilterEstimate, error) {
-	return builtin.FilterEstimate({{if (le .v 1)}}*{{end}}s.State.ThisEpochQAPowerSmoothed), nil
+	return {{if (le .v 1)}}builtin.FilterEstimate(*s.State.ThisEpochQAPowerSmoothed){{else if (eq .v 8)}}s.State.ThisEpochQAPowerSmoothed{{else}}builtin.FilterEstimate(s.State.ThisEpochQAPowerSmoothed){{end}}, nil
 }
 
 func (s *state{{.v}}) MinerCounts() (uint64, uint64, error) {
@@ -148,13 +150,13 @@ func (s *state{{.v}}) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state{{.v}}) CollectEligibleClaims(cacheInOut *builtin{{.latestVersion}}.MapReduceCache) ([]builtin{{.latestVersion}}.OwnedClaim, error) {
+func (s *state{{.v}}) CollectEligibleClaims(cacheInOut *{{if (gt .v 7)}}builtin{{.v}}{{else}}builtin{{.latestVersion}}{{end}}.MapReduceCache) ([]{{if (gt .v 7)}}builtin{{.v}}{{else}}builtin{{.latestVersion}}{{end}}.OwnedClaim, error) {
 {{if (ge .v 16)}}
 	return s.State.CollectEligibleClaims(s.store, cacheInOut)
 {{else}}
-	var res []builtin{{.latestVersion}}.OwnedClaim
+	var res []{{if (gt .v 7)}}builtin{{.v}}{{else}}builtin{{.latestVersion}}{{end}}.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin{{.latestVersion}}.OwnedClaim{
+		res = append(res, {{if (gt .v 7)}}builtin{{.v}}{{else}}builtin{{.latestVersion}}{{end}}.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v10.go
+++ b/chain/actors/builtin/power/v10.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin10 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power10 "github.com/filecoin-project/go-state-types/builtin/v10/power"
 	adt10 "github.com/filecoin-project/go-state-types/builtin/v10/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state10) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state10) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state10) CollectEligibleClaims(cacheInOut *builtin10.MapReduceCache) ([]builtin10.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin10.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin10.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v11.go
+++ b/chain/actors/builtin/power/v11.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin11 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power11 "github.com/filecoin-project/go-state-types/builtin/v11/power"
 	adt11 "github.com/filecoin-project/go-state-types/builtin/v11/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state11) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state11) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state11) CollectEligibleClaims(cacheInOut *builtin11.MapReduceCache) ([]builtin11.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin11.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin11.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v12.go
+++ b/chain/actors/builtin/power/v12.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin12 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power12 "github.com/filecoin-project/go-state-types/builtin/v12/power"
 	adt12 "github.com/filecoin-project/go-state-types/builtin/v12/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state12) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state12) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state12) CollectEligibleClaims(cacheInOut *builtin12.MapReduceCache) ([]builtin12.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin12.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin12.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v13.go
+++ b/chain/actors/builtin/power/v13.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin13 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power13 "github.com/filecoin-project/go-state-types/builtin/v13/power"
 	adt13 "github.com/filecoin-project/go-state-types/builtin/v13/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state13) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state13) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state13) CollectEligibleClaims(cacheInOut *builtin13.MapReduceCache) ([]builtin13.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin13.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin13.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v14.go
+++ b/chain/actors/builtin/power/v14.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin14 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power14 "github.com/filecoin-project/go-state-types/builtin/v14/power"
 	adt14 "github.com/filecoin-project/go-state-types/builtin/v14/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state14) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state14) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state14) CollectEligibleClaims(cacheInOut *builtin14.MapReduceCache) ([]builtin14.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin14.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin14.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v15.go
+++ b/chain/actors/builtin/power/v15.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin15 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power15 "github.com/filecoin-project/go-state-types/builtin/v15/power"
 	adt15 "github.com/filecoin-project/go-state-types/builtin/v15/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,11 +126,11 @@ func (s *state15) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state15) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state15) CollectEligibleClaims(cacheInOut *builtin15.MapReduceCache) ([]builtin15.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin15.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin15.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v16.go
+++ b/chain/actors/builtin/power/v16.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin16 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power16 "github.com/filecoin-project/go-state-types/builtin/v16/power"
 	adt16 "github.com/filecoin-project/go-state-types/builtin/v16/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,7 +126,7 @@ func (s *state16) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state16) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state16) CollectEligibleClaims(cacheInOut *builtin16.MapReduceCache) ([]builtin16.OwnedClaim, error) {
 
 	return s.State.CollectEligibleClaims(s.store, cacheInOut)
 

--- a/chain/actors/builtin/power/v17.go
+++ b/chain/actors/builtin/power/v17.go
@@ -11,7 +11,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	builtin17 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	power17 "github.com/filecoin-project/go-state-types/builtin/v17/power"
 	adt17 "github.com/filecoin-project/go-state-types/builtin/v17/util/adt"
 	"github.com/filecoin-project/go-state-types/manifest"
@@ -127,7 +126,7 @@ func (s *state17) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state17) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state17) CollectEligibleClaims(cacheInOut *builtin17.MapReduceCache) ([]builtin17.OwnedClaim, error) {
 
 	return s.State.CollectEligibleClaims(s.store, cacheInOut)
 

--- a/chain/actors/builtin/power/v8.go
+++ b/chain/actors/builtin/power/v8.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	builtin8 "github.com/filecoin-project/go-state-types/builtin"
 	power8 "github.com/filecoin-project/go-state-types/builtin/v8/power"
 	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
@@ -90,7 +89,7 @@ func (s *state8) MinerNominalPowerMeetsConsensusMinimum(a address.Address) (bool
 }
 
 func (s *state8) TotalPowerSmoothed() (builtin.FilterEstimate, error) {
-	return builtin.FilterEstimate(s.State.ThisEpochQAPowerSmoothed), nil
+	return s.State.ThisEpochQAPowerSmoothed, nil
 }
 
 func (s *state8) MinerCounts() (uint64, uint64, error) {
@@ -127,11 +126,11 @@ func (s *state8) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state8) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state8) CollectEligibleClaims(cacheInOut *builtin8.MapReduceCache) ([]builtin8.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin8.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin8.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/power/v9.go
+++ b/chain/actors/builtin/power/v9.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
 	builtin9 "github.com/filecoin-project/go-state-types/builtin"
 	power9 "github.com/filecoin-project/go-state-types/builtin/v9/power"
 	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
@@ -127,11 +126,11 @@ func (s *state9) ListAllMiners() ([]address.Address, error) {
 	return miners, nil
 }
 
-func (s *state9) CollectEligibleClaims(cacheInOut *builtin18.MapReduceCache) ([]builtin18.OwnedClaim, error) {
+func (s *state9) CollectEligibleClaims(cacheInOut *builtin9.MapReduceCache) ([]builtin9.OwnedClaim, error) {
 
-	var res []builtin18.OwnedClaim
+	var res []builtin9.OwnedClaim
 	err := s.ForEachClaim(func(miner address.Address, claim Claim) error {
-		res = append(res, builtin18.OwnedClaim{
+		res = append(res, builtin9.OwnedClaim{
 			Address:         miner,
 			RawBytePower:    claim.RawBytePower,
 			QualityAdjPower: claim.QualityAdjPower,

--- a/chain/actors/builtin/reward/state.go.template
+++ b/chain/actors/builtin/reward/state.go.template
@@ -16,7 +16,7 @@ import (
 	reward{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/builtin/reward"
 	smoothing{{.v}} "github.com/filecoin-project/specs-actors{{.import}}actors/util/smoothing"
 {{else}}
-	smoothing{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/smoothing"
+	{{if (ne .v 8)}}smoothing{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}util/smoothing"{{end}}
 	miner{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}miner"
 	reward{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}reward"
 {{end}}
@@ -88,10 +88,7 @@ func (s *state{{.v}}) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.Toke
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing{{.v}}.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		{{if (eq .v 8)}}*networkQAPower{{else}}smoothing{{.v}}.FilterEstimate(*networkQAPower){{end}},
 		circSupply,
 		epochsSinceRampStart,
 		rampDurationEpochs,
@@ -100,34 +97,29 @@ func (s *state{{.v}}) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.Toke
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing{{.v}}.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		{{if (eq .v 8)}}*networkQAPower{{else}}smoothing{{.v}}.FilterEstimate(*networkQAPower){{end}},
 		circSupply,
 	), nil
 {{end}}}
 {{else}}
 func (s *state0) InitialPledgeForPower(sectorWeight abi.StoragePower, networkTotalPledge abi.TokenAmount, networkQAPower *builtin.FilterEstimate, circSupply abi.TokenAmount, _ int64, _ uint64) (abi.TokenAmount, error) {
+	qaPower := smoothing0.FilterEstimate(*networkQAPower)
 	return miner0.InitialPledgeForPower(
 		sectorWeight,
 		s.State.ThisEpochBaselinePower,
 		networkTotalPledge,
 		s.State.ThisEpochRewardSmoothed,
-		&smoothing0.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		&qaPower,
 		circSupply), nil
 }
 {{end}}
 func (s *state{{.v}}) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
+	{{if (le .v 0)}}qaPower := smoothing{{.v}}.FilterEstimate(networkQAPower)
 	return miner{{.v}}.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		{{if (le .v 0)}}&{{end}}smoothing{{.v}}.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
-		sectorWeight), nil
+		&qaPower,
+		sectorWeight), nil{{else}}return miner{{.v}}.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
+		{{if (eq .v 8)}}networkQAPower{{else}}smoothing{{.v}}.FilterEstimate(networkQAPower){{end}},
+		sectorWeight), nil{{end}}
 }
 
 func (s *state{{.v}}) GetState() interface{} {

--- a/chain/actors/builtin/reward/v0.go
+++ b/chain/actors/builtin/reward/v0.go
@@ -74,24 +74,20 @@ func (s *state0) CumsumRealized() (reward0.Spacetime, error) {
 }
 
 func (s *state0) InitialPledgeForPower(sectorWeight abi.StoragePower, networkTotalPledge abi.TokenAmount, networkQAPower *builtin.FilterEstimate, circSupply abi.TokenAmount, _ int64, _ uint64) (abi.TokenAmount, error) {
+	qaPower := smoothing0.FilterEstimate(*networkQAPower)
 	return miner0.InitialPledgeForPower(
 		sectorWeight,
 		s.State.ThisEpochBaselinePower,
 		networkTotalPledge,
 		s.State.ThisEpochRewardSmoothed,
-		&smoothing0.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		&qaPower,
 		circSupply), nil
 }
 
 func (s *state0) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
+	qaPower := smoothing0.FilterEstimate(networkQAPower)
 	return miner0.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		&smoothing0.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		&qaPower,
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v10.go
+++ b/chain/actors/builtin/reward/v10.go
@@ -81,20 +81,14 @@ func (s *state10) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing10.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing10.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state10) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner10.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing10.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing10.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v11.go
+++ b/chain/actors/builtin/reward/v11.go
@@ -81,20 +81,14 @@ func (s *state11) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing11.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing11.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state11) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner11.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing11.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing11.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v12.go
+++ b/chain/actors/builtin/reward/v12.go
@@ -81,20 +81,14 @@ func (s *state12) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing12.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing12.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state12) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner12.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing12.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing12.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v13.go
+++ b/chain/actors/builtin/reward/v13.go
@@ -81,20 +81,14 @@ func (s *state13) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing13.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing13.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state13) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner13.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing13.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing13.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v14.go
+++ b/chain/actors/builtin/reward/v14.go
@@ -81,20 +81,14 @@ func (s *state14) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing14.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing14.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state14) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner14.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing14.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing14.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v15.go
+++ b/chain/actors/builtin/reward/v15.go
@@ -81,10 +81,7 @@ func (s *state15) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing15.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing15.FilterEstimate(*networkQAPower),
 		circSupply,
 		epochsSinceRampStart,
 		rampDurationEpochs,
@@ -93,10 +90,7 @@ func (s *state15) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 
 func (s *state15) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner15.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing15.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing15.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v16.go
+++ b/chain/actors/builtin/reward/v16.go
@@ -81,10 +81,7 @@ func (s *state16) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing16.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing16.FilterEstimate(*networkQAPower),
 		circSupply,
 		epochsSinceRampStart,
 		rampDurationEpochs,
@@ -93,10 +90,7 @@ func (s *state16) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 
 func (s *state16) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner16.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing16.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing16.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v17.go
+++ b/chain/actors/builtin/reward/v17.go
@@ -81,10 +81,7 @@ func (s *state17) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing17.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing17.FilterEstimate(*networkQAPower),
 		circSupply,
 		epochsSinceRampStart,
 		rampDurationEpochs,
@@ -93,10 +90,7 @@ func (s *state17) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 
 func (s *state17) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner17.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing17.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing17.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v18.go
+++ b/chain/actors/builtin/reward/v18.go
@@ -81,10 +81,7 @@ func (s *state18) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing18.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing18.FilterEstimate(*networkQAPower),
 		circSupply,
 		epochsSinceRampStart,
 		rampDurationEpochs,
@@ -93,10 +90,7 @@ func (s *state18) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmo
 
 func (s *state18) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner18.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing18.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing18.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v2.go
+++ b/chain/actors/builtin/reward/v2.go
@@ -81,20 +81,14 @@ func (s *state2) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing2.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing2.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state2) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner2.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing2.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing2.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v3.go
+++ b/chain/actors/builtin/reward/v3.go
@@ -81,20 +81,14 @@ func (s *state3) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing3.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing3.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state3) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner3.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing3.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing3.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v4.go
+++ b/chain/actors/builtin/reward/v4.go
@@ -81,20 +81,14 @@ func (s *state4) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing4.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing4.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state4) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner4.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing4.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing4.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v5.go
+++ b/chain/actors/builtin/reward/v5.go
@@ -81,20 +81,14 @@ func (s *state5) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing5.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing5.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state5) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner5.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing5.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing5.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v6.go
+++ b/chain/actors/builtin/reward/v6.go
@@ -81,20 +81,14 @@ func (s *state6) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing6.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing6.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state6) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner6.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing6.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing6.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v7.go
+++ b/chain/actors/builtin/reward/v7.go
@@ -81,20 +81,14 @@ func (s *state7) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing7.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing7.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state7) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner7.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing7.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing7.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v8.go
+++ b/chain/actors/builtin/reward/v8.go
@@ -9,7 +9,6 @@ import (
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	miner8 "github.com/filecoin-project/go-state-types/builtin/v8/miner"
 	reward8 "github.com/filecoin-project/go-state-types/builtin/v8/reward"
-	smoothing8 "github.com/filecoin-project/go-state-types/builtin/v8/util/smoothing"
 	"github.com/filecoin-project/go-state-types/manifest"
 
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -81,20 +80,14 @@ func (s *state8) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing8.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		*networkQAPower,
 		circSupply,
 	), nil
 }
 
 func (s *state8) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner8.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing8.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		networkQAPower,
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/reward/v9.go
+++ b/chain/actors/builtin/reward/v9.go
@@ -81,20 +81,14 @@ func (s *state9) InitialPledgeForPower(qaPower abi.StoragePower, _ abi.TokenAmou
 		qaPower,
 		s.State.ThisEpochBaselinePower,
 		s.State.ThisEpochRewardSmoothed,
-		smoothing9.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing9.FilterEstimate(*networkQAPower),
 		circSupply,
 	), nil
 }
 
 func (s *state9) PreCommitDepositForPower(networkQAPower builtin.FilterEstimate, sectorWeight abi.StoragePower) (abi.TokenAmount, error) {
 	return miner9.PreCommitDepositForPower(s.State.ThisEpochRewardSmoothed,
-		smoothing9.FilterEstimate{
-			PositionEstimate: networkQAPower.PositionEstimate,
-			VelocityEstimate: networkQAPower.VelocityEstimate,
-		},
+		smoothing9.FilterEstimate(networkQAPower),
 		sectorWeight), nil
 }
 

--- a/chain/actors/builtin/system/state.go.template
+++ b/chain/actors/builtin/system/state.go.template
@@ -50,7 +50,7 @@ func (s *state{{.v}}) GetBuiltinActors() cid.Cid {
 {{if (le .v 7)}}
 	return cid.Undef
 {{else}}
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 {{end}}
 }
 
@@ -58,7 +58,7 @@ func (s *state{{.v}}) SetBuiltinActors(c cid.Cid) error {
 {{if (le .v 7)}}
 	return xerrors.New("cannot set manifest cid before v8")
 {{else}}
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 {{end}}
 }

--- a/chain/actors/builtin/system/v10.go
+++ b/chain/actors/builtin/system/v10.go
@@ -43,13 +43,13 @@ func (s *state10) GetState() interface{} {
 
 func (s *state10) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state10) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v11.go
+++ b/chain/actors/builtin/system/v11.go
@@ -43,13 +43,13 @@ func (s *state11) GetState() interface{} {
 
 func (s *state11) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state11) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v12.go
+++ b/chain/actors/builtin/system/v12.go
@@ -43,13 +43,13 @@ func (s *state12) GetState() interface{} {
 
 func (s *state12) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state12) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v13.go
+++ b/chain/actors/builtin/system/v13.go
@@ -43,13 +43,13 @@ func (s *state13) GetState() interface{} {
 
 func (s *state13) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state13) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v14.go
+++ b/chain/actors/builtin/system/v14.go
@@ -43,13 +43,13 @@ func (s *state14) GetState() interface{} {
 
 func (s *state14) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state14) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v15.go
+++ b/chain/actors/builtin/system/v15.go
@@ -43,13 +43,13 @@ func (s *state15) GetState() interface{} {
 
 func (s *state15) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state15) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v16.go
+++ b/chain/actors/builtin/system/v16.go
@@ -43,13 +43,13 @@ func (s *state16) GetState() interface{} {
 
 func (s *state16) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state16) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v17.go
+++ b/chain/actors/builtin/system/v17.go
@@ -43,13 +43,13 @@ func (s *state17) GetState() interface{} {
 
 func (s *state17) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state17) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v18.go
+++ b/chain/actors/builtin/system/v18.go
@@ -43,13 +43,13 @@ func (s *state18) GetState() interface{} {
 
 func (s *state18) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state18) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v8.go
+++ b/chain/actors/builtin/system/v8.go
@@ -43,13 +43,13 @@ func (s *state8) GetState() interface{} {
 
 func (s *state8) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state8) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/system/v9.go
+++ b/chain/actors/builtin/system/v9.go
@@ -43,13 +43,13 @@ func (s *state9) GetState() interface{} {
 
 func (s *state9) GetBuiltinActors() cid.Cid {
 
-	return s.State.BuiltinActors
+	return s.BuiltinActors
 
 }
 
 func (s *state9) SetBuiltinActors(c cid.Cid) error {
 
-	s.State.BuiltinActors = c
+	s.BuiltinActors = c
 	return nil
 
 }

--- a/chain/actors/builtin/verifreg/state.go.template
+++ b/chain/actors/builtin/verifreg/state.go.template
@@ -126,8 +126,8 @@ func (s *state{{.v}}) GetAllocation(clientIdAddr address.Address, allocationId v
 {{if (le .v 8)}}
     return nil, false, xerrors.Errorf("unsupported in actors v{{.v}}")
 {{else}}
-	alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, verifreg{{.v}}.AllocationId(allocationId))
-	return (*Allocation)(alloc), ok, err{{end}}
+	alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, {{if (gt .v 9)}}verifreg{{.v}}.AllocationId(allocationId){{else}}allocationId{{end}})
+	return {{if (gt .v 9)}}(*Allocation)(alloc){{else}}alloc{{end}}, ok, err{{end}}
 }
 
 func (s *state{{.v}}) GetAllocations(clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
@@ -138,7 +138,7 @@ func (s *state{{.v}}) GetAllocations(clientIdAddr address.Address) (map[Allocati
 
 	retMap := make(map[AllocationId]Allocation, len(v{{.v}}Map))
 	for k, v := range v{{.v}}Map {
-		retMap[AllocationId(k)] = Allocation(v)
+		retMap[{{if (gt .v 9)}}AllocationId(k){{else}}k{{end}}] = {{if (gt .v 9)}}Allocation(v){{else}}v{{end}}
 	}
 
 	return retMap, err
@@ -153,7 +153,7 @@ func (s *state{{.v}}) GetAllAllocations() (map[AllocationId]Allocation, error) {
 
 	retMap := make(map[AllocationId]Allocation, len(v{{.v}}Map))
 	for k, v := range v{{.v}}Map {
-		retMap[AllocationId(k)] = Allocation(v)
+		retMap[{{if (gt .v 9)}}AllocationId(k){{else}}k{{end}}] = {{if (gt .v 9)}}Allocation(v){{else}}v{{end}}
 	}
 
 	return retMap, err
@@ -164,8 +164,8 @@ func (s *state{{.v}}) GetClaim(providerIdAddr address.Address, claimId verifreg9
 {{if (le .v 8)}}
     return nil, false, xerrors.Errorf("unsupported in actors v{{.v}}")
 {{else}}
-	claim, ok, err := s.FindClaim(s.store, providerIdAddr, verifreg{{.v}}.ClaimId(claimId))
-	return (*Claim)(claim), ok, err
+	claim, ok, err := s.FindClaim(s.store, providerIdAddr, {{if (gt .v 9)}}verifreg{{.v}}.ClaimId(claimId){{else}}claimId{{end}})
+	return {{if (gt .v 9)}}(*Claim)(claim){{else}}claim{{end}}, ok, err
 {{end}}
 }
 
@@ -177,7 +177,7 @@ func (s *state{{.v}}) GetClaims(providerIdAddr address.Address) (map[ClaimId]Cla
 
 	retMap := make(map[ClaimId]Claim, len(v{{.v}}Map))
 	for k, v := range v{{.v}}Map {
-		retMap[ClaimId(k)] = Claim(v)
+		retMap[{{if (gt .v 9)}}ClaimId(k){{else}}k{{end}}] = {{if (gt .v 9)}}Claim(v){{else}}v{{end}}
 	}
 
 	return retMap, err
@@ -193,7 +193,7 @@ func (s *state{{.v}}) GetAllClaims() (map[ClaimId]Claim, error) {
 
 	retMap := make(map[ClaimId]Claim, len(v{{.v}}Map))
 	for k, v := range v{{.v}}Map {
-		retMap[ClaimId(k)] = Claim(v)
+		retMap[{{if (gt .v 9)}}ClaimId(k){{else}}k{{end}}] = {{if (gt .v 9)}}Claim(v){{else}}v{{end}}
 	}
 
 	return retMap, err
@@ -211,9 +211,9 @@ func (s *state{{.v}}) GetClaimIdsBySector(providerIdAddr address.Address) (map[a
 	for k, v := range v{{.v}}Map {
 		claims, ok := retMap[v.Sector]
 		if !ok {
-			retMap[v.Sector] = []ClaimId{ClaimId(k)}
+			retMap[v.Sector] = []ClaimId{ {{if (gt .v 9)}}ClaimId(k){{else}}k{{end}} }
 		} else {
-			retMap[v.Sector] = append(claims, ClaimId(k))
+			retMap[v.Sector] = append(claims, {{if (gt .v 9)}}ClaimId(k){{else}}k{{end}})
 		}
 	}
 

--- a/chain/actors/builtin/verifreg/v9.go
+++ b/chain/actors/builtin/verifreg/v9.go
@@ -96,8 +96,8 @@ func (s *state9) GetState() interface{} {
 
 func (s *state9) GetAllocation(clientIdAddr address.Address, allocationId verifreg9.AllocationId) (*Allocation, bool, error) {
 
-	alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, verifreg9.AllocationId(allocationId))
-	return (*Allocation)(alloc), ok, err
+	alloc, ok, err := s.FindAllocation(s.store, clientIdAddr, allocationId)
+	return alloc, ok, err
 }
 
 func (s *state9) GetAllocations(clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
@@ -106,7 +106,7 @@ func (s *state9) GetAllocations(clientIdAddr address.Address) (map[AllocationId]
 
 	retMap := make(map[AllocationId]Allocation, len(v9Map))
 	for k, v := range v9Map {
-		retMap[AllocationId(k)] = Allocation(v)
+		retMap[k] = v
 	}
 
 	return retMap, err
@@ -119,7 +119,7 @@ func (s *state9) GetAllAllocations() (map[AllocationId]Allocation, error) {
 
 	retMap := make(map[AllocationId]Allocation, len(v9Map))
 	for k, v := range v9Map {
-		retMap[AllocationId(k)] = Allocation(v)
+		retMap[k] = v
 	}
 
 	return retMap, err
@@ -128,8 +128,8 @@ func (s *state9) GetAllAllocations() (map[AllocationId]Allocation, error) {
 
 func (s *state9) GetClaim(providerIdAddr address.Address, claimId verifreg9.ClaimId) (*Claim, bool, error) {
 
-	claim, ok, err := s.FindClaim(s.store, providerIdAddr, verifreg9.ClaimId(claimId))
-	return (*Claim)(claim), ok, err
+	claim, ok, err := s.FindClaim(s.store, providerIdAddr, claimId)
+	return claim, ok, err
 
 }
 
@@ -139,7 +139,7 @@ func (s *state9) GetClaims(providerIdAddr address.Address) (map[ClaimId]Claim, e
 
 	retMap := make(map[ClaimId]Claim, len(v9Map))
 	for k, v := range v9Map {
-		retMap[ClaimId(k)] = Claim(v)
+		retMap[k] = v
 	}
 
 	return retMap, err
@@ -152,7 +152,7 @@ func (s *state9) GetAllClaims() (map[ClaimId]Claim, error) {
 
 	retMap := make(map[ClaimId]Claim, len(v9Map))
 	for k, v := range v9Map {
-		retMap[ClaimId(k)] = Claim(v)
+		retMap[k] = v
 	}
 
 	return retMap, err
@@ -167,9 +167,9 @@ func (s *state9) GetClaimIdsBySector(providerIdAddr address.Address) (map[abi.Se
 	for k, v := range v9Map {
 		claims, ok := retMap[v.Sector]
 		if !ok {
-			retMap[v.Sector] = []ClaimId{ClaimId(k)}
+			retMap[v.Sector] = []ClaimId{k}
 		} else {
-			retMap[v.Sector] = append(claims, ClaimId(k))
+			retMap[v.Sector] = append(claims, k)
 		}
 	}
 

--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -6,17 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"github.com/filecoin-project/go-state-types/big"
-	builtin10 "github.com/filecoin-project/go-state-types/builtin"
-	builtin11 "github.com/filecoin-project/go-state-types/builtin"
-	builtin12 "github.com/filecoin-project/go-state-types/builtin"
-	builtin13 "github.com/filecoin-project/go-state-types/builtin"
-	builtin14 "github.com/filecoin-project/go-state-types/builtin"
-	builtin15 "github.com/filecoin-project/go-state-types/builtin"
-	builtin16 "github.com/filecoin-project/go-state-types/builtin"
-	builtin17 "github.com/filecoin-project/go-state-types/builtin"
-	builtin18 "github.com/filecoin-project/go-state-types/builtin"
-	builtin8 "github.com/filecoin-project/go-state-types/builtin"
-	builtin9 "github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/builtin"
 	market10 "github.com/filecoin-project/go-state-types/builtin/v10/market"
 	miner10 "github.com/filecoin-project/go-state-types/builtin/v10/miner"
 	verifreg10 "github.com/filecoin-project/go-state-types/builtin/v10/verifreg"
@@ -86,7 +76,7 @@ const (
 	ChainFinality                  = miner18.ChainFinality
 	SealRandomnessLookback         = ChainFinality
 	PaychSettleDelay               = paych18.SettleDelay
-	MaxPreCommitRandomnessLookback = builtin18.EpochsInDay + SealRandomnessLookback
+	MaxPreCommitRandomnessLookback = builtin.EpochsInDay + SealRandomnessLookback
 	DeclarationsMax                = 3000
 )
 
@@ -256,47 +246,47 @@ func SetConsensusMinerMinPower(p abi.StoragePower) {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin8.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin9.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin10.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin11.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin12.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin13.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin14.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin15.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin16.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin17.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
-	for _, policy := range builtin18.PoStProofPolicies {
+	for _, policy := range builtin.PoStProofPolicies {
 		policy.ConsensusMinerMinPower = p
 	}
 
@@ -459,57 +449,57 @@ func SetProviderCollateralSupplyTarget(num, denom big.Int) {
 		Denominator: denom,
 	}
 
-	market8.ProviderCollateralSupplyTarget = builtin8.BigFrac{
+	market8.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market9.ProviderCollateralSupplyTarget = builtin9.BigFrac{
+	market9.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market10.ProviderCollateralSupplyTarget = builtin10.BigFrac{
+	market10.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market11.ProviderCollateralSupplyTarget = builtin11.BigFrac{
+	market11.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market12.ProviderCollateralSupplyTarget = builtin12.BigFrac{
+	market12.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market13.ProviderCollateralSupplyTarget = builtin13.BigFrac{
+	market13.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market14.ProviderCollateralSupplyTarget = builtin14.BigFrac{
+	market14.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market15.ProviderCollateralSupplyTarget = builtin15.BigFrac{
+	market15.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market16.ProviderCollateralSupplyTarget = builtin16.BigFrac{
+	market16.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market17.ProviderCollateralSupplyTarget = builtin17.BigFrac{
+	market17.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
 
-	market18.ProviderCollateralSupplyTarget = builtin18.BigFrac{
+	market18.ProviderCollateralSupplyTarget = builtin.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
@@ -831,7 +821,7 @@ func GetMinSectorExpiration() abi.ChainEpoch {
 }
 
 func GetMaxPoStPartitions(nv network.Version, p abi.RegisteredPoStProof) (int, error) {
-	sectorsPerPart, err := builtin18.PoStProofWindowPoStPartitionSectors(p)
+	sectorsPerPart, err := builtin.PoStProofWindowPoStPartitionSectors(p)
 	if err != nil {
 		return 0, err
 	}
@@ -852,7 +842,7 @@ func GetSectorMaxLifetime(proof abi.RegisteredSealProof, nwVer network.Version) 
 		return builtin4.SealProofPoliciesV0[proof].SectorMaxLifetime
 	}
 
-	return builtin18.SealProofPoliciesV11[proof].SectorMaxLifetime
+	return builtin.SealProofPoliciesV11[proof].SectorMaxLifetime
 }
 
 func GetAddressedSectorsMax(nwVer network.Version) (int, error) {

--- a/chain/actors/policy/policy.go.template
+++ b/chain/actors/policy/policy.go.template
@@ -7,11 +7,11 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/network"
 
 	{{range .versions}}
 	{{if (ge . 8)}}
-        builtin{{.}} "github.com/filecoin-project/go-state-types/builtin"
         miner{{.}} "github.com/filecoin-project/go-state-types/builtin{{import .}}miner"
         market{{.}} "github.com/filecoin-project/go-state-types/builtin{{import .}}market"
         verifreg{{.}} "github.com/filecoin-project/go-state-types/builtin{{import .}}verifreg"
@@ -36,7 +36,7 @@ const (
 	ChainFinality                  = miner{{.latestVersion}}.ChainFinality
 	SealRandomnessLookback         = ChainFinality
 	PaychSettleDelay               = paych{{.latestVersion}}.SettleDelay
-	MaxPreCommitRandomnessLookback = builtin{{.latestVersion}}.EpochsInDay + SealRandomnessLookback
+	MaxPreCommitRandomnessLookback = builtin.EpochsInDay + SealRandomnessLookback
 	DeclarationsMax                = 3000
 )
 
@@ -124,11 +124,11 @@ func SetConsensusMinerMinPower(p abi.StoragePower) {
 		{{if (eq . 0)}}
 			power{{.}}.ConsensusMinerMinPower = p
 		{{else if (eq . 2)}}
-			for _, policy := range builtin{{.}}.SealProofPolicies {
+			for _, policy := range builtin2.SealProofPolicies {
 				policy.ConsensusMinerMinPower = p
 			}
 		{{else}}
-			for _, policy := range builtin{{.}}.PoStProofPolicies {
+			for _, policy := range {{if (ge . 8)}}builtin{{else}}builtin{{.}}{{end}}.PoStProofPolicies {
 				policy.ConsensusMinerMinPower = p
 			}
 		{{end}}
@@ -164,7 +164,7 @@ func GetMaxProveCommitDuration(ver actorstypes.Version, t abi.RegisteredSealProo
 func SetProviderCollateralSupplyTarget(num, denom big.Int) {
 {{range .versions}}
 	{{if (ge . 2)}}
-	market{{.}}.ProviderCollateralSupplyTarget = builtin{{.}}.BigFrac{
+	market{{.}}.ProviderCollateralSupplyTarget = {{if (ge . 8)}}builtin{{else}}builtin{{.}}{{end}}.BigFrac{
 		Numerator:   num,
 		Denominator: denom,
 	}
@@ -245,7 +245,7 @@ func GetMinSectorExpiration() abi.ChainEpoch {
 }
 
 func GetMaxPoStPartitions(nv network.Version, p abi.RegisteredPoStProof) (int, error) {
-	sectorsPerPart, err := builtin{{.latestVersion}}.PoStProofWindowPoStPartitionSectors(p)
+	sectorsPerPart, err := builtin.PoStProofWindowPoStPartitionSectors(p)
 	if err != nil {
 		return 0, err
 	}
@@ -266,7 +266,7 @@ func GetSectorMaxLifetime(proof abi.RegisteredSealProof, nwVer network.Version) 
 		return builtin4.SealProofPoliciesV0[proof].SectorMaxLifetime
 	}
 
-	return builtin{{.latestVersion}}.SealProofPoliciesV11[proof].SectorMaxLifetime
+	return builtin.SealProofPoliciesV11[proof].SectorMaxLifetime
 }
 
 func GetAddressedSectorsMax(nwVer network.Version) (int, error) {

--- a/chain/events/events_height.go
+++ b/chain/events/events_height.go
@@ -28,7 +28,7 @@ type heightEvents struct {
 	lk                        sync.Mutex
 	head                      *types.TipSet
 	tsHeights, triggerHeights map[abi.ChainEpoch][]*heightHandler
-	lastGc                    abi.ChainEpoch //nolint:structcheck
+	lastGc                    abi.ChainEpoch
 }
 
 func newHeightEvents(api EventHelperAPI, obs *observer, gcConfidence abi.ChainEpoch) *heightEvents {

--- a/chain/events/state/fastapi.go
+++ b/chain/events/state/fastapi.go
@@ -25,10 +25,10 @@ func WrapFastAPI(api FastChainApiAPI) ChainAPI {
 }
 
 func (a *fastAPI) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
-	ts, err := a.FastChainApiAPI.ChainGetTipSet(ctx, tsk)
+	ts, err := a.ChainGetTipSet(ctx, tsk)
 	if err != nil {
 		return nil, err
 	}
 
-	return a.FastChainApiAPI.StateGetActor(ctx, actor, ts.Parents())
+	return a.StateGetActor(ctx, actor, ts.Parents())
 }

--- a/chain/events/state/fastapi.go
+++ b/chain/events/state/fastapi.go
@@ -16,19 +16,21 @@ type FastChainApiAPI interface {
 
 type fastAPI struct {
 	FastChainApiAPI
+	api FastChainApiAPI
 }
 
 func WrapFastAPI(api FastChainApiAPI) ChainAPI {
 	return &fastAPI{
-		api,
+		FastChainApiAPI: api,
+		api:             api,
 	}
 }
 
 func (a *fastAPI) StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error) {
-	ts, err := a.ChainGetTipSet(ctx, tsk)
+	ts, err := a.api.ChainGetTipSet(ctx, tsk)
 	if err != nil {
 		return nil, err
 	}
 
-	return a.StateGetActor(ctx, actor, ts.Parents())
+	return a.api.StateGetActor(ctx, actor, ts.Parents())
 }

--- a/chain/exchange/client.go
+++ b/chain/exchange/client.go
@@ -219,7 +219,7 @@ func (c *client) processResponse(req *Request, res *Response, tipsets []*types.T
 
 		// Check `TipSet`s are connected (valid chain).
 		for i := 0; i < len(validRes.tipsets)-1; i++ {
-			if validRes.tipsets[i].IsChildOf(validRes.tipsets[i+1]) == false {
+			if !validRes.tipsets[i].IsChildOf(validRes.tipsets[i+1]) {
 				return nil, fmt.Errorf("tipsets are not connected at height (head - %d)/(head - %d)",
 					i, i+1)
 				// FIXME: Maybe give more information here, like CIDs.

--- a/chain/exchange/protocol.go
+++ b/chain/exchange/protocol.go
@@ -78,8 +78,8 @@ type parsedOptions struct {
 }
 
 func (options *parsedOptions) noOptionsSet() bool {
-	return options.IncludeHeaders == false &&
-		options.IncludeMessages == false
+	return !options.IncludeHeaders &&
+		!options.IncludeMessages
 }
 
 func parseOptions(optfield uint64) *parsedOptions {

--- a/chain/gen/genesis/f01_init.go
+++ b/chain/gen/genesis/f01_init.go
@@ -127,7 +127,8 @@ func SetupInitActor(ctx context.Context, bs bstore.Blockstore, netname string, i
 		return nil
 	}
 
-	if rootVerifier.Type == genesis.TAccount {
+	switch rootVerifier.Type {
+	case genesis.TAccount:
 		var ainfo genesis.AccountMeta
 		if err := json.Unmarshal(rootVerifier.Meta, &ainfo); err != nil {
 			return 0, nil, nil, xerrors.Errorf("unmarshaling account meta: %w", err)
@@ -136,14 +137,15 @@ func SetupInitActor(ctx context.Context, bs bstore.Blockstore, netname string, i
 		if err := amap.Put(abi.AddrKey(ainfo.Owner), &value); err != nil {
 			return 0, nil, nil, err
 		}
-	} else if rootVerifier.Type == genesis.TMultisig {
+	case genesis.TMultisig:
 		err := setupMsig(rootVerifier.Meta)
 		if err != nil {
 			return 0, nil, nil, xerrors.Errorf("setting up root verifier msig: %w", err)
 		}
 	}
 
-	if remainder.Type == genesis.TAccount {
+	switch remainder.Type {
+	case genesis.TAccount:
 		var ainfo genesis.AccountMeta
 		if err := json.Unmarshal(remainder.Meta, &ainfo); err != nil {
 			return 0, nil, nil, xerrors.Errorf("unmarshaling account meta: %w", err)
@@ -154,7 +156,7 @@ func SetupInitActor(ctx context.Context, bs bstore.Blockstore, netname string, i
 		if err := amap.Put(abi.AddrKey(ainfo.Owner), &value); err != nil {
 			return 0, nil, nil, err
 		}
-	} else if remainder.Type == genesis.TMultisig {
+	case genesis.TMultisig:
 		err := setupMsig(remainder.Meta)
 		if err != nil {
 			return 0, nil, nil, xerrors.Errorf("setting up remainder msig: %w", err)

--- a/chain/lf3/ec.go
+++ b/chain/lf3/ec.go
@@ -49,13 +49,13 @@ type f3TipSet struct {
 
 func (ts *f3TipSet) String() string       { return ts.TipSet.String() }
 func (ts *f3TipSet) Key() gpbft.TipSetKey { return ts.TipSet.Key().Bytes() }
-func (ts *f3TipSet) Epoch() int64         { return int64(ts.TipSet.Height()) }
+func (ts *f3TipSet) Epoch() int64         { return int64(ts.Height()) }
 
 func (ts *f3TipSet) FirstBlockHeader() *types.BlockHeader {
-	if ts.TipSet == nil || len(ts.TipSet.Blocks()) == 0 {
+	if ts.TipSet == nil || len(ts.Blocks()) == 0 {
 		return nil
 	}
-	return ts.TipSet.Blocks()[0]
+	return ts.Blocks()[0]
 }
 
 func (ts *f3TipSet) Beacon() []byte {

--- a/chain/market/fundmanager_test.go
+++ b/chain/market/fundmanager_test.go
@@ -424,9 +424,10 @@ func TestFundManagerWithdrawByWallet(t *testing.T) {
 		}
 		withdrawalCount = len(fa.withdrawals)
 
-		if withdrawalCount == 1 {
+		switch withdrawalCount {
+		case 1:
 			close(walletAQueuedUp)
-		} else if withdrawalCount == 3 {
+		case 3:
 			close(queueReady)
 			return true
 		}

--- a/chain/messagepool/check.go
+++ b/chain/messagepool/check.go
@@ -436,7 +436,7 @@ func (mp *MessagePool) checkMessages(ctx context.Context, msgs []*types.Message,
 			},
 		}
 
-		if balance.Int.Cmp(st.requiredFunds) < 0 {
+		if balance.Cmp(st.requiredFunds) < 0 {
 			check.OK = false
 			check.Err = "insufficient balance"
 		} else {

--- a/chain/messagepool/check_test.go
+++ b/chain/messagepool/check_test.go
@@ -25,7 +25,7 @@ func init() {
 func getCheckMessageStatus(statusCode api.CheckStatusCode, msgStatuses []api.MessageCheckStatus) (*api.MessageCheckStatus, error) {
 	for i := 0; i < len(msgStatuses); i++ {
 		iMsgStatuses := msgStatuses[i]
-		if iMsgStatuses.CheckStatus.Code == statusCode {
+		if iMsgStatuses.Code == statusCode {
 			return &iMsgStatuses, nil
 		}
 	}

--- a/chain/messagepool/messagepool_test.go
+++ b/chain/messagepool/messagepool_test.go
@@ -1114,7 +1114,7 @@ func TestCapGasFee(t *testing.T) {
 			return abi.NewTokenAmount(100_000_000_000), nil
 		}, msg, nil)
 		assert.Equal(t, msg.GasFeeCap.Int64(), int64(1000))
-		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(1000))
+		assert.Equal(t, msg.GasPremium.Int64(), int64(1000))
 	})
 
 	t.Run("use spec maxfee", func(t *testing.T) {
@@ -1125,7 +1125,7 @@ func TestCapGasFee(t *testing.T) {
 		}
 		CapGasFee(nil, msg, &api.MessageSendSpec{MaxFee: abi.NewTokenAmount(100_000_000_000)})
 		assert.Equal(t, msg.GasFeeCap.Int64(), int64(1000))
-		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(1000))
+		assert.Equal(t, msg.GasPremium.Int64(), int64(1000))
 	})
 
 	t.Run("use smaller feecap value when fee is enough", func(t *testing.T) {
@@ -1136,6 +1136,6 @@ func TestCapGasFee(t *testing.T) {
 		}
 		CapGasFee(nil, msg, &api.MessageSendSpec{MaxFee: abi.NewTokenAmount(100_000_000_000_000)})
 		assert.Equal(t, msg.GasFeeCap.Int64(), int64(100_000))
-		assert.Equal(t, msg.GasPremium.Int.Int64(), int64(100_000))
+		assert.Equal(t, msg.GasPremium.Int64(), int64(100_000))
 	})
 }

--- a/chain/messagepool/selection.go
+++ b/chain/messagepool/selection.go
@@ -99,7 +99,8 @@ func (sm *selectedMessages) tryToAdd(mc *msgChain) bool {
 		return false
 	}
 
-	if mc.sigType == crypto.SigTypeBLS {
+	switch mc.sigType {
+	case crypto.SigTypeBLS:
 		if sm.blsLimit < l {
 			return false
 		}
@@ -107,7 +108,7 @@ func (sm *selectedMessages) tryToAdd(mc *msgChain) bool {
 		sm.msgs = append(sm.msgs, mc.msgs...)
 		sm.blsLimit -= l
 		sm.gasLimit -= mc.gasLimit
-	} else if mc.sigType == crypto.SigTypeSecp256k1 || mc.sigType == crypto.SigTypeDelegated {
+	case crypto.SigTypeSecp256k1, crypto.SigTypeDelegated:
 		if sm.secpLimit < l {
 			return false
 		}
@@ -131,11 +132,12 @@ func (sm *selectedMessages) tryToAddWithDeps(mc *msgChain, mp *MessagePool, base
 	depMsgLimit := 0
 	smMsgLimit := 0
 
-	if mc.sigType == crypto.SigTypeBLS {
+	switch mc.sigType {
+	case crypto.SigTypeBLS:
 		smMsgLimit = sm.blsLimit
-	} else if mc.sigType == crypto.SigTypeSecp256k1 || mc.sigType == crypto.SigTypeDelegated {
+	case crypto.SigTypeSecp256k1, crypto.SigTypeDelegated:
 		smMsgLimit = sm.secpLimit
-	} else {
+	default:
 		return false
 	}
 
@@ -182,9 +184,10 @@ func (sm *selectedMessages) tryToAddWithDeps(mc *msgChain, mp *MessagePool, base
 	sm.msgs = append(sm.msgs, mc.msgs...)
 	sm.gasLimit -= chainGasLimit
 
-	if mc.sigType == crypto.SigTypeBLS {
+	switch mc.sigType {
+	case crypto.SigTypeBLS:
 		sm.blsLimit -= chainMsgLimit
-	} else if mc.sigType == crypto.SigTypeSecp256k1 || mc.sigType == crypto.SigTypeDelegated {
+	case crypto.SigTypeSecp256k1, crypto.SigTypeDelegated:
 		sm.secpLimit -= chainMsgLimit
 	}
 
@@ -193,11 +196,12 @@ func (sm *selectedMessages) tryToAddWithDeps(mc *msgChain, mp *MessagePool, base
 
 func (sm *selectedMessages) trimChain(mc *msgChain, mp *MessagePool, baseFee types.BigInt) {
 	msgLimit := buildconstants.BlockMessageLimit - len(sm.msgs)
-	if mc.sigType == crypto.SigTypeBLS {
+	switch mc.sigType {
+	case crypto.SigTypeBLS:
 		if msgLimit > sm.blsLimit {
 			msgLimit = sm.blsLimit
 		}
-	} else if mc.sigType == crypto.SigTypeSecp256k1 || mc.sigType == crypto.SigTypeDelegated {
+	case crypto.SigTypeSecp256k1, crypto.SigTypeDelegated:
 		if msgLimit > sm.secpLimit {
 			msgLimit = sm.secpLimit
 		}
@@ -714,10 +718,7 @@ func (mp *MessagePool) getPendingMessages(ctx context.Context, curTs, ts *types.
 	}()
 
 	// are we in sync?
-	inSync := false
-	if curTs.Height() == ts.Height() && curTs.Equals(ts) {
-		inSync = true
-	}
+	inSync := curTs.Height() == ts.Height() && curTs.Equals(ts)
 
 	mp.forEachPending(func(a address.Address, mset *msgSet) {
 		if inSync {

--- a/chain/stmgr/call.go
+++ b/chain/stmgr/call.go
@@ -184,9 +184,10 @@ func (sm *StateManager) callInternal(ctx context.Context, msg *types.Message, pr
 		if err != nil {
 			return nil, xerrors.Errorf("failed to lookup messages for parent tipset: %w", err)
 		}
-		if strategy == execAllMessages {
+		switch strategy {
+		case execAllMessages:
 			priorMsgs = append(tsMsgs, priorMsgs...)
-		} else if strategy == execSameSenderMessages {
+		case execSameSenderMessages:
 			var filteredTsMsgs []types.ChainMsg
 			for _, tsMsg := range tsMsgs {
 				//TODO we should technically be normalizing the filecoin address of from when we compare here

--- a/chain/stmgr/forks.go
+++ b/chain/stmgr/forks.go
@@ -146,7 +146,7 @@ func (us UpgradeSchedule) Validate() error {
 	for i := 1; i < len(us); i++ {
 		prev := &us[i-1]
 		curr := &us[i]
-		if !(prev.Network <= curr.Network) {
+		if prev.Network > curr.Network {
 			return xerrors.Errorf("cannot downgrade from version %d to version %d", prev.Network, curr.Network)
 		}
 		// Make sure the heights make sense.
@@ -154,7 +154,7 @@ func (us UpgradeSchedule) Validate() error {
 			// Previous upgrade was disabled.
 			continue
 		}
-		if !(prev.Height < curr.Height) {
+		if prev.Height >= curr.Height {
 			return xerrors.Errorf("upgrade heights must be strictly increasing: upgrade %d was at height %d, followed by upgrade %d at height %d", i-1, prev.Height, i, curr.Height)
 		}
 	}

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/gen"
-	"github.com/filecoin-project/lotus/chain/stmgr"
 	. "github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
@@ -666,7 +665,7 @@ func TestMigrtionCache(t *testing.T) {
 	ts, err := cg.ChainStore().GetTipsetByHeight(context.Background(), testForkHeight, nil, false)
 	require.NoError(t, err)
 
-	root, _, err := stmgr.ComputeState(context.Background(), sm, testForkHeight+1, []*types.Message{}, ts)
+	root, _, err := ComputeState(context.Background(), sm, testForkHeight+1, []*types.Message{}, ts)
 	require.NoError(t, err)
 	t.Log(root)
 

--- a/chain/store/snapshot.go
+++ b/chain/store/snapshot.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-f3/certstore"
-	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	bstore "github.com/filecoin-project/lotus/blockstore"
@@ -237,7 +236,7 @@ func (cs *ChainStore) Import(ctx context.Context, f3Ds dtypes.F3DS, r io.Reader)
 				prefix := F3DatastorePrefix()
 				f3DsWrapper := namespace.Wrap(f3Ds, prefix)
 
-				var f3Manifest *manifest.Manifest = buildconstants.F3Manifest()
+				f3Manifest := buildconstants.F3Manifest()
 				if f3Manifest != nil && f3Manifest.InitialPowerTable.Defined() {
 					log.Info("Importing F3Data to datastore")
 					if err := certstore.ImportSnapshotToDatastore(ctx, f3r, f3DsWrapper, f3Manifest); err != nil {
@@ -439,17 +438,15 @@ func (f *taskFifo) run() {
 			// no elements in fifo to put out.
 			// Try to read in and block.
 			// When done, try to put out or add to fifo.
+			elem, ok := <-f.in
+			if !ok {
+				close(f.out)
+				return
+			}
 			select {
-			case elem, ok := <-f.in:
-				if !ok {
-					close(f.out)
-					return
-				}
-				select {
-				case f.out <- elem:
-				default:
-					f.fifo = append(f.fifo, elem)
-				}
+			case f.out <- elem:
+			default:
+				f.fifo = append(f.fifo, elem)
 			}
 		}
 	}
@@ -556,14 +553,12 @@ func (s *walkScheduler) Wait() error {
 		if n := s.totalTasks.Load(); n == 0 {
 			break // finally fully done
 		}
-		select {
-		case task := <-s.workerTasks.out:
-			s.totalTasks.Add(-1)
-			if err != nil {
-				continue // just drain if errors happened.
-			}
-			err = s.processTask(task, 0)
+		task := <-s.workerTasks.out
+		s.totalTasks.Add(-1)
+		if err != nil {
+			continue // just drain if errors happened.
 		}
+		err = s.processTask(task, 0)
 	}
 	close(s.results)
 	errWrite := <-s.writeErrorChan

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -342,7 +342,7 @@ func (mv *MessageValidator) Validate(ctx context.Context, pid peer.ID, msg *pubs
 	}()
 
 	stats.Record(ctx, metrics.MessageReceived.M(1))
-	m, err := types.DecodeSignedMessage(msg.Message.GetData())
+	m, err := types.DecodeSignedMessage(msg.GetData())
 	if err != nil {
 		log.Warnf("failed to decode incoming message: %s", err)
 		ctx, _ = tag.New(ctx, tag.Insert(metrics.FailureType, "decode"))
@@ -411,7 +411,7 @@ func (mv *MessageValidator) validateLocalMessage(ctx context.Context, msg *pubsu
 	// do some lightweight validation
 	stats.Record(ctx, metrics.MessagePublished.M(1))
 
-	m, err := types.DecodeSignedMessage(msg.Message.GetData())
+	m, err := types.DecodeSignedMessage(msg.GetData())
 	if err != nil {
 		log.Warnf("failed to decode local message: %s", err)
 		recordFailure(ctx, metrics.MessageValidationFailure, "decode")

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -817,7 +817,7 @@ loop:
 		//  `MaxRequestLength` limitation, it should just be able to request
 		//  a segment of arbitrary length. The same burden is put on
 		//  `syncFork()` which needs to be aware this as well.
-		if blockSet[len(blockSet)-1].IsChildOf(blks[0]) == false {
+		if !blockSet[len(blockSet)-1].IsChildOf(blks[0]) {
 			return nil, xerrors.Errorf("retrieved segments of the chain are not connected at heights %d/%d",
 				blockSet[len(blockSet)-1].Height(), blks[0].Height())
 			// A successful `GetBlocks()` call is guaranteed to fetch at least

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -926,7 +926,7 @@ func TestSyncInputs(t *testing.T) {
 
 	fn := tu.nds[p1].(*impl.FullNodeAPI)
 
-	s := fn.SyncAPI.Syncer
+	s := fn.Syncer
 
 	err := s.ValidateBlock(context.TODO(), &types.FullBlock{
 		Header: &types.BlockHeader{},

--- a/chain/types/electionproof_test.go
+++ b/chain/types/electionproof_test.go
@@ -40,7 +40,7 @@ func TestPoissonFunction(t *testing.T) {
 				b.WriteString(p.next().String())
 				b.WriteRune('\n')
 			}
-			golden.Assert(t, []byte(b.String()))
+			golden.Assert(t, b.Bytes())
 		})
 	}
 }

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
-	mh "github.com/multiformats/go-multihash"
 	"github.com/multiformats/go-varint"
 	"golang.org/x/xerrors"
 
@@ -33,7 +32,7 @@ import (
 var expectedHashPrefix = cid.Prefix{
 	Version:  1,
 	Codec:    cid.DagCBOR,
-	MhType:   uint64(mh.BLAKE2B_MIN + 31),
+	MhType:   uint64(multihash.BLAKE2B_MIN + 31),
 	MhLength: 32,
 }.Bytes()
 
@@ -86,7 +85,7 @@ func (e *EthUint64) UnmarshalJSON(b []byte) error {
 }
 
 func EthUint64FromHex(s string) (EthUint64, error) {
-	parsedInt, err := strconv.ParseUint(strings.Replace(s, "0x", "", -1), 16, 64)
+	parsedInt, err := strconv.ParseUint(strings.ReplaceAll(s, "0x", ""), 16, 64)
 	if err != nil {
 		return EthUint64(0), err
 	}
@@ -128,7 +127,7 @@ type EthBigInt big.Int
 var EthBigIntZero = EthBigInt{Int: big.Zero().Int}
 
 func (e EthBigInt) String() string {
-	if e.Int == nil || e.Int.BitLen() == 0 {
+	if e.Int == nil || e.BitLen() == 0 {
 		return "0x0"
 	}
 	return fmt.Sprintf("0x%x", e.Int)
@@ -144,7 +143,7 @@ func (e *EthBigInt) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	replaced := strings.Replace(s, "0x", "", -1)
+	replaced := strings.ReplaceAll(s, "0x", "")
 	if len(replaced)%2 == 1 {
 		replaced = "0" + replaced
 	}
@@ -176,7 +175,7 @@ func (e *EthBytes) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s = strings.Replace(s, "0x", "", -1)
+	s = strings.ReplaceAll(s, "0x", "")
 	if len(s)%2 == 1 {
 		s = "0" + s
 	}
@@ -417,7 +416,7 @@ func (n *EthNonce) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s = strings.Replace(s, "0x", "", -1)
+	s = strings.ReplaceAll(s, "0x", "")
 	if len(s)%2 == 1 {
 		s = "0" + s
 	}

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -53,7 +53,7 @@ func TestEthIntUnmarshalJSON(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, tc.Output, i)
 
-		i, err = EthUint64FromString(strings.Replace(string(tc.Input.([]byte)), `"`, "", -1))
+		i, err = EthUint64FromString(strings.ReplaceAll(string(tc.Input.([]byte)), `"`, ""))
 		require.Nil(t, err)
 		require.Equal(t, tc.Output, i)
 	}
@@ -100,7 +100,7 @@ func TestEthHash(t *testing.T) {
 		err := h.UnmarshalJSON([]byte(hash))
 
 		require.Nil(t, err)
-		require.Equal(t, h.String(), strings.Replace(hash, `"`, "", -1))
+		require.Equal(t, h.String(), strings.ReplaceAll(hash, `"`, ""))
 
 		c := h.ToCid()
 		h1, err := EthHashFromCid(c)
@@ -135,7 +135,7 @@ func TestEthFilterID(t *testing.T) {
 		err := h.UnmarshalJSON([]byte(hash))
 
 		require.Nil(t, err)
-		require.Equal(t, h.String(), strings.Replace(hash, `"`, "", -1))
+		require.Equal(t, h.String(), strings.ReplaceAll(hash, `"`, ""))
 
 		jm, err := json.Marshal(h)
 		require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestEthSubscriptionID(t *testing.T) {
 		err := h.UnmarshalJSON([]byte(hash))
 
 		require.Nil(t, err)
-		require.Equal(t, h.String(), strings.Replace(hash, `"`, "", -1))
+		require.Equal(t, h.String(), strings.ReplaceAll(hash, `"`, ""))
 
 		jm, err := json.Marshal(h)
 		require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestEthAddr(t *testing.T) {
 		err := a.UnmarshalJSON([]byte(addr))
 
 		require.Nil(t, err)
-		require.Equal(t, a.String(), strings.Replace(addr, `"`, "", -1))
+		require.Equal(t, a.String(), strings.ReplaceAll(addr, `"`, ""))
 	}
 }
 

--- a/chain/types/ethtypes/rlp_test.go
+++ b/chain/types/ethtypes/rlp_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func mustDecodeHex(s string) []byte {
-	d, err := hex.DecodeString(strings.Replace(s, "0x", "", -1))
+	d, err := hex.DecodeString(strings.ReplaceAll(s, "0x", ""))
 	if err != nil {
 		panic(fmt.Errorf("err must be nil: %w", err))
 	}
@@ -84,10 +84,10 @@ func TestDecodeString(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		input, err := hex.DecodeString(strings.Replace(tc.Input.(string), "0x", "", -1))
+		input, err := hex.DecodeString(strings.ReplaceAll(tc.Input.(string), "0x", ""))
 		require.NoError(t, err)
 
-		output, err := hex.DecodeString(strings.Replace(tc.Output.(string), "0x", "", -1))
+		output, err := hex.DecodeString(strings.ReplaceAll(tc.Output.(string), "0x", ""))
 		require.NoError(t, err)
 
 		result, err := DecodeRLP(input)
@@ -128,7 +128,7 @@ func TestDecodeList(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		input, err := hex.DecodeString(strings.Replace(tc.Input.(string), "0x", "", -1))
+		input, err := hex.DecodeString(strings.ReplaceAll(tc.Input.(string), "0x", ""))
 		require.NoError(t, err)
 
 		result, err := DecodeRLP(input)
@@ -229,7 +229,7 @@ func TestDecodeLimits(t *testing.T) {
 		require.NoError(t, err)
 
 		// Unwrap the nested lists down to the leaf.
-		var cur interface{} = result
+		cur := result
 		for i := 0; i < depth; i++ {
 			lst, ok := cur.([]interface{})
 			require.True(t, ok, "expected list at depth %d", i)

--- a/chain/types/fil.go
+++ b/chain/types/fil.go
@@ -88,7 +88,7 @@ func (f FIL) UnmarshalText(text []byte) error {
 		return err
 	}
 
-	f.Int.Set(p.Int)
+	f.Set(p.Int)
 	return nil
 }
 

--- a/chain/vm/invoker.go
+++ b/chain/vm/invoker.go
@@ -215,8 +215,8 @@ func (*ActorRegistry) transform(instance invokee) (nativeCode, error) {
 		if !runtimeType.Implements(t.In(0)) {
 			return nil, newErr("first argument should be vmr.Runtime")
 		}
-		if t.In(1).Kind() != reflect.Ptr {
-			return nil, newErr("second argument should be of kind reflect.Ptr")
+		if t.In(1).Kind() != reflect.Pointer {
+			return nil, newErr("second argument should be of kind reflect.Pointer")
 		}
 
 		if t.NumOut() != 1 {

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -205,7 +205,6 @@ func (rt *Runtime) shimCall(f func() interface{}) (rval []byte, aerr aerrors.Act
 
 func (rt *Runtime) ValidateImmediateCallerAcceptAny() {
 	rt.abortIfAlreadyValidated()
-	return
 }
 
 func (rt *Runtime) CurrentBalance() abi.TokenAmount {

--- a/chain/vm/syscalls.go
+++ b/chain/vm/syscalls.go
@@ -276,7 +276,7 @@ func (ss *syscallShim) VerifySeal(info proof7.SealVerifyInfo) error {
 	proof := info.Proof
 	seed := []byte(info.InteractiveRandomness)
 
-	log.Debugf("Verif r:%s; d:%s; m:%s; t:%x; s:%x; N:%d; p:%x", info.SealedCID, info.UnsealedCID, miner, ticket, seed, info.SectorID.Number, proof)
+	log.Debugf("Verif r:%s; d:%s; m:%s; t:%x; s:%x; N:%d; p:%x", info.SealedCID, info.UnsealedCID, miner, ticket, seed, info.Number, proof)
 
 	// func(ctx context.Context, maddr address.Address, ssize abi.SectorSize, commD, commR, ticket, proof, seed []byte, sectorID abi.SectorNumber)
 	ok, err := ss.verifier.VerifySeal(info)
@@ -346,7 +346,7 @@ func (ss *syscallShim) BatchVerifySeals(inp map[address.Address][]proof7.SealVer
 				sema <- struct{}{}
 
 				if err := ss.VerifySeal(svi); err != nil {
-					log.Warnw("seal verify in batch failed", "miner", ma, "sectorNumber", svi.SectorID.Number, "err", err)
+					log.Warnw("seal verify in batch failed", "miner", ma, "sectorNumber", svi.Number, "err", err)
 					res[ix] = false
 				} else {
 					res[ix] = true

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -342,8 +342,8 @@ func (vm *LegacyVM) send(ctx context.Context, msg *types.Message, parent *Runtim
 					nmsg := Message{
 						msg: types.Message{
 							To:    aid,
-							From:  rt.Message.Caller(),
-							Value: rt.Message.ValueReceived(),
+							From:  rt.Caller(),
+							Value: rt.ValueReceived(),
 						},
 					}
 					rt.Message = &nmsg

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -33,7 +33,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
-	"github.com/filecoin-project/lotus/api"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/build/buildconstants"
@@ -1379,7 +1378,7 @@ var SlashConsensusFault = &cli.Command{
 			return err
 		}
 
-		proto := &api.MessagePrototype{
+		proto := &lapi.MessagePrototype{
 			Message: types.Message{
 				To:     b2.Miner,
 				From:   fromAddr,

--- a/cli/f3.go
+++ b/cli/f3.go
@@ -455,7 +455,7 @@ Examples:
 				}
 
 				var cert *certs.FinalityCertificate
-				for cctx.Context.Err() == nil {
+				for cctx.Err() == nil {
 					next, proceed := r.next()
 					if !proceed {
 						return nil

--- a/cli/helper.go
+++ b/cli/helper.go
@@ -47,7 +47,7 @@ func RunApp(app *ufcli.App) {
 	}()
 
 	if err := app.Run(os.Args); err != nil {
-		if cfg := logging.GetConfig(); !(cfg.Stdout || cfg.Stderr) {
+		if cfg := logging.GetConfig(); !cfg.Stdout && !cfg.Stderr {
 			// To avoid printing the error twice while making sure that log file contains the
 			// error, check the config and only print it if the output isn't stderr or
 			// stdout.

--- a/cli/miner/init_restore.go
+++ b/cli/miner/init_restore.go
@@ -17,7 +17,6 @@ import (
 	"github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/go-state-types/big"
 
-	"github.com/filecoin-project/lotus/api"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/build"
@@ -72,7 +71,7 @@ var restoreCmd = &cli.Command{
 
 		repoPath := cctx.String(FlagMinerRepo)
 
-		if err := restore(ctx, cctx, repoPath, storageCfg, nil, func(api lapi.FullNode, maddr address.Address, peerid peer.ID, mi api.MinerInfo) error {
+		if err := restore(ctx, cctx, repoPath, storageCfg, nil, func(api lapi.FullNode, maddr address.Address, peerid peer.ID, mi lapi.MinerInfo) error {
 			log.Info("Checking proof parameters")
 
 			if err := paramfetch.GetParams(ctx, build.ParametersJSON(), build.SrsJSON(), uint64(mi.SectorSize)); err != nil {
@@ -93,7 +92,7 @@ var restoreCmd = &cli.Command{
 	},
 }
 
-func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfig *storiface.StorageConfig, manageConfig func(*config.StorageMiner) error, after func(api lapi.FullNode, addr address.Address, peerid peer.ID, mi api.MinerInfo) error) error {
+func restore(ctx context.Context, cctx *cli.Context, targetPath string, strConfig *storiface.StorageConfig, manageConfig func(*config.StorageMiner) error, after func(api lapi.FullNode, addr address.Address, peerid peer.ID, mi lapi.MinerInfo) error) error {
 	if cctx.NArg() != 1 {
 		return lcli.IncorrectNumArgs(cctx)
 	}

--- a/cli/miner/proving.go
+++ b/cli/miner/proving.go
@@ -355,7 +355,6 @@ var provingRecoverFaultsCmd = &cli.Command{
 					return
 				}
 				results <- nil
-				return
 			}(msg)
 		}
 

--- a/cli/miner/sectors.go
+++ b/cli/miner/sectors.go
@@ -1308,13 +1308,14 @@ var sectorsBatchingPendingCommit = &cli.Command{
 			}
 			userInput = strings.ToLower(strings.TrimSpace(userInput))
 
-			if userInput == "yes" {
+			switch userInput {
+			case "yes":
 				err := cctx.Set("publish-now", "true")
 				if err != nil {
 					return xerrors.Errorf("setting publish-now flag: %w", err)
 				}
 				return cctx.Command.Action(cctx)
-			} else if userInput == "no" {
+			case "no":
 				return nil
 			}
 			fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")
@@ -1384,13 +1385,14 @@ var sectorsBatchingPendingPreCommit = &cli.Command{
 			}
 			userInput = strings.ToLower(strings.TrimSpace(userInput))
 
-			if userInput == "yes" {
+			switch userInput {
+			case "yes":
 				err := cctx.Set("publish-now", "true")
 				if err != nil {
 					return xerrors.Errorf("setting publish-now flag: %w", err)
 				}
 				return cctx.Command.Action(cctx)
-			} else if userInput == "no" {
+			case "no":
 				return nil
 			}
 			fmt.Println("Invalid input. Please answer with 'yes' or 'no'.")

--- a/cli/miner/storage.go
+++ b/cli/miner/storage.go
@@ -158,7 +158,7 @@ over time
 				AllowTo:    cctx.StringSlice("allow-to"),
 			}
 
-			if !(cfg.CanStore || cfg.CanSeal) {
+			if !cfg.CanStore && !cfg.CanSeal {
 				return xerrors.Errorf("must specify at least one of --store or --seal")
 			}
 

--- a/cli/send.go
+++ b/cli/send.go
@@ -114,7 +114,7 @@ var SendCmd = &cli.Command{
 				return ShowHelp(cctx, fmt.Errorf("failed to convert ETH address to FIL address: %w", err))
 			}
 			// ideally, this should never happen
-			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
+			if params.To.Protocol() != address.ID && params.To.Protocol() != address.Delegated {
 				return ShowHelp(cctx, fmt.Errorf("ETH addresses can only map to a FIL addresses starting with f410f or f0"))
 			}
 		}
@@ -187,7 +187,7 @@ var SendCmd = &cli.Command{
 			}
 
 			// We can only send to an f410f or f0 address.
-			if !(params.To.Protocol() == address.ID || params.To.Protocol() == address.Delegated) {
+			if params.To.Protocol() != address.ID && params.To.Protocol() != address.Delegated {
 				api := srv.FullNodeAPI()
 				// Resolve id addr if possible.
 				params.To, err = api.StateLookupID(ctx, params.To, types.EmptyTSK)

--- a/cli/sending_ui.go
+++ b/cli/sending_ui.go
@@ -183,7 +183,7 @@ func feeUI(baseFee abi.TokenAmount, gasLimit int64, maxFee *abi.TokenAmount, sen
 	required := big.Mul(baseFee, big.NewInt(gasLimit))
 	safe := big.Mul(required, big.NewInt(10))
 
-	price := fmt.Sprintf("%s", types.FIL(*maxFee).Unitless())
+	price := types.FIL(*maxFee).Unitless()
 
 	return func(t *imtui.Tui) error {
 		if t.CurrentKey != nil {
@@ -196,13 +196,13 @@ func feeUI(baseFee abi.TokenAmount, gasLimit int64, maxFee *abi.TokenAmount, sen
 					if err == nil {
 						p := big.Mul(big.Int(pF), types.NewInt(11))
 						p = big.Div(p, types.NewInt(10))
-						price = fmt.Sprintf("%s", types.FIL(p).Unitless())
+						price = types.FIL(p).Unitless()
 					}
 				case '-':
 					if err == nil {
 						p := big.Mul(big.Int(pF), types.NewInt(10))
 						p = big.Div(p, types.NewInt(11))
-						price = fmt.Sprintf("%s", types.FIL(p).Unitless())
+						price = types.FIL(p).Unitless()
 					}
 				default:
 				}

--- a/cli/state.go
+++ b/cli/state.go
@@ -31,7 +31,6 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/network"
 
-	"github.com/filecoin-project/lotus/api"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/blockstore"
@@ -410,7 +409,7 @@ var StateExecTraceCmd = &cli.Command{
 			return err
 		}
 
-		var trace *api.InvocResult
+		var trace *lapi.InvocResult
 		for _, t := range cso.Trace {
 			if t.Msg.From == msg.From && t.Msg.Nonce == msg.Nonce {
 				trace = t
@@ -580,9 +579,9 @@ var StateListMinersCmd = &cli.Command{
 				fmt.Printf("%s %d\n", miners[i], ndm[miners[i]])
 			}
 			return nil
+		case "", "none":
 		default:
 			return fmt.Errorf("unrecognized sorting order")
-		case "", "none":
 		}
 
 		for _, m := range miners {
@@ -1112,10 +1111,10 @@ var compStateMsg string
 
 type compStateHTMLIn struct {
 	TipSet *types.TipSet
-	Comp   *api.ComputeStateOutput
+	Comp   *lapi.ComputeStateOutput
 }
 
-func ComputeStateHTMLTempl(w io.Writer, ts *types.TipSet, o *api.ComputeStateOutput, printTiming bool, getCode func(addr address.Address) (cid.Cid, error)) error {
+func ComputeStateHTMLTempl(w io.Writer, ts *types.TipSet, o *lapi.ComputeStateOutput, printTiming bool, getCode func(addr address.Address) (cid.Cid, error)) error {
 	t, err := template.New("compute_state").Funcs(map[string]interface{}{
 		"GetCode":     getCode,
 		"GetMethod":   getMethod,

--- a/cli/sync.go
+++ b/cli/sync.go
@@ -281,10 +281,10 @@ func SyncWait(ctx context.Context, napi v0api.FullNode, watch bool) error {
 		for i, ss := range state.ActiveSyncs {
 			switch ss.Stage {
 			case api.StageSyncComplete:
-			default:
-				working = i
 			case api.StageIdle:
 				// not complete, not actively working
+			default:
+				working = i
 			}
 		}
 

--- a/cli/util/apiinfo.go
+++ b/cli/util/apiinfo.go
@@ -38,7 +38,7 @@ func ParseApiInfo(s string) APIInfo {
 func ParseApiInfoMulti(s string) []APIInfo {
 	var apiInfos []APIInfo
 
-	allAddrs := strings.SplitN(s, ",", -1)
+	allAddrs := strings.Split(s, ",")
 
 	for _, addr := range allAddrs {
 		apiInfos = append(apiInfos, ParseApiInfo(addr))

--- a/cli/wait.go
+++ b/cli/wait.go
@@ -22,11 +22,7 @@ var WaitApiCmd = &cli.Command{
 		ctx := ReqContext(cctx)
 		ctx, cancel := context.WithTimeout(ctx, cctx.Duration("timeout"))
 		defer cancel()
-		for {
-			if ctx.Err() != nil {
-				break
-			}
-
+		for ctx.Err() == nil {
 			api, closer, err := GetAPI(cctx)
 			if err != nil {
 				fmt.Printf("Not online yet... (%s)\n", err)

--- a/cli/worker/storage.go
+++ b/cli/worker/storage.go
@@ -111,7 +111,7 @@ var storageAttachCmd = &cli.Command{
 				AllowTo:    cctx.StringSlice("allow-to"),
 			}
 
-			if !(cfg.CanStore || cfg.CanSeal) {
+			if !cfg.CanStore && !cfg.CanSeal {
 				return xerrors.Errorf("must specify at least one of --store or --seal")
 			}
 

--- a/cli/worker/worker.go
+++ b/cli/worker/worker.go
@@ -87,7 +87,7 @@ func App() *cli.App {
 				Aliases: []string{"storagerepo"},
 				EnvVars: []string{"LOTUS_MINER_PATH", "LOTUS_STORAGE_PATH"},
 				Value:   "~/.lotusminer", // TODO: Consider XDG_DATA_HOME
-				Usage:   fmt.Sprintf("Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON"),
+				Usage:   "Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON",
 			},
 			&cli.BoolFlag{
 				Name:    "enable-gpu-proving",

--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -185,9 +185,9 @@ var importBenchCmd = &cli.Command{
 			bdgOpt := badger.DefaultOptions
 			bdgOpt.GcInterval = 0
 			bdgOpt.Options = bdg.DefaultOptions("")
-			bdgOpt.Options.SyncWrites = false
-			bdgOpt.Options.Truncate = true
-			bdgOpt.Options.DetectConflicts = false
+			bdgOpt.SyncWrites = false
+			bdgOpt.Truncate = true
+			bdgOpt.DetectConflicts = false
 
 			ds, err = badger.NewDatastore(tdir, &bdgOpt)
 		}

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -273,14 +273,15 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var smsg *types.SignedMessage
-	if r.RequestURI == "/send" {
+	switch r.RequestURI {
+	case "/send":
 		smsg, err = h.api.MpoolPushMessage(
 			h.ctx, &types.Message{
 				Value: types.BigInt(h.sendPerRequest),
 				From:  h.from,
 				To:    filecoinAddress,
 			}, nil)
-	} else if r.RequestURI == "/datacap" {
+	case "/datacap":
 		var params []byte
 		params, err = actors.SerializeParams(
 			&verifregtypes9.AddVerifiedClientParams{
@@ -298,7 +299,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				To:     verifreg.Address,
 				Method: verifreg.Methods.AddVerifiedClient,
 			}, nil)
-	} else {
+	default:
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/cmd/lotus-fountain/main.go
+++ b/cmd/lotus-fountain/main.go
@@ -300,7 +300,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Method: verifreg.Methods.AddVerifiedClient,
 			}, nil)
 	default:
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "unsupported endpoint", http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/lotus-health/main.go
+++ b/cmd/lotus-health/main.go
@@ -125,7 +125,6 @@ var watchHeadCmd = &cli.Command{
 				log.Info("Chain head is healthy")
 				time.Sleep(interval)
 			}
-			return
 		}()
 
 		restart, err := notifyHandler(ctx, name, nCh, sCh)

--- a/cmd/lotus-health/notify.go
+++ b/cmd/lotus-health/notify.go
@@ -20,10 +20,8 @@ func notifyHandler(ctx context.Context, n string, ch chan interface{}, sCh chan 
 		if err != nil {
 			return "", err
 		}
-		select {
-		case result := <-statusCh:
-			return result, nil
-		}
+		result := <-statusCh
+		return result, nil
 	// SIGTERM
 	case <-sCh:
 		os.Exit(1)

--- a/cmd/lotus-shed/import-car.go
+++ b/cmd/lotus-shed/import-car.go
@@ -74,12 +74,6 @@ var importCarCmd = &cli.Command{
 				}
 				fmt.Println()
 				return nil
-			default:
-				if err := f.Close(); err != nil {
-					return err
-				}
-				fmt.Println()
-				return err
 			case nil:
 				fmt.Printf("\r%s", blk.Cid())
 				if err := bs.Put(context.Background(), blk); err != nil {
@@ -88,6 +82,12 @@ var importCarCmd = &cli.Command{
 					}
 					return xerrors.Errorf("put %s: %w", blk.Cid(), err)
 				}
+			default:
+				if err := f.Close(); err != nil {
+					return err
+				}
+				fmt.Println()
+				return err
 			}
 		}
 	},

--- a/cmd/lotus-shed/keyinfo.go
+++ b/cmd/lotus-shed/keyinfo.go
@@ -124,8 +124,6 @@ var keyinfoVerifyCmd = &cli.Command{
 			if string(name) != list[0] {
 				return fmt.Errorf("%s of type %s; file is named for %s, but key is actually %s", fileName, keyInfo.Type, string(name), list[0])
 			}
-
-			break
 		default:
 			return fmt.Errorf("unknown keytype %s", keyInfo.Type)
 		}
@@ -210,8 +208,6 @@ var keyinfoImportCmd = &cli.Command{
 			}
 
 			fmt.Printf("%s\n", peerid.String())
-
-			break
 		case types.KTSecp256k1, types.KTBLS:
 			w, err := wallet.NewWallet(keystore)
 			if err != nil {
@@ -313,8 +309,6 @@ var keyinfoInfoCmd = &cli.Command{
 
 			kio.Address = peerid.String()
 			kio.PublicKey = base64.StdEncoding.EncodeToString(pkBytes)
-
-			break
 		case types.KTSecp256k1, types.KTBLS:
 			kio.Type = keyInfo.Type
 
@@ -368,10 +362,7 @@ var keyinfoNewCmd = &cli.Command{
 		flagOutput := cctx.String("output")
 
 		if i := SliceIndex(len(validTypes), func(i int) bool {
-			if keyType == validTypes[i] {
-				return true
-			}
-			return false
+			return keyType == validTypes[i]
 		}); i == -1 {
 			return fmt.Errorf("invalid key type argument provided '%s'", keyType)
 		}
@@ -400,8 +391,6 @@ var keyinfoNewCmd = &cli.Command{
 
 			keyAddr = peerid.String()
 			keyInfo = ki
-
-			break
 		case types.KTSecp256k1, types.KTBLS:
 			key, err := key.GenerateKey(keyType)
 			if err != nil {
@@ -410,8 +399,6 @@ var keyinfoNewCmd = &cli.Command{
 
 			keyAddr = key.Address.String()
 			keyInfo = key.KeyInfo
-
-			break
 		}
 
 		filename := flagOutput

--- a/cmd/lotus-shed/ledger.go
+++ b/cmd/lotus-shed/ledger.go
@@ -185,7 +185,7 @@ var ledgerKeyInfoCmd = &cli.Command{
 
 		if cctx.Bool("verbose") {
 			fmt.Println(addr)
-			fmt.Println(pubk)
+			fmt.Println(string(pubk))
 		}
 
 		a, err := address.NewFromString(addr)

--- a/cmd/lotus-shed/main.go
+++ b/cmd/lotus-shed/main.go
@@ -114,7 +114,7 @@ func main() {
 				Aliases: []string{"storagerepo"},
 				EnvVars: []string{"LOTUS_MINER_PATH", "LOTUS_STORAGE_PATH"},
 				Value:   "~/.lotusminer", // TODO: Consider XDG_DATA_HOME
-				Usage:   fmt.Sprintf("Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON"),
+				Usage:   "Specify miner repo path. flag storagerepo and env LOTUS_STORAGE_PATH are DEPRECATION, will REMOVE SOON",
 			},
 			&cli.StringFlag{
 				Name:  "log-level",

--- a/cmd/lotus-shed/math.go
+++ b/cmd/lotus-shed/math.go
@@ -30,11 +30,7 @@ func readLargeNumbers(i io.Reader) ([]types.BigInt, error) {
 	reader := bufio.NewReader(i)
 
 	exit := false
-	for {
-		if exit {
-			break
-		}
-
+	for !exit {
 		line, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
 			break

--- a/cmd/lotus-shed/miner-fees.go
+++ b/cmd/lotus-shed/miner-fees.go
@@ -237,17 +237,17 @@ var minerFeesCmd = &cli.Command{
 							switch depth {
 							case 0:
 								// At depth 0: SystemActorAddr (f00) -> CronActorAddr (f03) method 2 (EpochTick)
-								if !(trace.Msg.From == builtin.SystemActorAddr && trace.Msg.To == builtin.CronActorAddr && trace.Msg.Method == 2) {
+								if trace.Msg.From != builtin.SystemActorAddr || trace.Msg.To != builtin.CronActorAddr || trace.Msg.Method != 2 {
 									return "", false, nil
 								}
 							case 1:
 								// At depth 1: CronActorAddr (f03) -> StoragePowerActorAddr (f04) method 5 (OnEpochTickEnd)
-								if !(trace.Msg.From == builtin.CronActorAddr && trace.Msg.To == power.Address && trace.Msg.Method == 5) {
+								if trace.Msg.From != builtin.CronActorAddr || trace.Msg.To != power.Address || trace.Msg.Method != 5 {
 									return "", false, nil
 								}
 							case 2:
 								// At depth 2: StoragePowerActorAddr (f04) -> miner actors method 12 (OnDeferredCronEvent)
-								if !(trace.Msg.From == power.Address && trace.Msg.Method == 12) {
+								if trace.Msg.From != power.Address || trace.Msg.Method != 12 {
 									return "", false, nil
 								}
 							}
@@ -623,17 +623,17 @@ var minerFeesInspect = &cli.Command{
 				switch depth {
 				case 0:
 					// At depth 0: SystemActorAddr (f00) -> CronActorAddr (f03) method 2 (EpochTick)
-					if !(trace.Msg.From == builtin.SystemActorAddr && trace.Msg.To == builtin.CronActorAddr && trace.Msg.Method == 2) {
+					if trace.Msg.From != builtin.SystemActorAddr || trace.Msg.To != builtin.CronActorAddr || trace.Msg.Method != 2 {
 						return nil
 					}
 				case 1:
 					// At depth 1: CronActorAddr (f03) -> StoragePowerActorAddr (f04) method 5 (OnEpochTickEnd)
-					if !(trace.Msg.From == builtin.CronActorAddr && trace.Msg.To == power.Address && trace.Msg.Method == 5) {
+					if trace.Msg.From != builtin.CronActorAddr || trace.Msg.To != power.Address || trace.Msg.Method != 5 {
 						return nil
 					}
 				case 2:
 					// At depth 2: StoragePowerActorAddr (f04) -> miner actors method 12 (OnDeferredCronEvent)
-					if !(trace.Msg.From == power.Address && trace.Msg.Method == 12) {
+					if trace.Msg.From != power.Address || trace.Msg.Method != 12 {
 						return nil
 					}
 				}

--- a/cmd/lotus-shed/miner.go
+++ b/cmd/lotus-shed/miner.go
@@ -771,7 +771,7 @@ var minerLockedVestedCmd = &cli.Command{
 		miners := make(map[address.Address]abi.TokenAmount)
 		var minerCount int
 		var lockedCount int
-		var lockedFunds abi.TokenAmount = big.Zero()
+		lockedFunds := big.Zero()
 		_, _ = fmt.Fprintf(cctx.App.ErrWriter, "Scanning actors at epoch %d", head.Height())
 		err = tree.ForEach(func(addr address.Address, act *types.Actor) error {
 			totalCount++

--- a/cmd/lotus-shed/rpc.go
+++ b/cmd/lotus-shed/rpc.go
@@ -160,7 +160,7 @@ var rpcCmd = &cli.Command{
 			method := s.TokenText()
 
 			s.Scan()
-			params := line[s.Position.Offset:]
+			params := line[s.Offset:]
 
 			if err := send(method, params); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "%v", err)

--- a/cmd/lotus-shed/state-stats.go
+++ b/cmd/lotus-shed/state-stats.go
@@ -781,7 +781,7 @@ to reduce the number of decode operations performed by caching the decoded objec
 
 func collectSnapshotJobStats(ctx context.Context, in job, dag format.NodeGetter, visit func(c cid.Cid) bool) ([]result, error) {
 	// "state" and "churn" attempt further breakdown by actor type
-	if !(path.Dir(in.key) == "/statetree/latest") && !(path.Dir(in.key) == "/statetree/churn") {
+	if path.Dir(in.key) != "/statetree/latest" && path.Dir(in.key) != "/statetree/churn" {
 		dsc := &dagStatCollector{
 			ds:   dag,
 			walk: carWalkFunc,

--- a/cmd/lotus-sim/run.go
+++ b/cmd/lotus-sim/run.go
@@ -61,7 +61,7 @@ Signals:
 					_, _ = fmt.Fprintf(cctx.App.ErrWriter, "ERROR: failed to print info: %s\n", err)
 				}
 				_, _ = fmt.Fprintln(cctx.App.Writer, "---------------------")
-			case <-cctx.Context.Done():
+			case <-cctx.Done():
 				return cctx.Err()
 			default:
 			}

--- a/cmd/lotus-sim/simulation/stages/funding_stage.go
+++ b/cmd/lotus-sim/simulation/stages/funding_stage.go
@@ -127,7 +127,7 @@ func (fs *FundingStage) PackMessages(ctx context.Context, bb *blockbuilder.Block
 		if act.Balance.LessThan(fs.taxMin) {
 			return nil
 		}
-		if !(builtin.IsAccountActor(act.Code) || builtin.IsMultisigActor(act.Code)) {
+		if !builtin.IsAccountActor(act.Code) && !builtin.IsMultisigActor(act.Code) {
 			return nil
 		}
 		targets = append(targets, &actor{*act, addr})

--- a/cmd/lotus-stats/main.go
+++ b/cmd/lotus-stats/main.go
@@ -239,14 +239,11 @@ var runCmd = &cli.Command{
 		go func() {
 			t := time.NewTicker(time.Second)
 
-			for {
-				select {
-				case <-t.C:
-					sinceGenesis := build.Clock.Now().Sub(genesisTime)
-					expectedHeight := int64(sinceGenesis.Seconds()) / int64(buildconstants.BlockDelaySecs)
+			for range t.C {
+				sinceGenesis := build.Clock.Now().Sub(genesisTime)
+				expectedHeight := int64(sinceGenesis.Seconds()) / int64(buildconstants.BlockDelaySecs)
 
-					stats.Record(ctx, metrics.TipsetCollectionHeightExpected.M(expectedHeight))
-				}
+				stats.Record(ctx, metrics.TipsetCollectionHeightExpected.M(expectedHeight))
 			}
 		}()
 

--- a/cmd/lotus-worker/sealworker/rpc.go
+++ b/cmd/lotus-worker/sealworker/rpc.go
@@ -209,7 +209,7 @@ func (w *Worker) Discover(ctx context.Context) (apitypes.OpenRPCDocument, error)
 }
 
 func (w *Worker) Shutdown(ctx context.Context) error {
-	return w.LocalWorker.Close()
+	return w.Close()
 }
 
 var _ storiface.WorkerCalls = &Worker{}

--- a/cmd/tvx/exec.go
+++ b/cmd/tvx/exec.go
@@ -107,8 +107,8 @@ func runExec(c *cli.Context) error {
 
 func processTipsetOpts() error {
 	for _, opt := range execFlags.driverOpts.Value() {
-		switch ss := strings.Split(opt, "="); {
-		case ss[0] == optSaveBalances:
+		switch ss := strings.Split(opt, "="); ss[0] {
+		case optSaveBalances:
 			filename := ss[1]
 			log.Printf("saving balances after each tipset in: %s", filename)
 			balancesFile, err := os.Create(filename)

--- a/cmd/tvx/extract_message.go
+++ b/cmd/tvx/extract_message.go
@@ -14,7 +14,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/test-vectors/schema"
 
-	"github.com/filecoin-project/lotus/api"
 	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v1api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
@@ -208,7 +207,7 @@ func doExtractMessage(opts extractOpts) error {
 	// TODO sometimes this returns a nil receipt and no error ¯\_(ツ)_/¯
 	//  ex: https://filfox.info/en/message/bafy2bzacebpxw3yiaxzy2bako62akig46x3imji7fewszen6fryiz6nymu2b2
 	//  This code is lenient and skips receipt comparison in case of a nil receipt.
-	rec, err := FullAPI.StateSearchMsg(ctx, execTs.Key(), mcid, api.LookbackNoLimit, false)
+	rec, err := FullAPI.StateSearchMsg(ctx, execTs.Key(), mcid, lapi.LookbackNoLimit, false)
 	if err != nil {
 		return fmt.Errorf("failed to find receipt on chain: %w", err)
 	}
@@ -404,7 +403,7 @@ func fetchThisAndPrevTipset(ctx context.Context, api v1api.FullNode, target type
 // findMsgAndPrecursors ranges through the canonical messages slice, locating
 // the target message and returning precursors in accordance to the supplied
 // mode.
-func findMsgAndPrecursors(ctx context.Context, mode string, msgCid cid.Cid, sender address.Address, recipient address.Address, msgs []api.Message) (related []*types.Message, found bool, err error) {
+func findMsgAndPrecursors(ctx context.Context, mode string, msgCid cid.Cid, sender address.Address, recipient address.Address, msgs []lapi.Message) (related []*types.Message, found bool, err error) {
 	// Resolve addresses to IDs for canonicality.
 	senderID := mustResolveAddr(ctx, sender)
 	recipientID := mustResolveAddr(ctx, recipient)

--- a/gateway/proxy_eth_v1.go
+++ b/gateway/proxy_eth_v1.go
@@ -101,9 +101,10 @@ func (pv1 *reverseProxyV1) checkEthBlockParam(ctx context.Context, blkParam etht
 
 		var num ethtypes.EthUint64
 		if blkParam.PredefinedBlock != nil {
-			if *blkParam.PredefinedBlock == "earliest" {
+			switch *blkParam.PredefinedBlock {
+			case "earliest":
 				return xerrors.New("block param \"earliest\" is not supported")
-			} else if *blkParam.PredefinedBlock == "pending" || *blkParam.PredefinedBlock == "latest" {
+			case "pending", "latest":
 				// Head is always ok.
 				if lookback == 0 {
 					return nil

--- a/gateway/proxy_v2.go
+++ b/gateway/proxy_v2.go
@@ -712,9 +712,10 @@ func (pv2 *reverseProxyV2) checkEthBlockParam(ctx context.Context, blkParam etht
 
 		var num ethtypes.EthUint64
 		if blkParam.PredefinedBlock != nil {
-			if *blkParam.PredefinedBlock == "earliest" {
+			switch *blkParam.PredefinedBlock {
+			case "earliest":
 				return xerrors.New("block param \"earliest\" is not supported")
-			} else if *blkParam.PredefinedBlock == "pending" || *blkParam.PredefinedBlock == "latest" {
+			case "pending", "latest":
 				// Head is always ok.
 				if lookback == 0 {
 					return nil

--- a/gen/api/proxygen.go
+++ b/gen/api/proxygen.go
@@ -13,6 +13,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/lib/parsehelper"
 )
 
 type methodMeta struct {
@@ -142,15 +144,15 @@ func generate(path, pkg, outpkg, outfile string) error {
 	if err != nil {
 		return err
 	}
-	pkgs, err := parser.ParseDir(fset, apiDir, nil, parser.AllErrors|parser.ParseComments)
+	files, err := parsehelper.ParseDir(fset, apiDir, pkg, parser.AllErrors|parser.ParseComments)
 	if err != nil {
 		return err
 	}
 
-	ap := pkgs[pkg]
-
 	v := &Visitor{make(map[string]map[string]*methodMeta), map[string][]string{}}
-	ast.Walk(v, ap)
+	for _, f := range files {
+		ast.Walk(v, f)
+	}
 
 	type methodInfo struct {
 		Num                                      string
@@ -177,7 +179,7 @@ func generate(path, pkg, outpkg, outfile string) error {
 		Imports: map[string]string{},
 	}
 
-	for fn, f := range ap.Files {
+	for fn, f := range files {
 		if strings.HasSuffix(fn, "gen.go") {
 			continue
 		}

--- a/itests/daily_fees_test.go
+++ b/itests/daily_fees_test.go
@@ -41,8 +41,8 @@ func TestDailyFees(t *testing.T) {
 		client    kit.TestFullNode
 		genminer  kit.TestMiner
 		// don't upgrade until original sectors are fully proven and power updated
-		nv25epoch abi.ChainEpoch = builtin.EpochsInDay + 200         // Teep
-		nv26epoch abi.ChainEpoch = nv25epoch + builtin.EpochsInDay/2 // Tock
+		nv25epoch = abi.ChainEpoch(builtin.EpochsInDay + 200) // Teep
+		nv26epoch = nv25epoch + builtin.EpochsInDay/2         // Tock
 		feePostWg sync.WaitGroup
 	)
 	// itests start off with a FilReserved of 300M FIL, leading to a circulating supply of 0 initially,

--- a/itests/eth_filter_test.go
+++ b/itests/eth_filter_test.go
@@ -2326,16 +2326,16 @@ func AssertEthLogs(t *testing.T, actual []*ethtypes.EthLog, expected []ExpectedE
 
 		if !matched {
 			var buf strings.Builder
-			buf.WriteString(fmt.Sprintf("found unexpected log at height %d:\n", msg.ts.Height()))
-			buf.WriteString(fmt.Sprintf("  address: %s\n", elog.Address))
-			buf.WriteString(fmt.Sprintf("  topics: %s\n", formatTopics(elog.Topics)))
-			buf.WriteString(fmt.Sprintf("  data: %x\n", elog.Data))
+			fmt.Fprintf(&buf, "found unexpected log at height %d:\n", msg.ts.Height())
+			fmt.Fprintf(&buf, "  address: %s\n", elog.Address)
+			fmt.Fprintf(&buf, "  topics: %s\n", formatTopics(elog.Topics))
+			fmt.Fprintf(&buf, "  data: %x\n", elog.Data)
 			buf.WriteString("original events from receipt were:\n")
 			for i, ev := range msg.events {
-				buf.WriteString(fmt.Sprintf("event %d\n", i))
-				buf.WriteString(fmt.Sprintf("  emitter: %v\n", ev.Emitter))
+				fmt.Fprintf(&buf, "event %d\n", i)
+				fmt.Fprintf(&buf, "  emitter: %v\n", ev.Emitter)
 				for _, en := range ev.Entries {
-					buf.WriteString(fmt.Sprintf("  %s=%x\n", en.Key, en.Value))
+					fmt.Fprintf(&buf, "  %s=%x\n", en.Key, en.Value)
 				}
 			}
 
@@ -2346,10 +2346,10 @@ func AssertEthLogs(t *testing.T, actual []*ethtypes.EthLog, expected []ExpectedE
 	for i := range expected {
 		if _, ok := expectedMatched[i]; !ok {
 			var buf strings.Builder
-			buf.WriteString(fmt.Sprintf("did not find expected log with index %d:\n", i))
-			buf.WriteString(fmt.Sprintf("  address: %s\n", expected[i].Address))
-			buf.WriteString(fmt.Sprintf("  topics: %s\n", formatTopics(expected[i].Topics)))
-			buf.WriteString(fmt.Sprintf("  data: %x\n", expected[i].Data))
+			fmt.Fprintf(&buf, "did not find expected log with index %d:\n", i)
+			fmt.Fprintf(&buf, "  address: %s\n", expected[i].Address)
+			fmt.Fprintf(&buf, "  topics: %s\n", formatTopics(expected[i].Topics))
+			fmt.Fprintf(&buf, "  data: %x\n", expected[i].Data)
 			t.Error(buf.String())
 		}
 	}
@@ -2408,7 +2408,7 @@ func ParseEthLog(in map[string]interface{}) (*ethtypes.EthLog, error) {
 		if !ok {
 			return 0, xerrors.Errorf(k + " not a string")
 		}
-		parsedInt, err := strconv.ParseUint(strings.Replace(s, "0x", "", -1), 16, 64)
+		parsedInt, err := strconv.ParseUint(strings.ReplaceAll(s, "0x", ""), 16, 64)
 		if err != nil {
 			return 0, err
 		}

--- a/itests/eth_legacy_transactions_test.go
+++ b/itests/eth_legacy_transactions_test.go
@@ -62,7 +62,7 @@ func TestLegacyValueTransferValidSignature(t *testing.T) {
 
 	client.EVM().SignLegacyHomesteadTransaction(&tx, key.PrivateKey)
 	// Mangle signature
-	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
+	tx.V.Xor(tx.V.Int, big.NewInt(1).Int)
 
 	signed, err := tx.ToRlpSignedMsg()
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestLegacyEIP155ValueTransferValidSignature(t *testing.T) {
 	client.EVM().SignLegacyEIP155Transaction(tx, key.PrivateKey, big.NewInt(buildconstants.Eip155ChainId))
 	// Mangle signature
 	innerTx := tx.GetLegacyTx()
-	innerTx.V.Int.Xor(innerTx.V.Int, big.NewInt(1).Int)
+	innerTx.V.Xor(innerTx.V.Int, big.NewInt(1).Int)
 
 	signed, err := tx.ToRawTxBytesSigned()
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 
 	client.EVM().SignLegacyHomesteadTransaction(tx, key.PrivateKey)
 	// Mangle signature
-	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
+	tx.V.Xor(tx.V.Int, big.NewInt(1).Int)
 
 	signed, err := tx.ToRlpSignedMsg()
 	require.NoError(t, err)
@@ -331,7 +331,7 @@ func TestLegacyContractInvocation(t *testing.T) {
 
 	client.EVM().SignLegacyHomesteadTransaction(&invokeTx, key.PrivateKey)
 	// Mangle signature
-	invokeTx.V.Int.Xor(invokeTx.V.Int, big.NewInt(1).Int)
+	invokeTx.V.Xor(invokeTx.V.Int, big.NewInt(1).Int)
 
 	signed, err = invokeTx.ToRlpSignedMsg()
 	require.NoError(t, err)

--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -80,7 +80,7 @@ func TestValueTransferValidSignature(t *testing.T) {
 
 	client.EVM().SignTransaction(&tx, key.PrivateKey)
 	// Mangle signature
-	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
+	tx.V.Xor(tx.V.Int, big.NewInt(1).Int)
 
 	signed, err := tx.ToRlpSignedMsg()
 	require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestContractDeploymentValidSignature(t *testing.T) {
 
 	client.EVM().SignTransaction(tx, key.PrivateKey)
 	// Mangle signature
-	tx.V.Int.Xor(tx.V.Int, big.NewInt(1).Int)
+	tx.V.Xor(tx.V.Int, big.NewInt(1).Int)
 
 	signed, err := tx.ToRlpSignedMsg()
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestContractInvocation(t *testing.T) {
 
 	client.EVM().SignTransaction(&invokeTx, key.PrivateKey)
 	// Mangle signature
-	invokeTx.V.Int.Xor(invokeTx.V.Int, big.NewInt(1).Int)
+	invokeTx.V.Xor(invokeTx.V.Int, big.NewInt(1).Int)
 
 	signed, err := invokeTx.ToRlpSignedMsg()
 	require.NoError(t, err)
@@ -815,20 +815,20 @@ func TestTraceFilter(t *testing.T) {
 	require.NotEmpty(t, traces)
 
 	for i, trace := range traces {
-		t.Logf("Trace %d: TransactionPosition=%d, TransactionHash=%s, Type=%s", i, trace.TransactionPosition, trace.TransactionHash, trace.EthTrace.Type)
+		t.Logf("Trace %d: TransactionPosition=%d, TransactionHash=%s, Type=%s", i, trace.TransactionPosition, trace.TransactionHash, trace.Type)
 	}
 
 	// Assert that initial transactions returned by the trace are valid
 	require.Len(t, traces, 3)
 	require.Equal(t, 0, traces[0].TransactionPosition)
-	require.Equal(t, "call", traces[0].EthTrace.Type)
+	require.Equal(t, "call", traces[0].Type)
 	require.Equal(t, 0, traces[1].TransactionPosition)
-	require.Equal(t, "call", traces[1].EthTrace.Type)
+	require.Equal(t, "call", traces[1].Type)
 
 	// our transaction will be in the third element of traces with the expected hash
 	require.Equal(t, 0, traces[2].TransactionPosition)
 	require.Equal(t, hash, traces[2].TransactionHash)
-	require.Equal(t, "create", traces[2].EthTrace.Type)
+	require.Equal(t, "create", traces[2].Type)
 
 	toBlock = "latest"
 	filter = ethtypes.EthTraceFilterCriteria{
@@ -848,7 +848,7 @@ func TestTraceFilter(t *testing.T) {
 	require.Len(t, tracesAddressFilter, 1)
 	require.Equal(t, 0, tracesAddressFilter[0].TransactionPosition)
 	require.Equal(t, hash, tracesAddressFilter[0].TransactionHash)
-	require.Equal(t, "create", tracesAddressFilter[0].EthTrace.Type)
+	require.Equal(t, "create", tracesAddressFilter[0].Type)
 
 	after := ethtypes.EthUint64(1)
 	count := ethtypes.EthUint64(2)

--- a/itests/f3_test.go
+++ b/itests/f3_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/api"
-	lotus_api "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/lf3"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -74,14 +73,14 @@ func TestF3_InactiveModes(t *testing.T) {
 		{
 			mode: "disabled",
 			expectedErrors: map[string]any{
-				"F3GetOrRenewParticipationTicket": lotus_api.ErrF3Disabled,
-				"F3Participate":                   lotus_api.ErrF3Disabled,
-				"F3GetCertificate":                lotus_api.ErrF3Disabled,
-				"F3GetLatestCertificate":          lotus_api.ErrF3Disabled,
-				"F3GetManifest":                   lotus_api.ErrF3Disabled,
-				"F3GetECPowerTable":               lotus_api.ErrF3Disabled,
-				"F3GetF3PowerTable":               lotus_api.ErrF3Disabled,
-				"F3IsRunning":                     lotus_api.ErrF3Disabled,
+				"F3GetOrRenewParticipationTicket": api.ErrF3Disabled,
+				"F3Participate":                   api.ErrF3Disabled,
+				"F3GetCertificate":                api.ErrF3Disabled,
+				"F3GetLatestCertificate":          api.ErrF3Disabled,
+				"F3GetManifest":                   api.ErrF3Disabled,
+				"F3GetECPowerTable":               api.ErrF3Disabled,
+				"F3GetF3PowerTable":               api.ErrF3Disabled,
+				"F3IsRunning":                     api.ErrF3Disabled,
 			},
 			expectedValues: map[string]any{
 				"F3GetOrRenewParticipationTicket": (api.F3ParticipationTicket)(nil),
@@ -219,14 +218,14 @@ func TestF3_JsonRPCErrorsPassThrough(t *testing.T) {
 	e.waitTillF3Runs(5 * time.Second)
 
 	lease, err := n.F3Participate(e.testCtx, []byte("fish"))
-	require.ErrorIs(t, err, lotus_api.ErrF3ParticipationTicketInvalid)
+	require.ErrorIs(t, err, api.ErrF3ParticipationTicketInvalid)
 	require.Zero(t, lease)
 
 	addr, err := address.NewIDAddress(1413)
 	require.NoError(t, err)
 
 	ticket, err := n.F3GetOrRenewParticipationTicket(e.testCtx, addr, nil, 100)
-	require.ErrorIs(t, err, lotus_api.ErrF3ParticipationTooManyInstances)
+	require.ErrorIs(t, err, api.ErrF3ParticipationTooManyInstances)
 	require.Zero(t, ticket)
 }
 

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -1741,14 +1741,14 @@ func TestFEVMEamCreateTwiceFail(t *testing.T) {
 
 	req.Len(traces, 3)
 	req.EqualValues(wait.Height-1, traces[0].BlockNumber)
-	req.Equal("call", traces[0].EthTrace.Type)
-	req.Contains("Reverted", traces[0].EthTrace.Error)
+	req.Equal("call", traces[0].Type)
+	req.Contains("Reverted", traces[0].Error)
 	req.EqualValues(wait.Height-1, traces[1].BlockNumber)
-	req.Equal("create", traces[1].EthTrace.Type)
-	req.Equal("", traces[1].EthTrace.Error)
+	req.Equal("create", traces[1].Type)
+	req.Equal("", traces[1].Error)
 	req.EqualValues(wait.Height-1, traces[2].BlockNumber)
-	req.Equal("create", traces[2].EthTrace.Type)
-	req.Contains(traces[2].EthTrace.Error, "ErrForbidden")
+	req.Equal("create", traces[2].Type)
+	req.Contains(traces[2].Error, "ErrForbidden")
 }
 
 func TestFEVMEthTraceFilterFailedCreate(t *testing.T) {
@@ -1788,10 +1788,10 @@ func TestFEVMEthTraceFilterFailedCreate(t *testing.T) {
 	blockTraces, err := client.EthTraceBlock(ctx, blockNum)
 	req.NoError(err)
 	req.Len(blockTraces, 3)
-	req.Equal("call", blockTraces[0].EthTrace.Type)
-	req.Equal("create", blockTraces[1].EthTrace.Type)
-	req.Equal("create", blockTraces[2].EthTrace.Type)
-	req.Contains(blockTraces[2].EthTrace.Error, "ErrForbidden")
+	req.Equal("call", blockTraces[0].Type)
+	req.Equal("create", blockTraces[1].Type)
+	req.Equal("create", blockTraces[2].Type)
+	req.Contains(blockTraces[2].Error, "ErrForbidden")
 
 	// EthTraceFilter with a toAddress filter on a block containing failed creates.
 	fromBlock := blockNum

--- a/itests/get_messages_in_ts_test.go
+++ b/itests/get_messages_in_ts_test.go
@@ -46,17 +46,14 @@ func TestChainGetMessagesInTs(t *testing.T) {
 		<-headChangeCh //skip hccurrent
 
 		count := 0
-		for {
-			select {
-			case headChanges := <-headChangeCh:
-				for _, change := range headChanges {
-					if change.Type == store.HCApply {
-						msgs, err := client.ChainGetMessagesInTipset(ctx, change.Val.Key())
-						require.NoError(t, err)
-						count += len(msgs)
-						if count == iterations {
-							waitAllCh <- struct{}{}
-						}
+		for headChanges := range headChangeCh {
+			for _, change := range headChanges {
+				if change.Type == store.HCApply {
+					msgs, err := client.ChainGetMessagesInTipset(ctx, change.Val.Key())
+					require.NoError(t, err)
+					count += len(msgs)
+					if count == iterations {
+						waitAllCh <- struct{}{}
 					}
 				}
 			}

--- a/itests/kit/blockminer.go
+++ b/itests/kit/blockminer.go
@@ -122,7 +122,7 @@ func (p *partitionTracker) recordIfPost(t *testing.T, msg *types.Message) (ret b
 	defer func() {
 		ret = p.done(t)
 	}()
-	if !(msg.To == p.minerAddr) {
+	if msg.To != p.minerAddr {
 		return
 	}
 	if msg.Method != builtin.MethodsMiner.SubmitWindowedPoSt {

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -575,12 +575,12 @@ func (n *Ensemble) Start() *Ensemble {
 					Method: power.Methods.CreateMiner,
 					Params: params,
 				}
-				signed, err := m.FullNode.FullNode.MpoolPushMessage(ctx, createStorageMinerMsg, &api.MessageSendSpec{
+				signed, err := m.FullNode.MpoolPushMessage(ctx, createStorageMinerMsg, &api.MessageSendSpec{
 					MsgUuid: uuid.New(),
 				})
 				require.NoError(n.t, err)
 
-				mw, err := m.FullNode.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
+				mw, err := m.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
 				require.NoError(n.t, err)
 				require.Equal(n.t, exitcode.Ok, mw.Receipt.ExitCode)
 
@@ -601,12 +601,12 @@ func (n *Ensemble) Start() *Ensemble {
 					Value:  types.NewInt(0),
 				}
 
-				signed, err2 := m.FullNode.FullNode.MpoolPushMessage(ctx, msg, &api.MessageSendSpec{
+				signed, err2 := m.FullNode.MpoolPushMessage(ctx, msg, &api.MessageSendSpec{
 					MsgUuid: uuid.New(),
 				})
 				require.NoError(n.t, err2)
 
-				mw, err2 := m.FullNode.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
+				mw, err2 := m.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
 				require.NoError(n.t, err2)
 				require.Equal(n.t, exitcode.Ok, mw.Receipt.ExitCode)
 			}
@@ -639,7 +639,7 @@ func (n *Ensemble) Start() *Ensemble {
 		if !ok {
 			n.t.Fatalf("invalid config from repo, got: %T", c)
 		}
-		cfg.Common.API.RemoteListenAddress = m.RemoteListener.Addr().String()
+		cfg.API.RemoteListenAddress = m.RemoteListener.Addr().String()
 		cfg.Subsystems.EnableMining = m.options.subsystems.Has(SMining)
 		cfg.Subsystems.EnableSealing = m.options.subsystems.Has(SSealing)
 		cfg.Subsystems.EnableSectorStorage = m.options.subsystems.Has(SSectorStorage)
@@ -852,12 +852,12 @@ func (n *Ensemble) Start() *Ensemble {
 			Method: power.Methods.CreateMiner,
 			Params: params,
 		}
-		signed, err := m.FullNode.FullNode.MpoolPushMessage(ctx, createStorageMinerMsg, &api.MessageSendSpec{
+		signed, err := m.FullNode.MpoolPushMessage(ctx, createStorageMinerMsg, &api.MessageSendSpec{
 			MsgUuid: uuid.New(),
 		})
 		require.NoError(n.t, err)
 
-		mw, err := m.FullNode.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
+		mw, err := m.FullNode.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
 		require.NoError(n.t, err)
 		require.Equal(n.t, exitcode.Ok, mw.Receipt.ExitCode)
 

--- a/itests/kit/node_miner.go
+++ b/itests/kit/node_miner.go
@@ -47,16 +47,6 @@ func (ms MinerSubsystem) Has(single MinerSubsystem) bool {
 	return ms&single == single
 }
 
-func (ms MinerSubsystem) All() [MinerSubsystems]bool {
-	var out [MinerSubsystems]bool
-
-	for i := range out {
-		out[i] = ms&(1<<i) > 0
-	}
-
-	return out
-}
-
 // TestMiner represents a miner enrolled in an Ensemble.
 type TestMiner struct {
 	api.StorageMiner
@@ -103,7 +93,7 @@ func (tm *TestMiner) WaitSectorsProvingAllowFails(ctx context.Context, toCheck m
 
 		states := map[api.SectorState]int{}
 		for n := range toCheck {
-			st, err := tm.StorageMiner.SectorsStatus(ctx, n, false)
+			st, err := tm.SectorsStatus(ctx, n, false)
 			require.NoError(tm.t, err)
 			states[st.State]++
 			if st.State == api.SectorState(sealing.Proving) || st.State == api.SectorState(sealing.Available) || st.State == api.SectorState(sealing.Removed) {
@@ -128,7 +118,7 @@ func (tm *TestMiner) StartPledge(ctx context.Context, n, existing int, blockNoti
 			tm.t.Log("WAIT")
 		}
 		tm.t.Logf("PLEDGING %d", i)
-		_, err := tm.StorageMiner.PledgeSector(ctx)
+		_, err := tm.PledgeSector(ctx)
 		require.NoError(tm.t, err)
 	}
 
@@ -157,13 +147,13 @@ func (tm *TestMiner) StartPledge(ctx context.Context, n, existing int, blockNoti
 }
 
 func (tm *TestMiner) FlushSealingBatches(ctx context.Context) {
-	pcb, err := tm.StorageMiner.SectorPreCommitFlush(ctx)
+	pcb, err := tm.SectorPreCommitFlush(ctx)
 	require.NoError(tm.t, err)
 	if pcb != nil {
 		fmt.Printf("PRECOMMIT BATCH: %+v\n", pcb)
 	}
 
-	cb, err := tm.StorageMiner.SectorCommitFlush(ctx)
+	cb, err := tm.SectorCommitFlush(ctx)
 	require.NoError(tm.t, err)
 	if cb != nil {
 		fmt.Printf("COMMIT BATCH: %+v\n", cb)
@@ -195,7 +185,7 @@ func (tm *TestMiner) AddStorage(ctx context.Context, t *testing.T, conf func(*st
 
 	conf(cfg)
 
-	if !(cfg.CanStore || cfg.CanSeal) {
+	if !cfg.CanStore && !cfg.CanSeal {
 		t.Fatal("must specify at least one of CanStore or cfg.CanSeal")
 	}
 

--- a/itests/kit/node_worker.go
+++ b/itests/kit/node_worker.go
@@ -59,7 +59,7 @@ func (tm *TestWorker) AddStorage(ctx context.Context, t *testing.T, conf func(*s
 
 	conf(cfg)
 
-	if !(cfg.CanStore || cfg.CanSeal) {
+	if !cfg.CanStore && !cfg.CanSeal {
 		t.Fatal("must specify at least one of CanStore or cfg.CanSeal")
 	}
 

--- a/itests/migration_test.go
+++ b/itests/migration_test.go
@@ -1308,9 +1308,9 @@ func TestMigrationTeepTockFix(t *testing.T) {
 	kit.QuietMiningLogs()
 
 	var (
-		nv25Epoch    abi.ChainEpoch = 100
-		nv26Epoch    abi.ChainEpoch = nv25Epoch + 100
-		teepFixEpoch abi.ChainEpoch = nv26Epoch + 100
+		nv25Epoch    = abi.ChainEpoch(100)
+		nv26Epoch    = nv25Epoch + 100
+		teepFixEpoch = nv26Epoch + 100
 	)
 	const networkName = "testing-fake-proofs"
 	buildconstants.UpgradeTockFixHeight = teepFixEpoch // needed to be set for migration to run

--- a/itests/multisig/suite.go
+++ b/itests/multisig/suite.go
@@ -55,7 +55,7 @@ func RunMultisigTests(t *testing.T, client *kit.TestFullNode) {
 	// Extract msig robust address from output
 	expCreateOutPrefix := "Created new multisig:"
 	require.Regexp(t, regexp.MustCompile(expCreateOutPrefix), out)
-	parts := strings.Split(strings.TrimSpace(strings.Replace(out, expCreateOutPrefix, "", -1)), " ")
+	parts := strings.Split(strings.TrimSpace(strings.ReplaceAll(out, expCreateOutPrefix, "")), " ")
 	require.Len(t, parts, 2)
 	msigRobustAddr := parts[1]
 	fmt.Println("msig robust address:", msigRobustAddr)

--- a/itests/niporep_manual_test.go
+++ b/itests/niporep_manual_test.go
@@ -309,7 +309,7 @@ func TestManualNISectorOnboarding(t *testing.T) {
 						})
 					}
 					from := head.Height()
-					recentEvents, err := client.FullNode.GetActorEventsRaw(ctx, &types.ActorEventFilter{FromHeight: &from})
+					recentEvents, err := client.GetActorEventsRaw(ctx, &types.ActorEventFilter{FromHeight: &from})
 					req.NoError(err)
 					req.Len(recentEvents, len(sectors[i]))
 					for i, event := range recentEvents {
@@ -348,7 +348,7 @@ func TestManualNISectorOnboarding(t *testing.T) {
 						{Flags: 0x01, Codec: uint64(multicodec.Cbor), Key: "piece-size", Value: must.One(ipld.Encode(basicnode.NewInt(int64(snapPieces[0].Size)), dagcbor.Encode))},
 					}
 					from := head.Height()
-					recentEvents, err := client.FullNode.GetActorEventsRaw(ctx, &types.ActorEventFilter{FromHeight: &from})
+					recentEvents, err := client.GetActorEventsRaw(ctx, &types.ActorEventFilter{FromHeight: &from})
 					req.NoError(err)
 					req.Len(recentEvents, 1)
 					req.Equal(expectedEntries, recentEvents[0].Entries)

--- a/itests/path_detach_redeclare_test.go
+++ b/itests/path_detach_redeclare_test.go
@@ -131,7 +131,7 @@ func TestPathDetachRedeclare(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sps, 1)
 	require.Len(t, sps[newId], 1)
-	require.Equal(t, abi.SectorNumber(1), sps[newId][0].SectorID.Number)
+	require.Equal(t, abi.SectorNumber(1), sps[newId][0].Number)
 }
 
 func TestPathDetachRedeclareWorker(t *testing.T) {
@@ -290,7 +290,7 @@ func TestPathDetachRedeclareWorker(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sps, 1)
 	require.Len(t, sps[newId], 1)
-	require.Equal(t, abi.SectorNumber(1), sps[newId][0].SectorID.Number)
+	require.Equal(t, abi.SectorNumber(1), sps[newId][0].Number)
 }
 
 func TestPathDetachShared(t *testing.T) {

--- a/itests/sector_miner_collateral_test.go
+++ b/itests/sector_miner_collateral_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/lotus/api"
-	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/datacap"
@@ -90,7 +89,7 @@ func TestMinerBalanceCollateral(t *testing.T) {
 		for len(toCheck) > 0 {
 			states := map[api.SectorState]int{}
 			for n := range toCheck {
-				st, err := miner.StorageMiner.SectorsStatus(ctx, n, false)
+				st, err := miner.SectorsStatus(ctx, n, false)
 				require.NoError(t, err)
 				states[st.State]++
 				if st.State == api.SectorState(sealing.Proving) {
@@ -219,7 +218,7 @@ func TestPledgeCalculations(t *testing.T) {
 		}, nil)
 		require.NoError(t, err, "AddVerifier failed")
 
-		res, err := client.StateWaitMsg(ctx, sm.Cid(), 1, lapi.LookbackNoLimit, true)
+		res, err := client.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, res.Receipt.ExitCode)
 
@@ -239,7 +238,7 @@ func TestPledgeCalculations(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 
-		res, err = client.StateWaitMsg(ctx, sm.Cid(), 1, lapi.LookbackNoLimit, true)
+		res, err = client.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, res.Receipt.ExitCode)
 	}
@@ -279,7 +278,7 @@ func TestPledgeCalculations(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 
-		res, err := client.StateWaitMsg(ctx, sm.Cid(), 1, lapi.LookbackNoLimit, true)
+		res, err := client.StateWaitMsg(ctx, sm.Cid(), 1, api.LookbackNoLimit, true)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, res.Receipt.ExitCode)
 
@@ -440,7 +439,7 @@ func TestPledgeCalculations(t *testing.T) {
 		// new one that just uses sector size, duration and a simple verified size. They should be
 		// the same.
 
-		precommit, err := client.FullNode.StateSectorPreCommitInfo(ctx, testMinerAddr, sectorNumber, tsk)
+		precommit, err := client.StateSectorPreCommitInfo(ctx, testMinerAddr, sectorNumber, tsk)
 		require.NoError(t, err)
 
 		// nolint:staticcheck // SA1019 intentionally using a deprecated method
@@ -448,7 +447,7 @@ func TestPledgeCalculations(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("Pledge from precommit: %s", pledgeFromPrecommitCC)
 
-		pledge, err := client.FullNode.StateMinerInitialPledgeForSector(ctx, precommit.Info.Expiration-r.Height, sectorSize, verifiedSize, tsk)
+		pledge, err := client.StateMinerInitialPledgeForSector(ctx, precommit.Info.Expiration-r.Height, sectorSize, verifiedSize, tsk)
 		require.NoError(t, err)
 		t.Logf("Pledge from duration, size and verified: %s", pledge)
 

--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -96,7 +96,7 @@ func TestUnsealPiece(t *testing.T) {
 			case id == wpaths[0].ID: // worker path
 				if workers != storiface.FTNone {
 					require.Len(t, decls, 1)
-					require.EqualValues(t, workers.Strings(), decls[0].SectorFileType.Strings())
+					require.EqualValues(t, workers.Strings(), decls[0].Strings())
 				} else {
 					require.Len(t, decls, 0)
 				}
@@ -105,7 +105,7 @@ func TestUnsealPiece(t *testing.T) {
 			default: // miner path
 				if miners != storiface.FTNone {
 					require.Len(t, decls, 1)
-					require.EqualValues(t, miners.Strings(), decls[0].SectorFileType.Strings())
+					require.EqualValues(t, miners.Strings(), decls[0].Strings())
 				} else {
 					require.Len(t, decls, 0)
 				}

--- a/itests/splitstore_test.go
+++ b/itests/splitstore_test.go
@@ -21,7 +21,6 @@ import (
 	power6 "github.com/filecoin-project/specs-actors/v6/actors/builtin/power"
 
 	"github.com/filecoin-project/lotus/api"
-	lapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/blockstore/splitstore"
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/actors"
@@ -291,19 +290,13 @@ func TestCompactRetainsTipSetRef(t *testing.T) {
 }
 
 func waitForCompaction(ctx context.Context, t *testing.T, cIdx int64, n *kit.TestFullNode) {
-	for {
-		if splitStoreCompactionIndex(ctx, t, n) >= cIdx {
-			break
-		}
+	for splitStoreCompactionIndex(ctx, t, n) < cIdx {
 		time.Sleep(1 * time.Second)
 	}
 }
 
 func waitForPrune(ctx context.Context, t *testing.T, pIdx int64, n *kit.TestFullNode) {
-	for {
-		if splitStorePruneIndex(ctx, t, n) >= pIdx {
-			break
-		}
+	for splitStorePruneIndex(ctx, t, n) < pIdx {
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -461,7 +454,7 @@ func (g *Garbager) createMiner4Data(ctx context.Context) {
 	g.maddr4Data = retval.IDAddress
 }
 
-func (g *Garbager) createMiner(ctx context.Context) *lapi.MsgLookup {
+func (g *Garbager) createMiner(ctx context.Context) *api.MsgLookup {
 	owner, err := g.node.WalletDefaultAddress(ctx)
 	require.NoError(g.t, err)
 	worker := owner
@@ -484,7 +477,7 @@ func (g *Garbager) createMiner(ctx context.Context) *lapi.MsgLookup {
 
 	signed, err := g.node.MpoolPushMessage(ctx, createStorageMinerMsg, nil)
 	require.NoError(g.t, err)
-	mw, err := g.node.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, lapi.LookbackNoLimit, true)
+	mw, err := g.node.StateWaitMsg(ctx, signed.Cid(), buildconstants.MessageConfidence, api.LookbackNoLimit, true)
 	require.NoError(g.t, err)
 	require.True(g.t, mw.Receipt.ExitCode == 0, "garbager's internal create miner message failed")
 	return mw

--- a/lib/harmony/harmonydb/userfuncs.go
+++ b/lib/harmony/harmonydb/userfuncs.go
@@ -109,7 +109,7 @@ func (d dbscanRows) Close() error {
 	return nil
 }
 func (d dbscanRows) Columns() ([]string, error) {
-	return lo.Map(d.Rows.FieldDescriptions(), func(fd pgconn.FieldDescription, _ int) string {
+	return lo.Map(d.FieldDescriptions(), func(fd pgconn.FieldDescription, _ int) string {
 		return fd.Name
 	}), nil
 }

--- a/lib/parsehelper/parsehelper.go
+++ b/lib/parsehelper/parsehelper.go
@@ -1,0 +1,41 @@
+// Package parsehelper provides small helpers for working with go/ast and go/parser.
+package parsehelper
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ParseDir parses every *.go file directly in dir and returns the files belonging
+// to package pkgName, keyed by absolute file path. Files in other packages
+// (e.g. _test packages) are skipped.
+//
+// It is a focused replacement for the deprecated go/parser.ParseDir + *ast.Package
+// combo for tools that walk a single package's ASTs. It does not consider build
+// tags; if you need build-aware loading, use golang.org/x/tools/go/packages.
+func ParseDir(fset *token.FileSet, dir, pkgName string, mode parser.Mode) (map[string]*ast.File, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files := make(map[string]*ast.File)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		f, err := parser.ParseFile(fset, path, nil, mode)
+		if err != nil {
+			return nil, err
+		}
+		if f.Name.Name != pkgName {
+			continue
+		}
+		files[path] = f
+	}
+	return files, nil
+}

--- a/lib/parsehelper/parsehelper.go
+++ b/lib/parsehelper/parsehelper.go
@@ -27,7 +27,10 @@ func ParseDir(fset *token.FileSet, dir, pkgName string, mode parser.Mode) (map[s
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
+		path, err := filepath.Abs(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
 		f, err := parser.ParseFile(fset, path, nil, mode)
 		if err != nil {
 			return nil, err

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -329,7 +329,7 @@ minerLoop:
 			now := build.Clock.Now()
 			// Handle timing for broadcasting the block.
 			switch {
-			case btime == now:
+			case btime.Equal(now):
 				// block timestamp is perfectly aligned with time.
 			case btime.After(now):
 				// Wait until it's time to broadcast the block.

--- a/node/config/def.go
+++ b/node/config/def.go
@@ -219,8 +219,8 @@ func DefaultStorageMiner() *StorageMiner {
 		},
 	}
 
-	cfg.Common.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"
-	cfg.Common.API.RemoteListenAddress = "127.0.0.1:2345"
+	cfg.API.ListenAddress = "/ip4/127.0.0.1/tcp/2345/http"
+	cfg.API.RemoteListenAddress = "127.0.0.1:2345"
 	return cfg
 }
 

--- a/node/config/load.go
+++ b/node/config/load.go
@@ -134,7 +134,7 @@ func moveFieldValue(valPtr interface{}, oldPath []string, newPath []string) erro
 
 // recursively iterate into `path` to find the terminal value
 func getFieldValue(val interface{}, path []string) (reflect.Value, error) {
-	if reflect.ValueOf(val).Kind() == reflect.Ptr {
+	if reflect.ValueOf(val).Kind() == reflect.Pointer {
 		val = reflect.ValueOf(val).Elem().Interface()
 	}
 	field := reflect.ValueOf(val).FieldByName(path[0])
@@ -158,7 +158,7 @@ type movedField struct {
 // inspect the fields recursively within a struct and find any with "moved" tags
 func findMovedFields(path []string, val interface{}) []movedField {
 	dep := make([]movedField, 0)
-	if reflect.ValueOf(val).Kind() == reflect.Ptr {
+	if reflect.ValueOf(val).Kind() == reflect.Pointer {
 		val = reflect.ValueOf(val).Elem().Interface()
 	}
 	t := reflect.TypeOf(val)

--- a/node/health.go
+++ b/node/health.go
@@ -100,17 +100,14 @@ func NewReadyHandler(api lapi.FullNode) *HealthHandler {
 		const heightTolerance = uint64(5)
 		var nethealth, synchealth bool
 		minutely := time.NewTicker(time.Minute)
-		for {
-			select {
-			case <-minutely.C:
-				netstat, err := api.NetAutoNatStatus(ctx)
-				nethealth = err == nil && netstat.Reachability != network.ReachabilityUnknown
+		for range minutely.C {
+			netstat, err := api.NetAutoNatStatus(ctx)
+			nethealth = err == nil && netstat.Reachability != network.ReachabilityUnknown
 
-				nodestat, err := api.NodeStatus(ctx, false)
-				synchealth = err == nil && nodestat.SyncStatus.Behind < heightTolerance
+			nodestat, err := api.NodeStatus(ctx, false)
+			synchealth = err == nil && nodestat.SyncStatus.Behind < heightTolerance
 
-				h.SetHealthy(nethealth && synchealth)
-			}
+			h.SetHealthy(nethealth && synchealth)
 		}
 	}()
 	return &h

--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -8,7 +8,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
-	inet "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"golang.org/x/xerrors"
@@ -45,7 +44,7 @@ type LatencyMessage struct {
 	TSent    int64
 }
 
-type NewStreamFunc func(context.Context, peer.ID, ...protocol.ID) (inet.Stream, error)
+type NewStreamFunc func(context.Context, peer.ID, ...protocol.ID) (network.Stream, error)
 
 type Service struct {
 	h host.Host
@@ -71,7 +70,7 @@ func NewHelloService(h host.Host, cs *store.ChainStore, syncer *chain.Syncer, co
 	}
 }
 
-func (hs *Service) HandleStream(s inet.Stream) {
+func (hs *Service) HandleStream(s network.Stream) {
 	var hmsg HelloMessage
 	_ = s.SetReadDeadline(time.Now().Add(streamDeadline))
 	if err := cborutil.ReadCborRPC(s, &hmsg); err != nil {

--- a/node/impl/eth/gas.go
+++ b/node/impl/eth/gas.go
@@ -370,10 +370,7 @@ func gasSearch(
 	high := msg.GasLimit
 	low := msg.GasLimit
 
-	applyTsMessages := true
-	if os.Getenv("LOTUS_SKIP_APPLY_TS_MESSAGE_CALL_WITH_GAS") == "1" {
-		applyTsMessages = false
-	}
+	applyTsMessages := os.Getenv("LOTUS_SKIP_APPLY_TS_MESSAGE_CALL_WITH_GAS") != "1"
 
 	canSucceed := func(limit int64) (bool, error) {
 		msg.GasLimit = limit
@@ -472,7 +469,7 @@ func (g gasRewardSorter) Swap(i, j int) {
 	g[i], g[j] = g[j], g[i]
 }
 func (g gasRewardSorter) Less(i, j int) bool {
-	return g[i].premium.Int.Cmp(g[j].premium.Int) == -1
+	return g[i].premium.Cmp(g[j].premium.Int) == -1
 }
 
 type EthGasDisabled struct{}

--- a/node/impl/eth/reward_test.go
+++ b/node/impl/eth/reward_test.go
@@ -28,7 +28,7 @@ func TestReward(t *testing.T) {
 	for _, tc := range testcases {
 		msg := &types.Message{GasFeeCap: tc.maxFeePerGas, GasPremium: tc.maxPriorityFeePerGas}
 		reward := msg.EffectiveGasPremium(baseFee)
-		require.Equal(t, 0, reward.Int.Cmp(tc.answer.Int), reward, tc.answer)
+		require.Equal(t, 0, reward.Cmp(tc.answer.Int), reward, tc.answer)
 	}
 }
 

--- a/node/impl/eth/utils.go
+++ b/node/impl/eth/utils.go
@@ -216,14 +216,15 @@ func getTransactionHashByCid(ctx context.Context, cs ChainStore, c cid.Cid) (eth
 }
 
 func ethTxHashFromSignedMessage(smsg *types.SignedMessage) (ethtypes.EthHash, error) {
-	if smsg.Signature.Type == crypto.SigTypeDelegated {
+	switch smsg.Signature.Type {
+	case crypto.SigTypeDelegated:
 		tx, err := ethtypes.EthTransactionFromSignedFilecoinMessage(smsg)
 		if err != nil {
 			return ethtypes.EthHash{}, xerrors.Errorf("failed to convert from signed message: %w", err)
 		}
 
 		return tx.TxHash()
-	} else if smsg.Signature.Type == crypto.SigTypeSecp256k1 {
+	case crypto.SigTypeSecp256k1:
 		return ethtypes.EthHashFromCid(smsg.Cid())
 	}
 	// else BLS message
@@ -235,7 +236,8 @@ func newEthTxFromSignedMessage(smsg *types.SignedMessage, st *state.StateTree) (
 	var err error
 
 	// This is an eth tx
-	if smsg.Signature.Type == crypto.SigTypeDelegated {
+	switch smsg.Signature.Type {
+	case crypto.SigTypeDelegated:
 		ethTx, err := ethtypes.EthTransactionFromSignedFilecoinMessage(smsg)
 		if err != nil {
 			return ethtypes.EthTx{}, xerrors.Errorf("failed to convert from signed message: %w", err)
@@ -244,7 +246,7 @@ func newEthTxFromSignedMessage(smsg *types.SignedMessage, st *state.StateTree) (
 		if err != nil {
 			return ethtypes.EthTx{}, xerrors.Errorf("failed to convert from signed message: %w", err)
 		}
-	} else if smsg.Signature.Type == crypto.SigTypeSecp256k1 { // Secp Filecoin Message
+	case crypto.SigTypeSecp256k1: // Secp Filecoin Message
 		tx, err = ethTxFromNativeMessage(smsg.VMMessage(), st)
 		if err != nil {
 			return ethtypes.EthTx{}, err
@@ -253,7 +255,7 @@ func newEthTxFromSignedMessage(smsg *types.SignedMessage, st *state.StateTree) (
 		if err != nil {
 			return ethtypes.EthTx{}, err
 		}
-	} else { // BLS Filecoin message
+	default: // BLS Filecoin message
 		tx, err = ethTxFromNativeMessage(smsg.VMMessage(), st)
 		if err != nil {
 			return ethtypes.EthTx{}, err

--- a/node/impl/full/mpool.go
+++ b/node/impl/full/mpool.go
@@ -186,7 +186,7 @@ func (a *MpoolAPI) MpoolPushMessage(ctx context.Context, msg *types.Message, spe
 		return nil, xerrors.Errorf("MpoolPushMessage expects message nonce to be 0, was %d", msg.Nonce)
 	}
 
-	msg, err = a.GasAPI.GasEstimateMessageGas(ctx, msg, spec, types.EmptyTSK)
+	msg, err = a.GasEstimateMessageGas(ctx, msg, spec, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("GasEstimateMessageGas error: %w", err)
 	}
@@ -215,7 +215,7 @@ func (a *MpoolAPI) MpoolPushMessage(ctx context.Context, msg *types.Message, spe
 
 	// Sign and push the message
 	signedMsg, err := a.MessageSigner.SignMessage(ctx, msg, spec, func(smsg *types.SignedMessage) error {
-		if _, err := a.MpoolModuleAPI.MpoolPush(ctx, smsg); err != nil {
+		if _, err := a.MpoolPush(ctx, smsg); err != nil {
 			return xerrors.Errorf("mpool push: failed to push message: %w", err)
 		}
 		return nil

--- a/node/impl/gasutils/gasutils.go
+++ b/node/impl/gasutils/gasutils.go
@@ -121,10 +121,7 @@ func GasEstimateCallWithGas(
 		priorMsgs = append(priorMsgs, m)
 	}
 
-	applyTsMessages := true
-	if os.Getenv("LOTUS_SKIP_APPLY_TS_MESSAGE_CALL_WITH_GAS") == "1" {
-		applyTsMessages = false
-	}
+	applyTsMessages := os.Getenv("LOTUS_SKIP_APPLY_TS_MESSAGE_CALL_WITH_GAS") != "1"
 
 	// Try calling until we find a height with no migration.
 	var res *api.InvocResult

--- a/node/impl/storminer.go
+++ b/node/impl/storminer.go
@@ -97,7 +97,7 @@ func (sm *StorageMinerAPI) StorageAuthVerify(ctx context.Context, token string) 
 
 func (sm *StorageMinerAPI) ServeRemote(perm bool) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if perm == true {
+		if perm {
 			if !auth.HasPerm(r.Context(), nil, api.PermAdmin) {
 				w.WriteHeader(401)
 				_ = json.NewEncoder(w).Encode(struct{ Error string }{"unauthorized: missing write permission"})

--- a/node/modules/eth.go
+++ b/node/modules/eth.go
@@ -217,7 +217,7 @@ func MakeEthEventsExtended(cfg config.EventsConfig, enableEthRPC bool) func(EthE
 			subscriptionCtx                       = lctx
 			chainStore           eth.ChainStore   = params.ChainStore
 			stateManager         eth.StateManager = params.StateManager
-			chainIndexer         index.Indexer    = params.Indexer
+			chainIndexer                          = params.Indexer
 			eventFilterManager   *filter.EventFilterManager
 			tipSetFilterManager  *filter.TipSetFilterManager
 			memPoolFilterManager *filter.MemPoolFilterManager

--- a/node/options.go
+++ b/node/options.go
@@ -112,7 +112,7 @@ func FromVal[T any](v T) func() T {
 func as(in interface{}, as interface{}) interface{} {
 	outType := reflect.TypeOf(as)
 
-	if outType.Kind() != reflect.Ptr {
+	if outType.Kind() != reflect.Pointer {
 		panic("outType is not a pointer")
 	}
 

--- a/paychmgr/store.go
+++ b/paychmgr/store.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
-	cborrpc "github.com/filecoin-project/go-cbor-util"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-state-types/builtin/v8/paych"
 
@@ -312,7 +311,7 @@ func dskeyForMsg(mcid cid.Cid) datastore.Key {
 func (ps *Store) SaveNewMessage(ctx context.Context, channelID string, mcid cid.Cid) error {
 	k := dskeyForMsg(mcid)
 
-	b, err := cborrpc.Dump(&MsgInfo{ChannelID: channelID, MsgCid: mcid})
+	b, err := cborutil.Dump(&MsgInfo{ChannelID: channelID, MsgCid: mcid})
 	if err != nil {
 		return err
 	}
@@ -333,7 +332,7 @@ func (ps *Store) SaveMessageResult(ctx context.Context, mcid cid.Cid, msgErr err
 		minfo.Err = msgErr.Error()
 	}
 
-	b, err := cborrpc.Dump(minfo)
+	b, err := cborutil.Dump(minfo)
 	if err != nil {
 		return err
 	}
@@ -501,7 +500,7 @@ func marshallChannelInfo(ci *ChannelInfo) ([]byte, error) {
 	if ci.Channel == nil {
 		ci.Channel = &emptyAddr
 	}
-	return cborrpc.Dump(ci)
+	return cborutil.Dump(ci)
 }
 
 func unmarshallChannelInfo(stored *ChannelInfo, value []byte) (*ChannelInfo, error) {

--- a/scripts/docsgen-cli/doc_generator.go
+++ b/scripts/docsgen-cli/doc_generator.go
@@ -70,7 +70,7 @@ func (g *DocGenerator) generateDocs(name string) error {
 
 // writeAppHeader writes the application header documentation
 func (g *DocGenerator) writeAppHeader() error {
-	if _, err := g.writer.Write([]byte(fmt.Sprintf("# %s\n\n```\n", g.app.Name))); err != nil {
+	if _, err := fmt.Fprintf(g.writer, "# %s\n\n```\n", g.app.Name); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (g *DocGenerator) writeCommands(commands cli.Commands, rootName string, dep
 
 		cmdName := fmt.Sprintf("%s %s", rootName, cmd.Name)
 
-		if _, err := g.writer.Write([]byte(fmt.Sprintf("\n%s %s\n\n```\n", strings.Repeat("#", depth+2), cmdName))); err != nil {
+		if _, err := fmt.Fprintf(g.writer, "\n%s %s\n\n```\n", strings.Repeat("#", depth+2), cmdName); err != nil {
 			return err
 		}
 

--- a/storage/paths/local.go
+++ b/storage/paths/local.go
@@ -366,7 +366,7 @@ func (st *Local) declareSectors(ctx context.Context, p string, id storiface.ID, 
 		}
 
 		for _, decl := range decls[id] {
-			for _, fileType := range decl.SectorFileType.AllSet() {
+			for _, fileType := range decl.AllSet() {
 				indexed[storiface.Decl{
 					SectorID:       decl.SectorID,
 					SectorFileType: fileType,

--- a/storage/pipeline/fsm.go
+++ b/storage/pipeline/fsm.go
@@ -374,7 +374,7 @@ func (state *SectorInfo) logAppend(l Log) {
 		state.Log[2000] = Log{
 			Timestamp: uint64(time.Now().Unix()),
 			Message:   "truncating log (above 8000 entries)",
-			Kind:      fmt.Sprintf("truncate"),
+			Kind:      "truncate",
 		}
 
 		state.Log = append(state.Log[:2000], state.Log[6000:]...)

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -882,8 +882,8 @@ func (m *Sealing) tryGetDealSector(ctx context.Context, sp abi.RegisteredSealPro
 		maxUpgrading = cfg.MaxUpgradingSectors
 	}
 
-	canCreate := cfg.MakeNewSectorForDeals && !(cfg.MaxSealingSectorsForDeals > 0 && m.stats.curSealing() >= cfg.MaxSealingSectorsForDeals)
-	canUpgrade := !(maxUpgrading > 0 && m.stats.curSealing() >= maxUpgrading)
+	canCreate := cfg.MakeNewSectorForDeals && (cfg.MaxSealingSectorsForDeals <= 0 || m.stats.curSealing() < cfg.MaxSealingSectorsForDeals)
+	canUpgrade := maxUpgrading <= 0 || m.stats.curSealing() < maxUpgrading
 
 	// we want to try to upgrade when:
 	// - we can upgrade and prefer upgrades

--- a/storage/sealer/faults.go
+++ b/storage/sealer/faults.go
@@ -93,7 +93,7 @@ func (m *Manager) CheckProvable(ctx context.Context, pp abi.RegisteredPoStProof,
 
 			if !locked {
 				log.Warnw("CheckProvable Sector FAULT: can't acquire read lock", "sector", sector)
-				addBad(sector.ID, fmt.Sprint("can't acquire read lock"))
+				addBad(sector.ID, "can't acquire read lock")
 				return
 			}
 

--- a/storage/sealer/manager_test.go
+++ b/storage/sealer/manager_test.go
@@ -673,11 +673,7 @@ func TestRestartWorker(t *testing.T) {
 	<-arch
 	require.NoError(t, w.Close())
 
-	for {
-		if len(m.WorkerStats(ctx)) == 0 {
-			break
-		}
-
+	for len(m.WorkerStats(ctx)) != 0 {
 		time.Sleep(time.Millisecond * 3)
 	}
 

--- a/storage/sealer/mock/mock.go
+++ b/storage/sealer/mock/mock.go
@@ -302,8 +302,6 @@ func (mgr *SectorMgr) Fail() {
 	mgr.lk.Lock()
 	defer mgr.lk.Unlock()
 	mgr.failPoSt = true
-
-	return
 }
 
 func (mgr *SectorMgr) MarkCorrupted(sid storiface.SectorRef, corrupted bool) error {

--- a/storage/sealer/selector_task.go
+++ b/storage/sealer/selector_task.go
@@ -12,7 +12,7 @@ import (
 )
 
 type taskSelector struct {
-	best []storiface.StorageInfo //nolint: unused, structcheck
+	best []storiface.StorageInfo //nolint:unused
 }
 
 func newTaskSelector() *taskSelector {

--- a/storage/sectorblocks/blocks.go
+++ b/storage/sectorblocks/blocks.go
@@ -96,7 +96,7 @@ func (st *SectorBlocks) writeRef(ctx context.Context, dealID abi.DealID, sectorI
 }
 
 func (st *SectorBlocks) AddPiece(ctx context.Context, size abi.UnpaddedPieceSize, r io.Reader, d piece.PieceDealInfo) (abi.SectorNumber, abi.PaddedPieceSize, error) {
-	so, err := st.SectorBuilder.SectorAddPieceToAny(ctx, size, r, d)
+	so, err := st.SectorAddPieceToAny(ctx, size, r, d)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/tools/stats/sync/sync.go
+++ b/tools/stats/sync/sync.go
@@ -41,10 +41,10 @@ func SyncWait(ctx context.Context, napi SyncWaitApi) error {
 		for i, ss := range state.ActiveSyncs {
 			switch ss.Stage {
 			case api.StageSyncComplete:
-			default:
-				working = i
 			case api.StageIdle:
 				// not complete, not actively working
+			default:
+				working = i
 			}
 		}
 
@@ -164,11 +164,7 @@ func BufferedTipsetChannel(ctx context.Context, api BufferedTipsetChannelApi, la
 func loadTipsets(ctx context.Context, api BufferedTipsetChannelApi, curr *types.TipSet, lowestHeight abi.ChainEpoch) ([]*types.TipSet, error) {
 	log.Infow("loading tipsets", "to_height", lowestHeight, "from_height", curr.Height())
 	tipsets := []*types.TipSet{}
-	for {
-		if curr.Height() == 0 {
-			break
-		}
-
+	for curr.Height() > 0 {
 		if curr.Height() <= lowestHeight {
 			break
 		}


### PR DESCRIPTION
_Not a high priority to review & merge, I've had this sitting in my local waiting to be pushed; now rebased ontop of all the released code._

This is a pretty noisy diff but it's almost all just clean-ups. The noisiest bits are the actors wrappers and mostly it's replacing the inner struct references where they're not needed. The largest material change is the new `ParseDir` helper to replace the deprecated one we're currently using.

We have 4 notable exclusions here above the default:

* G117 wants `PrivateKey` struct fields gone, we have a few
* G118 context propagation failures .. there's 3 `context.TODO`/background sites that trigger this, we could probably fix these in a follow-up
* G703 path traversal taint in gen code
* G704 ssrf taint, hitting remote storage primitives, meh
