### PR TITLE
feat(mempool): raise MaxUntrustedActorPendingMessages from 10 to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ## 👌 Improvements
 
 * Silence libp2p config log spam ([filecoin-project/lotus#13612](https://github.com/filecoin-project/lotus/pull/13612))
+* feat(mempool): raise the default per-actor cap on the untrusted push path (`MaxUntrustedActorPendingMessages`) from 10 to 100, reducing spurious `ErrTooManyPendingMessages` rejections for normal-cadence senders relaying through `lotus-gateway` / public RPC ([filecoin-project/lotus#13636](https://github.com/filecoin-project/lotus/pull/13636))
 
 # Node and Miner v1.36.0 / 2026-05-13
 

--- a/chain/messagepool/messagepool.go
+++ b/chain/messagepool/messagepool.go
@@ -60,7 +60,7 @@ var baseFeeLowerBoundFactor = types.NewInt(10)
 var baseFeeLowerBoundFactorConservative = types.NewInt(100)
 
 var MaxActorPendingMessages = 1000
-var MaxUntrustedActorPendingMessages = 10
+var MaxUntrustedActorPendingMessages = 100
 
 var MaxNonceGap = uint64(4)
 
@@ -1152,7 +1152,7 @@ func (mp *MessagePool) getStateBalance(ctx context.Context, addr address.Address
 // differences from Push:
 //   - strict checks are enabled
 //   - extra strict add checks are used when adding the messages to the msgSet
-//     that means: no nonce gaps, at most 10 pending messages for the actor
+//     that means: no nonce gaps, at most 100 pending messages for the actor
 func (mp *MessagePool) PushUntrusted(ctx context.Context, m *types.SignedMessage) (cid.Cid, error) {
 	err := mp.checkMessage(ctx, m)
 	if err != nil {

--- a/itests/eth_transactions_test.go
+++ b/itests/eth_transactions_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
@@ -295,6 +296,12 @@ func TestContractInvocationMultiple(t *testing.T) {
 		totalMessages = 20
 		maxUntrusted  = 10
 	)
+
+	// Pin the untrusted-push cap so the test exercises a small, bounded
+	// scenario independent of the package default.
+	prev := messagepool.MaxUntrustedActorPendingMessages
+	messagepool.MaxUntrustedActorPendingMessages = maxUntrusted
+	t.Cleanup(func() { messagepool.MaxUntrustedActorPendingMessages = prev })
 
 	for _, untrusted := range []bool{true, false} {
 		t.Run(fmt.Sprintf("untrusted=%t", untrusted), func(t *testing.T) {

--- a/itests/mempool_test.go
+++ b/itests/mempool_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/messagepool"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 )
@@ -267,6 +268,12 @@ func TestMemPoolPushSingleNode(t *testing.T) {
 	const blockTime = 50 * time.Millisecond
 	const maxMessages = 20
 	const maxUntrusted = 10
+
+	// Pin the untrusted-push cap so the test exercises a small, bounded
+	// scenario independent of the package default.
+	prev := messagepool.MaxUntrustedActorPendingMessages
+	messagepool.MaxUntrustedActorPendingMessages = maxUntrusted
+	t.Cleanup(func() { messagepool.MaxUntrustedActorPendingMessages = prev })
 
 	for _, style := range []string{"MpoolPush", "MpoolPushUntrusted", "MpoolPushMessage"} {
 		t.Run(style, func(t *testing.T) {


### PR DESCRIPTION
## Related Issues
None. The current value has been unchanged since the untrusted push path was introduced in 3c7246196 (2020).

## Proposed Changes
- Raise `MaxUntrustedActorPendingMessages` from `10` to `100` in `chain/messagepool/messagepool.go`.
- Update the corresponding comment on `PushUntrusted`.
- Add a `CHANGELOG.md` entry under `## 👌 Improvements`.

## Additional Info
The per-actor cap on the untrusted push path — used by `lotus-gateway` and therefore every public RPC relaying `MpoolPush` from external clients — has been `10` since this path was introduced in 2020.

That value is too tight for normal usage. A sender pushing at modest cadence can easily have more than 10 messages in flight when basefee spikes briefly or block inclusion stalls, after which every subsequent send is rejected with `ErrTooManyPendingMessages`. The failure surfaces as a hard error on the send path rather than backpressure.

**Impact**
- Cap raised 10x but still an order of magnitude **below** the trusted-path cap (`MaxActorPendingMessages = 1000`), preserving the asymmetry that protects gateway operators from external spam.
- `maxNonceGap = 0` for untrusted messages is **unchanged** — pending messages must still form a contiguous nonce sequence from the on-chain nonce, so an attacker cannot park arbitrary future nonces.
- Worst-case additional per-actor memory: ~90 extra ` SignedMessage ` entries, negligible against the existing global pool bounds.
- No API or wire-format changes.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior (no test references the literal `10`; behavior is unchanged apart from the constant)
- [ ] CI is green