### PR TITLE
ci: grant pull-requests: read to precheck job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,9 @@ jobs:
     name: Check (precheck)
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       skip_checks: ${{ steps.changes.outputs.nonMarkdownFiles == 'false' }}
     steps:


### PR DESCRIPTION
This one's to better support private forks, it doesn't so much help this repo but it is more _correct_ than what we do now. The `pre-check` job uses `dorny/paths-filter` which uses the GitHub API to read the changed list of files. But in the workflow we `permissions: contents: read` which resets the default permissions. On public repos this is fine because it's always public to query the list of files. But on private repos the ability of the current GITHUB_TOKEN becomes restricted. So _within_ `pre-check` we grant `pull-requests: read` explicitly.