### PR TITLE
fix(chain): reject incomplete event query results from eth event indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ## 🐛 Bug Fixes
 
+- fix(eth): prevent `eth_getLogs` from returning successful empty or partial results when historical event-index coverage is incomplete. Block-hash queries now require a completed block event index, and range queries verify every canonical non-null tipset before returning logs. ([filecoin-project/lotus#13749](https://github.com/filecoin-project/lotus/issues/13749))
+- fix(eth): prevent `eth_getTransactionReceipt` from returning a successful receipt with an empty `logs` array while that transaction's events are still being indexed. The call now fails until event indexing is complete, while transactions that completed with no events still return an empty array. ([filecoin-project/lotus#13758](https://github.com/filecoin-project/lotus/issues/13758))
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))
 - fix(events): `GetActorEventsRaw` and `SubscribeActorEventsRaw` now reject a filter whose `toHeight` is negative. ([filecoin-project/lotus#13751](https://github.com/filecoin-project/lotus/pull/13751))
 - fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))

--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -293,12 +293,14 @@ type EventFilterManager struct {
 	mu            sync.Mutex // guards mutations to filters
 	filters       map[types.FilterID]EventFilter
 	currentHeight abi.ChainEpoch
+	chainRevision uint64 // incremented for every applied or reverted head change
 }
 
 func (m *EventFilterManager) Apply(ctx context.Context, from, to *types.TipSet) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.currentHeight = to.Height()
