### PR TITLE
fix(build): ffi-version-check should depend on module update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ MODULES+=$(FFI_PATH)
 BUILD_DEPS+=build/.filecoin-install
 CLEAN+=build/.filecoin-install
 
-ffi-version-check:  ## Check FFI version compatibility
+ffi-version-check: build/.update-modules ## Check FFI version compatibility
 	@[[ "$$(awk '/const Version/{print $$5}' extern/filecoin-ffi/version.go)" -eq 3 ]] || (echo "FFI version mismatch, update submodules"; exit 1)
 BUILD_DEPS+=ffi-version-check
 


### PR DESCRIPTION
Fixes an issue during clean builds where submodules might not be initialised, for example AUR.