### PR TITLE
fix(eth): reject non-minimal RLP integers in transaction parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))
 - fix(events): `GetActorEventsRaw` and `SubscribeActorEventsRaw` now reject a filter whose `toHeight` is negative. ([filecoin-project/lotus#13751](https://github.com/filecoin-project/lotus/pull/13751))
-- fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. A field padded with leading zero bytes decoded to the same transaction as its minimal form, so a re-encoded copy of an already-signed transaction recovered the same sender and reported the same transaction hash, while the hash handed back to the caller is derived from the submitted bytes and so no longer matched the one the node indexes. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
+- fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
 
 ## 👌 Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))
 - fix(events): `GetActorEventsRaw` and `SubscribeActorEventsRaw` now reject a filter whose `toHeight` is negative. ([filecoin-project/lotus#13751](https://github.com/filecoin-project/lotus/pull/13751))
+- fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. A field padded with leading zero bytes decoded to the same transaction as its minimal form, so a re-encoded copy of an already-signed transaction recovered the same sender and reported the same transaction hash, while the hash handed back to the caller is derived from the submitted bytes and so no longer matched the one the node indexes. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
 
 ## 👌 Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. A field padded with leading zero bytes decoded to the same transaction as its minimal form, so a re-encoded copy of an already-signed transaction recovered the same sender and reported the same transaction hash, while the hash handed back to the caller is derived from the submitted bytes and so no longer matched the one the node indexes. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
+
 ## 👌 Improvements
 
 # Node v1.36.2 / 2026-07-27

--- a/chain/types/ethtypes/eth_1559_transactions.go
+++ b/chain/types/ethtypes/eth_1559_transactions.go
@@ -151,24 +151,9 @@ func (tx *Eth1559TxArgs) InitialiseSignature(sig typescrypto.Signature) error {
 		return xerrors.Errorf("signature should be 65 bytes long, but got %d bytes", len(sig.Data))
 	}
 
-	r_, err := parseBigInt(sig.Data[0:32])
-	if err != nil {
-		return xerrors.Errorf("cannot parse r into EthBigInt")
-	}
-
-	s_, err := parseBigInt(sig.Data[32:64])
-	if err != nil {
-		return xerrors.Errorf("cannot parse s into EthBigInt")
-	}
-
-	v_, err := parseBigInt([]byte{sig.Data[64]})
-	if err != nil {
-		return xerrors.Errorf("cannot parse v into EthBigInt")
-	}
-
-	tx.R = r_
-	tx.S = s_
-	tx.V = v_
+	tx.R = bigIntFromBytes(sig.Data[0:32])
+	tx.S = bigIntFromBytes(sig.Data[32:64])
+	tx.V = bigIntFromBytes(sig.Data[64:65])
 
 	return nil
 }
@@ -236,27 +221,27 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, xerrors.Errorf("not an EIP-1559 transaction: should have 12 elements in the rlp list")
 	}
 
-	chainId, err := parseRlpInt(decoded[0])
+	chainId, err := parseInt(decoded[0])
 	if err != nil {
 		return nil, err
 	}
 
-	nonce, err := parseRlpInt(decoded[1])
+	nonce, err := parseInt(decoded[1])
 	if err != nil {
 		return nil, err
 	}
 
-	maxPriorityFeePerGas, err := parseRlpBigInt(decoded[2])
+	maxPriorityFeePerGas, err := parseBigInt(decoded[2])
 	if err != nil {
 		return nil, err
 	}
 
-	maxFeePerGas, err := parseRlpBigInt(decoded[3])
+	maxFeePerGas, err := parseBigInt(decoded[3])
 	if err != nil {
 		return nil, err
 	}
 
-	gasLimit, err := parseRlpInt(decoded[4])
+	gasLimit, err := parseInt(decoded[4])
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +251,7 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, err
 	}
 
-	value, err := parseRlpBigInt(decoded[6])
+	value, err := parseBigInt(decoded[6])
 	if err != nil {
 		return nil, err
 	}
@@ -281,17 +266,17 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, xerrors.Errorf("access list should be an empty list")
 	}
 