+	m.chainRevision++
 
 	if len(m.filters) == 0 {
 		return nil
@@ -330,6 +332,7 @@ func (m *EventFilterManager) Revert(ctx context.Context, from, to *types.TipSet)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.currentHeight = to.Height()
+	m.chainRevision++
 
 	if len(m.filters) == 0 {
 		return nil
@@ -357,6 +360,9 @@ func (m *EventFilterManager) Revert(ctx context.Context, from, to *types.TipSet)
 	return nil
 }
 
+// Fill returns a snapshot filter populated from the exact requested range. A
+// minimum height of -1 means start at the next event and skips historical
+// lookup.
 func (m *EventFilterManager) Fill(
 	ctx context.Context,
 	minHeight,
@@ -365,24 +371,40 @@ func (m *EventFilterManager) Fill(
 	addresses []address.Address,
 	keysWithCodec map[string][]types.ActorEventBlock,
 ) (EventFilter, error) {
-	m.mu.Lock()
-	if m.currentHeight == 0 {
-		// sync in progress, we haven't had an Apply
-		m.currentHeight = m.ChainStore.GetHeaviestTipSet().Height()
+	f, err := m.newEventFilter(minHeight, maxHeight, tipsetCid, addresses, keysWithCodec)
+	if err != nil {
+		return nil, err
 	}
-	currentHeight := m.currentHeight
-	m.mu.Unlock()
 
-	if m.ChainIndexer == nil && minHeight != -1 && minHeight < currentHeight {
+	if minHeight == -1 {
+		return f, nil
+	}
+	if m.ChainIndexer == nil {
 		return nil, xerrors.Errorf("historic event index disabled")
 	}
 
+	ces, err := m.getHistoricalEvents(ctx, f, maxHeight)
+	if err != nil {
+		return nil, err
+	}
+	f.setCollectedEvents(ces)
+
+	return f, nil
+}
+
+func (m *EventFilterManager) newEventFilter(
+	minHeight,
+	maxHeight abi.ChainEpoch,
+	tipsetCid cid.Cid,
+	addresses []address.Address,
+	keysWithCodec map[string][]types.ActorEventBlock,
+) (*eventFilter, error) {
 	id, err := newFilterID()
 	if err != nil {
 		return nil, xerrors.Errorf("new filter id: %w", err)
 	}
 
-	f := &eventFilter{
+	return &eventFilter{
 		id:            id,
 		minHeight:     minHeight,
 		maxHeight:     maxHeight,
@@ -390,29 +412,32 @@ func (m *EventFilterManager) Fill(
 		addresses:     addresses,
 		keysWithCodec: keysWithCodec,
 		maxResults:    m.MaxFilterResults,
-	}
-
-	if m.ChainIndexer != nil && minHeight != -1 && minHeight < currentHeight {
-		ef := &index.EventFilter{
-			MinHeight:     minHeight,
-			MaxHeight:     maxHeight,
-			TipsetCid:     tipsetCid,
-			Addresses:     addresses,
-			KeysWithCodec: keysWithCodec,
-			MaxResults:    m.MaxFilterResults,
-		}
-
-		ces, err := m.ChainIndexer.GetEventsForFilter(ctx, ef)
-		if err != nil {
-			return nil, xerrors.Errorf("get events for filter: %w", err)
-		}
-
-		f.setCollectedEvents(ces)
-	}
-
-	return f, nil
+	}, nil
 }
 
+func (m *EventFilterManager) getHistoricalEvents(
+	ctx context.Context,
+	f *eventFilter,
+	maxHeight abi.ChainEpoch,
+) ([]*index.CollectedEvent, error) {
+	ef := &index.EventFilter{
+		MinHeight:     f.minHeight,
+		MaxHeight:     maxHeight,
+		TipsetCid:     f.tipsetCid,
+		Addresses:     f.addresses,
+		KeysWithCodec: f.keysWithCodec,
+		MaxResults:    f.maxResults,
+	}
+
+	ces, err := m.ChainIndexer.GetEventsForFilter(ctx, ef)
+	if err != nil {
+		return nil, xerrors.Errorf("get events for filter: %w", err)
+	}
+	return ces, nil
+}
+
+// Install preloads the executable part of the requested range, then publishes
+// the filter for live collection without leaving a gap between those phases.
 func (m *EventFilterManager) Install(
 	ctx context.Context,
 	minHeight,
@@ -421,19 +446,80 @@ func (m *EventFilterManager) Install(
 	addresses []address.Address,
 	keysWithCodec map[string][]types.ActorEventBlock,
 ) (EventFilter, error) {
-	f, err := m.Fill(ctx, minHeight, maxHeight, tipsetCid, addresses, keysWithCodec)
+	f, err := m.newEventFilter(minHeight, maxHeight, tipsetCid, addresses, keysWithCodec)
 	if err != nil {
 		return nil, err
 	}
 
-	m.mu.Lock()
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		m.mu.Lock()
+		if err := ctx.Err(); err != nil {
+			m.mu.Unlock()
+			return nil, err
+		}
+		if m.currentHeight == 0 {
+			// Sync is still in progress and no Apply has established the
+			// manager's head yet.
+			m.currentHeight = m.ChainStore.GetHeaviestTipSet().Height()
+		}
+		currentHeight := m.currentHeight
+		chainRevision := m.chainRevision
+
+		// The filter starts at or after the current head, so there is no
+		// historical gap to fill. Register it while still holding the lock so
+		// the next Apply cannot pass it.
+		if minHeight == -1 || minHeight >= currentHeight {
+			m.installFilterLocked(f)
+			m.mu.Unlock()
+			return f, nil
+		}
+		if m.ChainIndexer == nil {
+			m.mu.Unlock()
+			return nil, xerrors.Errorf("historic event index disabled")
+		}
+
+		historicalMaxHeight := maxHeight
+		if historicalMaxHeight < 0 || historicalMaxHeight >= currentHeight {
+			// The installed filter retains its requested upper bound. Only its
+			// historical preload stops at the last executable tipset.
+			historicalMaxHeight = currentHeight - 1
+		}
+		m.mu.Unlock()
+
+		ces, queryErr := m.getHistoricalEvents(ctx, f, historicalMaxHeight)
+
+		m.mu.Lock()
+		if err := ctx.Err(); err != nil {
+			m.mu.Unlock()
+			return nil, err
+		}
+		if m.chainRevision != chainRevision {
+			// Apply or Revert moved the live boundary while the query was in
+			// flight. Discard both results and errors, then fill the new gap.
+			m.mu.Unlock()
+			continue
+		}
+		if queryErr != nil {
+			m.mu.Unlock()
+			return nil, queryErr
+		}
+
+		f.setCollectedEvents(ces)
+		m.installFilterLocked(f)
+		m.mu.Unlock()
+		return f, nil
+	}
+}
+
+func (m *EventFilterManager) installFilterLocked(f *eventFilter) {
 	if m.filters == nil {
 		m.filters = make(map[types.FilterID]EventFilter)
 	}
-	m.filters[f.(*eventFilter).id] = f
-	m.mu.Unlock()
-
-	return f, nil
+	m.filters[f.id] = f
 }
 
 func (m *EventFilterManager) Remove(ctx context.Context, id types.FilterID) error {

--- a/chain/events/filter/event_test.go
+++ b/chain/events/filter/event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	pseudo "math/rand"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -22,6 +23,250 @@ import (
 	"github.com/filecoin-project/lotus/chain/index"
 	"github.com/filecoin-project/lotus/chain/types"
 )
+
+type recordingChainIndexer struct {
+	index.Indexer
+	filter *index.EventFilter
+	events []*index.CollectedEvent
+	err    error
+}
+
+func (r *recordingChainIndexer) GetEventsForFilter(_ context.Context, f *index.EventFilter) ([]*index.CollectedEvent, error) {
+	cpy := *f
+	r.filter = &cpy
+	return r.events, r.err
+}
+
+func TestEventFilterManagerFillPreservesRequestedRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		minHeight abi.ChainEpoch
+		maxHeight abi.ChainEpoch
+	}{
+		{name: "future upper bound", minHeight: 90, maxHeight: 110},
+		{name: "open upper bound", minHeight: 90, maxHeight: -1},
+		{name: "entirely future range", minHeight: 105, maxHeight: 110},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			indexer := &recordingChainIndexer{}
+			manager := &EventFilterManager{
+				ChainIndexer:  indexer,
+				currentHeight: 100,
+			}
+
+			filter, err := manager.Fill(context.Background(), test.minHeight, test.maxHeight, cid.Undef, nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, indexer.filter)
+			require.Equal(t, test.minHeight, indexer.filter.MinHeight)
+			require.Equal(t, test.maxHeight, indexer.filter.MaxHeight)
+			require.Equal(t, test.maxHeight, filter.(*eventFilter).maxHeight)
+		})
+	}
+}
+
+func TestEventFilterManagerFillPropagatesSnapshotError(t *testing.T) {
+	wantErr := &index.ErrRangeInFuture{HighestEpoch: 100}
+	indexer := &recordingChainIndexer{err: wantErr}
+	manager := &EventFilterManager{
+		ChainIndexer:  indexer,
+		currentHeight: 100,
+	}
+
+	filter, err := manager.Fill(context.Background(), 105, 110, cid.Undef, nil, nil)
+	require.Nil(t, filter)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestEventFilterManagerInstallClampsHistoricalQueryToLastExecutedTipset(t *testing.T) {
+	epoch95 := abi.ChainEpoch(95)
+	epoch99 := abi.ChainEpoch(99)
+	tests := []struct {
+		name                    string
+		minHeight               abi.ChainEpoch
+		maxHeight               abi.ChainEpoch
+		wantHistoricalMaxHeight *abi.ChainEpoch
+	}{
+		{name: "open upper bound", minHeight: 90, maxHeight: -1, wantHistoricalMaxHeight: &epoch99},
+		{name: "current upper bound", minHeight: 90, maxHeight: 100, wantHistoricalMaxHeight: &epoch99},
+		{name: "future upper bound", minHeight: 90, maxHeight: 110, wantHistoricalMaxHeight: &epoch99},
+		{name: "historical upper bound", minHeight: 90, maxHeight: 95, wantHistoricalMaxHeight: &epoch95},
+		{name: "starts at current head", minHeight: 100, maxHeight: 110},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			indexer := &recordingChainIndexer{}
+			manager := &EventFilterManager{
+				ChainIndexer:  indexer,
+				currentHeight: 100,
+			}
+
+			filter, err := manager.Install(context.Background(), test.minHeight, test.maxHeight, cid.Undef, nil, nil)
+			require.NoError(t, err)
+			if test.wantHistoricalMaxHeight == nil {
+				require.Nil(t, indexer.filter)
+			} else {
+				require.NotNil(t, indexer.filter)
+				require.Equal(t, *test.wantHistoricalMaxHeight, indexer.filter.MaxHeight)
+			}
+			require.Equal(t, test.maxHeight, filter.(*eventFilter).maxHeight)
+			require.Contains(t, manager.filters, filter.ID())
+		})
+	}
+}
+
+type blockingChainIndexer struct {
+	index.Indexer
+	calls        chan *index.EventFilter
+	releaseFirst chan struct{}
+	callCount    int
+	firstEvents  []*index.CollectedEvent
+	firstErr     error
+	retryEvents  []*index.CollectedEvent
+	retryErr     error
+}
+
+func (b *blockingChainIndexer) GetEventsForFilter(ctx context.Context, f *index.EventFilter) ([]*index.CollectedEvent, error) {
+	cpy := *f
+	b.callCount++
+	select {
+	case b.calls <- &cpy:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if b.callCount == 1 {
+		select {
+		case <-b.releaseFirst:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return b.firstEvents, b.firstErr
+	}
+	return b.retryEvents, b.retryErr
+}
+
+func TestEventFilterManagerInstallRetriesIfChainAdvancesDuringPreload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	indexer := &blockingChainIndexer{
+		calls:        make(chan *index.EventFilter, 2),
+		releaseFirst: make(chan struct{}),
+		firstErr:     index.ErrNotFound,
+		retryEvents:  []*index.CollectedEvent{{Height: 100}},
+	}
+	manager := &EventFilterManager{
+		ChainIndexer:  indexer,
+		currentHeight: 100,
+	}
+
+	type installResult struct {
+		filter EventFilter
+		err    error
+	}
+	resultCh := make(chan installResult, 1)
+	go func() {
+		filter, err := manager.Install(ctx, 90, 110, cid.Undef, nil, nil)
+		resultCh <- installResult{filter: filter, err: err}
+	}()
+
+	var firstQuery *index.EventFilter
+	select {
+	case firstQuery = <-indexer.calls:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for first historical query")
+	}
+	require.Equal(t, abi.ChainEpoch(99), firstQuery.MaxHeight)
+
+	rng := pseudo.New(pseudo.NewSource(1374903))
+	ts100 := fakeTipSet(t, rng, 100, nil)
+	ts101 := fakeTipSet(t, rng, 101, ts100.Cids())
+	require.NoError(t, manager.Apply(ctx, ts100, ts101))
+	close(indexer.releaseFirst)
+
+	var secondQuery *index.EventFilter
+	select {
+	case secondQuery = <-indexer.calls:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for retried historical query")
+	}
+	require.Equal(t, abi.ChainEpoch(100), secondQuery.MaxHeight)
+
+	var result installResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for filter installation")
+	}
+	require.NoError(t, result.err)
+	require.Equal(t, abi.ChainEpoch(110), result.filter.(*eventFilter).maxHeight)
+	require.Contains(t, manager.filters, result.filter.ID())
+	require.Equal(t, indexer.retryEvents, result.filter.TakeCollectedEvents(ctx))
+}
+
+func TestEventFilterManagerInstallRetriesAfterSameHeightReorg(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	indexer := &blockingChainIndexer{
+		calls:        make(chan *index.EventFilter, 2),
+		releaseFirst: make(chan struct{}),
+		firstEvents:  []*index.CollectedEvent{{Height: 98}},
+		retryEvents:  []*index.CollectedEvent{{Height: 99}},
+	}
+	manager := &EventFilterManager{
+		ChainIndexer:  indexer,
+		currentHeight: 100,
+	}
+
+	type installResult struct {
+		filter EventFilter
+		err    error
+	}
+	resultCh := make(chan installResult, 1)
+	go func() {
+		filter, err := manager.Install(ctx, 90, 110, cid.Undef, nil, nil)
+		resultCh <- installResult{filter: filter, err: err}
+	}()
+
+	var firstQuery *index.EventFilter
+	select {
+	case firstQuery = <-indexer.calls:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for first historical query")
+	}
+	require.Equal(t, abi.ChainEpoch(99), firstQuery.MaxHeight)
+
+	rng := pseudo.New(pseudo.NewSource(1374904))
+	ts99 := fakeTipSet(t, rng, 99, nil)
+	oldTs100 := fakeTipSet(t, rng, 100, ts99.Cids())
+	newTs100 := fakeTipSet(t, rng, 100, ts99.Cids())
+	require.NoError(t, manager.Revert(ctx, oldTs100, ts99))
+	require.NoError(t, manager.Apply(ctx, ts99, newTs100))
+	close(indexer.releaseFirst)
+
+	var secondQuery *index.EventFilter
+	select {
+	case secondQuery = <-indexer.calls:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for historical query after reorg")
+	}
+	// The final height is still 100, so both queries end at 99. The second
+	// call proves installation noticed the branch change, not just the height.
+	require.Equal(t, abi.ChainEpoch(99), secondQuery.MaxHeight)
+
+	var result installResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for filter installation")
+	}
+	require.NoError(t, result.err)
+	require.Contains(t, manager.filters, result.filter.ID())
+	require.Equal(t, indexer.retryEvents, result.filter.TakeCollectedEvents(ctx))
+}
 
 func keysToKeysWithCodec(keys map[string][][]byte) map[string][]types.ActorEventBlock {
 	keysWithCodec := make(map[string][]types.ActorEventBlock)

--- a/chain/index/ddls.go
+++ b/chain/index/ddls.go
@@ -105,6 +105,7 @@ func preparedStatementMapping(ps *preparedStatements) map[**sql.Stmt]string {
 		&ps.updateTipsetToRevertedStmt:                "UPDATE tipset_message SET reverted = 1 WHERE tipset_key_cid = ?",
 		&ps.removeTipsetsBeforeHeightStmt:             "DELETE FROM tipset_message WHERE height < ?",
 		&ps.removeTipsetBloomsBeforeHeightStmt:        "DELETE FROM tipset_bloom WHERE height < ?",
+		&ps.removeTipsetBloomsFromHeightStmt:          "DELETE FROM tipset_bloom WHERE height >= ?",
 		&ps.removeEthHashesOlderThanStmt:              "DELETE FROM eth_tx_hash WHERE inserted_at < datetime('now', ?)",
 		&ps.updateTipsetsToRevertedFromHeightStmt:     "UPDATE tipset_message SET reverted = 1 WHERE height >= ?",
 		&ps.updateEventsToRevertedFromHeightStmt:      "UPDATE event SET reverted = 1 WHERE message_id IN (SELECT id FROM tipset_message WHERE height >= ?)",
@@ -120,6 +121,8 @@ func preparedStatementMapping(ps *preparedStatements) map[**sql.Stmt]string {
 		&ps.getTipsetEventEntriesStmt:                 "SELECT e.id, e.emitter_id, e.emitter_addr, ee.flags, ee.key, ee.codec, ee.value FROM event e JOIN event_entry ee ON ee.event_id = e.id JOIN tipset_message tm ON e.message_id = tm.id WHERE tm.tipset_key_cid = ? AND tm.reverted = 0 AND e.reverted = 0 ORDER BY e.event_index ASC, ee._rowid_ ASC",
 		&ps.insertTipsetBloomStmt:                     "INSERT INTO tipset_bloom (tipset_key_cid, height, bloom) VALUES (?, ?, ?) ON CONFLICT (tipset_key_cid) DO UPDATE SET height = excluded.height, bloom = excluded.bloom",
 		&ps.hasTipsetBloomStmt:                        "SELECT EXISTS(SELECT 1 FROM tipset_bloom WHERE tipset_key_cid = ?)",
+		&ps.hasTipsetEventCompletionStmt:              "SELECT EXISTS(SELECT 1 FROM tipset_bloom b JOIN tipset_message tm ON tm.tipset_key_cid = b.tipset_key_cid WHERE b.tipset_key_cid = ? LIMIT 1)",
+		&ps.getTipsetEventCompletionsByHeightStmt:     "SELECT b.tipset_key_cid FROM tipset_bloom b WHERE b.height BETWEEN ? AND ? AND EXISTS (SELECT 1 FROM tipset_message tm WHERE tm.tipset_key_cid = b.tipset_key_cid AND tm.reverted = 0)",
 		&ps.getTipsetBloomStmt:                        "SELECT bloom FROM tipset_bloom WHERE tipset_key_cid = ? LIMIT 1",
 		&ps.removeTipsetBloomStmt:                     "DELETE FROM tipset_bloom WHERE tipset_key_cid = ?",
 	}

--- a/chain/index/events.go
+++ b/chain/index/events.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -24,6 +23,11 @@ import (
 )
 
 const maxLookBackForWait = 120 // one hour of tipsets
+
+// Avoid an unbounded eager allocation when a trusted caller configures a very
+// large event range. The default public range (2,880 epochs) still fits in the
+// hint; larger ranges grow the map normally as the canonical chain is walked.
+const maxEventRangePreallocation = 8192
 
 var (
 	ErrMaxResultsReached = xerrors.New("filter matches too many events, try a more restricted filter")
@@ -380,153 +384,129 @@ func loadExecutedMessages(ctx context.Context, cs ChainStore, recomputeTipSetSta
 	return ems, nil
 }
 
-// checkFilterTipsetsIndexed verifies if a tipset, or a range of tipsets, specified by a given
-// filter is indexed. It checks for the existence of non-null rounds at the range boundaries.
-func (si *SqliteIndexer) checkFilterTipsetsIndexed(ctx context.Context, f *EventFilter) error {
-	// Three cases to consider:
-	// 1. Specific tipset is provided
-	// 2. Single tipset is specified by the height range (min=max)
-	// 3. Range of tipsets is specified by the height range (min!=max)
-	// We'll handle the first two cases here and the third case in checkRangeIndexedStatus
-
-	var tipsetKeyCid []byte
-	var err error
-
-	switch {
-	case f.TipsetCid != cid.Undef:
-		tipsetKeyCid = f.TipsetCid.Bytes()
-	case f.MinHeight >= 0 && f.MinHeight == f.MaxHeight:
-		tipsetKeyCid, err = si.getTipsetKeyCidByHeight(ctx, f.MinHeight)
-		if err != nil {
-			if err == ErrNotFound {
-				// this means that this is a null round and there exist no events for this epoch
-				return nil
-			}
-			return xerrors.Errorf("failed to get tipset key cid by height: %w", err)
-		}
-	default:
-		return si.checkRangeIndexedStatus(ctx, f.MinHeight, f.MaxHeight)
-	}
-
-	// If we couldn't determine a specific tipset, return ErrNotFound
-	if tipsetKeyCid == nil {
-		return ErrNotFound
-	}
-
-	// Check if the determined tipset is indexed
-	if exists, err := si.isTipsetIndexed(ctx, tipsetKeyCid); err != nil {
-		return xerrors.Errorf("failed to check if tipset is indexed: %w", err)
-	} else if exists {
-		return nil // Tipset is indexed
-	}
-
-	return ErrNotFound // Tipset is not indexed
+type eventRangeCoverage struct {
+	minHeight abi.ChainEpoch
+	maxHeight abi.ChainEpoch
+	tipsets   map[cid.Cid]struct{}
 }
 
-// checkRangeIndexedStatus verifies if a range of tipsets specified by the given height range is
-// indexed. It checks for the existence of non-null rounds at the range boundaries.
-func (si *SqliteIndexer) checkRangeIndexedStatus(ctx context.Context, minHeight abi.ChainEpoch, maxHeight abi.ChainEpoch) error {
+func (si *SqliteIndexer) getEventRangeCoverage(ctx context.Context, minHeight, maxHeight abi.ChainEpoch) (*eventRangeCoverage, error) {
 	head := si.cs.GetHeaviestTipSet()
+	if head == nil {
+		return nil, xerrors.New("failed to get head: head is nil")
+	}
+
+	if minHeight < 0 && maxHeight < 0 {
+		return nil, xerrors.New("filter must specify a minimum or maximum height")
+	}
+	if minHeight < 0 {
+		minHeight = 0
+	}
+	if maxHeight < 0 {
+		// Events from the heaviest tipset are not available until its child is
+		// applied, so an open range is pinned to the captured head's parent.
+		maxHeight = head.Height() - 1
+	}
 	if minHeight > head.Height() || maxHeight > head.Height() {
-		return &ErrRangeInFuture{HighestEpoch: int(head.Height())}
+		return nil, &ErrRangeInFuture{HighestEpoch: int(head.Height())}
 	}
 
-	// Find the first non-null round in the range
-	startCid, startHeight, err := si.findFirstNonNullRound(ctx, minHeight, maxHeight)
-	if err != nil {
-		return xerrors.Errorf("failed to find first non-null round: %w", err)
-	}
-	// If all rounds are null, consider the range valid
-	if startCid == nil {
-		return nil
-	}
-
-	// Find the last non-null round in the range
-	endCid, endHeight, err := si.findLastNonNullRound(ctx, maxHeight, minHeight)
-	if err != nil {
-		return xerrors.Errorf("failed to find last non-null round: %w", err)
-	}
-	// We should have already rulled out all rounds being null in the startCid check
-	if endCid == nil {
-		return xerrors.Errorf("unexpected error finding last non-null round: all rounds are null but start round is not (%d to %d)", minHeight, maxHeight)
-	}
-
-	// Check indexing status for start and end tipsets
-	if err := si.checkTipsetIndexedStatus(ctx, startCid, startHeight); err != nil {
-		return err
-	}
-	if err := si.checkTipsetIndexedStatus(ctx, endCid, endHeight); err != nil {
-		return err
-	}
-	// Assume (not necessarily correctly, but likely) that all tipsets within the range are indexed
-
-	return nil
-}
-
-func (si *SqliteIndexer) checkTipsetIndexedStatus(ctx context.Context, tipsetKeyCid []byte, height abi.ChainEpoch) error {
-	exists, err := si.isTipsetIndexed(ctx, tipsetKeyCid)
-	if err != nil {
-		return xerrors.Errorf("failed to check if tipset at epoch %d is indexed: %w", height, err)
-	} else if exists {
-		return nil // has been indexed
-	}
-	return ErrNotFound
-}
-
-// findFirstNonNullRound finds the first non-null round starting from minHeight up to maxHeight.
-// It updates the minHeight to the found height and returns the tipset key CID.
-func (si *SqliteIndexer) findFirstNonNullRound(ctx context.Context, minHeight abi.ChainEpoch, maxHeight abi.ChainEpoch) ([]byte, abi.ChainEpoch, error) {
-	for height := minHeight; height <= maxHeight; height++ {
-		cid, err := si.getTipsetKeyCidByHeight(ctx, height)
-		if err != nil {
-			if !errors.Is(err, ErrNotFound) {
-				return nil, 0, xerrors.Errorf("failed to get tipset key cid for height %d: %w", height, err)
-			}
-			// else null round, keep searching
-			continue
-		}
-		return cid, height, nil
-	}
-	// All rounds are null
-	return nil, 0, nil
-}
-
-// findLastNonNullRound finds the last non-null round starting from maxHeight down to minHeight
-func (si *SqliteIndexer) findLastNonNullRound(ctx context.Context, maxHeight abi.ChainEpoch, minHeight abi.ChainEpoch) ([]byte, abi.ChainEpoch, error) {
-	for height := maxHeight; height >= minHeight; height-- {
-		cid, err := si.getTipsetKeyCidByHeight(ctx, height)
-		if err == nil {
-			return cid, height, nil
-		}
-		if !errors.Is(err, ErrNotFound) {
-			return nil, 0, xerrors.Errorf("failed to get tipset key cid for height %d: %w", height, err)
+	tipsetCapacity := 0
+	if maxHeight >= minHeight && maxHeight >= 0 {
+		span := maxHeight - minHeight
+		if span < maxEventRangePreallocation {
+			tipsetCapacity = int(span) + 1
+		} else {
+			tipsetCapacity = maxEventRangePreallocation
 		}
 	}
-	// All rounds are null
-	return nil, 0, nil
-}
+	coverage := &eventRangeCoverage{
+		minHeight: minHeight,
+		maxHeight: maxHeight,
+		tipsets:   make(map[cid.Cid]struct{}, tipsetCapacity),
+	}
+	if maxHeight < minHeight || maxHeight < 0 {
+		return coverage, nil
+	}
 
-// getTipsetKeyCidByHeight retrieves the tipset key CID for a given height from the ChainStore
-func (si *SqliteIndexer) getTipsetKeyCidByHeight(ctx context.Context, height abi.ChainEpoch) ([]byte, error) {
-	ts, err := si.cs.GetTipsetByHeight(ctx, height, nil, false)
+	ts, err := si.cs.GetTipsetByHeight(ctx, maxHeight, head, true)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get tipset by height: %w", err)
+		return nil, xerrors.Errorf("failed to get canonical tipset at or before height %d: %w", maxHeight, err)
 	}
 	if ts == nil {
-		return nil, xerrors.Errorf("tipset is nil for height: %d", height)
+		return nil, xerrors.Errorf("failed to get canonical tipset at or before height %d: tipset is nil", maxHeight)
+	}
+	tsKey := ts.Key()
+
+	for ts.Height() >= minHeight {
+		if ts.Height() > maxHeight {
+			return nil, xerrors.Errorf("canonical tipset height %d is above requested maximum %d", ts.Height(), maxHeight)
+		}
+
+		tsKeyCid, err := tsKey.Cid()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get tipset key cid at height %d: %w", ts.Height(), err)
+		}
+		coverage.tipsets[tsKeyCid] = struct{}{}
+
+		if ts.Height() == 0 || ts.Height() == minHeight {
+			break
+		}
+		parentKey := ts.Parents()
+		parent, err := si.cs.GetTipSetFromKey(ctx, parentKey)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get parent of tipset at height %d: %w", ts.Height(), err)
+		}
+		if parent == nil {
+			return nil, xerrors.Errorf("failed to get parent of tipset at height %d: tipset is nil", ts.Height())
+		}
+		if parent.Height() >= ts.Height() {
+			return nil, xerrors.Errorf("invalid chain order: parent height %d is not below child height %d", parent.Height(), ts.Height())
+		}
+		ts = parent
+		tsKey = parentKey
 	}
 
-	if ts.Height() != height {
-		// this means that this is a null round
-		return nil, ErrNotFound
+	return coverage, nil
+}
+
+func (si *SqliteIndexer) isEventRangeIndexed(ctx context.Context, tx *sql.Tx, coverage *eventRangeCoverage) (bool, error) {
+	if len(coverage.tipsets) == 0 {
+		return true, nil
 	}
 
-	return toTipsetKeyCidBytes(ts)
+	rows, err := tx.Stmt(si.stmts.getTipsetEventCompletionsByHeightStmt).QueryContext(ctx, coverage.minHeight, coverage.maxHeight)
+	if err != nil {
+		return false, xerrors.Errorf("failed to query event index completion for range: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	completedTipsets := 0
+	for rows.Next() {
+		var tipsetKeyCidBytes []byte
+		if err := rows.Scan(&tipsetKeyCidBytes); err != nil {
+			return false, xerrors.Errorf("failed to read event index completion for range: %w", err)
+		}
+		tipsetKeyCid, err := cid.Cast(tipsetKeyCidBytes)
+		if err != nil {
+			return false, xerrors.Errorf("failed to parse event index completion tipset cid: %w", err)
+		}
+		if _, ok := coverage.tipsets[tipsetKeyCid]; ok {
+			// tipset_bloom.tipset_key_cid is a primary key, so each expected
+			// tipset can contribute at most once.
+			completedTipsets++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, xerrors.Errorf("failed while reading event index completion for range: %w", err)
+	}
+
+	return completedTipsets == len(coverage.tipsets), nil
 }
 
 // GetEventsForFilter returns matching events for the given filter
 // Returns nil, nil if the filter has no matching events
-// Returns nil, ErrNotFound if the filter has no matching events and the tipset is not indexed
+// Returns nil, ErrNotFound if event-index completion cannot be established for the requested tipsets
 // Returns nil, ErrBackfillRequired if the index is in degraded mode and requires a backfill
 // Returns nil, err for all other errors
 func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter) ([]*CollectedEvent, error) {
@@ -681,6 +661,9 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 				Value: row.value,
 			})
 		}
+		if err := q.Err(); err != nil {
+			return nil, xerrors.Errorf("failed while reading events: %w", err)
+		}
 
 		if len(ces) == 0 {
 			return nil, nil
@@ -689,7 +672,23 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 		return ces, nil
 	}
 
-	values, query, err := makePrefillFilterQuery(f)
+	queryFilter := f
+	var (
+		rangeCoverage *eventRangeCoverage
+		err           error
+	)
+	if f.TipsetCid == cid.Undef {
+		rangeCoverage, err = si.getEventRangeCoverage(ctx, f.MinHeight, f.MaxHeight)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to determine canonical event range: %w", err)
+		}
+		normalized := *f
+		normalized.MinHeight = rangeCoverage.minHeight
+		normalized.MaxHeight = rangeCoverage.maxHeight
+		queryFilter = &normalized
+	}
+
+	values, query, err := makePrefillFilterQuery(queryFilter)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to make prefill filter query: %w", err)
 	}
@@ -700,51 +699,108 @@ func (si *SqliteIndexer) GetEventsForFilter(ctx context.Context, f *EventFilter)
 	}
 	defer func() { _ = stmt.Close() }()
 
-	ces, err := getEventsFnc(stmt, values)
+	// indexEvents writes the tipset bloom after all event rows, including an
+	// empty bloom for a tipset with no events. Read rows and completion markers
+	// in one snapshot so a concurrent Apply, backfill, or GC cannot turn an
+	// incomplete read into an authoritative empty or partial result.
+	isTipsetCIDQuery := f.TipsetCid != cid.Undef
+	getEvents := func() ([]*CollectedEvent, bool, error) {
+		tx, err := si.db.BeginTx(ctx, nil)
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to begin event index read transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		if rangeCoverage != nil {
+			complete, err := si.isEventRangeIndexed(ctx, tx, rangeCoverage)
+			if err != nil {
+				return nil, false, err
+			}
+			if !complete {
+				return nil, false, nil
+			}
+		}
+
+		ces, err := getEventsFnc(tx.Stmt(stmt), values)
+		if err != nil {
+			return nil, false, err
+		}
+		if rangeCoverage != nil {
+			var lastTipsetKey types.TipSetKey
+			for i, ce := range ces {
+				// Results are ordered by height, message, and event index, so a
+				// contributing tipset's events are contiguous. Validate each run
+				// once instead of hashing the same TipSetKey for every event.
+				if i > 0 && ce.TipSetKey == lastTipsetKey {
+					continue
+				}
+				tsKeyCid, err := ce.TipSetKey.Cid()
+				if err != nil {
+					return nil, false, xerrors.Errorf("failed to get event tipset key cid: %w", err)
+				}
+				if _, ok := rangeCoverage.tipsets[tsKeyCid]; !ok {
+					return nil, false, nil
+				}
+				lastTipsetKey = ce.TipSetKey
+			}
+			return ces, true, nil
+		}
+
+		if len(ces) > 0 {
+			// Preserve reads from databases created before tipset blooms were
+			// introduced. Event rows are themselves sufficient for a non-empty
+			// result because indexEvents commits all rows atomically.
+			return ces, true, nil
+		}
+
+		var complete bool
+		if err := tx.Stmt(si.stmts.hasTipsetEventCompletionStmt).QueryRowContext(ctx, f.TipsetCid.Bytes()).Scan(&complete); err != nil {
+			return nil, false, xerrors.Errorf("failed to check if tipset event indexing is complete: %w", err)
+		}
+		return nil, complete, nil
+	}
+
+	ces, eventsComplete, err := getEvents()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get events: %w", err)
 	}
-	if len(ces) == 0 {
-		height := f.MaxHeight
-		if f.TipsetCid != cid.Undef {
-			ts, err := si.cs.GetTipSetByCid(ctx, f.TipsetCid)
-			if err != nil {
-				return nil, xerrors.Errorf("failed to get tipset by cid: %w", err)
-			}
-			if ts == nil {
-				return nil, xerrors.Errorf("failed to get tipset from cid: tipset is nil for cid: %s", f.TipsetCid)
-			}
-			height = ts.Height()
-		}
-		if height > 0 {
-			head := si.cs.GetHeaviestTipSet()
-			if head == nil {
-				return nil, xerrors.New("failed to get head: head is nil")
-			}
-			headHeight := head.Height()
-			maxLookBackHeight := headHeight - maxLookBackForWait
+	if eventsComplete {
+		return ces, nil
+	}
 
-			// if the height is old enough, we'll assume the index is caught up to it and not bother
-			// waiting for it to be indexed
-			if height <= maxLookBackHeight {
-				return nil, si.checkFilterTipsetsIndexed(ctx, f)
-			}
-		}
-
-		// there's no matching events for the filter, wait till index has caught up to the head and then retry
-		if err := si.waitTillHeadIndexed(ctx); err != nil {
-			return nil, xerrors.Errorf("failed to wait for head to be indexed: %w", err)
-		}
-		ces, err = getEventsFnc(stmt, values)
+	height := queryFilter.MaxHeight
+	if isTipsetCIDQuery {
+		ts, err := si.cs.GetTipSetByCid(ctx, f.TipsetCid)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get events: %w", err)
+			return nil, xerrors.Errorf("failed to get tipset by cid: %w", err)
 		}
-
-		if len(ces) == 0 {
-			return nil, si.checkFilterTipsetsIndexed(ctx, f)
+		if ts == nil {
+			return nil, xerrors.Errorf("failed to get tipset from cid: tipset is nil for cid: %s", f.TipsetCid)
+		}
+		height = ts.Height()
+	}
+	if height > 0 {
+		head := si.cs.GetHeaviestTipSet()
+		if head == nil {
+			return nil, xerrors.New("failed to get head: head is nil")
+		}
+		if height <= head.Height()-maxLookBackForWait {
+			return nil, ErrNotFound
 		}
 	}
 
+	// Recent coverage may still be catching up. Preserve the existing wait,
+	// then require the event-completion markers on the retry as well.
+	if err := si.waitTillHeadIndexed(ctx); err != nil {
+		return nil, xerrors.Errorf("failed to wait for head to be indexed: %w", err)
+	}
+	ces, eventsComplete, err = getEvents()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get events: %w", err)
+	}
+	if !eventsComplete {
+		return nil, ErrNotFound
+	}
 	return ces, nil
 }
 
