### PR TITLE
chore: add Snapcraft deprecation publisher

### DIFF
--- a/.github/workflows/snapcraft-deprecation.yml
+++ b/.github/workflows/snapcraft-deprecation.yml
@@ -1,0 +1,61 @@
+name: Publish Snapcraft Deprecation
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the built snaps to the Snap Store
+        required: true
+        type: boolean
+        default: false
+      release_channels:
+        description: Comma-separated Snap channels to release to
+        required: true
+        type: string
+        default: stable,candidate,edge
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  snapcraft:
+    name: Build ${{ matrix.snap-name }} deprecation snap
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        snap-name:
+          - lotus-filecoin
+          - lotus
+    steps:
+      - name: Check out lotus
+        uses: actions/checkout@v4
+
+      - name: Set snap name
+        if: matrix.snap-name != 'lotus-filecoin'
+        run: |
+          sed 's/^name: lotus-filecoin$/name: lotus/' snap/snapcraft.yaml > edited-snapcraft.yaml
+          mv edited-snapcraft.yaml snap/snapcraft.yaml
+
+      - name: Build snap
+        id: build
+        uses: snapcore/action-build@v1
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.snap-name }}-deprecation-snap
+          path: ${{ steps.build.outputs.snap }}
+
+      - name: Publish snap
+        if: inputs.publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ inputs.release_channels }}

--- a/Makefile
+++ b/Makefile
@@ -387,9 +387,9 @@ gen: actors-code-gen type-gen cfgdoc-gen docsgen api-gen  ## Run all generation 
 
 jen: gen  ## Alias for gen
 
-snap: lotus lotus-miner lotus-worker  ## Build snap package
+snap:  ## Build Snapcraft deprecation package
 	snapcraft
-	# snapcraft upload ./lotus_*.snap
+.PHONY: snap
 
 docsgen-cli:  ## Generate CLI documentation
 	$(GOCC) run ./scripts/docsgen-cli

--- a/cmd/snapcraft-deprecation/main.go
+++ b/cmd/snapcraft-deprecation/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+const notice = "Lotus is not distributed through Snap anymore (https://github.com/filecoin-project/lotus/issues/10002)\n" +
+	"Please install Lotus using another method from https://lotus.filecoin.io/lotus/install/prerequisites/"
+
+func main() {
+	fmt.Println(notice)
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: lotus-filecoin
+base: core20
+version: deprecated
+summary: Lotus Snap package deprecation notice
+description: |
+  Lotus is not distributed through Snap anymore.
+
+  Please install Lotus using another method from:
+  https://lotus.filecoin.io/lotus/install/prerequisites/
+
+  Deprecation tracking issue:
+  https://github.com/filecoin-project/lotus/issues/10002
+
+grade: stable
+confinement: strict
+
+parts:
+  lotus:
+    plugin: nil
+    source: .
+    build-snaps:
+      - go
+    override-build: |
+      set -eux
+
+      mkdir -p "$SNAPCRAFT_PART_INSTALL"
+      for binary in lotus lotus-miner lotus-worker; do
+        go build -trimpath -o "$SNAPCRAFT_PART_INSTALL/$binary" ./cmd/snapcraft-deprecation
+      done
+
+apps:
+  lotus:
+    command: lotus
+  lotus-miner:
+    command: lotus-miner
+  lotus-worker:
+    command: lotus-worker
+  lotus-daemon:
+    command: lotus
+    daemon: simple
+    install-mode: disable


### PR DESCRIPTION
## Summary
- add a tiny Snapcraft deprecation command that prints the install guidance from #10002
- add a Snapcraft manifest that packages that command under the old `lotus`, `lotus-miner`, `lotus-worker`, and `lotus-daemon` app names
- add a manual GitHub Actions workflow using `snapcore/action-build@v1` and `snapcore/action-publish@v1` to build `lotus` and `lotus-filecoin` deprecation snaps
- update `make snap` so it builds the deprecation package rather than normal Lotus binaries first

## Notes
This adapts Ian's `snapcraft-deprecation` branch onto current `master` without replacing the normal `make lotus`, `make lotus-miner`, or `make lotus-worker` targets.

After merge, publishing should be done by running the `Publish Snapcraft Deprecation` workflow manually with `publish=true`. The workflow expects the exported Snapcraft login data in the repository secret `SNAPCRAFT_STORE_CREDENTIALS` and defaults to releasing both snap names to `stable,candidate,edge`.

## Validation
- `go test ./cmd/snapcraft-deprecation`
- `GOOS=linux GOARCH=amd64 go build -trimpath -o /tmp/lotus-snapcraft-deprecation ./cmd/snapcraft-deprecation`
- `go run ./cmd/snapcraft-deprecation`
- YAML parse for `.github/workflows/snapcraft-deprecation.yml` and `snap/snapcraft.yaml`
- `git diff --check`
- `make -n snap`