### PR TITLE
chore(cli): lotus-miner info supports --actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Silence libp2p config log spam ([filecoin-project/lotus#13612](https://github.com/filecoin-project/lotus/pull/13612))
 * feat(mempool): raise the default per-actor cap on the untrusted push path (`MaxUntrustedActorPendingMessages`) from 10 to 100, reducing spurious `ErrTooManyPendingMessages` rejections for normal-cadence senders relaying through `lotus-gateway` / public RPC ([filecoin-project/lotus#13636](https://github.com/filecoin-project/lotus/pull/13636))
+* chore(cli): `lotus-miner info` supports `--actor` to query any miner without a local miner repo; miner-daemon-only sections (subsystems, start time, alerts, workers, sectors) are skipped when `--actor` is set
 
 # Node and Miner v1.36.0 / 2026-05-13
 

--- a/cli/miner/info.go
+++ b/cli/miner/info.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -56,12 +57,6 @@ var infoCmd = &cli.Command{
 }
 
 func infoCmdAct(cctx *cli.Context) error {
-	minerApi, closer, err := lcli.GetStorageMinerAPI(cctx)
-	if err != nil {
-		return err
-	}
-	defer closer()
-
 	fullapi, acloser, err := lcli.GetFullNodeAPIV1(cctx)
 	if err != nil {
 		return err
@@ -70,18 +65,28 @@ func infoCmdAct(cctx *cli.Context) error {
 
 	ctx := lcli.ReqContext(cctx)
 
-	subsystems, err := minerApi.RuntimeSubsystems(ctx)
-	if err != nil {
-		return err
-	}
+	var minerApi api.StorageMiner
+	if !cctx.IsSet("actor") {
+		var closer jsonrpc.ClientCloser
+		minerApi, closer, err = lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
 
-	fmt.Println("Enabled subsystems:", subsystems)
+		subsystems, err := minerApi.RuntimeSubsystems(ctx)
+		if err != nil {
+			return err
+		}
 
-	start, err := minerApi.StartTime(ctx)
-	if err != nil {
-		return err
+		fmt.Println("Enabled subsystems:", subsystems)
+
+		start, err := minerApi.StartTime(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("StartTime: %s (started at %s)\n", time.Since(start).Truncate(time.Second), start.Truncate(time.Second))
 	}
-	fmt.Printf("StartTime: %s (started at %s)\n", time.Since(start).Truncate(time.Second), start.Truncate(time.Second))
 
 	fmt.Print("Chain: ")
 
@@ -92,19 +97,21 @@ func infoCmdAct(cctx *cli.Context) error {
 
 	fmt.Println()
 
-	alerts, err := minerApi.LogAlerts(ctx)
-	if err != nil {
-		fmt.Printf("ERROR: getting alerts: %s\n", err)
-	}
-
-	activeAlerts := make([]alerting.Alert, 0)
-	for _, alert := range alerts {
-		if alert.Active {
-			activeAlerts = append(activeAlerts, alert)
+	if minerApi != nil {
+		alerts, err := minerApi.LogAlerts(ctx)
+		if err != nil {
+			fmt.Printf("ERROR: getting alerts: %s\n", err)
 		}
-	}
-	if len(activeAlerts) > 0 {
-		fmt.Printf("%s (check %s)\n", color.RedString("⚠ %d Active alerts", len(activeAlerts)), color.YellowString("lotus-miner log alerts"))
+
+		activeAlerts := make([]alerting.Alert, 0)
+		for _, alert := range alerts {
+			if alert.Active {
+				activeAlerts = append(activeAlerts, alert)
+			}
+		}
+		if len(activeAlerts) > 0 {
+			fmt.Printf("%s (check %s)\n", color.RedString("⚠ %d Active alerts", len(activeAlerts)), color.YellowString("lotus-miner log alerts"))
+		}
 	}
 
 	err = handleMiningInfo(ctx, cctx, fullapi, minerApi)
@@ -314,7 +321,7 @@ func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v1api.Full
 	}
 	fmt.Println()
 
-	if !cctx.Bool("hide-sectors-info") {
+	if nodeApi != nil && !cctx.Bool("hide-sectors-info") {
 		fmt.Println("Sectors:")
 		err = sectorsInfo(ctx, nodeApi)
 		if err != nil {
@@ -324,35 +331,37 @@ func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v1api.Full
 
 	fmt.Println()
 
-	ws, err := nodeApi.WorkerStats(ctx)
-	if err != nil {
-		fmt.Printf("ERROR: getting worker stats: %s\n", err)
-	} else {
-		workersByType := map[string]int{
-			sealtasks.WorkerSealing:     0,
-			sealtasks.WorkerWindowPoSt:  0,
-			sealtasks.WorkerWinningPoSt: 0,
-		}
-
-	wloop:
-		for _, st := range ws {
-			if !st.Enabled {
-				continue
+	if nodeApi != nil {
+		ws, err := nodeApi.WorkerStats(ctx)
+		if err != nil {
+			fmt.Printf("ERROR: getting worker stats: %s\n", err)
+		} else {
+			workersByType := map[string]int{
+				sealtasks.WorkerSealing:     0,
+				sealtasks.WorkerWindowPoSt:  0,
+				sealtasks.WorkerWinningPoSt: 0,
 			}
 
-			for _, task := range st.Tasks {
-				if task.WorkerType() != sealtasks.WorkerSealing {
-					workersByType[task.WorkerType()]++
-					continue wloop
+		wloop:
+			for _, st := range ws {
+				if !st.Enabled {
+					continue
 				}
-			}
-			workersByType[sealtasks.WorkerSealing]++
-		}
 
-		fmt.Printf("Workers: Seal(%d) WdPoSt(%d) WinPoSt(%d)\n",
-			workersByType[sealtasks.WorkerSealing],
-			workersByType[sealtasks.WorkerWindowPoSt],
-			workersByType[sealtasks.WorkerWinningPoSt])
+				for _, task := range st.Tasks {
+					if task.WorkerType() != sealtasks.WorkerSealing {
+						workersByType[task.WorkerType()]++
+						continue wloop
+					}
+				}
+				workersByType[sealtasks.WorkerSealing]++
+			}
+
+			fmt.Printf("Workers: Seal(%d) WdPoSt(%d) WinPoSt(%d)\n",
+				workersByType[sealtasks.WorkerSealing],
+				workersByType[sealtasks.WorkerWindowPoSt],
+				workersByType[sealtasks.WorkerWinningPoSt])
+		}
 	}
 
 	if cctx.IsSet("blocks") {

--- a/cli/miner/info.go
+++ b/cli/miner/info.go
@@ -427,7 +427,7 @@ func producedBlocks(ctx context.Context, count int, maddr address.Address, napi 
 	tty := isatty.IsTerminal(os.Stderr.Fd())
 
 	ts := head
-	fmt.Printf(" Epoch   | Block ID                                                       | Reward\n")
+	fmt.Printf(" Epoch   | Time                      | Block ID                                                       | Reward\n")
 	for count > 0 {
 		tsk := ts.Key()
 		bhs := ts.Blocks()
@@ -458,7 +458,11 @@ func producedBlocks(ctx context.Context, count int, maddr address.Address, napi 
 				minerReward := types.BigDiv(types.BigMul(types.NewInt(uint64(bh.ElectionProof.WinCount)),
 					blockReward), types.NewInt(uint64(builtin.ExpectedLeadersPerEpoch)))
 
-				fmt.Printf("%8d | %s | %s\n", ts.Height(), bh.Cid(), types.FIL(minerReward))
+				fmt.Printf("%8d | %s | %s | %s\n",
+					ts.Height(),
+					time.Unix(int64(bh.Timestamp), 0).Format("2006-01-02 15:04:05 -0700"),
+					bh.Cid(),
+					types.FIL(minerReward))
 				count--
 			} else if tty && bh.Height%120 == 0 {
 				_, _ = fmt.Fprintf(os.Stderr, "\r\x1b[0KChecking epoch %s", cliutil.EpochTime(head.Height(), bh.Height))

--- a/cli/miner/info.go
+++ b/cli/miner/info.go
@@ -188,7 +188,7 @@ func handleMiningInfo(ctx context.Context, cctx *cli.Context, fullapi v1api.Full
 		}
 		fmt.Printf("\tProving: %s (%s Faulty, %.2f%%)\n",
 			types.SizeStr(types.BigMul(types.NewInt(proving), types.NewInt(uint64(mi.SectorSize)))),
-			types.SizeStr(types.BigMul(types.NewInt(nfaults), types.NewInt(uint64(mi.SectorSize)))),
+			color.RedString(types.SizeStr(types.BigMul(types.NewInt(nfaults), types.NewInt(uint64(mi.SectorSize))))),
 			faultyPercentage)
 	}
 


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

## Proposed Changes
<!-- A clear list of the changes being made -->
  - **`lotus-miner info` supports `--actor`**: skip miner-daemon-only sections (subsystems, alerts, sectors, workers); chain-side info is preserved. Lets you query any miner without a local miner repo.
  - Color the `Faulty` size red in the `Proving:` line.
  - In `--blocks N` output, add a per-block timestamp column (`YYYY-MM-DD HH:MM:SS ±HHMM`).
## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [ ] CI is green
