### PR TITLE
fix(cli): warn when --api overrides configured API listen address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## 🐛 Bug Fixes
 - fix(api): trace transaction api returns the correct error ([filecoin-project/lotus#13614](https://github.com/filecoin-project/lotus/pull/13614))
+- fix(cli): warn when `lotus daemon --api` overrides the configured `API.ListenAddress` / `LOTUS_API_LISTENADDRESS`, making the selected API endpoint visible to operators ([filecoin-project/lotus#13670](https://github.com/filecoin-project/lotus/pull/13670))
 - fix(cli): RPC API URLs ending with a trailing slash no longer produce duplicate slashes before `/rpc/<version>` ([filecoin-project/lotus#13662](https://github.com/filecoin-project/lotus/pull/13662))
 - Fix off-by-one in `transactionPosition` returned by `trace_block`, `trace_filter` and `trace_transaction`. Positions were 1-indexed; per the Ethereum trace API spec they are 0-indexed and must match the corresponding `transactionIndex` from `eth_getBlockByNumber`. ([filecoin-project/lotus#13610](https://github.com/filecoin-project/lotus/pull/13610))
 - fix(eth): `eth_getTransactionReceipt` no longer fails when another transaction in the same block emits a large number of events. `MaxFilterResults` now caps only multi-tipset event queries; single-block calls (`eth_getLogs` with `BlockHash`, `eth_getBlockReceipts`, `eth_getTransactionReceipt`) bypass it. Public RPC operators should apply rate and response-size limits at the proxy layer for these calls; a single response can be large when a block contains log-heavy transactions ([filecoin-project/lotus#13617](https://github.com/filecoin-project/lotus/pull/13617))

--- a/cli/lotus/daemon.go
+++ b/cli/lotus/daemon.go
@@ -427,6 +427,12 @@ var DaemonCmd = &cli.Command{
 					if err != nil {
 						return err
 					}
+					configured, err := configuredAPIListenAddress(lr)
+					if err != nil {
+						log.Warnw("could not read configured API listen address before applying --api override", "error", err)
+					} else if warning := apiFlagOverrideWarning(configured, apima); warning != "" {
+						log.Warn(warning)
+					}
 					return lr.SetAPIEndpoint(apima)
 				})),
 			node.ApplyIf(func(s *node.Settings) bool { return !cctx.Bool("bootstrap") },
@@ -500,6 +506,28 @@ func readGenesis(path string) ([]byte, error) {
 		return build.DecompressAsZstd(genesisFile)
 	}
 	return io.ReadAll(genesisFile)
+}
+
+func configuredAPIListenAddress(lr repo.LockedRepo) (string, error) {
+	c, err := lr.Config()
+	if err != nil {
+		return "", err
+	}
+	cfg, ok := c.(*config.FullNode)
+	if !ok {
+		return "", xerrors.Errorf("invalid config for repo, got: %T", c)
+	}
+	return cfg.Common.API.ListenAddress, nil
+}
+
+func apiFlagOverrideWarning(configured string, override multiaddr.Multiaddr) string {
+	if configured == "" || override == nil {
+		return ""
+	}
+	if configured == override.String() {
+		return ""
+	}
+	return fmt.Sprintf("--api overrides configured API listen address %q (API.ListenAddress / LOTUS_API_LISTENADDRESS); using %q", configured, override.String())
 }
 
 func importKey(ctx context.Context, api lapi.FullNode, f string) error {

--- a/cli/lotus/daemon_test.go
+++ b/cli/lotus/daemon_test.go
@@ -7,13 +7,42 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	"github.com/multiformats/go-multiaddr"
 
 	"github.com/filecoin-project/lotus/node/repo"
 )
+
+func TestAPIFlagOverrideWarning(t *testing.T) {
+	configured := "/ip4/0.0.0.0/tcp/3456/http"
+	override, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	warning := apiFlagOverrideWarning(configured, override)
+	for _, want := range []string{"--api", "LOTUS_API_LISTENADDRESS", configured, override.String()} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("expected warning %q to contain %q", warning, want)
+		}
+	}
+}
+
+func TestAPIFlagOverrideWarningUnchangedAddress(t *testing.T) {
+	configured := "/ip4/127.0.0.1/tcp/1234"
+	override, err := multiaddr.NewMultiaddr(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if warning := apiFlagOverrideWarning(configured, override); warning != "" {
+		t.Fatalf("expected no warning for unchanged address, got %q", warning)
+	}
+}
 
 func TestRemoveExistingChainRemovesF3Data(t *testing.T) {
 	repoPath := t.TempDir()


### PR DESCRIPTION
## Summary
- warn when `lotus daemon --api` overrides the configured `API.ListenAddress`
- include both the configured listen address and the endpoint selected from `--api`
- add focused tests for warning and no-warning behavior

Fixes #12545

## Testing
- `gofmt -l cli/lotus/daemon.go cli/lotus/daemon_test.go`
- `git diff --check`
- `CGO_LDFLAGS="-L/opt/homebrew/lib" go test ./cli/lotus -run TestAPIFlagOverrideWarning -count=1`
- `CGO_LDFLAGS="-L/opt/homebrew/lib" go test ./cli/lotus -count=1`