### PR TITLE
fix(docker): move builder and runtime images to Debian trixie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ## 🐛 Bug Fixes
 
+- fix(docker): restore container builds after Debian bullseye's end of LTS by moving the `lotus-builder` and `lotus-base` stages to Debian 13 (trixie), and install `curl` so builds fetch prebuilt filecoin-ffi libraries instead of compiling them. Binaries extracted from the images now require a newer glibc than the previous bullseye-built binaries; check host compatibility before replacing extracted binaries. ([filecoin-project/lotus#13785](https://github.com/filecoin-project/lotus/pull/13785))
 - fix(eth): prevent `eth_getLogs` from returning successful empty or partial results when historical event-index coverage is incomplete. Block-hash queries now require a completed block event index, and range queries verify every canonical non-null tipset before returning logs. ([filecoin-project/lotus#13749](https://github.com/filecoin-project/lotus/issues/13749))
 - fix(eth): prevent `eth_getTransactionReceipt` from returning a successful receipt with an empty `logs` array while that transaction's events are still being indexed. The call now fails until event indexing is complete, while transactions that completed with no events still return an empty array. ([filecoin-project/lotus#13758](https://github.com/filecoin-project/lotus/issues/13758))
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## 🐛 Bug Fixes
 
-- fix(docker): restore container builds after Debian bullseye's end of LTS by moving the `lotus-builder` and `lotus-base` stages to Debian 13 (trixie), and install `curl` so builds fetch prebuilt filecoin-ffi libraries instead of compiling them. Binaries extracted from the images now require a newer glibc than the previous bullseye-built binaries; check host compatibility before replacing extracted binaries. ([filecoin-project/lotus#13785](https://github.com/filecoin-project/lotus/pull/13785))
+- fix(docker): update Debian from bullseye to trixie for `lotus-builder` and `lotus-base` stages; also fetch prebuilt filecoin-ffi libraries instead of compiling them. ([filecoin-project/lotus#13785](https://github.com/filecoin-project/lotus/pull/13785))
 - fix(eth): prevent `eth_getLogs` from returning successful empty or partial results when historical event-index coverage is incomplete. Block-hash queries now require a completed block event index, and range queries verify every canonical non-null tipset before returning logs. ([filecoin-project/lotus#13749](https://github.com/filecoin-project/lotus/issues/13749))
 - fix(eth): prevent `eth_getTransactionReceipt` from returning a successful receipt with an empty `logs` array while that transaction's events are still being indexed. The call now fails until event indexing is complete, while transactions that completed with no events still return an empty array. ([filecoin-project/lotus#13758](https://github.com/filecoin-project/lotus/issues/13758))
 - fix(network): prevent remote memory exhaustion through Lotus's default WebTransport listener by updating go-libp2p and webtransport-go (CVE-2026-57497). ([filecoin-project/lotus#13734](https://github.com/filecoin-project/lotus/pull/13734))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #####################################
-FROM debian:bullseye AS lotus-builder
+FROM debian:trixie AS lotus-builder
 MAINTAINER Lotus Development Team
 
 ARG GO_VERSION=1.25.7
@@ -7,6 +7,7 @@ ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     wget \
     git \
     build-essential \
@@ -74,7 +75,7 @@ ARG GOFLAGS=""
 RUN make buildall
 
 #####################################
-FROM ubuntu:22.04 AS lotus-base
+FROM debian:trixie AS lotus-base
 MAINTAINER Lotus Development Team
 
 # Base resources


### PR DESCRIPTION
## Proposed Changes

Move the `lotus-builder` stage from `debian:bullseye` to `debian:trixie` and the `lotus-base` runtime stage from `ubuntu:22.04` to `debian:trixie`, and install `curl` in the builder so the filecoin-ffi installer can fetch prebuilt libraries instead of compiling them from source.

This is the Docker portion of #13784 (thanks @LexLuthr), split out so the repo-wide build breakage can be fixed independently of the arm64 image work.

## Why

Every Docker CI job on `master` that is not served from layer cache has been failing since ~2026-09-04. Debian bullseye reached end of LTS on 2026-08-31 and `deb.debian.org`'s `bullseye-security` suite now has an expired `Valid-Until` and references `.deb` files that have been removed from the pool. Alternatives that do not work:

- `Acquire::Check-Valid-Until=false` alone: the package index still points at `.deb` files that 404.
- `archive.debian.org`: does not carry the security suite.
- Dropping `bullseye-security`: version conflicts with the security-patched packages already in the base image.
- Pinning all suites to `snapshot.debian.org`: works (tested on amd64 and arm64), but keeps building on a dead distribution. The team direction is to move to trixie, as in #13784.

The runtime base has to change with the builder because the runtime copies shared libraries out of the builder, and they must match the runtime's glibc.

## Compatibility note for reviewers

#13611 chose bullseye specifically so `lotus-shed` would run on older preminer hosts that lacked `GLIBC_2.32`-`2.34`. A `lotus-shed` built from this branch requires symbols up to `GLIBC_2.39` (verified with `objdump -T`), so binaries extracted from the images need a host with glibc 2.39 or newer (Ubuntu 24.04, Debian 13). Hosts that were too old for bookworm will also be too old for these binaries. See the open question on #13784 (https://github.com/filecoin-project/lotus/pull/13784#discussion_r3974490219).

The `libudev1` concern raised on #13784 does not apply: `libudev.so.1` is present in the `debian:trixie` base image.

## Testing

- Full `docker build --target lotus-builder` from a clean checkout of this branch on arm64: succeeds, `lotus --version` runs inside the image, `lotus-shed`/`lotus-miner`/`lotus-worker` all built.
- `apt-get install` of the builder package set verified on both `linux/amd64` and `linux/arm64` trixie.
- CI Docker matrix on this PR.

## Checklist

- [x] Commits have a clear commit message.
- [x] PR title conforms with contribution conventions
- [x] CHANGELOG.md updated
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHfd6BSZA1UR7b38Eguitq
