### PR TITLE
fix: sealing pipeline commit batch robustness and allocation validation

### DIFF
--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -70,9 +70,10 @@ type CommitBatcher struct {
 	getConfig dtypes.GetSealingConfigFunc
 	prover    storiface.Prover
 
-	cutoffs map[abi.SectorNumber]time.Time
-	todo    map[abi.SectorNumber]AggregateInput
-	waiting map[abi.SectorNumber][]chan sealiface.CommitBatchRes
+	cutoffs  map[abi.SectorNumber]time.Time
+	todo     map[abi.SectorNumber]AggregateInput
+	waiting  map[abi.SectorNumber][]chan sealiface.CommitBatchRes
+	failures map[abi.SectorNumber]int // Track consecutive non-retryable failures per sector
 
 	notify, stop, stopped chan struct{}
 	force                 chan chan []sealiface.CommitBatchRes
@@ -89,9 +90,10 @@ func NewCommitBatcher(mctx context.Context, maddr address.Address, api CommitBat
 		getConfig: getConfig,
 		prover:    prov,
 
-		cutoffs: map[abi.SectorNumber]time.Time{},
-		todo:    map[abi.SectorNumber]AggregateInput{},
-		waiting: map[abi.SectorNumber][]chan sealiface.CommitBatchRes{},
+		cutoffs:  map[abi.SectorNumber]time.Time{},
+		todo:     map[abi.SectorNumber]AggregateInput{},
+		waiting:  map[abi.SectorNumber][]chan sealiface.CommitBatchRes{},
+		failures: map[abi.SectorNumber]int{},
 
 		notify:  make(chan struct{}, 1),
 		force:   make(chan chan []sealiface.CommitBatchRes),
@@ -239,6 +241,34 @@ func (b *CommitBatcher) maybeStartBatch(notif bool) ([]sealiface.CommitBatchRes,
 		err = xerrors.Errorf("processBatchV2: %w", err)
 	}
 
+	// Defensive fallback: every queued sector must receive a result, otherwise
+	// AddCommit callers can remain blocked forever.
+	processed := map[abi.SectorNumber]struct{}{}
+	for _, r := range res {
+		for _, sn := range r.Sectors {
+			processed[sn] = struct{}{}
+		}
+	}
+
+	if len(processed) != total {
+		missingRes := sealiface.CommitBatchRes{
+			FailedSectors: map[abi.SectorNumber]string{},
+		}
+
+		for _, sn := range sectors {
+			if _, ok := processed[sn]; ok {
+				continue
+			}
+
+			missingRes.Sectors = append(missingRes.Sectors, sn)
+			missingRes.FailedSectors[sn] = "commit batcher dropped sector from processing"
+		}
+
+		if len(missingRes.Sectors) > 0 {
+			res = append(res, missingRes)
+		}
+	}
+
 	// Mark sectors as done
 	for _, r := range res {
 		if err != nil {
@@ -253,6 +283,7 @@ func (b *CommitBatcher) maybeStartBatch(notif bool) ([]sealiface.CommitBatchRes,
 			delete(b.waiting, sn)
 			delete(b.todo, sn)
 			delete(b.cutoffs, sn)
+			delete(b.failures, sn) // Clean up failure tracking
 		}
 	}
 
@@ -298,8 +329,14 @@ func (b *CommitBatcher) processBatchV2(cfg sealiface.Config, sectors []abi.Secto
 		return nil, err
 	}
 
+	// Eviction threshold: sectors with 5+ consecutive non-retryable failures are evicted
+	const maxFailures = 5
+
 	for _, sector := range sectors {
 		if b.todo[sector].DealIDPrecommit {
+			res.Sectors = append(res.Sectors, sector)
+			res.FailedSectors[sector] = "deal-id precommit sectors are not supported in ProveCommitSectors3 batching"
+			b.trackFailure(sector, maxFailures)
 			continue
 		}
 
@@ -309,6 +346,7 @@ func (b *CommitBatcher) processBatchV2(cfg sealiface.Config, sectors []abi.Secto
 		sc, err := b.getSectorCollateral(sector, manifest.Pieces, ts)
 		if err != nil {
 			res.FailedSectors[sector] = err.Error()
+			b.trackFailure(sector, maxFailures)
 			continue
 		}
 
@@ -318,14 +356,19 @@ func (b *CommitBatcher) processBatchV2(cfg sealiface.Config, sectors []abi.Secto
 			precomitInfo, err := b.api.StateSectorPreCommitInfo(b.mctx, b.maddr, sector, ts.Key())
 			if err != nil {
 				res.FailedSectors[sector] = err.Error()
+				b.trackFailure(sector, maxFailures)
 				continue
 			}
 			err = b.allocationCheck(manifest.Pieces, precomitInfo, abi.ActorID(mid), ts)
 			if err != nil {
 				res.FailedSectors[sector] = err.Error()
+				b.trackFailure(sector, maxFailures)
 				continue
 			}
 		}
+
+		// Reset failure counter on successful processing
+		delete(b.failures, sector)
 
 		params.SectorActivations = append(params.SectorActivations, b.todo[sector].ActivationManifest)
 		params.SectorProofs = append(params.SectorProofs, b.todo[sector].Proof)
@@ -334,6 +377,10 @@ func (b *CommitBatcher) processBatchV2(cfg sealiface.Config, sectors []abi.Secto
 	}
 
 	if len(infos) == 0 {
+		if len(res.Sectors) > 0 {
+			return []sealiface.CommitBatchRes{res}, nil
+		}
+
 		return nil, nil
 	}
 
@@ -514,6 +561,38 @@ func (b *CommitBatcher) Stop(ctx context.Context) error {
 	}
 }
 
+// trackFailure increments the failure counter for a sector and evicts it from the
+// batch queue if it exceeds maxFailures consecutive non-retryable failures.
+// This prevents sectors from being stuck in a perpetual retry loop.
+func (b *CommitBatcher) trackFailure(sector abi.SectorNumber, maxFailures int) {
+	b.failures[sector]++
+	failCount := b.failures[sector]
+
+	if failCount >= maxFailures {
+		log.Warnf("Evicting sector %d from commit batch after %d consecutive failures", sector, failCount)
+
+		// Deliver failure result to all waiters
+		failRes := sealiface.CommitBatchRes{
+			Sectors:       []abi.SectorNumber{sector},
+			FailedSectors: map[abi.SectorNumber]string{sector: "sector evicted from batch: too many non-retryable failures"},
+		}
+
+		for _, ch := range b.waiting[sector] {
+			select {
+			case ch <- failRes:
+			default:
+				log.Warnf("Failed to deliver eviction result for sector %d", sector)
+			}
+		}
+
+		// Clean up state for evicted sector
+		delete(b.waiting, sector)
+		delete(b.todo, sector)
+		delete(b.cutoffs, sector)
+		delete(b.failures, sector)
+	}
+}
+
 // TODO: If this returned epochs, it would make testing much easier
 func (b *CommitBatcher) getCommitCutoff(si SectorInfo) (time.Time, error) {
 	ts, err := b.api.ChainHead(b.mctx)
@@ -638,11 +717,14 @@ func (b *CommitBatcher) allocationCheck(Pieces []miner.PieceActivationManifest, 
 		if alloc.Size != p.Size {
 			return xerrors.Errorf("size mismatch for piece %s: expected %d and found %d", p.CID.String(), p.Size, alloc.Size)
 		}
-		if precomitInfo.Info.Expiration < ts.Height()+alloc.TermMin {
-			return xerrors.Errorf("sector expiration %d is before than allocation TermMin %d for piece %s", precomitInfo.Info.Expiration, ts.Height()+alloc.TermMin, p.CID.String())
+		// Use PreCommitEpoch as the fixed reference point instead of live ts.Height()
+		// This ensures the check is deterministic at precommit time and doesn't flip
+		// from valid to invalid as blocks pass
+		if precomitInfo.Info.Expiration < precomitInfo.PreCommitEpoch+alloc.TermMin {
+			log.Warnf("sector expiration %d is before than allocation TermMin %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMin, p.CID.String())
 		}
-		if precomitInfo.Info.Expiration > ts.Height()+alloc.TermMax {
-			return xerrors.Errorf("sector expiration %d is later than allocation TermMax %d for piece %s", precomitInfo.Info.Expiration, ts.Height()+alloc.TermMax, p.CID.String())
+		if precomitInfo.Info.Expiration > precomitInfo.PreCommitEpoch+alloc.TermMax {
+			log.Warnf("sector expiration %d is later than allocation TermMax %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMax, p.CID.String())
 		}
 	}
 	return nil

--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -243,29 +243,33 @@ func (b *CommitBatcher) maybeStartBatch(notif bool) ([]sealiface.CommitBatchRes,
 
 	// Defensive fallback: every queued sector must receive a result, otherwise
 	// AddCommit callers can remain blocked forever.
-	processed := map[abi.SectorNumber]struct{}{}
-	for _, r := range res {
-		for _, sn := range r.Sectors {
-			processed[sn] = struct{}{}
-		}
-	}
-
-	if len(processed) != total {
-		missingRes := sealiface.CommitBatchRes{
-			FailedSectors: map[abi.SectorNumber]string{},
+	// Only run when processBatchV2 succeeded. On batch-level errors, preserve the
+	// queue so sectors can be retried on the next batch attempt.
+	if err == nil {
+		processed := map[abi.SectorNumber]struct{}{}
+		for _, r := range res {
+			for _, sn := range r.Sectors {
+				processed[sn] = struct{}{}
+			}
 		}
 
-		for _, sn := range sectors {
-			if _, ok := processed[sn]; ok {
-				continue
+		if len(processed) != total {
+			missingRes := sealiface.CommitBatchRes{
+				FailedSectors: map[abi.SectorNumber]string{},
 			}
 
-			missingRes.Sectors = append(missingRes.Sectors, sn)
-			missingRes.FailedSectors[sn] = "commit batcher dropped sector from processing"
-		}
+			for _, sn := range sectors {
+				if _, ok := processed[sn]; ok {
+					continue
+				}
 
-		if len(missingRes.Sectors) > 0 {
-			res = append(res, missingRes)
+				missingRes.Sectors = append(missingRes.Sectors, sn)
+				missingRes.FailedSectors[sn] = "commit batcher dropped sector from processing"
+			}
+
+			if len(missingRes.Sectors) > 0 {
+				res = append(res, missingRes)
+			}
 		}
 	}
 
@@ -721,10 +725,10 @@ func (b *CommitBatcher) allocationCheck(Pieces []miner.PieceActivationManifest, 
 		// This ensures the check is deterministic at precommit time and doesn't flip
 		// from valid to invalid as blocks pass
 		if precomitInfo.Info.Expiration < precomitInfo.PreCommitEpoch+alloc.TermMin {
-			log.Warnf("sector expiration %d is before than allocation TermMin %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMin, p.CID.String())
+			return xerrors.Errorf("sector expiration %d is before allocation TermMin %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMin, p.CID.String())
 		}
 		if precomitInfo.Info.Expiration > precomitInfo.PreCommitEpoch+alloc.TermMax {
-			log.Warnf("sector expiration %d is later than allocation TermMax %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMax, p.CID.String())
+			return xerrors.Errorf("sector expiration %d is later than allocation TermMax %d for piece %s", precomitInfo.Info.Expiration, precomitInfo.PreCommitEpoch+alloc.TermMax, p.CID.String())
 		}
 	}
 	return nil

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-padreader"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/network"
 	"github.com/filecoin-project/go-statemachine"
 
 	"github.com/filecoin-project/lotus/api"
@@ -385,7 +387,7 @@ func (m *Sealing) sectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 			pieceInfo.PieceCID(), ts.Height(), startEpoch)
 	}
 
-	claimTerms, err := m.getClaimTerms(ctx, pieceInfo, ts.Key())
+	claimTerms, err := m.getClaimTerms(ctx, pieceInfo, ts.Key(), sp)
 	if err != nil {
 		return api.SectorOffset{}, err
 	}
@@ -417,13 +419,46 @@ func (m *Sealing) sectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 	return api.SectorOffset{Sector: res.sn, Offset: res.offset.Padded()}, res.err
 }
 
-func (m *Sealing) getClaimTerms(ctx context.Context, deal UniversalPieceInfo, tsk types.TipSetKey) (pieceClaimBounds, error) {
+func minAllocationTermForSealProof(nv network.Version, sp abi.RegisteredSealProof) (abi.ChainEpoch, error) {
+	av, err := actorstypes.VersionForNetwork(nv)
+	if err != nil {
+		return 0, xerrors.Errorf("getting actors version: %w", err)
+	}
+
+	msd, err := policy.GetMaxProveCommitDuration(av, sp)
+	if err != nil {
+		return 0, xerrors.Errorf("getting max prove commit duration: %w", err)
+	}
+
+	return policy.MaxPreCommitRandomnessLookback + msd + policy.GetMinSectorExpiration(), nil
+}
+
+func (m *Sealing) getClaimTerms(ctx context.Context, deal UniversalPieceInfo, tsk types.TipSetKey, sp abi.RegisteredSealProof) (pieceClaimBounds, error) {
 
 	all, err := deal.GetAllocation(ctx, m.Api, tsk)
 	if err != nil {
 		return pieceClaimBounds{}, err
 	}
 	if all != nil {
+		nv, err := m.Api.StateNetworkVersion(ctx, tsk)
+		if err != nil {
+			return pieceClaimBounds{}, err
+		}
+
+		minTerm, err := minAllocationTermForSealProof(nv, sp)
+		if err != nil {
+			return pieceClaimBounds{}, err
+		}
+		if all.TermMax < minTerm {
+			return pieceClaimBounds{}, xerrors.Errorf(
+				"allocation term max %d for piece %s is below the minimum required sector lifetime %d for seal proof %s",
+				all.TermMax,
+				deal.PieceCID(),
+				minTerm,
+				sp,
+			)
+		}
+
 		startEpoch, err := deal.StartEpoch()
 		if err != nil {
 			return pieceClaimBounds{}, err

--- a/storage/pipeline/precommit_policy.go
+++ b/storage/pipeline/precommit_policy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/storage/pipeline/piece"
 )
 
 type PreCommitPolicy interface {
@@ -22,6 +23,7 @@ type PreCommitPolicy interface {
 type Chain interface {
 	ChainHead(context.Context) (*types.TipSet, error)
 	StateNetworkVersion(ctx context.Context, tsk types.TipSetKey) (network.Version, error)
+	piece.AllocationAPI
 }
 
 // BasicPreCommitPolicy satisfies PreCommitPolicy. It has two modes:
@@ -66,6 +68,7 @@ func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, ps ...SafeSectorP
 	}
 
 	var end *abi.ChainEpoch
+	chainAPI := p.api
 
 	for _, p := range ps {
 		if !p.HasDealInfo() {
@@ -75,6 +78,28 @@ func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, ps ...SafeSectorP
 		endEpoch, err := p.EndEpoch()
 		if err != nil {
 			return 0, xerrors.Errorf("failed to get end epoch: %w", err)
+		}
+
+		alloc, err := p.GetAllocation(ctx, chainAPI, ts.Key())
+		if err != nil {
+			return 0, xerrors.Errorf("failed to get allocation: %w", err)
+		}
+		if alloc != nil {
+			pieceCID := p.PieceCID()
+			if alloc.Data != pieceCID {
+				return 0, xerrors.Errorf("allocation piece cid mismatch: expected %s, got %s", pieceCID, alloc.Data)
+			}
+
+			pieceSize := p.Piece().Size
+			if alloc.Size != pieceSize {
+				return 0, xerrors.Errorf("allocation piece size mismatch: expected %d, got %d", pieceSize, alloc.Size)
+			}
+
+			maxAllowed := ts.Height() + alloc.TermMax
+			if maxAllowed < endEpoch {
+				log.Warnf("deal end epoch %d is after allocation term maximum %d, clamping to maximum", endEpoch, maxAllowed)
+				endEpoch = maxAllowed
+			}
 		}
 
 		if endEpoch < ts.Height() {

--- a/storage/pipeline/precommit_policy.go
+++ b/storage/pipeline/precommit_policy.go
@@ -95,7 +95,11 @@ func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, ps ...SafeSectorP
 				return 0, xerrors.Errorf("allocation piece size mismatch: expected %d, got %d", pieceSize, alloc.Size)
 			}
 
-			maxAllowed := ts.Height() + alloc.TermMax
+			startEpoch, err := p.StartEpoch()
+			if err != nil {
+				return 0, xerrors.Errorf("failed to get start epoch for allocation: %w", err)
+			}
+			maxAllowed := startEpoch + alloc.TermMax
 			if maxAllowed < endEpoch {
 				log.Warnf("deal end epoch %d is after allocation term maximum %d, clamping to maximum", endEpoch, maxAllowed)
 				endEpoch = maxAllowed


### PR DESCRIPTION
## Summary

Fixes several bugs in the Lotus sealing pipeline that cause sectors to get stuck in perpetual retry loops, block callers indefinitely, and perform non-deterministic allocation validation.

Closes #13631

## Changes

### 1. Sectors stuck in infinite retry loop (`commit_batch.go`)
Track consecutive non-retryable failures per sector in the CommitBatcher. Sectors that fail 5 times consecutively are evicted from the batch queue with a failure result delivered to all waiters, preventing infinite retry loops on sectors that will never succeed.

### 2. AddCommit callers blocked forever (`commit_batch.go`)
Added a defensive fallback after `processBatchV2` that ensures every sector in the batch receives a result. If a sector is missing from the response, an explicit failure result is generated. Also fixed `processBatchV2` to return the `res` when `infos` is empty but there are failed sectors (previously returned nil).

### 3. Non-deterministic allocation TermMin/TermMax check (`commit_batch.go`)
Changed `allocationCheck` to use `PreCommitEpoch` as the fixed reference point instead of live `ts.Height()`. This makes the TermMin/TermMax validation deterministic regardless of when the batch is processed.

### 4. Missing allocation term validation (`input.go`)
Added `minAllocationTermForSealProof` to compute the minimum allocation term required based on seal proof parameters. `getClaimTerms` now rejects allocations whose `TermMax` is below this minimum, catching unsuitable allocations early.

### 5. Missing allocation validation in precommit policy (`precommit_policy.go`)
Added allocation lookup in `BasicPreCommitPolicy.Expiration` to validate piece CID/size against the on-chain allocation and clamp the deal end epoch to `TermMax` when it exceeds the allowed maximum.

## Affected Files
- `storage/pipeline/commit_batch.go` — failure tracking, eviction, defensive fallback, deterministic allocation checks
- `storage/pipeline/input.go` — allocation term validation
- `storage/pipeline/precommit_policy.go` — allocation validation and epoch clamping

## Test plan
- [ ] Verify sectors with non-retryable failures are evicted after 5 attempts
- [ ] Verify all queued sectors receive a result even if dropped during batch processing
- [ ] Verify allocation TermMin/TermMax checks are deterministic using PreCommitEpoch
- [ ] Verify allocations with insufficient TermMax are rejected in getClaimTerms
- [ ] Verify PreCommitPolicy validates allocation data and clamps expiration correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)