### PR TITLE
chore: update nv29 codename

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -197,7 +197,7 @@ type ForkUpgradeParams struct {
 	UpgradeTockHeight        abi.ChainEpoch
 	UpgradeGoldenWeekHeight  abi.ChainEpoch
 	UpgradeFireHorseHeight   abi.ChainEpoch
-	UpgradeXxHeight          abi.ChainEpoch
+	UpgradeSolsticeHeight    abi.ChainEpoch
 }
 
 // ChainExportConfig holds configuration for chain ranged exports.

--- a/build/buildconstants/params_2k.go
+++ b/build/buildconstants/params_2k.go
@@ -99,7 +99,7 @@ var UpgradeGoldenWeekHeight = abi.ChainEpoch(-31)
 
 var UpgradeFireHorseHeight = abi.ChainEpoch(-32)
 
-var UpgradeXxHeight = abi.ChainEpoch(200)
+var UpgradeSolsticeHeight = abi.ChainEpoch(200)
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandQuicknet,
@@ -182,7 +182,7 @@ func init() {
 	//	UpgradeTockFixHeight = getUpgradeHeight("LOTUS_TOCK_FIX_HEIGHT", UpgradeTockFixHeight)
 	UpgradeGoldenWeekHeight = getUpgradeHeight("LOTUS_GOLDENWEEK_HEIGHT", UpgradeGoldenWeekHeight)
 	UpgradeFireHorseHeight = getUpgradeHeight("LOTUS_FIREHORSE_HEIGHT", UpgradeFireHorseHeight)
-	UpgradeXxHeight = getUpgradeHeight("LOTUS_XX_HEIGHT", UpgradeXxHeight)
+	UpgradeSolsticeHeight = getUpgradeHeight("LOTUS_SOLSTICE_HEIGHT", UpgradeSolsticeHeight)
 
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 		0: DrandQuicknet,

--- a/build/buildconstants/params_butterfly.go
+++ b/build/buildconstants/params_butterfly.go
@@ -86,7 +86,7 @@ var UpgradeGoldenWeekHeight = abi.ChainEpoch(-31)
 
 const UpgradeFireHorseHeight = -32
 
-const UpgradeXxHeight = 999999999999999
+const UpgradeSolsticeHeight = 999999999999999
 
 var ConsensusMinerMinPower = abi.NewStoragePower(2 << 30)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)

--- a/build/buildconstants/params_calibnet.go
+++ b/build/buildconstants/params_calibnet.go
@@ -130,7 +130,7 @@ const UpgradeGoldenWeekHeight abi.ChainEpoch = 3007294
 // 2026-05-07T14:00:00Z
 const UpgradeFireHorseHeight = 3694534
 
-const UpgradeXxHeight = 999999999999999
+const UpgradeSolsticeHeight = 999999999999999
 
 var ConsensusMinerMinPower = abi.NewStoragePower(32 << 30)
 var PreCommitChallengeDelay = abi.ChainEpoch(150)

--- a/build/buildconstants/params_interop.go
+++ b/build/buildconstants/params_interop.go
@@ -86,7 +86,7 @@ var UpgradeGoldenWeekHeight = abi.ChainEpoch(-31)
 
 const UpgradeFireHorseHeight = -32
 
-const UpgradeXxHeight = 50
+const UpgradeSolsticeHeight = 50
 
 var DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 	0: DrandQuicknet,

--- a/build/buildconstants/params_mainnet.go
+++ b/build/buildconstants/params_mainnet.go
@@ -143,7 +143,7 @@ const UpgradeGoldenWeekHeight = abi.ChainEpoch(5348280)
 // 2026-05-27T:14:00:00Z
 var UpgradeFireHorseHeight = abi.ChainEpoch(6052800)
 
-var UpgradeXxHeight = abi.ChainEpoch(9999999999)
+var UpgradeSolsticeHeight = abi.ChainEpoch(9999999999)
 
 var UpgradeTeepInitialFilReserved = InitialFilReserved // FIP-0100: no change for mainnet
 
