### PR TITLE
refactor: use WaitGroup.Go in parmap

### DIFF
--- a/lib/parmap/parmap.go
+++ b/lib/parmap/parmap.go
@@ -71,17 +71,15 @@ func Par(concurrency int, arr interface{}, f interface{}) {
 
 	rf := reflect.ValueOf(f)
 
-	wg.Add(l)
 	for i := 0; i < l; i++ {
 		throttle <- struct{}{}
 
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() {
 				<-throttle
 			}()
 			rf.Call([]reflect.Value{varr.Index(i)})
-		}(i)
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->

No issue. `lib/parmap` still performs manual `WaitGroup.Add`/`Done` bookkeeping even though Lotus now requires Go 1.25.7.


## Proposed Changes
<!-- A clear list of the changes being made -->


- Launch each mapped call with `WaitGroup.Go`.
- Remove the matching manual `Add` and deferred `Done` calls.
- Preserve the existing throttle and wait behavior.

## Additional Info
<!-- Callouts, links to documentation, and etc -->

No changelog entry is needed: this is an internal, behavior-preserving refactor.


## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [ ] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] Tests exist for new functionality or change in behavior
- [x] CI is green