-	r, err := parseRlpBigInt(decoded[10])
+	r, err := parseBigInt(decoded[10])
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := parseRlpBigInt(decoded[11])
+	s, err := parseBigInt(decoded[11])
 	if err != nil {
 		return nil, err
 	}
 
-	v, err := parseRlpBigInt(decoded[9])
+	v, err := parseBigInt(decoded[9])
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/ethtypes/eth_1559_transactions.go
+++ b/chain/types/ethtypes/eth_1559_transactions.go
@@ -236,27 +236,27 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, xerrors.Errorf("not an EIP-1559 transaction: should have 12 elements in the rlp list")
 	}
 
-	chainId, err := parseInt(decoded[0])
+	chainId, err := parseRlpInt(decoded[0])
 	if err != nil {
 		return nil, err
 	}
 
-	nonce, err := parseInt(decoded[1])
+	nonce, err := parseRlpInt(decoded[1])
 	if err != nil {
 		return nil, err
 	}
 
-	maxPriorityFeePerGas, err := parseBigInt(decoded[2])
+	maxPriorityFeePerGas, err := parseRlpBigInt(decoded[2])
 	if err != nil {
 		return nil, err
 	}
 
-	maxFeePerGas, err := parseBigInt(decoded[3])
+	maxFeePerGas, err := parseRlpBigInt(decoded[3])
 	if err != nil {
 		return nil, err
 	}
 
-	gasLimit, err := parseInt(decoded[4])
+	gasLimit, err := parseRlpInt(decoded[4])
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, err
 	}
 
-	value, err := parseBigInt(decoded[6])
+	value, err := parseRlpBigInt(decoded[6])
 	if err != nil {
 		return nil, err
 	}
@@ -281,17 +281,17 @@ func parseEip1559Tx(data []byte) (*Eth1559TxArgs, error) {
 		return nil, xerrors.Errorf("access list should be an empty list")
 	}
 
-	r, err := parseBigInt(decoded[10])
+	r, err := parseRlpBigInt(decoded[10])
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := parseBigInt(decoded[11])
+	s, err := parseRlpBigInt(decoded[11])
 	if err != nil {
 		return nil, err
 	}
 
-	v, err := parseBigInt(decoded[9])
+	v, err := parseRlpBigInt(decoded[9])
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/ethtypes/eth_legacy_155_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_155_transactions.go
@@ -194,27 +194,13 @@ func (tx *EthLegacy155TxArgs) InitialiseSignature(sig typescrypto.Signature) err
 	}
 
 	// ignore the first byte of the signature as it's only used for legacy transaction identification
-	r_, err := parseBigInt(sig.Data[1:33])
-	if err != nil {
-		return fmt.Errorf("cannot parse r into EthBigInt: %w", err)
-	}
-
-	s_, err := parseBigInt(sig.Data[33:65])
-	if err != nil {
-		return fmt.Errorf("cannot parse s into EthBigInt: %w", err)
-	}
-
-	v_, err := parseBigInt(sig.Data[65:])
-	if err != nil {
-		return fmt.Errorf("cannot parse v into EthBigInt: %w", err)
-	}
-
+	v_ := bigIntFromBytes(sig.Data[65:])
 	if err := validateEIP155ChainId(v_); err != nil {
 		return fmt.Errorf("failed to validate EIP155 chain id: %w", err)
 	}
 
-	tx.legacyTx.R = r_
-	tx.legacyTx.S = s_
+	tx.legacyTx.R = bigIntFromBytes(sig.Data[1:33])
+	tx.legacyTx.S = bigIntFromBytes(sig.Data[33:65])
 	tx.legacyTx.V = v_
 	return nil
 }

