### PR TITLE
fix(wallet): render signing bytes for unrecognized message types in interactive mode

### DIFF
--- a/cmd/lotus-wallet/interactive.go
+++ b/cmd/lotus-wallet/interactive.go
@@ -140,13 +140,6 @@ func (c *InteractiveWallet) WalletSign(ctx context.Context, k address.Address, m
 		case api.MTDealProposal:
 			return xerrors.Errorf("TODO") // TODO
 		default:
-			// The node hardcodes MsgMeta{Type: api.MTUnknown} on this path, so
-			// the default branch is the NORMAL case, not an exotic one - and
-			// meta is entirely caller-supplied over JSON-RPC. Rendering only
-			// the address and type then asking "Accept the above?" lets a
-			// caller submit the CID bytes of an arbitrary crafted message and
-			// have the operator approve it blind. Render the signing bytes so
-			// the operator can see what is actually being approved.
 			log.Infow("WalletSign", "address", k, "type", meta.Type)
 			fmt.Printf("Signing bytes (%d bytes, hex):\n%s\n", len(msg), hex.EncodeToString(msg))
 			fmt.Println("WARNING: message type is not recognized; the above raw bytes are what will be signed. Approve only if you can verify them out-of-band.")

--- a/cmd/lotus-wallet/interactive.go
+++ b/cmd/lotus-wallet/interactive.go
@@ -140,7 +140,16 @@ func (c *InteractiveWallet) WalletSign(ctx context.Context, k address.Address, m
 		case api.MTDealProposal:
 			return xerrors.Errorf("TODO") // TODO
 		default:
+			// The node hardcodes MsgMeta{Type: api.MTUnknown} on this path, so
+			// the default branch is the NORMAL case, not an exotic one - and
+			// meta is entirely caller-supplied over JSON-RPC. Rendering only
+			// the address and type then asking "Accept the above?" lets a
+			// caller submit the CID bytes of an arbitrary crafted message and
+			// have the operator approve it blind. Render the signing bytes so
+			// the operator can see what is actually being approved.
 			log.Infow("WalletSign", "address", k, "type", meta.Type)
+			fmt.Printf("Signing bytes (%d bytes, hex):\n%s\n", len(msg), hex.EncodeToString(msg))
+			fmt.Println("WARNING: message type is not recognized; the above raw bytes are what will be signed. Approve only if you can verify them out-of-band.")
 		}
 
 		return nil


### PR DESCRIPTION
## Problem

`InteractiveWallet.WalletSign` switches on the caller-supplied `meta.Type`:

- `MTChainMsg` decodes `meta.Extra`, binds it to the signing bytes via `cid.CidFromBytes(msg)` / `cmsg.Cid().Equals(bc)`, and renders value, max fees, and decoded params.
- `MTDealProposal` errors out.
- **`default`** just `log.Infow`'s the address and type and returns nil — then `accept()` asks *"Accept the above?"* having shown the operator **only the address and type, not what is being signed**.

Two facts make the default branch the normal case rather than an exotic one:

1. `meta` is entirely caller-supplied over JSON-RPC.
2. `node/impl/full/wallet.go` `WalletSign` hardcodes `api.MsgMeta{Type: api.MTUnknown}`, so `MTUnknown` lands in the default branch on the standard path.

Net effect: a caller of a `--interactive` lotus-wallet can submit the CID bytes of an arbitrary crafted chain message, and the operator approves a signature over it with no rendering of the content.

## Fix

In the default branch, render the raw signing bytes (hex) and an explicit *"message type is not recognized"* warning, so the operator sees what is actually being approved and can verify it out-of-band.

## Verification

`go build ./cmd/lotus-wallet/` and `go vet` pass. Display-only change in the interactive approval path; no interface changes.

Made with Cursor

Made with [Cursor](https://cursor.com)