### PR TITLE
build: release Lotus Node v1.36.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 > * [CHANGELOG_1.1x.md](./documentation/changelog/CHANGELOG_1.1x.md) - v1.10.0 to v1.19.0
 > * [CHANGELOG_1.2x.md](./documentation/changelog/CHANGELOG_1.2x.md) - v1.20.0 to v1.29.2
 
-# UNRELEASED
+# Node v1.36.3 / 2026-09-07
+
+Lotus Node v1.36.3 is a recommended patch release focused on Ethereum RPC correctness (event-index completeness for `eth_getLogs`/`eth_getTransactionReceipt`, RLP validation), a WebTransport memory-exhaustion fix (CVE-2026-57497), sector-reporting UX, and operator tooling.
 
 ## ☢️ Upgrade Warnings ☢️
 
@@ -27,8 +29,31 @@
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))
 - fix(events): `GetActorEventsRaw` and `SubscribeActorEventsRaw` now reject a filter whose `toHeight` is negative. ([filecoin-project/lotus#13751](https://github.com/filecoin-project/lotus/pull/13751))
 - fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
+- fix(httpreader): `NewResumableReader` (used by `lotus daemon --import-snapshot` for HTTP(S) URLs) now returns the underlying parse error instead of silently returning `(nil, nil)` when a response is missing a valid `Content-Length` header. ([filecoin-project/lotus#13773](https://github.com/filecoin-project/lotus/pull/13773))
 
 ## 👌 Improvements
+
+## 📝 Changelog
+
+For the full set of changes since the last stable release:
+
+- Node: https://github.com/filecoin-project/lotus/compare/release/v1.36.2...release/v1.36.3
+
+## 👨‍👩‍👧‍👦 Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Rod Vagg | 4 | +2555/-46 | 21 |
+| LexLuthr | 1 | +1044/-217 | 10 |
+| Phi-rjan | 3 | +234/-90 | 19 |
+| Steve Loeppky | 7 | +275/-48 | 37 |
+| dependabot[bot] | 11 | +137/-141 | 24 |
+| Kaif | 2 | +102/-55 | 10 |
+| beck | 1 | +59/-80 | 4 |
+| fmterrors | 1 | +29/-5 | 2 |
+| Sash | 2 | +20/-9 | 2 |
+| zjuzhongwen | 1 | +3/-3 | 1 |
+| zloglevel | 1 | +2/-2 | 2 |
 
 # Node v1.36.2 / 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 # Node v1.36.3 / 2026-09-07
 
-Lotus Node v1.36.3 is a recommended patch release focused on Ethereum RPC correctness (event-index completeness for `eth_getLogs`/`eth_getTransactionReceipt`, RLP validation), a WebTransport memory-exhaustion fix (CVE-2026-57497), sector-reporting UX, and operator tooling.
+Lotus Node v1.36.3 is a recommended patch release focused on Ethereum RPC correctness (event-index completeness for `eth_getLogs`/`eth_getTransactionReceipt`, RLP validation), a WebTransport memory-exhaustion fix (CVE-2026-57497), sector-reporting UX, and operator tooling. This is the last expected patch release before a [minor release for nv29](https://github.com/filecoin-project/lotus/issues/13760).
 
 ## ☢️ Upgrade Warnings ☢️
 
@@ -30,8 +30,6 @@ Lotus Node v1.36.3 is a recommended patch release focused on Ethereum RPC correc
 - fix(events): `GetActorEventsRaw` and `SubscribeActorEventsRaw` now reject a filter whose `toHeight` is negative. ([filecoin-project/lotus#13751](https://github.com/filecoin-project/lotus/pull/13751))
 - fix(eth): `eth_sendRawTransaction` now rejects a transaction whose RLP integer fields are not minimally encoded, matching go-ethereum. ([filecoin-project/lotus#13744](https://github.com/filecoin-project/lotus/pull/13744))
 - fix(httpreader): `NewResumableReader` (used by `lotus daemon --import-snapshot` for HTTP(S) URLs) now returns the underlying parse error instead of silently returning `(nil, nil)` when a response is missing a valid `Content-Length` header. ([filecoin-project/lotus#13773](https://github.com/filecoin-project/lotus/pull/13773))
-
-## 👌 Improvements
 
 ## 📝 Changelog
 

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	context "context"
-	json "encoding/json"
+	jsontext "encoding/json/jsontext"
 	reflect "reflect"
 	time "time"
 
@@ -3018,7 +3018,7 @@ func (mr *MockFullNodeMockRecorder) StateDecodeParams(arg0, arg1, arg2, arg3, ar
 }
 
 // StateEncodeParams mocks base method.
-func (m *MockFullNode) StateEncodeParams(arg0 context.Context, arg1 cid.Cid, arg2 abi.MethodNum, arg3 json.RawMessage) ([]byte, error) {
+func (m *MockFullNode) StateEncodeParams(arg0 context.Context, arg1 cid.Cid, arg2 abi.MethodNum, arg3 jsontext.Value) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateEncodeParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	context "context"
-	jsontext "encoding/json/jsontext"
+	json "encoding/json"
 	reflect "reflect"
 	time "time"
 
@@ -3018,7 +3018,7 @@ func (mr *MockFullNodeMockRecorder) StateDecodeParams(arg0, arg1, arg2, arg3, ar
 }
 
 // StateEncodeParams mocks base method.
-func (m *MockFullNode) StateEncodeParams(arg0 context.Context, arg1 cid.Cid, arg2 abi.MethodNum, arg3 jsontext.Value) ([]byte, error) {
+func (m *MockFullNode) StateEncodeParams(arg0 context.Context, arg1 cid.Cid, arg2 abi.MethodNum, arg3 json.RawMessage) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateEncodeParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)

--- a/build/openrpc/full.json
+++ b/build/openrpc/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/gateway.json
+++ b/build/openrpc/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/miner.json
+++ b/build/openrpc/miner.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/v0/gateway.json
+++ b/build/openrpc/v0/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/v2/full.json
+++ b/build/openrpc/v2/full.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/v2/gateway.json
+++ b/build/openrpc/v2/gateway.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/openrpc/worker.json
+++ b/build/openrpc/worker.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Lotus RPC API",
-        "version": "v1.36.2-dev"
+        "version": "1.36.3"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NodeBuildVersion is the local build version of the Lotus daemon
-const NodeBuildVersion string = "v1.36.2-dev"
+const NodeBuildVersion string = "1.36.3"
 
 func NodeUserVersion() BuildVersion {
 	if os.Getenv("LOTUS_VERSION_IGNORE_COMMIT") == "1" {

--- a/documentation/en/cli-lotus.md
+++ b/documentation/en/cli-lotus.md
@@ -8,7 +8,7 @@ USAGE:
    lotus [global options] command [command options]
 
 VERSION:
-   v1.36.2-dev
+   1.36.3
 
 COMMANDS:
    daemon   Start a lotus daemon process


### PR DESCRIPTION
## Summary
- Bump `NodeBuildVersion` to `1.36.3`.
- Regenerate API docs, OpenRPC definitions and mocks via `make gen && make docsgen-cli`.

This is the release PR for [v1.36.3 (#13761)](https://github.com/filecoin-project/lotus/issues/13761). Opening it triggers CI to build release assets and create a draft GitHub release.

## Test plan
- [x] `make lotus` builds cleanly (`CGO_LDFLAGS="-L/opt/homebrew/lib"` needed locally on Apple Silicon per `documentation/misc/Building_a_network_skeleton.md`).
- [x] `git submodule status` shows no stale/dirty `extern/filecoin-ffi`.
- [ ] CI green, including release asset generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgizYxoMLyznFX4xhAda2L