### PR TITLE
chore(ci): switch to mockproofs where real proofs aren't needed

### DIFF
--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -309,13 +309,9 @@ func getPackages(testGroupName string) []string {
 func getNeedsParameters(testGroupName string) bool {
 	testGroupNames := []string{
 		"conformance",
-		"itest-api_v2",
 		"itest-api",
-		"itest-direct_data_onboard_verified",
 		"itest-direct_data_onboard",
-		"itest-eth_api_f3",
 		"itest-manual_onboarding",
-		"itest-net",
 		"itest-niporep_manual",
 		"itest-path_detach_redeclare",
 		"itest-sealing_resources",

--- a/itests/direct_data_onboard_test.go
+++ b/itests/direct_data_onboard_test.go
@@ -47,7 +47,7 @@ func TestActors13Migration(t *testing.T) {
 		blocktime = 2 * time.Millisecond
 		ctx       = context.Background()
 	)
-	client, _, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(), kit.UpgradeSchedule(stmgr.Upgrade{
+	client, _, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.UpgradeSchedule(stmgr.Upgrade{
 		Network: network.Version21,
 		Height:  -1,
 	}, stmgr.Upgrade{
@@ -69,7 +69,7 @@ func TestOnboardRawPiece(t *testing.T) {
 		ctx       = context.Background()
 	)
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC())
+	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC())
 	ens.InterconnectAll().BeginMiningMustPost(blocktime)
 
 	pieceSize := abi.PaddedPieceSize(2048).Unpadded()
@@ -122,7 +122,7 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 		ctx       = context.Background()
 	)
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) {
+	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) {
 		sc.RequireActivationSuccess = true
 		sc.RequireNotificationSuccess = true
 	}))
@@ -199,7 +199,6 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, abi.PaddedPieceSize(0), marketSector.Offset)
-		require.Equal(t, abi.SectorNumber(2), marketSector.Sector)
 	}
 
 	// raw ddo piece
@@ -236,13 +235,12 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, abi.PaddedPieceSize(1024), rawSector.Offset)
-		require.Equal(t, abi.SectorNumber(2), rawSector.Sector)
 	}
 
 	require.Equal(t, marketSector.Sector, rawSector.Sector) // sanity check same sector
 
 	toCheck := map[abi.SectorNumber]struct{}{
-		2: {},
+		rawSector.Sector: {},
 	}
 
 	miner.WaitSectorsProving(ctx, toCheck)
@@ -250,7 +248,7 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 	expectCommD, _, err := commp.PieceAggregateCommP(abi.RegisteredSealProof_StackedDrg2KiBV1_1, pieces)
 	require.NoError(t, err)
 
-	si, err := miner.SectorsStatus(ctx, 2, false)
+	si, err := miner.SectorsStatus(ctx, rawSector.Sector, false)
 	require.NoError(t, err)
 	require.Equal(t, expectCommD, *si.CommD)
 
@@ -293,12 +291,7 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		expectedDealIds := map[abi.SectorNumber][]abi.DealID{
-			0: {abi.DealID(0)},                // preseal, full-sector deal
-			1: {abi.DealID(1)},                // market deal, full-sector deal
-			2: {abi.DealID(rawSector.Sector)}, // the one we manually added, half-sector deal
-		}
-		require.Equal(t, expectedDealIds, actualSectorDeals)
+		require.Equal(t, []abi.DealID{dealID}, actualSectorDeals[rawSector.Sector])
 
 		// check actor events, verify deal-published is as expected
 		caddr, err := client.WalletDefaultAddress(context.Background())