@@ -165,8 +165,8 @@ func init() {
 	if os.Getenv("LOTUS_DISABLE_FIREHORSE") == "1" {
 		UpgradeFireHorseHeight = math.MaxInt64 - 1
 	}
-	if os.Getenv("LOTUS_DISABLE_XX") == "1" {
-		UpgradeXxHeight = math.MaxInt64 - 1
+	if os.Getenv("LOTUS_DISABLE_SOLSTICE") == "1" {
+		UpgradeSolsticeHeight = math.MaxInt64 - 1
 	}
 
 	// NOTE: DO NOT change this unless you REALLY know what you're doing. This is not consensus critical, however,

--- a/build/buildconstants/params_testground.go
+++ b/build/buildconstants/params_testground.go
@@ -112,7 +112,7 @@ var (
 	UpgradeTockFixHeight                 abi.ChainEpoch = -33
 	UpgradeGoldenWeekHeight              abi.ChainEpoch = -34
 	UpgradeFireHorseHeight               abi.ChainEpoch = -35
-	UpgradeXxHeight                      abi.ChainEpoch = -36
+	UpgradeSolsticeHeight                abi.ChainEpoch = -36
 
 	DrandSchedule = map[abi.ChainEpoch]DrandEnum{
 		0:                    DrandMainnet,

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -20710,7 +20710,7 @@
                                 "UpgradeTockHeight": 10101,
                                 "UpgradeGoldenWeekHeight": 10101,
                                 "UpgradeFireHorseHeight": 10101,
-                                "UpgradeXxHeight": 10101
+                                "UpgradeSolsticeHeight": 10101
                             },
                             "Eip155ChainID": 123,
                             "GenesisTimestamp": 42
@@ -20829,6 +20829,10 @@
                                     "title": "number",
                                     "type": "number"
                                 },
+                                "UpgradeSolsticeHeight": {
+                                    "title": "number",
+                                    "type": "number"
+                                },
                                 "UpgradeTapeHeight": {
                                     "title": "number",
                                     "type": "number"
@@ -20862,10 +20866,6 @@
                                     "type": "number"
                                 },
                                 "UpgradeWatermelonHeight": {
-                                    "title": "number",
-                                    "type": "number"
-                                },
-                                "UpgradeXxHeight": {
                                     "title": "number",
                                     "type": "number"
                                 }

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -9520,7 +9520,7 @@
                                 "UpgradeTockHeight": 10101,
                                 "UpgradeGoldenWeekHeight": 10101,
                                 "UpgradeFireHorseHeight": 10101,
-                                "UpgradeXxHeight": 10101
+                                "UpgradeSolsticeHeight": 10101
                             },
                             "Eip155ChainID": 123,
                             "GenesisTimestamp": 42
@@ -9639,6 +9639,10 @@
                                     "title": "number",
                                     "type": "number"
                                 },
+                                "UpgradeSolsticeHeight": {
+                                    "title": "number",
+                                    "type": "number"
+                                },
                                 "UpgradeTapeHeight": {
                                     "title": "number",
                                     "type": "number"
@@ -9672,10 +9676,6 @@
                                     "type": "number"
                                 },
                                 "UpgradeWatermelonHeight": {
-                                    "title": "number",
-                                    "type": "number"
-                                },
-                                "UpgradeXxHeight": {
                                     "title": "number",
                                     "type": "number"
                                 }

--- a/chain/consensus/filcns/upgrades.go
+++ b/chain/consensus/filcns/upgrades.go
@@ -375,7 +375,7 @@ func DefaultUpgradeSchedule() stmgr.UpgradeSchedule {
 		}},
 		Expensive: true,
 	}, {
-		Height:    buildconstants.UpgradeXxHeight,
+		Height:    buildconstants.UpgradeSolsticeHeight,
 		Network:   network.Version29,
 		Migration: UpgradeActorsV19,
 		PreMigrations: []stmgr.PreMigration{{

--- a/documentation/en/api-methods-v0-deprecated.md
+++ b/documentation/en/api-methods-v0-deprecated.md
@@ -4919,7 +4919,7 @@ Response:
     "UpgradeTockHeight": 10101,
     "UpgradeGoldenWeekHeight": 10101,
     "UpgradeFireHorseHeight": 10101,
-    "UpgradeXxHeight": 10101
+    "UpgradeSolsticeHeight": 10101
   },
   "Eip155ChainID": 123,
   "GenesisTimestamp": 42

--- a/documentation/en/api-methods-v1-stable.md
+++ b/documentation/en/api-methods-v1-stable.md
@@ -7495,7 +7495,7 @@ Response:
     "UpgradeTockHeight": 10101,
     "UpgradeGoldenWeekHeight": 10101,
     "UpgradeFireHorseHeight": 10101,
-    "UpgradeXxHeight": 10101
+    "UpgradeSolsticeHeight": 10101
   },
   "Eip155ChainID": 123,
   "GenesisTimestamp": 42

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -2076,7 +2076,7 @@ func (a *StateAPI) StateGetNetworkParams(ctx context.Context) (*api.NetworkParam
 			UpgradeTockHeight:        buildconstants.UpgradeTockHeight,
 			UpgradeGoldenWeekHeight:  buildconstants.UpgradeGoldenWeekHeight,
 			UpgradeFireHorseHeight:   buildconstants.UpgradeFireHorseHeight,
-			UpgradeXxHeight:          buildconstants.UpgradeXxHeight,
+			UpgradeSolsticeHeight:    buildconstants.UpgradeSolsticeHeight,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Proposed Changes

- Rename the nv29 placeholder codename from `XX` to `Solstice`.
- Rename the upgrade height constant to `UpgradeSolsticeHeight` across network build parameters, the upgrade schedule, and `StateGetNetworkParams`.
- Rename the development controls to `LOTUS_SOLSTICE_HEIGHT` and `LOTUS_DISABLE_SOLSTICE`.
- Regenerate the v0/v1 API documentation and OpenRPC schemas.
