### PR TITLE
docs(release): mention create-release-issue workflow

### DIFF
--- a/LOTUS_RELEASE_FLOW.md
+++ b/LOTUS_RELEASE_FLOW.md
@@ -91,7 +91,7 @@ These releases are not mandatory but are highly recommended, as they may contain
 * Lotus Miner: releases ship on an as-needed basis with no specified cadence. (See [Why isn't Lotus Miner released more frequently?](#why-isnt-lotus-miner-released-more-frequently))
 
 ## Release Process
-The specific steps executed for Lotus software releases are captured in the [Release Issue template](./documentation/misc/RELEASE_ISSUE_TEMPLATE.md).  `[cmd/release](./cmd/release/README.md) is used to help populate the template.
+The specific steps executed for Lotus software releases are captured in the [Release Issue template](./documentation/misc/RELEASE_ISSUE_TEMPLATE.md). [`cmd/release`](./cmd/release/README.md) is used to help populate the template, either from the command line or via the [Create Release Issue](https://github.com/filecoin-project/lotus/actions/workflows/create-release-issue.yml) GitHub Actions workflow.
 
 ## Release Candidates (RCs)
 

--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -58,4 +58,4 @@ Create a network-upgrade release issue with RC mode:
 
 ## Creating a Release Issue via GitHub Actions
 
-Instead of running `create-issue` locally, you can trigger the [Create Release Issue](https://github.com/filecoin-project/lotus/actions/workflows/create-release-issue.yml) workflow, which runs the same command in CI and opens the issue on your behalf.
+Instead of running `create-issue` locally, you can trigger the [Create Release Issue](https://github.com/filecoin-project/lotus/actions/workflows/create-release-issue.yml) workflow, which runs `create-issue` in CI with the same parameters. Unlike the local examples above, the workflow passes `--create-on-github=true` (so it actually opens the issue rather than just printing its content) and `--repo` to target this repository.

--- a/cmd/release/README.md
+++ b/cmd/release/README.md
@@ -55,3 +55,7 @@ Create a network-upgrade release issue with RC mode:
 ```sh
 ./release create-issue --type node --tag 1.31.0 --level minor --release-flow auto --network-upgrade 25 --discussion-link https://github.com/filecoin-project/lotus/discussions/12010 --changelog-link https://github.com/filecoin-project/lotus/blob/v1.31.0/CHANGELOG.md --rc1-date 2023-04-01 --stable-date 2023-05-01
 ```
+
+## Creating a Release Issue via GitHub Actions
+
+Instead of running `create-issue` locally, you can trigger the [Create Release Issue](https://github.com/filecoin-project/lotus/actions/workflows/create-release-issue.yml) workflow, which runs the same command in CI and opens the issue on your behalf.


### PR DESCRIPTION
## Summary
- Document the [Create Release Issue](https://github.com/filecoin-project/lotus/actions/workflows/create-release-issue.yml) GitHub Actions workflow in `cmd/release/README.md` as an alternative to running `create-issue` locally.
- Reference the same workflow from `LOTUS_RELEASE_FLOW.md`'s Release Process section, and fix a broken markdown link there (stray backtick before `[cmd/release]`).

## Test plan
- [x] Rendered markdown by inspection (link syntax fixed, no broken references)
- [ ] Docs-only change; no functional testing needed

https://claude.ai/code/session_01ArHv8Q3ULfu8zE7Gs72Z3X