### PR TITLE
docs(release): support no-RC release flow

### DIFF
--- a/.github/workflows/create-release-issue.yml
+++ b/.github/workflows/create-release-issue.yml
@@ -17,12 +17,20 @@ on:
       level:
         description: "What's the level of the release?"
         required: true
-        default: 'warning'
+        default: 'patch'
         type: choice
         options:
-          - major
           - minor
           - patch
+      release-flow:
+        description: "Which release flow should the issue use?"
+        required: true
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - rc
+          - no-rc
       network-upgrade:
         description: "What's the version of the network upgrade this release is related to? (e.g. 25)"
         required: false
@@ -33,7 +41,7 @@ on:
         description: "What's a link to the Lotus CHANGELOG entry for the network upgrade?"
         required: false
       rc1-date:
-        description: "What's the expected shipping date for RC1?"
+        description: "What's the expected shipping date for RC1? Ignored for no-RC releases."
         required: false
         default: "TBD"
       stable-date:
@@ -64,6 +72,7 @@ jobs:
             --type "${{ github.event.inputs.type }}" \
             --tag "${{ github.event.inputs.tag }}" \
             --level "${{ github.event.inputs.level }}" \
+            --release-flow "${{ github.event.inputs.release-flow }}" \
             --network-upgrade "${{ github.event.inputs.network-upgrade }}" \
             --discussion-link "${{ github.event.inputs.discussion-link }}" \
             --changelog-link "${{ github.event.inputs.changelog-link }}" \

