### PR TITLE
security(sub): promote deterministic-attacker mempool errors to ValidationReject

### DIFF
--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -359,6 +359,10 @@ func (mv *MessageValidator) Validate(ctx context.Context, pid peer.ID, msg *pubs
 		recordFailure(ctx, metrics.MessageValidationFailure, "add")
 		switch {
 
+		// Errors that arise from transient state disagreement between
+		// honest peers during reorgs or head advancement. Route to
+		// ValidationIgnore so peers with a stale head view do not accrue
+		// InvalidMessageDeliveries against them.
 		case errors.Is(err, messagepool.ErrSoftValidationFailure):
 			fallthrough
 		case errors.Is(err, messagepool.ErrRBFTooLowPremium):
@@ -367,15 +371,24 @@ func (mv *MessageValidator) Validate(ctx context.Context, pid peer.ID, msg *pubs
 			fallthrough
 		case errors.Is(err, messagepool.ErrNonceGap):
 			fallthrough
-		case errors.Is(err, messagepool.ErrGasFeeCapTooLow):
-			fallthrough
 		case errors.Is(err, messagepool.ErrNonceTooLow):
-			fallthrough
-		case errors.Is(err, messagepool.ErrNotEnoughFunds):
 			fallthrough
 		case errors.Is(err, messagepool.ErrExistingNonce):
 			return pubsub.ValidationIgnore
 
+		// Errors that a well-behaved peer would not gossip: the network
+		// minimum base fee and the sender's on-chain balance are both
+		// deterministically observable, so any peer forwarding a message
+		// that fails these checks is either malicious or catastrophically
+		// mis-configured. Route to ValidationReject so the -1000-weighted
+		// InvalidMessageDeliveriesWeight configured at
+		// node/modules/lp2p/pubsub.go actually engages. Prevents a peer
+		// from sustainably flooding the validator hot path (CBOR decode +
+		// state reads + optional sig verify) with zero peer-score cost.
+		case errors.Is(err, messagepool.ErrGasFeeCapTooLow):
+			fallthrough
+		case errors.Is(err, messagepool.ErrNotEnoughFunds):
+			fallthrough
 		case errors.Is(err, messagepool.ErrMessageTooBig):
 			fallthrough
 		case errors.Is(err, messagepool.ErrMessageValueTooHigh):


### PR DESCRIPTION
## Summary

The messages-topic pubsub validator (`MessageValidator.Validate` in `chain/sub/incoming.go`) routes eight classes of mempool validation error to `pubsub.ValidationIgnore`. In libp2p-pubsub semantics, `ValidationIgnore` does **not** increment the peer's `InvalidMessageDeliveries` counter, so the `-1000`-weighted `InvalidMessageDeliveriesWeight` configured for `MessagesTopic` at `node/modules/lp2p/pubsub.go:221` — with its documented design intent *"single invalid message is -100"* — never fires for these eight errors.

Two of the eight are attacker-deterministic:

- **`ErrGasFeeCapTooLow`** — the network minimum base fee is publicly observable and identical across all nodes at a given tipset. A message with `GasFeeCap < minimumBaseFee` is objectively invalid for anyone forwarding it.
- **`ErrNotEnoughFunds`** — the sender's on-chain balance is publicly observable against the tipset both peers share. A message that fails the balance check is not something a well-behaved peer would gossip.

An unauthenticated peer can therefore sustainably flood the messages topic and force every subscribed Lotus node through the full validator hot path — CBOR decode + `checkMessage` syntactic validation + `GasFeeCap` check (+ signature verify if the first two errors don't fire) — with zero peer-score cost. The documented `-1000` peer-score penalty is dead code for these two errors.

## What this PR does

Promotes `ErrGasFeeCapTooLow` and `ErrNotEnoughFunds` from the `ValidationIgnore` case to the `ValidationReject` case. Leaves all reorg-sensitive errors (`ErrSoftValidationFailure`, `ErrRBFTooLowPremium`, `ErrTooManyPendingMessages`, `ErrNonceGap`, `ErrNonceTooLow`, `ErrExistingNonce`) untouched so honest peers with a brief stale-head view during head advancement are not penalized.

Net change: 5 lines moved between two `switch` arms; comments added to document the design rationale for the split.

## Motivation and evidence

Full write-up, runnable PoC, measurement harness, and disclosure history are in the public gist:

- https://gist.github.com/MattHintz/f5b1d47642eee0a222be9e8bf624be83

The bug was originally reported to Immunefi as report #74372 on 2026-04-21. Filecoin closed it on 2026-05-01 as "known issue class" citing "a broader initiative underway to rework the concurrency model." Immunefi mediation closed on 2026-05-06 on PoC-compliance grounds (Go PoC cited as truncated; no recorded measurements).

**As of `filecoin-project/lotus@80a9830a` (2026-07-07), no upstream commits have touched the specific defect chain in the 10 weeks since closure:**

- `chain/sub/incoming.go`: only dep bumps and one queue-length change (#13176) since April 21; the `ValidationIgnore` switch is byte-identical to the April 21 version.
- `chain/messagepool/messagepool.go`: `MaxUntrustedActorPendingMessages` raised from 10 to 100 (#13636) — orthogonal to this bug. `pending snapshot` optimization (#13542) — reader-path, orthogonal.
- `node/modules/lp2p/pubsub.go`: no material change.
- `chain/sub/ratelimit/`: still zero import references across the entire repo (verified via GitHub code search).

I am publishing the completed runnable PoC and this minimal upstream patch now, 10 weeks after the closure, as a good-faith effort to close the specific bypass while the broader concurrency rework remains in-flight.

## Correctness

- The comparison uses the same `errors.Is(err, ...)` pattern already present in this switch statement; the two case arms are just moved between the `Ignore` and `Reject` branches.
- No new dependencies, no wire-format changes, no changes to the `MessagePool.Add` code path — the validator behavior on `ValidationAccept` is unchanged.
- False-positive risk on honest peers: **none for `ErrGasFeeCapTooLow`** (both peers compute `minimumBaseFee` against the same network parameters, deterministically). **Negligible for `ErrNotEnoughFunds`** (both peers compute balance against the same tipset via the same actor state; a legitimate peer would not gossip a message from an underfunded address). The reorg-sensitive errors remain in `ValidationIgnore`.

## What this PR does not close

- The `chain/sub/ratelimit/` package remains unwired. Wiring it into `MessageValidator.Validate` as a generous per-peer sliding-window cap would provide a second layer of defense against novel bypass paths and is orthogonal to this change.
- The deeper `addSema` capacity-1 serialization inside `chain/messagepool/messagepool.go:Add` is a separate concern. It can be exploited by an attacker willing to pay signature-verification cost per message (to pass `checkMessage` and reach the deeper `addTs` path where errors like `ErrExistingNonce` or `ErrTooManyPendingMessages` are thrown). That path is not fully closed by this PR; it is documented in the referenced gist and would be a natural follow-up if the "broader concurrency initiative" does not land it.

## Testing

The gist includes a compilable Go PoC (`attacker.go`, verified to build against `7db6708` and current HEAD) plus a shell harness that scrapes `MpoolAddDuration` and `MessageValidationDuration` histograms from the target's Prometheus endpoint. Expected results with the patch applied:

- Attacker publishing `ErrGasFeeCapTooLow`-inducing messages should observe their peer score decay past `GraylistThreshold` within seconds of the flood starting.
- Post-graylist, the attacker's mesh peering to the messages topic is dropped and the flood no longer reaches the validator hot path.
- Legitimate peers running through reorg-sensitive error paths (`ErrNonceGap`, `ErrExistingNonce`, etc.) continue to be `ValidationIgnore`d as before.

## Related

- Disclosure gist: https://gist.github.com/MattHintz/f5b1d47642eee0a222be9e8bf624be83
- Prior disclosure by same author (compound hello + chain-exchange amplification, published 2026-07-06): https://github.com/filecoin-project/lotus/pull/13701
- CWEs: CWE-405 (Asymmetric Resource Consumption), CWE-770 (Allocation of Resources Without Limits or Throttling)

Reported by [@MattHintz](https://github.com/MattHintz) (Immunefi handle: Venator).
