### PR TITLE
fix(eth): return pending eth tx from eth_getTransactionByHash when txHash index is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - feat(cli): `lotus-miner actor settle-deal` now uses gas-aware adaptive batching — deal batches whose estimated gas would exceed a fraction of the block gas limit (tunable via `--max-gas-fraction`, default 1/4) are automatically split so no single `SettleDealPaymentsExported` message hogs block capacity ([filecoin-project/lotus#13471](https://github.com/filecoin-project/lotus/issues/13471))
 
 ## 🐛 Bug Fixes
+- fix(eth): `eth_getTransactionByHash` no longer returns a false negative for a locally pending Ethereum transaction when the chain indexer has no txHash → message CID mapping for it. The mpool fallback now also matches pending Ethereum (delegated) messages by their real Ethereum transaction hash instead of relying solely on a Filecoin CID fabricated from the Ethereum tx hash ([filecoin-project/lotus#13665](https://github.com/filecoin-project/lotus/issues/13665))
 - fix(rpc): `GasEstimateMessageGas` with an empty `To` or `From` address no longer crashes the WebSocket server. ([filecoin-project/lotus#13672](https://github.com/filecoin-project/lotus/pull/13672))
 - fix(api): trace transaction api returns the correct error ([filecoin-project/lotus#13614](https://github.com/filecoin-project/lotus/pull/13614))
 - fix(cli): warn when `lotus daemon --api` overrides the configured `API.ListenAddress` / `LOTUS_API_LISTENADDRESS`, making the selected API endpoint visible to operators ([filecoin-project/lotus#13670](https://github.com/filecoin-project/lotus/pull/13670))

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/crypto"
 
 	"github.com/filecoin-project/lotus/api"
 	builtinactors "github.com/filecoin-project/lotus/chain/actors/builtin"
@@ -161,7 +162,23 @@ func (e *ethTransaction) EthGetTransactionByHashLimited(ctx context.Context, txH
 	}
 
 	for _, p := range pending {
-		if p.Cid() == c {
+		// Match a pending message either by its message CID or, for Ethereum (delegated)
+		// messages, by its real Ethereum transaction hash.
+		//
+		// The CID comparison covers the case where the chain indexer has the txHash -> CID
+		// mapping (c is the real message CID) as well as native messages whose Eth hash is
+		// derived from their CID. The hash comparison is required for the case where the
+		// indexer has no mapping for an Ethereum transaction: getCidForTransaction then
+		// cannot produce the real message CID from the Ethereum tx hash (EthHash.ToCid is
+		// only valid for blocks and Filecoin messages, not Ethereum tx hashes), so a
+		// locally pending Ethereum transaction would otherwise be reported as not found.
+		matched := p.Cid() == c
+		if !matched && p.Signature.Type == crypto.SigTypeDelegated {
+			if h, herr := ethTxHashFromSignedMessage(p); herr == nil && h == *txHash {
+				matched = true
+			}
+		}
+		if matched {
 			// We only return pending eth-account messages because we can't guarantee
 			// that the from/to addresses of other messages are conversable to 0x-style
 			// addresses. So we just ignore them.

--- a/node/impl/eth/transaction_test.go
+++ b/node/impl/eth/transaction_test.go
@@ -1,0 +1,115 @@
+package eth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/index"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/types/ethtypes"
+)
+
+// stubIndexer reports that it has no txHash -> message CID mapping for any hash,
+// simulating the case where the chain indexer has not (yet) indexed a locally
+// pending Ethereum transaction.
+type stubIndexer struct {
+	index.Indexer
+}
+
+func (stubIndexer) GetCidFromHash(context.Context, ethtypes.EthHash) (cid.Cid, error) {
+	return cid.Undef, index.ErrNotFound
+}
+
+// stubStateAPI never finds a transaction on-chain.
+type stubStateAPI struct{}
+
+func (stubStateAPI) StateSearchMsg(context.Context, types.TipSetKey, cid.Cid, abi.ChainEpoch, bool) (*api.MsgLookup, error) {
+	return nil, nil
+}
+
+// stubMpoolAPI returns a fixed set of pending messages.
+type stubMpoolAPI struct {
+	pending []*types.SignedMessage
+}
+
+func (s stubMpoolAPI) MpoolPending(context.Context, types.TipSetKey) ([]*types.SignedMessage, error) {
+	return s.pending, nil
+}
+
+func (stubMpoolAPI) MpoolGetNonce(context.Context, address.Address) (uint64, error) {
+	return 0, nil
+}
+
+func (stubMpoolAPI) MpoolPush(context.Context, *types.SignedMessage) (cid.Cid, error) {
+	return cid.Undef, nil
+}
+
+func (stubMpoolAPI) MpoolPushUntrusted(context.Context, *types.SignedMessage) (cid.Cid, error) {
+	return cid.Undef, nil
+}
+
+// TestEthGetTransactionByHashLimitedPendingNoIndex is a regression test for
+// https://github.com/filecoin-project/lotus/issues/13665: a locally pending
+// Ethereum transaction must still be returned by eth_getTransactionByHash even
+// when the chain indexer has no txHash -> message CID mapping for it. Before the
+// fix, getCidForTransaction fabricated a Filecoin CID from the Ethereum tx hash
+// (EthHash.ToCid, which is only valid for blocks and Filecoin messages), the
+// mpool scan compared that fabricated CID against the real message CID, never
+// matched, and the transaction was reported as not found.
+func TestEthGetTransactionByHashLimitedPendingNoIndex(t *testing.T) {
+	ctx := context.Background()
+
+	// A signed EIP-1559 transaction (chain id 314).
+	rawTx, err := ethtypes.DecodeHexString("0x02f86282013a8080808094ff000000000000000000000000000000000003ec8080c080a0f411a73e33523b40c1a916e79e67746bd01a4a4fb4ecfa87b441375a215ddfb4a0551692c1553574fab4c227ca70cb1c121dc3a2ef82179a9c984bd7acc0880a38")
+	require.NoError(t, err)
+
+	ethTx, err := ethtypes.ParseEthTransaction(rawTx)
+	require.NoError(t, err)
+
+	smsg, err := ethtypes.ToSignedFilecoinMessage(ethTx)
+	require.NoError(t, err)
+
+	// The Ethereum transaction hash a client would query with.
+	wantHash, err := ethTxHashFromSignedMessage(smsg)
+	require.NoError(t, err)
+
+	// The fabricated-CID fallback does not equal the real signed-message CID, so a
+	// CID-only mpool match (the pre-fix behavior) would miss this pending tx.
+	require.NotEqual(t, smsg.Cid(), wantHash.ToCid())
+
+	e := &ethTransaction{
+		chainIndexer: stubIndexer{},
+		stateApi:     stubStateAPI{},
+		mpoolApi:     stubMpoolAPI{pending: []*types.SignedMessage{smsg}},
+	}
+
+	// The pending tx is found by its real Ethereum hash despite the missing index.
+	tx, err := e.EthGetTransactionByHashLimited(ctx, &wantHash, api.LookbackNoLimit)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.Equal(t, wantHash, tx.Hash)
+
+	// An unknown hash that is not in the mpool returns an empty response, no error.
+	otherHash := wantHash
+	otherHash[0] ^= 0xff
+	missing, err := e.EthGetTransactionByHashLimited(ctx, &otherHash, api.LookbackNoLimit)
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	// An empty mpool returns an empty response, no error.
+	eEmpty := &ethTransaction{
+		chainIndexer: stubIndexer{},
+		stateApi:     stubStateAPI{},
+		mpoolApi:     stubMpoolAPI{},
+	}
+	empty, err := eEmpty.EthGetTransactionByHashLimited(ctx, &wantHash, api.LookbackNoLimit)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+}


### PR DESCRIPTION
## Related Issues

Fixes #13665

## Proposed Changes

`EthGetTransactionByHashLimited` (`eth_getTransactionByHash`) can return `nil` for a locally pending Ethereum transaction when the chain indexer has no `txHash -> message CID` mapping for it.

Root cause: when the indexer has no mapping, `getCidForTransaction` falls back to `txHash.ToCid()`. `EthHash.ToCid()` is documented as valid only for blocks and Filecoin messages, not Ethereum transaction hashes, so it fabricates a CID that does not match the real signed-message CID. The mpool fallback then compares `p.Cid() == c` against that fabricated CID and never matches, so a transaction that is actually sitting in `MpoolPending` is reported as not found.

This change takes the second of the two fixes suggested in the issue:

- In the `MpoolPending` fallback of `EthGetTransactionByHashLimited`, also match pending Ethereum (delegated) messages by their real Ethereum transaction hash (reusing the existing `ethTxHashFromSignedMessage` helper), in addition to the existing message-CID comparison.
- The message-CID comparison is preserved, so the indexer-hit path and native secp/bls messages (whose Eth hash is derived from their CID, where `ToCid()` is valid) keep working unchanged.
- `getCidForTransaction` is intentionally left returning `txHash.ToCid()` so native-message lookups through the shared helper (`EthGetMessageCidByTransactionHash`, `EthGetTransactionReceiptLimited`) are not regressed.
- Added `node/impl/eth/transaction_test.go` and a CHANGELOG.md Bug Fixes entry.

## Additional Info

The fabricated-CID `StateSearchMsg` lookup for an unindexed Ethereum tx is harmless (a content-addressed CID derived from a keccak hash cannot collide with a real message CID), so it is left in place; the behavioral fix is in the mpool match.

`node/impl/eth/transaction_test.go` reproduces the bug: a pending EIP-1559 transaction in `MpoolPending` with the indexer returning no mapping is now returned by its real Ethereum hash (the previous CID-only match returned `nil`), and an unknown hash and an empty mpool both return an empty response with no error. `go test ./node/impl/eth/...`, `go vet ./node/impl/eth/...`, and `gofmt` pass locally.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
