### PR TITLE
fix(stats): handle zero-sized head change buffers

### DIFF
--- a/tools/stats/headbuffer/head_buffer.go
+++ b/tools/stats/headbuffer/head_buffer.go
@@ -13,7 +13,7 @@ type HeadChangeStackBuffer struct {
 
 // NewHeadChangeStackBuffer buffer HeadChange events to avoid having to
 // deal with revert changes. Initialized size should be the average reorg
-// size + 1
+// size + 1. Non-positive sizes disable buffering.
 func NewHeadChangeStackBuffer(size int) *HeadChangeStackBuffer {
 	buffer := list.New()
 	buffer.Init()
@@ -28,6 +28,10 @@ func NewHeadChangeStackBuffer(size int) *HeadChangeStackBuffer {
 // the stack buffer grows larger than the initialized size, the
 // oldest HeadChange is returned.
 func (h *HeadChangeStackBuffer) Push(hc *api.HeadChange) (rethc *api.HeadChange) {
+	if h.size <= 0 {
+		return hc
+	}
+
 	if h.buffer.Len() >= h.size {
 		var ok bool
 

--- a/tools/stats/headbuffer/head_buffer_test.go
+++ b/tools/stats/headbuffer/head_buffer_test.go
@@ -40,4 +40,16 @@ func TestHeadBuffer(t *testing.T) {
 		hc = hb.Push(&api.HeadChange{Type: "8"})
 		require.Equal(t, hc.Type, "3b")
 	})
+
+	t.Run("Zero size passes changes through", func(t *testing.T) {
+		hb := NewHeadChangeStackBuffer(0)
+
+		hc := hb.Push(&api.HeadChange{Type: "1"})
+		require.Equal(t, "1", hc.Type)
+
+		hb.Pop()
+
+		hc = hb.Push(&api.HeadChange{Type: "2"})
+		require.Equal(t, "2", hc.Type)
+	})
 }


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

No issue. This is a small defensive fix for the stats head buffer.

[skip changelog]


## Proposed Changes
<!-- A clear list of the changes being made -->

- Treat non-positive `HeadChangeStackBuffer` sizes as pass-through mode.
- Add a regression test covering zero-sized buffers.
- Document the non-positive size behavior in the constructor comment.


## Additional Info
<!-- Callouts, links to documentation, and etc -->

This avoids a panic when `Push` is called on a buffer initialized with size `0`, while preserving the existing behavior for positive buffer sizes.


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