--- a/LOTUS_RELEASE_FLOW.md
+++ b/LOTUS_RELEASE_FLOW.md
@@ -42,7 +42,7 @@ This document aims to describe how the Lotus maintainers ship releases of Lotus.
 - **`MINOR` releases** are shipped for [network upgrades](./documentation/misc/Building_a_network_skeleton.md#context), API breaking changes, or non-backwards-compatible feature enhancements.
 - **`PATCH` releases** contain backwards-compatible bug fixes or feature enhancements.
 - Releases are almost always branched from the `master` branch, even if they include a network upgrade. The main exception is if there is a critical security patch we need to rush out. In that case, we would patch an existing release to increase release speed and reduce barrier to adoption.
-- We aim to ship a new release of the Lotus Node software approximately every 4 weeks, except during network upgrade periods which may have longer release cycles.
+- We aim to ship a new release of the Lotus Node software weekly, except during network upgrade periods which may have longer release cycles.
 - Lotus Miner releases ship on an as-needed basis with no specified cadence. (See [Why isn't Lotus Miner released more frequently?](#why-isnt-lotus-miner-released-more-frequently))
 
 
@@ -55,7 +55,7 @@ In order to achieve this, we need the following from our release process and con
 - Lotus version conventions make it clear what kind of changes are included in a release.
 - The ability to ship critical fixes quickly when needed.
 - A regular cadence of releases, so that users can know when a new Lotus Node release will be available.
-- A clear description of the various stages of testing that a Lotus Release Candidate (RC) goes through.
+- A clear description of the release process, including when Lotus Release Candidates (RCs) are required and when a direct stable release is appropriate.
 - Lotus Release issues will present a single source of truth for what may be contained in Lotus software releases, including security fixes, and how they will be disclosed.
 
 ## Adopted Conventions
@@ -87,7 +87,7 @@ These releases are not mandatory but are highly recommended, as they may contain
 
 ## Release Cadence
 
-* Lotus Node: we aim to ship a new release every 4 weeks. However, releases that include network upgrades usually have longer development and testing periods.
+* Lotus Node: we aim to ship a new release weekly. However, releases that include network upgrades usually have longer development and testing periods.
 * Lotus Miner: releases ship on an as-needed basis with no specified cadence. (See [Why isn't Lotus Miner released more frequently?](#why-isnt-lotus-miner-released-more-frequently))
 
 ## Release Process
@@ -95,8 +95,9 @@ The specific steps executed for Lotus software releases are captured in the [Rel
 
 ## Release Candidates (RCs)
 
-- For regular (i.e., no critical security patch) releases with no accompanying network upgrade, the RC period is typically around 1 week.
-- For releases accompanying network upgrades, the release candidate period is a lot longer to allow for more extensive testing, usually around 5 to 6 weeks.
+- Releases accompanying network upgrades require RC mode. Their release candidate period is a lot longer to allow for more extensive testing, usually around 5 to 6 weeks.
+- Routine releases with no accompanying network upgrade may use a direct stable release flow without publishing an RC first. This is the default flow for the weekly Lotus Node release cadence.
+- Maintainers may require RC mode for any release, including non-network-upgrade releases, when extra soak time is valuable. Examples include large or risky changes, actor-bundle or consensus-sensitive changes, major dependency updates, API breaking changes, migrations, or release-owner discretion.
 - Releases rushing out a critical security patch will likely have an RC period on the order of hours or days, or may even forgo the RC phase. To compensate for the release speed, these releases will include the minimum delta necessary, meaning they'll be a patch on top of an existing release rather than taking the latest changes in the `master` branch.
 
 ## Security Fix Policy
@@ -132,7 +133,7 @@ Golang tightly couples source code with versioning (major versions beyond v1 lea
 
 ### Do more frequent Lotus releases mean a change to network upgrade schedules?
 
-No. The starting-in-2024Q3 goal of more frequent (every 4 weeks) Lotus releases does not mean that there will be changes in the network upgrade schedule. At least as of 202408, the current cadence of Filecoin network upgrades is ~3 per year. We expect to usually uphold a 2 weeks upgrade time between a Lotus release candidate and a network upgrade on the Calibration network, and a 3 week upgrade time for a network upgrade on the Mainnet.
+No. The goal of more frequent weekly Lotus Node releases does not mean that there will be changes in the network upgrade schedule. At least as of 202408, the current cadence of Filecoin network upgrades is ~3 per year. We expect to usually uphold a 2 weeks upgrade time between a Lotus release candidate and a network upgrade on the Calibration network, and a 3 week upgrade time for a network upgrade on the Mainnet.
 
 ### How often do exchanges and key stakeholders need to upgrade?
 

--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -48,5 +48,10 @@ List Lotus Node and Lotus Miner version information with JSON formatted output:
 
 Create a new release issue from a template:
 ```sh
-./release create-issue --type node --tag 1.30.1 --level patch --network-upgrade --discussion-link https://github.com/filecoin-project/lotus/discussions/12010 --changelog-link https://github.com/filecoin-project/lotus/blob/v1.30.1/CHANGELOG.md --rc1-date 2023-04-01 --rc1-precision day --rc1-confidence confirmed --stable-date 2023-05-01 --stable-precision week --stable-confidence estimated
+./release create-issue --type node --tag 1.30.1 --level patch --release-flow auto --stable-date 2023-05-01
+```
+
+Create a network-upgrade release issue with RC mode:
+```sh
+./release create-issue --type node --tag 1.31.0 --level minor --release-flow auto --network-upgrade 25 --discussion-link https://github.com/filecoin-project/lotus/discussions/12010 --changelog-link https://github.com/filecoin-project/lotus/blob/v1.31.0/CHANGELOG.md --rc1-date 2023-04-01 --stable-date 2023-05-01
 ```

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -132,6 +132,12 @@ func getProject(name, version string) project {
 
 const releaseDateStringPattern = `^(Week of )?\d{4}-\d{2}-\d{2}( \(estimate\))?$`
 
+const (
+	releaseFlowAuto = "auto"
+	releaseFlowRC   = "rc"
+	releaseFlowNoRC = "no-rc"
+)
+
 func main() {
 	app := &cli.App{
 		Name:  "release",
@@ -213,6 +219,12 @@ func main() {
 						Required: false,
 					},
 					&cli.StringFlag{
+						Name:     "release-flow",
+						Usage:    "Which release flow should the issue use? (Options: auto, rc, no-rc). auto uses rc for network upgrades and no-rc otherwise.",
+						Value:    releaseFlowAuto,
+						Required: false,
+					},
+					&cli.StringFlag{
 						Name:     "rc1-date",
 						Usage:    fmt.Sprintf("What's the expected shipping date for RC1? (Pattern: '%s'))", releaseDateStringPattern),
 						Value:    "TBD",
@@ -275,6 +287,24 @@ func main() {
 						}
 					}
 
+					requestedReleaseFlow := c.String("release-flow")
+					switch requestedReleaseFlow {
+					case releaseFlowAuto, releaseFlowRC, releaseFlowNoRC:
+					default:
+						return fmt.Errorf("invalid value for the 'release-flow' flag. Allowed values are 'auto', 'rc', and 'no-rc'")
+					}
+					releaseFlow := requestedReleaseFlow
+					if releaseFlow == releaseFlowAuto {
+						if networkUpgrade != "" {
+							releaseFlow = releaseFlowRC
+						} else {
+							releaseFlow = releaseFlowNoRC
+						}
+					}
+					if releaseFlow == releaseFlowNoRC && networkUpgrade != "" {
+						return fmt.Errorf("invalid value for the 'release-flow' flag. no-rc releases are not allowed for network upgrades; use 'auto' or 'rc'")
+					}
+
 					changelogLink := c.String("changelog-link")
 					if changelogLink != "" {
 						_, err := url.ParseRequestURI(changelogLink)
@@ -286,7 +316,9 @@ func main() {
 					releaseDateStringRegexp := regexp.MustCompile(releaseDateStringPattern)
 
 					rc1Date := c.String("rc1-date")
-					if rc1Date != "TBD" {
+					if releaseFlow == releaseFlowNoRC {
+						rc1Date = "n/a"
+					} else if rc1Date != "TBD" {
 						matches := releaseDateStringRegexp.FindStringSubmatch(rc1Date)
 						if matches == nil {
 							return fmt.Errorf("rc1-date must be of form %s", releaseDateStringPattern)
@@ -310,6 +342,15 @@ func main() {
 					repoOwner := matches[1]
 					repoName := matches[2]
 
+					firstReleaseTarget := "Stable Release"
+					rcCandidates := []string{}
+					releaseTargets := []string{"Stable Release"}
+					if releaseFlow == releaseFlowRC {
+						firstReleaseTarget = "rc1"
+						rcCandidates = []string{"rc1", "rcX"}
+						releaseTargets = []string{"rc1", "rcX", "Stable Release"}
+					}
+
 					// Prepare template data
 					data := map[string]any{
 						"ContentGeneratedWithLotusReleaseCli": true,
@@ -318,6 +359,13 @@ func main() {
 						"Tag":                                 releaseVersion.String(),
 						"NextTag":                             releaseVersion.IncPatch().String(),
 						"Level":                               releaseLevel,
+						"RequestedReleaseFlow":                requestedReleaseFlow,
+						"ReleaseFlow":                         releaseFlow,
+						"NoRCRelease":                         releaseFlow == releaseFlowNoRC,
+						"RCRelease":                           releaseFlow == releaseFlowRC,
+						"FirstReleaseTarget":                  firstReleaseTarget,
+						"RCCandidates":                        rcCandidates,
+						"ReleaseTargets":                      releaseTargets,
 						"NetworkUpgrade":                      networkUpgrade,
 						"NetworkUpgradeDiscussionLink":        discussionLink,
 						"NetworkUpgradeChangelogEntryLink":    changelogLink,
@@ -348,7 +396,7 @@ func main() {
 					}
 					issueBody := issueBodyBuffer.String()
 
-					// Remove duplicate newlines before headers and list items since the templating leaves a lot extra newlines around.
+					// Remove duplicate newlines before headers, list items, and table rows since the templating leaves a lot extra newlines around.
 					// Extra newlines are present because go formatting control statements are done within HTML comments rather than using {{- -}}.
 					// HTML comments are used instead so that the template file parses as clean markdown on its own.
 					// In addition, HTML comments were also required within "ranges" in the template.
@@ -356,7 +404,7 @@ func main() {
 					// The one exception is after `</summary>` tags.  In that case we preserve the newlines,
 					// as without newlines the section doesn't do markdown formatting on GitHub.
 					// Since Go regexp doesn't support negative lookbehind, we just look for any non ">".
-					re := regexp.MustCompile(`([^>])\n\n+([^#*\[\|])`)
+					re := regexp.MustCompile(`([^>])\n\n+([^#*\[])`)
 					issueBody = re.ReplaceAllString(issueBody, "$1\n$2")
 
 					if !createOnGitHub {

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -226,7 +226,7 @@ func main() {
 					},
 					&cli.StringFlag{
 						Name:     "rc1-date",
-						Usage:    fmt.Sprintf("What's the expected shipping date for RC1? (Pattern: '%s'))", releaseDateStringPattern),
+						Usage:    fmt.Sprintf("What's the expected shipping date for RC1? (Pattern: '%s')", releaseDateStringPattern),
 						Value:    "TBD",
 						Required: false,
 					},
@@ -396,7 +396,7 @@ func main() {
 					}
 					issueBody := issueBodyBuffer.String()
 
-					// Remove duplicate newlines before headers, list items, and table rows since the templating leaves a lot extra newlines around.
+					// Collapse duplicate newlines in generated prose and table rows while preserving spacing before headers and list items.
 					// Extra newlines are present because go formatting control statements are done within HTML comments rather than using {{- -}}.
 					// HTML comments are used instead so that the template file parses as clean markdown on its own.
 					// In addition, HTML comments were also required within "ranges" in the template.

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -343,11 +343,9 @@ func main() {
 					repoName := matches[2]
 
 					firstReleaseTarget := "Stable Release"
-					rcCandidates := []string{}
 					releaseTargets := []string{"Stable Release"}
 					if releaseFlow == releaseFlowRC {
 						firstReleaseTarget = "rc1"
-						rcCandidates = []string{"rc1", "rcX"}
 						releaseTargets = []string{"rc1", "rcX", "Stable Release"}
 					}
 
@@ -364,7 +362,6 @@ func main() {
 						"NoRCRelease":                         releaseFlow == releaseFlowNoRC,
 						"RCRelease":                           releaseFlow == releaseFlowRC,
 						"FirstReleaseTarget":                  firstReleaseTarget,
-						"RCCandidates":                        rcCandidates,
 						"ReleaseTargets":                      releaseTargets,
 						"NetworkUpgrade":                      networkUpgrade,
 						"NetworkUpgradeDiscussionLink":        discussionLink,

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -3,11 +3,11 @@
 [//]: # (This content was generated using `{{.LotusReleaseCliString}}`.)
 [//]: # (Learn more at https://github.com/filecoin-project/lotus/tree/master/cmd/release#readme.)
 <!--{{end}}-->
-[//]: # (❗️ Complete the steps below as part of creating a release issue and mark them complete with an X or ✅ when done.)
+[//]: # (Complete the steps below as part of creating a release issue and mark them complete with an X or checkmark when done.)
 [//]: # (Agent/operator guide for completing this release issue:)
 [//]: # (1. Treat this issue as the mutable release ledger. Edit it for concrete release progress: links, checked boxes, dates, release URLs, CI/release status, announcement comment links, and short release-specific facts.)
-[//]: # (2. Put process/template improvements in the release-template-improvements PR from Before RC1, not directly in this issue.)
-[//]: # (3. Work top-to-bottom. Do not start RC release PR work until Dependencies for releases/rc1 has either linked blockers or an explicit "No additional dependencies" entry and the dependency checkpoint is complete.)
+[//]: # (2. Put process/template improvements in the release-template-improvements PR from Release Setup, not directly in this issue.)
+[//]: # (3. Work top-to-bottom. Do not start release PR work for a target until its Dependencies for releases section has linked blockers or an explicit "No additional dependencies" entry and the dependency checkpoint is complete.)
 [//]: # (4. For regular releases, create release branches from origin/master after dependencies are resolved. For critical security patches, follow the visible release/vX.Y.x guidance.)
 [//]: # (5. Keep the release issue and linked PRs synchronized as each step completes.)
 <!--{{if not .ContentGeneratedWithLotusReleaseCli}}-->
@@ -21,40 +21,41 @@
 <!-- At least as of 2025-03-20, it isn't possible to programmatically pin issues. -->
 [//]: # ([ ] Pin the issue on GitHub)
 
-# 😶‍🌫 Meta
-* Type: {{.Type}} 
+# Meta
+* Type: {{.Type}}
 * Level: {{.Level}}
+* Release flow: {{.ReleaseFlow}}<!--{{if ne .RequestedReleaseFlow .ReleaseFlow}}--> (resolved from {{.RequestedReleaseFlow}})<!--{{end}}-->
 * Related network upgrade version: <!--{{if not .NetworkUpgrade}}-->n/a<!--{{else}}-->nv{{.NetworkUpgrade}}
    * Scope, dates, and epochs: {{.NetworkUpgradeDiscussionLink}}
    * Lotus changelog with Lotus specifics: {{.NetworkUpgradeChangelogEntryLink}}
 <!--{{end}}-->
 
-# 🚢 Estimated shipping date
+# Estimated shipping date
 
 [//]: # (If/when we know an exact date, remove the "week of".)
 [//]: # (If a date week is an estimate, annotate with "estimate".)
 
 | Candidate | Expected Release Date | Release URL |
 |-----------|-----------------------|-------------|
+<!--{{if .RCRelease}}-->
 | RC1 | {{.RC1DateString}} | |
-| Stable (non-RC) | {{.StableDateString}} | |
+<!--{{end}}-->
+| Stable Release | {{.StableDateString}} | |
 
-# 🪢 Dependencies for releases
+# Dependencies for releases
 > [!NOTE]
-> 1. This is the set of changes that need to make it in for a given RC.  This is effectively the set of changes to cherry-pick from master.
+> 1. This is the set of changes that need to make it in for a given release target.
 > 2. They can be checked as done once they land in `master`.
-> 3. They are presented here for quick reference, but backporting is tracked in each `Release Checklist`.
+> 3. They are presented here for quick reference, but backporting is tracked in the corresponding release checklist.
 
-<!--{{/* Sprig is used for defining a list per https://stackoverflow.com/a/57959333 */}}-->
-<!--{{$rcVersions := list "rc1" "rcX" "Stable Release (non-RC)"}}-->
-<!--{{range $rc := $rcVersions}}-->
-## {{$rc}}
-- [ ] Add linked PRs/issues for changes that must land before {{$rc}}, or write "No additional dependencies for {{$rc}}" and mark the corresponding dependency checkpoint complete when confirmed.
+<!--{{range $target := .ReleaseTargets}}-->
+## {{$target}}
+- [ ] Add linked PRs/issues for changes that must land before {{$target}}, or write "No additional dependencies for {{$target}}" and mark the corresponding dependency checkpoint complete when confirmed.
 
 <!--{{end}}-->
-# ✅ Release Checklist
+# Release Checklist
 
-## ⬅️  Before RC1
+## Release Setup
 <details open>
   <summary>Section</summary>
 
@@ -66,11 +67,11 @@
    - Link to PR:
    - Open this as a draft PR and use it to collect release-process improvements discovered while running this checklist.
    - Suggested branch: `docs/release-v{{.Tag}}-template-improvements`
-   - This will get merged in a `Post Release` step.
-<!--{{if eq .Level "patch"}})-->
+   - This will get merged in a `Post-Release` step.
+<!--{{if eq .Level "patch"}}-->
 <!--  {{if contains "Node" .Type}}-->
 - [ ] Fork a new `release/v{{.Tag}}` branch from the `master` branch and make any further release-related changes to this branch.
-   - For regular releases, use `origin/master` after confirming every rc1 dependency above has landed.
+   - For regular releases, use `origin/master` after confirming every {{.FirstReleaseTarget}} dependency above has landed.
    - Suggested commands:
       ```sh
       git fetch origin master --tags
@@ -81,7 +82,7 @@
 <!--  {{end}}-->
 <!--  {{if contains "Miner" .Type}}-->
 - [ ] Fork a new `release/miner/v{{.Tag}}` branch from the `master` branch and make any further release-related changes to this branch.
-   - For regular releases, use `origin/master` after confirming every rc1 dependency above has landed.
+   - For regular releases, use `origin/master` after confirming every {{.FirstReleaseTarget}} dependency above has landed.
    - Suggested commands:
       ```sh
       git fetch origin master --tags
@@ -94,6 +95,7 @@
 <!--{{if eq .Level "minor"}}-->
 <!--  {{if contains "Node" .Type}}-->
 - [ ] Fork a new `release/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
+   - For regular releases, use `origin/master` after confirming every {{.FirstReleaseTarget}} dependency above has landed.
    - Suggested commands:
       ```sh
       git fetch origin master --tags
@@ -103,6 +105,7 @@
 <!--  {{end}}-->
 <!--  {{if contains "Miner" .Type}}-->
 - [ ] Fork a new `release/miner/v{{.Tag}}` branch from `master` and make any further release-related changes to this branch.
+   - For regular releases, use `origin/master` after confirming every {{.FirstReleaseTarget}} dependency above has landed.
    - Suggested commands:
       ```sh
       git fetch origin master --tags
@@ -112,8 +115,8 @@
 <!--  {{end}}-->
 <!--{{end}}-->
 <!--{{if ne .Level "patch"}}-->
-- `master` branch Version string updates
-   - [ ] bump the version(s) in `build/version.go` to `v{{.NextTag}}-dev`.
+- `master` branch version string updates
+   - [ ] Bump the version(s) in `build/version.go` to `v{{.NextTag}}-dev`.
 <!--{{  if contains "Node" .Type}}-->
       - Ensure to update `NodeBuildVersion`
 <!--{{  end}}-->
@@ -131,19 +134,30 @@
 <!--{{end}}-->
 </details>
 
-## 🏎️  RCs
+## RCs
+<!--{{if .NoRCRelease}}-->
+<details open>
+  <summary>Section</summary>
 
-<!--{{range $rc := $rcVersions}}-->
-<!--  {{$tagSuffix := ""}}-->
-<!--  {{if contains "rc" $rc}}-->
-<!--    {{$tagSuffix = printf "-%s" $rc}}-->
-<!--  {{end}}-->
+- Skipped. This release issue uses the no-RC flow for a release with no related network upgrade.
+- If release-owner review finds risk that needs soak time, regenerate or edit this issue with `--release-flow=rc`.
+
+</details>
+<!--{{else}}-->
+<!--{{range $rc := .RCCandidates}}-->
+<!--  {{$tagSuffix := printf "-%s" $rc}}-->
 ### {{$rc}}
 <details>
   <summary>Section</summary>
 
 > [!IMPORTANT]
-> These PRs should be done in and target the `release/v{{$.Tag}}` or `release/miner/v{{$.Tag}}` branch.
+> These PRs should be done in and target the relevant release branch for this issue.
+<!--  {{if contains "Node" $.Type}}-->
+> Node branch: `release/v{{$.Tag}}`
+<!--  {{end}}-->
+<!--  {{if contains "Miner" $.Type}}-->
+> Miner branch: `release/miner/v{{$.Tag}}`
+<!--  {{end}}-->
 
 #### Backport PR for {{$rc}}
 - [ ] All explicitly tracked items from `Dependencies for releases` have landed
@@ -182,12 +196,8 @@
 <!--  {{end}}-->
    - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
 <!--  {{if ne $.NetworkUpgrade ""}}-->
-<!--    {{if contains "rc" $rc}}-->
    - [ ] (network upgrade) Specify whether the Calibration or Mainnet upgrade epoch has been specified or not yet.
       - Example where these weren't specified yet: [PR #12169](https://github.com/filecoin-project/lotus/pull/12169)
-<!--    {{else}}-->
-   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
-<!--    {{end}}-->
 <!--  {{end}}-->
    - [ ] Ensure no missing content when spot checking git history
       - Find the previous stable tag first:
@@ -204,35 +214,128 @@
 - [ ] Mark the PR "ready for review" (non-draft)
 - [ ] Merge the PR
    - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
- - [ ] Update `🚢 Estimated shipping date` table
- - [ ] Comment on this issue announcing the release:
-    - Link to issue comment:
+- [ ] Update `Estimated shipping date` table
+- [ ] Comment on this issue announcing the release:
+   - Link to issue comment:
 
 #### Testing for {{$rc}}
 
 > [!NOTE]
-> Link to any special steps for testing releases beyond ensuring CI is green.  Steps can be inlined here or tracked elsewhere.
+> Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
 
 </details>
 <!--{{end}}-->
+<!--{{end}}-->
 
-## ➡ Post-Release
+## Stable Release
+<details{{if .NoRCRelease}} open{{end}}>
+  <summary>Section</summary>
+
+> [!IMPORTANT]
+> These PRs should be done in and target the relevant release branch for this issue.
+<!--{{if contains "Node" .Type}}-->
+> Node branch: `release/v{{.Tag}}`
+<!--{{end}}-->
+<!--{{if contains "Miner" .Type}}-->
+> Miner branch: `release/miner/v{{.Tag}}`
+<!--{{end}}-->
+
+#### Backport PR for Stable Release
+- [ ] All explicitly tracked items from `Dependencies for releases` have landed
+- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
+   - Deferred items:
+<!--{{if .NoRCRelease}}-->
+- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
+<!--{{else}}-->
+- [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
+- [ ] Create a PR with title `build: backport changes for {{.Type}} v{{.Tag}}`
+   - Link to PR:
+- [ ] Merge PR
+- [ ] Remove the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
+<!--{{end}}-->
+
+#### Release PR for Stable Release
+- [ ] Update the version string(s) in `build/version.go` to `{{.Tag}}` (without a leading `v`).
+<!--{{if contains "Node" .Type}}-->
+    - Change `NodeBuildVersion` to `{{.Tag}}`
+<!--{{end}}-->
+<!--{{if contains "Miner" .Type}}-->
+    - Change `MinerBuildVersion` to `{{.Tag}}`
+<!--{{end}}-->
+    - The release tags include the leading `v`; the values in `build/version.go` do not.
+<!--{{if and (contains "Node" .Type) (contains "Miner" .Type)}}-->
+    - If the release branches still point at the same commit, one PR that updates both version strings is expected. If the branches diverge later, add/link one PR per branch here.
+<!--{{end}}-->
+- [ ] Run `make gen && make docsgen-cli` to generate documentation
+- [ ] Create a draft PR with title `build: release Lotus {{.Type}} v{{.Tag}}`
+   - Link to PR:
+   - Opening a PR will trigger a CI run that will build assets, create a draft GitHub release, and attach the assets.
+- [ ] Changelog prep
+   - [ ] After the draft release exists, copy the auto-generated release notes into the CHANGELOG.
+      - Note: after a draft release exists, rerunning the [release workflow](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L220-L229) preserves the existing draft release body. If editorial review changes release-note content in CHANGELOG, update the draft GitHub release body too before merge; the [push-triggered publish step](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L307-L308) publishes that draft body.
+<!--{{if contains "Node" .Type}}-->
+      - Node release body: `gh release view v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
+<!--{{end}}-->
+<!--{{if contains "Miner" .Type}}-->
+      - Miner release body: `gh release view miner/v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
+<!--{{end}}-->
+   - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
+<!--{{if ne .NetworkUpgrade ""}}-->
+   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
+<!--{{end}}-->
+   - [ ] Ensure no missing content when spot checking git history
+      - Find the previous stable tag first:
+<!--{{if contains "Node" .Type}}-->
+         - Node: `git tag -l 'v*' | grep -v '-' | sort -V -r | head -n 1`
+<!--{{end}}-->
+<!--{{if contains "Miner" .Type}}-->
+         - Miner: `git tag -l 'miner/v*' | grep -v '-' | sort -V -r | head -n 1`
+<!--{{end}}-->
+      - Example command looking at git commits: `git log --oneline --graph PREVIOUS_TAG..HEAD`
+      - Example GitHub UI search looking at merged PRs into master, where `YYYY-MM-DD` is the previous stable release publish date: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
+      - Example `gh` cli command looking at merged PRs into master and sorted by title to group similar areas: `gh pr list --repo filecoin-project/lotus --search "base:master merged:>YYYY-MM-DD" --json number,mergedAt,author,title | jq -r '.[] | [.number, .mergedAt, .author.login, .title] | @tsv' | sort -k4`
+   - [ ] Review and update the draft GitHub release body so it matches the CHANGELOG.
+   - [ ] Update the PR with the commit(s) made to the CHANGELOG
+- [ ] Confirm the release PR CI is green, including release asset generation.
+- [ ] Confirm the release owner approves publishing this stable release.
+- [ ] Confirm any security-advisory staging needed for this release has an owner and follows [policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy).
+- [ ] Mark the PR "ready for review" (non-draft)
+- [ ] Merge the PR
+   - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
+- [ ] Update `Estimated shipping date` table
+- [ ] Comment on this issue announcing the release:
+   - Link to issue comment:
+
+#### Testing for Stable Release
+
+> [!NOTE]
+> Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
+
+</details>
+
+## Post-Release
 <details>
   <summary>Section</summary>
 
-- [ ] Open a PR against `master` cherry-picking the CHANGELOG commits from the `release/v{{.Tag}}` branch. Title it `chore(release): cherry-pick v{{.Tag}} changelog back to master`
+- [ ] Open a PR against `master` cherry-picking the CHANGELOG commits from the release branch. Title it `chore(release): cherry-pick v{{.Tag}} changelog back to master`
    - Link to PR:
+<!--{{if contains "Node" .Type}}-->
+   - Node source branch: `release/v{{.Tag}}`
+<!--{{end}}-->
+<!--{{if contains "Miner" .Type}}-->
+   - Miner source branch: `release/miner/v{{.Tag}}`
+<!--{{end}}-->
    - Assuming we followed [the process of merging changes into `master` first before backporting to the release branch](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#branch-and-tag-strategy), the only changes should be CHANGELOG updates.
-- [ ] Finish updating/merging the [RELEASE_ISSUE_TEMPLATE.md](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/RELEASE_ISSUE_TEMPLATE.md) PR from `Before RC1` with any improvements determined from this latest release iteration.
+- [ ] Finish updating/merging the [RELEASE_ISSUE_TEMPLATE.md](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/RELEASE_ISSUE_TEMPLATE.md) PR from `Release Setup` with any improvements determined from this latest release iteration.
 - [ ] Review and approve the auto-generated PR in [lotus-docs](https://github.com/filecoin-project/lotus-docs/pulls) that updates the latest Lotus version information.
 - [ ] Review and approve the auto-generated PR in [homebrew-lotus](https://github.com/filecoin-project/homebrew-lotus/pulls) that updates the homebrew to the latest Lotus version.
 - [ ] Stage any security advisories for future publishing per [policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy).
 </details>
 
-# ❤️ Contributors
+# Contributors
 
 See the final release notes!
 
-# ⁉️ Do you have questions?
+# Do you have questions?
 
 Leave a comment in this ticket!

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -32,7 +32,7 @@
 
 # Estimated shipping date
 
-[//]: # (If/when we know an exact date, remove the "week of".)
+[//]: # (If/when we know an exact date, remove the "Week of " prefix.)
 [//]: # (If a date week is an estimate, annotate with "estimate".)
 
 | Candidate | Expected Release Date | Release URL |

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -167,14 +167,14 @@
 > Miner branch: `release/miner/v{{$.Tag}}`
 <!--  {{end}}-->
 
-#### Backport PR for {{$target}}
+#### Release blockers and backports for {{$target}}
 - [ ] All explicitly tracked items from `Dependencies for releases` have landed
 <!--  {{if $stable}}-->
-- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
+- [ ] Account for every unresolved `release/backport` item: included in this release, intentionally deferred and linked below, or no longer a blocker.
    - Deferred items:
 <!--  {{end}}-->
 <!--  {{if and $stable $.NoRCRelease}}-->
-- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
+- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after all included dependencies landed.
 <!--  {{else if ne $target "rc1"}}-->
 - [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
 - [ ] Create a PR with title `build: backport changes for {{$.Type}} v{{$.Tag}}{{$tagSuffix}}`

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -143,12 +143,20 @@
 - If release-owner review finds risk that needs soak time, regenerate or edit this issue with `--release-flow=rc`.
 
 </details>
-<!--{{else}}-->
-<!--{{range $rc := .RCCandidates}}-->
-<!--  {{$tagSuffix := printf "-%s" $rc}}-->
-### {{$rc}}
+<!--{{end}}-->
+<!--{{range $target := .ReleaseTargets}}-->
+<!--  {{$stable := eq $target "Stable Release"}}-->
+<!--  {{$tagSuffix := ""}}-->
+<!--  {{if not $stable}}{{$tagSuffix = printf "-%s" $target}}{{end}}-->
+<!--  {{if $stable}}-->
+## Stable Release
+<details{{if $.NoRCRelease}} open{{end}}>
+  <summary>Section</summary>
+<!--  {{else}}-->
+### {{$target}}
 <details>
   <summary>Section</summary>
+<!--  {{end}}-->
 
 > [!IMPORTANT]
 > These PRs should be done in and target the relevant release branch for this issue.
@@ -159,9 +167,15 @@
 > Miner branch: `release/miner/v{{$.Tag}}`
 <!--  {{end}}-->
 
-#### Backport PR for {{$rc}}
+#### Backport PR for {{$target}}
 - [ ] All explicitly tracked items from `Dependencies for releases` have landed
-<!--  {{if ne $rc "rc1"}}-->
+<!--  {{if $stable}}-->
+- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
+   - Deferred items:
+<!--  {{end}}-->
+<!--  {{if and $stable $.NoRCRelease}}-->
+- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
+<!--  {{else if ne $target "rc1"}}-->
 - [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
 - [ ] Create a PR with title `build: backport changes for {{$.Type}} v{{$.Tag}}{{$tagSuffix}}`
    - Link to PR:
@@ -169,7 +183,7 @@
 - [ ] Remove the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
 <!--  {{end}}-->
 
-#### Release PR for {{$rc}}
+#### Release PR for {{$target}}
 - [ ] Update the version string(s) in `build/version.go` to `{{$.Tag}}{{$tagSuffix}}` (without a leading `v`).
 <!--  {{if contains "Node" $.Type}}-->
     - Change `NodeBuildVersion` to `{{$.Tag}}{{$tagSuffix}}`
@@ -196,8 +210,12 @@
 <!--  {{end}}-->
    - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
 <!--  {{if ne $.NetworkUpgrade ""}}-->
+<!--    {{if $stable}}-->
+   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
+<!--    {{else}}-->
    - [ ] (network upgrade) Specify whether the Calibration or Mainnet upgrade epoch has been specified or not yet.
       - Example where these weren't specified yet: [PR #12169](https://github.com/filecoin-project/lotus/pull/12169)
+<!--    {{end}}-->
 <!--  {{end}}-->
    - [ ] Ensure no missing content when spot checking git history
       - Find the previous stable tag first:
@@ -210,95 +228,15 @@
       - Example command looking at git commits: `git log --oneline --graph PREVIOUS_TAG..HEAD`
       - Example GitHub UI search looking at merged PRs into master, where `YYYY-MM-DD` is the previous stable release publish date: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
       - Example `gh` cli command looking at merged PRs into master and sorted by title to group similar areas: `gh pr list --repo filecoin-project/lotus --search "base:master merged:>YYYY-MM-DD" --json number,mergedAt,author,title | jq -r '.[] | [.number, .mergedAt, .author.login, .title] | @tsv' | sort -k4`
-    - [ ] Update the PR with the commit(s) made to the CHANGELOG
-- [ ] Mark the PR "ready for review" (non-draft)
-- [ ] Merge the PR
-   - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
-- [ ] Update `Estimated shipping date` table
-- [ ] Comment on this issue announcing the release:
-   - Link to issue comment:
-
-#### Testing for {{$rc}}
-
-> [!NOTE]
-> Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
-
-</details>
-<!--{{end}}-->
-<!--{{end}}-->
-
-## Stable Release
-<details{{if .NoRCRelease}} open{{end}}>
-  <summary>Section</summary>
-
-> [!IMPORTANT]
-> These PRs should be done in and target the relevant release branch for this issue.
-<!--{{if contains "Node" .Type}}-->
-> Node branch: `release/v{{.Tag}}`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-> Miner branch: `release/miner/v{{.Tag}}`
-<!--{{end}}-->
-
-#### Backport PR for Stable Release
-- [ ] All explicitly tracked items from `Dependencies for releases` have landed
-- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
-   - Deferred items:
-<!--{{if .NoRCRelease}}-->
-- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
-<!--{{else}}-->
-- [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
-- [ ] Create a PR with title `build: backport changes for {{.Type}} v{{.Tag}}`
-   - Link to PR:
-- [ ] Merge PR
-- [ ] Remove the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
-<!--{{end}}-->
-
-#### Release PR for Stable Release
-- [ ] Update the version string(s) in `build/version.go` to `{{.Tag}}` (without a leading `v`).
-<!--{{if contains "Node" .Type}}-->
-    - Change `NodeBuildVersion` to `{{.Tag}}`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-    - Change `MinerBuildVersion` to `{{.Tag}}`
-<!--{{end}}-->
-    - The release tags include the leading `v`; the values in `build/version.go` do not.
-<!--{{if and (contains "Node" .Type) (contains "Miner" .Type)}}-->
-    - If the release branches still point at the same commit, one PR that updates both version strings is expected. If the branches diverge later, add/link one PR per branch here.
-<!--{{end}}-->
-- [ ] Run `make gen && make docsgen-cli` to generate documentation
-- [ ] Create a draft PR with title `build: release Lotus {{.Type}} v{{.Tag}}`
-   - Link to PR:
-   - Opening a PR will trigger a CI run that will build assets, create a draft GitHub release, and attach the assets.
-- [ ] Changelog prep
-   - [ ] After the draft release exists, copy the auto-generated release notes into the CHANGELOG.
-      - Note: after a draft release exists, rerunning the [release workflow](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L220-L229) preserves the existing draft release body. If editorial review changes release-note content in CHANGELOG, update the draft GitHub release body too before merge; the [push-triggered publish step](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L307-L308) publishes that draft body.
-<!--{{if contains "Node" .Type}}-->
-      - Node release body: `gh release view v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-      - Miner release body: `gh release view miner/v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
-<!--{{end}}-->
-   - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
-<!--{{if ne .NetworkUpgrade ""}}-->
-   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
-<!--{{end}}-->
-   - [ ] Ensure no missing content when spot checking git history
-      - Find the previous stable tag first:
-<!--{{if contains "Node" .Type}}-->
-         - Node: `git tag -l 'v*' | grep -v '-' | sort -V -r | head -n 1`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-         - Miner: `git tag -l 'miner/v*' | grep -v '-' | sort -V -r | head -n 1`
-<!--{{end}}-->
-      - Example command looking at git commits: `git log --oneline --graph PREVIOUS_TAG..HEAD`
-      - Example GitHub UI search looking at merged PRs into master, where `YYYY-MM-DD` is the previous stable release publish date: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
-      - Example `gh` cli command looking at merged PRs into master and sorted by title to group similar areas: `gh pr list --repo filecoin-project/lotus --search "base:master merged:>YYYY-MM-DD" --json number,mergedAt,author,title | jq -r '.[] | [.number, .mergedAt, .author.login, .title] | @tsv' | sort -k4`
+<!--  {{if $stable}}-->
    - [ ] Review and update the draft GitHub release body so it matches the CHANGELOG.
+<!--  {{end}}-->
    - [ ] Update the PR with the commit(s) made to the CHANGELOG
+<!--  {{if $stable}}-->
 - [ ] Confirm the release PR CI is green, including release asset generation.
 - [ ] Confirm the release owner approves publishing this stable release.
 - [ ] Confirm any security-advisory staging needed for this release has an owner and follows [policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy).
+<!--  {{end}}-->
 - [ ] Mark the PR "ready for review" (non-draft)
 - [ ] Merge the PR
    - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
@@ -306,13 +244,13 @@
 - [ ] Comment on this issue announcing the release:
    - Link to issue comment:
 
-#### Testing for Stable Release
+#### Testing for {{$target}}
 
 > [!NOTE]
 > Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
 
 </details>
-
+<!--{{end}}-->
 ## Post-Release
 <details>
   <summary>Section</summary>


### PR DESCRIPTION
## Summary

- Document weekly Lotus Node releases and the new RC policy in `LOTUS_RELEASE_FLOW.md`.
- Add `--release-flow` to `cmd/release create-issue` with `auto`, `rc`, and `no-rc` modes.
- Restructure generated release issues into `Release Setup -> RCs -> Stable Release -> Post-Release`.
- Keep the RC section present but explicitly skipped for no-RC releases, and add stable-release guardrails for CI, backport blockers, release-owner approval, release body review, and security-advisory staging.
- Update the create-release-issue workflow to pass `release-flow`, ignore `rc1-date` for no-RC releases, remove the stale `major` option, and fix the invalid `level` default.

## Validation

- `go test ./cmd/release`
- Generated a no-RC Node patch release issue with `--release-flow auto` and an intentionally invalid `--rc1-date`; confirmed it resolves to no-RC and ignores the RC date.
- Generated RC release issues with `--release-flow auto` for a network upgrade and `--release-flow rc` explicitly.
- Confirmed `--release-flow no-rc --network-upgrade 99` fails with the expected validation error.
- `git diff --check`

Relates to #13668.