### PR TITLE
test(itests): stop double proving-period waits at null-round deadline boundaries

### DIFF
--- a/itests/deadlines_test.go
+++ b/itests/deadlines_test.go
@@ -91,8 +91,7 @@ func TestDeadlineToggling(t *testing.T) {
 	{
 		minerC.PledgeSectors(ctx, sectorsC, 0, nil)
 
-		di, err := client.StateMinerProvingDeadline(ctx, maddrC, types.EmptyTSK)
-		require.NoError(t, err)
+		di := client.CurrentProvingDeadline(ctx, maddrC)
 
 		t.Log("Running one proving period (miner C)")
 		t.Logf("End for head.Height > %d", di.PeriodStart+di.WPoStProvingPeriod*2)

--- a/itests/kit/node_full.go
+++ b/itests/kit/node_full.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/lotus/api"
@@ -98,6 +99,38 @@ func (f *TestFullNode) WaitTillChain(ctx context.Context, pred ChainPredicate) *
 	}
 	require.Fail(f.t, "chain condition not met")
 	return nil
+}
+
+// CurrentProvingDeadline returns the miner's proving deadline at the current
+// chain head, rewound if necessary so that di.Open <= head height.
+//
+// StateMinerProvingDeadline reads the parent state of the queried tipset. At a
+// deadline boundary that follows a null round the miner cron has not yet
+// advanced the recorded deadline, so NextNotElapsed reports the same deadline
+// index one proving period later, and a test waiting for
+// di.Open + di.WPoStProvingPeriod would wait two periods instead of one.
+func (f *TestFullNode) CurrentProvingDeadline(ctx context.Context, maddr address.Address) *dline.Info {
+	head, err := f.ChainHead(ctx)
+	require.NoError(f.t, err)
+
+	di, err := f.StateMinerProvingDeadline(ctx, maddr, head.Key())
+	require.NoError(f.t, err)
+
+	return DeadlineNotAfter(di, head.Height())
+}
+
+// DeadlineNotAfter rewinds di by whole proving periods until di.Open <= height.
+// The result keeps di.Index and may already have closed at height, so callers
+// should rely only on Open, PeriodStart and Index. It is exported so it can be
+// unit tested from an itest file: cmd/ci treats every _test.go under itests/
+// as an integration test group.
+func DeadlineNotAfter(di *dline.Info, height abi.ChainEpoch) *dline.Info {
+	for di.Open > height {
+		di = dline.NewInfo(di.PeriodStart-di.WPoStProvingPeriod, di.Index, height,
+			di.WPoStPeriodDeadlines, di.WPoStProvingPeriod, di.WPoStChallengeWindow,
+			di.WPoStChallengeLookback, di.FaultDeclarationCutoff)
+	}
+	return di
 }
 
 // WaitTillChainOrError waits until a specified chain condition is met. It returns

