### PR TITLE
feat(gateway): limit event filter height ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ## 👌 Improvements
 
+- feat(gateway): limit event queries and historical filter preloads to 360 epochs (three hours) by default across `EthGetLogs`, `EthNewFilter`, `GetActorEventsRaw`, and `SubscribeActorEventsRaw`. Gateway operators can change the limit with `--event-filter-max-height-range`, or set it to zero to disable the gateway limit. ([filecoin-project/lotus#13776](https://github.com/filecoin-project/lotus/pull/13776))
+
 # Node v1.36.2 / 2026-07-27
 
 Lotus Node v1.36.2 is a recommended patch release focused on Ethereum RPC correctness and compatibility, `StateWaitMsg` confidence handling, dependency reliability, and operator tooling.

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -168,6 +168,11 @@ var runCmd = &cli.Command{
 			Value: gateway.DefaultEthMaxFiltersPerConn,
 		},
 		&cli.Int64Flag{
+			Name:  "event-filter-max-height-range",
+			Usage: "Maximum height range allowed for event queries and historical filter preloads (0 = no limit)",
+			Value: int64(gateway.DefaultEventFilterMaxHeightRange),
+		},
+		&cli.Int64Flag{
 			Name:  "eth-trace-filter-max-block-range",
 			Usage: "Maximum block range allowed for expensive trace_filter requests (0 = no limit)",
 			Value: gateway.DefaultEthTraceFilterMaxBlockRange,
@@ -217,6 +222,7 @@ var runCmd = &cli.Command{
 			rateLimitTimeout            = cctx.Duration("rate-limit-timeout")
 			perHostConnectionsPerMinute = cctx.Int("conn-per-minute")
 			maxFiltersPerConn           = cctx.Int("eth-max-filters-per-conn")
+			eventFilterMaxHeightRange   = abi.ChainEpoch(cctx.Int64("event-filter-max-height-range"))
 			traceFilterMaxBlockRange    = cctx.Int64("eth-trace-filter-max-block-range")
 			enableCORS                  = cctx.Bool("cors")
 			enableRequestLogging        = cctx.Bool("request-logging")
@@ -249,6 +255,7 @@ var runCmd = &cli.Command{
 			gateway.WithRateLimit(globalRateLimit),
 			gateway.WithRateLimitTimeout(rateLimitTimeout),
 			gateway.WithEthMaxFiltersPerConn(maxFiltersPerConn),
+			gateway.WithEventFilterMaxHeightRange(eventFilterMaxHeightRange),
 			gateway.WithEthTraceFilterMaxBlockRange(traceFilterMaxBlockRange),
 		)
 		handler, err := gateway.Handler(

--- a/cmd/lotus-gateway/main.go
+++ b/cmd/lotus-gateway/main.go
@@ -189,6 +189,11 @@ var runCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
+		eventFilterMaxHeightRange := abi.ChainEpoch(cctx.Int64("event-filter-max-height-range"))
+		if eventFilterMaxHeightRange < 0 {
+			return fmt.Errorf("event-filter-max-height-range must be non-negative")
+		}
+
 		log.Info("Starting lotus gateway")
 
 		// Register all metric views
@@ -222,7 +227,6 @@ var runCmd = &cli.Command{
 			rateLimitTimeout            = cctx.Duration("rate-limit-timeout")
 			perHostConnectionsPerMinute = cctx.Int("conn-per-minute")
 			maxFiltersPerConn           = cctx.Int("eth-max-filters-per-conn")
-			eventFilterMaxHeightRange   = abi.ChainEpoch(cctx.Int64("event-filter-max-height-range"))
 			traceFilterMaxBlockRange    = cctx.Int64("eth-trace-filter-max-block-range")
 			enableCORS                  = cctx.Bool("cors")
 			enableRequestLogging        = cctx.Bool("request-logging")

--- a/cmd/lotus-gateway/main_test.go
+++ b/cmd/lotus-gateway/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestRunRejectsNegativeEventFilterRange(t *testing.T) {
+	app := &cli.App{Commands: []*cli.Command{runCmd}}
+	err := app.Run([]string{"lotus-gateway", "run", "--event-filter-max-height-range", "-1"})
+	require.EqualError(t, err, "event-filter-max-height-range must be non-negative")
+}

--- a/gateway/eth_utils.go
+++ b/gateway/eth_utils.go
@@ -11,9 +11,13 @@ package gateway
 // perform accurate range checks.
 
 import (
+	"context"
+	"math"
+
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
 
@@ -43,6 +47,120 @@ func (gw *Node) checkEthTraceFilterBlockRange(headHeight abi.ChainEpoch, filter 
 		return api.NewErrBlockRangeExceeded(maxRange, uint64(to-from))
 	}
 	return nil
+}
+
+type chainHeadHeightFunc func(context.Context) (abi.ChainEpoch, error)
+
+// checkEthEventFilterBlockRange checks the height range of an Ethereum event
+// filter.
+func (gw *Node) checkEthEventFilterBlockRange(ctx context.Context, filter *ethtypes.EthFilterSpec, getHeadHeight chainHeadHeightFunc) error {
+	if gw.eventFilterMaxHeightRange <= 0 || filter == nil || filter.BlockHash != nil {
+		return nil
+	}
+
+	fromTag := ethtypes.BlockTagLatest
+	if filter.FromBlock != nil {
+		fromTag = *filter.FromBlock
+	}
+	toTag := ethtypes.BlockTagLatest
+	if filter.ToBlock != nil {
+		toTag = *filter.ToBlock
+	}
+	if isEthEventHeadTag(fromTag) && isEthEventHeadTag(toTag) {
+		return nil
+	}
+
+	var headHeight abi.ChainEpoch
+	if isEthEventHeadTag(fromTag) || isEthEventHeadTag(toTag) {
+		var err error
+		headHeight, err = getHeadHeight(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	from, fromOK := resolveEthEventFilterBlockTag(fromTag, headHeight)
+	to, toOK := resolveEthEventFilterBlockTag(toTag, headHeight)
+	if !fromOK || !toOK {
+		// Let the full node return the authoritative error for unsupported or
+		// malformed block tags.
+		return nil
+	}
+	return gw.checkEventFilterHeightRange(from, to)
+}
+
+func (gw *Node) checkActorEventFilterHeightRange(ctx context.Context, filter *types.ActorEventFilter, getHeadHeight chainHeadHeightFunc) error {
+	if gw.eventFilterMaxHeightRange <= 0 || filter == nil {
+		return nil
+	}
+	if filter.TipSetKey != nil && !filter.TipSetKey.IsEmpty() {
+		return nil
+	}
+	if filter.FromHeight == nil && filter.ToHeight == nil {
+		return nil
+	}
+	if filter.FromHeight != nil && *filter.FromHeight < 0 {
+		return nil
+	}
+	if filter.ToHeight != nil && *filter.ToHeight < 0 {
+		return nil
+	}
+
+	var (
+		from abi.ChainEpoch
+		to   abi.ChainEpoch
+	)
+	if filter.FromHeight != nil && filter.ToHeight != nil {
+		from = *filter.FromHeight
+		to = *filter.ToHeight
+	} else {
+		headHeight, err := getHeadHeight(ctx)
+		if err != nil {
+			return err
+		}
+		from = headHeight
+		to = headHeight
+		if filter.FromHeight != nil {
+			from = *filter.FromHeight
+		}
+		if filter.ToHeight != nil {
+			to = *filter.ToHeight
+		}
+	}
+	return gw.checkEventFilterHeightRange(from, to)
+}
+
+func (gw *Node) checkEventFilterHeightRange(from, to abi.ChainEpoch) error {
+	if gw.eventFilterMaxHeightRange <= 0 || to <= from {
+		return nil
+	}
+	heightRange := to - from
+	if heightRange > gw.eventFilterMaxHeightRange {
+		return api.NewErrBlockRangeExceeded(uint64(gw.eventFilterMaxHeightRange), uint64(heightRange))
+	}
+	return nil
+}
+
+func isEthEventHeadTag(tag string) bool {
+	return tag == "" || tag == ethtypes.BlockTagLatest
+}
+
+func resolveEthEventFilterBlockTag(tag string, headHeight abi.ChainEpoch) (abi.ChainEpoch, bool) {
+	switch {
+	case isEthEventHeadTag(tag):
+		if headHeight > 0 {
+			return headHeight - 1, true
+		}
+		return 0, true
+	case tag == ethtypes.BlockTagEarliest:
+		return 0, true
+	default:
+		var num ethtypes.EthUint64
+		if err := num.UnmarshalJSON([]byte(`"` + tag + `"`)); err != nil || num > math.MaxInt64 {
+			return 0, false
+		}
+		return abi.ChainEpoch(num), true
+	}
 }
 
 // resolveTraceFilterBlockTag resolves the block tags supported by trace_filter

--- a/gateway/eth_utils.go
+++ b/gateway/eth_utils.go
@@ -118,12 +118,13 @@ func (gw *Node) checkActorEventFilterHeightRange(ctx context.Context, filter *ty
 		if err != nil {
 			return err
 		}
-		from = headHeight
-		to = headHeight
 		if filter.FromHeight != nil {
 			from = *filter.FromHeight
-		}
-		if filter.ToHeight != nil {
+			if headHeight > 0 {
+				to = headHeight - 1
+			}
+		} else {
+			from = headHeight
 			to = *filter.ToHeight
 		}
 	}

--- a/gateway/node.go
+++ b/gateway/node.go
@@ -25,12 +25,13 @@ import (
 var log = logger.Logger("gateway")
 
 const (
-	DefaultMaxLookbackDuration         = time.Hour * 24     // Default duration that a gateway request can look back in chain history
-	DefaultMaxMessageLookbackEpochs    = abi.ChainEpoch(20) // Default number of epochs that a gateway message lookup can look back in chain history
-	DefaultMaxMessageConfidence        = uint64(20)         // Default maximum confidence accepted by StateWaitMsg
-	DefaultRateLimitTimeout            = time.Second * 5    // Default timeout for rate limiting requests; where a request would take longer to wait than this value, it will be rejected
-	DefaultEthMaxFiltersPerConn        = 16                 // Default maximum number of ETH filters and subscriptions per websocket connection
-	DefaultEthTraceFilterMaxBlockRange = int64(100)         // Default maximum block range for EthTraceFilter on the gateway
+	DefaultMaxLookbackDuration         = time.Hour * 24      // Default duration that a gateway request can look back in chain history
+	DefaultMaxMessageLookbackEpochs    = abi.ChainEpoch(20)  // Default number of epochs that a gateway message lookup can look back in chain history
+	DefaultMaxMessageConfidence        = uint64(20)          // Default maximum confidence accepted by StateWaitMsg
+	DefaultRateLimitTimeout            = time.Second * 5     // Default timeout for rate limiting requests; where a request would take longer to wait than this value, it will be rejected
+	DefaultEthMaxFiltersPerConn        = 16                  // Default maximum number of ETH filters and subscriptions per websocket connection
+	DefaultEventFilterMaxHeightRange   = abi.ChainEpoch(360) // Default maximum height range for event queries on the gateway
+	DefaultEthTraceFilterMaxBlockRange = int64(100)          // Default maximum block range for EthTraceFilter on the gateway
 
 	basicRateLimitTokens  = 1
 	walletRateLimitTokens = 1
@@ -49,6 +50,7 @@ type Node struct {
 	rateLimiter                 *rate.Limiter
 	rateLimitTimeout            time.Duration
 	ethMaxFiltersPerConn        int
+	eventFilterMaxHeightRange   abi.ChainEpoch
 	ethTraceFilterMaxBlockRange int64
 	errLookback                 error
 }
@@ -62,6 +64,7 @@ type options struct {
 	rateLimit                   int
 	rateLimitTimeout            time.Duration
 	ethMaxFiltersPerConn        int
+	eventFilterMaxHeightRange   abi.ChainEpoch
 	ethTraceFilterMaxBlockRange int64
 }
 
@@ -128,6 +131,13 @@ func WithEthMaxFiltersPerConn(ethMaxFiltersPerConn int) Option {
 	}
 }
 
+// WithEventFilterMaxHeightRange sets the maximum height range allowed for event queries.
+func WithEventFilterMaxHeightRange(maxHeightRange abi.ChainEpoch) Option {
+	return func(opts *options) {
+		opts.eventFilterMaxHeightRange = maxHeightRange
+	}
+}
+
 // WithEthTraceFilterMaxBlockRange sets the maximum block range allowed for EthTraceFilter
 // requests on the gateway. This is typically tighter than the node-level MaxFilterHeightRange
 // because trace replay is significantly more expensive than log lookups.
@@ -145,6 +155,7 @@ func NewNode(v1 v1api.FullNode, v2 v2api.FullNode, opts ...Option) *Node {
 		maxMessageConfidence:        DefaultMaxMessageConfidence,
 		rateLimitTimeout:            DefaultRateLimitTimeout,
 		ethMaxFiltersPerConn:        DefaultEthMaxFiltersPerConn,
+		eventFilterMaxHeightRange:   DefaultEventFilterMaxHeightRange,
 		ethTraceFilterMaxBlockRange: DefaultEthTraceFilterMaxBlockRange,
 	}
 	for _, opt := range opts {
@@ -163,6 +174,7 @@ func NewNode(v1 v1api.FullNode, v2 v2api.FullNode, opts ...Option) *Node {
 		rateLimitTimeout:            options.rateLimitTimeout,
 		errLookback:                 fmt.Errorf("lookbacks of more than %s are disallowed", options.maxLookbackDuration),
 		ethMaxFiltersPerConn:        options.ethMaxFiltersPerConn,
+		eventFilterMaxHeightRange:   options.eventFilterMaxHeightRange,
 		ethTraceFilterMaxBlockRange: options.ethTraceFilterMaxBlockRange,
 	}
 	gateway.v1Proxy = &reverseProxyV1{

--- a/gateway/node_test.go
+++ b/gateway/node_test.go
@@ -533,11 +533,11 @@ func TestGatewayEventFilterRangeBoundaries(t *testing.T) {
 	fromHeight := abi.ChainEpoch(100)
 	actorFilter := &types.ActorEventFilter{FromHeight: &fromHeight}
 	headHeight = func(context.Context) (abi.ChainEpoch, error) {
-		return 460, nil
+		return 461, nil
 	}
 	require.NoError(t, gw.checkActorEventFilterHeightRange(ctx, actorFilter, headHeight))
 	headHeight = func(context.Context) (abi.ChainEpoch, error) {
-		return 461, nil
+		return 462, nil
 	}
 	rangeErr = nil
 	require.ErrorAs(t, gw.checkActorEventFilterHeightRange(ctx, actorFilter, headHeight), &rangeErr)

--- a/gateway/node_test.go
+++ b/gateway/node_test.go
@@ -444,3 +444,115 @@ func TestGatewayInterfacesDoNotExposeLimitedOrUntrusted(t *testing.T) {
 		check(t, reflect.TypeFor[v2api.Gateway]())
 	})
 }
+
+func TestGatewayRejectsOversizedEventRanges(t *testing.T) {
+	ctx := context.Background()
+	fromBlock := "0x64"
+	toBlock := "0x1cd" // 461 - 100 = 361 epochs
+	ethFilter := &ethtypes.EthFilterSpec{
+		FromBlock: &fromBlock,
+		ToBlock:   &toBlock,
+	}
+	fromHeight := abi.ChainEpoch(100)
+	toHeight := abi.ChainEpoch(461)
+	actorFilter := &types.ActorEventFilter{
+		FromHeight: &fromHeight,
+		ToHeight:   &toHeight,
+	}
+
+	cases := []struct {
+		name string
+		call func(*Node) error
+	}{
+		{"v1/EthGetLogs", func(gw *Node) error {
+			_, err := gw.v1Proxy.EthGetLogs(ctx, ethFilter)
+			return err
+		}},
+		{"v2/EthGetLogs", func(gw *Node) error {
+			_, err := gw.v2Proxy.EthGetLogs(ctx, ethFilter)
+			return err
+		}},
+		{"v1/EthNewFilter", func(gw *Node) error {
+			_, err := gw.v1Proxy.EthNewFilter(ctx, ethFilter)
+			return err
+		}},
+		{"v2/EthNewFilter", func(gw *Node) error {
+			_, err := gw.v2Proxy.EthNewFilter(ctx, ethFilter)
+			return err
+		}},
+		{"GetActorEventsRaw", func(gw *Node) error {
+			_, err := gw.v1Proxy.GetActorEventsRaw(ctx, actorFilter)
+			return err
+		}},
+		{"SubscribeActorEventsRaw", func(gw *Node) error {
+			_, err := gw.v1Proxy.SubscribeActorEventsRaw(ctx, actorFilter)
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockV1 := v1mocks.NewMockFullNode(ctrl)
+			mockV2 := v2mocks.NewMockFullNode(ctrl)
+			gw := NewNode(mockV1, mockV2)
+
+			err := tc.call(gw)
+			var rangeErr *api.ErrBlockRangeExceeded
+			require.ErrorAs(t, err, &rangeErr)
+			require.Equal(t, "block range exceeds maximum of 360 (got 361)", rangeErr.Error())
+		})
+	}
+}
+
+func TestGatewayEventFilterRangeBoundaries(t *testing.T) {
+	ctx := context.Background()
+	gw := &Node{eventFilterMaxHeightRange: DefaultEventFilterMaxHeightRange}
+
+	require.NoError(t, gw.checkEventFilterHeightRange(100, 460))
+	var rangeErr *api.ErrBlockRangeExceeded
+	require.ErrorAs(t, gw.checkEventFilterHeightRange(100, 461), &rangeErr)
+
+	fromBlock := "0x64"
+	latest := ethtypes.BlockTagLatest
+	ethFilter := &ethtypes.EthFilterSpec{
+		FromBlock: &fromBlock,
+		ToBlock:   &latest,
+	}
+	headHeight := func(context.Context) (abi.ChainEpoch, error) {
+		// Event execution is available through the head's parent, height 460.
+		return 461, nil
+	}
+	require.NoError(t, gw.checkEthEventFilterBlockRange(ctx, ethFilter, headHeight))
+	headHeight = func(context.Context) (abi.ChainEpoch, error) {
+		return 462, nil
+	}
+	rangeErr = nil
+	require.ErrorAs(t, gw.checkEthEventFilterBlockRange(ctx, ethFilter, headHeight), &rangeErr)
+
+	fromHeight := abi.ChainEpoch(100)
+	actorFilter := &types.ActorEventFilter{FromHeight: &fromHeight}
+	headHeight = func(context.Context) (abi.ChainEpoch, error) {
+		return 460, nil
+	}
+	require.NoError(t, gw.checkActorEventFilterHeightRange(ctx, actorFilter, headHeight))
+	headHeight = func(context.Context) (abi.ChainEpoch, error) {
+		return 461, nil
+	}
+	rangeErr = nil
+	require.ErrorAs(t, gw.checkActorEventFilterHeightRange(ctx, actorFilter, headHeight), &rangeErr)
+}
+
+func TestGatewayEventFilterRangeConfiguration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockV1 := v1mocks.NewMockFullNode(ctrl)
+	mockV2 := v2mocks.NewMockFullNode(ctrl)
+
+	gw := NewNode(mockV1, mockV2, WithEventFilterMaxHeightRange(10))
+	require.NoError(t, gw.checkEventFilterHeightRange(100, 110))
+	var rangeErr *api.ErrBlockRangeExceeded
+	require.ErrorAs(t, gw.checkEventFilterHeightRange(100, 111), &rangeErr)
+
+	gw = NewNode(mockV1, mockV2, WithEventFilterMaxHeightRange(0))
+	require.NoError(t, gw.checkEventFilterHeightRange(0, 1_000_000))
+}

--- a/gateway/proxy_eth_v1.go
+++ b/gateway/proxy_eth_v1.go
@@ -431,6 +431,10 @@ func (pv1 *reverseProxyV1) EthGetLogs(ctx context.Context, filter *ethtypes.EthF
 		return nil, err
 	}
 
+	if err := pv1.gateway.checkEthEventFilterBlockRange(ctx, filter, pv1.chainHeadHeight); err != nil {
+		return nil, err
+	}
+
 	if filter.FromBlock != nil {
 		if err := pv1.checkBlkParam(ctx, *filter.FromBlock, 0); err != nil {
 			return nil, err
@@ -486,6 +490,10 @@ func (pv1 *reverseProxyV1) EthGetFilterLogs(ctx context.Context, id ethtypes.Eth
 
 func (pv1 *reverseProxyV1) EthNewFilter(ctx context.Context, filter *ethtypes.EthFilterSpec) (ethtypes.EthFilterID, error) {
 	if err := pv1.gateway.limit(ctx, stateRateLimitTokens); err != nil {
+		return ethtypes.EthFilterID{}, err
+	}
+
+	if err := pv1.gateway.checkEthEventFilterBlockRange(ctx, filter, pv1.chainHeadHeight); err != nil {
 		return ethtypes.EthFilterID{}, err
 	}
 

--- a/gateway/proxy_fil_v1.go
+++ b/gateway/proxy_fil_v1.go
@@ -147,6 +147,17 @@ func (pv1 *reverseProxyV1) ChainHead(ctx context.Context) (*types.TipSet, error)
 	return pv1.server.ChainHead(ctx)
 }
 
+func (pv1 *reverseProxyV1) chainHeadHeight(ctx context.Context) (abi.ChainEpoch, error) {
+	head, err := pv1.server.ChainHead(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if head == nil {
+		return 0, xerrors.New("chain head is nil")
+	}
+	return head.Height(), nil
+}
+
 func (pv1 *reverseProxyV1) ChainGetMessage(ctx context.Context, mc cid.Cid) (*types.Message, error) {
 	if err := pv1.gateway.limit(ctx, chainRateLimitTokens); err != nil {
 		return nil, err
@@ -441,6 +452,10 @@ func (pv1 *reverseProxyV1) GetActorEventsRaw(ctx context.Context, filter *types.
 	if err := pv1.gateway.limit(ctx, stateRateLimitTokens); err != nil {
 		return nil, err
 	}
+
+	if err := pv1.gateway.checkActorEventFilterHeightRange(ctx, filter, pv1.chainHeadHeight); err != nil {
+		return nil, err
+	}
 	if filter != nil && filter.FromHeight != nil {
 		if err := pv1.gateway.checkKeyedTipSetHeight(ctx, *filter.FromHeight, types.EmptyTSK); err != nil {
 			return nil, err
@@ -451,6 +466,10 @@ func (pv1 *reverseProxyV1) GetActorEventsRaw(ctx context.Context, filter *types.
 
 func (pv1 *reverseProxyV1) SubscribeActorEventsRaw(ctx context.Context, filter *types.ActorEventFilter) (<-chan *types.ActorEvent, error) {
 	if err := pv1.gateway.limit(ctx, stateRateLimitTokens); err != nil {
+		return nil, err
+	}
+
+	if err := pv1.gateway.checkActorEventFilterHeightRange(ctx, filter, pv1.chainHeadHeight); err != nil {
 		return nil, err
 	}
 	if filter != nil && filter.FromHeight != nil {

--- a/gateway/proxy_v2.go
+++ b/gateway/proxy_v2.go
@@ -38,6 +38,17 @@ func (pv2 *reverseProxyV2) ChainGetTipSet(ctx context.Context, selector types.Ti
 	return pv2.server.ChainGetTipSet(ctx, selector)
 }
 
+func (pv2 *reverseProxyV2) chainHeadHeight(ctx context.Context) (abi.ChainEpoch, error) {
+	head, err := pv2.server.ChainGetTipSet(ctx, types.TipSetSelectors.Latest)
+	if err != nil {
+		return 0, err
+	}
+	if head == nil {
+		return 0, xerrors.New("chain head is nil")
+	}
+	return head.Height(), nil
+}
+
 func (pv2 *reverseProxyV2) ChainGetTipSetFinalityStatus(ctx context.Context) (*types.FinalityStatus, error) {
 	if err := pv2.gateway.limit(ctx, chainRateLimitTokens); err != nil {
 		return nil, err
@@ -436,6 +447,10 @@ func (pv2 *reverseProxyV2) EthGetLogs(ctx context.Context, filter *ethtypes.EthF
 		return nil, err
 	}
 
+	if err := pv2.gateway.checkEthEventFilterBlockRange(ctx, filter, pv2.chainHeadHeight); err != nil {
+		return nil, err
+	}
+
 	if filter.FromBlock != nil {
 		if err := pv2.checkBlkParam(ctx, *filter.FromBlock, 0); err != nil {
 			return nil, err
@@ -477,6 +492,10 @@ func (pv2 *reverseProxyV2) EthNewPendingTransactionFilter(ctx context.Context) (
 
 func (pv2 *reverseProxyV2) EthNewFilter(ctx context.Context, filter *ethtypes.EthFilterSpec) (ethtypes.EthFilterID, error) {
 	if err := pv2.gateway.limit(ctx, stateRateLimitTokens); err != nil {
+		return ethtypes.EthFilterID{}, err
+	}
+
+	if err := pv2.gateway.checkEthEventFilterBlockRange(ctx, filter, pv2.chainHeadHeight); err != nil {
 		return ethtypes.EthFilterID{}, err
 	}
 


### PR DESCRIPTION
Follow-up from https://github.com/filecoin-project/lotus/pull/13762 since range queries got slightly more expensive. This limits gateway range requests to 3h by default, configurable with a flag. 3h is still fairly generous compared to the Ethereum world.