### PR TITLE
security(hello): gate outbound FetchTipSet on strictly-heavier peer weight

### DIFF
--- a/node/hello/hello.go
+++ b/node/hello/hello.go
@@ -126,6 +126,28 @@ func (hs *Service) HandleStream(s inet.Stream) {
 	// We're trying to fetch the tipset from the peer that just said hello to us. No point in
 	// triggering any dials.
 	ctx := network.WithNoDial(context.Background(), "fetching filecoin hello tipset")
+
+	// Before dispatching the outbound FetchTipSet, verify the peer's claimed
+	// tipset weight is strictly heavier than our local heaviest. Without this
+	// gate, any unauthenticated peer can pin a handler goroutine and one
+	// outbound-stream slot for the full FetchTipSet deadline by advertising an
+	// arbitrary HeaviestTipSetWeight. See
+	// https://gist.github.com/MattHintz/3f4a1a82ef60cea6ea2df0fc9751426d
+	ourHead := hs.cs.GetHeaviestTipSet()
+	ourWeight, werr := hs.cs.Weight(ctx, ourHead)
+	if werr != nil {
+		log.Debugw("hello: failed to compute local chain weight, skipping fetch",
+			"peer", s.Conn().RemotePeer(), "err", werr)
+		return
+	}
+	if !hmsg.HeaviestTipSetWeight.GreaterThan(ourWeight) {
+		log.Debugw("hello: peer weight not heavier than local, skipping fetch",
+			"peer", s.Conn().RemotePeer(),
+			"peer_weight", hmsg.HeaviestTipSetWeight,
+			"local_weight", ourWeight)
+		return
+	}
+
 	ts, err := hs.syncer.FetchTipSet(ctx, s.Conn().RemotePeer(), types.NewTipSetKey(hmsg.HeaviestTipSet...))
 	if err != nil {
 		log.Debugf("failed to fetch tipset from peer during hello: %+v", err)


### PR DESCRIPTION
## Summary

Gate the outbound `FetchTipSet` dispatched from the hello handler on the peer's advertised `HeaviestTipSetWeight` being strictly greater than the node's local chain weight. Without the gate any peer that can dial the node can pin one handler goroutine and one outbound-stream slot for the full `FetchTipSet` deadline (5 s) per hello, by advertising an arbitrary weight.

The gate uses the same `hs.cs.GetHeaviestTipSet()` + `hs.cs.Weight(ctx, ...)` primitives already used by `SayHello` in the same file, so this is a two-primitive local change with no new dependencies.

## Motivation and evidence

Full disclosure article, source-code audit, and 4-phase paired-control measurements are published in the following gist:

- https://gist.github.com/MattHintz/3f4a1a82ef60cea6ea2df0fc9751426d

Headline measurements on a mainnet-state Lotus `v1.36.0` daemon (Forest snapshot at height 6,049,680), 50 attacker peer IDs, no rcmgr rejections across ~5.77M attacker streams:

- 433× amplification on `ChainGetBlockMessages` p50 (1.46 ms baseline → 633 ms under attack)
- 1,905× amplification at p95 (2.07 ms → 3,944 ms)
- Peak RSS 170 GB on real mainnet chain state
- OOM-kill in 7 s under an 8 GB cgroup cap
- Chain-sync amplification exceeds the 30 s epoch budget; a recovering node under attack cannot catch up

Coordinated disclosure ran May 26 – July 6 2026 via Immunefi (reports #79973, #80341). The case closed under the program's Sybil-attacks exclusion clause, not on technical merits. The two code paths involved (`node/hello/hello.go` and `chain/exchange/server.go`) are unchanged at `v1.36.0` HEAD. This PR addresses the first of three fixes proposed in the disclosure article; the other two (per-peer hello concurrency cap; cost-aware chain-exchange throttle) will follow as separate PRs.

## What this PR does not do

This PR closes the hello arm of the compound attack. It does not close the chain-exchange arm on its own. A chain-exchange-server work-budget cap is required to fully close the amplification; that will be submitted as a separate change.

## Correctness

- The comparison uses `GreaterThan`, matching the existing pattern in `chain/sync_manager.go` (`isHeavier`, line 495) and `chain/sync.go`.
- The gate uses `!hmsg.HeaviestTipSetWeight.GreaterThan(ourWeight)` so equal weights are also skipped, matching the semantics of the existing `SayHello` weight-report path.
- If local weight computation fails, the handler returns early rather than dispatching an unbounded fetch — fail-closed on the error path.
- `ourHead` uses `hs.cs.GetHeaviestTipSet()` which is a cheap in-memory read against the chain store head; no additional I/O is introduced on the fast path.

## Backwards compatibility

No protocol wire changes. No changes to the `HelloMessage` struct or to `SayHello`. Legitimate peers that advertise heavier weight are unaffected. Peers that advertise equal-or-lighter weight now skip the outbound fetch on the receiving side — this matches what the receiving node would do anyway once `FetchTipSet` returned, because `InformNewHead` is only called when `ts.TipSet().Height() > 0` and the sync manager only advances on strictly-heavier weight.

## Alternatives considered

1. **Per-peer hello concurrency cap.** Complementary, submitted as a follow-up PR. Guards against races where the local chain weight briefly lags advertised weight from a legitimate peer during head advancement.
2. **libp2p resource-manager per-protocol cost weighting.** Correct systemic fix but requires upstream go-libp2p changes; out of scope for this PR.
3. **Peer-reputation gate before dispatch.** Would require a durable scoring store, which the hello handler intentionally avoids to preserve stateless behaviour.

## Testing

The disclosure gist includes:
- `measure_sync_stall.py` — measurement harness for `ChainGetBlockMessages` latency, CPU, RSS
- `run_refile_phases.sh` — 4-phase experiment orchestrator (P0 baseline, P1 legit-only, P2 sybil-only, P3 compound+legit)
- `isolated_config.toml` — isolated-daemon config

I would recommend maintainers reproduce phase P0 vs P3 against a mainnet-state daemon before and after this patch. The expected result with the patch applied: hello-arm handler goroutines no longer block on `FetchTipSet`, and the RSS/CPU/latency amplification collapses substantially. The chain-exchange arm remains until Fix 3 lands.

## Related

- Disclosure gist: https://gist.github.com/MattHintz/3f4a1a82ef60cea6ea2df0fc9751426d
- CWEs: CWE-405 (Asymmetric Resource Consumption), CWE-770 (Allocation of Resources Without Limits or Throttling), CWE-400 (Uncontrolled Resource Consumption)

Reported by [@MattHintz](https://github.com/MattHintz) (Immunefi handle: Venator).