--- a/itests/kit/node_full.go
+++ b/itests/kit/node_full.go
@@ -121,9 +121,7 @@ func (f *TestFullNode) CurrentProvingDeadline(ctx context.Context, maddr address
 
 // DeadlineNotAfter rewinds di by whole proving periods until di.Open <= height.
 // The result keeps di.Index and may already have closed at height, so callers
-// should rely only on Open, PeriodStart and Index. It is exported so it can be
-// unit tested from an itest file: cmd/ci treats every _test.go under itests/
-// as an integration test group.
+// should rely only on Open, PeriodStart and Index.
 func DeadlineNotAfter(di *dline.Info, height abi.ChainEpoch) *dline.Info {
 	for di.Open > height {
 		di = dline.NewInfo(di.PeriodStart-di.WPoStProvingPeriod, di.Index, height,

--- a/itests/sector_terminate_test.go
+++ b/itests/sector_terminate_test.go
@@ -63,8 +63,7 @@ func TestTerminate(t *testing.T) {
 
 	{
 		// Wait until proven.
-		di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-		require.NoError(t, err)
+		di := client.CurrentProvingDeadline(ctx, maddr)
 
 		waitUntil := di.Open + di.WPoStProvingPeriod
 		t.Logf("End for head.Height > %d", waitUntil)
@@ -291,8 +290,7 @@ loop:
 		require.Equal(t, uint64(0), bflen(parts[0].LiveSectors))
 	}
 
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	waitUntil := di.PeriodStart + di.WPoStProvingPeriod + 20 // slack like above
 	t.Logf("End for head.Height > %d", waitUntil)

--- a/itests/wdpost_config_test.go
+++ b/itests/wdpost_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/dline"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
@@ -43,8 +44,7 @@ func TestWindowPostNoPreChecks(t *testing.T) {
 
 	maddr, err := miner.ActorAddress(ctx)
 	require.NoError(t, err)
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	mid, err := address.IDFromAddress(maddr)
 	require.NoError(t, err)
@@ -122,8 +122,7 @@ func TestWindowPostNoPreChecks(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Go through another PP, wait for sectors to become faulty")
 	waitUntil = di.Open + di.WPoStProvingPeriod
@@ -145,8 +144,7 @@ func TestWindowPostNoPreChecks(t *testing.T) {
 	err = miner.StorageMiner.(*impl.StorageMinerAPI).IStorageMgr.(*mock.SectorMgr).MarkFailed(s, false)
 	require.NoError(t, err)
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	waitUntil = di.Open + di.WPoStProvingPeriod
 	t.Logf("End for head.Height > %d", waitUntil)
@@ -168,8 +166,7 @@ func TestWindowPostNoPreChecks(t *testing.T) {
 
 	{
 		// Wait until proven.
-		di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-		require.NoError(t, err)
+		di = client.CurrentProvingDeadline(ctx, maddr)
 
 		waitUntil := di.Open + di.WPoStProvingPeriod
 		t.Logf("End for head.Height > %d\n", waitUntil)
@@ -208,8 +205,7 @@ func TestWindowPostMaxSectorsRecoveryConfig(t *testing.T) {
 
 	maddr, err := miner.ActorAddress(ctx)
 	require.NoError(t, err)
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	mid, err := address.IDFromAddress(maddr)
 	require.NoError(t, err)
@@ -253,8 +249,7 @@ func TestWindowPostMaxSectorsRecoveryConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Go through another PP, wait for sectors to become faulty")
 	waitUntil = di.Open + di.WPoStProvingPeriod
@@ -283,8 +278,7 @@ func TestWindowPostMaxSectorsRecoveryConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	waitUntil = di.Open + di.WPoStProvingPeriod + 200
 	t.Logf("End for head.Height > %d", waitUntil)
@@ -322,8 +316,7 @@ func TestWindowPostManualSectorsRecovery(t *testing.T) {
 
 	maddr, err := miner.ActorAddress(ctx)
 	require.NoError(t, err)
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	mid, err := address.IDFromAddress(maddr)
 	require.NoError(t, err)
@@ -377,8 +370,7 @@ func TestWindowPostManualSectorsRecovery(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Go through another PP, wait for sectors to become faulty")
 	waitUntil = di.Open + di.WPoStProvingPeriod
@@ -443,8 +435,7 @@ func TestWindowPostManualSectorsRecovery(t *testing.T) {
 
 	require.Equal(t, recoveredCount, uint64(2))
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Go through another PP, wait for sectors to become faulty")
 	waitUntil = di.Open + di.WPoStProvingPeriod
@@ -466,4 +457,51 @@ func TestWindowPostManualSectorsRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, recoveredCount, uint64(0))
+}
+
+// TestDeadlineNotAfter is a unit test for the clamp behind
+// kit.CurrentProvingDeadline. It lives here rather than in itests/kit because
+// cmd/ci treats every _test.go under itests/ as an integration test group.
+func TestDeadlineNotAfter(t *testing.T) {
+	const (
+		period      = abi.ChainEpoch(2880)
+		window      = abi.ChainEpoch(60)
+		periodStart = abi.ChainEpoch(658)
+		index       = uint64(37)
+	)
+	mk := func(ps, cur abi.ChainEpoch) *dline.Info {
+		return dline.NewInfo(ps, index, cur, 48, period, window, 20, 70)
+	}
+
+	t.Run("deadline containing height is unchanged", func(t *testing.T) {
+		di := mk(periodStart, periodStart+abi.ChainEpoch(index)*window+5)
+		require.Same(t, di, kit.DeadlineNotAfter(di, di.CurrentEpoch))
+	})
+
+	t.Run("deadline before height is unchanged", func(t *testing.T) {
+		di := mk(periodStart, periodStart+abi.ChainEpoch(index)*window+window)
+		require.Same(t, di, kit.DeadlineNotAfter(di, di.CurrentEpoch))
+	})
+
+	t.Run("next-period deadline is rewound to the current period", func(t *testing.T) {
+		// What StateMinerProvingDeadline returns at a deadline close when the
+		// preceding epoch was a null round: same index, next proving period.
+		height := periodStart + abi.ChainEpoch(index)*window + window
+		di := mk(periodStart+period, height)
+		require.Greater(t, di.Open, height)
+
+		got := kit.DeadlineNotAfter(di, height)
+		require.Equal(t, periodStart, got.PeriodStart)
+		require.Equal(t, index, got.Index)
+		require.Equal(t, height, got.CurrentEpoch)
+		require.Equal(t, height, got.Close)
+	})
+
+	t.Run("rewinds multiple periods", func(t *testing.T) {
+		height := periodStart + abi.ChainEpoch(index)*window
+		di := mk(periodStart+3*period, height)
+		got := kit.DeadlineNotAfter(di, height)
+		require.Equal(t, periodStart, got.PeriodStart)
+		require.Equal(t, height, got.Open)
+	})
 }

--- a/itests/wdpost_config_test.go
+++ b/itests/wdpost_config_test.go
@@ -467,39 +467,52 @@ func TestDeadlineNotAfter(t *testing.T) {
 		period      = abi.ChainEpoch(2880)
 		window      = abi.ChainEpoch(60)
 		periodStart = abi.ChainEpoch(658)
-		index       = uint64(37)
 	)
-	mk := func(ps, cur abi.ChainEpoch) *dline.Info {
-		return dline.NewInfo(ps, index, cur, 48, period, window, 20, 70)
+	mk := func(index uint64, cur abi.ChainEpoch) *dline.Info {
+		return dline.NewInfo(periodStart, index, cur, 48, period, window, 20, 70)
 	}
 
 	t.Run("deadline containing height is unchanged", func(t *testing.T) {
-		di := mk(periodStart, periodStart+abi.ChainEpoch(index)*window+5)
+		di := mk(37, periodStart+37*window+5)
 		require.Same(t, di, kit.DeadlineNotAfter(di, di.CurrentEpoch))
 	})
 
 	t.Run("deadline before height is unchanged", func(t *testing.T) {
-		di := mk(periodStart, periodStart+abi.ChainEpoch(index)*window+window)
+		di := mk(37, periodStart+38*window)
 		require.Same(t, di, kit.DeadlineNotAfter(di, di.CurrentEpoch))
 	})
 
-	t.Run("next-period deadline is rewound to the current period", func(t *testing.T) {
-		// What StateMinerProvingDeadline returns at a deadline close when the
-		// preceding epoch was a null round: same index, next proving period.
-		height := periodStart + abi.ChainEpoch(index)*window + window
-		di := mk(periodStart+period, height)
-		require.Greater(t, di.Open, height)
+	// What StateMinerProvingDeadline returns at a deadline close when the
+	// preceding epochs were null rounds: the recorded deadline has elapsed, so
+	// NextNotElapsed moves it to the next proving period with the same index.
+	for _, tc := range []struct {
+		name  string
+		index uint64
+		nulls abi.ChainEpoch
+	}{
+		{"one null round", 37, 1},
+		{"two null rounds", 37, 2},
+		{"one null round at the last deadline of the period", 47, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorded := mk(tc.index, periodStart+abi.ChainEpoch(tc.index)*window)
+			height := recorded.Close + tc.nulls - 1
+			jumped := dline.NewInfo(periodStart, tc.index, height, 48, period, window, 20, 70).NextNotElapsed()
+			require.Equal(t, periodStart+period, jumped.PeriodStart)
+			require.Greater(t, jumped.Open, height)
 
-		got := kit.DeadlineNotAfter(di, height)
-		require.Equal(t, periodStart, got.PeriodStart)
-		require.Equal(t, index, got.Index)
-		require.Equal(t, height, got.CurrentEpoch)
-		require.Equal(t, height, got.Close)
-	})
+			got := kit.DeadlineNotAfter(jumped, height)
+			require.Equal(t, periodStart, got.PeriodStart)
+			require.Equal(t, tc.index, got.Index)
+			require.Equal(t, recorded.Open, got.Open)
+			require.Equal(t, recorded.Close, got.Close)
+			require.Equal(t, height, got.CurrentEpoch)
+		})
+	}
 
 	t.Run("rewinds multiple periods", func(t *testing.T) {
-		height := periodStart + abi.ChainEpoch(index)*window
-		di := mk(periodStart+3*period, height)
+		height := periodStart + 37*window
+		di := dline.NewInfo(periodStart+3*period, 37, height, 48, period, window, 20, 70)
 		got := kit.DeadlineNotAfter(di, height)
 		require.Equal(t, periodStart, got.PeriodStart)
 		require.Equal(t, height, got.Open)

--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -66,8 +66,7 @@ func TestWindowPostDispute(t *testing.T) {
 	evilMinerAddr, err := evilMiner.ActorAddress(ctx)
 	require.NoError(t, err)
 
-	di, err := client.StateMinerProvingDeadline(ctx, evilMinerAddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, evilMinerAddr)
 
 	t.Logf("Running one proving period\n")
 

--- a/itests/wdpost_dispute_test.go
+++ b/itests/wdpost_dispute_test.go
@@ -239,8 +239,7 @@ func TestWindowPostDisputeFails(t *testing.T) {
 
 	miner.PledgeSectors(ctx, 10, 0, nil)
 
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Running one proving period")
 	waitUntil := di.PeriodStart + di.WPoStProvingPeriod*2 + 1

--- a/itests/wdpost_test.go
+++ b/itests/wdpost_test.go
@@ -63,8 +63,7 @@ func testWindowPostUpgrade(t *testing.T, blocktime time.Duration, nSectors int, 
 	maddr, err := miner.ActorAddress(ctx)
 	require.NoError(t, err)
 
-	di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di := client.CurrentProvingDeadline(ctx, maddr)
 
 	mid, err := address.IDFromAddress(maddr)
 	require.NoError(t, err)
@@ -142,8 +141,7 @@ func testWindowPostUpgrade(t *testing.T, blocktime time.Duration, nSectors int, 
 		require.NoError(t, err)
 	}
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	t.Log("Go through another PP, wait for sectors to become faulty")
 	waitUntil = di.Open + di.WPoStProvingPeriod
@@ -165,8 +163,7 @@ func testWindowPostUpgrade(t *testing.T, blocktime time.Duration, nSectors int, 
 	err = miner.StorageMiner.(*impl.StorageMinerAPI).IStorageMgr.(*mock.SectorMgr).MarkFailed(s, false)
 	require.NoError(t, err)
 
-	di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-	require.NoError(t, err)
+	di = client.CurrentProvingDeadline(ctx, maddr)
 
 	waitUntil = di.Open + di.WPoStProvingPeriod
 	t.Logf("End for head.Height > %d", waitUntil)
@@ -188,8 +185,7 @@ func testWindowPostUpgrade(t *testing.T, blocktime time.Duration, nSectors int, 
 
 	{
 		// Wait until proven.
-		di, err = client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-		require.NoError(t, err)
+		di = client.CurrentProvingDeadline(ctx, maddr)
 
 		waitUntil := di.Open + di.WPoStProvingPeriod
 		t.Logf("End for head.Height > %d\n", waitUntil)
@@ -324,8 +320,7 @@ waitForProof:
 	require.Contains(t, ret.Error, "expected proof of type StackedDRGWindow2KiBV1P1, got StackedDRGWindow2KiBV1")
 
 	for {
-		di, err := client.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
-		require.NoError(t, err)
+		di := client.CurrentProvingDeadline(ctx, maddr)
 		// wait until the deadline finishes.
 		if di.Index == ((params.Deadline + 1) % di.WPoStPeriodDeadlines) {
 			break


### PR DESCRIPTION
## Problem

`itest-wdpost_config` is flaky on master. One failure mode (run 34477798327, 2026-09-10) is `TestWindowPostMaxSectorsRecoveryConfig` asserting 11 active sectors and finding 12.

The tests wait for "one more proving period" with `di.Open + di.WPoStProvingPeriod`, where `di` comes from `StateMinerProvingDeadline`. That target always lands exactly on a deadline boundary. `StateMinerProvingDeadline` reads the parent state of the queried tipset and applies `dline.Info.NextNotElapsed`. When the epoch before that boundary was a null round, the miner cron has not yet advanced the recorded deadline, so the recorded deadline reads as elapsed and `NextNotElapsed` returns the same deadline index one proving period later. The next wait then covers two proving periods instead of one. With `RecoveringSectorLimit = 1` that lets both faulty sectors recover before the assertion, and in the other tests it silently adds 40 to 100 seconds, which contributes to the 10-minute timeouts this job also hits.

The failing log shows exactly this: a null round at epoch 5817, head at 5818, and a wait target of 11718 instead of 8838. Null rounds occur in roughly 0.7% of epochs in these tests, and the same pattern is used in about fifteen places across the wdpost itests, which matches the observed low but steady failure rate going back to at least 2025.

## Fix

Add `kit.CurrentProvingDeadline`, which queries the deadline at a pinned head tipset and rewinds the result by whole proving periods until `Open <= head height`, and use it at every itest call site that computes a proving-period wait from `Open` or `PeriodStart`. The clamp is a pure function, `kit.DeadlineNotAfter`, covered by `TestDeadlineNotAfter` in `wdpost_config_test.go` (it lives there rather than in `itests/kit` because `cmd/ci` treats every `_test.go` under `itests/` as an integration test group).

Call sites in `worker_test.go`, `wdpost_worker_config_test.go` and `wdpost_no_miner_storage_test.go` are left unchanged: they call `NextNotElapsed` or read `Close` on the result, which the helper does not promise to keep meaningful.

## Failure history, 2026-07-10 to 2026-09-10

`itest-wdpost_config` ran 48 times on master in this window: 44 passed, 4 failed (8.3%). Infra failures (dependabot compile breaks, invalid workflow template, branch-specific node startup errors) are excluded below.

| Date | Run | Branch | Mode | Detail | Fixed by this PR? |
|---|---|---|---|---|---|
| 2026-07-17 | [29557485839](https://github.com/filecoin-project/lotus/actions/runs/29557485839) | master | timeout | `NoPreChecks` 454s, `MaxSectorsRecoveryConfig` cut off at 10m | No |
| 2026-08-17 | [32072434415](https://github.com/filecoin-project/lotus/actions/runs/32072434415) | PR #13745 | timeout | `NoPreChecks` 259s, `MaxSectorsRecoveryConfig` 208s, `ManualSectorsRecovery` cut off | No |
| 2026-09-03 | [33804599274](https://github.com/filecoin-project/lotus/actions/runs/33804599274) | master | timeout | `NoPreChecks` 324s, `MaxSectorsRecoveryConfig` 263s, `ManualSectorsRecovery` cut off | No |
| 2026-09-05 | [33933735239](https://github.com/filecoin-project/lotus/actions/runs/33933735239) | PR #13782 | timeout | `NoPreChecks` 250s, `MaxSectorsRecoveryConfig` 202s, `ManualSectorsRecovery` cut off | No |
| 2026-09-07 | [34114789439](https://github.com/filecoin-project/lotus/actions/runs/34114789439) | master | timeout | `NoPreChecks` 443s, `MaxSectorsRecoveryConfig` cut off | No |
| 2026-09-09 | [34363976935](https://github.com/filecoin-project/lotus/actions/runs/34363976935) | PR #13784 | timeout | `NoPreChecks` 530s, `MaxSectorsRecoveryConfig` cut off | No |
| 2026-09-10 | [34477798327](https://github.com/filecoin-project/lotus/actions/runs/34477798327) | master | assertion | `MaxSectorsRecoveryConfig` expected 11 sectors, got 12; log shows null round at 5817 and wait target 11718 instead of 8838 | Yes |

Two distinct causes:

1. **Null-round deadline boundary race** (the Sep 10 row). This PR fixes it. It also removes the extra 40 to 100 seconds that the same race adds to any test in the file when it fires without changing an assertion, which is a small contribution to headroom.
2. **Slow hosted runner** (the six timeout rows). In the logs inspected (Sep 3, Sep 7) the wait targets advance in normal 2880-epoch steps, so no boundary jump was involved; the runner was simply taking 90 to 110 seconds per proving period instead of about 36. A healthy run needs roughly 367s of test time against Go's 10-minute default, and the CI group passes no `-timeout`. This PR does not address that. If timeouts continue after merge, the follow-up is a `-timeout` in `cmd/ci` `getGoTestFlags` for this group or a larger runner.

No single commit introduced either problem: the test file last changed in 2022, the job has always run on `ubuntu-latest`, and isolated failures of this job on PR branches go back to at least September 2025. The uptick since mid-August coincides with slower hosted runners, not a Lotus change.

## Verification

Local runs with the change: `wdpost_config_test.go` (all three integration tests plus `TestDeadlineNotAfter`), `wdpost_dispute_test.go` with `LOTUS_RUN_EXPENSIVE_TESTS=1`, `sector_terminate_test.go`, and `TestWindowedPost` all pass. `go vet`, `gofmt` and `make fiximports` are clean. Full `make lint` and the last two short tests in `wdpost_test.go` are left to CI.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxDeytJfEPbAh61kTv75R2
