### PR TITLE
fix(eth): resolve by-index transactions against post-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): resolve native Filecoin transaction recipients in `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` against the block post-state, matching `eth_getBlockByNumber` and `eth_getTransactionByHash` for transfers that create the recipient account ([filecoin-project/lotus#13699](https://github.com/filecoin-project/lotus/pull/13699))
 - fix(eth): return `ErrNullRound` for explicit null epochs in singleton block-execution ETH APIs. `eth_getBlockReceipts` / `EthGetBlockReceiptsLimited` now reject a null block number instead of returning receipts for the previous non-null tipset. State-at-epoch APIs such as `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`, `eth_estimateGas`, and `FilecoinAddressToEthAddress` continue to resolve null epochs to the previous non-null tipset because Filecoin state is defined at the null epoch and is unchanged from that previous state. Range/sampling APIs such as `eth_feeHistory` also continue to walk real tipsets and skip null epochs, including when resolving a null `newestBlock` anchor to the previous non-null tipset. ([filecoin-project/lotus#13694](https://github.com/filecoin-project/lotus/pull/13694))
 - fix(eth): return `null` from `eth_getTransactionByHash` and `eth_getTransactionReceipt` for transaction hashes that were replaced before execution, matching Ethereum replacement semantics ([filecoin-project/lotus#13664](https://github.com/filecoin-project/lotus/pull/13664))
 

--- a/itests/eth_hash_lookup_test.go
+++ b/itests/eth_hash_lookup_test.go
@@ -309,6 +309,18 @@ func TestTransactionHashLookupBlsFilecoinMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &toEth, chainTx.To)
 
+	blockHashTx, err := client.EthGetTransactionByBlockHashAndIndex(ctx, *chainTx.BlockHash, *chainTx.TransactionIndex)
+	require.NoError(t, err)
+	require.NotNil(t, blockHashTx)
+	require.Equal(t, hash, blockHashTx.Hash)
+	require.Equal(t, &toEth, blockHashTx.To)
+
+	blockNumberTx, err := client.EthGetTransactionByBlockNumberAndIndex(ctx, chainTx.BlockNumber.Hex(), *chainTx.TransactionIndex)
+	require.NoError(t, err)
+	require.NotNil(t, blockNumberTx)
+	require.Equal(t, hash, blockNumberTx.Hash)
+	require.Equal(t, &toEth, blockNumberTx.To)
+
 	const expectedHex = "868e10c4" +
 		"0000000000000000000000000000000000000000000000000000000000000000" +
 		"0000000000000000000000000000000000000000000000000000000000000000" +

--- a/node/impl/eth/transaction.go
+++ b/node/impl/eth/transaction.go
@@ -447,8 +447,15 @@ func (e *ethTransaction) getTransactionByTipsetAndIndex(ctx context.Context, ts 
 		return nil, xerrors.Errorf("failed to get tipset key cid: %w", err)
 	}
 
-	// First, get the state tree
-	st, err := e.stateManager.StateTree(ts.ParentState())
+	// Native-message EthTx conversion needs this tipset's post-state. Filecoin
+	// messages execute after ts.ParentState(); a transfer can create its
+	// recipient here, and parent state would resolve the receiver to the sentinel.
+	stateRoot, _, err := e.stateManager.TipSetState(ctx, ts)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to compute tipset state: %w", err)
+	}
+
+	st, err := e.stateManager.StateTree(stateRoot)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to load state tree: %w", err)
 	}


### PR DESCRIPTION
Use the queried tipset's post-state when converting native Filecoin messages for eth_getTransactionByBlock{Hash,Number}AndIndex.

State gets used for address lookup so we end up with sentinel values for new accounts.

Discovered by @LesnyRumcajs.