### PR TITLE
feat(cli): merge state active-sectors into state sectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@
 
 ## ☢️ Upgrade Warnings ☢️
 
+- `lotus state active-sectors` has been removed. Use `lotus state sectors --active` instead. ([filecoin-project/lotus#XXXXX](https://github.com/filecoin-project/lotus/pull/13743))
+
 ## ⭐ New Features
+
+- feat(cli): `lotus state sectors` gained an `--active` flag (replacing the now-removed `lotus state active-sectors`) and now prints `Activation`, `Expiration`, `InitialPledge`, and `DailyFee` for each sector by default. Pass `--human` to render epochs as calendar time and attoFIL amounts as FIL instead of raw numbers. ([filecoin-project/lotus#XXXXX](https://github.com/filecoin-project/lotus/pull/13743))
 
 ## 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@
 
 ## ☢️ Upgrade Warnings ☢️
 
-- `lotus state active-sectors` has been removed. Use `lotus state sectors --active` instead. ([filecoin-project/lotus#XXXXX](https://github.com/filecoin-project/lotus/pull/13743))
+- `lotus state active-sectors` has been removed and merged into `lotus state sectors`, which now defaults to active sectors only (previously it returned every committed sector). Use `lotus state sectors --all` for the previous full-sector-set behavior. ([filecoin-project/lotus#13743](https://github.com/filecoin-project/lotus/pull/13743))
 
 ## ⭐ New Features
 
-- feat(cli): `lotus state sectors` gained an `--active` flag (replacing the now-removed `lotus state active-sectors`) and now prints `Activation`, `Expiration`, `InitialPledge`, and `DailyFee` for each sector by default. Pass `--human` to render epochs as calendar time and attoFIL amounts as FIL instead of raw numbers. ([filecoin-project/lotus#XXXXX](https://github.com/filecoin-project/lotus/pull/13743))
+- feat(cli): `lotus state sectors` now prints `Activation`, `Expiration`, `InitialPledge`, and `DailyFee` for each sector by default, and gained a `--human` flag to render epochs as local calendar time and attoFIL amounts as FIL instead of raw numbers. ([filecoin-project/lotus#13743](https://github.com/filecoin-project/lotus/pull/13743))
 
 ## 🐛 Bug Fixes
 

--- a/cli/clicommands/state.go
+++ b/cli/clicommands/state.go
@@ -24,7 +24,6 @@ var StateCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		lcli.StatePowerCmd,
 		lcli.StateSectorsCmd,
-		lcli.StateActiveSectorsCmd,
 		lcli.StateListActorsCmd,
 		lcli.StateListMinersCmd,
 		lcli.StateCircSupplyCmd,

--- a/cli/state.go
+++ b/cli/state.go
@@ -241,7 +241,7 @@ var StatePowerCmd = &cli.Command{
 
 var StateSectorsCmd = &cli.Command{
 	Name:      "sectors",
-	Usage:     "Query the sector set of a miner",
+	Usage:     "Query the active sector set of a miner (use --all for the full sector set)",
 	ArgsUsage: "[minerAddress]",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
@@ -249,8 +249,8 @@ var StateSectorsCmd = &cli.Command{
 			Usage: "show sector deadlines and partitions",
 		},
 		&cli.BoolFlag{
-			Name:  "active",
-			Usage: "only show sectors that are currently active (have power)",
+			Name:  "all",
+			Usage: "show all sectors",
 		},
 		&cli.BoolFlag{
 			Name:  "human",
@@ -281,10 +281,10 @@ var StateSectorsCmd = &cli.Command{
 		}
 
 		var sectors []*miner.SectorOnChainInfo
-		if cctx.Bool("active") {
-			sectors, err = api.StateMinerActiveSectors(ctx, maddr, ts.Key())
-		} else {
+		if cctx.Bool("all") {
 			sectors, err = api.StateMinerSectors(ctx, maddr, nil, ts.Key())
+		} else {
+			sectors, err = api.StateMinerActiveSectors(ctx, maddr, ts.Key())
 		}
 		if err != nil {
 			return err

--- a/cli/state.go
+++ b/cli/state.go
@@ -254,7 +254,7 @@ var StateSectorsCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "human",
-			Usage: "show human-readable time and FIL values instead of raw epoch/attoFIL",
+			Usage: "show human-readable local time and FIL values instead of raw epoch/attoFIL",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -301,7 +301,9 @@ var StateSectorsCmd = &cli.Command{
 
 		epochStr := func(e abi.ChainEpoch) string {
 			if human {
-				return cliutil.EpochTimeTs(ts.Height(), e, ts)
+				// t is in the local timezone of the machine running this command.
+				t := time.Unix(int64(ts.MinTimestamp()+(uint64(e-ts.Height())*buildconstants.BlockDelaySecs)), 0)
+				return t.Format(time.DateTime)
 			}
 			return fmt.Sprintf("%d", e)
 		}

--- a/cli/state.go
+++ b/cli/state.go
@@ -303,7 +303,7 @@ var StateSectorsCmd = &cli.Command{
 			if human {
 				// t is in the local timezone of the machine running this command.
 				t := time.Unix(int64(ts.MinTimestamp()+(uint64(e-ts.Height())*buildconstants.BlockDelaySecs)), 0)
-				return t.Format(time.DateTime)
+				return t.Format(time.RFC3339)
 			}
 			return fmt.Sprintf("%d", e)
 		}

--- a/cli/state.go
+++ b/cli/state.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
+	"encoding/csv"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -254,7 +255,7 @@ var StateSectorsCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "human",
-			Usage: "show human-readable local time and FIL values instead of raw epoch/attoFIL",
+			Usage: "show human-readable UTC time and FIL values instead of raw epoch/attoFIL",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -293,46 +294,58 @@ var StateSectorsCmd = &cli.Command{
 		showPartitions := cctx.Bool("show-partitions")
 		human := cctx.Bool("human")
 
-		header := "Sector Number, Sealed CID, Activation, Expiration, InitialPledge, DailyFee"
-		if showPartitions {
-			header = "Sector Number, Deadline, Partition, Sealed CID, Activation, Expiration, InitialPledge, DailyFee"
-		}
-		fmt.Println(header)
-
 		epochStr := func(e abi.ChainEpoch) string {
 			if human {
-				// t is in the local timezone of the machine running this command.
-				t := time.Unix(int64(ts.MinTimestamp()+(uint64(e-ts.Height())*buildconstants.BlockDelaySecs)), 0)
-				return t.Format(time.RFC3339)
+				t := time.Unix(int64(ts.MinTimestamp()+(uint64(e-ts.Height())*buildconstants.BlockDelaySecs)), 0).UTC()
+				return t.Format(time.DateTime)
 			}
 			return fmt.Sprintf("%d", e)
 		}
 
 		filStr := func(v abi.TokenAmount) string {
-			if human {
-				return types.FIL(v).String()
-			}
 			if v.Int == nil {
 				return "0"
+			}
+			if human {
+				return types.FIL(v).Unitless()
 			}
 			return v.String()
 		}
 
+		header := []string{"Sector Number"}
+		if showPartitions {
+			header = append(header, "Deadline", "Partition")
+		}
+		header = append(header, "Sealed CID")
+		if human {
+			header = append(header, "Activation (UTC)", "Expiration (UTC)", "InitialPledge (FIL)", "DailyFee (FIL)")
+		} else {
+			header = append(header, "Activation", "Expiration", "InitialPledge (attoFIL)", "DailyFee (attoFIL)")
+		}
+
+		w := csv.NewWriter(os.Stdout)
+		if err := w.Write(header); err != nil {
+			return xerrors.Errorf("writing csv header: %w", err)
+		}
+
 		for _, s := range sectors {
+			row := []string{fmt.Sprintf("%d", s.SectorNumber)}
 			if showPartitions {
 				sp, err := api.StateSectorPartition(ctx, maddr, s.SectorNumber, ts.Key())
 				if err != nil {
 					return err
 				}
-				fmt.Printf("%d, %d, %d, %s, %s, %s, %s, %s\n", s.SectorNumber, sp.Deadline, sp.Partition, s.SealedCID,
-					epochStr(s.Activation), epochStr(s.Expiration), filStr(s.InitialPledge), filStr(s.DailyFee))
-			} else {
-				fmt.Printf("%d, %s, %s, %s, %s, %s\n", s.SectorNumber, s.SealedCID,
-					epochStr(s.Activation), epochStr(s.Expiration), filStr(s.InitialPledge), filStr(s.DailyFee))
+				row = append(row, fmt.Sprintf("%d", sp.Deadline), fmt.Sprintf("%d", sp.Partition))
+			}
+			row = append(row, s.SealedCID.String(), epochStr(s.Activation), epochStr(s.Expiration), filStr(s.InitialPledge), filStr(s.DailyFee))
+
+			if err := w.Write(row); err != nil {
+				return xerrors.Errorf("writing csv row: %w", err)
 			}
 		}
 
-		return nil
+		w.Flush()
+		return w.Error()
 	},
 }
 

--- a/cli/state.go
+++ b/cli/state.go
@@ -40,6 +40,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -247,66 +248,13 @@ var StateSectorsCmd = &cli.Command{
 			Name:  "show-partitions",
 			Usage: "show sector deadlines and partitions",
 		},
-	},
-	Action: func(cctx *cli.Context) error {
-		api, closer, err := GetFullNodeAPI(cctx)
-		if err != nil {
-			return err
-		}
-		defer closer()
-
-		ctx := ReqContext(cctx)
-
-		if cctx.NArg() != 1 {
-			return IncorrectNumArgs(cctx)
-		}
-
-		maddr, err := address.NewFromString(cctx.Args().First())
-		if err != nil {
-			return err
-		}
-
-		ts, err := LoadTipSet(ctx, cctx, api)
-		if err != nil {
-			return err
-		}
-
-		sectors, err := api.StateMinerSectors(ctx, maddr, nil, ts.Key())
-		if err != nil {
-			return err
-		}
-
-		showPartitions := cctx.Bool("show-partitions")
-		header := "Sector Number, Sealed CID"
-		if showPartitions {
-			header = "Sector Number, Deadline, Partition, Sealed CID"
-		}
-		fmt.Println(header)
-
-		for _, s := range sectors {
-			if showPartitions {
-				sp, err := api.StateSectorPartition(ctx, maddr, s.SectorNumber, ts.Key())
-				if err != nil {
-					return err
-				}
-				fmt.Printf("%d, %d, %d, %s\n", s.SectorNumber, sp.Deadline, sp.Partition, s.SealedCID)
-			} else {
-				fmt.Printf("%d, %s\n", s.SectorNumber, s.SealedCID)
-			}
-		}
-
-		return nil
-	},
-}
-
-var StateActiveSectorsCmd = &cli.Command{
-	Name:      "active-sectors",
-	Usage:     "Query the active sector set of a miner",
-	ArgsUsage: "[minerAddress]",
-	Flags: []cli.Flag{
 		&cli.BoolFlag{
-			Name:  "show-partitions",
-			Usage: "show sector deadlines and partitions",
+			Name:  "active",
+			Usage: "only show sectors that are currently active (have power)",
+		},
+		&cli.BoolFlag{
+			Name:  "human",
+			Usage: "show human-readable time and FIL values instead of raw epoch/attoFIL",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -332,17 +280,41 @@ var StateActiveSectorsCmd = &cli.Command{
 			return err
 		}
 
-		sectors, err := api.StateMinerActiveSectors(ctx, maddr, ts.Key())
+		var sectors []*miner.SectorOnChainInfo
+		if cctx.Bool("active") {
+			sectors, err = api.StateMinerActiveSectors(ctx, maddr, ts.Key())
+		} else {
+			sectors, err = api.StateMinerSectors(ctx, maddr, nil, ts.Key())
+		}
 		if err != nil {
 			return err
 		}
 
 		showPartitions := cctx.Bool("show-partitions")
-		header := "Sector Number, Sealed CID"
+		human := cctx.Bool("human")
+
+		header := "Sector Number, Sealed CID, Activation, Expiration, InitialPledge, DailyFee"
 		if showPartitions {
-			header = "Sector Number, Deadline, Partition, Sealed CID"
+			header = "Sector Number, Deadline, Partition, Sealed CID, Activation, Expiration, InitialPledge, DailyFee"
 		}
 		fmt.Println(header)
+
+		epochStr := func(e abi.ChainEpoch) string {
+			if human {
+				return cliutil.EpochTimeTs(ts.Height(), e, ts)
+			}
+			return fmt.Sprintf("%d", e)
+		}
+
+		filStr := func(v abi.TokenAmount) string {
+			if human {
+				return types.FIL(v).String()
+			}
+			if v.Int == nil {
+				return "0"
+			}
+			return v.String()
+		}
 
 		for _, s := range sectors {
 			if showPartitions {
@@ -350,9 +322,11 @@ var StateActiveSectorsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Printf("%d, %d, %d, %s\n", s.SectorNumber, sp.Deadline, sp.Partition, s.SealedCID)
+				fmt.Printf("%d, %d, %d, %s, %s, %s, %s, %s\n", s.SectorNumber, sp.Deadline, sp.Partition, s.SealedCID,
+					epochStr(s.Activation), epochStr(s.Expiration), filStr(s.InitialPledge), filStr(s.DailyFee))
 			} else {
-				fmt.Printf("%d, %s\n", s.SectorNumber, s.SealedCID)
+				fmt.Printf("%d, %s, %s, %s, %s, %s\n", s.SectorNumber, s.SealedCID,
+					epochStr(s.Activation), epochStr(s.Expiration), filStr(s.InitialPledge), filStr(s.DailyFee))
 			}
 		}
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1380,7 +1380,7 @@ USAGE:
 OPTIONS:
    --show-partitions  show sector deadlines and partitions (default: false)
    --active           only show sectors that are currently active (have power) (default: false)
-   --human            show human-readable time and FIL values instead of raw epoch/attoFIL (default: false)
+   --human            show human-readable local time and FIL values instead of raw epoch/attoFIL (default: false)
    --help, -h         show help
 ```
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1380,7 +1380,7 @@ USAGE:
 OPTIONS:
    --show-partitions  show sector deadlines and partitions (default: false)
    --all              show all sectors (default: false)
-   --human            show human-readable local time and FIL values instead of raw epoch/attoFIL (default: false)
+   --human            show human-readable UTC time and FIL values instead of raw epoch/attoFIL (default: false)
    --help, -h         show help
 ```
 

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1326,7 +1326,7 @@ CATEGORY:
 
 COMMANDS:
    power                       Query network or miner power
-   sectors                     Query the sector set of a miner
+   sectors                     Query the active sector set of a miner (use --all for the full sector set)
    list-actors                 list all actors in the network
    list-miners                 list all miners in the network
    circulating-supply          Get the exact current circulating supply of Filecoin
@@ -1372,14 +1372,14 @@ OPTIONS:
 
 ```
 NAME:
-   lotus state sectors - Query the sector set of a miner
+   lotus state sectors - Query the active sector set of a miner (use --all for the full sector set)
 
 USAGE:
    lotus state sectors [command options] [minerAddress]
 
 OPTIONS:
    --show-partitions  show sector deadlines and partitions (default: false)
-   --active           only show sectors that are currently active (have power) (default: false)
+   --all              show all sectors (default: false)
    --human            show human-readable local time and FIL values instead of raw epoch/attoFIL (default: false)
    --help, -h         show help
 ```

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -1327,7 +1327,6 @@ CATEGORY:
 COMMANDS:
    power                       Query network or miner power
    sectors                     Query the sector set of a miner
-   active-sectors              Query the active sector set of a miner
    list-actors                 list all actors in the network
    list-miners                 list all miners in the network
    circulating-supply          Get the exact current circulating supply of Filecoin
@@ -1380,20 +1379,8 @@ USAGE:
 
 OPTIONS:
    --show-partitions  show sector deadlines and partitions (default: false)
-   --help, -h         show help
-```
-
-### lotus state active-sectors
-
-```
-NAME:
-   lotus state active-sectors - Query the active sector set of a miner
-
-USAGE:
-   lotus state active-sectors [command options] [minerAddress]
-
-OPTIONS:
-   --show-partitions  show sector deadlines and partitions (default: false)
+   --active           only show sectors that are currently active (have power) (default: false)
+   --human            show human-readable time and FIL values instead of raw epoch/attoFIL (default: false)
    --help, -h         show help
 ```
 


### PR DESCRIPTION
`lotus state active-sectors` duplicated the entire body of `lotus state sectors`. Merge it into a single `sectors` command backed by one code path.

**Behavior change**: `lotus state sectors` now defaults to **active sectors only** (previously it returned every committed sector). Pass `--all` to get the full sector set, matching the old default.

Also add `Activation`, `Expiration`, `InitialPledge`, and `DailyFee` columns to the output (previously only available via the single-sector `lotus state sector` lookup), plus a `--human` flag to render epochs as local calendar time and attoFIL amounts as FIL instead of raw values.

BREAKING:
- `lotus state active-sectors` is removed; use `lotus state sectors` (now active-only by default).
- `lotus state sectors` (no flags) now returns only active sectors instead of all sectors; pass `--all` for the previous behavior.

---
preview
```
Sector Number,Deadline,Partition,Sealed CID,Activation (UTC),Expiration (UTC),InitialPledge (FIL),DailyFee (FIL)
3000,0,0,bagboea4b5abcaptvduacbo2fxtiayksj4wtpiia7hap3p4g22qnopvsfxmnvlhkn,2024-11-19 13:49:00,2028-05-19 18:31:00,9.9999998430674944,0
3001,0,0,bagboea4b5abcawc5xvwmdzpvp55enhavc4fd4dqfi2xkmuvh4f5uchpqb5xm6ibu,2024-11-19 14:17:30,2028-05-19 19:11:30,9.9999998430674944,0
3002,0,0,bagboea4b5abcbflojifl4unpxzan5w37q3syrethfmorejcjrxsprtsgbbvn2jti,2024-11-19 14:18:00,2028-05-19 19:20:30,9.9999998430674944,0
3003,0,0,bagboea4b5abca3p76me7hgwa6to4nl4jyrs3ulemeyxrvnp54tq2jxk6iqurbzyw,2024-11-19 14:43:00,2028-05-19 19:22:00,9.9999998430674944,0
3004,0,0,bagboea4b5abcb7fmajdtvibaeuonk66xsalnpqe6zll3dq6rzkw42q5qvhhtwlqq,2024-11-19 15:42:00,2028-05-19 19:24:00,9.9999998430674944,0
3005,0,0,bagboea4b5abcag3wcdpwqf2izhgmazf5ciquqh7z72rcnd56wkz3j56lsgrlsg22,2024-11-19 14:42:30,2028-05-19 19:24:30,9.9999998430674944,0
3006,0,0,bagboea4b5abcbu6i2jxbhwbxbnjp6gz7shbubri6kvfqkfe6n6n5xfnokcfelpcl,2024-11-19 14:20:00,2028-05-19 19:26:30,9.9999998430674944,0
3007,0,0,bagboea4b5abcbkpw36fqvanc7dl2t2wlzt4gjs7fk4s23yr3ni6p5ho2fjdee2q7,2024-11-19 15:42:30,2028-05-19 19:29:00,9.9999998430674944,0
3008,0,0,bagboea4b5abcatwdga4quggjeggps7gsvamyg4e3wysfplsfmlvygugevvx43fkk,2024-11-19 15:43:30,2028-05-19 19:30:00,9.9999998430674944,0
```

