### PR TITLE
test(ci): derive proof params from explicit real-proof markers

### DIFF
--- a/cli/miner/allinfo_test.go
+++ b/cli/miner/allinfo_test.go
@@ -22,7 +22,7 @@ func TestMinerAllInfo(t *testing.T) {
 
 	kit.QuietMiningLogs()
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs())
+	client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(), kit.WithRealStorageManager())
 	ens.InterconnectAll().BeginMiningMustPost(5 * time.Millisecond)
 
 	run := func(t *testing.T) {

--- a/cli/miner/allinfo_test.go
+++ b/cli/miner/allinfo_test.go
@@ -22,7 +22,7 @@ func TestMinerAllInfo(t *testing.T) {
 
 	kit.QuietMiningLogs()
 
-	client, miner, ens := kit.EnsembleMinimal(t)
+	client, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs())
 	ens.InterconnectAll().BeginMiningMustPost(5 * time.Millisecond)
 
 	run := func(t *testing.T) {

--- a/cmd/ci/main.go
+++ b/cmd/ci/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"slices"
@@ -275,6 +278,9 @@ func getPackages(testGroupName string) []string {
 		return []string{createPackagePath("itests", strings.Join([]string{strings.TrimPrefix(testGroupName, "itest-"), "test.go"}, "_"))}
 	}
 
+	// Keep the non-itest groups in sync with the Makefile's unittests target:
+	// go list ./... excluding ./itests. unit-rest is the catch-all bucket for
+	// packages that do not have a more specific CI group.
 	testGroupNameToPackages := map[string][]string{
 		"multicore-sdr": {createPackagePath("storage", "sealer", "ffiwrapper")},
 		"conformance":   {createPackagePath("conformance")},
@@ -295,10 +301,16 @@ func getPackages(testGroupName string) []string {
 			createPackagePath("build", "..."),
 			createPackagePath("chain", "..."),
 			createPackagePath("conformance", "..."),
+			createPackagePath("gen", "..."),
+			createPackagePath("genesis", "..."),
 			createPackagePath("gateway", "..."),
 			createPackagePath("journal", "..."),
 			createPackagePath("lib", "..."),
+			createPackagePath("metrics", "..."),
+			createPackagePath("miner", "..."),
 			createPackagePath("paychmgr", "..."),
+			createPackagePath("scripts", "..."),
+			createPackagePath("system", "..."),
 			createPackagePath("tools", "..."),
 		},
 	}
@@ -307,27 +319,92 @@ func getPackages(testGroupName string) []string {
 }
 
 func getNeedsParameters(testGroupName string) bool {
+	if testGroupCallsFunction(testGroupName, "RealProofs") {
+		return true
+	}
+
 	testGroupNames := []string{
 		"conformance",
-		"itest-api",
-		"itest-direct_data_onboard",
-		"itest-manual_onboarding",
-		"itest-niporep_manual",
-		"itest-path_detach_redeclare",
-		"itest-sealing_resources",
-		"itest-sector_import_full",
-		"itest-sector_import_simple",
-		"itest-sector_pledge",
-		"itest-sector_unseal",
-		"itest-wdpost_no_miner_storage",
-		"itest-wdpost_worker_config",
-		"itest-wdpost",
-		"itest-worker",
 		"multicore-sdr",
-		"unit-cli",
 		"unit-storage",
 	}
 	return slices.Contains(testGroupNames, testGroupName)
+}
+
+func testGroupCallsFunction(testGroupName string, name string) bool {
+	for _, packagePath := range getPackages(testGroupName) {
+		if pathCallsFunction(packagePath, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathCallsFunction(packagePath string, name string) bool {
+	if strings.HasSuffix(packagePath, string(os.PathSeparator)+"...") {
+		return dirCallsFunction(strings.TrimSuffix(packagePath, string(os.PathSeparator)+"..."), name, true)
+	}
+
+	info, err := os.Stat(packagePath)
+	if err != nil {
+		log.WithError(err).WithField("path", packagePath).Warn("failed to scan test path for proof mode")
+		return false
+	}
+	if !info.IsDir() {
+		return fileCallsFunction(packagePath, name)
+	}
+	return dirCallsFunction(packagePath, name, false)
+}
+
+func dirCallsFunction(dir string, name string, recursive bool) bool {
+	found := false
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if path != dir && !recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), "_test.go") && fileCallsFunction(path, name) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		log.WithError(err).WithField("dir", dir).Warn("failed to scan test directory for proof mode")
+	}
+	return found
+}
+
+func fileCallsFunction(filename string, name string) bool {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, 0)
+	if err != nil {
+		log.WithError(err).WithField("file", filename).Warn("failed to scan test file for proof mode")
+		return false
+	}
+
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			found = fn.Name == name
+		case *ast.SelectorExpr:
+			found = fn.Sel.Name == name
+		}
+		return !found
+	})
+	return found
 }
 
 func getSkipConformance(testGroupName string) bool {

--- a/cmd/ci/main_test.go
+++ b/cmd/ci/main_test.go
@@ -50,7 +50,7 @@ func TestGetNeedsParametersScansTestFiles(t *testing.T) {
 		{name: "itest-api_v2", want: false},
 		{name: "itest-direct_data_onboard", want: true},
 		{name: "itest-direct_data_onboard_verified", want: false},
-		{name: "unit-cli", want: true},
+		{name: "unit-cli", want: false},
 		{name: "unit-storage", want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/ci/main_test.go
+++ b/cmd/ci/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileCallsFunction(t *testing.T) {
+	dir := t.TempDir()
+
+	commentOnly := filepath.Join(dir, "comment_only_test.go")
+	if err := os.WriteFile(commentOnly, []byte(`package main
+
+// kit.RealProofs()
+func TestCommentOnly(t *testing.T) {}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if fileCallsFunction(commentOnly, "RealProofs") {
+		t.Fatal("comment-only RealProofs marker should not match")
+	}
+
+	withCall := filepath.Join(dir, "with_call_test.go")
+	if err := os.WriteFile(withCall, []byte(`package main
+
+func TestWithCall(t *testing.T) {
+	_ = kit.RealProofs()
+}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !fileCallsFunction(withCall, "RealProofs") {
+		t.Fatal("RealProofs call should match")
+	}
+}
+
+func TestGetNeedsParametersScansTestFiles(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(filepath.Join(wd, "..", ".."))
+
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{name: "itest-api", want: true},
+		{name: "itest-api_v2", want: false},
+		{name: "itest-direct_data_onboard", want: true},
+		{name: "itest-direct_data_onboard_verified", want: false},
+		{name: "unit-cli", want: true},
+		{name: "unit-storage", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getNeedsParameters(tc.name); got != tc.want {
+				t.Fatalf("getNeedsParameters(%q) = %t, want %t", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/itests/api_test.go
+++ b/itests/api_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAPI(t *testing.T) {
 
-	ts := apiSuite{}
+	ts := apiSuite{opts: []interface{}{kit.RealProofs()}}
 	t.Run("testMiningReal", ts.testMiningReal)
 	ts.opts = append(ts.opts, kit.ThroughRPC())
 	t.Run("testMiningReal", ts.testMiningReal)

--- a/itests/daily_fees_test.go
+++ b/itests/daily_fees_test.go
@@ -101,7 +101,7 @@ func TestDailyFees(t *testing.T) {
 	// Miner A will only be a genesis Miner with power allocated in the genesis block and will not
 	// onboard any sectors from here on
 	ens := kit.NewEnsemble(t,
-		kit.MockProofs(true),
+		kit.MockProofs(),
 		kit.RootVerifier(rootKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifierKey, abi.NewTokenAmount(initialBigBalance)),
 		kit.Account(verifiedClientKey, abi.NewTokenAmount(initialBigBalance)),

--- a/itests/direct_data_onboard_test.go
+++ b/itests/direct_data_onboard_test.go
@@ -357,7 +357,7 @@ func TestOnboardRawPieceSnap(t *testing.T) {
 		ctx       = context.Background()
 	)
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) {
+	client, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs(), kit.ThroughRPC(), kit.MutateSealingConfig(func(sc *config.SealingConfig) {
 		sc.PreferNewSectorsForDeals = false
 		sc.MakeNewSectorForDeals = false
 		sc.MakeCCSectorsAvailable = true

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -81,7 +81,7 @@ func init() {
 //
 // Create a new ensemble with:
 //
-//	ens := kit.NewEnsemble()
+//	ens := kit.NewEnsemble(t, kit.MockProofs())
 //
 // Create full nodes and miners:
 //
@@ -107,14 +107,14 @@ func init() {
 //
 // The API is chainable, so it's possible to do a lot in a very succinct way:
 //
-//	kit.NewEnsemble().FullNode(&full).Miner(&miner, &full).Start().InterconnectAll().BeginMining()
+//	kit.NewEnsemble(t, kit.MockProofs()).FullNode(&full).Miner(&miner, &full).Start().InterconnectAll().BeginMining()
 //
 // You can also find convenient fullnode:miner presets, such as 1:1, 1:2,
 // and 2:1, e.g.:
 //
-//	kit.EnsembleMinimal()
-//	kit.EnsembleOneTwo()
-//	kit.EnsembleTwoOne()
+//	kit.EnsembleMinimal(t, kit.MockProofs())
+//	kit.EnsembleOneTwo(t, kit.MockProofs())
+//	kit.EnsembleTwoOne(t, kit.MockProofs())
 type Ensemble struct {
 	t            *testing.T
 	bootstrapped bool
@@ -149,6 +149,7 @@ func NewEnsemble(t *testing.T, opts ...EnsembleOpt) *Ensemble {
 		err := o(&options)
 		require.NoError(t, err)
 	}
+	require.NotEqual(t, proofModeUnset, options.proofMode, "proof mode must be explicit: use kit.MockProofs() or kit.RealProofs()")
 
 	n := &Ensemble{t: t, options: &options}
 	n.active.bms = make(map[*TestMiner]*BlockMiner)

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -785,18 +785,22 @@ func (n *Ensemble) Start() *Ensemble {
 
 		if n.options.mockProofs {
 			opts = append(opts,
-				node.Override(new(*mock.SectorMgr), func() (*mock.SectorMgr, error) {
-					return mock.NewMockSectorMgr(presealSectors), nil
-				}),
-				node.Override(new(sectorstorage.SectorManager), node.From(new(*mock.SectorMgr))),
-				node.Override(new(sectorstorage.Unsealer), node.From(new(*mock.SectorMgr))),
-				node.Override(new(sectorstorage.PieceProvider), node.From(new(*mock.SectorMgr))),
-
 				node.Override(new(proofs.Verifier), proofsmock.MockVerifier),
 				node.Override(new(storiface.Verifier), mock.MockVerifier),
 				node.Override(new(storiface.Prover), mock.MockProver),
-				node.Unset(new(*sectorstorage.Manager)),
 			)
+
+			if !n.options.realStorageManager {
+				opts = append(opts,
+					node.Override(new(*mock.SectorMgr), func() (*mock.SectorMgr, error) {
+						return mock.NewMockSectorMgr(presealSectors), nil
+					}),
+					node.Override(new(sectorstorage.SectorManager), node.From(new(*mock.SectorMgr))),
+					node.Override(new(sectorstorage.Unsealer), node.From(new(*mock.SectorMgr))),
+					node.Override(new(sectorstorage.PieceProvider), node.From(new(*mock.SectorMgr))),
+					node.Unset(new(*sectorstorage.Manager)),
+				)
+			}
 		}
 
 		// start node

--- a/itests/kit/ensemble_opts.go
+++ b/itests/kit/ensemble_opts.go
@@ -1,6 +1,7 @@
 package kit
 
 import (
+	"errors"
 	"time"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -13,6 +14,14 @@ import (
 
 type EnsembleOpt func(opts *ensembleOpts) error
 
+type proofMode int
+
+const (
+	proofModeUnset proofMode = iota
+	proofModeMock
+	proofModeReal
+)
+
 type genesisAccount struct {
 	key            *key.Key
 	initialBalance abi.TokenAmount
@@ -22,6 +31,7 @@ type ensembleOpts struct {
 	pastOffset   time.Duration
 	verifiedRoot genesisAccount
 	accounts     []genesisAccount
+	proofMode    proofMode
 	mockProofs   bool
 	networkName  string
 
@@ -38,18 +48,31 @@ var DefaultEnsembleOpts = ensembleOpts{
 }
 
 // MockProofs activates mock proofs for the entire ensemble.
-func MockProofs(e ...bool) EnsembleOpt {
-	if len(e) > 0 && !e[0] {
-		return func(opts *ensembleOpts) error {
-			return nil
-		}
-	}
-
+func MockProofs() EnsembleOpt {
 	return func(opts *ensembleOpts) error {
+		if opts.proofMode == proofModeReal {
+			return errors.New("proof mode already set to real proofs; use either kit.MockProofs() or kit.RealProofs()")
+		}
+		opts.proofMode = proofModeMock
 		opts.mockProofs = true
 		// since we're using mock proofs, we don't need to download
 		// proof parameters
 		build.DisableBuiltinAssets = true
+		return nil
+	}
+}
+
+// RealProofs activates real proofs for the entire ensemble.
+// CI scans for this marker when deciding whether to download proof parameters
+// for an itest.
+func RealProofs() EnsembleOpt {
+	return func(opts *ensembleOpts) error {
+		if opts.proofMode == proofModeMock {
+			return errors.New("proof mode already set to mock proofs; use either kit.MockProofs() or kit.RealProofs()")
+		}
+		opts.proofMode = proofModeReal
+		opts.mockProofs = false
+		build.DisableBuiltinAssets = false
 		return nil
 	}
 }

--- a/itests/kit/ensemble_opts.go
+++ b/itests/kit/ensemble_opts.go
@@ -28,12 +28,13 @@ type genesisAccount struct {
 }
 
 type ensembleOpts struct {
-	pastOffset   time.Duration
-	verifiedRoot genesisAccount
-	accounts     []genesisAccount
-	proofMode    proofMode
-	mockProofs   bool
-	networkName  string
+	pastOffset         time.Duration
+	verifiedRoot       genesisAccount
+	accounts           []genesisAccount
+	proofMode          proofMode
+	mockProofs         bool
+	realStorageManager bool
+	networkName        string
 
 	upgradeSchedule stmgr.UpgradeSchedule
 }
@@ -73,6 +74,16 @@ func RealProofs() EnsembleOpt {
 		opts.proofMode = proofModeReal
 		opts.mockProofs = false
 		build.DisableBuiltinAssets = false
+		return nil
+	}
+}
+
+// WithRealStorageManager keeps the real storage manager wired when using
+// MockProofs. This is useful for tests that exercise the storage-manager API
+// surface without needing real cryptographic proofs.
+func WithRealStorageManager() EnsembleOpt {
+	return func(opts *ensembleOpts) error {
+		opts.realStorageManager = true
 		return nil
 	}
 }

--- a/itests/manual_onboarding_test.go
+++ b/itests/manual_onboarding_test.go
@@ -42,10 +42,14 @@ func TestManualSectorOnboarding(t *testing.T) {
 				client    kit.TestFullNode
 				minerA    kit.TestMiner // A is a standard genesis miner
 			)
+			proofs := kit.RealProofs()
+			if withMockProofs {
+				proofs = kit.MockProofs()
+			}
 
 			// Setup and begin mining with a single miner (A)
 			// Miner A will only be a genesis Miner with power allocated in the genesis block and will not onboard any sectors from here on
-			ens := kit.NewEnsemble(t, kit.MockProofs(withMockProofs)).
+			ens := kit.NewEnsemble(t, proofs).
 				FullNode(&client, kit.SectorSize(defaultSectorSize)).
 				// preseal more than the default number of sectors to ensure that the genesis miner has power
 				// because our unmanaged miners won't produce blocks so we may get null rounds

--- a/itests/niporep_manual_test.go
+++ b/itests/niporep_manual_test.go
@@ -219,10 +219,14 @@ func TestManualNISectorOnboarding(t *testing.T) {
 				client       kit.TestFullNode
 				genesisMiner kit.TestMiner
 			)
+			proofs := kit.RealProofs()
+			if tc.mockProofs {
+				proofs = kit.MockProofs()
+			}
 
 			// Setup and begin mining with a single genesis block miner, this miner won't be used
 			// in the test beyond mining the chain and maintaining power
-			ens := kit.NewEnsemble(t, kit.MockProofs(tc.mockProofs)).
+			ens := kit.NewEnsemble(t, proofs).
 				FullNode(&client, kit.SectorSize(defaultSectorSize)).
 				// preseal more than the default number of sectors to ensure that the genesis miner has power
 				// because our unmanaged miners won't produce blocks so we may get null rounds
@@ -374,7 +378,7 @@ func TestNISectorFailureCases(t *testing.T) {
 		client       kit.TestFullNode
 		genesisMiner kit.TestMiner
 	)
-	ens := kit.NewEnsemble(t, kit.MockProofs(true)).
+	ens := kit.NewEnsemble(t, kit.MockProofs()).
 		FullNode(&client, kit.SectorSize(defaultSectorSize)).
 		Miner(&genesisMiner, &client, kit.PresealSectors(5), kit.SectorSize(defaultSectorSize), kit.WithAllSubsystems()).
 		Start().

--- a/itests/path_detach_redeclare_test.go
+++ b/itests/path_detach_redeclare_test.go
@@ -30,7 +30,7 @@ func TestPathDetachRedeclare(t *testing.T) {
 		miner    kit.TestMiner
 		wiw, wdw kit.TestWorker
 	)
-	ens := kit.NewEnsemble(t, kit.LatestActorsAt(-1)).
+	ens := kit.NewEnsemble(t, kit.RealProofs(), kit.LatestActorsAt(-1)).
 		FullNode(&client, kit.ThroughRPC()).
 		Miner(&miner, &client, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.PresealSectors(2), kit.NoStorage()).
 		Worker(&miner, &wiw, kit.ThroughRPC(), kit.NoStorage(), kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt})).
@@ -145,7 +145,7 @@ func TestPathDetachRedeclareWorker(t *testing.T) {
 		miner           kit.TestMiner
 		wiw, wdw, sealw kit.TestWorker
 	)
-	ens := kit.NewEnsemble(t, kit.LatestActorsAt(-1)).
+	ens := kit.NewEnsemble(t, kit.RealProofs(), kit.LatestActorsAt(-1)).
 		FullNode(&client, kit.ThroughRPC()).
 		Miner(&miner, &client, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.PresealSectors(2), kit.NoStorage()).
 		Worker(&miner, &wiw, kit.ThroughRPC(), kit.NoStorage(), kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt})).
@@ -304,7 +304,7 @@ func TestPathDetachShared(t *testing.T) {
 		miner           kit.TestMiner
 		wiw, wdw, sealw kit.TestWorker
 	)
-	ens := kit.NewEnsemble(t, kit.LatestActorsAt(-1)).
+	ens := kit.NewEnsemble(t, kit.RealProofs(), kit.LatestActorsAt(-1)).
 		FullNode(&client, kit.ThroughRPC()).
 		Miner(&miner, &client, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.PresealSectors(2), kit.NoStorage()).
 		Worker(&miner, &wiw, kit.ThroughRPC(), kit.NoStorage(), kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt})).

--- a/itests/sealing_resources_test.go
+++ b/itests/sealing_resources_test.go
@@ -26,7 +26,7 @@ func TestPledgeMaxConcurrentGet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, miner, ens := kit.EnsembleMinimal(t, kit.NoStorage()) // no mock proofs
+	_, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs(), kit.NoStorage())
 	ens.InterconnectAll().BeginMiningMustPost(blockTime)
 
 	// separate sealed and storage paths so that finalize move needs to happen

--- a/itests/sector_import_full_test.go
+++ b/itests/sector_import_full_test.go
@@ -66,7 +66,7 @@ func TestSectorImport(t *testing.T) {
 			// Start a miner node
 
 			// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
-			client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC())
+			client, miner, _, ens := kit.EnsembleOneTwo(t, kit.RealProofs(), kit.ThroughRPC())
 			ens.InterconnectAll().BeginMining(blockTime)
 
 			ctx := context.Background()

--- a/itests/sector_import_simple_test.go
+++ b/itests/sector_import_simple_test.go
@@ -40,7 +40,7 @@ func TestSectorImportAfterPC2(t *testing.T) {
 	// Start a miner node
 
 	// We use two miners so that in case the actively tested miner misses PoSt, we still have a blockchain
-	client, miner, _, ens := kit.EnsembleOneTwo(t, kit.ThroughRPC())
+	client, miner, _, ens := kit.EnsembleOneTwo(t, kit.RealProofs(), kit.ThroughRPC())
 
 	ens.InterconnectAll().BeginMining(blockTime)
 

--- a/itests/sector_pledge_test.go
+++ b/itests/sector_pledge_test.go
@@ -64,7 +64,11 @@ func TestPledgeBatching(t *testing.T) {
 
 		kit.QuietMiningLogs()
 
-		client, miner, ens := kit.EnsembleMinimal(t, kit.MockProofs(!aggregate))
+		proofs := kit.RealProofs()
+		if !aggregate {
+			proofs = kit.MockProofs()
+		}
+		client, miner, ens := kit.EnsembleMinimal(t, proofs)
 		ens.InterconnectAll().BeginMiningMustPost(blockTime)
 
 		client.WaitTillChain(ctx, kit.HeightAtLeast(10))
@@ -198,9 +202,9 @@ func TestPledgeSynth(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		_, miner, ens := kit.EnsembleMinimal(t, kit.MutateSealingConfig(func(sc *config.SealingConfig) {
+		_, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs(), kit.MutateSealingConfig(func(sc *config.SealingConfig) {
 			sc.UseSyntheticPoRep = true
-		})) // no mock proofs
+		}))
 
 		ens.InterconnectAll().BeginMiningMustPost(blockTime)
 

--- a/itests/sector_unseal_test.go
+++ b/itests/sector_unseal_test.go
@@ -22,12 +22,12 @@ func TestUnsealPiece(t *testing.T) {
 	blockTime := 1 * time.Millisecond
 	kit.QuietMiningLogs()
 
-	_, miner, ens := kit.EnsembleMinimal(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+	_, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
 		kit.NoStorage(), // no storage to have better control over path settings
 		kit.MutateSealingConfig(func(sc *config.SealingConfig) {
 			sc.FinalizeEarly = true
 			sc.AlwaysKeepUnsealedCopy = false
-		})) // no mock proofs
+		}))
 
 	var worker kit.TestWorker
 	ens.Worker(miner, &worker, kit.ThroughRPC(), kit.NoStorage(), // no storage to have better control over path settings

--- a/itests/wdpost_no_miner_storage_test.go
+++ b/itests/wdpost_no_miner_storage_test.go
@@ -29,7 +29,7 @@ func TestWindowPostNoMinerStorage(t *testing.T) {
 		miner           kit.TestMiner
 		wiw, wdw, sealw kit.TestWorker
 	)
-	ens := kit.NewEnsemble(t, kit.LatestActorsAt(-1)).
+	ens := kit.NewEnsemble(t, kit.RealProofs(), kit.LatestActorsAt(-1)).
 		FullNode(&client, kit.ThroughRPC()).
 		Miner(&miner, &client, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.PresealSectors(presealSectors), kit.NoStorage()).
 		Worker(&miner, &wiw, kit.ThroughRPC(), kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt})).

--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -263,7 +263,7 @@ func TestWindowPostV1P1NV20(t *testing.T) {
 
 	blocktime := 2 * time.Millisecond
 
-	client, miner, ens := kit.EnsembleMinimal(t, kit.GenesisNetworkVersion(network.Version20))
+	client, miner, ens := kit.EnsembleMinimal(t, kit.RealProofs(), kit.GenesisNetworkVersion(network.Version20))
 	ens.InterconnectAll().BeginMining(blocktime)
 
 	maddr, err := miner.ActorAddress(ctx)

--- a/itests/wdpost_worker_config_test.go
+++ b/itests/wdpost_worker_config_test.go
@@ -31,6 +31,7 @@ func TestWindowPostNoBuiltinWindow(t *testing.T) {
 	sectors := 2 * 48 * 2
 
 	client, miner, _, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ConstructorOpts(
@@ -88,6 +89,7 @@ func TestWindowPostNoBuiltinWindowWithWorker(t *testing.T) {
 	sectors := 2 * 48 * 2
 
 	client, miner, _, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ConstructorOpts(

--- a/itests/worker_test.go
+++ b/itests/worker_test.go
@@ -35,8 +35,8 @@ import (
 
 func TestWorkerPledge(t *testing.T) {
 	ctx := context.Background()
-	_, miner, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
-		kit.WithSealWorkerTasks) // no mock proofs
+	_, miner, worker, ens := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+		kit.WithSealWorkerTasks)
 
 	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -49,10 +49,10 @@ func TestWorkerPledge(t *testing.T) {
 
 func TestWorkerPledgeSpread(t *testing.T) {
 	ctx := context.Background()
-	_, miner, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(),
+	_, miner, worker, ens := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(),
 		kit.WithSealWorkerTasks,
 		kit.WithAssigner("spread"),
-	) // no mock proofs
+	)
 
 	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -65,10 +65,10 @@ func TestWorkerPledgeSpread(t *testing.T) {
 
 func TestWorkerPledgeLocalFin(t *testing.T) {
 	ctx := context.Background()
-	_, miner, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(),
+	_, miner, worker, ens := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(),
 		kit.WithSealWorkerTasks,
 		kit.WithDisallowRemoteFinalize(true),
-	) // no mock proofs
+	)
 
 	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -81,8 +81,8 @@ func TestWorkerPledgeLocalFin(t *testing.T) {
 
 func TestWorkerDataCid(t *testing.T) {
 	ctx := context.Background()
-	_, miner, worker, _ := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
-		kit.WithSealWorkerTasks) // no mock proofs
+	_, miner, worker, _ := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+		kit.WithSealWorkerTasks)
 
 	e, err := worker.Enabled(ctx)
 	require.NoError(t, err)
@@ -114,8 +114,8 @@ func TestWinningPostWorker(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	client, _, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(),
-		kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt})) // no mock proofs
+	client, _, worker, ens := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(),
+		kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTGenerateWinningPoSt}))
 
 	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -135,6 +135,7 @@ func TestWindowPostWorker(t *testing.T) {
 	sectors := 2 * 48 * 2
 
 	client, miner, _, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -264,6 +265,7 @@ func TestWindowPostWorkerSkipBadSector(t *testing.T) {
 	var badsector uint64 = 100000
 
 	client, miner, _, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -378,6 +380,7 @@ func TestWindowPostWorkerManualPoSt(t *testing.T) {
 	sectors := 2 * 48 * 2
 
 	client, miner, _, _ := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -411,6 +414,7 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 	sectors := 2 * 48 * 2
 
 	_, miner, badWorker, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.PresealSectors(sectors), // 2 sectors per partition, 2 partitions in all 48 deadlines
 		kit.LatestActorsAt(-1),
 		kit.ThroughRPC(),
@@ -446,8 +450,8 @@ func TestWindowPostWorkerDisconnected(t *testing.T) {
 
 func TestSchedulerRemoveRequest(t *testing.T) {
 	ctx := context.Background()
-	_, miner, worker, _ := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
-		kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTAddPiece, sealtasks.TTPreCommit1})) // no mock proofs
+	_, miner, worker, _ := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithNoLocalSealing(true),
+		kit.WithTaskTypes([]sealtasks.TaskType{sealtasks.TTAddPiece, sealtasks.TTPreCommit1}))
 
 	//ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -491,7 +495,7 @@ func TestWorkerName(t *testing.T) {
 	name := "thisstringisprobablynotahostnameihope"
 
 	ctx := context.Background()
-	_, miner, worker, ens := kit.EnsembleWorker(t, kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithWorkerName(name))
+	_, miner, worker, ens := kit.EnsembleWorker(t, kit.RealProofs(), kit.WithAllSubsystems(), kit.ThroughRPC(), kit.WithWorkerName(name))
 
 	ens.InterconnectAll().BeginMining(50 * time.Millisecond)
 
@@ -522,6 +526,7 @@ func TestWindowPostV1P1NV20Worker(t *testing.T) {
 	blocktime := 2 * time.Millisecond
 
 	client, miner, _, ens := kit.EnsembleWorker(t,
+		kit.RealProofs(),
 		kit.GenesisNetworkVersion(network.Version20),
 		kit.ConstructorOpts(
 			node.Override(new(config.ProvingConfig), func() config.ProvingConfig {


### PR DESCRIPTION
Introduces a kit.RealProofs() and makes it so that itests must declare either real or mock proofs explicitly. We then look for use of RealProofs() to determine whether that test needs proof params in CI.

Reduces the possibility of cmd/ci/main.go getting out of sync with the facts of the needs of itests.
