### PR TITLE
fix(eth): reject null epochs for block execution APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): return `ErrNullRound` for explicit null epochs in singleton block-execution ETH APIs. `eth_getBlockReceipts` / `EthGetBlockReceiptsLimited` now reject a null block number instead of returning receipts for the previous non-null tipset. State-at-epoch APIs such as `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`, `eth_estimateGas`, and `FilecoinAddressToEthAddress` continue to resolve null epochs to the previous non-null tipset because Filecoin state is defined at the null epoch and is unchanged from that previous state. Range/sampling APIs such as `eth_feeHistory` also continue to walk real tipsets and skip null epochs, including when resolving a null `newestBlock` anchor to the previous non-null tipset. ([filecoin-project/lotus#13694](https://github.com/filecoin-project/lotus/pull/13694))
+
 ## 👌 Improvements
 
 # Node and Miner v1.36.1 / 2026-06-30

--- a/api/api_full.go
+++ b/api/api_full.go
@@ -820,6 +820,14 @@ type FullNode interface {
 	// "Latest executed epoch" refers to the tipset that this node currently
 	// accepts as the best parent tipset, based on the blocks it is accumulating
 	// within the HEAD tipset.
+	//
+	// Filecoin may have null epochs with no tipset. ETH APIs that inspect a
+	// concrete block or that block's execution reject explicit numeric null
+	// epochs with ErrNullRound. ETH APIs that read state at an epoch, or sample
+	// real tipsets across a range, may resolve null epochs to the previous
+	// non-null tipset. Filecoin state is defined for the null epoch and is
+	// identical to that previous state, and range APIs skip null epochs when
+	// walking parent tipsets.
 
 	// EthAccounts will always return [] since we don't expect Lotus to manage private keys
 	EthAccounts(ctx context.Context) ([]ethtypes.EthAddress, error) //perm:read

--- a/api/v2api/full.go
+++ b/api/v2api/full.go
@@ -150,6 +150,14 @@ type FullNode interface {
 	// "Latest executed epoch" refers to the tipset that this node currently
 	// accepts as the best parent tipset, based on the blocks it is accumulating
 	// within the HEAD tipset.
+	//
+	// Filecoin may have null epochs with no tipset. ETH APIs that inspect a
+	// concrete block or that block's execution reject explicit numeric null
+	// epochs with ErrNullRound. ETH APIs that read state at an epoch, or sample
+	// real tipsets across a range, may resolve null epochs to the previous
+	// non-null tipset. Filecoin state is defined for the null epoch and is
+	// identical to that previous state, and range APIs skip null epochs when
+	// walking parent tipsets.
 
 	// EthFilecoinAPI methods
 

--- a/documentation/en/api-methods-v1-stable.md
+++ b/documentation/en/api-methods-v1-stable.md
@@ -1892,6 +1892,14 @@ Ethereum clients expect transactions returned via eth_getBlock* to have a receip
 accepts as the best parent tipset, based on the blocks it is accumulating
 within the HEAD tipset.
 
+Filecoin may have null epochs with no tipset. ETH APIs that inspect a
+concrete block or that block's execution reject explicit numeric null
+epochs with ErrNullRound. ETH APIs that read state at an epoch, or sample
+real tipsets across a range, may resolve null epochs to the previous
+non-null tipset. Filecoin state is defined for the null epoch and is
+identical to that previous state, and range APIs skip null epochs when
+walking parent tipsets.
+
 
 ### EthAccounts
 EthAccounts will always return [] since we don't expect Lotus to manage private keys

--- a/documentation/en/api-methods-v2-experimental.md
+++ b/documentation/en/api-methods-v2-experimental.md
@@ -514,6 +514,14 @@ Ethereum clients expect transactions returned via eth_getBlock* to have a receip
 accepts as the best parent tipset, based on the blocks it is accumulating
 within the HEAD tipset.
 
+Filecoin may have null epochs with no tipset. ETH APIs that inspect a
+concrete block or that block's execution reject explicit numeric null
+epochs with ErrNullRound. ETH APIs that read state at an epoch, or sample
+real tipsets across a range, may resolve null epochs to the previous
+non-null tipset. Filecoin state is defined for the null epoch and is
+identical to that previous state, and range APIs skip null epochs when
+walking parent tipsets.
+
 
 ### EthAccounts
 EthAccounts returns a list of Ethereum accounts managed by the node.

--- a/itests/fevm_test.go
+++ b/itests/fevm_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-keccak"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -1657,6 +1656,7 @@ func TestEthNullRoundHandling(t *testing.T) {
 	}
 
 	nullBlockHex := fmt.Sprintf("0x%x", int(nullHeight))
+	nullBlockParam := ethtypes.NewEthBlockNumberOrHashFromNumber(ethtypes.EthUint64(nullHeight))
 	client.WaitTillChain(ctx, kit.HeightAtLeast(nullHeight+2))
 	testCases := []struct {
 		name     string
@@ -1670,9 +1670,30 @@ func TestEthNullRoundHandling(t *testing.T) {
 			},
 		},
 		{
-			name: "EthFeeHistory",
+			name: "EthGetBlockTransactionCountByNumber",
 			testFunc: func() error {
-				_, err := client.EthFeeHistory(ctx, jsonrpc.RawParams([]byte(`[1,"`+nullBlockHex+`",[]]`)))
+				_, err := client.EthGetBlockTransactionCountByNumber(ctx, nullBlockHex)
+				return err
+			},
+		},
+		{
+			name: "EthGetTransactionByBlockNumberAndIndex",
+			testFunc: func() error {
+				_, err := client.EthGetTransactionByBlockNumberAndIndex(ctx, nullBlockHex, ethtypes.EthUint64(0))
+				return err
+			},
+		},
+		{
+			name: "EthGetBlockReceipts",
+			testFunc: func() error {
+				_, err := client.EthGetBlockReceipts(ctx, nullBlockParam)
+				return err
+			},
+		},
+		{
+			name: "EthGetBlockReceiptsLimited",
+			testFunc: func() error {
+				_, err := client.EthGetBlockReceiptsLimited(ctx, nullBlockParam, api.LookbackNoLimit)
 				return err
 			},
 		},
@@ -1695,9 +1716,6 @@ func TestEthNullRoundHandling(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.testFunc()
-			if err == nil {
-				return
-			}
 			require.Error(t, err)
 
 			// Test errors.Is

--- a/node/impl/eth/api.go
+++ b/node/impl/eth/api.go
@@ -160,12 +160,25 @@ type EthModuleAPI interface {
 // TipSetResolver is responsible for translating Ethereum API input to tipsets. It may use static
 // rules or F3 to resolve "latest" and "safe" tags as appropriate.
 //
-// In most cases, errors from TipSetResolver should be returned as-is if they are within the
-// top-level of a JSONRPC method so ErrNullRound is properly wrapped when encountered.
+// Explicit numeric block parameters need a per-call-site choice for null epochs:
+//
+//   - strict=true means the API needs an actual tipset at the requested epoch. Use this for
+//     block identity and block execution APIs, such as block lookups, transaction-by-block-index,
+//     block receipts, and block traces. A null epoch returns api.ErrNullRound.
+//   - strict=false means the API is reading or simulating against state at the requested epoch.
+//     Filecoin state is defined across null epochs and is identical to the previous non-null
+//     tipset state, so resolving to that previous tipset is intentional. Range or sampling APIs
+//     such as eth_feeHistory may also use non-strict resolution when they operate on real tipsets
+//     at or before an epoch rather than requiring every epoch in the range to contain a tipset.
+//
+// Tags such as "latest", "pending", "safe", and "finalized" resolve to a concrete tipset before
+// this distinction applies. Block-hash lookups are naturally strict because null epochs have no
+// block hash. In most cases, errors from TipSetResolver should be returned as-is if they are within
+// the top-level of a JSONRPC method so ErrNullRound is properly wrapped when encountered.
 type TipSetResolver interface {
 	GetTipSetByHash(ctx context.Context, blkParam ethtypes.EthHash) (*types.TipSet, error)
 	GetTipsetByBlockNumber(ctx context.Context, blkParam string, strict bool) (*types.TipSet, error)
-	GetTipsetByBlockNumberOrHash(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash) (*types.TipSet, error)
+	GetTipsetByBlockNumberOrHash(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash, strict bool) (*types.TipSet, error)
 }
 
 // SyncAPI is a minimal version of full.SyncAPI

--- a/node/impl/eth/gas.go
+++ b/node/impl/eth/gas.go
@@ -208,7 +208,7 @@ func (e *ethGas) EthEstimateGas(ctx context.Context, p jsonrpc.RawParams) (ethty
 	if params.BlkParam == nil {
 		ts = e.chainStore.GetHeaviestTipSet()
 	} else {
-		ts, err = e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, *params.BlkParam)
+		ts, err = e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, *params.BlkParam, false)
 		if err != nil {
 			return ethtypes.EthUint64(0), err
 		}
@@ -251,7 +251,7 @@ func (e *ethGas) EthCall(ctx context.Context, tx ethtypes.EthCall, blkParam etht
 		return nil, xerrors.Errorf("failed to convert ethcall to filecoin message: %w", err)
 	}
 
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam, false)
 	if err != nil {
 		return nil, err // don't wrap, to preserve ErrNullRound
 	}

--- a/node/impl/eth/lookup.go
+++ b/node/impl/eth/lookup.go
@@ -59,7 +59,7 @@ func (e *ethLookup) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 		return nil, xerrors.Errorf("cannot get Filecoin address: %w", err)
 	}
 
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam, false)
 	if err != nil {
 		return nil, err // don't wrap, to preserve ErrNullRound
 	}
@@ -145,7 +145,7 @@ func (e *ethLookup) EthGetCode(ctx context.Context, ethAddr ethtypes.EthAddress,
 }
 
 func (e *ethLookup) EthGetStorageAt(ctx context.Context, ethAddr ethtypes.EthAddress, position ethtypes.EthBytes, blkParam ethtypes.EthBlockNumberOrHash) (ethtypes.EthBytes, error) {
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam, false)
 	if err != nil {
 		return nil, err // don't wrap, to preserve ErrNullRound
 	}
@@ -242,7 +242,7 @@ func (e *ethLookup) EthGetBalance(ctx context.Context, address ethtypes.EthAddre
 		return ethtypes.EthBigInt{}, err
 	}
 
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam, false)
 	if err != nil {
 		return ethtypes.EthBigInt{}, err // don't wrap, to preserve ErrNullRound
 	}

--- a/node/impl/eth/tipsetresolver.go
+++ b/node/impl/eth/tipsetresolver.go
@@ -204,7 +204,7 @@ func (tsr *tipSetResolver) GetTipsetByBlockNumber(ctx context.Context, blkParam 
 	return ts, nil
 }
 
-func (tsr *tipSetResolver) GetTipsetByBlockNumberOrHash(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash) (*types.TipSet, error) {
+func (tsr *tipSetResolver) GetTipsetByBlockNumberOrHash(ctx context.Context, blkParam ethtypes.EthBlockNumberOrHash, strict bool) (*types.TipSet, error) {
 	head := tsr.cs.GetHeaviestTipSet()
 
 	predefined := blkParam.PredefinedBlock
@@ -220,6 +220,9 @@ func (tsr *tipSetResolver) GetTipsetByBlockNumberOrHash(ctx context.Context, blk
 		ts, err := tsr.cs.GetTipsetByHeight(ctx, height, head, true)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get tipset at height: %v", height)
+		}
+		if strict && ts.Height() != height {
+			return nil, api.NewErrNullRound(height)
 		}
 		return ts, nil
 	}

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -256,7 +256,7 @@ func (e *ethTransaction) EthGetTransactionCount(ctx context.Context, sender etht
 	}
 
 	// For all other cases, get the tipset based on the block parameter
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blkParam, false)
 	if err != nil {
 		return ethtypes.EthUint64(0), err // don't wrap, to preserve ErrNullRound
 	}
@@ -350,7 +350,7 @@ func (e *ethTransaction) EthGetBlockReceipts(ctx context.Context, blockParam eth
 }
 
 func (e *ethTransaction) EthGetBlockReceiptsLimited(ctx context.Context, blockParam ethtypes.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*ethtypes.EthTxReceipt, error) {
-	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blockParam)
+	ts, err := e.tipsetResolver.GetTipsetByBlockNumberOrHash(ctx, blockParam, true)
 	if err != nil {
 		return nil, err // don't wrap, to preserve ErrNullRound
 	}


### PR DESCRIPTION
[Slack converstation](https://filecoinproject.slack.com/archives/CP50PPW2X/p1782995781143339) w/ analysis from @LesnyRumcajs.

What I've done in here:

1. Enshrine a rule in documentation: **"ETH APIs that inspect a concrete block or that block's execution reject explicit numeric null epochs with ErrNullRound. ETH APIs that read state at an epoch, or sample real tipsets across a range, may resolve null epochs to the previous non-null tipset. Filecoin state is defined for the null epoch and is identical to that previous state, and range APIs skip null epochs when walking parent tipsets."**

2. Fix `eth_getBlockReceipts` (originally reported issue), now strict.