@@ -775,8 +831,8 @@ func makePrefillFilterQuery(f *EventFilter) ([]any, string, error) {
 			}
 		}
 		// unless asking for a specific tipset, we never want to see reverted historical events
-		clauses = append(clauses, "e.reverted=?")
-		values = append(values, false)
+		clauses = append(clauses, "tm.reverted=?", "e.reverted=?")
+		values = append(values, false, false)
 	}
 
 	if f.MsgCid != cid.Undef {

--- a/chain/index/events_test.go
+++ b/chain/index/events_test.go
@@ -30,52 +30,70 @@ func TestGetEventsForFilterNoEvents(t *testing.T) {
 	si, _, cs := setupWithHeadIndexed(t, headHeight, rng)
 	t.Cleanup(func() { _ = si.Close() })
 
-	// Create a fake tipset at various heights used in the test
-	fakeTipsets := make(map[abi.ChainEpoch]*types.TipSet)
-	for _, ts := range []abi.ChainEpoch{1, 10, 20} {
-		fakeTipsets[ts] = fakeTipSet(t, rng, ts, nil)
-		cs.SetTipsetByHeightAndKey(ts, fakeTipsets[ts].Key(), fakeTipsets[ts])
-		cs.SetTipSetByCid(t, fakeTipsets[ts])
+	// Create a sparse canonical chain for the heights used in the test.
+	fakeTipsets := map[abi.ChainEpoch]*types.TipSet{
+		1: fakeTipSet(t, rng, 1, nil),
+	}
+	fakeTipsets[10] = fakeTipSet(t, rng, 10, fakeTipsets[1].Cids())
+	fakeTipsets[20] = fakeTipSet(t, rng, 20, fakeTipsets[10].Cids())
+	for height, ts := range fakeTipsets {
+		cs.SetTipsetByHeightAndKey(height, ts.Key(), ts)
+		cs.SetTipSetByCid(t, ts)
 	}
 
 	// tipset is not indexed
-	f := &EventFilter{
+	heightFilter := &EventFilter{
 		MinHeight: 1,
 		MaxHeight: 1,
 	}
-	ces, err := si.GetEventsForFilter(ctx, f)
+	ces, err := si.GetEventsForFilter(ctx, heightFilter)
 	require.True(t, errors.Is(err, ErrNotFound))
 	require.Equal(t, 0, len(ces))
 
 	tsCid, err := fakeTipsets[1].Key().Cid()
 	require.NoError(t, err)
-	f = &EventFilter{
+	blockFilter := &EventFilter{
 		TipsetCid: tsCid,
 	}
 
-	ces, err = si.GetEventsForFilter(ctx, f)
+	ces, err = si.GetEventsForFilter(ctx, blockFilter)
 	require.True(t, errors.Is(err, ErrNotFound))
 	require.Equal(t, 0, len(ces))
 
-	// tipset is indexed but has no events
+	// Message metadata alone does not prove event indexing completed.
 	err = withTx(ctx, si.db, func(tx *sql.Tx) error {
 		return si.indexTipset(ctx, tx, fakeTipsets[1])
 	})
 	require.NoError(t, err)
 
-	ces, err = si.GetEventsForFilter(ctx, f)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(ces))
+	ces, err = si.GetEventsForFilter(ctx, heightFilter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, ces)
+	ces, err = si.GetEventsForFilter(ctx, blockFilter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, ces)
 
-	f = &EventFilter{
-		TipsetCid: tsCid,
-	}
-	ces, err = si.GetEventsForFilter(ctx, f)
+	// A completed event index writes an empty bloom for a block with no events.
+	executionTipset := fakeTipSet(t, rng, 2, fakeTipsets[1].Cids())
+	cs.SetTipsetByHeightAndKey(executionTipset.Height(), executionTipset.Key(), executionTipset)
+	cs.SetTipSetByCid(t, executionTipset)
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(context.Context, ChainStore, *types.TipSet, *types.TipSet) ([]executedMessage, error) {
+		return nil, nil
+	})
+	require.NoError(t, si.Apply(ctx, fakeTipsets[1], executionTipset))
+
+	ces, err = si.GetEventsForFilter(ctx, heightFilter)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(ces))
+	require.Empty(t, ces)
+	ces, err = si.GetEventsForFilter(ctx, blockFilter)
+	require.NoError(t, err)
+	require.Empty(t, ces)
 
 	// search for a range that is not indexed
-	f = &EventFilter{
+	f := &EventFilter{
 		MinHeight: 10,
 		MaxHeight: 20,
 	}
@@ -100,6 +118,334 @@ func TestGetEventsForFilterNoEvents(t *testing.T) {
 	ces, err = si.GetEventsForFilter(ctx, f)
 	require.ErrorIs(t, err, &ErrRangeInFuture{})
 	require.Equal(t, 0, len(ces))
+}
+
+func TestGetEventsForFilterReturnsNotFoundUntilEventsAreIndexed(t *testing.T) {
+	ctx := context.Background()
+	rng := pseudo.New(pseudo.NewSource(13758))
+
+	msgTipset := fakeTipSet(t, rng, 1, nil)
+	executionTipset := fakeTipSet(t, rng, 2, msgTipset.Cids())
+
+	cs := newDummyChainStore()
+	cs.SetHeaviestTipSet(executionTipset)
+	cs.SetTipsetByHeightAndKey(msgTipset.Height(), msgTipset.Key(), msgTipset)
+	cs.SetTipsetByHeightAndKey(executionTipset.Height(), executionTipset.Key(), executionTipset)
+	cs.SetTipSetByCid(t, msgTipset)
+	cs.SetTipSetByCid(t, executionTipset)
+
+	msg := fakeMessage(address.TestAddress, address.TestAddress)
+	msgWithoutEvents := fakeMessage(address.TestAddress, address.TestAddress)
+	msgWithoutEvents.Nonce++
+	cs.SetMessagesForTipset(msgTipset, []types.ChainMsg{msg, msgWithoutEvents})
+
+	si, err := NewSqliteIndexer(":memory:", cs, 0, false, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(context.Context, ChainStore, *types.TipSet, *types.TipSet) ([]executedMessage, error) {
+		return []executedMessage{
+			{
+				msg: msg,
+				evs: []types.Event{*fakeEvent(abi.ActorID(1), []kv{{k: "t1", v: []byte("topic")}}, nil)},
+			},
+			{msg: msgWithoutEvents},
+		}, nil
+	})
+
+	// Message-only population records tipsets and messages without executing
+	// them to collect events.
+	require.NoError(t, withTx(ctx, si.db, func(tx *sql.Tx) error {
+		if err := si.indexTipset(ctx, tx, msgTipset); err != nil {
+			return err
+		}
+		return si.indexTipset(ctx, tx, executionTipset)
+	}))
+
+	msgTipsetCid, err := msgTipset.Key().Cid()
+	require.NoError(t, err)
+	blockFilter := &EventFilter{
+		MinHeight: -1,
+		MaxHeight: -1,
+		TipsetCid: msgTipsetCid,
+		Codec:     multicodec.Raw,
+	}
+
+	events, err := si.GetEventsForFilter(ctx, blockFilter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+
+	filter := &EventFilter{
+		MinHeight: -1,
+		MaxHeight: -1,
+		TipsetCid: msgTipsetCid,
+		MsgCid:    msg.Cid(),
+		Codec:     multicodec.Raw,
+	}
+
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+
+	require.NoError(t, si.Apply(ctx, msgTipset, executionTipset))
+	events, err = si.GetEventsForFilter(ctx, blockFilter)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, msg.Cid(), events[0].MsgCid)
+
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, msg.Cid(), events[0].MsgCid)
+
+	filter.MsgCid = msgWithoutEvents.Cid()
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.NoError(t, err)
+	require.Empty(t, events)
+	filter.MsgCid = msg.Cid()
+
+	// GC removes tipset rows (and cascades to events) before removing bloom
+	// rows. During that interval, the completion marker must not make missing
+	// event data look like an authoritative empty result.
+	_, err = si.stmts.removeTipsetsBeforeHeightStmt.ExecContext(ctx, executionTipset.Height())
+	require.NoError(t, err)
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+	events, err = si.GetEventsForFilter(ctx, blockFilter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+}
+
+func TestGetEventsForFilterRejectsPartiallyIndexedRange(t *testing.T) {
+	ctx := context.Background()
+	rng := pseudo.New(pseudo.NewSource(13749))
+
+	ts10 := fakeTipSet(t, rng, 10, nil)
+	ts11 := fakeTipSet(t, rng, 11, ts10.Cids())
+	ts12 := fakeTipSet(t, rng, 12, ts11.Cids())
+	ts13 := fakeTipSet(t, rng, 13, ts12.Cids())
+
+	cs := newDummyChainStore()
+	cs.SetHeaviestTipSet(ts13)
+	for _, ts := range []*types.TipSet{ts10, ts11, ts12, ts13} {
+		cs.SetTipsetByHeightAndKey(ts.Height(), ts.Key(), ts)
+		cs.SetTipSetByCid(t, ts)
+	}
+
+	msg10 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg11 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg11.Nonce++
+	msg12 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg12.Nonce += 2
+	cs.SetMessagesForTipset(ts10, []types.ChainMsg{msg10})
+	cs.SetMessagesForTipset(ts11, []types.ChainMsg{msg11})
+	cs.SetMessagesForTipset(ts12, []types.ChainMsg{msg12})
+
+	si, err := NewSqliteIndexer(":memory:", cs, 0, false, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(_ context.Context, _ ChainStore, msgTs, _ *types.TipSet) ([]executedMessage, error) {
+		switch msgTs.Height() {
+		case 10:
+			return []executedMessage{{
+				msg: msg10,
+				evs: []types.Event{*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "t1", v: []byte("first")}}, multicodec.Raw)},
+			}}, nil
+		case 11:
+			return []executedMessage{{msg: msg11}}, nil
+		case 12:
+			return []executedMessage{{
+				msg: msg12,
+				evs: []types.Event{*fakeEventWithCodec(abi.ActorID(2), []kv{{k: "t1", v: []byte("last")}}, multicodec.Raw)},
+			}}, nil
+		default:
+			return nil, nil
+		}
+	})
+
+	require.NoError(t, si.Apply(ctx, ts10, ts11))
+	require.NoError(t, si.Apply(ctx, ts12, ts13))
+
+	// A completed non-canonical tipset at the missing height must not stand in
+	// for the canonical tipset. This gives the completion query the same number
+	// of rows as the requested range while leaving canonical ts11 incomplete.
+	staleTs11 := fakeTipSet(t, rng, 11, ts10.Cids())
+	staleTs12 := fakeTipSet(t, rng, 12, staleTs11.Cids())
+	cs.SetTipSetByCid(t, staleTs11)
+	cs.SetTipSetByCid(t, staleTs12)
+	cs.SetMessagesForTipset(staleTs11, []types.ChainMsg{msg11})
+	require.NoError(t, si.Apply(ctx, staleTs11, staleTs12))
+	staleTs11Cid, err := staleTs11.Key().Cid()
+	require.NoError(t, err)
+	staleEvents, err := si.GetEventsForFilter(ctx, &EventFilter{TipsetCid: staleTs11Cid})
+	require.NoError(t, err)
+	require.Empty(t, staleEvents)
+
+	filter := &EventFilter{MinHeight: 10, MaxHeight: 12, Codec: multicodec.Raw}
+	events, err := si.GetEventsForFilter(ctx, filter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+
+	require.NoError(t, si.Apply(ctx, ts11, ts12))
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, abi.ChainEpoch(10), events[0].Height)
+	require.Equal(t, abi.ChainEpoch(12), events[1].Height)
+
+	// An open upper bound is pinned to the captured head's last executable
+	// tipset, so it neither requires nor returns events from the head itself.
+	events, err = si.GetEventsForFilter(ctx, &EventFilter{MinHeight: 10, MaxHeight: -1, Codec: multicodec.Raw})
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, abi.ChainEpoch(10), events[0].Height)
+	require.Equal(t, abi.ChainEpoch(12), events[1].Height)
+}
+
+func TestGetEventsForFilterRejectsNonCanonicalEventRows(t *testing.T) {
+	ctx := context.Background()
+	rng := pseudo.New(pseudo.NewSource(1374902))
+
+	ts10 := fakeTipSet(t, rng, 10, nil)
+	ts11 := fakeTipSet(t, rng, 11, ts10.Cids())
+	ts12 := fakeTipSet(t, rng, 12, ts11.Cids())
+	staleTs11 := fakeTipSet(t, rng, 11, ts10.Cids())
+	staleTs12 := fakeTipSet(t, rng, 12, staleTs11.Cids())
+
+	cs := newDummyChainStore()
+	cs.SetHeaviestTipSet(ts12)
+	for _, ts := range []*types.TipSet{ts10, ts11, ts12} {
+		cs.SetTipsetByHeightAndKey(ts.Height(), ts.Key(), ts)
+		cs.SetTipSetByCid(t, ts)
+	}
+	cs.SetTipSetByCid(t, staleTs11)
+	cs.SetTipSetByCid(t, staleTs12)
+
+	msg10 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg11 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg11.Nonce++
+	staleMsg11 := fakeMessage(address.TestAddress, address.TestAddress)
+	staleMsg11.Nonce += 2
+	cs.SetMessagesForTipset(ts10, []types.ChainMsg{msg10})
+	cs.SetMessagesForTipset(ts11, []types.ChainMsg{msg11})
+	cs.SetMessagesForTipset(staleTs11, []types.ChainMsg{staleMsg11})
+
+	si, err := NewSqliteIndexer(":memory:", cs, 0, false, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(_ context.Context, _ ChainStore, msgTs, _ *types.TipSet) ([]executedMessage, error) {
+		switch msgTs.Key() {
+		case ts10.Key():
+			return []executedMessage{{msg: msg10}}, nil
+		case ts11.Key():
+			return []executedMessage{{msg: msg11}}, nil
+		case staleTs11.Key():
+			return []executedMessage{{
+				msg: staleMsg11,
+				evs: []types.Event{*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "t1", v: []byte("stale")}}, multicodec.Raw)},
+			}}, nil
+		default:
+			return nil, nil
+		}
+	})
+
+	// Complete the canonical range, then leave a non-reverted event row from a
+	// fork at the same height. The SQL height predicate can see that row, but
+	// the canonical coverage check must reject the whole result.
+	require.NoError(t, si.Apply(ctx, ts10, ts11))
+	require.NoError(t, si.Apply(ctx, ts11, ts12))
+	require.NoError(t, si.Apply(ctx, staleTs11, staleTs12))
+	staleTs11Cid, err := staleTs11.Key().Cid()
+	require.NoError(t, err)
+
+	// Leave the stale event row in place but remove its completion marker. This
+	// makes the canonical completion check pass using only canonical markers,
+	// so the result-membership check is what must reject the stale row.
+	_, err = si.stmts.removeTipsetBloomStmt.ExecContext(ctx, staleTs11Cid.Bytes())
+	require.NoError(t, err)
+	staleEvents, err := si.GetEventsForFilter(ctx, &EventFilter{TipsetCid: staleTs11Cid, Codec: multicodec.Raw})
+	require.NoError(t, err)
+	require.Len(t, staleEvents, 1)
+
+	events, err := si.GetEventsForFilter(ctx, &EventFilter{MinHeight: 10, MaxHeight: 11, Codec: multicodec.Raw})
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+}
+
+func TestGetEventsForFilterRangeSkipsNullRounds(t *testing.T) {
+	ctx := context.Background()
+	rng := pseudo.New(pseudo.NewSource(1374901))
+
+	ts10 := fakeTipSet(t, rng, 10, nil)
+	ts12 := fakeTipSet(t, rng, 12, ts10.Cids())
+	ts13 := fakeTipSet(t, rng, 13, ts12.Cids())
+
+	cs := newDummyChainStore()
+	cs.SetHeaviestTipSet(ts13)
+	cs.SetTipsetByHeightAndKey(10, ts10.Key(), ts10)
+	cs.SetTipsetByHeightAndKey(11, ts10.Key(), ts10)
+	cs.SetTipsetByHeightAndKey(12, ts12.Key(), ts12)
+	cs.SetTipsetByHeightAndKey(13, ts13.Key(), ts13)
+	for _, ts := range []*types.TipSet{ts10, ts12, ts13} {
+		cs.SetTipSetByCid(t, ts)
+	}
+
+	msg10 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg12 := fakeMessage(address.TestAddress, address.TestAddress)
+	msg12.Nonce++
+	cs.SetMessagesForTipset(ts10, []types.ChainMsg{msg10})
+	cs.SetMessagesForTipset(ts12, []types.ChainMsg{msg12})
+
+	si, err := NewSqliteIndexer(":memory:", cs, 0, false, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	si.setExecutedMessagesLoaderFunc(func(_ context.Context, _ ChainStore, msgTs, _ *types.TipSet) ([]executedMessage, error) {
+		switch msgTs.Height() {
+		case 10:
+			return []executedMessage{{
+				msg: msg10,
+				evs: []types.Event{*fakeEventWithCodec(abi.ActorID(1), []kv{{k: "t1", v: []byte("before-null")}}, multicodec.Raw)},
+			}}, nil
+		case 12:
+			return []executedMessage{{
+				msg: msg12,
+				evs: []types.Event{*fakeEventWithCodec(abi.ActorID(2), []kv{{k: "t1", v: []byte("after-null")}}, multicodec.Raw)},
+			}}, nil
+		default:
+			return nil, nil
+		}
+	})
+
+	require.NoError(t, si.Apply(ctx, ts10, ts12))
+	require.NoError(t, si.Apply(ctx, ts12, ts13))
+
+	events, err := si.GetEventsForFilter(ctx, &EventFilter{MinHeight: 10, MaxHeight: 12, Codec: multicodec.Raw})
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	require.Equal(t, abi.ChainEpoch(10), events[0].Height)
+	require.Equal(t, abi.ChainEpoch(12), events[1].Height)
+
+	// A range containing only null rounds has no event-index completion
+	// markers to require and authoritatively returns no events.
+	events, err = si.GetEventsForFilter(ctx, &EventFilter{MinHeight: 11, MaxHeight: 11, Codec: multicodec.Raw})
+	require.NoError(t, err)
+	require.Empty(t, events)
 }
 
 func TestGetEventsForFilterWithEvents(t *testing.T) {
@@ -156,7 +502,7 @@ func TestGetEventsForFilterWithEvents(t *testing.T) {
 
 	// Create a fake tipset at height 1
 	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
-	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, fakeTipSet1.Cids())
 
 	// Set the dummy chainstore to return this tipset for height 1
 	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1) // empty DB
@@ -227,14 +573,15 @@ func TestGetEventsForFilterWithEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, reverted2)
 