@@ -330,7 +323,7 @@ func TestOnboardMixedMarketDDO(t *testing.T) {
 					case "deal-published", "deal-activated":
 						expectedEntries := []types.EventEntry{
 							{Flags: 0x03, Codec: uint64(multicodec.Cbor), Key: "$type", Value: keyBytes},
-							{Flags: 0x03, Codec: uint64(multicodec.Cbor), Key: "id", Value: must.One(ipld.Encode(basicnode.NewInt(2), dagcbor.Encode))},
+							{Flags: 0x03, Codec: uint64(multicodec.Cbor), Key: "id", Value: must.One(ipld.Encode(basicnode.NewInt(int64(dealID)), dagcbor.Encode))},
 							{Flags: 0x03, Codec: uint64(multicodec.Cbor), Key: "client", Value: must.One(ipld.Encode(basicnode.NewInt(int64(clientId)), dagcbor.Encode))},
 							{Flags: 0x03, Codec: uint64(multicodec.Cbor), Key: "provider", Value: must.One(ipld.Encode(basicnode.NewInt(int64(minerId)), dagcbor.Encode))},
 						}

--- a/itests/direct_data_onboard_verified_test.go
+++ b/itests/direct_data_onboard_verified_test.go
@@ -55,7 +55,7 @@ func TestOnboardRawPieceVerified_WithActorEvents(t *testing.T) {
 	verifierKey := must.One(key.GenerateKey(types.KTSecp256k1))
 	verifiedClientKey := must.One(key.GenerateKey(types.KTBLS))
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(),
+	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(),
 		kit.RootVerifier(rootKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifierKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifiedClientKey, abi.NewTokenAmount(initialBigBalance)),
@@ -158,6 +158,7 @@ func TestOnboardRawPieceVerified_WithActorEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allocations, 1) // allocation has been claimed, leaving the bogus one
 
+	client.WaitTillChain(ctx, kit.HeightAtLeast(bogusAllocationExpiry+1))
 	ddoVerifiedRemoveAllocations(ctx, t, client, verifiedClientAddr, clientId)
 
 	// check that we have no more allocations
@@ -630,7 +631,7 @@ func TestVerifiedDDOExtendClaim(t *testing.T) {
 	verifiedClientKey2 := must.One(key.GenerateKey(types.KTBLS))
 	unverifiedClient := must.One(key.GenerateKey(types.KTBLS))
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(),
+	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.ThroughRPC(),
 		kit.RootVerifier(rootKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifierKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifiedClientKey1, abi.NewTokenAmount(initialBigBalance)),

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -182,6 +182,9 @@ func NewEnsemble(t *testing.T, opts ...EnsembleOpt) *Ensemble {
 	if n.options.mockProofs {
 		require.NoError(t, build.UseNetworkBundle("testing-fake-proofs"))
 	} else {
+		// MockProofs disables built-in assets globally; restore them for later
+		// ensembles that need real proof parameters or other bundled assets.
+		build.DisableBuiltinAssets = false
 		require.NoError(t, build.UseNetworkBundle(n.options.networkName))
 	}
 

--- a/itests/net_test.go
+++ b/itests/net_test.go
@@ -19,7 +19,7 @@ import (
 func TestNetConn(t *testing.T) {
 	ctx := context.Background()
 
-	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t)
+	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t, kit.MockProofs())
 
 	secondNodeID, err := secondNode.ID(ctx)
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestNetConn(t *testing.T) {
 
 func TestNetStat(t *testing.T) {
 
-	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t)
+	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t, kit.MockProofs())
 	ctx := context.Background()
 
 	sId, err := secondNode.ID(ctx)
@@ -119,7 +119,7 @@ func TestNetStat(t *testing.T) {
 
 func TestNetLimit(t *testing.T) {
 
-	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t)
+	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t, kit.MockProofs())
 	ctx := context.Background()
 
 	sId, err := secondNode.ID(ctx)
@@ -140,7 +140,7 @@ func TestNetLimit(t *testing.T) {
 func TestNetBlockPeer(t *testing.T) {
 	ctx := context.Background()
 
-	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t)
+	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t, kit.MockProofs())
 
 	firstAddrInfo, _ := firstNode.NetAddrsListen(ctx)
 	firstNodeID, err := firstNode.ID(ctx)
@@ -193,7 +193,7 @@ func TestNetBlockPeer(t *testing.T) {
 func TestNetBlockIPAddr(t *testing.T) {
 	ctx := context.Background()
 
-	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t)
+	firstNode, secondNode, _, _ := kit.EnsembleTwoOne(t, kit.MockProofs())
 
 	firstAddrInfo, _ := firstNode.NetAddrsListen(ctx)
 	secondAddrInfo, _ := secondNode.NetAddrsListen(ctx)

--- a/storage/sealer/mock/mock.go
+++ b/storage/sealer/mock/mock.go
@@ -77,7 +77,19 @@ func (mgr *SectorMgr) SectorsUnsealPiece(ctx context.Context, sector storiface.S
 }
 
 func (mgr *SectorMgr) DataCid(ctx context.Context, size abi.UnpaddedPieceSize, r io.Reader) (abi.PieceInfo, error) {
-	panic("todo")
+	c, err := commp.GeneratePieceCIDFromFile(abi.RegisteredSealProof_StackedDrg64GiBV1_1, r, size)
+	if err != nil {
+		return abi.PieceInfo{}, xerrors.Errorf("generating piece CID: %w", err)
+	}
+
+	if _, err := commcid.CIDToPieceCommitmentV1(c); err != nil {
+		return abi.PieceInfo{}, err
+	}
+
+	return abi.PieceInfo{
+		Size:     size.Padded(),
+		PieceCID: c,
+	}, nil
 }
 
 func (mgr *SectorMgr) AddPiece(ctx context.Context, sectorID storiface.SectorRef, existingPieces []abi.UnpaddedPieceSize, size abi.UnpaddedPieceSize, r io.Reader) (abi.PieceInfo, error) {


### PR DESCRIPTION
Inspired by #13675, there's a few more places we can use mockproofs in our itests