### PR TITLE
refactor: drop obsolete network-version guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Silence libp2p config log spam ([filecoin-project/lotus#13612](https://github.com/filecoin-project/lotus/pull/13612))
 * feat(mempool): raise the default per-actor cap on the untrusted push path (`MaxUntrustedActorPendingMessages`) from 10 to 100, reducing spurious `ErrTooManyPendingMessages` rejections for normal-cadence senders relaying through `lotus-gateway` / public RPC ([filecoin-project/lotus#13636](https://github.com/filecoin-project/lotus/pull/13636))
 * chore(cli): `lotus-miner info` supports `--actor` to query any miner without a local miner repo; miner-daemon-only sections (subsystems, start time, alerts, workers, sectors) are skipped when `--actor` is set
+* chore: remove obsolete network-version guards across CLI, state-manager, storage, and miner code. ([filecoin-project/lotus#TODO](https://github.com/filecoin-project/lotus/pull/TODO))
 
 # Node and Miner v1.36.0 / 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * Silence libp2p config log spam ([filecoin-project/lotus#13612](https://github.com/filecoin-project/lotus/pull/13612))
 * feat(mempool): raise the default per-actor cap on the untrusted push path (`MaxUntrustedActorPendingMessages`) from 10 to 100, reducing spurious `ErrTooManyPendingMessages` rejections for normal-cadence senders relaying through `lotus-gateway` / public RPC ([filecoin-project/lotus#13636](https://github.com/filecoin-project/lotus/pull/13636))
 * chore(cli): `lotus-miner info` supports `--actor` to query any miner without a local miner repo; miner-daemon-only sections (subsystems, start time, alerts, workers, sectors) are skipped when `--actor` is set
-* chore: remove obsolete network-version guards across CLI, state-manager, storage, and miner code. ([filecoin-project/lotus#TODO](https://github.com/filecoin-project/lotus/pull/TODO))
+* chore: remove obsolete network-version guards across CLI, state-manager, storage, and miner code. ([filecoin-project/lotus#13680](https://github.com/filecoin-project/lotus/pull/13680))
 
 # Node and Miner v1.36.0 / 2026-05-13
 

--- a/chain/actors/builtin/miner/actor.go.template
+++ b/chain/actors/builtin/miner/actor.go.template
@@ -167,25 +167,6 @@ type Partition interface {
 type SectorOnChainInfo = minertypes{{.latestVersion}}.SectorOnChainInfo
 
 func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof, configWantSynthetic bool) (abi.RegisteredSealProof, error) {
-	// We added support for the new proofs in network version 7, and removed support for the old
-	// ones in network version 8.
-	if nver < network.Version7 {
-		switch proof {
-		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1:
-			return abi.RegisteredSealProof_StackedDrg2KiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1:
-			return abi.RegisteredSealProof_StackedDrg8MiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1:
-			return abi.RegisteredSealProof_StackedDrg512MiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1:
-			return abi.RegisteredSealProof_StackedDrg32GiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1:
-			return abi.RegisteredSealProof_StackedDrg64GiBV1, nil
-		default:
-			return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
-		}
-	}
-
 	if nver < MinSyntheticPoRepVersion || !configWantSynthetic {
 		switch proof {
 		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:

--- a/chain/actors/builtin/miner/miner.go
+++ b/chain/actors/builtin/miner/miner.go
@@ -277,25 +277,6 @@ type Partition interface {
 type SectorOnChainInfo = minertypes19.SectorOnChainInfo
 
 func PreferredSealProofTypeFromWindowPoStType(nver network.Version, proof abi.RegisteredPoStProof, configWantSynthetic bool) (abi.RegisteredSealProof, error) {
-	// We added support for the new proofs in network version 7, and removed support for the old
-	// ones in network version 8.
-	if nver < network.Version7 {
-		switch proof {
-		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1:
-			return abi.RegisteredSealProof_StackedDrg2KiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow8MiBV1:
-			return abi.RegisteredSealProof_StackedDrg8MiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow512MiBV1:
-			return abi.RegisteredSealProof_StackedDrg512MiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow32GiBV1:
-			return abi.RegisteredSealProof_StackedDrg32GiBV1, nil
-		case abi.RegisteredPoStProof_StackedDrgWindow64GiBV1:
-			return abi.RegisteredSealProof_StackedDrg64GiBV1, nil
-		default:
-			return -1, xerrors.Errorf("unrecognized window post type: %d", proof)
-		}
-	}
-
 	if nver < MinSyntheticPoRepVersion || !configWantSynthetic {
 		switch proof {
 		case abi.RegisteredPoStProof_StackedDrgWindow2KiBV1, abi.RegisteredPoStProof_StackedDrgWindow2KiBV1_1:

--- a/chain/stmgr/utils.go
+++ b/chain/stmgr/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/manifest"
+	"github.com/filecoin-project/go-state-types/network"
 	gstStore "github.com/filecoin-project/go-state-types/store"
 
 	"github.com/filecoin-project/lotus/api"
@@ -163,6 +164,7 @@ func TipSetGetterForTipset(cs *store.ChainStore, ts *types.TipSet) vm.TipSetGett
 
 func GetLookbackTipSetForRound(ctx context.Context, sm *StateManager, ts *types.TipSet, round abi.ChainEpoch) (*types.TipSet, cid.Cid, error) {
 	var lbr abi.ChainEpoch
+	nv := sm.GetNetworkVersion(ctx, round)
 	lb := policy.GetWinningPoStSectorSetLookback(sm.GetNetworkVersion(ctx, round))
 	if round > lb {
 		lbr = round - lb
@@ -170,13 +172,17 @@ func GetLookbackTipSetForRound(ctx context.Context, sm *StateManager, ts *types.
 
 	// more null blocks than our lookback
 	if lbr >= ts.Height() {
-		// This should never happen at this point, but may happen before
-		// network version 3 (where the lookback was only 10 blocks).
-		st, _, err := sm.TipSetState(ctx, ts)
-		if err != nil {
-			return nil, cid.Undef, err
+		// Legitimate while the 10-block WinningPoSt lookback was active (nv <= 3),
+		// where >9 consecutive null rounds could push lbr past ts.Height().
+		// Any lookback at genesis should resolve to genesis.
+		if nv <= network.Version3 || ts.Height() == 0 {
+			st, _, err := sm.TipSetState(ctx, ts)
+			if err != nil {
+				return nil, cid.Undef, err
+			}
+			return ts, st, nil
 		}
-		return ts, st, nil
+		return nil, cid.Undef, xerrors.Errorf("lookback height %d is at or after base height %d", lbr, ts.Height())
 	}
 
 	// Get the tipset after the lookback tipset, or the next non-null one.

--- a/chain/vm/vm.go
+++ b/chain/vm/vm.go
@@ -157,8 +157,7 @@ func (vm *LegacyVM) makeRuntime(ctx context.Context, msg *types.Message, parent 
 	}
 
 	if parent != nil {
-		// TODO: The version check here should be unnecessary, but we can wait to take it out
-		if !parent.allowInternal && rt.NetworkVersion() >= network.Version7 {
+		if !parent.allowInternal {
 			rt.Abortf(exitcode.SysErrForbidden, "internal calls currently disabled")
 		}
 		rt.gasUsed = parent.gasUsed

--- a/cli/filplus.go
+++ b/cli/filplus.go
@@ -22,10 +22,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
 	verifregtypes13 "github.com/filecoin-project/go-state-types/builtin/v13/verifreg"
-	verifregtypes8 "github.com/filecoin-project/go-state-types/builtin/v8/verifreg"
 	datacap2 "github.com/filecoin-project/go-state-types/builtin/v9/datacap"
 	verifregtypes9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v0api"
@@ -896,30 +894,17 @@ var filplusSignRemoveDataCapProposal = &cli.Command{
 			}
 		}
 
-		nv, err := api.StateNetworkVersion(ctx, types.EmptyTSK)
-		if err != nil {
-			return xerrors.Errorf("failed to get network version: %w", err)
-		}
-
 		paramBuf := new(bytes.Buffer)
 		paramBuf.WriteString(verifregtypes9.SignatureDomainSeparation_RemoveDataCap)
-		if nv <= network.Version16 {
-			params := verifregtypes8.RemoveDataCapProposal{
-				RemovalProposalID: id,
-				DataCapAmount:     allowanceToRemove,
-				VerifiedClient:    clientIdAddr,
-			}
 
-			err = params.MarshalCBOR(paramBuf)
-		} else {
-			params := verifregtypes9.RemoveDataCapProposal{
-				RemovalProposalID: verifregtypes9.RmDcProposalID{ProposalID: id},
-				DataCapAmount:     allowanceToRemove,
-				VerifiedClient:    clientIdAddr,
-			}
-
-			err = params.MarshalCBOR(paramBuf)
+		params := verifregtypes9.RemoveDataCapProposal{
+			RemovalProposalID: verifregtypes9.RmDcProposalID{ProposalID: id},
+			DataCapAmount:     allowanceToRemove,
+			VerifiedClient:    clientIdAddr,
 		}
+
+		err = params.MarshalCBOR(paramBuf)
+
 		if err != nil {
 			return xerrors.Errorf("failed to marshall paramBuf: %w", err)
 		}

--- a/cli/wallet.go
+++ b/cli/wallet.go
@@ -19,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/build/buildconstants"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
@@ -773,21 +772,14 @@ var walletMarketWithdraw = &cli.Command{
 			return err
 		}
 
-		nv, err := api.StateNetworkVersion(ctx, wait.TipSet)
-		if err != nil {
+		var withdrawn abi.TokenAmount
+		if err := withdrawn.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
 			return err
 		}
 
-		if nv >= network.Version14 {
-			var withdrawn abi.TokenAmount
-			if err := withdrawn.UnmarshalCBOR(bytes.NewReader(wait.Receipt.Return)); err != nil {
-				return err
-			}
-
-			afmt.Printf("Successfully withdrew %s \n", types.FIL(withdrawn))
-			if withdrawn.LessThan(amt) {
-				fmt.Printf("Note that this is less than the requested amount of %s \n", types.FIL(amt))
-			}
+		afmt.Printf("Successfully withdrew %s \n", types.FIL(withdrawn))
+		if withdrawn.LessThan(amt) {
+			fmt.Printf("Note that this is less than the requested amount of %s \n", types.FIL(amt))
 		}
 
 		return nil

--- a/cli/wallet_test.go
+++ b/cli/wallet_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -19,7 +20,6 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 
 	"github.com/filecoin-project/lotus/api"
-	apitypes "github.com/filecoin-project/lotus/api/types"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/mock"
 )
@@ -516,9 +516,13 @@ func TestWalletMarketWithdraw(t *testing.T) {
 	h, err := hex.DecodeString("12209cbc07c3f991725836a3aa2a581ca2029198aa420b9d99bc0e131d9f3e2cbe47")
 	assert.NoError(t, err)
 	cid := cid.NewCidV0(multihash.Multihash(h))
-	msgLookup := api.MsgLookup{}
 
-	var networkVers apitypes.NetworkVersion
+	withdrawn := abi.NewTokenAmount(80)
+	returnBuf := new(bytes.Buffer)
+	assert.NoError(t, withdrawn.MarshalCBOR(returnBuf))
+	msgLookup := api.MsgLookup{
+		Receipt: types.MessageReceipt{Return: returnBuf.Bytes()},
+	}
 
 	gomock.InOrder(
 		mockApi.EXPECT().StateMarketBalance(ctx, addr, types.TipSetKey{}).Return(balance, nil),
@@ -527,7 +531,6 @@ func TestWalletMarketWithdraw(t *testing.T) {
 		// available should be 80.. escrow - locked - reserve
 		mockApi.EXPECT().MarketWithdraw(ctx, addr, addr, big.NewInt(80)).Return(cid, nil),
 		mockApi.EXPECT().StateWaitMsg(ctx, cid, uint64(5), abi.ChainEpoch(int64(-1)), true).Return(&msgLookup, nil),
-		mockApi.EXPECT().StateNetworkVersion(ctx, types.TipSetKey{}).Return(networkVers, nil),
 	)
 
 	err = app.Run([]string{"wallet", "market", "withdraw", "--wallet", addr.String()})

--- a/cmd/lotus-sim/simulation/stages/precommit_stage.go
+++ b/cmd/lotus-sim/simulation/stages/precommit_stage.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
 	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
@@ -194,51 +193,49 @@ func (stage *PreCommitStage) packMiner(
 
 	// Commit the pre-commits.
 	added := 0
-	if nv >= network.Version13 {
-		targetBatchSize := maxPreCommitBatchSize
-		for targetBatchSize >= minPreCommitBatchSize && len(infos) >= minPreCommitBatchSize {
-			batch := infos
-			if len(batch) > targetBatchSize {
-				batch = batch[:targetBatchSize]
-			}
-			params := minertypes.PreCommitSectorBatchParams{
-				Sectors: batch,
-			}
-			enc, err := actors.SerializeParams(&params)
-			if err != nil {
-				return added, false, err
-			}
-			// NOTE: just in-case, sendAndFund will "fund" and re-try for any message
-			// that fails due to "insufficient funds".
-			if _, err := stage.funding.SendAndFund(bb, &types.Message{
-				To:     minerAddr,
-				From:   minerInfo.Worker,
-				Value:  abi.NewTokenAmount(0),
-				Method: builtin.MethodsMiner.PreCommitSectorBatch,
-				Params: enc,
-			}); blockbuilder.IsOutOfGas(err) {
-				// try again with a smaller batch.
-				targetBatchSize /= 2
-				continue
-			} else if aerr, ok := err.(aerrors.ActorError); ok && !aerr.IsFatal() {
-				// Log the error and move on. No reason to stop.
-				log.Errorw("failed to pre-commit for unknown reasons",
-					"error", aerr,
-					"sectors", batch,
-				)
-				return added, false, nil
-			} else if err != nil {
-				return added, false, err
-			}
-
-			for _, info := range batch {
-				if err := stage.committer.EnqueueProveCommit(minerAddr, epoch, toSectorPreCommitInfo(info)); err != nil {
-					return added, false, err
-				}
-				added++
-			}
-			infos = infos[len(batch):]
+	targetBatchSize := maxPreCommitBatchSize
+	for targetBatchSize >= minPreCommitBatchSize && len(infos) >= minPreCommitBatchSize {
+		batch := infos
+		if len(batch) > targetBatchSize {
+			batch = batch[:targetBatchSize]
 		}
+		params := minertypes.PreCommitSectorBatchParams{
+			Sectors: batch,
+		}
+		enc, err := actors.SerializeParams(&params)
+		if err != nil {
+			return added, false, err
+		}
+		// NOTE: just in-case, sendAndFund will "fund" and re-try for any message
+		// that fails due to "insufficient funds".
+		if _, err := stage.funding.SendAndFund(bb, &types.Message{
+			To:     minerAddr,
+			From:   minerInfo.Worker,
+			Value:  abi.NewTokenAmount(0),
+			Method: builtin.MethodsMiner.PreCommitSectorBatch,
+			Params: enc,
+		}); blockbuilder.IsOutOfGas(err) {
+			// try again with a smaller batch.
+			targetBatchSize /= 2
+			continue
+		} else if aerr, ok := err.(aerrors.ActorError); ok && !aerr.IsFatal() {
+			// Log the error and move on. No reason to stop.
+			log.Errorw("failed to pre-commit for unknown reasons",
+				"error", aerr,
+				"sectors", batch,
+			)
+			return added, false, nil
+		} else if err != nil {
+			return added, false, err
+		}
+
+		for _, info := range batch {
+			if err := stage.committer.EnqueueProveCommit(minerAddr, epoch, toSectorPreCommitInfo(info)); err != nil {
+				return added, false, err
+			}
+			added++
+		}
+		infos = infos[len(batch):]
 	}
 	for _, info := range infos {
 		enc, err := actors.SerializeParams(&info) //nolint

--- a/cmd/lotus-sim/simulation/stages/provecommit_stage.go
+++ b/cmd/lotus-sim/simulation/stages/provecommit_stage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 	minertypes "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/go-state-types/network"
 	miner5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/miner"
 	power5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/power"
 
@@ -130,105 +129,102 @@ func (stage *ProveCommitStage) packProveCommitsMiner(
 
 	log := bb.L().With("miner", minerAddr)
 
-	nv := bb.NetworkVersion()
 	for sealType, snos := range pending {
-		if nv >= network.Version13 {
-			for len(snos) > minProveCommitBatchSize {
-				batchSize := maxProveCommitBatchSize
-				if len(snos) < batchSize {
-					batchSize = len(snos)
-				}
-				batch := snos[:batchSize]
+		for len(snos) > minProveCommitBatchSize {
+			batchSize := maxProveCommitBatchSize
+			if len(snos) < batchSize {
+				batchSize = len(snos)
+			}
+			batch := snos[:batchSize]
 
-				proof, err := mock.MockAggregateSealProof(sealType, minerAddr, batchSize)
+			proof, err := mock.MockAggregateSealProof(sealType, minerAddr, batchSize)
+			if err != nil {
+				return res, err
+			}
+
+			params := miner5.ProveCommitAggregateParams{
+				SectorNumbers:  bitfield.New(),
+				AggregateProof: proof,
+			}
+			for _, sno := range batch {
+				params.SectorNumbers.Set(uint64(sno))
+			}
+
+			enc, err := actors.SerializeParams(&params)
+			if err != nil {
+				return res, err
+			}
+
+			if _, err := stage.funding.SendAndFund(bb, &types.Message{
+				From:   info.Worker,
+				To:     minerAddr,
+				Value:  abi.NewTokenAmount(0),
+				Method: builtin.MethodsMiner.ProveCommitAggregate,
+				Params: enc,
+			}); err == nil {
+				res.done += len(batch)
+			} else if blockbuilder.IsOutOfGas(err) {
+				res.full = true
+				return res, nil
+			} else if aerr, ok := err.(aerrors.ActorError); !ok || aerr.IsFatal() {
+				// If we get a random error, or a fatal actor error, bail.
+				return res, err
+			} else if aerr.RetCode() == exitcode.ErrNotFound || aerr.RetCode() == exitcode.ErrIllegalArgument {
+				// If we get a "not-found" or illegal argument error, try to
+				// remove any missing prove-commits and continue. This can
+				// happen either because:
+				//
+				// 1. The pre-commit failed on execution (but not when
+				// packing). This shouldn't happen, but we might as well
+				// gracefully handle it.
+				// 2. The pre-commit has expired. We'd have to be really
+				// backloged to hit this case, but we might as well handle
+				// it.
+				// First, split into "good" and "missing"
+				good, err := stage.filterProveCommits(ctx, bb, minerAddr, batch)
 				if err != nil {
-					return res, err
+					log.Errorw("failed to filter prove commits", "error", err)
+					// fail with the original error.
+					return res, aerr
 				}
-
-				params := miner5.ProveCommitAggregateParams{
-					SectorNumbers:  bitfield.New(),
-					AggregateProof: proof,
-				}
-				for _, sno := range batch {
-					params.SectorNumbers.Set(uint64(sno))
-				}
-
-				enc, err := actors.SerializeParams(&params)
-				if err != nil {
-					return res, err
-				}
-
-				if _, err := stage.funding.SendAndFund(bb, &types.Message{
-					From:   info.Worker,
-					To:     minerAddr,
-					Value:  abi.NewTokenAmount(0),
-					Method: builtin.MethodsMiner.ProveCommitAggregate,
-					Params: enc,
-				}); err == nil {
-					res.done += len(batch)
-				} else if blockbuilder.IsOutOfGas(err) {
-					res.full = true
-					return res, nil
-				} else if aerr, ok := err.(aerrors.ActorError); !ok || aerr.IsFatal() {
-					// If we get a random error, or a fatal actor error, bail.
-					return res, err
-				} else if aerr.RetCode() == exitcode.ErrNotFound || aerr.RetCode() == exitcode.ErrIllegalArgument {
-					// If we get a "not-found" or illegal argument error, try to
-					// remove any missing prove-commits and continue. This can
-					// happen either because:
-					//
-					// 1. The pre-commit failed on execution (but not when
-					// packing). This shouldn't happen, but we might as well
-					// gracefully handle it.
-					// 2. The pre-commit has expired. We'd have to be really
-					// backloged to hit this case, but we might as well handle
-					// it.
-					// First, split into "good" and "missing"
-					good, err := stage.filterProveCommits(ctx, bb, minerAddr, batch)
-					if err != nil {
-						log.Errorw("failed to filter prove commits", "error", err)
-						// fail with the original error.
-						return res, aerr
-					}
-					removed := len(batch) - len(good)
-					if removed == 0 {
-						log.Errorw("failed to prove-commit for unknown reasons",
-							"error", aerr,
-							"sectors", batch,
-						)
-						res.failed += len(batch)
-					} else if len(good) == 0 {
-						log.Errorw("failed to prove commit missing pre-commits",
-							"error", aerr,
-							"discarded", removed,
-						)
-						res.failed += len(batch)
-					} else {
-						// update the pending sector numbers in-place to remove the expired ones.
-						snos = snos[removed:]
-						copy(snos, good)
-						pending.finish(sealType, removed)
-
-						log.Errorw("failed to prove commit expired/missing pre-commits",
-							"error", aerr,
-							"discarded", removed,
-							"kept", len(good),
-						)
-						res.failed += removed
-
-						// Then try again.
-						continue
-					}
-				} else {
-					log.Errorw("failed to prove commit sector(s)",
-						"error", err,
+				removed := len(batch) - len(good)
+				if removed == 0 {
+					log.Errorw("failed to prove-commit for unknown reasons",
+						"error", aerr,
 						"sectors", batch,
 					)
 					res.failed += len(batch)
+				} else if len(good) == 0 {
+					log.Errorw("failed to prove commit missing pre-commits",
+						"error", aerr,
+						"discarded", removed,
+					)
+					res.failed += len(batch)
+				} else {
+					// update the pending sector numbers in-place to remove the expired ones.
+					snos = snos[removed:]
+					copy(snos, good)
+					pending.finish(sealType, removed)
+
+					log.Errorw("failed to prove commit expired/missing pre-commits",
+						"error", aerr,
+						"discarded", removed,
+						"kept", len(good),
+					)
+					res.failed += removed
+
+					// Then try again.
+					continue
 				}
-				pending.finish(sealType, len(batch))
-				snos = snos[len(batch):]
+			} else {
+				log.Errorw("failed to prove commit sector(s)",
+					"error", err,
+					"sectors", batch,
+				)
+				res.failed += len(batch)
 			}
+			pending.finish(sealType, len(batch))
+			snos = snos[len(batch):]
 		}
 		for len(snos) > 0 && res.unbatched < power5.MaxMinerProveCommitsPerEpoch {
 			sno := snos[0]

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
-	cbg "github.com/whyrusleeping/cbor-gen"
 	"go.uber.org/fx"
 	"golang.org/x/xerrors"
 
@@ -25,8 +24,6 @@ import (
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/network"
-	market2 "github.com/filecoin-project/specs-actors/v2/actors/builtin/market"
-	market5 "github.com/filecoin-project/specs-actors/v5/actors/builtin/market"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build/buildconstants"
@@ -983,96 +980,6 @@ func (a *StateAPI) StateGetAllClaims(ctx context.Context, tsk types.TipSetKey) (
 }
 
 func (a *StateAPI) StateComputeDataCID(ctx context.Context, maddr address.Address, sectorType abi.RegisteredSealProof, deals []abi.DealID, tsk types.TipSetKey) (cid.Cid, error) {
-	nv, err := a.StateNetworkVersion(ctx, tsk)
-	if err != nil {
-		return cid.Cid{}, err
-	}
-
-	if nv < network.Version13 {
-		return a.stateComputeDataCIDv1(ctx, maddr, sectorType, deals, tsk)
-	} else if nv < network.Version21 {
-		return a.stateComputeDataCIDv2(ctx, maddr, sectorType, deals, tsk)
-	}
-	return a.stateComputeDataCIDv3(ctx, maddr, sectorType, deals, tsk)
-}
-
-func (a *StateAPI) stateComputeDataCIDv1(ctx context.Context, maddr address.Address, sectorType abi.RegisteredSealProof, deals []abi.DealID, tsk types.TipSetKey) (cid.Cid, error) {
-	var err error
-	ccparams, err := actors.SerializeParams(&market2.ComputeDataCommitmentParams{
-		DealIDs:    deals,
-		SectorType: sectorType,
-	})
-
-	if err != nil {
-		return cid.Undef, xerrors.Errorf("computing params for ComputeDataCommitment: %w", err)
-	}
-	ccmt := &types.Message{
-		To:    market.Address,
-		From:  maddr,
-		Value: types.NewInt(0),
-		// Hard coded, because the method has since been deprecated
-		Method: 8,
-		Params: ccparams,
-	}
-	r, err := a.StateCall(ctx, ccmt, tsk)
-	if err != nil {
-		return cid.Undef, xerrors.Errorf("calling ComputeDataCommitment: %w", err)
-	}
-	if r.MsgRct.ExitCode != 0 {
-		return cid.Undef, xerrors.Errorf("receipt for ComputeDataCommitment had exit code %d", r.MsgRct.ExitCode)
-	}
-
-	var c cbg.CborCid
-	if err := c.UnmarshalCBOR(bytes.NewReader(r.MsgRct.Return)); err != nil {
-		return cid.Undef, xerrors.Errorf("failed to unmarshal CBOR to CborCid: %w", err)
-	}
-
-	return cid.Cid(c), nil
-}
-
-func (a *StateAPI) stateComputeDataCIDv2(ctx context.Context, maddr address.Address, sectorType abi.RegisteredSealProof, deals []abi.DealID, tsk types.TipSetKey) (cid.Cid, error) {
-	var err error
-	ccparams, err := actors.SerializeParams(&market5.ComputeDataCommitmentParams{
-		Inputs: []*market5.SectorDataSpec{
-			{
-				DealIDs:    deals,
-				SectorType: sectorType,
-			},
-		},
-	})
-
-	if err != nil {
-		return cid.Undef, xerrors.Errorf("computing params for ComputeDataCommitment: %w", err)
-	}
-	ccmt := &types.Message{
-		To:    market.Address,
-		From:  maddr,
-		Value: types.NewInt(0),
-		// Hard coded, because the method has since been deprecated
-		Method: 8,
-		Params: ccparams,
-	}
-	r, err := a.StateCall(ctx, ccmt, tsk)
-	if err != nil {
-		return cid.Undef, xerrors.Errorf("calling ComputeDataCommitment: %w", err)
-	}
-	if r.MsgRct.ExitCode != 0 {
-		return cid.Undef, xerrors.Errorf("receipt for ComputeDataCommitment had exit code %d", r.MsgRct.ExitCode)
-	}
-
-	var cr market5.ComputeDataCommitmentReturn
-	if err := cr.UnmarshalCBOR(bytes.NewReader(r.MsgRct.Return)); err != nil {
-		return cid.Undef, xerrors.Errorf("failed to unmarshal CBOR to CborCid: %w", err)
-	}
-
-	if len(cr.CommDs) != 1 {
-		return cid.Undef, xerrors.Errorf("CommD output must have 1 entry")
-	}
-
-	return cid.Cid(cr.CommDs[0]), nil
-}
-
-func (a *StateAPI) stateComputeDataCIDv3(ctx context.Context, maddr address.Address, sectorType abi.RegisteredSealProof, deals []abi.DealID, tsk types.TipSetKey) (cid.Cid, error) {
 	if len(deals) == 0 {
 		return cid.Undef, nil
 	}

--- a/storage/pipeline/commit_batch.go
+++ b/storage/pipeline/commit_batch.go
@@ -346,7 +346,7 @@ func (b *CommitBatcher) processBatchV2(cfg sealiface.Config, sectors []abi.Secto
 
 	if aggregate {
 		params.SectorProofs = nil // can't be set when aggregating
-		arp, err := b.aggregateProofType(nv)
+		arp, err := b.aggregateProofType()
 		if err != nil {
 			res.Error = err.Error()
 			return []sealiface.CommitBatchRes{res}, xerrors.Errorf("getting aggregate proof type: %w", err)
@@ -607,10 +607,7 @@ func (b *CommitBatcher) getSectorCollateral(sn abi.SectorNumber, pieces []miner.
 
 	return collateral, nil
 }
-func (b *CommitBatcher) aggregateProofType(nv network.Version) (abi.RegisteredAggregationProof, error) {
-	if nv < network.Version16 {
-		return abi.RegisteredAggregationProof_SnarkPackV1, nil
-	}
+func (b *CommitBatcher) aggregateProofType() (abi.RegisteredAggregationProof, error) {
 	return abi.RegisteredAggregationProof_SnarkPackV2, nil
 }
 

--- a/storage/pipeline/input.go
+++ b/storage/pipeline/input.go
@@ -365,12 +365,7 @@ func (m *Sealing) sectorAddPieceToAny(ctx context.Context, size abi.UnpaddedPiec
 		return api.SectorOffset{}, xerrors.Errorf("couldn't get chain head: %w", err)
 	}
 
-	nv, err := m.Api.StateNetworkVersion(ctx, types.EmptyTSK)
-	if err != nil {
-		return api.SectorOffset{}, xerrors.Errorf("getting network version: %w", err)
-	}
-
-	if err := pieceInfo.Valid(nv); err != nil {
+	if err := pieceInfo.Valid(); err != nil {
 		return api.SectorOffset{}, xerrors.Errorf("piece metadata invalid: %w", err)
 	}
 
@@ -956,11 +951,6 @@ func (m *Sealing) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showO
 		return api.SectorInfo{}, err
 	}
 
-	nv, err := m.Api.StateNetworkVersion(ctx, types.EmptyTSK)
-	if err != nil {
-		return api.SectorInfo{}, xerrors.Errorf("getting network version: %w", err)
-	}
-
 	deals := make([]abi.DealID, len(info.Pieces))
 	pieces := make([]api.SectorPiece, len(info.Pieces))
 	for i, piece := range info.Pieces {
@@ -971,7 +961,7 @@ func (m *Sealing) SectorsStatus(ctx context.Context, sid abi.SectorNumber, showO
 		}
 
 		pdi := piece.Impl()
-		if pdi.Valid(nv) != nil {
+		if pdi.Valid() != nil {
 			continue
 		}
 

--- a/storage/pipeline/piece/piece_info.go
+++ b/storage/pipeline/piece/piece_info.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
@@ -50,7 +49,7 @@ func (ds *PieceDealInfo) isBuiltinMarketDeal() bool {
 
 // Valid validates the deal info after being accepted through RPC, checks that
 // the deal metadata is well-formed.
-func (ds *PieceDealInfo) Valid(nv network.Version) error {
+func (ds *PieceDealInfo) Valid() error {
 	hasLegacyDealInfo := ds.PublishCid != nil && ds.DealID != 0 && ds.DealProposal != nil
 	hasPieceActivationManifest := ds.PieceActivationManifest != nil
 
@@ -76,14 +75,6 @@ func (ds *PieceDealInfo) Valid(nv network.Version) error {
 	}
 	if ds.DealSchedule.EndEpoch <= ds.DealSchedule.StartEpoch {
 		return xerrors.Errorf("invalid deal end epoch %d (start %d)", ds.DealSchedule.EndEpoch, ds.DealSchedule.StartEpoch)
-	}
-
-	if hasPieceActivationManifest {
-		if nv < network.Version22 {
-			return xerrors.Errorf("direct-data-onboarding pieces aren't accepted before network version 22")
-		}
-
-		// todo any more checks seem reasonable to put here?
 	}
 
 	return nil

--- a/storage/pipeline/receive.go
+++ b/storage/pipeline/receive.go
@@ -87,11 +87,6 @@ func (m *Sealing) checkSectorMeta(ctx context.Context, meta api.RemoteSectorMeta
 		return SectorInfo{}, xerrors.Errorf("getting chain head: %w", err)
 	}
 
-	nv, err := m.Api.StateNetworkVersion(ctx, ts.Key())
-	if err != nil {
-		return SectorInfo{}, xerrors.Errorf("getting network version: %w", err)
-	}
-
 	var info SectorInfo
 	var validatePoRep bool
 
@@ -235,7 +230,7 @@ func (m *Sealing) checkSectorMeta(ctx context.Context, meta api.RemoteSectorMeta
 				continue // cc
 			}
 
-			err := info.Pieces[i].DealInfo().Valid(nv)
+			err := info.Pieces[i].DealInfo().Valid()
 			if err != nil {
 				return SectorInfo{}, xerrors.Errorf("piece %d deal info invalid: %w", i, err)
 			}

--- a/storage/pipeline/types.go
+++ b/storage/pipeline/types.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/verifreg"
@@ -50,7 +49,7 @@ type UniversalPieceInfo interface {
 	String() string
 	Key() piece.PieceKey
 
-	Valid(nv network.Version) error
+	Valid() error
 	StartEpoch() (abi.ChainEpoch, error)
 	EndEpoch() (abi.ChainEpoch, error)
 	PieceCID() cid.Cid
@@ -306,8 +305,8 @@ func (sp *SafeSectorPiece) Key() piece.PieceKey {
 	return sp.real.DealInfo.Key()
 }
 
-func (sp *SafeSectorPiece) Valid(nv network.Version) error {
-	return sp.real.DealInfo.Valid(nv)
+func (sp *SafeSectorPiece) Valid() error {
+	return sp.real.DealInfo.Valid()
 }
 
 func (sp *SafeSectorPiece) StartEpoch() (abi.ChainEpoch, error) {

--- a/storage/wdpost/wdpost_run.go
+++ b/storage/wdpost/wdpost_run.go
@@ -151,14 +151,7 @@ func (s *WindowPoStScheduler) runSubmitPoST(
 	defer span.End()
 
 	// Get randomness from tickets
-	// use the challenge epoch if we've upgraded to network version 4
-	// (actors version 2). We want to go back as far as possible to be safe.
-	commEpoch := deadline.Open
-	if ver, err := s.api.StateNetworkVersion(ctx, types.EmptyTSK); err != nil {
-		log.Errorw("failed to get network version to determine PoSt epoch randomness lookback", "error", err)
-	} else if ver >= network.Version4 {
-		commEpoch = deadline.Challenge
-	}
+	commEpoch := deadline.Challenge
 
 	commRand, err := s.api.StateGetRandomnessFromTickets(ctx, crypto.DomainSeparationTag_PoStChainCommit, commEpoch, nil, ts.Key())
 	if err != nil {
@@ -220,18 +213,10 @@ func (s *WindowPoStScheduler) checkSectors(ctx context.Context, check bitfield.B
 		})
 	}
 
-	nv, err := s.api.StateNetworkVersion(ctx, types.EmptyTSK)
-	if err != nil {
-		return bitfield.BitField{}, xerrors.Errorf("failed to get network version: %w", err)
-	}
-
 	pp := s.proofType
-	// TODO: Drop after nv19 comes and goes
-	if nv >= network.Version19 {
-		pp, err = pp.ToV1_1PostProof()
-		if err != nil {
-			return bitfield.BitField{}, xerrors.Errorf("failed to convert to v1_1 post proof: %w", err)
-		}
+	pp, err = pp.ToV1_1PostProof()
+	if err != nil {
+		return bitfield.BitField{}, xerrors.Errorf("failed to convert to v1_1 post proof: %w", err)
 	}
 
 	bad, err := s.faultTracker.CheckProvable(ctx, pp, tocheck, func(ctx context.Context, id abi.SectorID) (cid.Cid, bool, error) {


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->



## Proposed Changes
<!-- A clear list of the changes being made -->
* Cleaning up network version guards
* Removing network version guards that only apply to commands at network head and so are deadcode
* No changes to syncing code -- syncing from genesis still theoretically possible

## Additional Info
<!-- Callouts, links to documentation, and etc -->

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [x] New features have usage guidelines and / or documentation updates in
  - [x] [Lotus Documentation](https://lotus.filecoin.io)
  - [x] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [x] CI is green