-	// fetching events fails if excludeReverted is true i.e. we request events by height
+	// Revert removes the completion bloom for the parent whose events were
+	// reverted, so a canonical-height query must fail closed until re-execution.
 	f = &EventFilter{
 		MinHeight: 1,
 		MaxHeight: 1,
 	}
 	ces, err = si.GetEventsForFilter(ctx, f)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(ces))
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, ces)
 
 	// works if excludeReverted is false i.e. we request events by hash
 	f = &EventFilter{
@@ -498,7 +845,7 @@ func TestGetEventsForFilterWithRawCodec(t *testing.T) {
 	t.Run("FilterEventsByRawCodecWithoutKeys", func(t *testing.T) {
 		f := &EventFilter{
 			MinHeight: 1,
-			MaxHeight: 2,
+			MaxHeight: 1,
 			Codec:     codecRaw, // Set to RAW codec
 		}
 
@@ -614,7 +961,7 @@ func TestMaxFilterResults(t *testing.T) {
 
 	// Create fake tipsets
 	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
-	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, fakeTipSet1.Cids())
 
 	// Associate tipsets with their heights and CIDs
 	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1) // Height 1
@@ -644,7 +991,7 @@ func TestMaxFilterResults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &EventFilter{
 				MinHeight:  1,
-				MaxHeight:  2,
+				MaxHeight:  1,
 				MaxResults: tc.maxResults,
 			}
 
@@ -755,8 +1102,8 @@ func TestMaxFilterResultsTipsetBoundary(t *testing.T) {
 	}
 
 	fakeTipSet1 := fakeTipSet(t, rng, 1, nil)
-	fakeTipSet2 := fakeTipSet(t, rng, 2, nil)
-	fakeTipSet3 := fakeTipSet(t, rng, 3, nil)
+	fakeTipSet2 := fakeTipSet(t, rng, 2, fakeTipSet1.Cids())
+	fakeTipSet3 := fakeTipSet(t, rng, 3, fakeTipSet2.Cids())
 	cs.SetTipsetByHeightAndKey(1, fakeTipSet1.Key(), fakeTipSet1)
 	cs.SetTipsetByHeightAndKey(2, fakeTipSet2.Key(), fakeTipSet2)
 	cs.SetTipsetByHeightAndKey(3, fakeTipSet3.Key(), fakeTipSet3)
@@ -915,22 +1262,21 @@ func TestEventFilterMsgCid(t *testing.T) {
 		requireEventEmitter(t, ces, 1, 2)
 	})
 
-	t.Run("MsgCid combined with mismatched TipsetCid returns nothing", func(t *testing.T) {
+	t.Run("MsgCid with a TipsetCid whose events are not indexed returns not found", func(t *testing.T) {
 		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
 			TipsetCid: otherTsCid,
 			MsgCid:    fm1.Cid(),
 		})
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrNotFound)
 		require.Empty(t, ces)
 	})
 
 	t.Run("MsgCid not present in tipset returns nothing", func(t *testing.T) {
-		// A valid CID the indexer has not seen as a message; the tipset is indexed so the
-		// filter just returns no rows.
+		// A valid CID the indexer has not seen as a message; event indexing for the
+		// tipset completed, so the filter authoritatively returns no rows.
 		ces, err := si.GetEventsForFilter(ctx, &EventFilter{
-			MinHeight: 1,
-			MaxHeight: 1,
-			MsgCid:    tsCid,
+			TipsetCid: tsCid,
+			MsgCid:    otherTsCid,
 		})
 		require.NoError(t, err)
 		require.Empty(t, ces)

--- a/chain/index/indexer.go
+++ b/chain/index/indexer.go
@@ -35,6 +35,7 @@ type preparedStatements struct {
 	updateTipsetToNonRevertedStmt         *sql.Stmt
 	removeTipsetsBeforeHeightStmt         *sql.Stmt
 	removeTipsetBloomsBeforeHeightStmt    *sql.Stmt
+	removeTipsetBloomsFromHeightStmt      *sql.Stmt
 	removeEthHashesOlderThanStmt          *sql.Stmt
 	updateTipsetsToRevertedFromHeightStmt *sql.Stmt
 	updateEventsToRevertedFromHeightStmt  *sql.Stmt
@@ -51,6 +52,8 @@ type preparedStatements struct {
 	getTipsetEventEntriesStmt             *sql.Stmt
 	insertTipsetBloomStmt                 *sql.Stmt
 	hasTipsetBloomStmt                    *sql.Stmt
+	hasTipsetEventCompletionStmt          *sql.Stmt
+	getTipsetEventCompletionsByHeightStmt *sql.Stmt
 	getTipsetBloomStmt                    *sql.Stmt
 	removeTipsetBloomStmt                 *sql.Stmt
 

--- a/chain/index/reconcile.go
+++ b/chain/index/reconcile.go
@@ -135,6 +135,13 @@ func (si *SqliteIndexer) ReconcileWithChain(ctx context.Context, head *types.Tip
 		if _, err = tx.StmtContext(ctx, si.stmts.updateEventsToRevertedFromHeightStmt).ExecContext(ctx, int64(reconciliationEpoch-1)); err != nil {
 			return xerrors.Errorf("failed to mark events as reverted: %w", err)
 		}
+		// A bloom is the completion marker for its tipset's event index. Events
+		// at reconciliationEpoch-1 are reverted because of deferred execution,
+		// so invalidate their marker and all later markers before replay. A
+		// successful replay rebuilds them; an incomplete replay must fail closed.
+		if _, err = tx.StmtContext(ctx, si.stmts.removeTipsetBloomsFromHeightStmt).ExecContext(ctx, int64(reconciliationEpoch-1)); err != nil {
+			return xerrors.Errorf("failed to remove event completion blooms: %w", err)
+		}
 
 		log.Infof("marked %d tipsets as reverted from height %d", rowsAffected, reconciliationEpoch)
 

--- a/chain/index/reconcile_test.go
+++ b/chain/index/reconcile_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
@@ -16,6 +17,53 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
+
+func TestReconcileInvalidatesEventCompletionBeforeIncompleteReplay(t *testing.T) {
+	ctx := context.Background()
+	rng := pseudo.New(pseudo.NewSource(13749))
+
+	common := fakeTipSet(t, rng, 1, nil)
+	oldHead := fakeTipSet(t, rng, 2, common.Cids())
+	newHead := fakeTipSet(t, rng, 2, common.Cids())
+
+	cs := newDummyChainStore()
+	cs.SetTipsetByHeightAndKey(common.Height(), common.Key(), common)
+	cs.SetTipsetByHeightAndKey(oldHead.Height(), oldHead.Key(), oldHead)
+	cs.SetTipSetByCid(t, common)
+	cs.SetTipSetByCid(t, oldHead)
+	cs.SetTipSetByCid(t, newHead)
+	cs.SetHeaviestTipSet(oldHead)
+
+	si, err := NewSqliteIndexer(":memory:", cs, 0, false, 100)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = si.Close() })
+
+	si.SetActorToDelegatedAddresFunc(func(context.Context, abi.ActorID, *types.TipSet) (address.Address, bool) {
+		return address.TestAddress, true
+	})
+	eventsAvailable := true
+	si.setExecutedMessagesLoaderFunc(func(context.Context, ChainStore, *types.TipSet, *types.TipSet) ([]executedMessage, error) {
+		if !eventsAvailable {
+			return nil, ipld.ErrNotFound{}
+		}
+		return nil, nil
+	})
+
+	require.NoError(t, si.Apply(ctx, common, oldHead))
+	filter := &EventFilter{MinHeight: common.Height(), MaxHeight: common.Height()}
+	events, err := si.GetEventsForFilter(ctx, filter)
+	require.NoError(t, err)
+	require.Empty(t, events)
+
+	cs.SetTipsetByHeightAndKey(newHead.Height(), newHead.Key(), newHead)
+	cs.SetHeaviestTipSet(newHead)
+	eventsAvailable = false
+	require.NoError(t, si.ReconcileWithChain(ctx, newHead))
+
+	events, err = si.GetEventsForFilter(ctx, filter)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, events)
+}
 
 func TestReconcileGapTooLarge(t *testing.T) {
 	ctx := context.Background()

--- a/node/impl/eth/utils_test.go
+++ b/node/impl/eth/utils_test.go
@@ -2,15 +2,46 @@ package eth
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+
+	"github.com/filecoin-project/lotus/chain/index"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
+
+type unavailableEthEvents struct {
+	EthEventsInternal
+}
+
+func (unavailableEthEvents) GetEthLogsForBlockAndTransaction(context.Context, *ethtypes.EthHash, cid.Cid) ([]ethtypes.EthLog, error) {
+	return nil, index.ErrNotFound
+}
+
+func TestNewEthTxReceiptFailsWhenEventIndexIsIncomplete(t *testing.T) {
+	gasPrice := ethtypes.EthBigInt(big.NewInt(1))
+	to := ethtypes.EthAddress{}
+	tx := ethtypes.EthTx{
+		To:       &to,
+		Gas:      1,
+		GasPrice: &gasPrice,
+	}
+	eventsRoot := cid.Undef
+	msgReceipt := types.NewMessageReceiptV1(exitcode.Ok, nil, 1, &eventsRoot)
+
+	receipt, err := newEthTxReceipt(context.Background(), tx, cid.Undef, big.Zero(), msgReceipt, unavailableEthEvents{})
+	require.ErrorIs(t, err, index.ErrNotFound)
+	require.Equal(t, ethtypes.EthTxReceipt{}, receipt)
+}
 
 func TestABIEncoding(t *testing.T) {
 	// Generated from https://abi.hashex.org/


### PR DESCRIPTION
## Related Issues
<!-- Link issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made -->
Fixes #13749 (partially) and #13758 

## Proposed Changes
<!-- A clear list of the changes being made -->
- Use `tipset_bloom` as the event-index completion marker. The bloom is written
  only after event indexing finishes, including for tipsets with zero events.
- Require the completion marker to have corresponding retained tipset metadata,
  preventing orphaned blooms left during GC from authorizing empty results.
- Resolve every canonical non-null tipset in a requested range and require an
  exact completion marker for each one.
- Ignore null rounds and reject stale-fork event rows from canonical range
  queries.
- Read completion markers and matching events in the same SQLite transaction so
  concurrent indexing, backfill, reverts, or GC cannot create a partial read.
- Invalidate bloom completion markers during reconciliation before replaying
  events.
- Check SQLite row iteration errors instead of returning partially decoded
  results.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
### Why `Fill` and `Install` were separated
`EventFilterManager.Fill` previously served two different behaviors:
1. One-time snapshot queries, which require the exact requested range.
2. Installed live filters, which preload available history and then collect
   future events.

The stricter range validation correctly rejects a historical query extending
through the current head or into the future. Passing an installed filter's live
upper bound directly to the indexer would therefore prevent forward-looking
filters from being installed.

The two paths are now explicit:

- `Fill` forwards the exact requested bounds and propagates incomplete or future
  range errors.
- `Install` preloads only through the last executable height while preserving
  the caller's original upper bound for live collection.
`Install` also records a chain revision before querying history. If an apply or
revert occurs during the query, it discards the stale result or error and
retries. Final validation and filter registration happen under the same lock,
preventing an event from falling between historical preload and live
registration.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions)
- [x] Update CHANGELOG.md or signal that this change does not need it per [contribution conventions](https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#changelog-management)
- [ ] New features have usage guidelines and / or documentation updates in
  - [ ] [Lotus Documentation](https://lotus.filecoin.io)
  - [ ] [Discussion Tutorials](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [x] Tests exist for new functionality or change in behavior
- [ ] CI is green
