### PR TITLE
fix(api): check readiness immediately on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ## 🐛 Bug Fixes
 
+- fix(api): check `/health/readyz` immediately on startup instead of waiting for the first one-minute polling interval.
 - fix(docker): update Debian from bullseye to trixie for `lotus-builder` and `lotus-base` stages; also fetch prebuilt filecoin-ffi libraries instead of compiling them. ([filecoin-project/lotus#13785](https://github.com/filecoin-project/lotus/pull/13785))
 - fix(eth): prevent `eth_getLogs` from returning successful empty or partial results when historical event-index coverage is incomplete. Block-hash queries now require a completed block event index, and range queries verify every canonical non-null tipset before returning logs. ([filecoin-project/lotus#13749](https://github.com/filecoin-project/lotus/issues/13749))
 - fix(eth): prevent `eth_getTransactionReceipt` from returning a successful receipt with an empty `logs` array while that transaction's events are still being indexed. The call now fails until event indexing is complete, while transactions that completed with no events still return an empty array. ([filecoin-project/lotus#13758](https://github.com/filecoin-project/lotus/issues/13758))

--- a/node/health.go
+++ b/node/health.go
@@ -98,18 +98,23 @@ func NewReadyHandler(api lapi.FullNode) *HealthHandler {
 	h := HealthHandler{}
 	go func() {
 		const heightTolerance = uint64(5)
-		var nethealth, synchealth bool
+		check := func() {
+			netstat, err := api.NetAutoNatStatus(ctx)
+			nethealth := err == nil && netstat.Reachability != network.ReachabilityUnknown
+
+			nodestat, err := api.NodeStatus(ctx, false)
+			synchealth := err == nil && nodestat.SyncStatus.Behind < heightTolerance
+
+			h.SetHealthy(nethealth && synchealth)
+		}
+
+		check()
+
 		minutely := time.NewTicker(time.Minute)
 		for {
 			select {
 			case <-minutely.C:
-				netstat, err := api.NetAutoNatStatus(ctx)
-				nethealth = err == nil && netstat.Reachability != network.ReachabilityUnknown
-
-				nodestat, err := api.NodeStatus(ctx, false)
-				synchealth = err == nil && nodestat.SyncStatus.Behind < heightTolerance
-
-				h.SetHealthy(nethealth && synchealth)
+				check()
 			}
 		}
 	}()

--- a/node/health_test.go
+++ b/node/health_test.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/mocks"
+)
+
+func TestNewReadyHandlerChecksImmediately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	fullNode := mocks.NewMockFullNode(ctrl)
+	fullNode.EXPECT().NetAutoNatStatus(gomock.Any()).Return(api.NatInfo{
+		Reachability: network.ReachabilityPublic,
+	}, nil).AnyTimes()
+	fullNode.EXPECT().NodeStatus(gomock.Any(), false).Return(api.NodeStatus{
+		SyncStatus: api.NodeSyncStatus{Behind: 0},
+	}, nil).AnyTimes()
+
+	handler := NewReadyHandler(fullNode)
+
+	require.Eventually(t, func() bool {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/health/readyz", nil))
+		return response.Code == http.StatusOK
+	}, time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Related Issues

No issue. This is a small correctness fix for the existing `/health/readyz` endpoint.

Related context: #12587 documents that `/health/readyz` is intended to be used as a Kubernetes readiness endpoint.

## Proposed Changes

- Run the readiness check once immediately when `NewReadyHandler` starts, rather than waiting for the first one-minute ticker interval.
- Keep the existing one-minute polling interval and readiness criteria unchanged.
- Add a regression test verifying that an already-ready node becomes healthy without waiting for the first periodic tick.
- Add an entry to the UNRELEASED bug fixes section of `CHANGELOG.md`.

## Additional Info

`HealthHandler` starts in the unhealthy state. Previously, `NewReadyHandler` only evaluated `NetAutoNatStatus` and `NodeStatus` after the first `time.Minute` ticker event. As a result, an otherwise-ready node could return HTTP 503 from `/health/readyz` for up to one minute after the handler was created.

This can unnecessarily keep a healthy Lotus node out of a Kubernetes Service or load-balancer pool during startup.

The readiness criteria themselves are unchanged. This change only performs the same check once immediately before continuing with the existing periodic checks.

PR #8692 describes the health endpoints as being useful for Kubernetes readiness and liveness probes. Issue #12587 also confirms that `/health/readyz` is intended specifically as a Kubernetes readiness endpoint.

## Checklist

Before you mark the PR ready for review, please make sure that:

- [x] Commits have a clear commit message.
- [x] PR title conforms with contribution conventions.
- [x] Updated `CHANGELOG.md`.
- [x] No new user-facing feature or documentation is required.
- [x] Tests exist for the behavior change.
- [x] CI is green.