### PR TITLE
build: release Lotus Node v1.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,22 @@
 
 ## ⭐ New Features
 
+## 🐛 Bug Fixes
+
+## 👌 Improvements
+
+# Node v1.36.2 / 2026-07-24
+
+Lotus Node v1.36.2 is a recommended patch release focused on Ethereum RPC correctness and compatibility, `StateWaitMsg` confidence handling, dependency reliability, and operator tooling.
+
+## ☢️ Upgrade Warnings ☢️
+
+- Tracing configuration has changed: the deprecated Jaeger exporter has been replaced by an OTLP HTTP exporter. The `LOTUS_JAEGER_*` environment variables are no longer supported; configure `LOTUS_OTEL_EXPORTER_ENDPOINT` and `LOTUS_OTEL_EXPORTER_INSECURE` instead. ([filecoin-project/lotus#13533](https://github.com/filecoin-project/lotus/pull/13533))
+
+## ⭐ New Features
+
 - feat(lotus-shed): accept Ethereum transaction hashes in msg ([filecoin-project/lotus#13727](https://github.com/filecoin-project/lotus/pull/13727))
-- feat(cli): `lotus-miner actor settle-deal` now uses gas-aware adaptive batching — deal batches whose estimated gas would exceed a fraction of the block gas limit (tunable via `--max-gas-fraction`, default 1/4) are automatically split so no single `SettleDealPaymentsExported` message hogs block capacity ([filecoin-project/lotus#13471](https://github.com/filecoin-project/lotus/issues/13471))
+- feat(cli): `lotus-miner actor settle-deal` now uses gas-aware adaptive batching — deal batches whose estimated gas would exceed a fraction of the block gas limit (tunable via `--max-gas-fraction`, default 1/4) are automatically split so no single `SettleDealPaymentsExported` message hogs block capacity ([filecoin-project/lotus#13669](https://github.com/filecoin-project/lotus/pull/13669))
 
 ## 🐛 Bug Fixes
 
@@ -24,12 +38,41 @@
 - fix(eth): return `ErrNullRound` for explicit null epochs in singleton block-execution ETH APIs. `eth_getBlockReceipts` / `EthGetBlockReceiptsLimited` now reject a null block number instead of returning receipts for the previous non-null tipset. State-at-epoch APIs such as `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_call`, `eth_estimateGas`, and `FilecoinAddressToEthAddress` continue to resolve null epochs to the previous non-null tipset because Filecoin state is defined at the null epoch and is unchanged from that previous state. Range/sampling APIs such as `eth_feeHistory` also continue to walk real tipsets and skip null epochs, including when resolving a null `newestBlock` anchor to the previous non-null tipset. ([filecoin-project/lotus#13694](https://github.com/filecoin-project/lotus/pull/13694))
 - fix(eth): return `null` from `eth_getTransactionByHash` and `eth_getTransactionReceipt` for transaction hashes that were replaced before execution, matching Ethereum replacement semantics ([filecoin-project/lotus#13664](https://github.com/filecoin-project/lotus/pull/13664))
 - fix(eth): `eth_getLogs`, `eth_newFilter` and the `logs` variant of `eth_subscribe` now reject a filter that specifies more than 4 topic positions, matching the Ethereum JSON-RPC spec and go-ethereum. Previously the surplus positions were accepted but could never match an event (EVM logs carry at most `t1`..`t4`), so the filter silently returned no results while still adding one event-index join per position. ([filecoin-project/lotus#13676](https://github.com/filecoin-project/lotus/pull/13676))
+- fix(eth): reject malformed `EthNonce` JSON values that do not decode to exactly 8 bytes instead of panicking on short inputs or silently truncating long inputs. ([filecoin-project/lotus#13696](https://github.com/filecoin-project/lotus/pull/13696))
 
 ## 👌 Improvements
 
 - chore(deps): update `go-libp2p-pubsub` to v0.17.0. Lotus now uses the replacement outbound-stream trace events and the Google Protobuf size API. ([filecoin-project/lotus#13707](https://github.com/filecoin-project/lotus/pull/13707))
 - chore(deps): update libp2p networking dependencies. This includes libp2p's updated handling of unspecified listen addresses, so nodes listening on `0.0.0.0`/`::` may report or advertise concrete interface addresses returned by libp2p. ([filecoin-project/lotus#13588](https://github.com/filecoin-project/lotus/pull/13588))
-- refactor(tracing): replace deprecated `jaeger` exporter with OTLP HTTP exporter. The `LOTUS_JAEGER_*` environment variables have been replaced by `LOTUS_OTEL_EXPORTER_ENDPOINT` and `LOTUS_OTEL_EXPORTER_INSECURE`. ([filecoin-project/lotus#13533](https://github.com/filecoin-project/lotus/pull/13533))
+- chore(deps): update `go-jsonrpc` to v0.10.2 and `go-f3` to v0.8.14, including WebSocket ping handling, response/channel hardening, and delayed F3 bootstrap retry throttling. ([filecoin-project/lotus#13726](https://github.com/filecoin-project/lotus/pull/13726))
+- chore(bootstrap): use `/dnsaddr` for ChainSafe bootstrap peers to allow peer changes through DNS, and remove the inactive `fil.devtty.eu` peers. ([filecoin-project/lotus#13715](https://github.com/filecoin-project/lotus/pull/13715))
+
+## 📝 Changelog
+
+For the full set of changes since the last stable release:
+
+- Node: https://github.com/filecoin-project/lotus/compare/release/v1.36.1...release/v1.36.2
+
+## 👨‍👩‍👧‍👦 Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Rod Vagg | 17 | +2851/-1774 | 99 |
+| nijoe1 | 1 | +1277/-123 | 15 |
+| dependabot[bot] | 25 | +767/-340 | 50 |
+| Phi-rjan | 7 | +284/-299 | 21 |
+| ZenGround0 | 1 | +171/-366 | 17 |
+| Matt Van Horn | 1 | +246/-19 | 4 |
+| iyiola-dev | 1 | +89/-113 | 9 |
+| William Morriss | 1 | +114/-2 | 6 |
+| LexLuthr | 1 | +101/-6 | 3 |
+| Kaif | 2 | +59/-7 | 5 |
+| Linghao | 1 | +58/-0 | 3 |
+| Jakub Sztandera | 1 | +26/-10 | 2 |
+| Phi | 3 | +18/-16 | 15 |
+| Hubert | 1 | +2/-9 | 2 |
+| futurehua | 1 | +5/-5 | 5 |
+| web3-bot | 1 | +1/-1 | 1 |
 
 # Node and Miner v1.36.1 / 2026-06-30
 

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/v0/gateway.json
+++ b/build/openrpc/v0/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/v2/full.json
+++ b/build/openrpc/v2/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/v2/gateway.json
+++ b/build/openrpc/v2/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.2"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "v1.36.2-dev"
+const NodeBuildVersion string = "1.36.2"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -8,7 +8,7 @@ USAGE:
    lotus [global options] command [command options]
 
 VERSION:
-   v1.36.2-dev
+   1.36.2
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
## Summary

- set `NodeBuildVersion` to `1.36.2`
- regenerate OpenRPC specifications and Lotus CLI documentation
- add and editorially review the stable v1.36.2 changelog entry

## Why

Prepare the no-RC Lotus Node v1.36.2 patch release tracked in #13702. This PR targets the dedicated `release/v1.36.2` branch created from `origin/master` after all release dependencies landed.

## Impact

The Lotus Node reports the stable `1.36.2` version. `MinerBuildVersion` remains at `v1.36.2-dev` because this is a Node-only release.

The release notes call out the tracing configuration migration from `LOTUS_JAEGER_*` to `LOTUS_OTEL_EXPORTER_*` and include all user-facing changes found in the history audit.

## Validation

- `CGO_LDFLAGS=-L/opt/homebrew/lib make gen`
- `CGO_LDFLAGS=-L/opt/homebrew/lib make docsgen-cli`
- `CGO_LDFLAGS=-L/opt/homebrew/lib go test ./build ./cmd/release`
- `git diff --check`
- generated draft release and six archive/CID/SHA512 assets
- spot-checked `v1.36.1..origin/master` and merged PRs since the previous stable release
- final CI: 101 succeeded, 5 skipped, 0 pending, 0 failed

## Release checklist

- [x] Update `NodeBuildVersion` to `1.36.2`
- [x] Run required generators
- [x] Create the draft GitHub release and release assets
- [x] Copy and editorially review release notes in `CHANGELOG.md`
- [x] Confirm final CI is green
- [x] Confirm security-advisory staging has ownership
- [ ] Confirm explicit release-owner approval to publish
- [x] Mark ready for review
- [ ] Merge and publish

Part of #13702; keep that issue open through publish and post-release work.