### PR TITLE
docs(release): dedupe Stable Release section into the release-target loop

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -343,11 +343,9 @@ func main() {
 					repoName := matches[2]
 
 					firstReleaseTarget := "Stable Release"
-					rcCandidates := []string{}
 					releaseTargets := []string{"Stable Release"}
 					if releaseFlow == releaseFlowRC {
 						firstReleaseTarget = "rc1"
-						rcCandidates = []string{"rc1", "rcX"}
 						releaseTargets = []string{"rc1", "rcX", "Stable Release"}
 					}
 
@@ -364,7 +362,6 @@ func main() {
 						"NoRCRelease":                         releaseFlow == releaseFlowNoRC,
 						"RCRelease":                           releaseFlow == releaseFlowRC,
 						"FirstReleaseTarget":                  firstReleaseTarget,
-						"RCCandidates":                        rcCandidates,
 						"ReleaseTargets":                      releaseTargets,
 						"NetworkUpgrade":                      networkUpgrade,
 						"NetworkUpgradeDiscussionLink":        discussionLink,

--- a/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
+++ b/documentation/misc/RELEASE_ISSUE_TEMPLATE.md
@@ -143,12 +143,20 @@
 - If release-owner review finds risk that needs soak time, regenerate or edit this issue with `--release-flow=rc`.
 
 </details>
-<!--{{else}}-->
-<!--{{range $rc := .RCCandidates}}-->
-<!--  {{$tagSuffix := printf "-%s" $rc}}-->
-### {{$rc}}
+<!--{{end}}-->
+<!--{{range $target := .ReleaseTargets}}-->
+<!--  {{$stable := eq $target "Stable Release"}}-->
+<!--  {{$tagSuffix := ""}}-->
+<!--  {{if not $stable}}{{$tagSuffix = printf "-%s" $target}}{{end}}-->
+<!--  {{if $stable}}-->
+## Stable Release
+<details{{if $.NoRCRelease}} open{{end}}>
+  <summary>Section</summary>
+<!--  {{else}}-->
+### {{$target}}
 <details>
   <summary>Section</summary>
+<!--  {{end}}-->
 
 > [!IMPORTANT]
 > These PRs should be done in and target the relevant release branch for this issue.
@@ -159,9 +167,15 @@
 > Miner branch: `release/miner/v{{$.Tag}}`
 <!--  {{end}}-->
 
-#### Backport PR for {{$rc}}
+#### Backport PR for {{$target}}
 - [ ] All explicitly tracked items from `Dependencies for releases` have landed
-<!--  {{if ne $rc "rc1"}}-->
+<!--  {{if $stable}}-->
+- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
+   - Deferred items:
+<!--  {{end}}-->
+<!--  {{if and $stable $.NoRCRelease}}-->
+- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
+<!--  {{else if ne $target "rc1"}}-->
 - [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
 - [ ] Create a PR with title `build: backport changes for {{$.Type}} v{{$.Tag}}{{$tagSuffix}}`
    - Link to PR:
@@ -169,7 +183,7 @@
 - [ ] Remove the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
 <!--  {{end}}-->
 
-#### Release PR for {{$rc}}
+#### Release PR for {{$target}}
 - [ ] Update the version string(s) in `build/version.go` to `{{$.Tag}}{{$tagSuffix}}` (without a leading `v`).
 <!--  {{if contains "Node" $.Type}}-->
     - Change `NodeBuildVersion` to `{{$.Tag}}{{$tagSuffix}}`
@@ -196,8 +210,12 @@
 <!--  {{end}}-->
    - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
 <!--  {{if ne $.NetworkUpgrade ""}}-->
+<!--    {{if $stable}}-->
+   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
+<!--    {{else}}-->
    - [ ] (network upgrade) Specify whether the Calibration or Mainnet upgrade epoch has been specified or not yet.
       - Example where these weren't specified yet: [PR #12169](https://github.com/filecoin-project/lotus/pull/12169)
+<!--    {{end}}-->
 <!--  {{end}}-->
    - [ ] Ensure no missing content when spot checking git history
       - Find the previous stable tag first:
@@ -210,95 +228,15 @@
       - Example command looking at git commits: `git log --oneline --graph PREVIOUS_TAG..HEAD`
       - Example GitHub UI search looking at merged PRs into master, where `YYYY-MM-DD` is the previous stable release publish date: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
       - Example `gh` cli command looking at merged PRs into master and sorted by title to group similar areas: `gh pr list --repo filecoin-project/lotus --search "base:master merged:>YYYY-MM-DD" --json number,mergedAt,author,title | jq -r '.[] | [.number, .mergedAt, .author.login, .title] | @tsv' | sort -k4`
-    - [ ] Update the PR with the commit(s) made to the CHANGELOG
-- [ ] Mark the PR "ready for review" (non-draft)
-- [ ] Merge the PR
-   - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
-- [ ] Update `Estimated shipping date` table
-- [ ] Comment on this issue announcing the release:
-   - Link to issue comment:
-
-#### Testing for {{$rc}}
-
-> [!NOTE]
-> Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
-
-</details>
-<!--{{end}}-->
-<!--{{end}}-->
-
-## Stable Release
-<details{{if .NoRCRelease}} open{{end}}>
-  <summary>Section</summary>
-
-> [!IMPORTANT]
-> These PRs should be done in and target the relevant release branch for this issue.
-<!--{{if contains "Node" .Type}}-->
-> Node branch: `release/v{{.Tag}}`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-> Miner branch: `release/miner/v{{.Tag}}`
-<!--{{end}}-->
-
-#### Backport PR for Stable Release
-- [ ] All explicitly tracked items from `Dependencies for releases` have landed
-- [ ] Confirm there are no unresolved `release/backport` blockers unless they are intentionally deferred and linked here:
-   - Deferred items:
-<!--{{if .NoRCRelease}}-->
-- [ ] No additional backport PR is needed because this no-RC release branch was created from `origin/master` after dependency resolution.
-<!--{{else}}-->
-- [ ] Backported [everything with the "backport" label](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+)
-- [ ] Create a PR with title `build: backport changes for {{.Type}} v{{.Tag}}`
-   - Link to PR:
-- [ ] Merge PR
-- [ ] Remove the "backport" label from all backported PRs (no ["backport" issues](https://github.com/filecoin-project/lotus/issues?q=label%3Arelease%2Fbackport+))
-<!--{{end}}-->
-
-#### Release PR for Stable Release
-- [ ] Update the version string(s) in `build/version.go` to `{{.Tag}}` (without a leading `v`).
-<!--{{if contains "Node" .Type}}-->
-    - Change `NodeBuildVersion` to `{{.Tag}}`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-    - Change `MinerBuildVersion` to `{{.Tag}}`
-<!--{{end}}-->
-    - The release tags include the leading `v`; the values in `build/version.go` do not.
-<!--{{if and (contains "Node" .Type) (contains "Miner" .Type)}}-->
-    - If the release branches still point at the same commit, one PR that updates both version strings is expected. If the branches diverge later, add/link one PR per branch here.
-<!--{{end}}-->
-- [ ] Run `make gen && make docsgen-cli` to generate documentation
-- [ ] Create a draft PR with title `build: release Lotus {{.Type}} v{{.Tag}}`
-   - Link to PR:
-   - Opening a PR will trigger a CI run that will build assets, create a draft GitHub release, and attach the assets.
-- [ ] Changelog prep
-   - [ ] After the draft release exists, copy the auto-generated release notes into the CHANGELOG.
-      - Note: after a draft release exists, rerunning the [release workflow](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L220-L229) preserves the existing draft release body. If editorial review changes release-note content in CHANGELOG, update the draft GitHub release body too before merge; the [push-triggered publish step](https://github.com/filecoin-project/lotus/blob/master/.github/workflows/release.yml#L307-L308) publishes that draft body.
-<!--{{if contains "Node" .Type}}-->
-      - Node release body: `gh release view v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-      - Miner release body: `gh release view miner/v{{.Tag}} --repo filecoin-project/lotus --json body -q .body`
-<!--{{end}}-->
-   - [ ] Perform editorial review (e.g., callout breaking changes, new features, FIPs, actor bundles)
-<!--{{if ne .NetworkUpgrade ""}}-->
-   - [ ] (network upgrade) Ensure the Mainnet upgrade epoch is specified.
-<!--{{end}}-->
-   - [ ] Ensure no missing content when spot checking git history
-      - Find the previous stable tag first:
-<!--{{if contains "Node" .Type}}-->
-         - Node: `git tag -l 'v*' | grep -v '-' | sort -V -r | head -n 1`
-<!--{{end}}-->
-<!--{{if contains "Miner" .Type}}-->
-         - Miner: `git tag -l 'miner/v*' | grep -v '-' | sort -V -r | head -n 1`
-<!--{{end}}-->
-      - Example command looking at git commits: `git log --oneline --graph PREVIOUS_TAG..HEAD`
-      - Example GitHub UI search looking at merged PRs into master, where `YYYY-MM-DD` is the previous stable release publish date: https://github.com/filecoin-project/lotus/pulls?q=is%3Apr+base%3Amaster+merged%3A%3EYYYY-MM-DD
-      - Example `gh` cli command looking at merged PRs into master and sorted by title to group similar areas: `gh pr list --repo filecoin-project/lotus --search "base:master merged:>YYYY-MM-DD" --json number,mergedAt,author,title | jq -r '.[] | [.number, .mergedAt, .author.login, .title] | @tsv' | sort -k4`
+<!--  {{if $stable}}-->
    - [ ] Review and update the draft GitHub release body so it matches the CHANGELOG.
+<!--  {{end}}-->
    - [ ] Update the PR with the commit(s) made to the CHANGELOG
+<!--  {{if $stable}}-->
 - [ ] Confirm the release PR CI is green, including release asset generation.
 - [ ] Confirm the release owner approves publishing this stable release.
 - [ ] Confirm any security-advisory staging needed for this release has an owner and follows [policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy).
+<!--  {{end}}-->
 - [ ] Mark the PR "ready for review" (non-draft)
 - [ ] Merge the PR
    - Merging the PR will trigger a CI run that will build assets, attach the assets to the GitHub release, publish the GitHub release, and create the corresponding git tag.
@@ -306,13 +244,13 @@
 - [ ] Comment on this issue announcing the release:
    - Link to issue comment:
 
-#### Testing for Stable Release
+#### Testing for {{$target}}
 
 > [!NOTE]
 > Link to any special steps for testing releases beyond ensuring CI is green. Steps can be inlined here or tracked elsewhere.
 
 </details>
-
+<!--{{end}}-->
 ## Post-Release
 <details>
   <summary>Section</summary>


### PR DESCRIPTION
## Summary

Targets #13697. I just wanted to see whether we could avoid the copy/paste duplication between the new `Stable Release` section and the `rcX` sections in `RELEASE_ISSUE_TEMPLATE.md` — everything else in #13697 I'm happy with. Take it or leave it; feel free to squash it into #13697, cherry-pick the parts you like, or close it.

In #13697 the checklist body appears twice: once inside the `{{range $rc := .RCCandidates}}` loop and once again, hand-copied, under `## Stable Release`. That's ~100 near-identical lines that have to be kept in sync by hand.

Note the template *already* did this with a single loop before #13697 (`{{$rcVersions := list "rc1" "rcX" "Stable Release (non-RC)"}}` with `{{if contains "rc" $rc}}` conditionals), so this is mostly restoring that structure on top of the new content.

## What this does

Ranges over `.ReleaseTargets` (which #13697 already computes, and already uses for `Dependencies for releases`) and derives `{{$stable := eq $target "Stable Release"}}`. The seven real differences each become a one-line conditional:

| Difference | How it's expressed |
|---|---|
| `## Stable Release` vs `### rcX`, and `<details open>` for no-RC | one `{{if $stable}}` at the section head |
| version tag suffix | `{{$tagSuffix := ""}}` + `{{if not $stable}}{{$tagSuffix = printf "-%s" $target}}{{end}}` |
| backport-blockers checkbox | `{{if $stable}}` |
| no-RC "no backport needed" vs the backport PR block | `{{if and $stable $.NoRCRelease}} … {{else if ne $target "rc1"}}` |
| network upgrade epoch wording | `{{if $stable}}` (as the pre-#13697 template did) |
| "Review and update the draft GitHub release body" | `{{if $stable}}` |
| CI-green / release-owner / security-advisory guardrails | `{{if $stable}}` |

`.RCCandidates` is then redundant with `.ReleaseTargets`, so it's dropped from `cmd/release/main.go`.

Net: **-62 lines** in the template (31 insertions / 93 deletions), and the RC-vs-stable differences are visible as explicit conditionals instead of something a reviewer has to diff two 100-line blocks to find.

## Validation

Generated issues from #13697's template and from this one for three configurations and diffed the bodies:

- `--type node --tag 1.35.0 --level minor --release-flow no-rc` — **byte-identical**
- `--type both --tag 1.35.1 --level patch --release-flow auto` — **byte-identical**
- `--type node --tag 1.36.0 --level minor --network-upgrade 28 --release-flow rc` — identical **except two lines**

The two-line exception: #13697's RC branch indents `- [ ] Update the PR with the commit(s) made to the CHANGELOG` by 4 spaces while its stable copy uses 3. Merging them forces one choice; I kept 3, which matches every sibling bullet. That divergence is itself an example of the copy-paste drift this avoids.

Also ran `go build ./cmd/release` and `git diff --check`.

## One gotcha worth knowing about

The blank-line collapsing regex in `main.go` (`([^>])\n\n+(...)`) treats **any** line ending in `>` as a barrier, not just `</summary>`. So `<details{{if $.NoRCRelease}} open{{end}}>` and its `  <summary>Section</summary>` have to stay on adjacent lines *within the same* `{{if}}`/`{{else}}` branch, otherwise a stray blank line shows up between them in the generated issue. That's why `<summary>` is repeated in both branches rather than factored out. Same reason the literal blank line before `## Post-Release` is now dropped: the loop's closing `<!--{{end}}-->` supplies it.

That constraint is worth removing rather than working around, so I opened **#13732** against `master` separately: it strips the comment wrappers before parsing instead of collapsing newlines afterwards, which deletes that regex entirely and makes the generated whitespace simply match the template's. It also switches the generator from `html/template` to `text/template` — the current package HTML-escapes interpolated data, so a `--discussion-link` containing `&` renders as `&amp;`.

**#13732 is independent of this PR and of #13697** — it changes only how the template is rendered, not what it says. Since both touch the same file, whoever lands second gets a small textual merge; if #13732 lands first, the `<details>`/`<summary>` adjacency note above stops applying, though keeping them adjacent is still fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