--- a/chain/types/ethtypes/eth_legacy_homestead_transactions.go
+++ b/chain/types/ethtypes/eth_legacy_homestead_transactions.go
@@ -169,27 +169,13 @@ func (tx *EthLegacyHomesteadTxArgs) InitialiseSignature(sig typescrypto.Signatur
 	}
 
 	// ignore the first byte of the signature as it's only used for legacy transaction identification
-	r_, err := parseBigInt(sig.Data[1:33])
-	if err != nil {
-		return fmt.Errorf("cannot parse r into EthBigInt: %w", err)
-	}
-
-	s_, err := parseBigInt(sig.Data[33:65])
-	if err != nil {
-		return fmt.Errorf("cannot parse s into EthBigInt: %w", err)
-	}
-
-	v_, err := parseBigInt([]byte{sig.Data[65]})
-	if err != nil {
-		return fmt.Errorf("cannot parse v into EthBigInt: %w", err)
-	}
-
+	v_ := bigIntFromBytes(sig.Data[65:66])
 	if !v_.Equals(big.NewInt(27)) && !v_.Equals(big.NewInt(28)) {
 		return fmt.Errorf("legacy homestead transactions only support 27 or 28 for v")
 	}
 
-	tx.R = r_
-	tx.S = s_
+	tx.R = bigIntFromBytes(sig.Data[1:33])
+	tx.S = bigIntFromBytes(sig.Data[33:65])
 	tx.V = v_
 	return nil
 }

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -369,6 +369,39 @@ func parseBigInt(v interface{}) (big.Int, error) {
 	return big.NewFromGo(&b), nil
 }
 
+// checkMinimalInt rejects an RLP integer field that carries leading zero bytes.
+// Integers are encoded minimally, so a leading zero is a second encoding of a
+// value that already has one.
+func checkMinimalInt(v interface{}) error {
+	data, ok := v.([]byte)
+	if !ok {
+		return fmt.Errorf("cannot parse interface to int: input is not a byte array")
+	}
+	if len(data) > 0 && data[0] == 0 {
+		return fmt.Errorf("cannot parse interface to int: non-minimal encoding with leading zeros")
+	}
+	return nil
+}
+
+// parseRlpInt parses an integer field decoded from a transaction's RLP list.
+// Unlike parseInt, which is also used on fixed-width signature components where
+// leading zeros are part of the value, it requires a minimal encoding.
+func parseRlpInt(v interface{}) (int, error) {
+	if err := checkMinimalInt(v); err != nil {
+		return 0, err
+	}
+	return parseInt(v)
+}
+
+// parseRlpBigInt is parseBigInt for a field decoded from a transaction's RLP
+// list, requiring a minimal encoding.
+func parseRlpBigInt(v interface{}) (big.Int, error) {
+	if err := checkMinimalInt(v); err != nil {
+		return big.Zero(), err
+	}
+	return parseBigInt(v)
+}
+
 func parseBytes(v interface{}) ([]byte, error) {
 	val, ok := v.([]byte)
 	if !ok {
@@ -445,17 +478,17 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, fmt.Errorf("not a Legacy transaction: should have 9 elements in the rlp list")
 	}
 
-	nonce, err := parseInt(decoded[0])
+	nonce, err := parseRlpInt(decoded[0])
 	if err != nil {
 		return nil, err
 	}
 
-	gasPrice, err := parseBigInt(decoded[1])
+	gasPrice, err := parseRlpBigInt(decoded[1])
 	if err != nil {
 		return nil, err
 	}
 
-	gasLimit, err := parseInt(decoded[2])
+	gasLimit, err := parseRlpInt(decoded[2])
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +498,7 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, err
 	}
 
-	value, err := parseBigInt(decoded[4])
+	value, err := parseRlpBigInt(decoded[4])
 	if err != nil {
 		return nil, err
 	}
@@ -475,17 +508,17 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, fmt.Errorf("input is not a byte slice")
 	}
 
