### PR TITLE
feat(cli): gas-aware adaptive batching for settle-deal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## ⭐ New Features
 
 - feat(eth): add `eth_baseFee` JSON-RPC method returning the base fee for the next block, matching geth behavior via `ComputeBaseFee` on the current tipset ([filecoin-project/lotus#13615](https://github.com/filecoin-project/lotus/pull/13615))
+- feat(cli): `lotus-miner actor settle-deal` now uses gas-aware adaptive batching — deal batches whose estimated gas would exceed a fraction of the block gas limit (tunable via `--max-gas-fraction`, default 1/4) are automatically split so no single `SettleDealPaymentsExported` message hogs block capacity ([filecoin-project/lotus#13471](https://github.com/filecoin-project/lotus/issues/13471))
 
 ## 🐛 Bug Fixes
 - fix(api): trace transaction api returns the correct error ([filecoin-project/lotus#13614](https://github.com/filecoin-project/lotus/pull/13614))

--- a/cli/spcli/actor.go
+++ b/cli/spcli/actor.go
@@ -2,6 +2,7 @@ package spcli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -41,6 +42,47 @@ import (
 	"github.com/filecoin-project/lotus/node/impl"
 )
 
+// splitDealBatchesByGas takes pre-sorted deal IDs and an initial max chunk
+// size, then for each chunk estimates gas via the provided estimator; if a
+// chunk would exceed the ceiling it is split in half and retried until each
+// sub-batch fits (or cannot be split below a single deal). It returns the
+// final list of deal-ID batches.
+func splitDealBatchesByGas(dealIDs []uint64, maxDeals int, estimate func(deals []uint64) (gasLimit int64, err error), gasCeiling int64) ([][]uint64, error) {
+	var out [][]uint64
+	for _, chunk := range lo.Chunk(dealIDs, maxDeals) {
+		batches, err := splitDealBatchByGas(chunk, estimate, gasCeiling)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, batches...)
+	}
+	return out, nil
+}
+
+func splitDealBatchByGas(deals []uint64, estimate func(deals []uint64) (gasLimit int64, err error), gasCeiling int64) ([][]uint64, error) {
+	gasLimit, err := estimate(deals)
+	if err != nil {
+		return nil, err
+	}
+
+	if gasLimit <= gasCeiling || len(deals) == 1 {
+		return [][]uint64{deals}, nil
+	}
+
+	mid := len(deals) / 2
+	left, err := splitDealBatchByGas(deals[:mid], estimate, gasCeiling)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := splitDealBatchByGas(deals[mid:], estimate, gasCeiling)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(left, right...), nil
+}
+
 func ActorDealSettlementCmd(getActor ActorAddressGetter) *cli.Command {
 	return &cli.Command{
 		Name:      "settle-deal",
@@ -60,6 +102,11 @@ func ActorDealSettlementCmd(getActor ActorAddressGetter) *cli.Command {
 				Name:  "max-deals",
 				Usage: "the maximum number of deals contained in each message",
 				Value: 20,
+			},
+			&cli.IntFlag{
+				Name:  "max-gas-fraction",
+				Usage: "denominator of build.BlockGasLimit used as the per-message gas ceiling (default 4 = 1/4 block)",
+				Value: 4,
 			},
 			&cli.BoolFlag{
 				Name:  "skip-wait-msg",
@@ -173,31 +220,91 @@ func ActorDealSettlementCmd(getActor ActorAddressGetter) *cli.Command {
 				}
 			}
 
-			msgLen := (len(dealIDs) + cctx.Int("max-deals") - 1) / cctx.Int("max-deals")
-			fmt.Printf("There are a total of %v deals, and about %v messages will be sent out.\n", len(dealIDs), msgLen)
-
-			if !cctx.Bool("really-do-it") {
-				return fmt.Errorf("pass --really-do-it to confirm this action")
-			}
-
 			sort.Slice(dealIDs, func(i, j int) bool {
 				return dealIDs[i] < dealIDs[j]
 			})
-			dealChucks := lo.Chunk(dealIDs, cctx.Int("max-deals"))
 
-			var msgs []*types.Message
-			for _, deals := range dealChucks {
+			makeSettleDealPaymentsMessage := func(deals []uint64) (*types.Message, error) {
 				dealParams := bitfield.NewFromSet(deals)
 				params, err := actors.SerializeParams(&dealParams)
 				if err != nil {
-					return err
+					return nil, err
 				}
-				msg := &types.Message{
+				return &types.Message{
 					To:     marketactor.Address,
 					From:   fromAddr,
 					Value:  types.NewInt(0),
 					Method: marketactor.Methods.SettleDealPaymentsExported,
 					Params: params,
+				}, nil
+			}
+
+			gasFraction := cctx.Int("max-gas-fraction")
+			if gasFraction <= 0 {
+				gasFraction = 4
+			}
+			gasCeiling := buildconstants.BlockGasLimit / int64(gasFraction)
+
+			type singleDealOverGasCeiling struct {
+				dealID   uint64
+				gasLimit int64
+			}
+			var singleDealWarnings []singleDealOverGasCeiling
+
+			estimate := func(deals []uint64) (int64, error) {
+				msg, err := makeSettleDealPaymentsMessage(deals)
+				if err != nil {
+					return 0, err
+				}
+
+				estimatedMsg, err := api.GasEstimateMessageGas(ctx, msg, nil, types.EmptyTSK)
+				if err != nil {
+					if errors.Is(err, &lapi.ErrOutOfGas{}) {
+						if len(deals) == 1 {
+							return 0, xerrors.Errorf("deal %d cannot be settled: its SettleDealPaymentsExported message exceeds the block gas limit: %w", deals[0], err)
+						}
+						return gasCeiling + 1, nil
+					}
+					return 0, err
+				}
+
+				if estimatedMsg.GasLimit > gasCeiling && len(deals) == 1 {
+					singleDealWarnings = append(singleDealWarnings, singleDealOverGasCeiling{
+						dealID:   deals[0],
+						gasLimit: estimatedMsg.GasLimit,
+					})
+				}
+
+				return estimatedMsg.GasLimit, nil
+			}
+
+			dealBatches, err := splitDealBatchesByGas(dealIDs, cctx.Int("max-deals"), estimate, gasCeiling)
+			if err != nil {
+				return err
+			}
+
+			dealCounts := make([]int, 0, len(dealBatches))
+			for _, deals := range dealBatches {
+				dealCounts = append(dealCounts, len(deals))
+			}
+			fmt.Printf("There are a total of %d deals; gas-aware splitting will send %d messages with deal counts: %v.\n", len(dealIDs), len(dealBatches), dealCounts)
+			for _, warning := range singleDealWarnings {
+				if warning.gasLimit > 0 {
+					fmt.Printf("warning: deal %d has estimated gas %d above ceiling %d; sending it as a single-deal batch because it cannot be split further.\n", warning.dealID, warning.gasLimit, gasCeiling)
+					continue
+				}
+				fmt.Printf("warning: deal %d exceeds gas ceiling %d; sending it as a single-deal batch because it cannot be split further.\n", warning.dealID, gasCeiling)
+			}
+
+			if !cctx.Bool("really-do-it") {
+				return fmt.Errorf("pass --really-do-it to confirm this action")
+			}
+
+			var msgs []*types.Message
+			for _, deals := range dealBatches {
+				msg, err := makeSettleDealPaymentsMessage(deals)
+				if err != nil {
+					return err
 				}
 				msgs = append(msgs, msg)
 			}

--- a/cli/spcli/actor_test.go
+++ b/cli/spcli/actor_test.go
@@ -1,0 +1,118 @@
+package spcli
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitDealBatchesByGas(t *testing.T) {
+	expectedErr := errors.New("estimate failed")
+
+	tests := []struct {
+		name       string
+		dealIDs    []uint64
+		maxDeals   int
+		gasCeiling int64
+		estimate   func(deals []uint64) (int64, error)
+		want       [][]uint64
+		wantErr    error
+		check      func(t *testing.T, dealIDs []uint64, batches [][]uint64, calls int)
+	}{
+		{
+			name:       "happy path under ceiling returns single unchanged batch",
+			dealIDs:    []uint64{1, 2, 3, 4},
+			maxDeals:   20,
+			gasCeiling: 100,
+			estimate: func(deals []uint64) (int64, error) {
+				return int64(len(deals) * 10), nil
+			},
+			want: [][]uint64{{1, 2, 3, 4}},
+			check: func(t *testing.T, dealIDs []uint64, batches [][]uint64, calls int) {
+				assert.Equal(t, 1, calls)
+			},
+		},
+		{
+			name:       "over ceiling batch recursively splits without dropping or duplicating deals",
+			dealIDs:    []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			maxDeals:   10,
+			gasCeiling: 30,
+			estimate: func(deals []uint64) (int64, error) {
+				return int64(len(deals) * 10), nil
+			},
+			check: func(t *testing.T, dealIDs []uint64, batches [][]uint64, calls int) {
+				for _, batch := range batches {
+					assert.LessOrEqual(t, int64(len(batch)*10), int64(30))
+				}
+
+				seen := map[uint64]struct{}{}
+				var got []uint64
+				for _, batch := range batches {
+					for _, dealID := range batch {
+						if _, ok := seen[dealID]; ok {
+							t.Fatalf("duplicate deal ID %d in returned batches", dealID)
+						}
+						seen[dealID] = struct{}{}
+						got = append(got, dealID)
+					}
+				}
+				sort.Slice(got, func(i, j int) bool {
+					return got[i] < got[j]
+				})
+				require.Equal(t, dealIDs, got)
+			},
+		},
+		{
+			name:       "single deal over ceiling is still emitted",
+			dealIDs:    []uint64{42},
+			maxDeals:   20,
+			gasCeiling: 10,
+			estimate: func(deals []uint64) (int64, error) {
+				return 1000, nil
+			},
+			want: [][]uint64{{42}},
+			check: func(t *testing.T, dealIDs []uint64, batches [][]uint64, calls int) {
+				assert.Equal(t, 1, calls)
+			},
+		},
+		{
+			name:       "estimator error aborts without batches",
+			dealIDs:    []uint64{1, 2, 3},
+			maxDeals:   20,
+			gasCeiling: 100,
+			estimate: func(deals []uint64) (int64, error) {
+				return 0, expectedErr
+			},
+			wantErr: expectedErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			estimate := func(deals []uint64) (int64, error) {
+				calls++
+				return tt.estimate(deals)
+			}
+
+			batches, err := splitDealBatchesByGas(tt.dealIDs, tt.maxDeals, estimate, tt.gasCeiling)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, batches)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.want != nil {
+				require.Equal(t, tt.want, batches)
+			}
+			if tt.check != nil {
+				tt.check(t, tt.dealIDs, batches, calls)
+			}
+		})
+	}
+}

--- a/documentation/en/cli-lotus-miner.md
+++ b/documentation/en/cli-lotus-miner.md
@@ -256,13 +256,14 @@ USAGE:
    lotus-miner actor settle-deal [command options] [...dealIds]
 
 OPTIONS:
-   --confidence value  number of block confirmations to wait for (default: 5)
-   --from value        specify where to send the message from (any address)
-   --max-deals value   the maximum number of deals contained in each message (default: 20)
-   --skip-wait-msg     skip to check the message status (default: false)
-   --all-deals         settle all deals. only expired deals are calculated by default (default: false)
-   --really-do-it      Actually send transaction performing the action (default: false)
-   --help, -h          show help
+   --confidence value        number of block confirmations to wait for (default: 5)
+   --from value              specify where to send the message from (any address)
+   --max-deals value         the maximum number of deals contained in each message (default: 20)
+   --max-gas-fraction value  denominator of build.BlockGasLimit used as the per-message gas ceiling (default 4 = 1/4 block) (default: 4)
+   --skip-wait-msg           skip to check the message status (default: false)
+   --all-deals               settle all deals. only expired deals are calculated by default (default: false)
+   --really-do-it            Actually send transaction performing the action (default: false)
+   --help, -h                show help
 ```
 
 ### lotus-miner actor withdraw


### PR DESCRIPTION
## Related Issues

Refs #13471

Today the settle-deal command groups deals into settlement messages purely by count, using the fixed max-deals threshold. When a miner has many expiring deals, one of those messages can claim a large share of a block's gas, which is exactly the congestion the issue asks us to avoid. The fix makes batching aware of the gas each prospective message would actually cost, so no single settlement message hogs the block.

## Proposed Changes

The command now estimates the gas of each prospective settlement message before sending it. If a batch would cost more than a configurable fraction of the block gas limit, the batch is split in half and re-estimated until every message fits comfortably under that ceiling. This mirrors the adaptive-splitting approach the miner already uses when compacting partitions, so the behavior should feel familiar to maintainers and operators alike.

Operators who want to tune how aggressively batches are split can use the new max-gas-fraction flag, which defaults to a quarter of the block gas limit. Small jobs are unaffected: when every batch already fits, the messages sent are identical to before, and the existing confirmation, dry-run, and wait-for-message behavior is untouched. Before sending, the command now reports how many messages will go out and how many deals each one carries.

Two edge cases get explicit handling. A single deal whose estimate is over the soft ceiling cannot be split any further, so it is still sent, with a warning. A single deal whose estimate genuinely exceeds the block gas limit cannot be mined at all, so rather than quietly emitting an unsendable message the command stops with a clear error naming the deal.

## Additional Info

The splitting logic lives in a small pure helper so it can be unit-tested without a live node. The added tests cover the happy path where nothing splits, a batch that splits recursively without dropping or duplicating any deal, a single deal that stays over the ceiling without looping forever, and the estimator-error path. A changelog entry is included under New Features in the unreleased section.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates inline in the command and flag help text
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
