### PR TITLE
ci(pr-title-check): make title check resilient to out-of-order runs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: pr-title-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-pr-title:
     if: github.event.pull_request.draft == false
@@ -22,7 +26,15 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const title = context.payload.pull_request.title;
+            // Fetch the PR fresh rather than trusting context.payload.pull_request.title,
+            // which is a snapshot from when the triggering event was dispatched. A run can
+            // sit queued long enough that the title changes again before it executes,
+            // causing it to validate (and post a status for) a title that's already stale.
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const title = pr.title;
             // This should match https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions
             // 202408: Beyond Conventional Commit conventions, we also optionally support the "scope" outside of parenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
             const conventionalPattern = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w.-]+\))?!?:?\s([\w.-]+:)?\s?["'`a-z].+$/;

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,11 +30,18 @@ jobs:
             // which is a snapshot from when the triggering event was dispatched. A run can
             // sit queued long enough that the title changes again before it executes,
             // causing it to validate (and post a status for) a title that's already stale.
-            const { data: pr } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.payload.pull_request.number
-            });
-            const title = pr.title;
+            // Fall back to the payload title if the live fetch fails, so a transient API
+            // error doesn't block a merge over a title that was already valid.
+            let title = context.payload.pull_request.title;
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: context.payload.pull_request.number
+              });
+              title = pr.title;
+            } catch (error) {
+              core.warning(`Failed to fetch live PR title, falling back to event payload title: ${error.message}`);
+            }
             // This should match https://github.com/filecoin-project/lotus/blob/master/CONTRIBUTING.md#pr-title-conventions
             // 202408: Beyond Conventional Commit conventions, we also optionally support the "scope" outside of parenthesis for a transitionary period from legacy conventions per https://github.com/filecoin-project/lotus/pull/12340 
             const conventionalPattern = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w.-]+\))?!?:?\s([\w.-]+:)?\s?["'`a-z].+$/;


### PR DESCRIPTION
## Summary
- Add a `concurrency` group keyed on the PR number so a new PR Title Check run cancels any still-queued/in-progress run for the same PR, instead of letting stale runs finish out of order.
- Fetch the PR title live via `github.rest.pulls.get()` instead of trusting `context.payload.pull_request.title`, which is only a snapshot from when the triggering event was dispatched.

## Motivation
Diagnosed from [#13762](https://github.com/filecoin-project/lotus/pull/13762): rapid title edits during PR creation fired several `pull_request_target` runs in quick succession. One run got stuck in the Actions queue for over an hour and executed against a stale (already-fixed) title, completing *after* a later successful run and overwriting the check status with a failure — even though the live title was correct and matched the regex the whole time.

Both changes address this independently:
- The concurrency group prevents the stale run from surviving to completion once superseded.
- Fetching the live title removes the dependency on run ordering entirely, since even a run that isn't cancelled will validate against the current title rather than a snapshot.

## Test plan
- [x] Syntax-checked the extracted `github-script` block with `node --check`
- [ ] Verify a burst of rapid title edits on a real PR results in a single, correct final check status