### PR TITLE
fix(eth): validate nonce length in EthNonce.UnmarshalJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ## 🐛 Bug Fixes
 
 - fix(eth): return `ErrNullRound` for explicit null epochs in singleton block-execution ETH APIs. `eth_getBlockReceipts` / `EthGetBlockReceiptsLimited` now reject a null block number instead of returning receipts for the previous non-null tipset. State-at-epoch APIs such as `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`, `eth_estimateGas`, and `FilecoinAddressToEthAddress` continue to resolve null epochs to the previous non-null tipset because Filecoin state is defined at the null epoch and is unchanged from that previous state. Range/sampling APIs such as `eth_feeHistory` also continue to walk real tipsets and skip null epochs, including when resolving a null `newestBlock` anchor to the previous non-null tipset. ([filecoin-project/lotus#13694](https://github.com/filecoin-project/lotus/pull/13694))
+- fix(eth): reject Ethereum nonce values that do not decode to exactly 8 bytes in `EthNonce.UnmarshalJSON` instead of panicking on shorter input or silently truncating longer input, matching the length validation already applied to `EthHash` and `EthAddress` ([filecoin-project/lotus#13696](https://github.com/filecoin-project/lotus/pull/13696))
 
 ## 👌 Improvements
 

--- a/chain/types/ethtypes/eth_types.go
+++ b/chain/types/ethtypes/eth_types.go
@@ -420,16 +420,11 @@ func (n *EthNonce) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s = strings.Replace(s, "0x", "", -1)
-	if len(s)%2 == 1 {
-		s = "0" + s
-	}
-
-	decoded, err := hex.DecodeString(s)
+	decoded, err := decodeHexString(s, len(n))
 	if err != nil {
 		return err
 	}
-	copy(n[:], decoded[:8])
+	copy(n[:], decoded)
 	return nil
 }
 

--- a/chain/types/ethtypes/eth_types_test.go
+++ b/chain/types/ethtypes/eth_types_test.go
@@ -266,6 +266,23 @@ func TestUnmarshalEthBytes(t *testing.T) {
 	}
 }
 
+func TestUnmarshalEthNonce(t *testing.T) {
+	// a well-formed 8-byte nonce round-trips unchanged
+	valid := `"0x0102030405060708"`
+	var n EthNonce
+	require.NoError(t, n.UnmarshalJSON([]byte(valid)))
+	data, err := n.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, valid, string(data))
+
+	// anything that does not decode to exactly 8 bytes is rejected instead of
+	// panicking (short input) or being silently truncated (long input)
+	for _, tc := range []string{`"0x"`, `"0x01"`, `"0x010203040506070809"`} {
+		var n EthNonce
+		require.Error(t, n.UnmarshalJSON([]byte(tc)))
+	}
+}
+
 func TestEthFilterResultMarshalJSON(t *testing.T) {
 	hash1, err := ParseEthHash("013dbb9442ca9667baccc6230fcd5c1c4b2d4d2870f4bd20681d4d47cfd15184")
 	require.NoError(t, err, "eth hash")


### PR DESCRIPTION
## Related Issues

None. `EthNonce.UnmarshalJSON` panics on a nonce string that decodes to fewer than 8 bytes and silently truncates one that decodes to more.

## Proposed Changes

`EthNonce` is a fixed 8-byte type. Its `UnmarshalJSON` stripped the `0x` prefix, hex-decoded, then ran `copy(n[:], decoded[:8])` with no check on the decoded length. A value like `"0x01"` decodes to a single byte, so `decoded[:8]` slices out of range and panics; a value longer than 8 bytes is quietly cut down to the first eight. The sibling fixed-width types already avoid both: `EthHash` and `EthAddress` route their decode through `decodeHexString`, which requires the exact byte length before copying.

This sends `EthNonce.UnmarshalJSON` through the same helper (`decodeHexString(s, len(n))`), so a nonce that does not decode to exactly 8 bytes is rejected with an error. A well-formed nonce still round-trips unchanged, since `MarshalJSON` always emits 16 hex digits.

## Additional Info

Found while diffing the fixed-width `UnmarshalJSON` methods in this package; `EthNonce` was the only one not enforcing its own length. Added `TestUnmarshalEthNonce` covering the valid round-trip plus the short and long reject cases. It panics against the current code and passes after the change.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