-	v, err := parseBigInt(decoded[6])
+	v, err := parseRlpBigInt(decoded[6])
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := parseBigInt(decoded[7])
+	r, err := parseRlpBigInt(decoded[7])
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := parseBigInt(decoded[8])
+	s, err := parseRlpBigInt(decoded[8])
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/ethtypes/eth_transactions.go
+++ b/chain/types/ethtypes/eth_transactions.go
@@ -337,6 +337,9 @@ func formatBigInt(val big.Int) ([]byte, error) {
 	return removeLeadingZeros(b), nil
 }
 
+// parseInt parses an integer field of a transaction's RLP list. RLP integers are
+// minimally encoded, so a leading zero byte is a second encoding of a value that
+// already has one and is rejected.
 func parseInt(v interface{}) (int, error) {
 	data, ok := v.([]byte)
 	if !ok {
@@ -348,6 +351,9 @@ func parseInt(v interface{}) (int, error) {
 	if len(data) > 8 {
 		return 0, fmt.Errorf("cannot parse interface to int: length is more than 8 bytes")
 	}
+	if data[0] == 0 {
+		return 0, fmt.Errorf("cannot parse interface to int: non-minimal encoding with leading zeros")
+	}
 	var value int64
 	r := bytes.NewReader(append(make([]byte, 8-len(data)), data...))
 	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
@@ -356,6 +362,10 @@ func parseInt(v interface{}) (int, error) {
 	return int(value), nil
 }
 
+// parseBigInt parses an integer field of a transaction's RLP list, requiring a
+// minimal encoding for the same reason as parseInt. Fixed-width values, where a
+// leading zero is part of the value rather than padding, go through
+// bigIntFromBytes instead.
 func parseBigInt(v interface{}) (big.Int, error) {
 	data, ok := v.([]byte)
 	if !ok {
@@ -364,42 +374,19 @@ func parseBigInt(v interface{}) (big.Int, error) {
 	if len(data) == 0 {
 		return big.Zero(), nil
 	}
+	if data[0] == 0 {
+		return big.Zero(), fmt.Errorf("cannot parse interface to big.Int: non-minimal encoding with leading zeros")
+	}
+	return bigIntFromBytes(data), nil
+}
+
+// bigIntFromBytes reads raw big-endian bytes as an unsigned integer, accepting
+// leading zeros. Signature components are stored at a fixed width, so their
+// leading zeros carry value and must not be treated as padding.
+func bigIntFromBytes(data []byte) big.Int {
 	var b mathbig.Int
 	b.SetBytes(data)
-	return big.NewFromGo(&b), nil
-}
-
-// checkMinimalInt rejects an RLP integer field that carries leading zero bytes.
-// Integers are encoded minimally, so a leading zero is a second encoding of a
-// value that already has one.
-func checkMinimalInt(v interface{}) error {
-	data, ok := v.([]byte)
-	if !ok {
-		return fmt.Errorf("cannot parse interface to int: input is not a byte array")
-	}
-	if len(data) > 0 && data[0] == 0 {
-		return fmt.Errorf("cannot parse interface to int: non-minimal encoding with leading zeros")
-	}
-	return nil
-}
-
-// parseRlpInt parses an integer field decoded from a transaction's RLP list.
-// Unlike parseInt, which is also used on fixed-width signature components where
-// leading zeros are part of the value, it requires a minimal encoding.
-func parseRlpInt(v interface{}) (int, error) {
-	if err := checkMinimalInt(v); err != nil {
-		return 0, err
-	}
-	return parseInt(v)
-}
-
-// parseRlpBigInt is parseBigInt for a field decoded from a transaction's RLP
-// list, requiring a minimal encoding.
-func parseRlpBigInt(v interface{}) (big.Int, error) {
-	if err := checkMinimalInt(v); err != nil {
-		return big.Zero(), err
-	}
-	return parseBigInt(v)
+	return big.NewFromGo(&b)
 }
 
 func parseBytes(v interface{}) ([]byte, error) {
@@ -478,17 +465,17 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, fmt.Errorf("not a Legacy transaction: should have 9 elements in the rlp list")
 	}
 
-	nonce, err := parseRlpInt(decoded[0])
+	nonce, err := parseInt(decoded[0])
 	if err != nil {
 		return nil, err
 	}
 
-	gasPrice, err := parseRlpBigInt(decoded[1])
+	gasPrice, err := parseBigInt(decoded[1])
 	if err != nil {
 		return nil, err
 	}
 
-	gasLimit, err := parseRlpInt(decoded[2])
+	gasLimit, err := parseInt(decoded[2])
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +485,7 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, err
 	}
 
-	value, err := parseRlpBigInt(decoded[4])
+	value, err := parseBigInt(decoded[4])
 	if err != nil {
 		return nil, err
 	}
@@ -508,17 +495,17 @@ func parseLegacyTx(data []byte) (EthTransaction, error) {
 		return nil, fmt.Errorf("input is not a byte slice")
 	}
 
-	v, err := parseRlpBigInt(decoded[6])
+	v, err := parseBigInt(decoded[6])
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := parseRlpBigInt(decoded[7])
+	r, err := parseBigInt(decoded[7])
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := parseRlpBigInt(decoded[8])
+	s, err := parseBigInt(decoded[8])
 	if err != nil {
 		return nil, err
 	}

--- a/chain/types/ethtypes/eth_transactions_test.go
+++ b/chain/types/ethtypes/eth_transactions_test.go
@@ -167,11 +167,10 @@ func TestEthTransactionFromSignedFilecoinMessage(t *testing.T) {
 }
 
 func TestParseEthTransactionNonMinimalInts(t *testing.T) {
-	// RLP integers carry no leading zero bytes, so a field encoded with one
-	// decodes to a value that already has a shorter encoding. Both forms parse
-	// to the same transaction and recover the same sender, which would let
-	// anyone rewrite the bytes of someone else's signed transaction and get a
-	// different EthHashFromTxBytes out of it.
+	// RLP integers carry no leading zero bytes, so a padded field is a second
+	// encoding of a value that already has one. Rejecting it keeps a signed
+	// transaction to a single valid encoding, which is what makes the hash of the
+	// submitted bytes and the hash the transaction is indexed under the same hash.
 	testcases := []struct {
 		name  string
 		rawTx string

--- a/chain/types/ethtypes/eth_transactions_test.go
+++ b/chain/types/ethtypes/eth_transactions_test.go
@@ -165,3 +165,47 @@ func TestEthTransactionFromSignedFilecoinMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestParseEthTransactionNonMinimalInts(t *testing.T) {
+	// RLP integers carry no leading zero bytes, so a field encoded with one
+	// decodes to a value that already has a shorter encoding. Both forms parse
+	// to the same transaction and recover the same sender, which would let
+	// anyone rewrite the bytes of someone else's signed transaction and get a
+	// different EthHashFromTxBytes out of it.
+	testcases := []struct {
+		name  string
+		rawTx string
+	}{
+		{
+			// nonce 0x02 re-encoded as the two byte string {0x00, 0x02}
+			"eip1559 nonce",
+			"0x02f85b8401df5e768200028301d69083086a5e835532dd808080c080a0457e33227ac7ceee2ef121755e26b872b6fb04221993f9939349bb7b0a3e1595a02d8ef379e1d2a9e30fa61c92623cc9ed72d80cf6a48cfea341cb916bcc0a81bc",
+		},
+		{
+			// maxPriorityFeePerGas 0x01d690 re-encoded as {0x00, 0x01, 0xd6, 0x90}
+			"eip1559 maxPriorityFeePerGas",
+			"0x02f85a8401df5e7602840001d69083086a5e835532dd808080c080a0457e33227ac7ceee2ef121755e26b872b6fb04221993f9939349bb7b0a3e1595a02d8ef379e1d2a9e30fa61c92623cc9ed72d80cf6a48cfea341cb916bcc0a81bc",
+		},
+		{
+			// nonce 0x03 re-encoded as the two byte string {0x00, 0x03}
+			"legacy nonce",
+			"0xf8618200030182520794b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ba098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa07778cde41a8a37f6a087622b38bc201bd3e7df06dce067569d4def1b53dba98c",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseEthTransaction(mustDecodeHex(tc.rawTx))
+			require.ErrorContains(t, err, "non-minimal encoding")
+		})
+	}
+
+	// the minimally encoded forms of the same transactions still parse
+	for _, rawTx := range []string{
+		"0x02f8598401df5e76028301d69083086a5e835532dd808080c080a0457e33227ac7ceee2ef121755e26b872b6fb04221993f9939349bb7b0a3e1595a02d8ef379e1d2a9e30fa61c92623cc9ed72d80cf6a48cfea341cb916bcc0a81bc",
+		"0xf85f030182520794b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a801ba098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa07778cde41a8a37f6a087622b38bc201bd3e7df06dce067569d4def1b53dba98c",
+	} {
+		_, err := ParseEthTransaction(mustDecodeHex(rawTx))
+		require.NoError(t, err)
+	}
+}

--- a/node/impl/eth/send.go
+++ b/node/impl/eth/send.go
@@ -66,7 +66,9 @@ func (e *ethSend) ethSendRawTransaction(ctx context.Context, rawTx ethtypes.EthB
 		}
 	}
 
-	return ethtypes.EthHashFromTxBytes(rawTx), nil
+	// Callers look the transaction up by this hash, so it must be the one it is
+	// indexed under.
+	return txHash, nil
 }
 
 type EthSendDisabled struct{}


### PR DESCRIPTION
## Related Issues

None. The RLP transaction parsers accept integer fields that carry leading zero bytes, which gives an already-signed transaction more than one valid encoding.

## Proposed Changes

RLP integers are minimally encoded, so a field padded with leading zeros decodes to a value that already has a shorter encoding, and the padded bytes parse to an identical transaction. That matters here because `sender()` and `TxHash()` both re-encode the parsed fields before hashing rather than hashing the bytes that came in, so a padded copy of somebody else's signed transaction recovers the original sender and reports the original transaction hash, and `eth_sendRawTransaction` accepts it. The submitter is the one who notices: that method returns `EthHashFromTxBytes(rawTx)`, taken from the submitted bytes, but indexes the transaction under `TxHash()`, and for a padded encoding those two disagree, so `eth_getTransactionByHash` on the returned hash stays null while the transaction executes normally. I found it while checking what the parsers do with encodings the RLP layer itself permits, since `decodeLength` rejects leading zeros in a length prefix but nothing was checking the field contents. This adds `parseRlpInt`/`parseRlpBigInt`, which require a minimal encoding, and routes every integer field of `parseEip1559Tx` and `parseLegacyTx` through them, covering EIP-1559, legacy Homestead and legacy EIP-155. `parseInt` and `parseBigInt` are deliberately left permissive because `InitialiseSignature` also calls `parseBigInt` on fixed-width 32-byte signature components, where a leading zero byte is part of the value and not padding.

## Additional Info

go-ethereum rejects the same encodings when decoding into an integer field (`rlp: non-canonical integer (leading zero bytes)`), so this only narrows us toward its behaviour; a canonical encoder never emits these, and the existing vectors still parse.

`TestParseEthTransactionNonMinimalInts` covers a padded nonce and a padded `maxPriorityFeePerGas` on EIP-1559 and a padded nonce on legacy, built by re-encoding the signed vectors already in this package, plus the minimal forms to confirm they still parse. All three padded cases parse without error on master and are rejected after the change.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
