### PR TITLE
refactor(chain): use slices.SortFunc for peer ordering

### DIFF
--- a/chain/block_receipt_tracker.go
+++ b/chain/block_receipt_tracker.go
@@ -1,7 +1,7 @@
 package chain
 
 import (
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -63,8 +63,8 @@ func (brt *blockReceiptTracker) GetPeers(ts *types.TipSet) []peer.ID {
 		out = append(out, p)
 	}
 
-	sort.Slice(out, func(i, j int) bool {
-		return ps.peers[out[i]].Before(ps.peers[out[j]])
+	slices.SortFunc(out, func(a, b peer.ID) int {
+		return ps.peers[a].Compare(ps.peers[b])
 	})
 
 	return out


### PR DESCRIPTION

## Proposed Changes

Replace reflection-based `sort.Slice` with `slices.SortFunc`.




## Checklist

- [x] Commits have a clear commit message.
- [x] PR title conforms with contribution conventions.
- [x] This change does not need a CHANGELOG entry.
- [x] CI is green.