### PR TITLE
fix(cli): join API info RPC paths safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## 🐛 Bug Fixes
 - fix(api): trace transaction api returns the correct error ([filecoin-project/lotus#13614](https://github.com/filecoin-project/lotus/pull/13614))
-
+- fix(cli): RPC API URLs ending with a trailing slash no longer produce duplicate slashes before `/rpc/<version>` ([filecoin-project/lotus#13662](https://github.com/filecoin-project/lotus/pull/13662))
 - Fix off-by-one in `transactionPosition` returned by `trace_block`, `trace_filter` and `trace_transaction`. Positions were 1-indexed; per the Ethereum trace API spec they are 0-indexed and must match the corresponding `transactionIndex` from `eth_getBlockByNumber`. ([filecoin-project/lotus#13610](https://github.com/filecoin-project/lotus/pull/13610))
 - fix(eth): `eth_getTransactionReceipt` no longer fails when another transaction in the same block emits a large number of events. `MaxFilterResults` now caps only multi-tipset event queries; single-block calls (`eth_getLogs` with `BlockHash`, `eth_getBlockReceipts`, `eth_getTransactionReceipt`) bypass it. Public RPC operators should apply rate and response-size limits at the proxy layer for these calls; a single response can be large when a block contains log-heavy transactions ([filecoin-project/lotus#13617](https://github.com/filecoin-project/lotus/pull/13617))
 - fix(gateway): align v2 RPC surface (`/rpc/v2`) with v1; remove `*Limited` and `*Untrusted` eth method variants ([filecoin-project/lotus#13628](https://github.com/filecoin-project/lotus/pull/13628))

--- a/cli/util/apiinfo.go
+++ b/cli/util/apiinfo.go
@@ -64,14 +64,14 @@ func (a APIInfo) DialArgs(version string) (string, error) {
 			return true
 		})
 
-		return scheme + "://" + addr + "/rpc/" + version, nil
+		return url.JoinPath(scheme+"://"+addr, "rpc", version)
 	}
 
 	_, err = url.Parse(a.Addr)
 	if err != nil {
 		return "", err
 	}
-	return a.Addr + "/rpc/" + version, nil
+	return url.JoinPath(a.Addr, "rpc", version)
 }
 
 func (a APIInfo) Host() (string, error) {

--- a/cli/util/apiinfo_test.go
+++ b/cli/util/apiinfo_test.go
@@ -139,6 +139,11 @@ func TestAPIInfoDialArgs(t *testing.T) {
 			want: "https://api.node.glif.io/rpc/v1",
 		},
 		{
+			name: "https URL with trailing slash",
+			addr: "https://api.node.glif.io/",
+			want: "https://api.node.glif.io/rpc/v1",
+		},
+		{
 			name: "wss URL passes through",
 			addr: "wss://host.example",
 			want: "wss://host.example/rpc/v1",


### PR DESCRIPTION
## Summary

Use `url.JoinPath` when constructing RPC URLs from API info.

If a user accidentally sets `FULLNODE_API_INFO` with a trailing slash, for example:

```
FULLNODE_API_INFO=https://node.glif.io/space06/lotus/
```

Lotus currently appends `/rpc/v0` directly, producing:

```
https://node.glif.io/space06/lotus//rpc/v0
```

Joining the path avoids the duplicate slash while preserving the existing output for normal inputs.

## Test

```
go test ./cli/util
```